### PR TITLE
[ez][ui] fix space between check s in asset health report card

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
@@ -169,7 +169,7 @@ const Criteria = React.memo(
               <Body>
                 <Link to={assetDetailsPathForKey(assetKey, {view: 'checks'})}>
                   {numberFormatter.format(metadata.numNotExecutedChecks)} /{' '}
-                  {numberFormatter.format(metadata.totalNumChecks)} check{' '}
+                  {numberFormatter.format(metadata.totalNumChecks)} check
                   {ifPlural(metadata.totalNumChecks, '', 's')} not executed
                 </Link>
               </Body>


### PR DESCRIPTION
## Summary & Motivation
before 
<img width="330" alt="Screenshot 2025-05-15 at 1 47 44 PM" src="https://github.com/user-attachments/assets/4d773232-02c5-4e17-9696-ef7a04b144f4" />

after
<img width="330" alt="Screenshot 2025-05-15 at 1 40 28 PM" src="https://github.com/user-attachments/assets/f2caa05a-8129-4147-98f2-29c3f2f3d78d" />

