### PR TITLE
Add init file to monitoring job dir

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/builder.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/builder.py
@@ -23,13 +23,14 @@ from dagster._grpc.client import DEFAULT_SENSOR_GRPC_TIMEOUT
 from dagster._record import record
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._time import get_current_datetime
+from dagster_shared.serdes import whitelist_for_serdes
+from pydantic import Field
+
 from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.monitoring_job.event_stream import persist_events
 from dagster_airlift.core.monitoring_job.utils import structured_log
 from dagster_airlift.core.utils import monitoring_job_name
-from dagster_shared.serdes import whitelist_for_serdes
-from pydantic import Field
 
 MAIN_LOOP_TIMEOUT_SECONDS = DEFAULT_SENSOR_GRPC_TIMEOUT - 20
 DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS = 30

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/event_stream.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/event_stream.py
@@ -25,6 +25,7 @@ from dagster._core.utils import make_new_run_id
 from dagster._record import record
 from dagster._time import datetime_from_timestamp
 from dagster._utils.merger import merge_dicts
+
 from dagster_airlift.constants import (
     DAG_ID_TAG_KEY,
     DAG_RUN_ID_TAG_KEY,

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/utils.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/utils.py
@@ -14,6 +14,7 @@ from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.execution.context.op_execution_context import OpExecutionContext
 from dagster._core.storage.dagster_run import DagsterRun, RunsFilter
 from dagster._core.storage.tags import EXTERNALLY_MANAGED_ASSETS_TAG
+
 from dagster_airlift.constants import DAG_ID_TAG_KEY, DAG_RUN_ID_TAG_KEY, OBSERVATION_RUN_TAG_KEY
 from dagster_airlift.core.runtime_representations import DagRun, TaskInstance
 from dagster_airlift.core.serialization.serialized_data import DagHandle, TaskHandle


### PR DESCRIPTION
## Summary & Motivation
The monitoring job directory is getting excluded from the packaged version of dagster-airlift, this seems like a smoking gun.
## How I Tested These Changes
I have not been able to reproduce the "directory not included" behavior locally yet.
