### PR TITLE
[bug] Fix issue with op_tags being dropped for observable source assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -109,14 +109,22 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> list[AssetsDefinit
 def create_external_asset_from_source_asset(source_asset: SourceAsset) -> AssetsDefinition:
     if source_asset.observe_fn is not None:
         keys_by_output_name = {"result": source_asset.key}
-        node_def = OpDefinition(
+        node_def = OpDefinition.dagster_internal_init(
             name=source_asset.key.to_python_identifier(),
             compute_fn=wrap_source_asset_observe_fn_in_op_compute_fn(source_asset),
             # We need to access the raw attribute because the property will return a computed value that
             # includes requirements for the io manager. Those requirements will be inferred again when
             # we create an AssetsDefinition.
             required_resource_keys=source_asset._required_resource_keys,  # noqa: SLF001,
+            ins=source_asset.op.ins,
             outs={"result": Out(io_manager_key=source_asset.io_manager_key)},
+            description=source_asset.op.description,
+            config_schema=source_asset.op.config_schema,
+            version=None,
+            retry_policy=source_asset.op.retry_policy,
+            code_version=source_asset.op.version,
+            pool=source_asset.op.pool,
+            tags=source_asset.op_tags,
         )
         extra_metadata_entries = {}
         execution_type = AssetExecutionType.OBSERVATION


### PR DESCRIPTION
## Summary & Motivation

Reported by a user -- we were not properly passing this information through. Originally, I fixed this by just forwarding the tags through this call, but then I realized there were a lot of other properties we were dropping at the same time.

Switched to using dagster_internal_init instead, and filled in a bunch of other properties (most of which will probably always be None but still)


## How I Tested These Changes

## Changelog

Fixed an issue that would cause `op_tags` set on `@observable_source_asset`s to be dropped from the underlying step context object when executed.
