### PR TITLE
Bring back ipc protocol methods to dagster_shared

### DIFF
--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -7,8 +7,7 @@ from collections.abc import Generator, Iterator, Sequence
 from contextlib import contextmanager, nullcontext
 from typing import TYPE_CHECKING, AbstractSet, Any, Optional, Union  # noqa: UP035
 
-from dagster_shared.record import record
-from dagster_shared.serdes import whitelist_for_serdes
+from dagster_shared.ipc import IPCErrorMessage
 
 import dagster._check as check
 from dagster._core.definitions import ScheduleEvaluationContext
@@ -56,24 +55,12 @@ from dagster._grpc.types import ExecuteExternalJobArgs, ExecutionPlanSnapshotArg
 from dagster._serdes import deserialize_value
 from dagster._time import datetime_from_timestamp
 from dagster._utils import start_termination_thread
-from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
+from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.interrupts import capture_interrupts
 
 if TYPE_CHECKING:
     from dagster._core.definitions.schedule_definition import ScheduleExecutionData
     from dagster._core.definitions.sensor_definition import SensorExecutionData
-
-
-@whitelist_for_serdes
-@record
-class IPCErrorMessage:
-    """This represents a user error encountered during the IPC call. This indicates a business
-    logic error, rather than a protocol. Consider this a "task failed successfully"
-    use case.
-    """
-
-    serializable_error_info: SerializableErrorInfo
-    message: Optional[str]
 
 
 class RunInSubprocessComplete:

--- a/python_modules/libraries/dagster-shared/dagster_shared/ipc.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/ipc.py
@@ -1,16 +1,25 @@
 import _thread as thread
 import os
+import os.path
 import signal
 import subprocess
 import sys
 import tempfile
 import threading
+import time
+import traceback
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from subprocess import Popen
-from typing import Any, Callable, Optional
+from types import TracebackType
+from typing import Any, Callable, Optional, Union
+
+from typing_extensions import TypeAlias
 
 import dagster_shared.check as check
+from dagster_shared.error import SerializableErrorInfo
+from dagster_shared.record import record
+from dagster_shared.serdes import deserialize_value, serialize_value, whitelist_for_serdes
 from dagster_shared.seven import IS_WINDOWS
 
 # Windows subprocess termination utilities. See here for why we send on Windows:
@@ -169,3 +178,169 @@ def ipc_tempfile() -> Iterator[str]:
         yield temp_file.name
     finally:
         os.remove(temp_file.name)
