### PR TITLE
[ui] Use claude to replace usage of styled-components with CSS modules

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Page.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Page.module.css
@@ -1,0 +1,6 @@
+.page {
+  height: 100%;
+  overflow-y: auto;
+  padding-bottom: 64px;
+  width: 100%;
+}

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Page.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Page.tsx
@@ -1,8 +1,11 @@
-import styled from 'styled-components';
+import * as React from 'react';
+import styles from './Page.module.css';
 
-export const Page = styled.div`
-  height: 100%;
-  overflow-y: auto;
-  padding-bottom: 64px;
-  width: 100%;
-`;
+export const Page: React.FC<React.HTMLAttributes<HTMLDivElement>> = (props) => {
+  const { children, className, ...rest } = props;
+  return (
+    <div className={className ? `${styles.page} ${className}` : styles.page} {...rest}>
+      {children}
+    </div>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.module.css
@@ -1,0 +1,11 @@
+.pageHeaderContainer {
+  width: 100%;
+}
+
+/**
+ * Blueprint breadcrumbs annoyingly have a built-in height.
+ */
+.pageHeaderContainer :global(.bp5-breadcrumbs) {
+  height: auto;
+  min-height: 30px;
+}

--- a/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components';
+import styles from './PageHeader.module.css';
 
 import {Box} from './Box';
 import {Colors} from './Color';
@@ -18,7 +18,8 @@ interface Props {
 export const PageHeader = (props: Props) => {
   const {title, tags, right, tabs} = props;
   return (
-    <PageHeaderContainer
+    <Box
+      className={styles.pageHeaderContainer}
       background={Colors.backgroundLight()}
       padding={{horizontal: 24}}
       border="bottom"
@@ -37,18 +38,6 @@ export const PageHeader = (props: Props) => {
         </Box>
       )}
       {tabs}
-    </PageHeaderContainer>
+    </Box>
   );
 };
-
-const PageHeaderContainer = styled(Box)`
-  width: 100%;
-
-  /**
-   * Blueprint breadcrumbs annoyingly have a built-in height.
-   */
-  .bp5-breadcrumbs {
-    height: auto;
-    min-height: 30px;
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/TokenizingField.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TokenizingField.module.css
@@ -1,0 +1,88 @@
+/* This file was converted from styled-components to CSS modules */
+.tagInput {
+  background-color: var(--color-background-default);
+  border: none;
+  border-radius: 8px;
+  box-shadow: var(--color-border-default) inset 0px 0px 0px 1px;
+  color: var(--color-text-default);
+  min-width: 400px;
+  transition: box-shadow 150ms;
+}
+
+.tagInput input {
+  background-color: var(--color-background-default);
+  color: var(--color-text-default);
+  font-size: 14px;
+  font-weight: 400;
+  padding-left: 4px;
+  padding-bottom: 2px;
+  padding-top: 2px;
+}
+
+.tagInput.active {
+  background-color: var(--color-background-default);
+  color: var(--color-text-default);
+  box-shadow:
+    var(--color-border-default) inset 0px 0px 0px 1px,
+    var(--color-focus-ring) 0 0 0 3px;
+}
+
+.tagInput :global(.bp5-tag-input-values:first-child) :global(.bp5-input-ghost:first-child) {
+  padding-left: 8px;
+}
+
+.tagInput :global(.bp5-tag-input-values) {
+  margin-right: 4px;
+  margin-top: 4px;
+}
+
+.tagInput :global(.bp5-tag-input-values) > * {
+  margin-bottom: 4px;
+}
+
+.tagInput :global(.bp5-tag) {
+  border-radius: 6px;
+  display: inline-flex;
+  flex-direction: row;
+  font-size: 12px;
+  line-height: 16px;
+  align-items: center;
+  max-width: 400px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding: 4px 8px;
+  user-select: none;
+}
+
+.tagInput :global(.bp5-tag.bp5-minimal:not([class*='bp5-intent-'])) {
+  background-color: var(--color-background-gray);
+  color: var(--color-text-default);
+}
+
+.tagInput :global(.bp5-tag.bp5-minimal.bp5-intent-success) {
+  background-color: var(--color-background-green);
+  color: var(--color-text-green);
+}
+
+.tagInput :global(.bp5-tag.bp5-minimal.bp5-intent-warning) {
+  background-color: var(--color-background-yellow);
+  color: var(--color-text-yellow);
+}
+
+.tagInput :global(.bp5-tag.bp5-minimal.bp5-intent-danger) {
+  background-color: var(--color-background-red);
+  color: var(--color-text-red);
+}
+
+.menu {
+  width: 400px;
+}
+
+.fullWidth {
+  max-width: 100%;
+}
+
+.defaultWidth {
+  max-width: 600px;
+}

--- a/js_modules/dagster-ui/packages/ui-components/src/components/TokenizingField.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TokenizingField.tsx
@@ -1,13 +1,14 @@
 // eslint-disable-next-line no-restricted-imports
 import {TagInput} from '@blueprintjs/core';
 import * as React from 'react';
-import styled from 'styled-components';
+import clsx from 'clsx';
 
 import {Box} from './Box';
 import {Colors} from './Color';
 import {Menu, MenuItem} from './Menu';
 import {Popover} from './Popover';
 import {Spinner} from './Spinner';
+import styles from './TokenizingField.module.css';
 
 const MAX_SUGGESTIONS = 100;
 
@@ -378,7 +379,7 @@ export const TokenizingField = ({
       content={
         suggestions.length > 0 ? (
           <div style={{maxHeight: 235, overflowY: 'scroll'}} ref={menuRef}>
-            <StyledMenu>
+            <Menu className={styles.menu}>
               {suggestions.map((suggestion, idx) => (
                 <MenuItem
                   data-idx={idx}
@@ -394,15 +395,19 @@ export const TokenizingField = ({
                   }}
                 />
               ))}
-            </StyledMenu>
+            </Menu>
           </div>
         ) : (
           <div />
         )
       }
     >
-      <StyledTagInput
-        className={className}
+      <TagInput
+        className={clsx(
+          styles.tagInput,
+          fullwidth ? styles.fullWidth : styles.defaultWidth,
+          className
+        )}
         values={values.map((v) => (v.token ? `${v.token}:${v.value}` : v.value))}
         inputValue={typed}
         onRemove={(_, idx) => {
@@ -440,7 +445,6 @@ export const TokenizingField = ({
             }
           },
         }}
-        $maxWidth={fullwidth ? '100%' : undefined}
         onAdd={() => false}
         onKeyDown={onKeyDown}
         tagProps={{minimal: true}}
@@ -456,84 +460,3 @@ export const TokenizingField = ({
     </Popover>
   );
 };
-
-export const StyledTagInput = styled(TagInput)<{$maxWidth?: any}>`
-  background-color: ${Colors.backgroundDefault()};
-  border: none;
-  border-radius: 8px;
-  box-shadow: ${Colors.borderDefault()} inset 0px 0px 0px 1px;
-  color: ${Colors.textDefault()};
-  min-width: 400px;
-  max-width: ${(p) => (p.$maxWidth ? p.$maxWidth : '600px')};
-  transition: box-shadow 150ms;
-
-  input {
-    background-color: ${Colors.backgroundDefault()};
-    color: ${Colors.textDefault()};
-    font-size: 14px;
-    font-weight: 400;
-    padding-left: 4px;
-    padding-bottom: 2px;
-    padding-top: 2px;
-  }
-
-  &&.bp5-tag-input.bp5-active {
-    background-color: ${Colors.backgroundDefault()};
-    color: ${Colors.textDefault()};
-    box-shadow:
-      ${Colors.borderDefault()} inset 0px 0px 0px 1px,
-      ${Colors.focusRing()} 0 0 0 3px;
-  }
-
-  && .bp5-tag-input-values:first-child .bp5-input-ghost:first-child {
-    padding-left: 8px;
-  }
-
-  && .bp5-tag-input-values {
-    margin-right: 4px;
-    margin-top: 4px;
-  }
-
-  && .bp5-tag-input-values > * {
-    margin-bottom: 4px;
-  }
-
-  .bp5-tag {
-    border-radius: 6px;
-    display: inline-flex;
-    flex-direction: row;
-    font-size: 12px;
-    line-height: 16px;
-    align-items: center;
-    max-width: 400px;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    padding: 4px 8px;
-    user-select: none;
-  }
-
-  .bp5-tag.bp5-minimal:not([class*='bp5-intent-']) {
-    background-color: ${Colors.backgroundGray()};
-    color: ${Colors.textDefault()};
-  }
-
-  .bp5-tag.bp5-minimal.bp5-intent-success {
-    background-color: ${Colors.backgroundGreen()};
-    color: ${Colors.textGreen()};
-  }
-
-  .bp5-tag.bp5-minimal.bp5-intent-warning {
-    background-color: ${Colors.backgroundYellow()};
-    color: ${Colors.textYellow()};
-  }
-
-  .bp5-tag.bp5-minimal.bp5-intent-danger {
-    background-color: ${Colors.backgroundRed()};
-    color: ${Colors.textRed()};
-  }
-`;
-
-const StyledMenu = styled(Menu)`
-  width: 400px;
-`;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/UnstyledButton.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/UnstyledButton.module.css
@@ -1,0 +1,30 @@
+/* This file was converted from styled-components to CSS modules */
+.unstyledButton {
+  border: 0;
+  background-color: transparent;
+  border-radius: 4px;
+  color: var(--color-text-default);
+  cursor: pointer;
+  padding: 0;
+  text-align: start;
+  transition:
+    box-shadow 150ms,
+    opacity 150ms;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.expandedClick {
+  padding: var(--expanded-click-px);
+  margin: calc(-1 * var(--expanded-click-px));
+}
+
+.unstyledButton:disabled {
+  color: inherit;
+  cursor: default;
+  opacity: 0.6;
+}
+
+.outlineOnHover:hover {
+  box-shadow: 0 0 0 1px var(--color-keyline-default);
+}

--- a/js_modules/dagster-ui/packages/ui-components/src/components/UnstyledButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/UnstyledButton.tsx
@@ -1,46 +1,36 @@
-import styled, {css} from 'styled-components';
+import * as React from 'react';
+import clsx from 'clsx';
+import styles from './UnstyledButton.module.css';
 
-import {Colors} from './Color';
-
-interface Props {
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   $expandedClickPx?: number;
   $outlineOnHover?: boolean;
 }
 
-export const UnstyledButton = styled.button<Props>`
-  border: 0;
-  background-color: transparent;
-  border-radius: 4px;
-  color: ${Colors.textDefault()};
-  cursor: pointer;
-  padding: 0;
-  text-align: start;
-  transition:
-    box-shadow 150ms,
-    opacity 150ms;
-  user-select: none;
-  white-space: nowrap;
+export const UnstyledButton = React.forwardRef<HTMLButtonElement, Props>(
+  ({$expandedClickPx, $outlineOnHover, className, style, ...rest}, ref) => {
+    const buttonStyle = React.useMemo(() => {
+      if ($expandedClickPx) {
+        return {
+          ...style,
+          '--expanded-click-px': `${$expandedClickPx}px`,
+        };
+      }
+      return style;
+    }, [style, $expandedClickPx]);
 
-  ${({$expandedClickPx}) =>
-    $expandedClickPx
-      ? css`
-          padding: ${$expandedClickPx}px;
-          margin: -${$expandedClickPx}px;
-        `
-      : null}
-
-  &:disabled {
-    color: inherit;
-    cursor: default;
-    opacity: 0.6;
-  }
-
-  ${({$outlineOnHover}) =>
-    $outlineOnHover
-      ? css`
-          &:hover {
-            box-shadow: 0 0 0 1px var(--color-keyline-default);
-          }
-        `
-      : null}
-`;
+    return (
+      <button
+        ref={ref}
+        className={clsx(
+          styles.unstyledButton,
+          $expandedClickPx ? styles.expandedClick : null,
+          $outlineOnHover ? styles.outlineOnHover : null,
+          className,
+        )}
+        style={buttonStyle}
+        {...rest}
+      />
+    );
+  },
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/app/WebSocketProvider.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/WebSocketProvider.module.css
@@ -1,0 +1,19 @@
+/*
+  Styles for the WebSocketStatus indicator circle.
+  Originally from styled-components in WebSocketProvider.tsx:
+  align-self: center;
+  width: 12px;
+  height: 12px;
+  display: inline-block;
+  border-radius: 7px;
+  border: 1px solid var(--color-accent-primary);
+*/
+
+.circle {
+  align-self: center;
+  width: 12px;
+  height: 12px;
+  display: inline-block;
+  border-radius: 7px;
+  border: 1px solid var(--color-accent-primary);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/WebSocketProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/WebSocketProvider.tsx
@@ -1,10 +1,10 @@
 import {Colors} from '@dagster-io/ui-components';
 import debounce from 'lodash/debounce';
 import * as React from 'react';
-import styled from 'styled-components';
-import {SubscriptionClient} from 'subscriptions-transport-ws';
+import styles from './WebSocketProvider.module.css';
 
 import {useFeatureFlags} from './Flags';
+import {SubscriptionClient} from 'subscriptions-transport-ws';
 
 type Availability = 'attempting-to-connect' | 'unavailable' | 'available';
 
@@ -126,30 +126,41 @@ export const WebSocketProvider = (props: Props) => {
   return <WebSocketContext.Provider value={value}>{children}</WebSocketContext.Provider>;
 };
 
-const Circle = styled.div`
-  align-self: center;
-  width: 12px;
-  height: 12px;
-  display: inline-block;
-  border-radius: 7px;
-  border: 1px solid ${Colors.accentPrimary()};
-`;
-
-export const WebSocketStatus = (props: React.ComponentProps<typeof Circle>) => (
+export const WebSocketStatus = (props: React.ComponentProps<'div'>) => (
   <WebSocketContext.Consumer>
     {({status}) =>
       ({
         [WebSocket.CONNECTING]: (
-          <Circle style={{background: Colors.accentLime()}} title="Connecting..." {...props} />
+          <div
+            className={styles.circle}
+            style={{background: Colors.accentLime()}}
+            title="Connecting..."
+            {...props}
+          />
         ),
         [WebSocket.OPEN]: (
-          <Circle style={{background: Colors.accentGreen()}} title="Connected" {...props} />
+          <div
+            className={styles.circle}
+            style={{background: Colors.accentGreen()}}
+            title="Connected"
+            {...props}
+          />
         ),
         [WebSocket.CLOSING]: (
-          <Circle style={{background: Colors.accentGray()}} title="Closing..." {...props} />
+          <div
+            className={styles.circle}
+            style={{background: Colors.accentGray()}}
+            title="Closing..."
+            {...props}
+          />
         ),
       })[status] || (
-        <Circle style={{background: Colors.accentGray()}} title="Disconnected" {...props} />
+        <div
+          className={styles.circle}
+          style={{background: Colors.accentGray()}}
+          title="Disconnected"
+          {...props}
+        />
       )
     }
   </WebSocketContext.Consumer>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/KeyboardTag.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/KeyboardTag.module.css
@@ -1,0 +1,12 @@
+.keyboardTag {
+  background: var(--color-background-gray);
+  border-radius: 4px;
+  padding: 2px 4px;
+  margin-left: 6px;
+  font-size: 12px;
+  color: var(--color-text-light);
+}
+
+.withinTooltip {
+  color: var(--color-accent-white);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/KeyboardTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/KeyboardTag.tsx
@@ -1,17 +1,20 @@
-import {Colors} from '@dagster-io/ui-components';
-import styled from 'styled-components';
+import clsx from 'clsx';
+import styles from './KeyboardTag.module.css';
 
 interface KeyboardTagProps {
-  $withinTooltip?: boolean;
+  withinTooltip?: boolean;
+  className?: string;
 }
 
-export const KeyboardTag = styled.div<KeyboardTagProps>`
-  ${(props) => {
-    return props.$withinTooltip ? `color: ${Colors.accentWhite()}` : `color: ${Colors.textLight()}`;
-  }};
-  background: ${Colors.backgroundGray()};
-  border-radius: 4px;
-  padding: 2px 4px;
-  margin-left: 6px;
-  font-size: 12px;
-`;
+export const KeyboardTag = ({withinTooltip, className, ...rest}: KeyboardTagProps & React.HTMLAttributes<HTMLDivElement>) => {
+  return (
+    <div 
+      className={clsx(
+        styles.keyboardTag, 
+        withinTooltip ? styles.withinTooltip : null,
+        className
+      )}
+      {...rest}
+    />
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/VirtualizedAutomationRow.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/VirtualizedAutomationRow.module.css
@@ -1,0 +1,4 @@
+.automationRowGrid {
+  display: grid;
+  height: 100%;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/VirtualizedAutomationRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/VirtualizedAutomationRow.tsx
@@ -1,7 +1,6 @@
 import {Box} from '@dagster-io/ui-components';
-import styled from 'styled-components';
-
 import {HeaderCell, HeaderRow} from '../ui/VirtualizedTable';
+import styles from './VirtualizedAutomationRow.module.css';
 
 export const TEMPLATE_COLUMNS = '60px minmax(400px, 1.5fr) 240px 1fr 200px 200px';
 
@@ -20,8 +19,12 @@ export const VirtualizedAutomationHeader = ({checkbox}: {checkbox: React.ReactNo
   );
 };
 
-export const AutomationRowGrid = styled(Box)`
-  display: grid;
-  grid-template-columns: ${TEMPLATE_COLUMNS};
-  height: 100%;
-`;
+export const AutomationRowGrid = ({children, ...rest}) => (
+  <Box 
+    className={styles.automationRowGrid} 
+    style={{gridTemplateColumns: TEMPLATE_COLUMNS}} 
+    {...rest}
+  >
+    {children}
+  </Box>
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/ParentOpNode.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/ParentOpNode.module.css
@@ -1,0 +1,7 @@
+.labeledParentRect {
+  transition:
+    x 250ms ease-out,
+    y 250ms ease-out,
+    width 250ms ease-out,
+    height 250ms ease-out;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/ParentOpNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/ParentOpNode.tsx
@@ -1,6 +1,6 @@
 import {Colors} from '@dagster-io/ui-components';
 import {Fragment} from 'react';
-import styled from 'styled-components';
+import clsx from 'clsx';
 
 import {ExternalConnectionNode} from './ExternalConnectionNode';
 import {MappingLine} from './MappingLine';
@@ -11,6 +11,8 @@ import {Edge} from './common';
 import {OpGraphOpFragment} from './types/OpGraph.types';
 import {titleOfIO} from '../app/titleOfIO';
 import {OpNameOrPath} from '../ops/OpNameOrPath';
+
+import styles from './ParentOpNode.module.css';
 
 interface ParentOpNodeProps {
   layout: OpGraphLayout;
@@ -231,10 +233,11 @@ const SVGLabeledRect = ({
   </g>
 );
 
-export const SVGLabeledParentRect = styled(SVGLabeledRect)`
-  transition:
-    x 250ms ease-out,
-    y 250ms ease-out,
-    width 250ms ease-out,
-    height 250ms ease-out;
-`;
+export const SVGLabeledParentRect = (props: Parameters<typeof SVGLabeledRect>[0]) => {
+  return (
+    <SVGLabeledRect
+      {...props}
+      className={clsx(styles.labeledParentRect, props.className)}
+    />
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsIdentifierDot.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsIdentifierDot.module.css
@@ -1,0 +1,7 @@
+.insightsIdentifierDot {
+  border-radius: 50%;
+  height: 12px;
+  width: 12px;
+  flex-shrink: 0;
+  cursor: pointer;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsIdentifierDot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsIdentifierDot.tsx
@@ -1,10 +1,26 @@
-import styled from 'styled-components';
+import React from 'react';
+import styles from './InsightsIdentifierDot.module.css';
 
-export const InsightsIdentifierDot = styled.div<{$color: string}>`
-  background-color: ${({$color}) => $color};
-  border-radius: 50%;
-  height: 12px;
-  width: 12px;
-  flex-shrink: 0;
-  cursor: pointer;
-`;
+interface InsightsIdentifierDotProps {
+  color: string;
+  className?: string;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+}
+
+export const InsightsIdentifierDot: React.FC<InsightsIdentifierDotProps> = ({
+  color,
+  className,
+  onClick,
+  ...rest
+}) => {
+  return (
+    <div
+      className={
+        className ? `${styles.insightsIdentifierDot} ${className}` : styles.insightsIdentifierDot
+      }
+      style={{backgroundColor: color}}
+      onClick={onClick}
+      {...rest}
+    />
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/VirtualizedInstanceConcurrencyTable.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/VirtualizedInstanceConcurrencyTable.module.css
@@ -1,0 +1,4 @@
+.rowGrid {
+  display: grid;
+  height: 100%;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/VirtualizedInstanceConcurrencyTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/VirtualizedInstanceConcurrencyTable.tsx
@@ -2,7 +2,7 @@ import {Box, Icon, useDelayedState} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import {useRef} from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+import styles from './VirtualizedInstanceConcurrencyTable.module.css';
 
 import {gql, useQuery} from '../apollo-client';
 import {
@@ -85,7 +85,11 @@ const ConcurrencyRow = ({
   const path = `/deployment/concurrency/${encodeURIComponent(concurrencyKey)}`;
   return (
     <Row $height={height} $start={start}>
-      <RowGrid border="bottom">
+      <Box 
+        className={styles.rowGrid} 
+        border="bottom" 
+        style={{gridTemplateColumns: POOL_TEMPLATE_COLUMNS}}
+      >
         <RowCell>
           <Box flex={{gap: 4, alignItems: 'center'}}>
             <Icon name="dynamic_feed" />
@@ -95,7 +99,7 @@ const ConcurrencyRow = ({
         <RowCell>
           {limit ? <div>{limit.slotCount}</div> : <LoadingOrNone queryResult={queryResult} />}
         </RowCell>
-      </RowGrid>
+      </Box>
     </Row>
   );
 };
@@ -123,8 +127,3 @@ const SINGLE_CONCURRENCY_KEY_QUERY = gql`
   }
 `;
 
-const RowGrid = styled(Box)`
-  display: grid;
-  grid-template-columns: ${POOL_TEMPLATE_COLUMNS};
-  height: 100%;
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillAssetPartitionsTable.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillAssetPartitionsTable.module.css
@@ -1,0 +1,26 @@
+.rowGrid {
+  display: grid;
+  grid-template-columns: var(--template-columns);
+  height: 100%;
+}
+
+.statusBarContainer {
+  border-radius: 8px;
+  background-color: var(--color-background-light);
+  display: grid;
+  height: 12px;
+  width: 200px;
+  overflow: hidden;
+}
+
+.statusBarSuccess {
+  background: var(--color-accent-green);
+}
+
+.statusBarFailed {
+  background: var(--color-accent-red);
+}
+
+.statusBarInProgress {
+  background: var(--color-accent-blue);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillAssetPartitionsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillAssetPartitionsTable.tsx
@@ -10,8 +10,9 @@ import {
 import {useVirtualizer} from '@tanstack/react-virtual';
 import React, {useRef} from 'react';
 import {Link, useHistory} from 'react-router-dom';
-import styled from 'styled-components';
+import clsx from 'clsx';
 
+import styles from './BackfillAssetPartitionsTable.module.css';
 import {
   BackfillPartitionsForAssetKeyQuery,
   BackfillPartitionsForAssetKeyQueryVariables,
@@ -35,6 +36,9 @@ import {Container, HeaderCell, HeaderRow, Inner, Row, RowCell} from '../../ui/Vi
 import {numberFormatter} from '../../ui/formatters';
 
 const TEMPLATE_COLUMNS = '60% repeat(4, 1fr)';
+
+// Define CSS variable for template columns
+document.documentElement.style.setProperty('--template-columns', TEMPLATE_COLUMNS);
 
 type AssetBackfillStatus = NonNullable<
   BackfillDetailsBackfillFragment['assetBackfillData']
@@ -215,7 +219,7 @@ export const VirtualizedBackfillPartitionsRow = ({
       $start={start}
       data-testid={testId(`backfill-asset-row-${tokenForAssetKey(asset.assetKey)}`)}
     >
-      <RowGrid border="bottom">
+      <Box className={styles.rowGrid} border="bottom">
         <RowCell>
           <Box
             flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'baseline'}}
@@ -281,16 +285,10 @@ export const VirtualizedBackfillPartitionsRow = ({
             </RowCell>
           </>
         )}
-      </RowGrid>
+      </Box>
     </Row>
   );
 };
-
-const RowGrid = styled(Box)`
-  display: grid;
-  grid-template-columns: ${TEMPLATE_COLUMNS};
-  height: 100%;
-`;
 
 export const BACKFILL_PARTITIONS_FOR_ASSET_KEY_QUERY = gql`
   query BackfillPartitionsForAssetKey($backfillId: String!, $assetKey: AssetKeyInput!) {
@@ -329,20 +327,15 @@ export function StatusBar({
   return (
     <Box flex={{direction: 'column', alignItems: 'flex-end', gap: 2}}>
       <div
+        className={styles.statusBarContainer}
         style={{
-          borderRadius: '8px',
-          backgroundColor: Colors.backgroundLight(),
-          display: 'grid',
           gridTemplateColumns: `${pctSucceeded.toFixed(2)}% ${pctFailed.toFixed(2)}% ${pctInProgress.toFixed(2)}%`,
           gridTemplateRows: '100%',
-          height: '12px',
-          width: '200px',
-          overflow: 'hidden',
         }}
       >
-        <div style={{background: Colors.accentGreen()}} />
-        <div style={{background: Colors.accentRed()}} />
-        <div style={{background: Colors.accentBlue()}} />
+        <div className={styles.statusBarSuccess} />
+        <div className={styles.statusBarFailed} />
+        <div className={styles.statusBarInProgress} />
       </div>
       <Caption color={Colors.textLight()}>{`${pctFinal}% completed`}</Caption>
     </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillOverviewDetails.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillOverviewDetails.module.css
@@ -1,0 +1,5 @@
+.label {
+  color: var(--color-text-light);
+  font-size: 12px;
+  line-height: 16px;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillOverviewDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillOverviewDetails.tsx
@@ -1,5 +1,5 @@
-import {Box, Colors} from '@dagster-io/ui-components';
-import styled from 'styled-components';
+import {Box} from '@dagster-io/ui-components';
+import styles from './BackfillOverviewDetails.module.css';
 
 import {BackfillStatusTagForPage} from './BackfillStatusTagForPage';
 import {LiveDuration} from './LiveDuration';
@@ -51,13 +51,7 @@ export const BackfillOverviewDetails = ({backfill}: {backfill: any}) => (
 
 const Detail = ({label, detail}: {label: JSX.Element | string; detail: JSX.Element | string}) => (
   <Box flex={{direction: 'column', gap: 4}} style={{minWidth: '280px'}}>
-    <Label>{label}</Label>
+    <div className={styles.label}>{label}</div>
     <div>{detail}</div>
   </Box>
 );
-
-const Label = styled.div`
-  color: ${Colors.textLight()};
-  font-size: 12px;
-  line-height: 16px;
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.module.css
@@ -1,0 +1,12 @@
+/* Button with no styling, used for interactive tags */
+.tagButton {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+}
+
+.tagButton:focus {
+  outline: none;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -1,8 +1,9 @@
 import {Box, Colors, Icon, Mono, Tag, useDelayedState} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+import clsx from 'clsx';
 
+import styles from './BackfillRow.module.css';
 import {BackfillActionsMenu} from './BackfillActionsMenu';
 import {BackfillStatusTagForPage} from './BackfillStatusTagForPage';
 import {SingleBackfillQuery, SingleBackfillQueryVariables} from './types/BackfillRow.types';
@@ -283,11 +284,11 @@ const BackfillRequestedRange = ({
     <Box flex={{direction: 'column', gap: 8}}>
       <div>
         {partitionNames ? (
-          <TagButton onClick={onExpand}>
+          <button className={styles.tagButton} onClick={onExpand}>
             <Tag intent="primary" interactive>
               {numPartitionsLabel}
             </Tag>
-          </TagButton>
+          </button>
         ) : (
           <Tag intent="primary">{numPartitionsLabel}</Tag>
         )}
@@ -310,17 +311,6 @@ const RequestedPartitionStatusBar = ({all, requested}: {all: string[]; requested
   return <PartitionStatus small hideStatusTooltip partitionNames={all} health={health} />;
 };
 
-const TagButton = styled.button`
-  border: none;
-  background: none;
-  cursor: pointer;
-  padding: 0;
-  margin: 0;
-
-  :focus {
-    outline: none;
-  }
-`;
 
 export const SINGLE_BACKFILL_CANCELABLE_RUNS_QUERY = gql`
   query SingleBackfillQuery($backfillId: String!) {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStatusTagForPage.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStatusTagForPage.module.css
@@ -1,0 +1,11 @@
+.tagButton {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+}
+
+.tagButton:focus {
+  outline: none;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStatusTagForPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStatusTagForPage.tsx
@@ -1,10 +1,11 @@
 import {Box, ButtonLink, Tag} from '@dagster-io/ui-components';
-import styled from 'styled-components';
 
 import {showCustomAlert} from '../../app/CustomAlertProvider';
 import {PythonErrorInfo} from '../../app/PythonErrorInfo';
 import {PythonErrorFragment} from '../../app/types/PythonErrorFragment.types';
 import {BulkActionStatus} from '../../graphql/types';
+
+import styles from './BackfillStatusTagForPage.module.css';
 
 type BackfillState = {
   status: BulkActionStatus;
@@ -19,9 +20,9 @@ export const BackfillStatusTagForPage = ({backfill}: {backfill: BackfillState}) 
 
     return (
       <Box margin={{bottom: 12}} flex={{gap: 8}}>
-        <TagButton onClick={onClick}>
+        <button className={styles.tagButton} onClick={onClick}>
           <Tag intent="danger">{status}</Tag>
-        </TagButton>
+        </button>
         <ButtonLink onClick={onClick}>View error</ButtonLink>
       </Box>
     );
@@ -47,15 +48,3 @@ export const BackfillStatusTagForPage = ({backfill}: {backfill: BackfillState}) 
       return <Tag>{status}</Tag>;
   }
 };
-
-const TagButton = styled.button`
-  border: none;
-  background: none;
-  cursor: pointer;
-  padding: 0;
-  margin: 0;
-
-  :focus {
-    outline: none;
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/InstigationUtils.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/InstigationUtils.module.css
@@ -1,0 +1,19 @@
+/* Status table styles */
+.statusTable {
+  font-size: 13px;
+  border-spacing: 0;
+}
+
+.statusTable tr {
+  box-shadow: none;
+}
+
+.statusTable tbody > tr > td {
+  background: transparent;
+  box-shadow: none !important;
+  padding: 1px 0;
+}
+
+.statusTable tbody > tr > td:first-child {
+  color: var(--color-text-light);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/InstigationUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/InstigationUtils.tsx
@@ -1,6 +1,6 @@
 import {Colors, Group, Mono} from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+import clsx from 'clsx';
 
 import {TICK_TAG_FRAGMENT} from './InstigationTick';
 import {gql} from '../apollo-client';
@@ -9,6 +9,7 @@ import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {LastRunSummary} from '../instance/LastRunSummary';
 import {RunStatusIndicator} from '../runs/RunStatusDots';
 import {RUN_TIME_FRAGMENT, titleForRun} from '../runs/RunUtils';
+import styles from './InstigationUtils.module.css';
 
 export const InstigatedRunStatus = ({
   instigationState,
@@ -77,24 +78,9 @@ export const INSTIGATION_STATE_FRAGMENT = gql`
   ${TICK_TAG_FRAGMENT}
 `;
 
-export const StatusTable = styled.table`
-  font-size: 13px;
-  border-spacing: 0;
-
-  &&&&& tr {
-    box-shadow: none;
-  }
-
-  &&&&& tbody > tr > td {
-    background: transparent;
-    box-shadow: none !important;
-    padding: 1px 0;
-  }
-
-  &&&&& tbody > tr > td:first-child {
-    color: ${Colors.textLight()};
-  }
-`;
+export const StatusTable = (props: React.TableHTMLAttributes<HTMLTableElement>) => (
+  <table {...props} className={clsx(styles.statusTable, props.className)} />
+);
 
 export const DYNAMIC_PARTITIONS_REQUEST_RESULT_FRAGMENT = gql`
   fragment DynamicPartitionsRequestResultFragment on DynamicPartitionsRequestResult {

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.module.css
@@ -1,0 +1,4 @@
+.tableWrapper th,
+.tableWrapper td {
+  vertical-align: middle !important;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -22,7 +22,9 @@ import {Chart} from 'chart.js';
 import zoomPlugin from 'chartjs-plugin-zoom';
 import * as React from 'react';
 import {useState} from 'react';
-import styled from 'styled-components';
+import clsx from 'clsx';
+
+import styles from './TickHistory.module.css';
 
 import {TICK_TAG_FRAGMENT} from './InstigationTick';
 import {HISTORY_TICK_FRAGMENT, RUN_STATUS_FRAGMENT, RunStatusLink} from './InstigationUtils';
@@ -205,7 +207,7 @@ export const TicksTable = ({
         </Box>
       </Box>
       {ticks.length ? (
-        <TableWrapper>
+        <Table className={styles.tableWrapper}>
           <thead>
             <tr>
               <th style={{width: 120}}>Timestamp</th>
@@ -231,7 +233,7 @@ export const TicksTable = ({
               />
             ))}
           </tbody>
-        </TableWrapper>
+        </Table>
       ) : (
         <Box padding={{vertical: 32}} flex={{justifyContent: 'center'}}>
           <NonIdealState icon="no-results" title="No ticks to display" />
@@ -579,9 +581,3 @@ const TICK_HISTORY_QUERY = gql`
   ${HISTORY_TICK_FRAGMENT}
 `;
 
-const TableWrapper = styled(Table)`
-  th,
-  td {
-    vertical-align: middle !important;
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickMaterializationsTable.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickMaterializationsTable.module.css
@@ -1,0 +1,9 @@
+.rowGrid {
+  display: grid;
+  grid-template-columns: var(--template-columns);
+  height: 100%;
+}
+
+.rowGrid > * {
+  justify-content: center;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickMaterializationsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickMaterializationsTable.tsx
@@ -15,7 +15,7 @@ import {
 import {useVirtualizer} from '@tanstack/react-virtual';
 import {useMemo, useRef, useState} from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+import clsx from 'clsx';
 
 import {gql, useQuery} from '../apollo-client';
 import {
@@ -31,6 +31,7 @@ import {AssetKeyInput} from '../graphql/types';
 import {Container, HeaderRow} from '../ui/VirtualizedTable';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
+import styles from './TickMaterializationsTable.module.css';
 
 const TEMPLATE_COLUMNS = '30% 17% 53%';
 
@@ -173,7 +174,7 @@ const AssetDetailRow = ({
 
   return (
     <Row $start={$start} $height={$height}>
-      <RowGrid border="bottom">
+      <Box className={styles.rowGrid} border="bottom" style={{'--template-columns': TEMPLATE_COLUMNS} as React.CSSProperties}>
         <RowCell>
           <AssetLink path={assetKey.path} icon="asset" textStyle="middle-truncate" />
         </RowCell>
@@ -211,19 +212,10 @@ const AssetDetailRow = ({
             </>
           ) : null}
         </RowCell>
-      </RowGrid>
+      </Box>
     </Row>
   );
 };
-
-const RowGrid = styled(Box)`
-  display: grid;
-  grid-template-columns: ${TEMPLATE_COLUMNS};
-  height: 100%;
-  > * {
-    justify-content: center;
-  }
-`;
 
 const ASSET_GROUP_QUERY = gql`
   query AssetGroupAndLocationQuery($assetKey: AssetKeyInput!) {

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/RepoSelector.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/RepoSelector.module.css
@@ -1,0 +1,24 @@
+.repoLabel {
+  cursor: pointer;
+  display: block;
+  font-weight: 500;
+  overflow: hidden;
+  position: relative;
+  top: 1px;
+  transition: filter 50ms linear;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.repoLabel:focus,
+.repoLabel:active {
+  outline: none;
+}
+
+.repoLabel:hover {
+  filter: opacity(0.8);
+}
+
+.repoLocation {
+  color: var(--color-text-light);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/RepoSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/RepoSelector.tsx
@@ -12,6 +12,7 @@ import {
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
+import clsx from 'clsx';
 
 import {
   NO_RELOAD_PERMISSION_TEXT,
@@ -21,6 +22,7 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
+import styles from './RepoSelector.module.css';
 
 export interface RepoSelectorOption {
   repositoryLocation: {name: string};
@@ -87,9 +89,9 @@ export const RepoSelector = (props: Props) => {
                   />
                 </td>
                 <td>
-                  <RepoLabel htmlFor={`switch-${addressString}`}>
+                  <label className={styles.repoLabel} htmlFor={`switch-${addressString}`}>
                     <Box flex={{direction: 'column', gap: 4}}>
-                      <RepoLocation>{addressString}</RepoLocation>
+                      <div className={styles.repoLocation}>{addressString}</div>
                       <Box flex={{direction: 'column', gap: 2}}>
                         {option.repository.displayMetadata.map(({key, value}) => (
                           <Caption
@@ -99,7 +101,7 @@ export const RepoSelector = (props: Props) => {
                         ))}
                       </Box>
                     </Box>
-                  </RepoLabel>
+                  </label>
                 </td>
                 <td>
                   <Link to={workspacePathFromAddress(repoAddress)} onClick={() => onBrowse()}>
@@ -117,31 +119,6 @@ export const RepoSelector = (props: Props) => {
     </div>
   );
 };
-
-const RepoLabel = styled.label`
-  cursor: pointer;
-  display: block;
-  font-weight: 500;
-  overflow: hidden;
-  position: relative;
-  top: 1px;
-  transition: filter 50ms linear;
-  user-select: none;
-  white-space: nowrap;
-
-  :focus,
-  :active {
-    outline: none;
-  }
-
-  :hover {
-    filter: opacity(0.8);
-  }
-`;
-
-const RepoLocation = styled.div`
-  color: ${Colors.textLight()};
-`;
 
 const ReloadButton = ({repoAddress}: {repoAddress: RepoAddress}) => {
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/ExecutionStateDot.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/ExecutionStateDot.module.css
@@ -1,0 +1,43 @@
+/*
+ExecutionStateDot styles for each IStepState value.
+Colors reference Dagster CSS variables.
+*/
+.dot {
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  border-radius: 5.5px;
+  transition: background 200ms linear;
+}
+
+.running {
+  background: var(--color-accent-gray);
+}
+.succeeded {
+  background: var(--color-accent-green);
+}
+.skipped {
+  background: var(--color-accent-yellow);
+}
+.failed,
+.preparing,
+.retryRequested,
+.unknown {
+  background: var(--color-accent-red);
+}
+
+.running:hover {
+  background: var(--color-accent-gray-hover);
+}
+.succeeded:hover {
+  background: var(--color-accent-green-hover);
+}
+.skipped:hover {
+  background: var(--color-accent-yellow-hover);
+}
+.failed:hover,
+.preparing:hover,
+.retryRequested:hover,
+.unknown:hover {
+  background: var(--color-accent-red-hover);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/ExecutionStateDot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/ExecutionStateDot.tsx
@@ -1,34 +1,20 @@
-import {Colors} from '@dagster-io/ui-components';
-import styled from 'styled-components';
+import React from 'react';
+import clsx from 'clsx';
 
 import {IStepState} from './RunMetadataProvider';
+import styles from './ExecutionStateDot.module.css';
 
-export const ExecutionStateDot = styled.div<{state: IStepState}>`
-  display: inline-block;
-  width: 11px;
-  height: 11px;
-  border-radius: 5.5px;
-  transition: background 200ms linear;
-  background: ${({state}) =>
-    ({
-      [IStepState.RUNNING]: Colors.accentGray(),
-      [IStepState.SUCCEEDED]: Colors.accentGreen(),
-      [IStepState.SKIPPED]: Colors.accentYellow(),
-      [IStepState.FAILED]: Colors.accentRed(),
-      [IStepState.PREPARING]: Colors.accentRed(),
-      [IStepState.RETRY_REQUESTED]: Colors.accentRed(),
-      [IStepState.UNKNOWN]: Colors.accentRed(),
-    })[state]};
-  &:hover {
-    background: ${({state}) =>
-      ({
-        [IStepState.RUNNING]: Colors.accentGrayHover(),
-        [IStepState.SUCCEEDED]: Colors.accentGreenHover(),
-        [IStepState.SKIPPED]: Colors.accentYellowHover(),
-        [IStepState.FAILED]: Colors.accentRedHover(),
-        [IStepState.PREPARING]: Colors.accentRedHover(),
-        [IStepState.RETRY_REQUESTED]: Colors.accentRedHover(),
-        [IStepState.UNKNOWN]: Colors.accentRedHover(),
-      })[state]};
-  }
-`;
+// Map IStepState to CSS module classnames
+const stateClassMap: Record<IStepState, string> = {
+  [IStepState.RUNNING]: styles.running || '',
+  [IStepState.SUCCEEDED]: styles.succeeded || '',
+  [IStepState.SKIPPED]: styles.skipped || '',
+  [IStepState.FAILED]: styles.failed || '',
+  [IStepState.PREPARING]: styles.preparing || '',
+  [IStepState.RETRY_REQUESTED]: styles.retryRequested || '',
+  [IStepState.UNKNOWN]: styles.unknown || '',
+};
+
+export const ExecutionStateDot = ({state}: {state: IStepState}) => (
+  <div className={clsx(styles.dot, stateClassMap[state])} />
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTableHeader.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTableHeader.module.css
@@ -1,0 +1,35 @@
+/* Styles for LogsScrollingTableHeader converted from styled-components */
+.headersContainer {
+  display: flex;
+  color: var(--color-text-light);
+  text-transform: uppercase;
+  font-size: 12px;
+  border-bottom: 1px solid var(--color-keyline-default);
+  z-index: 2;
+}
+
+.headerContainer {
+  flex-shrink: 0;
+  position: relative;
+  user-select: none;
+  display: inline-block;
+  padding: 0 12px;
+  line-height: 32px;
+}
+
+.headerDragHandle {
+  width: 1px;
+  height: 20000px;
+  position: absolute;
+  padding: 0 2px;
+}
+
+.headerLabel {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.infoContainer {
+  /* For Info column */
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTableHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTableHeader.tsx
@@ -1,8 +1,8 @@
 import {Colors} from '@dagster-io/ui-components';
 import * as React from 'react';
-import styled from 'styled-components';
 
 import {getJSONForKey} from '../hooks/useStateWithStorage';
+import styles from './LogsScrollingTableHeader.module.css';
 
 const ColumnWidthsStorageKey = 'ColumnWidths';
 const ColumnWidths = Object.assign(
@@ -107,17 +107,27 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     const isDraggable = !!this.props.onResize;
 
     return (
-      <HeaderContainer style={{width: this.props.width}}>
-        <HeaderDragHandle
+      <div className={styles.headerContainer} style={{width: this.props.width}}>
+        <div
+          className={styles.headerDragHandle}
           onMouseDown={isDraggable ? this.onMouseDown : undefined}
-          isDraggable={isDraggable}
-          isDragging={this.state.isDragging}
-          side={this.props.handleSide || 'right'}
+          style={{
+            cursor: isDraggable ? 'ew-resize' : 'default',
+            zIndex: 2,
+            right: this.props.handleSide === 'right' ? '-2px' : undefined,
+            left: this.props.handleSide === 'left' ? '-2px' : undefined,
+          }}
         >
-          <div />
-        </HeaderDragHandle>
-        <HeaderLabel>{this.props.children}</HeaderLabel>
-      </HeaderContainer>
+          <div
+            style={{
+              width: '1px',
+              height: '100%',
+              background: this.state.isDragging ? Colors.accentGray() : Colors.keylineDefault(),
+            }}
+          />
+        </div>
+        <div className={styles.headerLabel}>{this.props.children}</div>
+      </div>
     );
   }
 }
@@ -125,7 +135,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
 export const Headers = () => {
   const widths = React.useContext(ColumnWidthsContext);
   return (
-    <HeadersContainer>
+    <div className={styles.headersContainer}>
       <Header
         width={widths.timestamp}
         onResize={(width) => widths.onChange({...widths, timestamp: width})}
@@ -141,51 +151,9 @@ export const Headers = () => {
       >
         Event Type
       </Header>
-      <HeaderContainer style={{flex: 1}}>Info</HeaderContainer>
-    </HeadersContainer>
+      <div className={styles.infoContainer} style={{flex: 1}}>
+        Info
+      </div>
+    </div>
   );
 };
-
-export const HeadersContainer = styled.div`
-  display: flex;
-  color: ${Colors.textLight()};
-  text-transform: uppercase;
-  font-size: 12px;
-  border-bottom: 1px solid ${Colors.keylineDefault()};
-  z-index: 2;
-`;
-
-export const HeaderContainer = styled.div`
-  flex-shrink: 0;
-  position: relative;
-  user-select: none;
-  display: inline-block;
-  padding: 0 12px;
-  line-height: 32px;
-`;
-
-// eslint-disable-next-line no-unexpected-multiline
-const HeaderDragHandle = styled.div<{
-  side: 'left' | 'right';
-  isDraggable: boolean;
-  isDragging: boolean;
-}>`
-  width: 1px;
-  height: 20000px;
-  position: absolute;
-  cursor: ${({isDraggable}) => (isDraggable ? 'ew-resize' : 'default')};
-  z-index: 2;
-  ${({side}) => (side === 'right' ? `right: -2px;` : `left: -2px;`)}
-  padding: 0 2px;
-  & > div {
-    width: 1px;
-    height: 100%;
-    background: ${({isDragging}) => (isDragging ? Colors.accentGray() : Colors.keylineDefault())};
-  }
-`;
-
-const HeaderLabel = styled.div`
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.module.css
@@ -1,0 +1,5 @@
+/* Styles for LogsToolbar converted from styled-components */
+.nonMatchCheckbox {
+  margin: 0 4px 0 12px;
+  white-space: nowrap;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
@@ -11,7 +11,7 @@ import {
   Tooltip,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
-import styled from 'styled-components';
+import clsx from 'clsx';
 
 import {FilterOption, LogFilterSelect} from './LogFilterSelect';
 import {LogLevel} from './LogLevel';
@@ -22,6 +22,7 @@ import {getRunFilterProviders} from './getRunFilterProviders';
 import {EnabledRunLogLevelsKey, validateLogLevels} from './useQueryPersistedLogFilter';
 import {OptionsContainer, OptionsDivider} from '../gantt/VizComponents';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
+import styles from './LogsToolbar.module.css';
 
 export enum LogType {
   structured = 'structured',
@@ -336,7 +337,8 @@ const StructuredLogToolbar = ({
         onChange={onChange}
       />
       {filterText ? (
-        <NonMatchCheckbox
+        <Checkbox
+          className={styles.nonMatchCheckbox}
           checked={filter.hideNonMatches}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
             onSetFilter({...filter, hideNonMatches: event.currentTarget.checked})
@@ -355,11 +357,3 @@ const StructuredLogToolbar = ({
     </>
   );
 };
-
-const NonMatchCheckbox = styled(Checkbox)`
-  &&& {
-    margin: 0 4px 0 12px;
-  }
-
-  white-space: nowrap;
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RawLogContent.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RawLogContent.module.css
@@ -1,0 +1,129 @@
+.content {
+  padding: 10px;
+  background-color: var(--color-background-light);
+}
+
+.lineNumberContainer {
+  border-right: 1px solid var(--color-keyline-default);
+  padding: 10px 10px 10px 20px;
+  margin-right: 5px;
+  background-color: var(--color-background-light-hover);
+  opacity: 0.8;
+  color: var(--color-text-lighter);
+  min-height: 100%;
+  user-select: none;
+}
+
+.lineNumberContainer > div {
+  text-align: right;
+}
+
+.contentContainer {
+  display: flex;
+  flex-direction: row;
+  min-height: 100%;
+  background-color: var(--color-background-light);
+}
+
+.fileContainer {
+  flex: 1;
+  height: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.fileContainerHidden {
+  display: none;
+}
+
+.fileFooter {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  height: 30px;
+  background-color: var(--color-background-light);
+  border-top: 0.5px solid var(--color-keyline-default);
+  color: var(--color-text-light);
+  padding: 2px 5px;
+  font-size: 0.85em;
+}
+
+.fileFooterHidden {
+  display: none;
+}
+
+.fileContent {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.relativeContainer {
+  flex: 1;
+  position: relative;
+}
+
+.logContent {
+  color: var(--color-text-default);
+  font-family: var(--font-family-monospace);
+  font-size: 14px;
+  font-variant-ligatures: none;
+  white-space: pre;
+  overflow: auto;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.loadingContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: var(--color-background-default);
+  opacity: 0.3;
+}
+
+.scrollToast {
+  position: absolute;
+  height: 30px;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: flex-start;
+  z-index: 1;
+}
+
+.scrollToTop {
+  background-color: var(--color-background-lighter);
+  padding: 12px 20px 12px 14px;
+  border-bottom-right-radius: 5px;
+  border-bottom-left-radius: 5px;
+  color: var(--color-text-default);
+  border: 1px solid var(--color-border-default);
+  border-width: 0 1px 1px 1px;
+  cursor: pointer;
+  transition: background-color 100ms linear;
+}
+
+.scrollToTop:hover {
+  background-color: var(--color-background-lighter-hover);
+  border-color: var(--color-border-hover);
+}
+
+.fileWarning {
+  background-color: var(--color-background-yellow);
+  padding: 10px 20px;
+  margin: 20px 70px;
+  border-radius: 5px;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RepoSectionHeader.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RepoSectionHeader.module.css
@@ -1,0 +1,11 @@
+/* RepoName styled component -> .repoName */
+.repoName {
+  font-weight: 600;
+  color: var(--color-text-default);
+}
+
+/* RepoLocation styled component -> .repoLocation */
+.repoLocation {
+  color: var(--color-text-light);
+  margin-left: 4px;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RepoSectionHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RepoSectionHeader.tsx
@@ -1,9 +1,8 @@
 import {Box, Colors, Icon} from '@dagster-io/ui-components';
-import * as React from 'react';
-import styled from 'styled-components';
 
 import {TableSectionHeader, TableSectionHeaderProps} from '../workspace/TableSectionHeader';
 import {DUNDER_REPO_NAME} from '../workspace/buildRepoAddress';
+import styles from './RepoSectionHeader.module.css';
 
 interface Props extends TableSectionHeaderProps {
   repoName: string;
@@ -19,21 +18,12 @@ export const RepoSectionHeader = (props: Props) => {
       <Box flex={{alignItems: 'center', gap: 8}}>
         <Icon name="folder" color={Colors.accentGray()} />
         <div>
-          <RepoName>{isDunderRepoName ? repoLocation : repoName}</RepoName>
+          <span className={styles.repoName}>{isDunderRepoName ? repoLocation : repoName}</span>
           {showLocation && !isDunderRepoName ? (
-            <RepoLocation>{`@${repoLocation}`}</RepoLocation>
+            <span className={styles.repoLocation}>{`@${repoLocation}`}</span>
           ) : null}
         </div>
       </Box>
     </TableSectionHeader>
   );
 };
-
-const RepoName = styled.span`
-  font-weight: 600;
-`;
-
-const RepoLocation = styled.span`
-  font-weight: 400;
-  color: ${Colors.textLighter()};
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.module.css
@@ -1,0 +1,11 @@
+/* Styles for RunActionsMenu converted from styled-components */
+.slashShortcut {
+  border-radius: 4px;
+  padding: 0px 6px;
+  background: var(--color-background-light);
+  color: var(--color-text-light);
+}
+
+.linkNoUnderline {
+  text-decoration: none !important;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
@@ -18,7 +18,7 @@ import uniq from 'lodash/uniq';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import {RunMetricsDialog} from 'shared/runs/RunMetricsDialog.oss';
-import styled from 'styled-components';
+import styles from './RunActionsMenu.module.css';
 
 import {DeletionDialog} from './DeletionDialog';
 import {ReexecutionDialog} from './ReexecutionDialog';
@@ -143,7 +143,7 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
                       }}
                       padding={{horizontal: 8}}
                     >
-                      <SlashShortcut>t</SlashShortcut>
+                      <div className={styles.slashShortcut}>t</div>
                     </Box>
                   </div>
                 }
@@ -152,8 +152,9 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
               />
 
               {run.pipelineSnapshotId ? (
-                <LinkNoUnderline
+                <Link
                   to={getPipelineSnapshotLink(run.pipelineName, run.pipelineSnapshotId)}
+                  className={styles.linkNoUnderline}
                 >
                   <MenuItem
                     tagName="button"
@@ -161,7 +162,7 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
                     text="View snapshot"
                     onClick={() => setVisibleDialog('tags')}
                   />
-                </LinkNoUnderline>
+                </Link>
               ) : null}
               <MenuDivider />
               <>
@@ -482,15 +483,4 @@ export const PIPELINE_ENVIRONMENT_QUERY = gql`
       }
     }
   }
-`;
-
-const SlashShortcut = styled.div`
-  border-radius: 4px;
-  padding: 0px 6px;
-  background: ${Colors.backgroundLight()};
-  color: ${Colors.textLight()};
-`;
-
-const LinkNoUnderline = styled(Link)`
-  text-decoration: none !important;
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/StepLogsDialog.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/StepLogsDialog.module.css
@@ -1,0 +1,7 @@
+/* Styles for StepLogsDialog converted from styled-components */
+.logsContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 65vh;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/StepLogsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/StepLogsDialog.tsx
@@ -11,7 +11,7 @@ import {
 import {useMemo, useState} from 'react';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+import styles from './StepLogsDialog.module.css';
 
 import {CapturedOrExternalLogPanel} from './CapturedLogPanel';
 import {DefaultLogLevels} from './LogLevel';
@@ -144,7 +144,7 @@ export const StepLogsDialogContent = ({
     });
 
   return (
-    <LogsContainer>
+    <div className={styles.logsContainer}>
       <LogsToolbar
         metadata={metadata}
         logType={logType}
@@ -184,13 +184,6 @@ export const StepLogsDialogContent = ({
           metadata={metadata}
         />
       )}
-    </LogsContainer>
+    </div>
   );
 };
-
-const LogsContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  height: 65vh;
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.module.css
@@ -1,0 +1,55 @@
+.container {
+  background-color: var(--color-background-default);
+  border-radius: 8px;
+  box-shadow:
+    2px 2px 8px var(--color-shadow-default),
+    var(--color-keyline-default) inset 0px 0px 0px 1px;
+  max-height: 60vh;
+  left: calc(50% - 300px);
+  overflow: hidden;
+  width: 600px;
+  top: 20vh;
+}
+
+.searchBox {
+  background: var(--color-background-default);
+  border-radius: 8px;
+  border: none;
+  align-items: center;
+  box-shadow: var(--color-border-default) inset 0px 0px 0px 1px;
+  display: flex;
+  padding: 12px 20px 12px 12px;
+  transition: all 100ms linear;
+}
+
+.searchBox:hover {
+  box-shadow: var(--color-border-hover) 0 0 0 1px inset;
+}
+
+.searchBoxWithQuery {
+  border-radius: 8px 8px 0 0;
+  box-shadow: var(--color-keyline-default) inset 0px 0px 0px 1px;
+}
+
+.searchBoxWithQuery:hover {
+  box-shadow: var(--color-keyline-default) 0 0 0 1px inset;
+}
+
+.searchInput {
+  background-color: transparent;
+  border: none;
+  color: var(--color-text-default);
+  font-family: var(--font-family-default);
+  font-size: 18px;
+  margin-left: 4px;
+  outline: none;
+  width: 100%;
+}
+
+.searchInput::placeholder {
+  color: var(--color-text-disabled);
+}
+
+.searchInput:focus {
+  outline: none;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -5,7 +5,8 @@ import Fuse from 'fuse.js';
 import debounce from 'lodash/debounce';
 import * as React from 'react';
 import {useHistory} from 'react-router-dom';
-import styled from 'styled-components';
+import clsx from 'clsx';
+import styles from './SearchDialog.module.css';
 
 import {SearchResults} from './SearchResults';
 import {SearchResult} from './types';
@@ -213,10 +214,10 @@ export const SearchDialog = () => {
         onClose={() => dispatch({type: 'hide-dialog'})}
         transitionDuration={100}
       >
-        <Container>
-          <SearchBox $hasQueryString={!!queryString.length}>
+        <div className={styles.container}>
+          <div className={clsx(styles.searchBox, !!queryString.length && styles.searchBoxWithQuery)}>
             <Icon name="search" color={Colors.accentGray()} size={20} />
-            <SearchInput
+            <input className={styles.searchInput}
               data-search-input="1"
               autoFocus
               spellCheck={false}
@@ -227,7 +228,7 @@ export const SearchDialog = () => {
               value={queryString}
             />
             {loading ? <Spinner purpose="body-text" /> : null}
-          </SearchBox>
+          </div>
           <SearchResults
             highlight={highlight}
             queryString={queryString}
@@ -235,63 +236,9 @@ export const SearchDialog = () => {
             onClickResult={onClickResult}
             searching={loading || state.searching}
           />
-        </Container>
+        </div>
       </Overlay>
     </>
   );
 };
 
-const Container = styled.div`
-  background-color: ${Colors.backgroundDefault()};
-  border-radius: 8px;
-  box-shadow:
-    2px 2px 8px ${Colors.shadowDefault()},
-    ${Colors.keylineDefault()} inset 0px 0px 0px 1px;
-  max-height: 60vh;
-  left: calc(50% - 300px);
-  overflow: hidden;
-  width: 600px;
-  top: 20vh;
-`;
-
-export interface SearchBoxProps {
-  readonly $hasQueryString: boolean;
-}
-
-export const SearchBox = styled.div<SearchBoxProps>`
-  background: ${Colors.backgroundDefault()};
-  border-radius: ${({$hasQueryString}) => ($hasQueryString ? '8px 8px 0 0' : '8px')};
-  border: none;
-  align-items: center;
-  box-shadow: ${({$hasQueryString}) =>
-      $hasQueryString ? Colors.keylineDefault() : Colors.borderDefault()}
-    inset 0px 0px 0px 1px;
-  display: flex;
-  padding: 12px 20px 12px 12px;
-  transition: all 100ms linear;
-
-  :hover {
-    box-shadow: ${({$hasQueryString}) =>
-        $hasQueryString ? Colors.keylineDefault() : Colors.borderHover()}
-      0 0 0 1px inset;
-  }
-`;
-
-export const SearchInput = styled.input`
-  background-color: transparent;
-  border: none;
-  color: ${Colors.textDefault()};
-  font-family: ${FontFamily.default};
-  font-size: 18px;
-  margin-left: 4px;
-  outline: none;
-  width: 100%;
-
-  &::placeholder {
-    color: ${Colors.textDisabled()};
-  }
-
-  ::focus {
-    outline: none;
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputAutoCompleteResults.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputAutoCompleteResults.module.css
@@ -1,0 +1,5 @@
+.keyHintWrapper {
+  border-radius: 8px;
+  padding: 4px;
+  background-color: var(--color-background-gray-hover);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputAutoCompleteResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputAutoCompleteResults.tsx
@@ -11,7 +11,7 @@ import {
 } from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import React, {useEffect} from 'react';
-import styled from 'styled-components';
+import styles from './SelectionInputAutoCompleteResults.module.css';
 
 import {Suggestion} from './SelectionAutoCompleteProvider';
 import {IndeterminateLoadingBar} from '../ui/IndeterminateLoadingBar';
@@ -97,24 +97,24 @@ export const SelectionInputAutoCompleteResults = React.memo(
           >
             <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
               <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-                <KeyHintWrapper>
+                <div className={styles.keyHintWrapper}>
                   <Icon name="arrow_upward" size={12} style={{margin: 0}} />
-                </KeyHintWrapper>
-                <KeyHintWrapper>
+                </div>
+                <div className={styles.keyHintWrapper}>
                   <Icon name="arrow_downward" size={12} style={{margin: 0}} />
-                </KeyHintWrapper>
+                </div>
                 <BodySmall>to navigate</BodySmall>
               </Box>
               <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-                <KeyHintWrapper>
+                <div className={styles.keyHintWrapper}>
                   <BodySmall>Tab</BodySmall>
-                </KeyHintWrapper>
+                </div>
                 <BodySmall>to select</BodySmall>
               </Box>
               <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-                <KeyHintWrapper>
+                <div className={styles.keyHintWrapper}>
                   <BodySmall>Enter</BodySmall>
-                </KeyHintWrapper>
+                </div>
                 <BodySmall>to search</BodySmall>
               </Box>
             </Box>
@@ -136,8 +136,3 @@ export const SelectionInputAutoCompleteResults = React.memo(
   },
 );
 
-const KeyHintWrapper = styled.div`
-  border-radius: 8px;
-  padding: 4px;
-  background-color: ${Colors.backgroundGrayHover()};
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.module.css
@@ -1,0 +1,3 @@
+.targetCell button {
+  line-height: 20px;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -12,7 +12,7 @@ import {
 import {useState} from 'react';
 import {Link} from 'react-router-dom';
 import {SensorAlertDetails} from 'shared/sensors/SensorAlertDetails.oss';
-import styled from 'styled-components';
+import styles from './SensorDetails.module.css';
 
 import {EditCursorDialog} from './EditCursorDialog';
 import {SensorMonitoredAssets} from './SensorMonitoredAssets';
@@ -182,14 +182,14 @@ export const SensorDetails = ({
           {(sensor.targets && sensor.targets.length) || assetSelection ? (
             <tr>
               <td>Target</td>
-              <TargetCell>
+              <td className={styles.targetCell}>
                 <AutomationTargetList
                   targets={sensor.targets}
                   repoAddress={repoAddress}
                   assetSelection={assetSelection || null}
                   automationType={sensor.sensorType}
                 />
-              </TargetCell>
+              </td>
             </tr>
           ) : null}
           <tr>
@@ -262,8 +262,3 @@ export const SensorDetails = ({
   );
 };
 
-const TargetCell = styled.td`
-  button {
-    line-height: 20px;
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateScheduleDialog.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateScheduleDialog.module.css
@@ -1,0 +1,3 @@
+.scheduleDescriptor {
+  padding-bottom: 2px;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateScheduleDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateScheduleDialog.tsx
@@ -20,6 +20,7 @@ import {
 } from '@dagster-io/ui-components';
 import {useCallback, useContext, useMemo, useRef, useState} from 'react';
 import styled from 'styled-components';
+import styles from './EvaluateScheduleDialog.module.css';
 
 import {RunRequestTable} from './DryRunRequestTable';
 import {RUN_REQUEST_FRAGMENT} from './RunRequestFragment';
@@ -273,7 +274,7 @@ const EvaluateSchedule = ({repoAddress, name, onClose, jobName}: Props) => {
       selectedTimestampRef.current = selectedTimestamp || timestamps[0] || null;
       return (
         <Box flex={{direction: 'column', gap: 8}}>
-          <ScheduleDescriptor>Select an evaluation time to simulate</ScheduleDescriptor>
+          <div className={styles.scheduleDescriptor}>Select an evaluation time to simulate</div>
           <Popover
             isOpen={isTickSelectionOpen}
             position="bottom-left"
@@ -645,10 +646,6 @@ const Grid = styled.div`
   button {
     margin-top: 4px;
   }
-`;
-
-const ScheduleDescriptor = styled.div`
-  padding-bottom: 2px;
 `;
 
 const SkipReasonNonIdealStateWrapper = styled.div`

--- a/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/TypeWithTooltip.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/TypeWithTooltip.module.css
@@ -1,0 +1,16 @@
+.typeLink:hover {
+  text-decoration: none;
+}
+
+.typeName {
+  background: var(--color-background-blue);
+  border: none;
+  padding: 2px 4px;
+  border-bottom: 1px solid var(--color-accent-blue);
+  border-radius: 0.25em;
+  font-size: 12px;
+  font-weight: 500;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/TypeWithTooltip.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/TypeWithTooltip.tsx
@@ -1,6 +1,6 @@
 import {Colors} from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+import styles from './TypeWithTooltip.module.css';
 
 import {gql} from '../apollo-client';
 
@@ -18,13 +18,13 @@ export const TypeWithTooltip = (props: ITypeWithTooltipProps) => {
   // TODO: link to most inner type
   if (name) {
     return (
-      <TypeLink to={{search: `?tab=types&typeName=${displayName}`}}>
-        <TypeName>{displayName}</TypeName>
-      </TypeLink>
+      <Link className={styles.typeLink} to={{search: `?tab=types&typeName=${displayName}`}}>
+        <code className={styles.typeName}>{displayName}</code>
+      </Link>
     );
   }
 
-  return <TypeName>{displayName}</TypeName>;
+  return <code className={styles.typeName}>{displayName}</code>;
 };
 
 export const DAGSTER_TYPE_WITH_TOOLTIP_FRAGMENT = gql`
@@ -35,21 +35,3 @@ export const DAGSTER_TYPE_WITH_TOOLTIP_FRAGMENT = gql`
   }
 `;
 
-const TypeLink = styled(Link)`
-  :hover {
-    text-decoration: none;
-  }
-`;
-
-const TypeName = styled.code`
-  background: ${Colors.backgroundBlue()};
-  border: none;
-  padding: 2px 4px;
-  border-bottom: 1px solid ${Colors.accentBlue()};
-  border-radius: 0.25em;
-  font-size: 12px;
-  font-weight: 500;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/FilterDropdown.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/FilterDropdown.module.css
@@ -1,0 +1,29 @@
+.textInputWrapper {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+}
+
+.textInputWrapper > *:first-child {
+  flex-grow: 1;
+}
+
+.textInputWrapper input {
+  background-color: var(--color-popover-background);
+  padding: 12px 16px;
+}
+
+.textInputWrapper input,
+.textInputWrapper input:focus,
+.textInputWrapper input:active,
+.textInputWrapper input:hover {
+  box-shadow: none;
+  background-color: var(--color-popover-background);
+}
+
+.slashShortcut {
+  border-radius: 4px;
+  padding: 0px 6px;
+  background: var(--color-background-light);
+  color: var(--color-text-light);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/FilterDropdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/FilterDropdown.tsx
@@ -15,12 +15,14 @@ import {useRef, useState} from 'react';
 import * as React from 'react';
 import styled, {createGlobalStyle} from 'styled-components';
 import {v4 as uuidv4} from 'uuid';
+import clsx from 'clsx';
 
 import {FilterObject} from './useFilter';
 import {ShortcutHandler} from '../../app/ShortcutHandler';
 import {useSetStateUpdateCallback} from '../../hooks/useSetStateUpdateCallback';
 import {useUpdatingRef} from '../../hooks/useUpdatingRef';
 import {Container, Inner, Row} from '../../ui/VirtualizedTable';
+import styles from './FilterDropdown.module.css';
 
 interface FilterDropdownProps {
   filters: FilterObject[];
@@ -222,7 +224,7 @@ export const FilterDropdown = ({filters, setIsOpen, setPortaledElements}: Filter
 
   return (
     <div>
-      <TextInputWrapper>
+      <div className={styles.textInputWrapper}>
         <TextInput
           type="text"
           value={search}
@@ -245,9 +247,9 @@ export const FilterDropdown = ({filters, setIsOpen, setPortaledElements}: Filter
           flex={{justifyContent: 'center', alignItems: 'center'}}
           padding={{vertical: 12, horizontal: 16}}
         >
-          <SlashShortcut>f</SlashShortcut>
+          <div className={styles.slashShortcut}>f</div>
         </Box>
-      </TextInputWrapper>
+      </div>
       <Menu>
         <DropdownMenuContainer id={menuKey} ref={dropdownRef} onKeyDown={handleKeyDown}>
           {selectedFilter && selectedFilter.isLoadingFilters ? (
@@ -386,29 +388,6 @@ const DropdownMenuContainer = styled.div`
   }
 `;
 
-const TextInputWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  flex-gap: 12px;
-
-  > *:first-child {
-    flex-grow: 1;
-  }
-
-  input {
-    background-color: ${Colors.popoverBackground()};
-    padding: 12px 16px;
-
-    &,
-    :focus,
-    :active,
-    :hover {
-      box-shadow: none;
-      background-color: ${Colors.popoverBackground()};
-    }
-  }
-`;
-
 type FilterDropdownMenuItemProps = React.ComponentProps<typeof MenuItem> & {
   menuKey: string;
   index: number;
@@ -440,13 +419,6 @@ const StyledMenuItem = styled(MenuItem)`
   &.bp5-active:focus {
     box-shadow: initial;
   }
-`;
-
-const SlashShortcut = styled.div`
-  border-radius: 4px;
-  padding: 0px 6px;
-  background: ${Colors.backgroundLight()};
-  color: ${Colors.textLight()};
 `;
 
 const PopoverStyle = createGlobalStyle`

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilter.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilter.module.css
@@ -1,0 +1,5 @@
+.filterTagHighlightedText {
+  font-weight: 600;
+  font-size: 12px;
+  max-width: 100px;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilter.tsx
@@ -1,7 +1,7 @@
 import {BaseTag, Colors, Icon, IconName} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {useMemo} from 'react';
-import styled from 'styled-components';
+import styles from './useFilter.module.css';
 
 import {TruncatedTextWithFullTextOnHover} from '../../nav/getLeftNavItemsForOption';
 import {testId} from '../../testing/testId';
@@ -72,12 +72,6 @@ export const FilterTag = ({
   );
 };
 
-const FilterTagHighlightedTextSpan = styled(TruncatedTextWithFullTextOnHover)<{color: string}>`
-  color: ${({color}) => color};
-  font-weight: 600;
-  font-size: 12px;
-  max-width: 100px;
-`;
 
 export const FilterTagHighlightedText = React.forwardRef(
   (
@@ -92,8 +86,9 @@ export const FilterTagHighlightedText = React.forwardRef(
     ref: React.ForwardedRef<HTMLDivElement>,
   ) => {
     return (
-      <FilterTagHighlightedTextSpan
-        color={color}
+      <TruncatedTextWithFullTextOnHover
+        className={styles.filterTagHighlightedText}
+        style={{color}}
         text={
           <>
             {children}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useTimeRangeFilter.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useTimeRangeFilter.module.css
@@ -1,0 +1,42 @@
+.container {
+  height: 430px;
+}
+
+/* Hide the default date picker for Chrome, Edge, and Safari */
+.container input[type='date']::-webkit-calendar-picker-indicator {
+  display: none;
+}
+
+/* Hide the default date picker for Firefox */
+.container input[type='date']::-moz-calendar-picker-indicator {
+  display: none;
+}
+
+/* Hide the default date picker for Internet Explorer */
+.container input[type='date']::-ms-calendar-picker-indicator {
+  display: none;
+}
+
+.container :global(.DayPickerKeyboardShortcuts_show) {
+  display: none;
+}
+
+.container :global(.CalendarDay__hovered_span),
+.container :global(.CalendarDay__hovered_span:hover),
+.container :global(.CalendarDay__selected_span),
+.container :global(.CalendarDay__selected_span:hover) {
+  background: var(--color-background-blue);
+  color: var(--color-text-blue);
+  border: 1px solid #e4e7e7;
+}
+
+.container :global(.CalendarDay__selected),
+.container :global(.CalendarDay__selected:active),
+.container :global(.CalendarDay__selected:hover) {
+  background: var(--color-background-blue-hover);
+  border: 1px solid #e4e7e7;
+}
+
+.container :global(.DateInput_input__focused) {
+  border-color: var(--color-border-default);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useTimeRangeFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useTimeRangeFilter.tsx
@@ -6,7 +6,7 @@ import isEqual from 'lodash/isEqual';
 // eslint-disable-next-line no-restricted-imports
 import momentTZ from 'moment-timezone';
 import {useContext, useEffect, useMemo, useState} from 'react';
-import styled from 'styled-components';
+import styles from './useTimeRangeFilter.module.css';
 
 import {FilterObject, FilterTag, FilterTagHighlightedText} from './useFilter';
 import {TimeContext} from '../../app/time/TimeContext';
@@ -308,7 +308,7 @@ export function CustomTimeRangeFilterDialog({
 
   return (
     <Dialog isOpen={isOpen} title="Select a date range" onClosed={close} style={{width: '652px'}}>
-      <Container>
+      <div className={styles.container}>
         <Box flex={{direction: 'row', gap: 8}} padding={16}>
           <DateRangePicker
             minimumNights={0}
@@ -331,7 +331,7 @@ export function CustomTimeRangeFilterDialog({
             isOutsideRange={() => false}
           />
         </Box>
-      </Container>
+      </div>
       <DialogFooter topBorder>
         <Button
           onClick={() => {
@@ -355,43 +355,3 @@ export function CustomTimeRangeFilterDialog({
   );
 }
 
-const Container = styled.div`
-  height: 430px;
-
-  /* Hide the default date picker for Chrome, Edge, and Safari */
-  input[type='date']::-webkit-calendar-picker-indicator {
-    display: none;
-  }
-
-  /* Hide the default date picker for Firefox */
-  input[type='date']::-moz-calendar-picker-indicator {
-    display: none;
-  }
-
-  /* Hide the default date picker for Internet Explorer */
-  input[type='date']::-ms-calendar-picker-indicator {
-    display: none;
-  }
-
-  .DayPickerKeyboardShortcuts_show {
-    display: none;
-  }
-
-  .CalendarDay__hovered_span,
-  .CalendarDay__hovered_span:hover,
-  .CalendarDay__selected_span,
-  .CalendarDay__selected_span:hover {
-    background: ${Colors.backgroundBlue()};
-    color: ${Colors.textBlue()};
-    border: 1px solid #e4e7e7;
-  }
-  .CalendarDay__selected,
-  .CalendarDay__selected:active,
-  .CalendarDay__selected:hover {
-    background: ${Colors.backgroundBlueHover()};
-    border: 1px solid #e4e7e7;
-  }
-  .DateInput_input__focused {
-    border-color: ${Colors.borderDefault()};
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/GraphQueryInput.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/GraphQueryInput.module.css
@@ -1,0 +1,51 @@
+.customTable {
+  border-left: none;
+  border: 1px solid var(--color-keyline-default);
+  border-top: none;
+  margin-bottom: 12px;
+}
+
+.customTable :global(tr:last-child td) {
+  box-shadow: inset 1px 1px 0 var(--color-keyline-default) !important;
+}
+
+.customTable :global(tr:last-child td:first-child),
+.customTable :global(td:first-child),
+.customTable :global(th:first-child) {
+  vertical-align: middle;
+  box-shadow: inset 0 1px 0 var(--color-keyline-default) !important;
+}
+
+.opInfoWrap {
+  width: 350px;
+  padding: 10px 16px 10px 16px;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  position: absolute;
+  top: 100%;
+  margin-top: 2px;
+  font-size: 0.85rem;
+  background: var(--color-background-default);
+  color: var(--color-text-light);
+  box-shadow: 1px 1px 3px var(--color-shadow-default);
+  z-index: 2;
+  left: 0;
+}
+
+.opCountWrap {
+  composes: opInfoWrap;
+}
+
+.enterHint {
+  position: absolute;
+  right: 6px;
+  top: 5px;
+  border-radius: 5px;
+  border: 1px solid var(--color-border-default);
+  background: var(--color-background-default);
+  font-weight: 500;
+  font-size: 12px;
+  color: var(--color-text-light);
+  padding: 2px 6px;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/GraphQueryInput.tsx
@@ -21,7 +21,7 @@ import isEqual from 'lodash/isEqual';
 import uniq from 'lodash/uniq';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+import styles from './GraphQueryInput.module.css';
 
 import {GraphQueryItem, filterByQuery} from '../app/GraphQueryImpl';
 import {dynamicKeyWithoutIndex, isDynamicStep} from '../gantt/DynamicStepSupport';
@@ -288,7 +288,7 @@ export const GraphQueryInput = React.memo(
     const flattenGraphsFlag = props.flattenGraphs ? '!' : '';
 
     const opCountInfo = props.linkToPreview && (
-      <OpCountWrap $hasWrap={flattenGraphsEnabled}>
+      <div className={styles.opCountWrap} style={{marginTop: flattenGraphsEnabled ? 0 : 2}}>
         {`${filterByQuery(props.items, pendingValue).all.length} matching ops`}
         <Link
           target="_blank"
@@ -301,7 +301,7 @@ export const GraphQueryInput = React.memo(
         >
           Graph Preview <Icon color={Colors.linkDefault()} name="open_in_new" />
         </Link>
-      </OpCountWrap>
+      </div>
     );
 
     return (
@@ -370,11 +370,11 @@ export const GraphQueryInput = React.memo(
               className={props.className}
               ref={inputRef}
             />
-            {focused && uncomitted && <EnterHint>Enter</EnterHint>}
+            {focused && uncomitted && <div className={styles.enterHint}>Enter</div>}
             {focused &&
               props.linkToPreview &&
               (flattenGraphsEnabled ? (
-                <OpInfoWrap>
+                <div className={styles.opInfoWrap}>
                   <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
                     <Checkbox
                       label="Flatten subgraphs"
@@ -392,7 +392,7 @@ export const GraphQueryInput = React.memo(
                     </Tooltip>
                   </Box>
                   {opCountInfo}
-                </OpInfoWrap>
+                </div>
               ) : (
                 opCountInfo
               ))}
@@ -456,7 +456,7 @@ const InfoIconDialog = () => {
         <DialogBody>
           <Box flex={{direction: 'column', gap: 10}}>
             <div>Create custom filter queries to fine tune which assets appear in the graph.</div>
-            <CustomTable>
+            <Table className={styles.customTable}>
               <thead>
                 <tr>
                   <th>Query</th>
@@ -525,7 +525,7 @@ const InfoIconDialog = () => {
                   <td>Render two disjointed lineage segments</td>
                 </tr>
               </tbody>
-            </CustomTable>
+            </Table>
           </Box>
         </DialogBody>
         <DialogFooter topBorder>
@@ -546,55 +546,3 @@ const InfoIconDialog = () => {
   );
 };
 
-const CustomTable = styled(Table)`
-  border-left: none;
-
-  &&& tr {
-    &:last-child td {
-      box-shadow: inset 1px 1px 0 ${Colors.keylineDefault()} !important;
-    }
-    &:last-child td:first-child,
-    td:first-child,
-    th:first-child {
-      vertical-align: middle;
-      box-shadow: inset 0 1px 0 ${Colors.keylineDefault()} !important;
-    }
-  }
-  border: 1px solid ${Colors.keylineDefault()};
-  border-top: none;
-  margin-bottom: 12px;
-`;
-
-const OpInfoWrap = styled.div`
-  width: 350px;
-  padding: 10px 16px 10px 16px;
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  position: absolute;
-  top: 100%;
-  margin-top: 2px;
-  font-size: 0.85rem;
-  background: ${Colors.backgroundDefault()};
-  color: ${Colors.textLight()};
-  box-shadow: 1px 1px 3px ${Colors.shadowDefault()};
-  z-index: 2;
-  left: 0;
-`;
-
-const OpCountWrap = styled(OpInfoWrap)<{$hasWrap: boolean}>`
-  margin-top: ${(p) => (p.$hasWrap ? 0 : 2)}px;
-`;
-
-const EnterHint = styled.div`
-  position: absolute;
-  right: 6px;
-  top: 5px;
-  border-radius: 5px;
-  border: 1px solid ${Colors.borderDefault()};
-  background: ${Colors.backgroundDefault()};
-  font-weight: 500;
-  font-size: 12px;
-  color: ${Colors.textLight()};
-  padding: 2px 6px;
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Markdown.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Markdown.module.css
@@ -1,0 +1,26 @@
+.container table {
+  border: none;
+  font-family: var(--font-family-monospace);
+  font-size: 14px;
+}
+
+.container table tr th {
+  box-shadow: none !important;
+  color: var(--color-text-light);
+  font-family: var(--font-family-default);
+  font-size: 12px;
+  font-weight: normal;
+  padding: 2px 8px;
+  text-align: left;
+}
+
+.container table tr td {
+  box-shadow: none !important;
+  padding: 2px 8px;
+  font-variant-ligatures: none;
+}
+
+.container table tr th:last-child,
+.container table tr td:last-child {
+  padding-right: 0;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Markdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Markdown.tsx
@@ -1,5 +1,5 @@
 import {Colors, FontFamily} from '@dagster-io/ui-components';
-import styled from 'styled-components';
+import styles from './Markdown.module.css';
 
 import {lazy} from '../util/lazy';
 
@@ -11,37 +11,9 @@ interface Props {
 
 export const Markdown = (props: Props) => {
   return (
-    <Container>
+    <div className={styles.container}>
       <MarkdownWithPlugins {...props} />
-    </Container>
+    </div>
   );
 };
 
-const Container = styled.div`
-  &&& table {
-    border: none;
-    font-family: ${FontFamily.monospace};
-    font-size: 14px;
-  }
-
-  &&& table tr th {
-    box-shadow: none !important;
-    color: ${Colors.textLight()};
-    font-family: ${FontFamily.default};
-    font-size: 12px;
-    font-weight: normal;
-    padding: 2px 8px;
-    text-align: left;
-  }
-
-  &&& table tr td {
-    box-shadow: none !important;
-    padding: 2px 8px;
-    font-variant-ligatures: none;
-  }
-
-  &&& table tr th:last-child,
-  &&& table tr td:last-child {
-    padding-right: 0;
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/TagActions.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/TagActions.module.css
@@ -1,0 +1,44 @@
+.actionContainer {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+/* Shared styles for button and link */
+.tagButtonBase {
+  border: none;
+  background: var(--color-tooltip-background);
+  color: var(--color-tooltip-text);
+  cursor: pointer;
+  padding: 8px 12px;
+  text-align: left;
+  opacity: 0.85;
+  transition: opacity 50ms linear;
+}
+
+.tagButtonBase:not(:last-child) {
+  box-shadow: -1px 0 0 inset var(--color-border-hover);
+}
+
+.tagButtonBase:focus {
+  outline: none;
+}
+
+/* Button specific styles */
+.tagButton {
+  composes: tagButtonBase;
+}
+
+.tagButton:hover {
+  opacity: 1;
+}
+
+/* Link specific styles */
+.tagButtonLink {
+  composes: tagButtonBase;
+}
+
+.tagButtonLink:hover {
+  color: var(--color-tooltip-text);
+  text-decoration: none;
+  opacity: 1;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/TagActions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/TagActions.tsx
@@ -1,7 +1,7 @@
 import {Box, Caption, Colors, Popover} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled, {css} from 'styled-components';
+import styles from './TagActions.module.css';
 
 import {TagType} from '../runs/RunTag';
 
@@ -16,19 +16,19 @@ export type TagAction =
     };
 
 export const TagActions = ({data, actions}: {data: TagType; actions: TagAction[]}) => (
-  <ActionContainer background={Colors.tooltipBackground()} flex={{direction: 'row'}}>
+  <Box className={styles.actionContainer} background={Colors.tooltipBackground()} flex={{direction: 'row'}}>
     {actions.map((action, ii) =>
       'to' in action ? (
-        <TagButtonLink to={action.to} key={ii}>
+        <Link className={styles.tagButtonLink} to={action.to} key={ii}>
           <Caption>{action.label}</Caption>
-        </TagButtonLink>
+        </Link>
       ) : (
-        <TagButton key={ii} onClick={() => action.onClick(data)}>
+        <button className={styles.tagButton} key={ii} onClick={() => action.onClick(data)}>
           <Caption>{action.label}</Caption>
-        </TagButton>
+        </button>
       ),
     )}
-  </ActionContainer>
+  </Box>
 );
 
 export const TagActionsPopover = ({
@@ -56,44 +56,3 @@ export const TagActionsPopover = ({
   );
 };
 
-const ActionContainer = styled(Box)`
-  border-radius: 8px;
-  overflow: hidden;
-`;
-
-const TagButtonSharedStyles = css`
-  border: none;
-  background: ${Colors.tooltipBackground()};
-  color: ${Colors.tooltipText()};
-  cursor: pointer;
-  padding: 8px 12px;
-  text-align: left;
-  opacity: 0.85;
-  transition: opacity 50ms linear;
-
-  :not(:last-child) {
-    box-shadow: -1px 0 0 inset ${Colors.borderHover()};
-  }
-
-  :focus {
-    outline: none;
-  }
-`;
-
-const TagButton = styled.button`
-  ${TagButtonSharedStyles}
-
-  :hover {
-    opacity: 1;
-  }
-`;
-
-const TagButtonLink = styled(Link)`
-  ${TagButtonSharedStyles}
-
-  :hover {
-    color: ${Colors.tooltipText()};
-    text-decoration: none;
-    opacity: 1;
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/ToggleableSection.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/ToggleableSection.module.css
@@ -1,0 +1,7 @@
+.rotateable {
+  /* Base styling for the rotateable element */
+}
+
+.rotated {
+  transform: rotate(-90deg);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/ToggleableSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/ToggleableSection.tsx
@@ -1,6 +1,7 @@
 import {Box, Colors, Icon} from '@dagster-io/ui-components';
 import * as React from 'react';
-import styled from 'styled-components';
+import clsx from 'clsx';
+import styles from './ToggleableSection.module.css';
 
 export const ToggleableSection = ({
   isInitiallyOpen,
@@ -24,16 +25,12 @@ export const ToggleableSection = ({
         padding={{vertical: 12, right: 20, left: 16}}
         style={{cursor: 'pointer'}}
       >
-        <Rotateable $rotate={!isOpen}>
+        <span className={clsx(styles.rotateable, !isOpen ? styles.rotated : null)}>
           <Icon name="arrow_drop_down" />
-        </Rotateable>
+        </span>
         <div style={{flex: 1}}>{title}</div>
       </Box>
       {isOpen && <Box>{children}</Box>}
     </Box>
   );
 };
-
-const Rotateable = styled.span<{$rotate: boolean}>`
-  ${({$rotate}) => ($rotate ? 'transform: rotate(-90deg);' : '')}
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryCountTags.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryCountTags.module.css
@@ -1,0 +1,5 @@
+.countLink:hover,
+.countLink:active {
+  outline: none;
+  text-decoration: none;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryCountTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryCountTags.tsx
@@ -1,6 +1,6 @@
 import {Box, Tag, Tooltip} from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+import styles from './RepositoryCountTags.module.css';
 
 import {DagsterRepoOption} from './WorkspaceContext/util';
 import {RepoAddress} from './types';
@@ -25,44 +25,37 @@ export const RepositoryCountTags = ({
         content={assetGroupCount === 1 ? '1 asset group' : `${assetGroupCount} asset groups`}
         placement="top"
       >
-        <CountLink to={workspacePathFromAddress(repoAddress, '/assets')}>
+        <Link className={styles.countLink} to={workspacePathFromAddress(repoAddress, '/assets')}>
           <Tag interactive icon="asset_group">
             {assetGroupCount}
           </Tag>
-        </CountLink>
+        </Link>
       </Tooltip>
       <Tooltip content={jobCount === 1 ? '1 job' : `${jobCount} jobs`} placement="top">
-        <CountLink to={workspacePathFromAddress(repoAddress, '/jobs')}>
+        <Link className={styles.countLink} to={workspacePathFromAddress(repoAddress, '/jobs')}>
           <Tag interactive icon="job">
             {jobCount}
           </Tag>
-        </CountLink>
+        </Link>
       </Tooltip>
       <Tooltip
         content={scheduleCount === 1 ? '1 schedule' : `${scheduleCount} schedules`}
         placement="top"
       >
-        <CountLink to={workspacePathFromAddress(repoAddress, '/schedules')}>
+        <Link className={styles.countLink} to={workspacePathFromAddress(repoAddress, '/schedules')}>
           <Tag interactive icon="schedule">
             {scheduleCount}
           </Tag>
-        </CountLink>
+        </Link>
       </Tooltip>
       <Tooltip content={sensorCount === 1 ? '1 sensor' : `${sensorCount} sensors`} placement="top">
-        <CountLink to={workspacePathFromAddress(repoAddress, '/sensors')}>
+        <Link className={styles.countLink} to={workspacePathFromAddress(repoAddress, '/sensors')}>
           <Tag interactive icon="sensors">
             {sensorCount}
           </Tag>
-        </CountLink>
+        </Link>
       </Tooltip>
     </Box>
   );
 };
 
-const CountLink = styled(Link)`
-  :hover,
-  :active {
-    outline: none;
-    text-decoration: none;
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.module.css
@@ -1,0 +1,4 @@
+.rowGrid {
+  display: grid;
+  height: 100%;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -2,7 +2,8 @@ import {Box, Caption, Checkbox, Colors, Icon, Skeleton} from '@dagster-io/ui-com
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import {getAssetSelectionQueryString} from 'shared/asset-selection/useAssetSelectionState.oss';
-import styled from 'styled-components';
+import clsx from 'clsx';
+import styles from './VirtualizedAssetRow.module.css';
 
 import {RepoAddress} from './types';
 import {
@@ -91,7 +92,13 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
 
   return (
     <Row $height={height} $start={start} data-testid={testId(`row-${tokenForAssetKey({path})}`)}>
-      <RowGrid border="bottom" $showRepoColumn={showRepoColumn}>
+      <Box 
+        className={styles.rowGrid}
+        border="bottom"
+        style={{
+          gridTemplateColumns: showRepoColumn ? TEMPLATE_COLUMNS_FOR_CATALOG : TEMPLATE_COLUMNS
+        }}
+      >
         {showCheckboxColumn ? (
           <RowCell>
             <Checkbox checked={checked} onChange={onChange} />
@@ -242,7 +249,13 @@ export const VirtualizedAssetCatalogHeader = ({
 
 export const ShimmerRow = (props: {$height: number; $start: number; $showRepoColumn: boolean}) => (
   <Row {...props}>
-    <RowGrid border="bottom" $showRepoColumn={props.$showRepoColumn}>
+    <Box 
+      className={styles.rowGrid}
+      border="bottom"
+      style={{
+        gridTemplateColumns: props.$showRepoColumn ? TEMPLATE_COLUMNS_FOR_CATALOG : TEMPLATE_COLUMNS
+      }}
+    >
       <RowCell>
         <Skeleton $height={21} $width="45%" />
       </RowCell>
@@ -262,7 +275,7 @@ export const ShimmerRow = (props: {$height: number; $start: number; $showRepoCol
           </RowCell>
         </>
       ) : null}
-    </RowGrid>
+    </Box>
   </Row>
 );
 
@@ -276,12 +289,6 @@ export const VirtualizedAssetHeader = ({nameLabel}: {nameLabel: React.ReactNode}
   );
 };
 
-const RowGrid = styled(Box)<{$showRepoColumn: boolean}>`
-  display: grid;
-  grid-template-columns: ${({$showRepoColumn}) =>
-    $showRepoColumn ? TEMPLATE_COLUMNS_FOR_CATALOG : TEMPLATE_COLUMNS};
-  height: 100%;
-`;
 
 const LIVE_QUERY_DELAY = 250;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.module.css
@@ -1,0 +1,4 @@
+.rowGrid {
+  display: grid;
+  grid-template-columns: var(--template-columns);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
@@ -2,7 +2,7 @@ import {Box, Colors, JoinedButtons, MiddleTruncate} from '@dagster-io/ui-compone
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
-import styled from 'styled-components';
+import clsx from 'clsx';
 
 import {CodeLocationMenu} from './CodeLocationMenu';
 import {ImageName, LocationStatus, ModuleOrPackageOrFile, ReloadButton} from './CodeLocationRowSet';
@@ -21,6 +21,7 @@ import {featureEnabled} from '../app/Flags';
 import {AnchorButton} from '../ui/AnchorButton';
 import {TimeFromNow} from '../ui/TimeFromNow';
 import {HeaderCell, HeaderRow, RowCell} from '../ui/VirtualizedTable';
+import styles from './VirtualizedCodeLocationRow.module.css';
 
 export type CodeLocationRowType =
   | {
@@ -56,7 +57,11 @@ export const VirtualizedCodeLocationRow = React.forwardRef(
 
     return (
       <div ref={ref} data-index={index}>
-        <RowGrid border="bottom">
+        <Box
+          className={styles.rowGrid}
+          style={{'--template-columns': TEMPLATE_COLUMNS}}
+          border="bottom"
+        >
           <RowCell>
             <Box flex={{direction: 'column', gap: 4}}>
               <div style={{fontWeight: 500}}>
@@ -95,7 +100,7 @@ export const VirtualizedCodeLocationRow = React.forwardRef(
               {locationEntry ? <CodeLocationMenu locationNode={locationEntry} /> : null}
             </JoinedButtons>
           </RowCell>
-        </RowGrid>
+        </Box>
       </div>
     );
   },
@@ -119,7 +124,11 @@ export const VirtualizedCodeLocationRepositoryRow = React.forwardRef(
 
     return (
       <div ref={ref} data-index={index}>
-        <RowGrid border="bottom">
+        <Box
+          className={styles.rowGrid}
+          style={{'--template-columns': TEMPLATE_COLUMNS}}
+          border="bottom"
+        >
           <RowCell>
             <Box flex={{direction: 'column', gap: 4}}>
               <div style={{fontWeight: 500}}>
@@ -161,7 +170,7 @@ export const VirtualizedCodeLocationRepositoryRow = React.forwardRef(
               <CodeLocationMenu locationNode={locationEntry} />
             </JoinedButtons>
           </RowCell>
-        </RowGrid>
+        </Box>
       </div>
     );
   },
@@ -178,8 +187,3 @@ export const VirtualizedCodeLocationHeader = () => {
     </HeaderRow>
   );
 };
-
-const RowGrid = styled(Box)`
-  display: grid;
-  grid-template-columns: ${TEMPLATE_COLUMNS};
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedJobRow.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedJobRow.module.css
@@ -1,0 +1,32 @@
+/*
+RowGrid:
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 180px 96px 80px;
+  height: 100%;
+
+ScheduleSensorTagContainer:
+  width: 100%;
+  > .bp5-popover-target {
+    width: 100%;
+  }
+*/
+
+.rowGrid {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 180px 96px 80px;
+  height: 100%;
+}
+
+.jobNameContainer {
+  max-width: 100%;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.scheduleSensorTagContainer {
+  width: 100%;
+}
+
+.scheduleSensorTagContainer :global(.bp5-popover-target) {
+  width: 100%;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedJobRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedJobRow.tsx
@@ -1,7 +1,6 @@
 import {Box, MiddleTruncate, useDelayedState} from '@dagster-io/ui-components';
 import {forwardRef, useMemo} from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
 
 import {CaptionText, LoadingOrNone} from './VirtualizedWorkspaceTable';
 import {buildPipelineSelector} from './WorkspaceContext/util';
@@ -18,6 +17,8 @@ import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
 import {SCHEDULE_SWITCH_FRAGMENT} from '../schedules/ScheduleSwitchFragment';
 import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitchFragment';
 import {HeaderCell, HeaderRow, RowCell} from '../ui/VirtualizedTable';
+import styles from './VirtualizedJobRow.module.css';
+import clsx from 'clsx';
 
 const TEMPLATE_COLUMNS = '1.5fr 1fr 180px 96px 80px';
 
@@ -66,9 +67,9 @@ export const VirtualizedJobRow = forwardRef(
 
     return (
       <div data-index={index} ref={ref}>
-        <RowGrid border="bottom">
+        <Box className={styles.rowGrid} border="bottom">
           <RowCell>
-            <div style={{maxWidth: '100%', whiteSpace: 'nowrap', fontWeight: 500}}>
+            <div className={styles.jobNameContainer}>
               <Link to={workspacePathFromAddress(repoAddress, `/jobs/${name}`)}>
                 <MiddleTruncate text={name} />
               </Link>
@@ -78,13 +79,13 @@ export const VirtualizedJobRow = forwardRef(
           <RowCell>
             {schedules.length || sensors.length ? (
               <Box flex={{direction: 'column', alignItems: 'flex-start', gap: 8}}>
-                <ScheduleSensorTagContainer>
+                <div className={styles.scheduleSensorTagContainer}>
                   <ScheduleOrSensorTag
                     schedules={schedules}
                     sensors={sensors}
                     repoAddress={repoAddress}
                   />
-                </ScheduleSensorTagContainer>
+                </div>
               </Box>
             ) : (
               <LoadingOrNone queryResult={queryResult} />
@@ -121,7 +122,7 @@ export const VirtualizedJobRow = forwardRef(
               />
             </Box>
           </RowCell>
-        </RowGrid>
+        </Box>
       </div>
     );
   },
@@ -138,20 +139,6 @@ export const VirtualizedJobHeader = () => {
     </HeaderRow>
   );
 };
-
-const RowGrid = styled(Box)`
-  display: grid;
-  grid-template-columns: ${TEMPLATE_COLUMNS};
-  height: 100%;
-`;
-
-const ScheduleSensorTagContainer = styled.div`
-  width: 100%;
-
-  > .bp5-popover-target {
-    width: 100%;
-  }
-`;
 
 const SINGLE_JOB_QUERY = gql`
   query SingleJobQuery($selector: PipelineSelector!) {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.module.css
@@ -1,0 +1,4 @@
+.rowGrid {
+  display: grid;
+  height: 100%;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
@@ -13,7 +13,8 @@ import {
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+import styles from './VirtualizedScheduleRow.module.css';
+import clsx from 'clsx';
 
 import {LoadingOrNone} from './VirtualizedWorkspaceTable';
 import {isThisThingAJob, useRepository} from './WorkspaceContext/util';
@@ -149,7 +150,12 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
 
   return (
     <Row $height={height} $start={start}>
-      <RowGrid border="bottom" $showCheckboxColumn={showCheckboxColumn}>
+      <Box 
+        className={styles.rowGrid} 
+        border="bottom" 
+        style={{
+          gridTemplateColumns: showCheckboxColumn ? TEMPLATE_COLUMNS_WITH_CHECKBOX : TEMPLATE_COLUMNS
+        }}>
         {showCheckboxColumn ? (
           <RowCell>
             <Tooltip
@@ -277,7 +283,7 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
             <span style={{color: Colors.textLight()}}>{'\u2013'}</span>
           )}
         </RowCell>
-      </RowGrid>
+      </Box>
     </Row>
   );
 };
@@ -305,12 +311,6 @@ export const VirtualizedScheduleHeader = (props: {checkbox: React.ReactNode}) =>
   );
 };
 
-const RowGrid = styled(Box)<{$showCheckboxColumn: boolean}>`
-  display: grid;
-  grid-template-columns: ${({$showCheckboxColumn}) =>
-    $showCheckboxColumn ? TEMPLATE_COLUMNS_WITH_CHECKBOX : TEMPLATE_COLUMNS};
-  height: 100%;
-`;
 
 export const SINGLE_SCHEDULE_QUERY = gql`
   query SingleScheduleQuery($selector: ScheduleSelector!) {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.module.css
@@ -1,0 +1,12 @@
+.rowGrid {
+  display: grid;
+  height: 100%;
+}
+
+.rowGrid {
+  grid-template-columns: var(--VirtualizedSensorRow-template-columns);
+}
+
+.showCheckboxColumn {
+  grid-template-columns: var(--VirtualizedSensorRow-template-columns-with-checkbox);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.tsx
@@ -11,7 +11,7 @@ import {
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
+import clsx from 'clsx';
 
 import {LoadingOrNone} from './VirtualizedWorkspaceTable';
 import {RepoAddress} from './types';
@@ -35,6 +35,7 @@ import {
 } from '../sensors/types/SensorRoot.types';
 import {TickStatusTag} from '../ticks/TickStatusTag';
 import {HeaderCell, HeaderRow, Row, RowCell} from '../ui/VirtualizedTable';
+import styles from './VirtualizedSensorRow.module.css';
 
 const TEMPLATE_COLUMNS = '1.5fr 180px 1fr 76px 120px 148px 180px';
 const TEMPLATE_COLUMNS_WITH_CHECKBOX = `60px ${TEMPLATE_COLUMNS}`;
@@ -138,7 +139,15 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
 
   return (
     <Row $height={height} $start={start}>
-      <RowGrid border="bottom" $showCheckboxColumn={showCheckboxColumn}>
+      <Box
+        className={clsx(styles.rowGrid, showCheckboxColumn ? styles.showCheckboxColumn : null)}
+        style={{
+          // These CSS vars allow the CSS module to switch grid-template-columns
+          '--VirtualizedSensorRow-template-columns': TEMPLATE_COLUMNS,
+          '--VirtualizedSensorRow-template-columns-with-checkbox': TEMPLATE_COLUMNS_WITH_CHECKBOX,
+        }}
+        border="bottom"
+      >
         {showCheckboxColumn ? (
           <RowCell>
             <Tooltip
@@ -239,7 +248,7 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
             <LoadingOrNone queryResult={sensorQueryResult} />
           )}
         </RowCell>
-      </RowGrid>
+      </Box>
     </Row>
   );
 };
@@ -265,13 +274,6 @@ export const VirtualizedSensorHeader = ({checkbox}: {checkbox: React.ReactNode})
     </HeaderRow>
   );
 };
-
-const RowGrid = styled(Box)<{$showCheckboxColumn: boolean}>`
-  display: grid;
-  grid-template-columns: ${({$showCheckboxColumn}) =>
-    $showCheckboxColumn ? TEMPLATE_COLUMNS_WITH_CHECKBOX : TEMPLATE_COLUMNS};
-  height: 100%;
-`;
 
 export const SENSOR_TYPE_META: Record<
   SensorType,

--- a/js_modules/dagster-ui/packages/ui-core/types/css-variables.d.ts
+++ b/js_modules/dagster-ui/packages/ui-core/types/css-variables.d.ts
@@ -1,0 +1,9 @@
+// My css.d.ts file
+import type * as CSS from 'csstype';
+
+declare module 'csstype' {
+  interface Properties {
+    // Allow CSS Custom Properties
+    [index: `--${string}`]: any;
+  }
+}


### PR DESCRIPTION
## Summary & Motivation

This is a demonstration / progress report.  I've been iteratively refining a prompt and it runs on most of our basic* styled-components usage. So far, I have been running it on a file, reading + approving the result, and then running it on the next file. My attempts to say "just run it on this whole folder" have not gone well - too much of the detail of the prompt seems to get lost, and it tends to start tromping around in the code.

There are a few major caveats I've discovered so far:

- In styled-components, we can reference JS-defined constants directly in our CSS.  In styled components we either have to 1) define a custom CSS variable, passed ala `<div ... style={{'--custom-var': TEMPLATE_COLUMNS}} />` , and then use it in the CSS module, or 2) extract those aspects of the CSS and attach them as styles, ala `<div ... style={{gridTemplateColumns: TEMPLATE_COLUMNS}} />`.   In my call sites my preference is for the latter, but I'm finding my own preference varies a lot.

- In styled-components, we frequently attach styles to other styled-components, eg: "IconWrapper within this Button should have color X".  These are challenging to move to CSS modules and I had to edit the prompt significantly to stop claude from making up classnames and trying to port these nested selectors.

Tips I've learned:

- Claude code outperforms VSCode (using GPT4.1) but I primarily prefer it because it's cli interface makes it easier to tell it exactly what file to touch. VSCode infers the context, and you can attach files, etc., but you have to attach it and clear the auto-attached context, etc. Then you have to undo it if it did it wrong, clear out your chat to do it again, etc.

- Claude code passes chat history unless you do `/clear`. Running `/clear` between files makes this transform faster + cheaper.

- Creating a prompt with an explicit "bucket each styled-component into one of these three categories" step seems to give much better results than asking for the general task and then adding "considerations / rules" afterwards.


# Current Prompt:

## Styled Components to CSS Modules:

Create a file with the same base name beside this file. eg: for `LeftNav.tsx`, a CSS file called `LeftNav.module.css`

For each styled component, identify which of the three categories it falls into below. After you have picked a category you should perform the requested change:

1. Skip styled components that would require using `:global()` on nested selectors that use styled-components `${}` syntax. Do not convert references to custom components to `:global()`! You cannot assume a component named "BigTable" has a className ".BigTable". Report these as issues. In this example, `WrapContainer` cannot be replaced and the styled component must be left in the file:

```
import { Body2, Button } from '@dagster-io/ui-components';

const WrapContainer = styled.div`
  max-width: 100%;

  ${Link} {
    color: red;
  }
  div > ${IconWrapper} {
    color: ${Colors.textLight()};
  }
  & > ${Button} {
    white-space: nowrap;
  }
`;
```

2. Remove styled components of basic HTML elements (div, span, button, etc). Replace each usage of the component with direct usage of the CSS modules classes. For example, a `<ButtonContainer />` div should become `<div className={styles.buttonContainer}>`. You should remove the small components completely.

3. For styled components that wrap capitalized (custom) components defined in the project, like `Box`, `BaseTable`, `Tooltip`, or `Icon` and apply additional styles, delete the styled component wrapper and make each callsite render the component and apply the additional styles via a className. For example, a `styled(Icon)` might become `<Icon className={styles.bigIcon} />`. It's preferable to remove the intermediate named component in favor of passing the className directly to the component being styled. Do not remove other props that were passed through to the custom component.

Important Rules To Follow:

- When the styled component takes props, you have an additional decision to make:

  - Inline Styles: If the prop is a pixel value, a color, or conditionally applies just one CSS rule, use a plain `style` prop to express it instead of making an additional CSS class.

  - Modifier Classes: If the component does not offer a `style` prop, or more CSS rules are impacted, use additional class modifiers to create the same variants in the CSS module, and use the `clsx` package to apply the classnames in place of passing props to the styled component. Our linter will not allow the use of classname references as object keys, so you should use clsx like this: `clsx(styles.base, isBeingModified ? styles.modifier : null)`

  For example, in this case:

  ```
  export const TEMPLATE_COLUMNS = '60px minmax(400px, 1.5fr) 240px 1fr 200px 200px';

  export const AutomationRowGrid = styled(Box)`
    display: grid;
    grid-template-columns: ${TEMPLATE_COLUMNS};
    height: 100%;
    `;
  ```

  It is preferable to output this result:

  ```
  <Box className={styles.automationRowGrid} style={{gridTemplateColumns: TEMPLATE_COLUMNS}} />
  ```

- References to the `Colors` object can be replaced with vars - `Colors.textLight()` in a styled component becomes `var(--color-text-light)` in CSS.

- If you want to pass Javascript constants or prop values into the CSS module as variables, that's great -- use kebab case naming like `var(--custom-width)`

- Do not remove comments in the source code. Comments on styled-components definitions should be moved to the CSS module.

- You can assume the clsx package is already installed.

Make sure to apply these rules when performing the conversion.

```

```
