### PR TITLE
[components] expose ResolvedAssetKey from top

### DIFF
--- a/python_modules/dagster/dagster/components/__init__.py
+++ b/python_modules/dagster/dagster/components/__init__.py
@@ -21,6 +21,7 @@ from dagster.components.resolved.core_models import (
     AssetAttributesModel as AssetAttributesModel,
     AssetPostProcessorModel as AssetPostProcessorModel,
     ResolvedAssetCheckSpec as ResolvedAssetCheckSpec,
+    ResolvedAssetKey as ResolvedAssetKey,
     ResolvedAssetSpec as ResolvedAssetSpec,
 )
 from dagster.components.resolved.model import (


### PR DESCRIPTION


## Changelog

[components] `ResolvedAssetKey` is now exported from `dagster.components`