### PR TITLE
[ui] Observe UI mentions “materialized” for non-materializable assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeHealthRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeHealthRow.tsx
@@ -38,10 +38,10 @@ export const AssetNodeHealthRow = ({
           <AssetLatestRunSpinner liveData={liveData} purpose="caption-text" />
           <span style={{color: Colors.textBlue()}}>
             {numMaterializing === 1
-              ? `Materializing 1 partition...`
+              ? `Executing 1 partition...`
               : numMaterializing
-                ? `Materializing ${numMaterializing} partitions...`
-                : `Materializing...`}
+                ? `Executing ${numMaterializing} partitions...`
+                : `Executing...`}
           </span>
         </Box>
         {!numMaterializing || numMaterializing === 1 ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
@@ -272,16 +272,16 @@ const Criteria = React.memo(
         case 'materialization':
           switch (status) {
             case AssetHealthStatus.DEGRADED:
-              return {text: 'Failed to materialize', shouldDim: false};
+              return {text: 'Execution failed', shouldDim: false};
             case AssetHealthStatus.HEALTHY:
-              return {text: 'Successfully materialized', shouldDim: false};
+              return {text: 'Successfully executed', shouldDim: false};
             case AssetHealthStatus.WARNING:
-              return {text: 'Materialization warning', shouldDim: false};
+              return {text: 'Execution warning', shouldDim: false};
             case undefined:
             case AssetHealthStatus.NOT_APPLICABLE:
-              return {text: 'No materializations', shouldDim: true};
+              return {text: 'No executions', shouldDim: true};
             case AssetHealthStatus.UNKNOWN:
-              return {text: 'Materialization unknown', shouldDim: true};
+              return {text: 'Execution status unknown', shouldDim: true};
             default:
               assertUnreachable(status);
           }


### PR DESCRIPTION
## Summary & Motivation

Fixes https://linear.app/dagster-labs/issue/OPER-1860/asset-nodes-for-observed-source-assets-should-be-green-not-grey

This PR updates the observe UI to avoid using the "materialize" term on non-materializable assets. 

I wonder if we change all these to say "executed" to avoid needing to pass the definition information down in, but will defer to @braunjj!  It isn't much work to choose the right verb, just involves a bit more context about the nodes.

Fixed:

<img width="967" alt="image" src="https://github.com/user-attachments/assets/5147d839-3999-4ed3-9a9c-c2e81043f64d" />

## How I Tested These Changes

Tested manually with observable source assets with the faceted nodes feature flag turned on and off. 

## Changelog

[ui] With the Observe UI feature flag enabled, observable assets no longer reference "materialization" status.