### PR TITLE
[dagster-airlift] allow for components-based filtering

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/job_builder.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/job_builder.py
@@ -4,7 +4,7 @@ from dagster import JobDefinition
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.decorators.job_decorator import job
 
-from dagster_airlift.core.dag_asset import dag_asset_metadata
+from dagster_airlift.core.dag_asset import peered_dag_asset_metadata
 from dagster_airlift.core.serialization.serialized_data import (
     SerializedAirflowDefinitionsData,
     SerializedDagData,
@@ -21,7 +21,7 @@ def construct_dag_jobs(
         JobDefinition.for_external_job(
             asset_keys=[spec.key for spec in mapped_specs[dag_id]],
             name=job_name(dag_id),
-            metadata=dag_asset_metadata(dag_data.dag_info),
+            metadata=peered_dag_asset_metadata(dag_data.dag_info, dag_data.source_code),
             tags=airflow_job_tags(dag_id),
         )
         for dag_id, dag_data in serialized_data.dag_datas.items()

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -384,16 +384,19 @@ def _get_dag_to_spec_mapping(
 def build_job_based_airflow_defs(
     *,
     airflow_instance: AirflowInstance,
+    retrieval_filter: Optional[AirflowFilter] = None,
     mapped_defs: Optional[Definitions] = None,
+    source_code_retrieval_enabled: Optional[bool] = None,
 ) -> Definitions:
     mapped_defs = mapped_defs or Definitions()
+    retrieval_filter = retrieval_filter or AirflowFilter()
     mapped_assets = type_narrow_defs_assets(mapped_defs)
     serialized_airflow_data = AirflowInstanceDefsLoader(
         airflow_instance=airflow_instance,
         mapped_assets=mapped_assets,
         dag_selector_fn=None,
-        source_code_retrieval_enabled=True,
-        retrieval_filter=AirflowFilter(),
+        source_code_retrieval_enabled=source_code_retrieval_enabled,
+        retrieval_filter=retrieval_filter,
     ).get_or_fetch_state()
     assets_with_airflow_data = _apply_airflow_data_to_specs(
         [

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
@@ -10,13 +10,18 @@ import yaml
 from click.testing import CliRunner
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import pushd
 from dagster.components.cli import cli
-from dagster_airlift.constants import DAG_MAPPING_METADATA_KEY, TASK_MAPPING_METADATA_KEY
+from dagster_airlift.constants import (
+    DAG_MAPPING_METADATA_KEY,
+    SOURCE_CODE_METADATA_KEY,
+    TASK_MAPPING_METADATA_KEY,
+)
 from dagster_airlift.core.components.airflow_instance.component import AirflowInstanceComponent
 from dagster_airlift.test import make_instance
-from dagster_airlift.test.test_utils import asset_spec
+from dagster_airlift.test.test_utils import asset_spec, get_job_from_defs
 
 ensure_dagster_tests_import()
 from dagster_tests.components_tests.utils import (
@@ -92,6 +97,11 @@ def test_load_dags_basic(component_for_test: type[AirflowInstanceComponent]) -> 
 
     assert defs.jobs
     assert len(list(defs.jobs)) == 3  # monitoring job + 2 dag jobs.
+    for job_name in ["dag_1", "dag_2"]:
+        job = get_job_from_defs(job_name, defs)
+        assert job is not None
+        assert isinstance(job, JobDefinition)
+        assert job.metadata.get(SOURCE_CODE_METADATA_KEY) is not None
 
 
 def _scaffold_airlift(scaffold_format: str):
@@ -288,3 +298,50 @@ def test_mwaa_auth(component_for_test: type[AirflowInstanceComponent]):
         )
         assert defs.jobs
         assert len(list(defs.jobs)) == 3  # monitoring job + 2 dag jobs.
+
+
+def test_source_code_retrieval_disabled(
+    component_for_test: type[AirflowInstanceComponent], temp_cwd: Path
+):
+    defs = build_component_defs_for_test(
+        component_for_test,
+        {
+            "auth": {
+                "type": "basic_auth",
+                "webserver_url": "http://localhost:8080",
+                "username": "admin",
+                "password": "admin",
+            },
+            "name": "test_instance",
+            "source_code_retrieval_enabled": False,
+        },
+    )
+    assert defs.jobs
+    dag1_job = get_job_from_defs("dag_1", defs)
+    assert dag1_job is not None
+    assert isinstance(dag1_job, JobDefinition)
+    assert dag1_job.metadata.get(SOURCE_CODE_METADATA_KEY) is None
+
+
+def test_airflow_filter(component_for_test: type[AirflowInstanceComponent], temp_cwd: Path):
+    defs = build_component_defs_for_test(
+        component_for_test,
+        {
+            "auth": {
+                "type": "basic_auth",
+                "webserver_url": "http://localhost:8080",
+                "username": "admin",
+                "password": "admin",
+            },
+            "name": "test_instance",
+            "filter": {
+                "dag_id_ilike": "dag_1",
+            },
+        },
+    )
+    assert defs.jobs
+    dag1_job = get_job_from_defs("dag_1", defs)
+    assert dag1_job is not None
+
+    dag2_job = get_job_from_defs("dag_2", defs)
+    assert dag2_job is None


### PR DESCRIPTION
## Summary & Motivation
Allows component-based Airlift to use the AirflowFilter API, as well as disable source code retrieval.
## How I Tested These Changes
New unit tests