### PR TITLE
make one thread per origin in ProxyServerManager

### DIFF
--- a/python_modules/dagster/dagster/_cli/proxy_server_manager.py
+++ b/python_modules/dagster/dagster/_cli/proxy_server_manager.py
@@ -10,18 +10,25 @@ from typing_extensions import Self
 import dagster._check as check
 from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
+from dagster._core.remote_representation.grpc_server_registry import (
+    GrpcServerRegistry,
+    ServerRegistryEntry,
+)
 from dagster._core.remote_representation.origin import (
     GrpcServerCodeLocationOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin,
 )
 from dagster._core.workspace.context import WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
-from dagster._grpc.server import INCREASE_TIMEOUT_DAGSTER_YAML_MSG, GrpcServerCommand
+from dagster._grpc.server import (
+    INCREASE_TIMEOUT_DAGSTER_YAML_MSG,
+    GrpcServerCommand,
+    GrpcServerProcess,
+)
 
 
 def get_auto_restart_code_server_interval() -> int:
-    return int(os.getenv("DAGSTER_CODE_SERVER_AUTO_RESTART_INTERVAL", "30"))
+    return int(os.getenv("DAGSTER_CODE_SERVER_AUTO_RESTART_INTERVAL", "5"))
 
 
 class ProxyServerManager(AbstractContextManager):
@@ -58,20 +65,24 @@ class ProxyServerManager(AbstractContextManager):
 
         self.__shutdown_event = threading.Event()
 
-        self.__process_monitoring_thread = threading.Thread(
-            target=self.process_monitoring_thread, daemon=True
-        )
-        self.__process_monitoring_thread.start()
+        self._process_monitoring_threads = []
         self._initialize_endpoints()
 
     def _initialize_endpoints(self) -> None:
         """Initialize the endpoints for the code server processes."""
         for origin in self._origins:
-            # Calling get_grpc_endpoint will start the server process if it is not already running.
             if isinstance(origin, ManagedGrpcPythonEnvCodeLocationOrigin):
-                self._grpc_server_registry.get_grpc_endpoint(origin)
+                # Calling get_grpc_server_entry will start the server process if it is not already running.
+                server_entry = self._grpc_server_registry.get_grpc_server_entry(origin)
+                if isinstance(server_entry, ServerRegistryEntry):
+                    server_process = server_entry.process
+                    monitoring_thread = threading.Thread(
+                        target=self._process_monitoring_thread, args=(server_process,), daemon=True
+                    )
+                    monitoring_thread.start()
+                    self._process_monitoring_threads.append(monitoring_thread)
 
-    def process_monitoring_thread(self) -> None:
+    def _process_monitoring_thread(self, process_entry: GrpcServerProcess) -> None:
         """Thread responsible for monitoring the code server processes.
         - If the proxy servers exit unexpectedly, restarts them.
         - Heartbeats the proxy servers to let them know that the caller process is still alive.
@@ -80,31 +91,25 @@ class ProxyServerManager(AbstractContextManager):
             self.__shutdown_event.wait(get_auto_restart_code_server_interval())
             if self.__shutdown_event.is_set():
                 break
-            for origin in self._origins:
-                # We only process managed gRPC servers here.
-                if isinstance(origin, ManagedGrpcPythonEnvCodeLocationOrigin):
-                    process = self._grpc_server_registry.get_grpc_server_process(origin)
-                    if not process:
-                        # Waiting for the process to start
-                        continue
-                    if process.server_process and process.server_process.poll() is not None:
-                        logging.getLogger(__name__).warning(
-                            f"Code server process has exited with code {process.server_process.poll()}. Restarting the code server process."
-                        )
-                        process.start_server_process()
-                        continue
-                    client = process.create_client()
-                    try:
-                        client.heartbeat("ping")
-                    except DagsterUserCodeUnreachableError:
-                        continue
+            if process_entry.server_process and process_entry.server_process.poll() is not None:
+                logging.getLogger(__name__).warning(
+                    f"Code server process has exited with code {process_entry.server_process.poll()}. Restarting the code server process."
+                )
+                process_entry.start_server_process()
+                continue
+            client = process_entry.create_client()
+            try:
+                client.heartbeat("ping")
+            except DagsterUserCodeUnreachableError:
+                continue
 
     def __enter__(self) -> Self:
         return self
 
     def __exit__(self, exception_type, exception_value, traceback) -> None:
         self.__shutdown_event.set()
-        self.__process_monitoring_thread.join()
+        for thread in self._process_monitoring_threads:
+            thread.join()
         self._stack.close()
 
     def get_code_server_specs(self) -> Sequence[Mapping[str, Mapping[str, Any]]]:

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -223,6 +223,9 @@ class DagsterProxyApiServicer(DagsterApiServicer):
                 break
 
             if self.__last_heartbeat_time < time.time() - heartbeat_timeout:
+                self._logger.warning(
+                    f"No heartbeat received in {heartbeat_timeout} seconds, shutting down"
+                )
                 self._shutdown_once_executions_finish_event.set()
                 self._grpc_server_registry.shutdown_all_processes()
 
@@ -261,6 +264,8 @@ class DagsterProxyApiServicer(DagsterApiServicer):
 
     def Heartbeat(self, request, context):
         self.__last_heartbeat_time = time.time()
+        echo = request.echo
+        return dagster_api_pb2.PingReply(echo=echo)
 
     def StreamingPing(self, request, context):
         return self._streaming_query("StreamingPing", request, context)

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -498,6 +498,9 @@ class DagsterApiServer(DagsterApiServicer):
                 break
 
             if self.__last_heartbeat_time < time.time() - heartbeat_timeout:
+                self._logger.warning(
+                    f"No heartbeat received in {heartbeat_timeout} seconds, shutting down"
+                )
                 self._shutdown_once_executions_finish_event.set()
 
     def _cleanup_thread(self) -> None:


### PR DESCRIPTION
## Summary & Motivation

In https://github.com/dagster-io/dagster/pull/28991 we moved from one thread per code location making heartbeat pings to a single background thread iterating through each code location making heartbeat pings. This means that if there are many origins or slow origins that its possible for a code server to miss its heartbeat and shut down incorrectly. This resolves that by moving back to one heartbeat thread per code location.

## How I Tested These Changes
Exiting test coverage for dagster dev, plus:
Create a workspace.yaml with 6 code locations that is slow to start up (e.g. a time.sleep(15) at the start)
Before: `dagster dev` would fail to start up some code locations with an error since they never got an initial heartbeat
Now: starts up correctly

## Changelog
Fixed an issue where `dagster dev` would sometimes raise a gRPC error when loading several code locations at once.