### PR TITLE
[dagster-fivetran] Identify asset in group name error message in fivetran_assets decorator

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -122,8 +122,8 @@ def fivetran_assets(
 
     if any([spec for spec in specs if spec.group_name]) and group_name:
         raise DagsterInvariantViolationError(
-            "Cannot set group_name parameter on fivetran_assets if one or more of the "
-            "Fivetran asset specs have a group_name defined."
+            f"Cannot set group_name parameter on fivetran_assets {name} with connector ID {connector_id} - "
+            f"one or more of the Fivetran asset specs have a group_name defined."
         )
 
     return multi_asset(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -122,7 +122,7 @@ def fivetran_assets(
 
     if any([spec for spec in specs if spec.group_name]) and group_name:
         raise DagsterInvariantViolationError(
-            f"Cannot set group_name parameter on fivetran_assets {name} with connector ID {connector_id} - "
+            f"Cannot set group_name parameter on fivetran_assets with connector ID {connector_id} - "
             f"one or more of the Fivetran asset specs have a group_name defined."
         )
 


### PR DESCRIPTION
## Summary & Motivation

As title - add the connector ID to help user find the faulty assets def.


