### PR TITLE
[components] add ComponentOrigin to Definitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
         CacheableAssetsDefinition,
     )
     from dagster._core.definitions.definitions_load_context import DefinitionsLoadContext
+    from dagster.components.origin import ComponentOrigin
 
 T = TypeVar("T")
 
@@ -56,6 +57,7 @@ class _Repository:
         default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
         resource_key_mapping: Optional[Mapping[int, str]] = None,
+        component_origins: Optional[Sequence["ComponentOrigin"]] = None,
     ):
         self.name = check.opt_str_param(name, "name")
         self.description = check.opt_str_param(description, "description")
@@ -74,6 +76,7 @@ class _Repository:
         self.resource_key_mapping = check.opt_mapping_param(
             resource_key_mapping, "resource_key_mapping", key_type=int, value_type=str
         )
+        self.component_origins = component_origins
 
     def __call__(
         self,
@@ -148,6 +151,7 @@ class _Repository:
                 default_executor_def=self.default_executor_def,
                 default_logger_defs=self.default_logger_defs,
                 top_level_resources=self.top_level_resources,
+                component_origins=self.component_origins,
             )
             repository_load_data = (
                 RepositoryLoadData(

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Any, Callable, NamedTuple, Optional, Union
 
+from dagster_shared.record import ImportFrom
 from typing_extensions import Self
 
 import dagster._check as check
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
     from dagster._core.definitions.run_config import RunConfig
     from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
     from dagster._core.storage.asset_value_loader import AssetValueLoader
+    from dagster.components.origin import ComponentOrigin
 
 
 @public
@@ -379,6 +381,10 @@ class Definitions(IHaveNew):
             Arbitrary metadata for the Definitions. Not displayed in the UI but accessible on
             the Definitions instance at runtime.
 
+        component_origins (Optional[Sequence[ComponentOrigins]]):
+            Information about the Components that were used to construct part of this
+            Definitions object.
+
     Example usage:
 
     .. code-block:: python
@@ -421,6 +427,9 @@ class Definitions(IHaveNew):
     # After we fix the bug, we should remove AssetsDefinition from the set of accepted types.
     asset_checks: Optional[Iterable[AssetsDefinition]] = None
     metadata: Mapping[str, MetadataValue]
+    component_origins: Optional[
+        Sequence[Annotated["ComponentOrigin", ImportFrom("dagster.components.origin")]]
+    ] = None
 
     def __new__(
         cls,
@@ -437,6 +446,7 @@ class Definitions(IHaveNew):
         loggers: Optional[Mapping[str, LoggerDefinition]] = None,
         asset_checks: Optional[Iterable[AssetsDefinition]] = None,
         metadata: Optional[RawMetadataMapping] = None,
+        component_origins: Optional[Sequence["ComponentOrigin"]] = None,
     ):
         return super().__new__(
             cls,
@@ -449,6 +459,7 @@ class Definitions(IHaveNew):
             loggers=loggers,
             asset_checks=asset_checks,
             metadata=normalize_metadata(check.opt_mapping_param(metadata, "metadata")),
+            component_origins=component_origins,
         )
 
     @public
@@ -633,6 +644,7 @@ class Definitions(IHaveNew):
         jobs = []
         asset_checks = []
         metadata = {}
+        component_origins = []
 
         resources = {}
         resource_key_indexes: dict[str, int] = {}
@@ -676,6 +688,9 @@ class Definitions(IHaveNew):
                 executor = def_set.executor
                 executor_index = i
 
+            if def_set.component_origins:
+                component_origins.extend(def_set.component_origins)
+
         return Definitions(
             assets=assets,
             schedules=schedules,
@@ -686,6 +701,7 @@ class Definitions(IHaveNew):
             loggers=loggers,
             asset_checks=asset_checks,
             metadata=metadata,
+            component_origins=component_origins,
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from dagster._core.definitions.partitioned_schedule import (
         UnresolvedPartitionedAssetScheduleDefinition,
     )
+    from dagster.components.origin import ComponentOrigin
 
 T = TypeVar("T")
 Resolvable = Callable[[], T]
@@ -196,6 +197,9 @@ class RepositoryData(ABC):
         """Mapping[AssetCheckKey, AssetChecksDefinition]: Get the asset checks definitions for the repository."""
         return {}
 
+    def get_component_origins(self) -> Optional[Sequence["ComponentOrigin"]]:
+        return None
+
     def load_all_definitions(self):
         # force load of all lazy constructed code artifacts
         self.get_all_jobs()
@@ -223,6 +227,7 @@ class CachingRepositoryData(RepositoryData):
         unresolved_partitioned_asset_schedules: Mapping[
             str, "UnresolvedPartitionedAssetScheduleDefinition"
         ],
+        component_origins: Optional[Sequence["ComponentOrigin"]],
     ):
         """Constructs a new CachingRepositoryData object.
 
@@ -313,6 +318,7 @@ class CachingRepositoryData(RepositoryData):
         self._assets_checks_defs_by_key = asset_checks_defs_by_key
         self._top_level_resources = top_level_resources
         self._utilized_env_vars = utilized_env_vars
+        self._component_origins = component_origins
 
         self._sensors = CacheingDefinitionIndex(
             SensorDefinition,
@@ -364,6 +370,7 @@ class CachingRepositoryData(RepositoryData):
         default_executor_def: Optional[ExecutorDefinition] = None,
         default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
+        component_origins: Optional[Sequence["ComponentOrigin"]] = None,
     ) -> "CachingRepositoryData":
         """Static constructor.
 
@@ -382,6 +389,7 @@ class CachingRepositoryData(RepositoryData):
             default_executor_def=default_executor_def,
             default_logger_defs=default_logger_defs,
             top_level_resources=top_level_resources,
+            component_origins=component_origins,
         )
 
     def get_env_vars_by_top_level_resource(self) -> Mapping[str, AbstractSet[str]]:
@@ -510,6 +518,9 @@ class CachingRepositoryData(RepositoryData):
             )
             for key, ad in self._assets_checks_defs_by_key.items()
         }
