### PR TITLE
[dagster-dbt] Pass `group_name` param to `@dbt_assets` decorator

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -36,6 +36,7 @@ def dbt_assets(
     dagster_dbt_translator: Optional[DagsterDbtTranslator] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     op_tags: Optional[Mapping[str, Any]] = None,
+    group_name: Optional[str] = None,
     required_resource_keys: Optional[set[str]] = None,
     project: Optional[DbtProject] = None,
     retry_policy: Optional[RetryPolicy] = None,
@@ -72,6 +73,10 @@ def dbt_assets(
             Frameworks may expect and require certain metadata to be attached to a op. Values that
             are not strings will be json encoded and must meet the criteria that
             `json.loads(json.dumps(value)) == value`.
+        group_name (Optional[str]): A string name used to organize multiple assets into groups. This
+            group name will be applied to all assets produced by this dbt_assets as long as the manifest
+            does not contain dbt assets whose group spec is set already. Additionally, unexecutable assets,
+            such as dbt sources, will be excluded.
         required_resource_keys (Optional[Set[str]]): Set of required resource handles.
         project (Optional[DbtProject]): A DbtProject instance which provides a pointer to the dbt
             project location and manifest. Not required, but needed to attach code references from
@@ -360,6 +365,7 @@ def dbt_assets(
         required_resource_keys=required_resource_keys,
         partitions_def=partitions_def,
         op_tags=resolved_op_tags,
+        group_name=group_name,
         backfill_policy=backfill_policy,
         retry_policy=retry_policy,
         pool=pool,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -701,6 +701,19 @@ def test_with_group_replacements(test_jaffle_shop_manifest: dict[str, Any]) -> N
         assert expected_specs_by_key[asset_key].group_name == expected_group
 
 
+def test_dbt_assets_group_name_param(test_jaffle_shop_manifest: dict[str, Any]) -> None:
+    custom_group = "custom_group"
+
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest,
+        group_name=custom_group,
+    )
+    def my_dbt_assets(): ...
+
+    for asset_key in my_dbt_assets.group_names_by_key:
+        assert my_dbt_assets.group_names_by_key[asset_key] == custom_group
+
+
 def test_with_code_version_replacements(test_jaffle_shop_manifest: dict[str, Any]) -> None:
     expected_code_version = "customized_code_version"
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -702,16 +702,16 @@ def test_with_group_replacements(test_jaffle_shop_manifest: dict[str, Any]) -> N
 
 
 def test_dbt_assets_group_name_param(test_jaffle_shop_manifest: dict[str, Any]) -> None:
-    custom_group = "custom_group"
+    group_name = "custom_group"
 
     @dbt_assets(
         manifest=test_jaffle_shop_manifest,
-        group_name=custom_group,
+        group_name=group_name,
     )
     def my_dbt_assets(): ...
 
     for asset_key in my_dbt_assets.group_names_by_key:
-        assert my_dbt_assets.group_names_by_key[asset_key] == custom_group
+        assert my_dbt_assets.group_names_by_key[asset_key] == group_name
 
 
 def test_with_code_version_replacements(test_jaffle_shop_manifest: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary & Motivation
Added the `group_name` parameter to the `@dbt_assets` decorator, allowing users to organize generated dbt assets under a customizable group in the Dagster UI. This improves asset organization, navigation, and insight for larger projects.

⚠️ If any dbt assets in the manifest have a group already set, adding `group_name` will raise an error: `Cannot set group_name parameter on multi_asset if one or more of the AssetSpecs/AssetOuts supplied to this multi_asset have a group_name defined.`
⚠️ Only executable assets are grouped; unexecutable assets, such as dbt sources, are excluded.

## How I Tested These Changes
1. Manually verified the Dagster UI after implementing the changes and using the new parameter for my dbt assets. As one can see in the asset catalog and global lineage screenshots, the dbt assets are correctly assigned to the new group called `custom_group` (except the source assets which are unexecutable and are left in the `default` group).

<img width="1512" alt="Screenshot 2025-05-18 at 14 20 44" src="https://github.com/user-attachments/assets/2d9f0364-d5d2-46fa-b6e2-c64adadbeb9e" />

---

<img width="1512" alt="Screenshot 2025-05-18 at 14 28 19" src="https://github.com/user-attachments/assets/88919294-da97-474a-9d14-b41abe42a603" />

---
---

2. Added a pytest for this new parameter which passed.
<img width="1512" alt="Screenshot 2025-05-18 at 14 14 30" src="https://github.com/user-attachments/assets/865ae2fe-a983-446f-ad45-baca2d4aa23f" />

## Changelog

> Pass `group_name` param to `@dbt_assets` decorator
