### PR TITLE
[Perf] use murmurhash for memoizing assets by key

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionFiltering.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionFiltering.tsx
@@ -6,6 +6,7 @@ import {tokenForAssetKey} from '../asset-graph/Utils';
 import {AssetNodeForGraphQueryFragment} from '../asset-graph/types/useAssetGraphData.types';
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {AssetNode} from '../graphql/types';
+import {hashObject} from '../util/hashObject';
 import {weakMapMemoize} from '../util/weakMapMemoize';
 
 type Nullable<T> = {
@@ -51,7 +52,8 @@ export const useAssetSelectionFiltering = <
     [assets, includeExternalAssets],
   );
 
-  const assetsByKeyStringified = useMemo(() => JSON.stringify(assetsByKey), [assetsByKey]);
+  // Use a hash of the assetsByKey object to avoid re-rendering the asset graph when the assetsByKey object is updated but the keys are the same
+  const assetsByKeyHash = useMemo(() => hashObject(assetsByKey), [assetsByKey]);
   const {loading, graphQueryItems, graphAssetKeys} = useAssetGraphData(
     assetSelection,
     useMemo(
@@ -65,7 +67,7 @@ export const useAssetSelectionFiltering = <
         externalAssets,
       }),
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [assetsByKeyStringified, assetsLoading, useWorker, externalAssets],
+      [assetsByKeyHash, assetsLoading, useWorker, externalAssets],
     ),
   );
 


### PR DESCRIPTION
## Summary & Motivation

Rather than JSON.stringifying an array of thousands of assets lets use our new hashing function to reduce memory usage.

## How I Tested These Changes

Loaded the asset graph with app-proxy and saw perf impact of this change was negligble 