+
+
+ExceptionInfo: TypeAlias = Union[
+    tuple[type[BaseException], BaseException, TracebackType],
+    tuple[None, None, None],
+]
+
+
+def _serializable_error_info_from_exc_info(
+    exc_info: ExceptionInfo,
+) -> SerializableErrorInfo:
+    # `sys.exc_info() return Tuple[None, None, None] when there is no exception being processed. We accept this in
+    # the type signature here since this function is meant to directly receive the return value of
+    # `sys.exc_info`, but the function should never be called when there is no exception to process.
+    exc_type, e, tb = exc_info
+    tb_exc = traceback.TracebackException(
+        check.not_none(exc_type), check.not_none(e), check.not_none(tb)
+    )
+    return SerializableErrorInfo.from_traceback(tb_exc)
+
+
+class FileBasedWriteStream:
+    def __init__(self, file_path):
+        check.str_param("file_path", file_path)
+        self._file_path = file_path
+
+    def send(self, dagster_named_tuple):
+        _send(self._file_path, dagster_named_tuple)
+
+    def send_error(self, exc_info, message=None):
+        _send_error(self._file_path, exc_info, message=message)
+
+
+def _send(file_path, obj):
+    with open(os.path.abspath(file_path), "a+") as fp:
+        fp.write(serialize_value(obj) + "\n")
+
+
+def _send_error(file_path, exc_info, message):
+    return _send(
+        file_path,
+        IPCErrorMessage(
+            serializable_error_info=_serializable_error_info_from_exc_info(exc_info),
+            message=message,
+        ),
+    )
+
+
+def _process_line(file_pointer, sleep_interval=0.1):
+    while True:
+        line = file_pointer.readline()
+        if line:
+            return deserialize_value(line.rstrip())
+        time.sleep(sleep_interval)
+
+
+def _poll_process(ipc_process):
+    if not ipc_process:
+        return
+    if ipc_process.poll() is not None:
+        raise DagsterIPCProtocolError(
+            f"Process exited with return code {ipc_process.returncode} while waiting for events"
+        )
+
+
+def ipc_read_event_stream(file_path, timeout=30, ipc_process=None):
+    # Wait for file to be ready
+    sleep_interval = 0.1
+    elapsed_time = 0
+    while elapsed_time < timeout and not os.path.exists(file_path):
+        _poll_process(ipc_process)
+        elapsed_time += sleep_interval
+        time.sleep(sleep_interval)
+
+    if not os.path.exists(file_path):
+        raise DagsterIPCProtocolError(
+            f"Timeout: read stream has not received any data in {timeout} seconds"
+        )
+
+    with open(os.path.abspath(file_path)) as file_pointer:
+        message = _process_line(file_pointer)
+        while elapsed_time < timeout and message is None:
+            _poll_process(ipc_process)
+            elapsed_time += sleep_interval
+            time.sleep(sleep_interval)
+            message = _process_line(file_pointer)
+
+        # Process start message
+        if not isinstance(message, IPCStartMessage):
+            raise DagsterIPCProtocolError(
+                f"Attempted to read stream at file {file_path}, but first message was not an "
+                "IPCStartMessage"
+            )
+
+        message = _process_line(file_pointer)
+        while not isinstance(message, IPCEndMessage):
+            if message is None:
+                _poll_process(ipc_process)
+            yield message
+            message = _process_line(file_pointer)
+
+
+@contextmanager
+def ipc_write_stream(file_path):
+    check.str_param("file_path", file_path)
+    _send(file_path, IPCStartMessage())
+    try:
+        yield FileBasedWriteStream(file_path)
+    except Exception:  # pylint: disable=broad-except
+        _send_error(file_path, sys.exc_info(), message=None)
+    finally:
+        _send(file_path, IPCEndMessage())
+
+
+def write_unary_input(input_file, obj):
+    check.str_param(input_file, "input_file")
+    check.not_none_param(obj, "obj")
+    with open(os.path.abspath(input_file), "w") as fp:
+        fp.write(serialize_value(obj))
+
+
+def read_unary_input(input_file):
+    check.str_param(input_file, "input_file")
+    with open(os.path.abspath(input_file)) as fp:
+        return deserialize_value(fp.read())
+
+
+def ipc_write_unary_response(output_file, obj):
+    check.not_none_param(obj, "obj")
+    with ipc_write_stream(output_file) as stream:
+        stream.send(obj)
+
+
+def read_unary_response(output_file, timeout=30, ipc_process=None):
+    messages = list(ipc_read_event_stream(output_file, timeout=timeout, ipc_process=ipc_process))
+    check.invariant(len(messages) == 1)
+    return messages[0]
+
+
+@whitelist_for_serdes
+@record
+class IPCStartMessage:
+    pass
+
+
+@whitelist_for_serdes
+@record
+class IPCErrorMessage:
+    """This represents a user error encountered during the IPC call. This indicates a business
+    logic error, rather than a protocol.
+    """
+
+    serializable_error_info: SerializableErrorInfo
+    message: Optional[str]
+
+
+@whitelist_for_serdes
+@record
+class IPCEndMessage:
+    pass
+
+
+class DagsterIPCProtocolError(Exception):
+    """This indicates that something went wrong with the protocol. E.g. the
+    process being called did not emit an IPCStartMessage first.
+    """


### PR DESCRIPTION
Summary:
These were recently removed in https://github.com/dagster-io/dagster/pull/28847 but may have some life in them yet for communicating between dg and the dagster cli. Need to figure out where the tests ended up..

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
