### PR TITLE
[docs] Reference architecture tags

### DIFF
--- a/docs/docs/examples/bluesky/index.md
+++ b/docs/docs/examples/bluesky/index.md
@@ -6,6 +6,7 @@ last_update:
 sidebar_position: 10
 sidebar_custom_props:
   logo: images/integrations/dbt/dbt.svg
+tags: [code-example]
 ---
 
 # Analyzing Bluesky data

--- a/docs/docs/examples/llm-fine-tuning/index.md
+++ b/docs/docs/examples/llm-fine-tuning/index.md
@@ -6,6 +6,7 @@ last_update:
 sidebar_position: 10
 sidebar_custom_props:
   logo: images/integrations/openai.svg
+tags: [code-example]
 ---
 
 # Fine-tune an LLM

--- a/docs/docs/examples/modal/index.md
+++ b/docs/docs/examples/modal/index.md
@@ -6,6 +6,7 @@ last_update:
 sidebar_position: 10
 sidebar_custom_props:
   logo: images/integrations/modal.svg
+tags: [code-example]
 ---
 
 :::note

--- a/docs/docs/examples/prompt-engineering/index.md
+++ b/docs/docs/examples/prompt-engineering/index.md
@@ -6,6 +6,7 @@ last_update:
 sidebar_position: 10
 sidebar_custom_props:
   logo: images/integrations/anthropic.svg
+tags: [code-example]
 ---
 
 In this example, you'll build a pipeline with Dagster that:

--- a/docs/docs/examples/ra-etl-reverse-etl.md
+++ b/docs/docs/examples/ra-etl-reverse-etl.md
@@ -1,11 +1,13 @@
 ---
 title: ETL/Reverse ETL
-description: Reference architecture diagram
+description: A pipeline that ingests, models, and syncs data between source systems and a warehouse.
 last_update:
   author: Dennis Hume
 sidebar_position: 10
 sidebar_custom_props:
   logo: images/integrations/snowflake.svg
+  referenceArchitecture: true
+tags: [reference-architecture]
 ---
 
 # ETL/Reverse ETL

--- a/docs/docs/examples/ra-rag.md
+++ b/docs/docs/examples/ra-rag.md
@@ -1,11 +1,13 @@
 ---
 title: Retrieval-Augmented Generation (RAG)
-description: Reference architecture diagram
+description: A RAG system that indexes data and uses retrieved context to generate responses.
 last_update:
   author: Dennis Hume
 sidebar_position: 10
 sidebar_custom_props:
   logo: images/integrations/weaviate.png
+  referenceArchitecture: true
+tags: [reference-architecture]
 ---
 
 # Retrieval-Augmented Generation (RAG)

--- a/docs/docs/examples/ra-real-time.md
+++ b/docs/docs/examples/ra-real-time.md
@@ -1,11 +1,13 @@
 ---
 title: Real-time
-description: Reference architecture diagram
+description: A real-time system that detects abandoned carts and sends notifications to a marketing platform.
 last_update:
   author: Dennis Hume
 sidebar_position: 10
 sidebar_custom_props:
   logo: images/integrations/clickhouse.png
+  referenceArchitecture: true
+tags: [reference-architecture]
 ---
 
 # Real-time

--- a/docs/docs/examples/rag/index.md
+++ b/docs/docs/examples/rag/index.md
@@ -6,6 +6,7 @@ last_update:
 sidebar_position: 10
 sidebar_custom_props:
   logo: images/integrations/pinecone.svg
+tags: [code-example]
 ---
 
 :::note

--- a/docs/docs/tags.yml
+++ b/docs/docs/tags.yml
@@ -9,7 +9,7 @@ dagster-supported:
 ai:
   label: 'AI'
   permalink: '/integrations/ai'
-  description: 'AI integrations'
+  description: 'AI integrations.'
 etl:
   label: 'ETL'
   permalink: '/integrations/etl'
@@ -42,3 +42,11 @@ other:
   label: 'other'
   permalink: '/integrations/other'
   description: 'Other integrations'
+reference-architecture:
+  label: 'reference-architecture'
+  permalink: '/examples/reference-architecture'
+  description: 'Reference architecture.'
+code-example:
+  label: 'code-example'
+  permalink: '/examples/code-example'
+  description: 'Code example.'

--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -83,7 +83,7 @@ function CardLayout({
             )}
             {referenceArchitecture && (
               <span style={{marginLeft: 'auto'}}>
-                <div className={clsx(styles.cardTags)}>Reference Architecture</div>
+                <div className={clsx(styles.cardTags)}>Reference architecture</div>
               </span>
             )}
           </div>

--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -47,12 +47,14 @@ function CardLayout({
   title,
   description,
   community,
+  referenceArchitecture,
 }: {
   href: string;
   title: string;
   logo?: string;
   description?: string;
   community: boolean;
+  referenceArchitecture: boolean;
 }): ReactNode {
   return (
     <CardContainer href={href}>
@@ -77,6 +79,11 @@ function CardLayout({
             {community && (
               <span style={{marginLeft: 'auto'}}>
                 <div className={clsx(styles.cardTags)}>Community</div>
+              </span>
+            )}
+            {referenceArchitecture && (
+              <span style={{marginLeft: 'auto'}}>
+                <div className={clsx(styles.cardTags)}>Reference Architecture</div>
               </span>
             )}
           </div>
@@ -117,6 +124,7 @@ function CardLink({item}: {item: PropSidebarItemLink}): ReactNode {
   //const icon = item?.customProps?.myEmoji ?? (isInternalUrl(item.href) ? '📄️' : '🔗');
   const logo: string | null = item?.customProps?.logo || null;
   const community: boolean = item?.customProps?.community || false;
+  const referenceArchitecture: boolean = item?.customProps?.referenceArchitecture || false;
   const doc = useDocById(item.docId ?? undefined);
 
   return (
@@ -126,6 +134,7 @@ function CardLink({item}: {item: PropSidebarItemLink}): ReactNode {
       title={item.label}
       description={item.description ?? doc?.description}
       community={community}
+      referenceArchitecture={referenceArchitecture}
     />
   );
 }


### PR DESCRIPTION
## Summary & Motivation
Adding `tags` to examples for reference architectures vs code examples. Also updating `docs/src/theme/DocCard/index.tsx` to include an optional parameter for reference architectures so the tag can appear on the card.

![Screenshot 2025-05-19 at 12 59 41 PM](https://github.com/user-attachments/assets/2a7a32d4-5a7a-4bb0-a88d-4201d5b56cda)

I don't love that it is inconsistent in one of the three having a line break. Can't think of how to fix without changing to a single word.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
