### PR TITLE
[components] Add testing utilities. Use them to test single asset in dagster-test

### DIFF
--- a/python_modules/dagster-test/dagster_test/dg_defs/dagster_tests/components_tests/testing_tests/test_build_components/my_asset.py
+++ b/python_modules/dagster-test/dagster_test/dg_defs/dagster_tests/components_tests/testing_tests/test_build_components/my_asset.py
@@ -1,0 +1,6 @@
+from dagster import asset
+
+
+@asset
+def my_asset():
+    pass

--- a/python_modules/dagster/dagster/components/core/context.py
+++ b/python_modules/dagster/dagster/components/core/context.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, Union
 
+from dagster_shared import check
 from dagster_shared.yaml_utils.source_position import SourcePositionTree
 
 from dagster._annotations import PublicAttr, preview, public
@@ -81,6 +82,14 @@ class ComponentLoadContext:
         return self._with_resolution_context(
             self.resolution_context.with_source_position_tree(source_position_tree)
         )
+
+    def for_defs_path(self, path: Union[str, Path]) -> "ComponentLoadContext":
+        path = Path(path) if isinstance(path, str) else path
+        check.invariant(
+            not path.is_absolute(),
+            "Path must be relative to the defs module path",
+        )
+        return dataclasses.replace(self, path=self.defs_module_path / path)
 
     def for_path(self, path: Path) -> "ComponentLoadContext":
         return dataclasses.replace(self, path=path)

--- a/python_modules/dagster/dagster/components/test/build_components.py
+++ b/python_modules/dagster/dagster/components/test/build_components.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from typing import Any, TypeVar, Union
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._utils.pydantic_yaml import enrich_validation_errors_with_source_position
+from dagster.components import Component, ComponentLoadContext
+from dagster.components.core.defs_module import CompositeYamlComponent, get_component
+from dagster_shared import check
+from dagster_shared.yaml_utils import parse_yaml_with_source_position
+from pydantic import TypeAdapter
+
+T = TypeVar("T")
+T_Component = TypeVar("T_Component", bound=Component)
+
+
+def build_components_at_defs_path(
+    context: ComponentLoadContext,
+    defs_path: Union[str, Path],
+) -> list[Component]:
+    component = check.inst(
+        get_component(context.for_defs_path(defs_path)), Component, "Expected a Component"
+    )
+
+    return (
+        list(component.components) if isinstance(component, CompositeYamlComponent) else [component]
+    )
+
+
+def build_component_at_path(
+    context: ComponentLoadContext, defs_path: Union[str, Path]
+) -> Component:
+    components = build_components_at_defs_path(context, defs_path)
+    check.invariant(len(components) == 1, "Expected a single component")
+    return components[0]
+
+
+def build_component_defs_at_path(
+    context: ComponentLoadContext,
+    defs_path: Union[str, Path],
+) -> Definitions:
+    components = build_components_at_defs_path(context, defs_path)
+    return Definitions.merge(*[component.build_defs(context) for component in components])
+
+
+def load_context_and_component_for_test(
+    component_type: type[T_Component], attrs: Union[str, dict[str, Any]]
+) -> tuple[ComponentLoadContext, T_Component]:
+    context = ComponentLoadContext.for_test()
+    context = context.with_rendering_scope(component_type.get_additional_scope())
+    model_cls = check.not_none(
+        component_type.get_model_cls(), "Component must have schema for direct test"
+    )
+    if isinstance(attrs, str):
+        source_positions = parse_yaml_with_source_position(attrs)
+        with enrich_validation_errors_with_source_position(
+            source_positions.source_position_tree, []
+        ):
+            attributes = TypeAdapter(model_cls).validate_python(source_positions.value)
+    else:
+        attributes = TypeAdapter(model_cls).validate_python(attrs)
+    component = component_type.load(attributes, context)
+    return context, component
+
+
+def load_component_for_test(
+    component_type: type[T_Component], attrs: Union[str, dict[str, Any]]
+) -> T_Component:
+    _, component = load_context_and_component_for_test(component_type, attrs)
+    return component
+
+
+def build_component_defs_for_test(
+    component_type: type[Component], attrs: dict[str, Any]
+) -> Definitions:
+    context, component = load_context_and_component_for_test(component_type, attrs)
+    return component.build_defs(context)

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved_from.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved_from.py
@@ -9,8 +9,7 @@ from dagster.components.core.context import ComponentLoadContext
 from dagster.components.resolved.base import Model, Resolvable
 from dagster.components.resolved.errors import ResolutionException
 from dagster.components.resolved.model import Resolver
-
-from dagster_tests.components_tests.utils import load_component_for_test
+from dagster.components.test.build_components import load_component_for_test
 
 
 class MyModel(Model):

