### PR TITLE
Temporarily remove dataproc/spark docs check

### DIFF
--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -82,6 +82,3 @@ allowlist_externals =
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -vv {posargs}
-  make dataproc
-  make spark_docs
-  git diff --exit-code


### PR DESCRIPTION
This regressed again:

https://github.com/dagster-io/dagster/pull/29903
https://github.com/dagster-io/dagster/pull/29871

I'm just removing for the time being because as far as I can tell, this is just alerting us to a change in docs formatting and hardly seems worth halting the entire build for.

I think when we reintroduce, we should figure out:
- why this has been bouncing back and forth between passing and failing
- whether there's a better home for it than in this tox command. If it were actually captured in pytest, then we'd be able to more easily mute around its failures directly with Buildkite Test Engine. And it doesn't really seem related to to the automation module anyway - it's presumably only relevant to these two integrations.