+
+    def get_component_origins(self) -> Optional[Sequence["ComponentOrigin"]]:
+        return self._component_origins
 
     def _check_node_defs(self, job_defs: Sequence[JobDefinition]) -> None:
         node_defs = {}

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -50,6 +50,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_check_spec import AssetCheckKey
     from dagster._core.definitions.events import AssetKey
+    from dagster.components.origin import ComponentOrigin
 
 # We throw an error if the user attaches an instance of a custom `PartitionsDefinition` subclass to
 # a definition-- we can't support custom PartitionsDefinition subclasses due to us needing to load
@@ -154,6 +155,7 @@ def build_caching_repository_data_from_list(
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
     top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
     resource_key_mapping: Optional[Mapping[int, str]] = None,
+    component_origins: Optional[Sequence["ComponentOrigin"]] = None,
 ) -> CachingRepositoryData:
     from dagster._core.definitions import AssetsDefinition
     from dagster._core.definitions.partitioned_schedule import (
@@ -376,6 +378,7 @@ def build_caching_repository_data_from_list(
         top_level_resources=top_level_resources or {},
         utilized_env_vars=utilized_env_vars,
         unresolved_partitioned_asset_schedules=unresolved_partitioned_asset_schedules,
+        component_origins=component_origins,
     )
 
 
@@ -438,6 +441,7 @@ def build_caching_repository_data_from_dict(
         top_level_resources={},
         utilized_env_vars={},
         unresolved_partitioned_asset_schedules={},
+        component_origins=None,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -421,6 +421,9 @@ class RepositoryDefinition:
             ],
         )
 
+    def get_component_origins(self):
+        return self._repository_data.get_component_origins()
+
     # If definition comes from the @repository decorator, then the __call__ method will be
     # overwritten. Therefore, we want to maintain the call-ability of repository definitions.
     def __call__(self, *args, **kwargs):

--- a/python_modules/dagster/dagster/components/core/load_defs.py
+++ b/python_modules/dagster/dagster/components/core/load_defs.py
@@ -10,6 +10,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._utils.warnings import suppress_dagster_warnings
 from dagster.components.core.context import ComponentLoadContext, use_component_load_context
+from dagster.components.origin import ComponentOrigin
 
 PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY = "plugin_component_types_json"
 
@@ -90,5 +91,12 @@ def load_defs(defs_root: ModuleType, project_root: Optional[Path] = None) -> Def
 
         return Definitions.merge(
             root_component.build_defs(context),
-            Definitions(metadata={PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY: components_json}),
+            Definitions(
+                metadata={PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY: components_json},
+                component_origins=[
+                    ComponentOrigin(
+                        root_component=root_component,
+                    )
+                ],
+            ),
         )

--- a/python_modules/dagster/dagster/components/origin.py
+++ b/python_modules/dagster/dagster/components/origin.py
@@ -1,0 +1,8 @@
+from dagster_shared.record import record
+
+from dagster.components.component.component import Component
+
+
+@record
+class ComponentOrigin:
+    root_component: Component

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
@@ -28,6 +28,7 @@ def test_load_from_path() -> None:
         AssetKey("up2_dash"),
         AssetKey("override_key_dash"),
     }
+    assert defs.component_origins
 
 
 def test_load_from_location_path() -> None:


### PR DESCRIPTION
The first step in making components information available through more of the system is attaching the originating component information to the definitions that are created.

## How I Tested These Changes

