### PR TITLE
[dagster-dbt] Fix dbt cli invocation params for OpExecutionContext

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import textwrap
+from contextlib import suppress
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
@@ -28,6 +29,7 @@ from dagster import (
     define_asset_job,
     get_dagster_logger,
 )
+from dagster._core.errors import DagsterInvalidPropertyError
 from dagster._core.definitions.asset_spec import SYSTEM_METADATA_KEY_DAGSTER_TYPE
 from dagster._core.definitions.metadata import TableMetadataSet
 from dagster._core.types.dagster_type import Nothing
@@ -404,7 +406,9 @@ def get_updated_cli_invocation_params_for_context(
     manifest: Mapping[str, Any],
     dagster_dbt_translator: "DagsterDbtTranslator",
 ) -> DbtCliInvocationPartialParams:
-    assets_def = context.assets_def if isinstance(context, AssetExecutionContext) else None
+    assets_def: Optional[AssetsDefinition] = None
+    with suppress(DagsterInvalidPropertyError):
+        assets_def = context.assets_def if context else assets_def
 
     selection_args: list[str] = []
     indirect_selection = os.getenv(DBT_INDIRECT_SELECTION_ENV, None)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -3,7 +3,6 @@ import os
 import textwrap
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
-from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, AbstractSet, Annotated, Any, Final, Optional, Union  # noqa: UP035
 
@@ -31,7 +30,6 @@ from dagster import (
 )
 from dagster._core.definitions.asset_spec import SYSTEM_METADATA_KEY_DAGSTER_TYPE
 from dagster._core.definitions.metadata import TableMetadataSet
-from dagster._core.errors import DagsterInvalidPropertyError
 from dagster._core.types.dagster_type import Nothing
 from dagster._record import ImportFrom, record
 
@@ -406,9 +404,9 @@ def get_updated_cli_invocation_params_for_context(
     manifest: Mapping[str, Any],
     dagster_dbt_translator: "DagsterDbtTranslator",
 ) -> DbtCliInvocationPartialParams:
-    assets_def: Optional[AssetsDefinition] = None
-    with suppress(DagsterInvalidPropertyError):
-        assets_def = context.assets_def if context else assets_def
+    assets_def: Optional[AssetsDefinition] = (
+        getattr(context, "assets_def", None) if context else None
+    )
 
     selection_args: list[str] = []
     indirect_selection = os.getenv(DBT_INDIRECT_SELECTION_ENV, None)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -1,9 +1,9 @@
 import hashlib
 import os
 import textwrap
-from contextlib import suppress
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, AbstractSet, Annotated, Any, Final, Optional, Union  # noqa: UP035
 
@@ -29,9 +29,9 @@ from dagster import (
     define_asset_job,
     get_dagster_logger,
 )
-from dagster._core.errors import DagsterInvalidPropertyError
 from dagster._core.definitions.asset_spec import SYSTEM_METADATA_KEY_DAGSTER_TYPE
 from dagster._core.definitions.metadata import TableMetadataSet
