### PR TITLE
[resolved] Add Resolver.passthrough()

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/model.py
+++ b/python_modules/dagster/dagster/components/resolved/model.py
@@ -102,6 +102,15 @@ class Resolver:
             examples=examples,
         )
 
+    @staticmethod
+    def passthrough():
+        """Resolve this field by returning the underlying value, without resolving any
+        nested resolvers or processing any template variables.
+        """
+        return Resolver(
+            lambda context, field_value: field_value,
+        )
+
     def execute(
         self,
         context: "ResolutionContext",


### PR DESCRIPTION
## Summary

Adds `Resolver.passthrough()`, which does not resolve/process the field value. Useful to prevent a string field from having template variables resolved.

## Test Plan

Unit tests.

## Changelog

> [dagster-components] Introduced Resolver.passthrough() to avoid processing fields on a component.
