### PR TITLE
Fix issue with "Re-execute from asset failure"

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1749,6 +1749,8 @@ class DagsterInstance(DynamicPartitionsStore):
         # find the set of planned assets and checks
         to_reexecute: set[EntityKey] = set()
         for step in execution_plan_snapshot.steps:
+            if step.key not in execution_plan_snapshot.step_keys_to_execute:
+                continue
             to_reexecute_for_step = {
                 key
                 for key in step.entity_keys


### PR DESCRIPTION
## Summary & Motivation

If you do "re-execute from step failure" before "re-execute from asset failure", this does not subset the actual ExecutionPlanSnapshot object, so all the previous steps will still be in there, even though they weren't executed.

This messed with the logic we were using in this function, that just iterated over all steps without checking if they were actually intended to be executed

## How I Tested These Changes

## Changelog

Fixed an issue with the new "re-execute from asset failure" functionality that could cause additional steps to be included if the job was previously re-executed from step failure.
