### PR TITLE
[docs] extend note for dbt defer feature

### DIFF
--- a/docs/docs/integrations/libraries/dbt/reference.md
+++ b/docs/docs/integrations/libraries/dbt/reference.md
@@ -177,6 +177,8 @@ If you are using [Components](/guides/labs/components), you can prepare your `Db
 
 This feature requires the `DAGSTER_BUILD_STATEDIR` environment variable to be set in your CI/CD. Learn more about required environment variables in CI/CD for Dagster+ [here](/dagster-plus/features/ci-cd/configuring-ci-cd).
 
+You will also need to run the `dagster-cloud ci dagster-dbt project manage-state` command in your prod deployment before it can be run from in branch deployments. This will create the baseline for comparison in the branch deployments. 
+
 :::
 
 It is possible to leverage [dbt defer](https://docs.getdbt.com/reference/node-selection/defer) by passing a `state_path` to <PyObject section="libraries" object="DbtProject" module="dagster_dbt" />. This is useful for testing recent changes made in development against the state of the dbt project in production. Using `dbt defer`, you can run a subset of models or tests, those that have been changed between development and production, without having to build their upstream parents first.

--- a/docs/docs/integrations/libraries/dbt/reference.md
+++ b/docs/docs/integrations/libraries/dbt/reference.md
@@ -177,7 +177,7 @@ If you are using [Components](/guides/labs/components), you can prepare your `Db
 
 This feature requires the `DAGSTER_BUILD_STATEDIR` environment variable to be set in your CI/CD. Learn more about required environment variables in CI/CD for Dagster+ [here](/dagster-plus/features/ci-cd/configuring-ci-cd).
 
-+You will also need to run the `dagster-cloud ci dagster-dbt project manage-state` command in your prod deployment before it can be run in branch deployments. This will create the baseline for comparison in the branch deployments.
+You will also need to run the `dagster-cloud ci dagster-dbt project manage-state` command in your prod deployment before it can be run in branch deployments. This will create the baseline for comparison in the branch deployments.
 
 :::
 

--- a/docs/docs/integrations/libraries/dbt/reference.md
+++ b/docs/docs/integrations/libraries/dbt/reference.md
@@ -177,7 +177,7 @@ If you are using [Components](/guides/labs/components), you can prepare your `Db
 
 This feature requires the `DAGSTER_BUILD_STATEDIR` environment variable to be set in your CI/CD. Learn more about required environment variables in CI/CD for Dagster+ [here](/dagster-plus/features/ci-cd/configuring-ci-cd).
 
-You will also need to run the `dagster-cloud ci dagster-dbt project manage-state` command in your prod deployment before it can be run from in branch deployments. This will create the baseline for comparison in the branch deployments. 
++You will also need to run the `dagster-cloud ci dagster-dbt project manage-state` command in your prod deployment before it can be run in branch deployments. This will create the baseline for comparison in the branch deployments.
 
 :::
 


### PR DESCRIPTION
## Summary & Motivation
To use this feature the `dagster-cloud ci dagster-dbt project manage-state command` also needs to be run in prod deployment before it can be run from in a branch deployment. So a step in the CI/CD workflow with it must be added for the prod deployment and deployment executed with it.

## How I Tested These Changes
👀