### PR TITLE
DOC-1159 Remove dg/components slack channel from labs index page

### DIFF
--- a/docs/docs/guides/labs/index.md
+++ b/docs/docs/guides/labs/index.md
@@ -4,7 +4,7 @@ sidebar_class_name: hidden
 title: Labs
 ---
 
-The features in this section are under active development. You may encounter feature gaps, and the APIs may change. To report issues or give feedback, please join the #dg-components channel in the [Dagster Community Slack](https://www.dagster.io/slack/).
+The features in this section are under active development. You may encounter feature gaps, and the APIs may change.
 
 - [`dg` CLI](/guides/labs/dg/)
 - [Components](/guides/labs/components/)


### PR DESCRIPTION
## Summary & Motivation

Removing the link to the dg/Components feedback channel from the Labs index page, since we'll be adding more preview features to Labs.

## How I Tested These Changes

Local build.

## Changelog

> Insert changelog entry or delete this section.