--- a/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_build_components.py
+++ b/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_build_components.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.definitions_class import Definitions
+from dagster.components.component.component import Component
+from dagster.components.test.build_components import (
+    build_component_at_path,
+    build_component_defs_at_path,
+)
+from dagster_tests.components_tests.testing_tests.utils import (
+    defs_for_test_file,
+    get_dagster_relative_path,
+    get_dagster_test_component_load_context,
+)
+
+
+def get_dagster_module_root() -> Path:
+    return Path(__file__).parent.parent.parent.parent
+
+
+def defs_for_current_test_file() -> Definitions:
+    return defs_for_test_file(get_dagster_module_root(), Path(__file__))
+
+
+# This is what tests will look like it you following this pattern
+def test_what_test_will_look_like():
+    defs = defs_for_current_test_file()
+    assert defs.get_assets_def("my_asset").key == AssetKey("my_asset")
+
+
+def test_build_single_asset_python_module() -> None:
+    context = get_dagster_test_component_load_context()
+    defs_path = "dagster_tests/components_tests/testing_tests/test_build_components/my_asset.py"
+    component = build_component_at_path(context, defs_path)
+    assert isinstance(component, Component)
+
+    defs = build_component_defs_at_path(context, defs_path)
+    assert defs.get_assets_def("my_asset").key == AssetKey("my_asset")
+
+
+def test_build_components_python_subpackage() -> None:
+    context = get_dagster_test_component_load_context()
+    defs_path = "dagster_tests/components_tests/testing_tests/test_build_components"
+    component = build_component_at_path(context, defs_path)
+    assert isinstance(component, Component)
+
+    defs = build_component_defs_at_path(context, defs_path)
+    assert defs.get_assets_def("my_asset").key == AssetKey("my_asset")
+
+
+def test_dagster_relative_root_path() -> None:
+    path = get_dagster_relative_path(get_dagster_module_root(), Path(__file__))
+    assert str(path) == str(
+        Path("dagster_tests/components_tests/testing_tests/test_build_components")
+    )
+
+
+def test_build_relative_path_with_defs_path() -> None:
+    # This is how I imagine most tests getting wriitten
+    defs = defs_for_current_test_file()
+    assert defs.get_assets_def("my_asset").key == AssetKey("my_asset")

--- a/python_modules/dagster/dagster_tests/components_tests/testing_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/components_tests/testing_tests/utils.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from typing import Optional
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster.components.core.context import ComponentLoadContext
+from dagster.components.test.build_components import build_component_defs_at_path
+
+
+def get_dagster_test_project_root() -> Path:
+    return Path(__file__).parent.parent.parent.parent.parent / "dagster-test"
+
+
+def get_dagster_test_component_load_context(
+    defs_path: Optional[Path] = None,
+) -> ComponentLoadContext:
+    import dagster_test.dg_defs
+
+    context = ComponentLoadContext.for_module(dagster_test.dg_defs, get_dagster_test_project_root())
+    return context.for_defs_path(defs_path) if defs_path else context
+
+
+def get_dagster_relative_path(module_root_path: Path, path: Path) -> Path:
+    relative_path = path.relative_to(module_root_path)
+    if relative_path.suffix == ".py":
+        relative_path = relative_path.with_suffix("")
+
+    return relative_path
+
+
+def defs_path_in_dagster_test_project(module_root_path: Path, dunderfile_path: Path) -> Path:
+    return get_dagster_relative_path(module_root_path, dunderfile_path)
+
+
+def defs_for_test_file(module_root_path: Path, dunderfile_path: Path) -> Definitions:
+    return build_component_defs_at_path(
+        get_dagster_test_component_load_context(),
+        defs_path=defs_path_in_dagster_test_project(
+            module_root_path,
+            dunderfile_path,
+        ),
+    )

--- a/python_modules/dagster/dagster_tests/components_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/components_tests/utils.py
@@ -9,56 +9,17 @@ from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import TracebackType
-from typing import Any, Iterable, Optional, TypeVar, Union  # noqa: UP035
+from typing import Any, Iterable, Optional, TypeVar  # noqa: UP035
 
 import tomlkit
 from click.testing import Result
-from dagster import Definitions
 from dagster._utils import alter_sys_path, pushd
-from dagster._utils.pydantic_yaml import enrich_validation_errors_with_source_position
 from dagster.components import Component, ComponentLoadContext
 from dagster.components.core.defs_module import CompositeYamlComponent, get_component
 from dagster.components.utils import ensure_loadable_path
-from dagster_shared import check
-from dagster_shared.yaml_utils import parse_yaml_with_source_position
-from pydantic import TypeAdapter
 
 T = TypeVar("T")
 T_Component = TypeVar("T_Component", bound=Component)