+from dagster._core.errors import DagsterInvalidPropertyError
 from dagster._core.types.dagster_type import Nothing
 from dagster._record import ImportFrom, record
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -408,7 +408,7 @@ def get_updated_cli_invocation_params_for_context(
     try:
         assets_def = context.assets_def if context else None
     except DagsterInvalidPropertyError:
-        # If asset defs is None in an OpExecutionContext, we raise a DagsterInvalidPropertyError,
+        # If assets_def is None in an OpExecutionContext, we raise a DagsterInvalidPropertyError,
         # but we don't want to raise the error here.
         assets_def = None
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -30,8 +30,8 @@ from dagster import (
 )
 from dagster._core.definitions.asset_spec import SYSTEM_METADATA_KEY_DAGSTER_TYPE
 from dagster._core.definitions.metadata import TableMetadataSet
-from dagster._core.types.dagster_type import Nothing
 from dagster._core.errors import DagsterInvalidPropertyError
+from dagster._core.types.dagster_type import Nothing
 from dagster._record import ImportFrom, record
 
 from dagster_dbt.dbt_project import DbtProject

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_asset_decorator.py
@@ -1,9 +1,9 @@
 from collections.abc import Mapping
-from typing import Any, Optional, Type, Union
+from typing import Any, Optional, Union
 
 import pytest
 import responses
-from dagster import AssetKey, AssetExecutionContext, OpExecutionContext
+from dagster import AssetExecutionContext, AssetKey, OpExecutionContext
 from dagster_dbt.asset_utils import build_dbt_specs
 from dagster_dbt.cloud_v2.asset_decorator import dbt_cloud_assets
 from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace
@@ -223,7 +223,7 @@ def test_asset_defs_with_custom_metadata(
 def test_selections(
     workspace: DbtCloudWorkspace,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
-    context_type: Union[Type[AssetExecutionContext], Type[OpExecutionContext]],
+    context_type: Union[type[AssetExecutionContext], type[OpExecutionContext]],
     select: Optional[str],
     exclude: Optional[str],
     selector: Optional[str],
@@ -250,7 +250,7 @@ def test_selections(
         exclude=exclude,
         selector=selector,
     )
-    def my_dbt_assets(context: context_type): ...
+    def my_dbt_assets(context: context_type): ...  # pyright: ignore
 
     assert len(my_dbt_assets.keys) == len(expected_specs)
     assert my_dbt_assets.keys == {spec.key for spec in expected_specs}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_asset_decorator.py
@@ -1,9 +1,9 @@
 from collections.abc import Mapping
-from typing import Any, Optional
+from typing import Any, Optional, Type, Union
 
 import pytest
 import responses
-from dagster import AssetKey
+from dagster import AssetKey, AssetExecutionContext, OpExecutionContext
 from dagster_dbt.asset_utils import build_dbt_specs
 from dagster_dbt.cloud_v2.asset_decorator import dbt_cloud_assets
 from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace
@@ -63,6 +63,17 @@ def test_asset_defs_with_custom_metadata(
     workspace.load_specs.cache_clear()
 
 
+@pytest.mark.parametrize(
+    "context_type",
+    [
+        OpExecutionContext,
+        AssetExecutionContext,
+    ],
+    ids=[
+        "dbt_cloud_cli_selection_with_op_execution_context",
+        "dbt_cloud_cli_selection_with_asset_execution_context",
+    ],
+)
 @pytest.mark.parametrize(
     ["select", "exclude", "selector", "expected_dbt_resource_names"],
     [
@@ -212,6 +223,7 @@ def test_asset_defs_with_custom_metadata(
 def test_selections(
     workspace: DbtCloudWorkspace,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
+    context_type: Union[Type[AssetExecutionContext], Type[OpExecutionContext]],
     select: Optional[str],
     exclude: Optional[str],
     selector: Optional[str],
@@ -238,7 +250,7 @@ def test_selections(
         exclude=exclude,
         selector=selector,
     )
-    def my_dbt_assets(): ...
+    def my_dbt_assets(context: context_type): ...
 
     assert len(my_dbt_assets.keys) == len(expected_specs)
     assert my_dbt_assets.keys == {spec.key for spec in expected_specs}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -2,7 +2,7 @@ import os
 import shutil
 from dataclasses import replace
 from pathlib import Path
-from typing import Any, Optional, Union, cast, Type
+from typing import Any, Optional, Union, cast
 
 import pydantic
 import pytest
@@ -456,9 +456,9 @@ def test_dbt_source_freshness_execution(test_dbt_source_freshness_manifest: dict
     ],
 )
 def test_dbt_cli_asset_selection(
-        context_type: Union[Type[AssetExecutionContext], Type[OpExecutionContext]],
-        test_jaffle_shop_manifest: dict[str, Any],
-        dbt: DbtCliResource
+    context_type: Union[type[AssetExecutionContext], type[OpExecutionContext]],
+    test_jaffle_shop_manifest: dict[str, Any],
+    dbt: DbtCliResource,
 ) -> None:
     dbt_select = " ".join(
         [
@@ -468,7 +468,7 @@ def test_dbt_cli_asset_selection(
     )
 
     @dbt_assets(manifest=test_jaffle_shop_manifest, select=dbt_select)
-    def my_dbt_assets(context: context_type, dbt: DbtCliResource):
+    def my_dbt_assets(context: context_type, dbt: DbtCliResource):  # pyright: ignore
         dbt_cli_invocation = dbt.cli(["build"], context=context)
 
         assert dbt_cli_invocation.process.args == ["dbt", "build", "--select", dbt_select]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -2,7 +2,7 @@ import os
 import shutil
 from dataclasses import replace
 from pathlib import Path
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union, cast, Type
 
 import pydantic
 import pytest
@@ -444,8 +444,21 @@ def test_dbt_source_freshness_execution(test_dbt_source_freshness_manifest: dict
     assert result.success
 
 
+@pytest.mark.parametrize(
+    "context_type",
+    [
+        OpExecutionContext,
+        AssetExecutionContext,
+    ],
+    ids=[
+        "dbt_cli_selection_with_op_execution_context",
+        "dbt_cli_selection_with_asset_execution_context",
+    ],
+)
 def test_dbt_cli_asset_selection(
-    test_jaffle_shop_manifest: dict[str, Any], dbt: DbtCliResource
+        context_type: Union[Type[AssetExecutionContext], Type[OpExecutionContext]],
+        test_jaffle_shop_manifest: dict[str, Any],
+        dbt: DbtCliResource
 ) -> None:
     dbt_select = " ".join(
         [
@@ -455,7 +468,7 @@ def test_dbt_cli_asset_selection(
     )
 
     @dbt_assets(manifest=test_jaffle_shop_manifest, select=dbt_select)
-    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+    def my_dbt_assets(context: context_type, dbt: DbtCliResource):
         dbt_cli_invocation = dbt.cli(["build"], context=context)
 
         assert dbt_cli_invocation.process.args == ["dbt", "build", "--select", dbt_select]


### PR DESCRIPTION
## Summary & Motivation

Fixes #29918.

The error was introduced in https://github.com/dagster-io/dagster/pull/29650 when addressing this [comment](https://github.com/dagster-io/dagster/pull/29650#discussion_r2064866321).

Context:

When creating an asset definition, it is allowed to use `OpExecutionContext` as the type hint for the context, like

```python
@dbt_assets(manifest=manifest)
def my_dbt_assets(context: OpExecutionExecution, dbt: DbtCliResource):
    ...
```

Issue:

We removed the `suppress(DagsterInvalidPropertyError)` statement in `get_updated_cli_invocation_params_for_context`, and used `assets_def = context.assets_def if isinstance(context, AssetExecutionContext) else None` instead. The problem is that the context may be typed as `OpExecutionContext` even though the context is an instance of `AssetExecutionContext`. 

For that specific use case, we were not entering the if context and assets_def is not None condition in the function, so the  dbt cli params were not properly returned.

Solution:

~~This PR brings back the `suppress(DagsterInvalidPropertyError)` statement. We don't what type hint will be used for the context, and using the suppress statement makes sure that Dagster doesn't yell when accessing `context.asset_defs`.~~

This PR uses getattr to access context.asset_defs without using the suppress statement and isinstance.


## How I Tested These Changes

Updated tests with BK

## Changelog

[dagster-dbt] An issue causing dbt CLI invocation to fail when materializing assets was fixed. This issue occurred only for assets for which `OpExecutionContext` was used as the type hint for the context. 
