### PR TITLE
[dagster-dlt] Fix component execution

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
@@ -124,11 +124,11 @@ class DltLoadCollectionComponent(Component, Resolvable):
 
     @property
     def dlt_pipeline_resource(self) -> "DagsterDltResource":
+        from dagster_dlt import DagsterDltResource
+
         return DagsterDltResource()
 
     def build_defs(self, context: ComponentLoadContext) -> dg.Definitions:
-        from dagster_dlt import DagsterDltResource
-
         output = []
         for load in self.loads:
 

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -8,7 +8,7 @@ import textwrap
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import pytest
 import yaml
@@ -16,7 +16,6 @@ from click.testing import CliRunner
 from dagster import AssetKey
 from dagster._core.definitions import materialize
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path, pushd
@@ -27,6 +26,10 @@ from dagster.components.core.context import use_component_load_context
 from dagster_dg.utils import ensure_dagster_dg_tests_import
 from dagster_dlt import DagsterDltResource, DltLoadCollectionComponent
 from dagster_dlt.components.dlt_load_collection.component import DltLoadSpecModel
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.assets import AssetsDefinition
+
 
 ensure_dagster_tests_import()
 from dagster_tests.components_tests.utils import get_underlying_component

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -8,13 +8,15 @@ import textwrap
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, cast
 
 import pytest
 import yaml
 from click.testing import CliRunner
 from dagster import AssetKey
+from dagster._core.definitions import materialize
 from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path, pushd
@@ -23,7 +25,7 @@ from dagster.components import ComponentLoadContext
 from dagster.components.cli import cli
 from dagster.components.core.context import use_component_load_context
 from dagster_dg.utils import ensure_dagster_dg_tests_import
-from dagster_dlt import DltLoadCollectionComponent
+from dagster_dlt import DagsterDltResource, DltLoadCollectionComponent
 from dagster_dlt.components.dlt_load_collection.component import DltLoadSpecModel
 
 ensure_dagster_tests_import()
@@ -411,3 +413,20 @@ def test_scaffold_component_with_source_and_destination():
 
         # should be many loads, not hardcoding in case dlt changes
         assert len(component.loads) > 1
+
+
+def test_execute_component(dlt_pipeline: Pipeline):
+    defs = DltLoadCollectionComponent(
+        loads=[
+            DltLoadSpecModel(
+                source=dlt_source(),
+                pipeline=dlt_pipeline,
+            )
+        ]
+    ).build_defs(ComponentLoadContext.for_test())
+
+    asset_def = cast("AssetsDefinition", next(iter(defs.assets or [])))
+    result = materialize(
+        assets=[asset_def], resources={"dlt_pipeline_resource": DagsterDltResource()}
+    )
+    assert result.success


### PR DESCRIPTION
## Summary

Fixes the values we yield from dlt component execution. Previously we'd yield the actual pipeline results instead of what the dlt resource emits from its run method.

## Test plan

New test which explicitly runs a component defined asset.