### PR TITLE
[resolved] out-of-the-box support for union types

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -4,7 +4,18 @@ from dataclasses import MISSING, fields, is_dataclass
 from enum import Enum, auto
 from functools import partial
 from types import GenericAlias
-from typing import Annotated, Any, Final, Literal, Optional, TypeVar, Union, get_args, get_origin
+from typing import (
+    Annotated,
+    Any,
+    Final,
+    Literal,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+)
 
 import yaml
 from dagster_shared.record import get_record_annotations, get_record_defaults, is_record, record
@@ -405,7 +416,7 @@ def _dig_for_resolver(annotation, path: Sequence[_TypeContainer]) -> Optional[Re
     elif origin in (Union, UnionType):
         resolvers = [_dig_for_resolver(arg, path) for arg in args]
         if all(r is not None for r in resolvers):
-            return Resolver.union(*resolvers)
+            return Resolver.union(*cast("list[Resolver]", resolvers))
 
     elif origin in (
         Sequence,

--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -30,6 +30,7 @@ except ImportError:
 class _TypeContainer(Enum):
     SEQUENCE = auto()
     OPTIONAL = auto()
+    UNION = auto()
 
 
 _DERIVED_MODEL_REGISTRY = {}
@@ -400,6 +401,11 @@ def _dig_for_resolver(annotation, path: Sequence[_TypeContainer]) -> Optional[Re
             res = _dig_for_resolver(left_t, [*path, _TypeContainer.OPTIONAL])
             if res:
                 return res
+
+    elif origin in (Union, UnionType):
+        resolvers = [_dig_for_resolver(arg, path) for arg in args]
+        if all(r is not None for r in resolvers):
+            return Resolver.union(*resolvers)
 
     elif origin in (
         Sequence,

--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -4,18 +4,7 @@ from dataclasses import MISSING, fields, is_dataclass
 from enum import Enum, auto
 from functools import partial
 from types import GenericAlias
-from typing import (
-    Annotated,
-    Any,
-    Final,
-    Literal,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-    get_args,
-    get_origin,
-)
+from typing import Annotated, Any, Final, Literal, Optional, TypeVar, Union, get_args, get_origin
 
 import yaml
 from dagster_shared.record import get_record_annotations, get_record_defaults, is_record, record
@@ -41,7 +30,6 @@ except ImportError:
 class _TypeContainer(Enum):
     SEQUENCE = auto()
     OPTIONAL = auto()
-    UNION = auto()
 
 
 _DERIVED_MODEL_REGISTRY = {}
@@ -413,10 +401,12 @@ def _dig_for_resolver(annotation, path: Sequence[_TypeContainer]) -> Optional[Re
             if res:
                 return res
 
-    elif origin in (Union, UnionType):
+    if origin in (Union, UnionType):
         resolvers = [_dig_for_resolver(arg, path) for arg in args]
         if all(r is not None for r in resolvers):
-            return Resolver.union(*cast("list[Resolver]", resolvers))
+            return Resolver.union(
+                *check.is_list(resolvers, of_type=Resolver),
+            )
 
     elif origin in (
         Sequence,

--- a/python_modules/dagster/dagster/components/resolved/model.py
+++ b/python_modules/dagster/dagster/components/resolved/model.py
@@ -84,6 +84,19 @@ class Resolver:
         return Resolver(ParentFn(fn), **kwargs)
 
     @staticmethod
+    def union(*resolvers: "Resolver"):
+        return Resolver(
+            lambda context, field_value: next(
+                (
+                    r.fn.callable(context, field_value)
+                    for r in resolvers
+                    if r.fn.callable(context, field_value)
+                ),
+                None,
+            ),
+        )
+
+    @staticmethod
     def default(
         *,
         model_field_name: Optional[str] = None,

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved_from.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved_from.py
@@ -1,5 +1,6 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Annotated, Optional
+from typing import Annotated, Literal, Optional, Union
 
 from dagster.components import Component
 from dagster.components.resolved.base import Model, Resolvable
@@ -16,7 +17,7 @@ def test_nested_resolvable():
     class ResolvableComponent(Component, Resolvable, Model):
         thing: MyModel
 
-        def build_defs(self, _): ...  # type: ignore
+        def build_defs(self, _): ...
 
     c = load_component_for_test(
         ResolvableComponent,
@@ -38,7 +39,7 @@ thing:
             ),
         ]
 
-        def build_defs(self, _): ...  # type: ignore
+        def build_defs(self, _): ...
 
     c = load_component_for_test(
         ResolveFromComponent,
@@ -61,7 +62,7 @@ thing:
             ),
         ]
 
-        def build_defs(self, _): ...  # type: ignore
+        def build_defs(self, _): ...
 
     c = load_component_for_test(
         ResolveFromListComponent,
@@ -86,7 +87,7 @@ def test_class():
             self.thing = thing
             self.num = num
 
-        def build_defs(self, _):  # type: ignore
+        def build_defs(self, _):
             return []
 
     c = load_component_for_test(
@@ -99,3 +100,113 @@ thing:
     )
     assert c.thing.foo
     assert c.num == 123
+
+
+def test_union_resolvable():
+    class FooModel(Model):
+        foo: str
+
+    class BarModel(Model):
+        bar: str
+
+    @dataclass
+    class ResolveFromListComponent(Component, Resolvable):
+        thing: Union[FooModel, BarModel]
+
+        def build_defs(self, _): ...
+
+    c = load_component_for_test(
+        ResolveFromListComponent,
+        """
+thing:
+  foo: hi
+        """,
+    )
+    assert isinstance(c.thing, FooModel)
+    assert c.thing.foo == "hi"
+
+    c = load_component_for_test(
+        ResolveFromListComponent,
+        """
+thing:
+  bar: hello
+        """,
+    )
+    assert isinstance(c.thing, BarModel)
+    assert c.thing.bar == "hello"
+
+
+def test_union_resolvable_complex():
+    class FooModel(Model):
+        foo: str
+
+    # Test a nested model, in a sequence, with a custom resolver
+    class NumModel(Model):
+        num: Annotated[int, Resolver(lambda _, v: int(v), model_field_type=str)]
+
+    @dataclass
+    class ResolveFromListComponent(Component, Resolvable):
+        thing: Union[FooModel, Sequence[NumModel]]
+
+        def build_defs(self, _): ...
+
+    c = load_component_for_test(
+        ResolveFromListComponent,
+        """
+thing:
+  foo: hi
+        """,
+    )
+    assert isinstance(c.thing, FooModel)
+    assert c.thing.foo == "hi"
+
+    c = load_component_for_test(
+        ResolveFromListComponent,
+        """
+thing:
+  - num: '123'
+  - num: '456'
+        """,
+    )
+    assert isinstance(c.thing, list)
+    assert len(c.thing) == 2
+    assert c.thing[0].num == 123
+    assert c.thing[1].num == 456
+
+
+def test_union_resolvable_discriminator():
+    class FooModel(Model):
+        type: Literal["foo"] = "foo"
+        value: str
+
+    class BarModel(Model):
+        type: Literal["bar"] = "bar"
+        value: str
+
+    @dataclass
+    class ResolveFromListComponent(Component, Resolvable):
+        thing: Union[FooModel, BarModel]
+
+        def build_defs(self, _): ...
+
+    c = load_component_for_test(
+        ResolveFromListComponent,
+        """
+thing:
+  type: foo
+  value: hi
+        """,
+    )
+    assert isinstance(c.thing, FooModel)
+    assert c.thing.value == "hi"
+
+    c = load_component_for_test(
+        ResolveFromListComponent,
+        """
+thing:
+  type: bar
+  value: hello
+        """,
+    )
+    assert isinstance(c.thing, BarModel)
+    assert c.thing.value == "hello"

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved_from.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved_from.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass
 from typing import Annotated, Literal, Optional, Union
 
 import pytest
+from dagster._core.definitions.definitions_class import Definitions
 from dagster.components import Component
+from dagster.components.core.context import ComponentLoadContext
 from dagster.components.resolved.base import Model, Resolvable
 from dagster.components.resolved.errors import ResolutionException
 from dagster.components.resolved.model import Resolver
@@ -18,6 +20,9 @@ class MyModel(Model):
 def test_nested_resolvable():
     class ResolvableComponent(Component, Resolvable, Model):
         thing: MyModel
+
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            return Definitions()
 
     c = load_component_for_test(
         ResolvableComponent,
@@ -39,6 +44,9 @@ thing:
             ),
         ]
 
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            return Definitions()
+
     c = load_component_for_test(
         ResolveFromComponent,
         """
@@ -59,6 +67,9 @@ thing:
                 model_field_type=str,
             ),
         ]
+
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            return Definitions()
 
     c = load_component_for_test(
         ResolveFromListComponent,
@@ -83,6 +94,9 @@ def test_class():
             self.thing = thing
             self.num = num
 
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            return Definitions()
+
     c = load_component_for_test(
         ResolveFromComponent,
         """
@@ -105,6 +119,9 @@ def test_union_resolvable():
     @dataclass
     class ResolveFromListComponent(Component, Resolvable):
         thing: Union[FooModel, BarModel]
+
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            return Definitions()
 
     c = ResolveFromListComponent.resolve_from_yaml(
         """
@@ -136,6 +153,9 @@ def test_union_resolvable_complex():
     @dataclass
     class ResolveFromListComponent(Component, Resolvable):
         thing: Union[FooModel, Sequence[NumModel]]
+
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            return Definitions()
 
     c = load_component_for_test(
         ResolveFromListComponent,
@@ -173,6 +193,9 @@ def test_union_resolvable_discriminator():
     @dataclass
     class ResolveFromUnionComponent(Component, Resolvable):
         thing: Union[FooModel, BarModel]
+
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            return Definitions()
 
     c = load_component_for_test(
         ResolveFromUnionComponent,
@@ -227,6 +250,9 @@ def test_union_nested_custom_resolver():
             ],
         ]
 
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            return Definitions()
+
     c = ResolveUnionResolversComponent.resolve_from_yaml(
         """
 thing:
@@ -277,6 +303,9 @@ def test_union_nested_custom_resolver_no_match():
                 Resolver(lambda _, v: _raise_exc(), model_field_type=BarModel),
             ],
         ]
+
+        def build_defs(self, context: ComponentLoadContext) -> Definitions:
+            return Definitions()
 
     with pytest.raises(
         ResolutionException,

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved_from.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved_from.py
@@ -19,8 +19,6 @@ def test_nested_resolvable():
     class ResolvableComponent(Component, Resolvable, Model):
         thing: MyModel
 
-        def build_defs(self, _): ...
-
     c = load_component_for_test(
         ResolvableComponent,
         """
@@ -40,8 +38,6 @@ thing:
                 model_field_type=str,
             ),
         ]
-
-        def build_defs(self, _): ...
 
     c = load_component_for_test(
         ResolveFromComponent,
@@ -63,8 +59,6 @@ thing:
                 model_field_type=str,
             ),
         ]
-
-        def build_defs(self, _): ...
 
     c = load_component_for_test(
         ResolveFromListComponent,
@@ -89,9 +83,6 @@ def test_class():
             self.thing = thing
             self.num = num
 
-        def build_defs(self, _):
-            return []
-
     c = load_component_for_test(
         ResolveFromComponent,
         """
@@ -114,8 +105,6 @@ def test_union_resolvable():
     @dataclass
     class ResolveFromListComponent(Component, Resolvable):
         thing: Union[FooModel, BarModel]
-
-        def build_defs(self, _): ...
 
     c = ResolveFromListComponent.resolve_from_yaml(
         """
@@ -147,8 +136,6 @@ def test_union_resolvable_complex():
     @dataclass
     class ResolveFromListComponent(Component, Resolvable):
         thing: Union[FooModel, Sequence[NumModel]]
-
-        def build_defs(self, _): ...
 
     c = load_component_for_test(
         ResolveFromListComponent,
@@ -186,8 +173,6 @@ def test_union_resolvable_discriminator():
     @dataclass
     class ResolveFromUnionComponent(Component, Resolvable):
         thing: Union[FooModel, BarModel]
-
-        def build_defs(self, _): ...
 
     c = load_component_for_test(
         ResolveFromUnionComponent,
@@ -242,8 +227,6 @@ def test_union_nested_custom_resolver():
             ],
         ]
 
-        def build_defs(self, _): ...
-
     c = ResolveUnionResolversComponent.resolve_from_yaml(
         """
 thing:
@@ -294,8 +277,6 @@ def test_union_nested_custom_resolver_no_match():
                 Resolver(lambda _, v: _raise_exc(), model_field_type=BarModel),
             ],
         ]
-
-        def build_defs(self, _): ...
 
     with pytest.raises(
         ResolutionException,


### PR DESCRIPTION
## Summary

Natively support `Union` types in `Resolvable` models, ended up being quite straightforward.

## Test Plan

Unit tests.