-
-
-def load_context_and_component_for_test(
-    component_type: type[T_Component], attrs: Union[str, dict[str, Any]]
-) -> tuple[ComponentLoadContext, T_Component]:
-    context = ComponentLoadContext.for_test()
-    context = context.with_rendering_scope(component_type.get_additional_scope())
-    model_cls = check.not_none(
-        component_type.get_model_cls(), "Component must have schema for direct test"
-    )
-    if isinstance(attrs, str):
-        source_positions = parse_yaml_with_source_position(attrs)
-        with enrich_validation_errors_with_source_position(
-            source_positions.source_position_tree, []
-        ):
-            attributes = TypeAdapter(model_cls).validate_python(source_positions.value)
-    else:
-        attributes = TypeAdapter(model_cls).validate_python(attrs)
-    component = component_type.load(attributes, context)
-    return context, component
-
-
-def load_component_for_test(
-    component_type: type[T_Component], attrs: Union[str, dict[str, Any]]
-) -> T_Component:
-    _, component = load_context_and_component_for_test(component_type, attrs)
-    return component
-
-
-def build_component_defs_for_test(
-    component_type: type[Component], attrs: dict[str, Any]
-) -> Definitions:
-    context, component = load_context_and_component_for_test(component_type, attrs)
-    return component.build_defs(context)
 
 
 def generate_component_lib_pyproject_toml(name: str, is_project: bool = False) -> str:

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
@@ -24,10 +24,8 @@ from dagster_airlift.test import make_instance
 from dagster_airlift.test.test_utils import asset_spec, get_job_from_defs
 
 ensure_dagster_tests_import()
-from dagster_tests.components_tests.utils import (
-    build_component_defs_for_test,
-    temp_code_location_bar,
-)
+from dagster.components.test.build_components import build_component_defs_for_test
+from dagster_tests.components_tests.utils import temp_code_location_bar
 
 
 @pytest.fixture

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -27,14 +27,14 @@ from dagster_dbt.components.dbt_project.component import get_projects_from_dbt_c
 from dagster_shared import check
 
 ensure_dagster_tests_import()
+from dagster.components.test.build_components import (
+    build_component_defs_for_test,
+    load_component_for_test,
+)
 from dagster_tests.components_tests.integration_tests.component_loader import (
     load_test_component_defs,
 )
-from dagster_tests.components_tests.utils import (
-    build_component_defs_for_test,
-    create_project_from_components,
-    load_component_for_test,
-)
+from dagster_tests.components_tests.utils import create_project_from_components
 
 STUB_LOCATION_PATH = Path(__file__).parent / "code_locations" / "dbt_project_location"
 COMPONENT_RELPATH = "defs/jaffle_shop_dbt"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_templated_custom_keys_dbt_project.py
@@ -12,10 +12,10 @@ from dagster_dbt import DbtProject, DbtProjectComponent
 
 ensure_dagster_tests_import()
 
+from dagster.components.test.build_components import build_component_defs_for_test
 from dagster_tests.components_tests.integration_tests.component_loader import (
     load_test_component_defs,
 )
-from dagster_tests.components_tests.utils import build_component_defs_for_test
 
 STUB_LOCATION_PATH = (
     Path(__file__).parent / "code_locations" / "templated_custom_keys_dbt_project_location"

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -33,11 +33,8 @@ from dagster_sling import SlingReplicationCollectionComponent, SlingResource
 
 ensure_dagster_tests_import()
 
-from dagster_tests.components_tests.utils import (
-    build_component_defs_for_test,
-    get_underlying_component,
-    temp_code_location_bar,
-)
+from dagster.components.test.build_components import build_component_defs_for_test
+from dagster_tests.components_tests.utils import get_underlying_component, temp_code_location_bar
 
 if TYPE_CHECKING:
     from dagster._core.definitions.assets import AssetsDefinition


### PR DESCRIPTION
## Summary & Motivation

Adding a "hello world" asset to test out our new testing format.

Most controversial is the pattern I am proposing for this test project, where the path in its defs folder lines up with the path in dagster_tests. This will keep that project organizined, and if you folllow that convention you can use the utilities provided to load the right set of definitions easily.

You need to provide two paths:

1. The path of the root dagster module
2. `__FILE__`

If you do that you can call

```
def get_dagster_module_root() -> Path:
    return Path(__file__).parent.parent.parent.parent

def defs_for_current_test_file() -> Definitions:
    return defs_for_test_file(get_dagster_module_root(), Path(__file__))
```

And then test cases look like:

```python
def test_build_relative_path_with_defs_path() -> None:
    # This is how I imagine most tests getting wriitten
    defs = defs_for_current_test_file()
    assert defs.get_assets_def("my_asset").key == AssetKey("my_asset"
```

This might be a bit much so just flagging it

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
