### PR TITLE
[resolved] provide suggestions in error messages where resolved core models exist

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -230,11 +230,11 @@ def _get_annotations(
         return init_kwargs
     else:
         raise ResolutionException(
-            f"Invalid Resolvable type {resolved_type} could not determine fields, expected:\n"
+            f"Invalid Resolvable type {resolved_type}, could not determine fields. Resolved subclasses must be one of the following:\n"
             "* class with __init__\n"
             "* @dataclass\n"
             "* pydantic Model\n"
-            "* @record\n"
+            "* @dagster_shared.record.record\n"
         )
 
 
@@ -331,14 +331,23 @@ def _get_resolver(annotation: Any, field_name: str) -> "Resolver":
     res = _dig_for_resolver(annotation, [])
     if res:
         return res
+
+    from dagster.components.resolved.core_models import CORE_MODEL_SUGGESTIONS
+
+    core_model_suggestion = ""
+    if annotation in CORE_MODEL_SUGGESTIONS:
+        core_model_suggestion = f"\n\nAn annotated resolver for {annotation.__name__} is available, you may wish to use it instead: {CORE_MODEL_SUGGESTIONS[annotation]}"
+
     raise ResolutionException(
         "Could not derive resolver for annotation\n"
         f"  {field_name}: {annotation}\n"
         "Field types are expected to be:\n"
-        "* serializable types such as str, float, int, bool, list, etc\n"
+        "* serializable types, such as str, float, int, bool, list, etc\n"
         "* Resolvable subclasses\n"
         "* pydantic Models\n"
-        "* Annotated with an appropriate Resolver"
+        "* Annotated with an appropriate dagster.components.Resolver\n"
+        f"  e.g. Annotated[{annotation.__name__}, Resolver(fn=..., model_field_type=...)]"
+        f"{core_model_suggestion}"
     )
 
 

--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -342,7 +342,7 @@ def _get_resolver(annotation: Any, field_name: str) -> "Resolver":
         "Could not derive resolver for annotation\n"
         f"  {field_name}: {annotation}\n"
         "Field types are expected to be:\n"
-        "* serializable types, such as str, float, int, bool, list, etc\n"
+        "* serializable types such as str, float, int, bool, list, etc\n"
         "* Resolvable subclasses\n"
         "* pydantic Models\n"
         "* Annotated with an appropriate dagster.components.Resolver\n"

--- a/python_modules/dagster/dagster/components/resolved/core_models.py
+++ b/python_modules/dagster/dagster/components/resolved/core_models.py
@@ -324,3 +324,9 @@ AssetPostProcessor: TypeAlias = Annotated[
         model_field_type=AssetPostProcessorModel.model(),
     ),
 ]
+
+CORE_MODEL_SUGGESTIONS = {
+    AssetKey: "ResolvedAssetKey",
+    AssetSpec: "ResolvedAssetSpec",
+    AssetCheckSpec: "AssetCheckSpec",
+}

--- a/python_modules/dagster/dagster/components/resolved/core_models.py
+++ b/python_modules/dagster/dagster/components/resolved/core_models.py
@@ -328,5 +328,5 @@ AssetPostProcessor: TypeAlias = Annotated[
 CORE_MODEL_SUGGESTIONS = {
     AssetKey: "ResolvedAssetKey",
     AssetSpec: "ResolvedAssetSpec",
-    AssetCheckSpec: "AssetCheckSpec",
+    AssetCheckSpec: "ResolvedAssetCheckSpec",
 }

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved.py
@@ -37,6 +37,18 @@ def test_error():
         MyNewThing.resolve_from_yaml("")
 
 
+def test_error_core_model_suggestion():
+    @dataclass
+    class MyKeyThing(Resolvable):
+        key: AssetKey
+
+    with pytest.raises(
+        ResolutionException,
+        match=r".*An annotated resolver for AssetKey is available, you may wish to use it instead: ResolvedAssetKey",
+    ):
+        MyKeyThing.resolve_from_yaml("")
+
+
 def test_nested():
     @dataclass
     class OtherThing(Resolvable):


### PR DESCRIPTION
## Summary

Slight tweaks to resolved error messages, providing suggestions for users to use built-in resolved models for common classes (`AssetKey`, `AssetSpec`, `AssetCheckSpec`):
```python
dagster.components.resolved.errors.ResolutionException: Could not derive resolver for annotation
  asset_key: <class 'dagster._core.definitions.asset_key.AssetKey'>
Field types are expected to be:
* serializable types, such as str, float, int, bool, list, etc
* Resolvable subclasses
* pydantic Models
* Annotated with an appropriate dagster.components.Resolver
  e.g. Annotated[AssetKey, Resolver(fn=..., model_field_type=...)]

An annotated resolver for AssetKey is available, you may wish to use it instead: ResolvedAssetKey
```


## Test Plan

Unit test.

## Changelog

> [components] Added suggestions to component model error messages when built-in resolvers exist.