### PR TITLE
[dagster-dbt] Support dbt assets with select with saved queries

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -71,29 +71,6 @@ def select_unique_ids_from_manifest(
             else {}
         )
 
-        saved_queries = (
-            {
-                "saved_queries": {
-                    # saved query nodes must be of type SavedQuery
-                    unique_id: SavedQuery.from_dict(info)
-                    for unique_id, info in manifest_json["saved_queries"].items()
-                },
-            }
-            if manifest_json.get("saved_queries")
-            else {}
-        )
-    else:
-        saved_queries = (
-            {
-                "saved_queries": {
-                    unique_id: _DictShim(info)
-                    for unique_id, info in manifest_json["saved_queries"].items()
-                },
-            }
-            if manifest_json.get("saved_queries")
-            else {}
-        )
-
     manifest = Manifest(
         nodes={unique_id: _DictShim(info) for unique_id, info in manifest_json["nodes"].items()},
         sources={
@@ -121,6 +98,17 @@ def select_unique_ids_from_manifest(
         ),
         **(
             {
+                "saved_queries": {
+                    # Saved query nodes must be defined using the SavedQuery class
+                    unique_id: SavedQuery.from_dict(info)
+                    for unique_id, info in manifest_json["saved_queries"].items()
+                },
+            }
+            if manifest_json.get("saved_queries")
+            else {}
+        ),
+        **(
+            {
                 "selectors": {
                     unique_id: _DictShim(info)
                     for unique_id, info in manifest_json["selectors"].items()
@@ -130,7 +118,6 @@ def select_unique_ids_from_manifest(
             else {}
         ),
         **unit_tests,
-        **saved_queries,
     )
 
     child_map = manifest_json["child_map"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -1137,7 +1137,7 @@ def test_dbt_with_python_interleaving(
 
 
 @pytest.mark.parametrize("select", ["fqn:*", "tag:test"])
-def test_dbt_with_semantic_models(
+def test_dbt_with_semantic_models_and_saved_queries(
     test_dbt_semantic_models_manifest: dict[str, Any], select: str
 ) -> None:
     @dbt_assets(manifest=test_dbt_semantic_models_manifest, select=select)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/models/semantic_model.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_semantic_models/models/semantic_model.yml
@@ -15,3 +15,9 @@ semantic_models:
       - name: total_order_amount
         agg: sum
         description: Gross customer lifetime spend inclusive of taxes.
+
+saved_queries:
+  - name: customers_query
+    description: Customer query
+    label: Customer query
+    query_params: {}


### PR DESCRIPTION
## Summary & Motivation

Similar to https://github.com/dagster-io/dagster/pull/23232.

~~In dbt core 1.8 and higher,~~ we must represent saved queries using the `SavedQuery` class provided by dbt. Otherwise, using selection args with a dbt project that uses saved queries raises an exception.

Edit: This is also required for dbt core 1.7 and higher

## How I Tested These Changes

Updated tests with BK

## Changelog

[dagster-dbt] An issue occurring when using dbt selection arguments with a dbt project using saved queries has been fixed.
