### PR TITLE
[dg] Make should_run_dagster_in_process check for dagster availability (BUILD-1190)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -1,4 +1,5 @@
 import datetime
+import importlib.util
 import json
 import logging
 import os
@@ -412,6 +413,9 @@ class DgContext:
         and we should attempt to run dagster subcommands directly in process.
         """
         if self.use_dg_managed_environment:
+            return False
+
+        if importlib.util.find_spec("dagster") is None:
             return False
 
         if os.getenv("DG_DISABLE_IN_PROCESS"):


### PR DESCRIPTION
## Summary & Motivation

Currently `should_run_dagster_in_process` can return True when `dagster` is not actually installed in the `dg` environment. This can cause real-world isolated tool `dg` installations to fail.

## How I Tested These Changes

Existing test suite
