### PR TITLE
Fix BoolSource env vars evaluating to true when they are set to a false-y string

### DIFF
--- a/python_modules/dagster/dagster/_config/source.py
+++ b/python_modules/dagster/dagster/_config/source.py
@@ -1,5 +1,7 @@
 import os
 
+from dagster_shared.utils import get_boolean_string_value
+
 import dagster._check as check
 from dagster._config.config_type import ScalarUnion
 from dagster._config.errors import PostProcessingError
@@ -86,7 +88,7 @@ class BoolSourceType(ScalarUnion):
         check.invariant(key == "env", "Only valid key is env")
         value = _ensure_env_variable(cfg)
         try:
-            return bool(value)
+            return get_boolean_string_value(value)
         except ValueError as e:
             raise PostProcessingError(
                 f'Value "{value}" stored in env variable "{cfg}" cannot be coerced into an bool.'

--- a/python_modules/dagster/dagster/_utils/tags.py
+++ b/python_modules/dagster/dagster/_utils/tags.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import dagster_shared.seven as seven
+from dagster_shared.utils import get_boolean_string_value
 
 from dagster import _check as check
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -98,7 +99,7 @@ def get_boolean_tag_value(tag_value: Optional[str], default_value: bool = False)
     if tag_value is None:
         return default_value
 
-    return tag_value.lower() not in {"false", "none", "0", ""}
+    return get_boolean_string_value(tag_value)
 
 
 # ########################

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_source_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_source_types.py
@@ -100,3 +100,7 @@ def test_bool_source():
     with environ({"DAGSTER_TEST_ENV_VAR": "True"}):
         assert process_config(BoolSource, {"env": "DAGSTER_TEST_ENV_VAR"}).success
         assert process_config(BoolSource, {"env": "DAGSTER_TEST_ENV_VAR"}).value is True
+
+    with environ({"DAGSTER_TEST_ENV_VAR": "False"}):
+        assert process_config(BoolSource, {"env": "DAGSTER_TEST_ENV_VAR"}).success
+        assert process_config(BoolSource, {"env": "DAGSTER_TEST_ENV_VAR"}).value is False

--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/__init__.py
@@ -75,3 +75,7 @@ def environ(env: Mapping[str, str]) -> Iterator[None]:
                     del os.environ[key]
             else:
                 os.environ[key] = value
+
+
+def get_boolean_string_value(tag_value: str):
+    return tag_value.lower() not in {"false", "none", "0", ""}


### PR DESCRIPTION
## Summary & Motivation
This seems to be clearly what the user would intend when using this field.

## How I Tested These Changes
New test case

## Changelog
Fixed an issue where setting an environment variable to the string "false", "0" or "None" for a dagster config field using a BoolSource would evaluate to True.