### PR TITLE
[dg] [ontology] Update dg list components to list component types (BUILD-1198)

### DIFF
--- a/docs/docs/guides/labs/components/using-environment-variables-in-components.md
+++ b/docs/docs/guides/labs/components/using-environment-variables-in-components.md
@@ -23,7 +23,7 @@ We'll install `dagster-sling` and scaffold an empty Sling connection component:
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/using-env/3-uv-add-sling.txt" />
 
 <WideContent maxSize={1100}>
-  <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/using-env/4-dg-list-component-types.txt" />
+  <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/using-env/4-dg-list-components.txt" />
 </WideContent>
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/using-env/5-dg-scaffold-sling.txt" />

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/4-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/4-dg-list-components.txt
@@ -1,0 +1,18 @@
+dg list components
+
+Plugin object cache is invalidated or empty. Building cache...
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Key                                                         ┃ Summary                                                ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster.components.DefinitionsComponent                     │ An arbitrary set of dagster definitions.               │
+├─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
+│ dagster.components.DefsFolderComponent                      │ A folder which may contain multiple submodules, each   │
+│                                                             │ which define components.                               │
+├─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
+│ dagster.components.PipesSubprocessScriptCollectionComponent │ Assets that wrap Python scripts executed with          │
+│                                                             │ Dagster's PipesSubprocessClient.                       │
+├─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────┤
+│ dagster_sling.SlingReplicationCollectionComponent           │ Expose one or more Sling replications to Dagster as    │
+│                                                             │ assets.                                                │
+└─────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────┘

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_using_env.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_using_env.py
@@ -263,9 +263,9 @@ def test_component_docs_using_env(
                 print_cmd="uv add dagster-sling",
             )
             context.run_command_and_snippet_output(
-                cmd="dg list plugins",
+                cmd="dg list components",
                 snippet_path=SNIPPETS_DIR
-                / f"{context.get_next_snip_number()}-dg-list-component-types.txt",
+                / f"{context.get_next_snip_number()}-dg-list-components.txt",
             )
 
             # Scaffold dbt project components

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -55,6 +55,7 @@ COMPONENT_LIBRARY_CONTEXT_COMMANDS = [
 REGISTRY_CONTEXT_COMMANDS = [
     CommandSpec(tuple(), "--rebuild-plugin-cache"),
     CommandSpec(("docs", "serve")),
+    CommandSpec(("list", "component")),
     CommandSpec(("list", "plugins")),
     CommandSpec(("utils", "inspect-component-type"), DEFAULT_COMPONENT_TYPE),
 ]
@@ -65,7 +66,6 @@ PROJECT_CONTEXT_COMMANDS = [
     CommandSpec(("utils", "configure-editor"), "vscode"),
     CommandSpec(("utils", "generate-component-schema")),
     CommandSpec(("check", "yaml")),
-    CommandSpec(("list", "component")),
     CommandSpec(("list", "defs")),
     CommandSpec(("list", "env")),
     CommandSpec(("scaffold", DEFAULT_COMPONENT_TYPE, "foot")),

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 import os
 import re
 import shutil
@@ -587,6 +588,11 @@ def match_terminal_box_output(output: str, expected_output: str):
             f"Expected: {expected_output_line}"
         )
     return True
+
+
+def match_json_output(output: str, expected_output: str):
+    """Compare two JSON strings, ignoring whitespace and newlines."""
+    return json.dumps(json.loads(output)) == json.dumps(json.loads(expected_output))
 
 
 # Windows sometimes provides short (8.3) paths in output, which can be difficult to match exactly.


### PR DESCRIPTION
## Summary & Motivation

Changes the `dg list component(s)` command to list component types instead of instances. Example output:

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Component Type                                     ┃ Summary                                                         ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ dagster_test.components.AllMetadataEmptyComponent  │                                                                 │
├────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ dagster_test.components.ComplexAssetComponent      │ An asset that has a complex schema.                             │
├────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ dagster_test.components.SimpleAssetComponent       │ A simple asset that returns a constant string value.            │
├────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ dagster_test.components.SimplePipesScriptComponent │ A simple asset that runs a Python script with the Pipes         │
│                                                    │ subprocess client.                                              │
└────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────┘
```

## How I Tested These Changes

New unit tests.

## Changelog

The `dg list component` command now lists component types instead of instances.