### PR TITLE
[ui] Fix clipping in the asset graph on some faceted nodes

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -45,56 +45,54 @@ export const AssetNode = React.memo(({definition, selected, onChangeAssetSelecti
   const marginTopForCenteringNode = !hasChecks ? ASSET_NODE_STATUS_ROW_HEIGHT / 2 : 0;
 
   return (
-    <AssetInsetForHoverEffect>
-      <AssetNodeContainer $selected={selected}>
-        <Box
-          flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
-          style={{minHeight: ASSET_NODE_TAGS_HEIGHT, marginTop: marginTopForCenteringNode}}
-        >
-          <div>
-            <StaleReasonsTag liveData={liveData} assetKey={definition.assetKey} />
-          </div>
-          <ChangedReasonsTag
-            changedReasons={definition.changedReasons}
-            assetKey={definition.assetKey}
-          />
-        </Box>
-        <AssetNodeBox $selected={selected} $isMaterializable={definition.isMaterializable}>
-          <AssetNameRow definition={definition} />
-          <Box style={{padding: '6px 8px'}} flex={{direction: 'column', gap: 4}} border="top">
-            {definition.description ? (
-              <AssetDescription $color={Colors.textDefault()}>
-                {markdownToPlaintext(definition.description).split('\n')[0]}
-              </AssetDescription>
-            ) : (
-              <AssetDescription $color={Colors.textLight()}>No description</AssetDescription>
-            )}
-            {definition.isPartitioned && definition.isMaterializable && (
-              <PartitionCountTags definition={definition} liveData={liveData} />
-            )}
-          </Box>
-          {featureEnabled(FeatureFlag.flagUseNewObserveUIs) ? (
-            <AssetNodeHealthRow definition={definition} liveData={liveData} />
+    <AssetNodeContainer $selected={selected}>
+      <Box
+        flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
+        style={{minHeight: ASSET_NODE_TAGS_HEIGHT, marginTop: marginTopForCenteringNode}}
+      >
+        <div>
+          <StaleReasonsTag liveData={liveData} assetKey={definition.assetKey} />
+        </div>
+        <ChangedReasonsTag
+          changedReasons={definition.changedReasons}
+          assetKey={definition.assetKey}
+        />
+      </Box>
+      <AssetNodeBox $selected={selected} $isMaterializable={definition.isMaterializable}>
+        <AssetNameRow definition={definition} />
+        <Box style={{padding: '6px 8px'}} flex={{direction: 'column', gap: 4}} border="top">
+          {definition.description ? (
+            <AssetDescription $color={Colors.textDefault()}>
+              {markdownToPlaintext(definition.description).split('\n')[0]}
+            </AssetDescription>
           ) : (
-            <AssetNodeStatusRow definition={definition} liveData={liveData} />
+            <AssetDescription $color={Colors.textLight()}>No description</AssetDescription>
           )}
-          {hasChecks && <AssetNodeChecksRow definition={definition} liveData={liveData} />}
-        </AssetNodeBox>
-        <Box
-          style={{minHeight: ASSET_NODE_TAGS_HEIGHT}}
-          flex={{alignItems: 'center', direction: 'row-reverse', gap: 8}}
-        >
-          {definition.kinds.map((kind) => (
-            <AssetKind
-              key={kind}
-              kind={kind}
-              style={{position: 'relative', margin: 0}}
-              onChangeAssetSelection={onChangeAssetSelection}
-            />
-          ))}
+          {definition.isPartitioned && definition.isMaterializable && (
+            <PartitionCountTags definition={definition} liveData={liveData} />
+          )}
         </Box>
-      </AssetNodeContainer>
-    </AssetInsetForHoverEffect>
+        {featureEnabled(FeatureFlag.flagUseNewObserveUIs) ? (
+          <AssetNodeHealthRow definition={definition} liveData={liveData} />
+        ) : (
+          <AssetNodeStatusRow definition={definition} liveData={liveData} />
+        )}
+        {hasChecks && <AssetNodeChecksRow definition={definition} liveData={liveData} />}
+      </AssetNodeBox>
+      <Box
+        style={{minHeight: ASSET_NODE_TAGS_HEIGHT}}
+        flex={{alignItems: 'center', direction: 'row-reverse', gap: 8}}
+      >
+        {definition.kinds.map((kind) => (
+          <AssetKind
+            key={kind}
+            kind={kind}
+            style={{position: 'relative', margin: 0}}
+            onChangeAssetSelection={onChangeAssetSelection}
+          />
+        ))}
+      </Box>
+    </AssetNodeContainer>
   );
 }, isEqual);
 
@@ -252,11 +250,10 @@ export const AssetNodeMinimalWithHealth = ({
   if (facets !== null) {
     const topTagsPresent = facets.has(AssetNodeFacet.UnsyncedTag);
     const bottomTagsPresent = facets.has(AssetNodeFacet.KindTag);
-    paddingTop = ASSET_NODE_VERTICAL_PADDING + (topTagsPresent ? ASSET_NODE_TAGS_HEIGHT : 0);
+    paddingTop = ASSET_NODE_VERTICAL_MARGIN + (topTagsPresent ? ASSET_NODE_TAGS_HEIGHT : 0);
     nodeHeight =
       height -
-      ASSET_NODE_VERTICAL_PADDING * 2 -
-      ASSET_NODE_INSET_VERTICAL_PADDING * 2 -
+      ASSET_NODE_VERTICAL_MARGIN * 2 -
       (topTagsPresent ? ASSET_NODE_TAGS_HEIGHT : ASSET_NODE_HOVER_EXPAND_HEIGHT) -
       (bottomTagsPresent ? ASSET_NODE_TAGS_HEIGHT : 0);
 
@@ -267,37 +264,32 @@ export const AssetNodeMinimalWithHealth = ({
   }
 
   return (
-    <AssetInsetForHoverEffect>
-      <MinimalAssetNodeContainer $selected={selected} style={{paddingTop}}>
-        <TooltipStyled
-          content={displayName}
-          canShow={displayName.length > 14}
-          targetTagName="div"
-          position="top"
+    <MinimalAssetNodeContainer $selected={selected} style={{paddingTop}}>
+      <TooltipStyled
+        content={displayName}
+        canShow={displayName.length > 14}
+        targetTagName="div"
+        position="top"
+      >
+        <MinimalAssetNodeBox
+          $selected={selected}
+          $isMaterializable={isMaterializable}
+          $background={backgroundColor}
+          $border={borderColor}
+          $inProgress={!!inProgressRuns}
+          $isQueued={!!queuedRuns}
+          $height={nodeHeight}
         >
-          <MinimalAssetNodeBox
-            $selected={selected}
-            $isMaterializable={isMaterializable}
-            $background={backgroundColor}
-            $border={borderColor}
-            $inProgress={!!inProgressRuns}
-            $isQueued={!!queuedRuns}
-            $height={nodeHeight}
-          >
-            {isChanged ? (
-              <MinimalNodeChangedDot
-                changedReasons={definition.changedReasons}
-                assetKey={assetKey}
-              />
-            ) : null}
-            {isStale ? <MinimalNodeStaleDot assetKey={assetKey} liveData={liveData} /> : null}
-            <MinimalName style={{fontSize: 24}} $isMaterializable={isMaterializable}>
-              {withMiddleTruncation(displayName, {maxLength: 18})}
-            </MinimalName>
-          </MinimalAssetNodeBox>
-        </TooltipStyled>
-      </MinimalAssetNodeContainer>
-    </AssetInsetForHoverEffect>
+          {isChanged ? (
+            <MinimalNodeChangedDot changedReasons={definition.changedReasons} assetKey={assetKey} />
+          ) : null}
+          {isStale ? <MinimalNodeStaleDot assetKey={assetKey} liveData={liveData} /> : null}
+          <MinimalName style={{fontSize: 24}} $isMaterializable={isMaterializable}>
+            {withMiddleTruncation(displayName, {maxLength: 18})}
+          </MinimalName>
+        </MinimalAssetNodeBox>
+      </TooltipStyled>
+    </MinimalAssetNodeContainer>
   );
 };
 
@@ -326,11 +318,10 @@ export const AssetNodeMinimalOld = ({
   if (facets !== null) {
     const topTagsPresent = facets.has(AssetNodeFacet.UnsyncedTag);
     const bottomTagsPresent = facets.has(AssetNodeFacet.KindTag);
-    paddingTop = ASSET_NODE_VERTICAL_PADDING + (topTagsPresent ? ASSET_NODE_TAGS_HEIGHT : 0);
+    paddingTop = ASSET_NODE_VERTICAL_MARGIN + (topTagsPresent ? ASSET_NODE_TAGS_HEIGHT : 0);
     nodeHeight =
       height -
-      ASSET_NODE_VERTICAL_PADDING * 2 -
-      ASSET_NODE_INSET_VERTICAL_PADDING * 2 -
+      ASSET_NODE_VERTICAL_MARGIN * 2 -
       (topTagsPresent ? ASSET_NODE_TAGS_HEIGHT : ASSET_NODE_HOVER_EXPAND_HEIGHT) -
       (bottomTagsPresent ? ASSET_NODE_TAGS_HEIGHT : 0);
 
@@ -341,37 +332,32 @@ export const AssetNodeMinimalOld = ({
   }
 
   return (
-    <AssetInsetForHoverEffect>
-      <MinimalAssetNodeContainer $selected={selected} style={{paddingTop}}>
-        <TooltipStyled
-          content={displayName}
-          canShow={displayName.length > 14}
-          targetTagName="div"
-          position="top"
+    <MinimalAssetNodeContainer $selected={selected} style={{paddingTop}}>
+      <TooltipStyled
+        content={displayName}
+        canShow={displayName.length > 14}
+        targetTagName="div"
+        position="top"
+      >
+        <MinimalAssetNodeBox
+          $selected={selected}
+          $isMaterializable={isMaterializable}
+          $background={background}
+          $border={border}
+          $inProgress={!!inProgressRuns}
+          $isQueued={!!queuedRuns}
+          $height={nodeHeight}
         >
-          <MinimalAssetNodeBox
-            $selected={selected}
-            $isMaterializable={isMaterializable}
-            $background={background}
-            $border={border}
-            $inProgress={!!inProgressRuns}
-            $isQueued={!!queuedRuns}
-            $height={nodeHeight}
-          >
-            {isChanged ? (
-              <MinimalNodeChangedDot
-                changedReasons={definition.changedReasons}
-                assetKey={assetKey}
-              />
-            ) : null}
-            {isStale ? <MinimalNodeStaleDot assetKey={assetKey} liveData={liveData} /> : null}
-            <MinimalName style={{fontSize: 24}} $isMaterializable={isMaterializable}>
-              {withMiddleTruncation(displayName, {maxLength: 18})}
-            </MinimalName>
-          </MinimalAssetNodeBox>
-        </TooltipStyled>
-      </MinimalAssetNodeContainer>
-    </AssetInsetForHoverEffect>
+          {isChanged ? (
+            <MinimalNodeChangedDot changedReasons={definition.changedReasons} assetKey={assetKey} />
+          ) : null}
+          {isStale ? <MinimalNodeStaleDot assetKey={assetKey} liveData={liveData} /> : null}
+          <MinimalName style={{fontSize: 24}} $isMaterializable={isMaterializable}>
+            {withMiddleTruncation(displayName, {maxLength: 18})}
+          </MinimalName>
+        </MinimalAssetNodeBox>
+      </TooltipStyled>
+    </MinimalAssetNodeContainer>
   );
 };
 
@@ -417,24 +403,15 @@ export const ASSET_NODE_FRAGMENT = gql`
   }
 `;
 
-export const ASSET_NODE_INSET_VERTICAL_PADDING = 2;
-
-export const AssetInsetForHoverEffect = styled.div`
-  padding: ${ASSET_NODE_INSET_VERTICAL_PADDING}px 4px ${ASSET_NODE_INSET_VERTICAL_PADDING}px 4px;
-  height: 100%;
-
-  & *:focus {
-    outline: 0;
-  }
-`;
-
-export const ASSET_NODE_VERTICAL_PADDING = 6;
+export const ASSET_NODE_VERTICAL_MARGIN = 6;
 
 export const AssetNodeContainer = styled.div<{$selected: boolean}>`
   user-select: none;
   cursor: pointer;
-  padding: 0 ${ASSET_NODE_VERTICAL_PADDING}px;
-  overflow: clip;
+
+  & *:focus {
+    outline: 0;
+  }
 `;
 
 const AssetNodeShowOnHover = styled.span`
@@ -457,7 +434,7 @@ export const AssetNodeBox = styled.div<{
   background: ${Colors.backgroundDefault()};
   border-radius: 10px;
   position: relative;
-  margin: 6px 0;
+  margin: ${ASSET_NODE_VERTICAL_MARGIN}px 0;
   transition: all 150ms linear;
   &:hover {
     ${(p) => !p.$selected && `border: 2px solid ${Colors.lineageNodeBorderHover()};`};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode2025.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode2025.tsx
@@ -8,7 +8,6 @@ import styled from 'styled-components';
 
 import {
   AssetDescription,
-  AssetInsetForHoverEffect,
   AssetNameRow,
   AssetNodeBox,
   AssetNodeContainer,
@@ -59,98 +58,96 @@ export const AssetNodeWithLiveData = ({
   automationData?: AssetAutomationFragment | undefined;
 }) => {
   return (
-    <AssetInsetForHoverEffect>
-      <AssetNodeContainer $selected={selected}>
-        {facets.has(AssetNodeFacet.UnsyncedTag) ? (
-          <Box
-            flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
-            style={{minHeight: ASSET_NODE_TAGS_HEIGHT}}
-          >
-            <div>
-              <StaleReasonsTag liveData={liveData} assetKey={definition.assetKey} />
-            </div>
-            <ChangedReasonsTag
-              changedReasons={definition.changedReasons}
-              assetKey={definition.assetKey}
+    <AssetNodeContainer $selected={selected}>
+      {facets.has(AssetNodeFacet.UnsyncedTag) ? (
+        <Box
+          flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
+          style={{minHeight: ASSET_NODE_TAGS_HEIGHT}}
+        >
+          <div>
+            <StaleReasonsTag liveData={liveData} assetKey={definition.assetKey} />
+          </div>
+          <ChangedReasonsTag
+            changedReasons={definition.changedReasons}
+            assetKey={definition.assetKey}
+          />
+        </Box>
+      ) : (
+        <div style={{minHeight: ASSET_NODE_HOVER_EXPAND_HEIGHT}} />
+      )}
+      <AssetNodeBox $selected={selected} $isMaterializable={definition.isMaterializable}>
+        <AssetNameRow definition={definition} />
+        {facets.has(AssetNodeFacet.Description) && (
+          <AssetNodeRow label={null}>
+            {definition.description ? (
+              <AssetDescription $color={Colors.textDefault()}>
+                {markdownToPlaintext(definition.description).split('\n')[0]}
+              </AssetDescription>
+            ) : (
+              <AssetDescription $color={Colors.textDefault()}>No description</AssetDescription>
+            )}
+          </AssetNodeRow>
+        )}
+        {facets.has(AssetNodeFacet.Owner) && (
+          <AssetNodeRow label={labelForFacet(AssetNodeFacet.Owner)}>
+            {definition.owners.length > 0 ? (
+              <SingleOwnerOrTooltip owners={definition.owners} />
+            ) : null}
+          </AssetNodeRow>
+        )}
+        {facets.has(AssetNodeFacet.LatestEvent) && (
+          <AssetNodeRow label={labelForFacet(AssetNodeFacet.LatestEvent)}>
+            {assetNodeLatestEventContent({definition, liveData})}
+          </AssetNodeRow>
+        )}
+        {facets.has(AssetNodeFacet.Checks) && (
+          <AssetNodeRow label={labelForFacet(AssetNodeFacet.Checks)}>
+            {liveData && liveData.assetChecks.length > 0 ? (
+              <Link
+                to={assetDetailsPathForKey(definition.assetKey, {view: 'checks'})}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <AssetChecksStatusSummary
+                  liveData={liveData}
+                  rendering="dag2025"
+                  assetKey={definition.assetKey}
+                />
+              </Link>
+            ) : null}
+          </AssetNodeRow>
+        )}
+        {facets.has(AssetNodeFacet.Freshness) &&
+          (featureEnabled(FeatureFlag.flagUseNewObserveUIs) ? (
+            <AssetNodeFreshnessRow definition={definition} liveData={liveData} />
+          ) : (
+            <AssetNodeFreshnessRowOld liveData={liveData} />
+          ))}
+        {facets.has(AssetNodeFacet.Automation) && (
+          <AssetNodeAutomationRow definition={definition} automationData={automationData} />
+        )}
+        {facets.has(AssetNodeFacet.Status) &&
+          (featureEnabled(FeatureFlag.flagUseNewObserveUIs) ? (
+            <AssetNodeHealthRow definition={definition} liveData={liveData} />
+          ) : (
+            <AssetNodeStatusRow definition={definition} liveData={liveData} />
+          ))}
+      </AssetNodeBox>
+      {facets.has(AssetNodeFacet.KindTag) && (
+        <Box
+          style={{minHeight: ASSET_NODE_TAGS_HEIGHT}}
+          flex={{alignItems: 'center', direction: 'row-reverse', gap: 8}}
+        >
+          {definition.kinds.map((kind) => (
+            <AssetKind
+              key={kind}
+              kind={kind}
+              style={{position: 'relative', margin: 0}}
+              onChangeAssetSelection={onChangeAssetSelection}
             />
-          </Box>
-        ) : (
-          <div style={{minHeight: ASSET_NODE_HOVER_EXPAND_HEIGHT}} />
-        )}
-        <AssetNodeBox $selected={selected} $isMaterializable={definition.isMaterializable}>
-          <AssetNameRow definition={definition} />
-          {facets.has(AssetNodeFacet.Description) && (
-            <AssetNodeRow label={null}>
-              {definition.description ? (
-                <AssetDescription $color={Colors.textDefault()}>
-                  {markdownToPlaintext(definition.description).split('\n')[0]}
-                </AssetDescription>
-              ) : (
-                <AssetDescription $color={Colors.textDefault()}>No description</AssetDescription>
-              )}
-            </AssetNodeRow>
-          )}
-          {facets.has(AssetNodeFacet.Owner) && (
-            <AssetNodeRow label={labelForFacet(AssetNodeFacet.Owner)}>
-              {definition.owners.length > 0 ? (
-                <SingleOwnerOrTooltip owners={definition.owners} />
-              ) : null}
-            </AssetNodeRow>
-          )}
-          {facets.has(AssetNodeFacet.LatestEvent) && (
-            <AssetNodeRow label={labelForFacet(AssetNodeFacet.LatestEvent)}>
-              {assetNodeLatestEventContent({definition, liveData})}
-            </AssetNodeRow>
-          )}
-          {facets.has(AssetNodeFacet.Checks) && (
-            <AssetNodeRow label={labelForFacet(AssetNodeFacet.Checks)}>
-              {liveData && liveData.assetChecks.length > 0 ? (
-                <Link
-                  to={assetDetailsPathForKey(definition.assetKey, {view: 'checks'})}
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <AssetChecksStatusSummary
-                    liveData={liveData}
-                    rendering="dag2025"
-                    assetKey={definition.assetKey}
-                  />
-                </Link>
-              ) : null}
-            </AssetNodeRow>
-          )}
-          {facets.has(AssetNodeFacet.Freshness) &&
-            (featureEnabled(FeatureFlag.flagUseNewObserveUIs) ? (
-              <AssetNodeFreshnessRow definition={definition} liveData={liveData} />
-            ) : (
-              <AssetNodeFreshnessRowOld liveData={liveData} />
-            ))}
-          {facets.has(AssetNodeFacet.Automation) && (
-            <AssetNodeAutomationRow definition={definition} automationData={automationData} />
-          )}
-          {facets.has(AssetNodeFacet.Status) &&
-            (featureEnabled(FeatureFlag.flagUseNewObserveUIs) ? (
-              <AssetNodeHealthRow definition={definition} liveData={liveData} />
-            ) : (
-              <AssetNodeStatusRow definition={definition} liveData={liveData} />
-            ))}
-        </AssetNodeBox>
-        {facets.has(AssetNodeFacet.KindTag) && (
-          <Box
-            style={{minHeight: ASSET_NODE_TAGS_HEIGHT}}
-            flex={{alignItems: 'center', direction: 'row-reverse', gap: 8}}
-          >
-            {definition.kinds.map((kind) => (
-              <AssetKind
-                key={kind}
-                kind={kind}
-                style={{position: 'relative', margin: 0}}
-                onChangeAssetSelection={onChangeAssetSelection}
-              />
-            ))}
-          </Box>
-        )}
-      </AssetNodeContainer>
-    </AssetInsetForHoverEffect>
+          ))}
+        </Box>
+      )}
+    </AssetNodeContainer>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -378,9 +378,14 @@ export const getAssetNodeDimensions = (def: {
 };
 
 export const getAssetNodeDimensions2025 = (facets: Set<AssetNodeFacet>) => {
-  let height = 50; // box padding + border + name
+  let height = 0;
 
-  height += ASSET_NODE_STATUS_ROW_HEIGHT * facets.size;
+  if (facets.size === 0) {
+    height = 60;
+  } else {
+    height = 50; // box padding + border + name
+    height += ASSET_NODE_STATUS_ROW_HEIGHT * facets.size;
+  }
 
   return {width: ASSET_NODE_WIDTH, height};
 };


### PR DESCRIPTION
## Summary & Motivation

Was fixing an issue with the Observe UI and noticed that the new asset nodes are clipped occasionally. This is happening because our hover effect is a `scale(1.03)`, but the "3%" varies based on the height of the nodes, which now changes considerably.

We have been doing the `overflow: clip` for about two years (https://github.com/dagster-io/dagster/commit/e5bfb148b638fd5790d612e19b3b57005b06e1cc#diff-5cd3875eb046b0feb171eb764678d4efc1517fa1853515e2f53b044b4dc5795cL393). I removed it, and also removed the "inset" wrapper we were using to give space for the hover effect, and tested the old + new asset nodes in FF + Chrome + Safari.  They all seem fine, and the node positioning is actually simpler with these wrappers and padding removed.

@hellendag any chance you remember what we originally needed `overflow: clip` for? I think it was probably a browser issue at the time? I know we had trouble with Safari at one point but it's working well with these removed now.


<img width="495" alt="image" src="https://github.com/user-attachments/assets/77f4d4eb-5014-4c29-962e-7a0ba3c3b607" />

After: 

<img width="516" alt="image" src="https://github.com/user-attachments/assets/6499c2b6-90e8-4547-86c2-b053f77957c2" />
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/907897c5-0590-4d9a-885f-e3a345d45839" />
