### PR TITLE
[dagster-dbt] Identify asset in group name error message in dbt_cloud_assets decorator

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/asset_decorator.py
@@ -62,8 +62,9 @@ def dbt_cloud_assets(
 
     if any([spec for spec in specs if spec.group_name]) and group_name:
         raise DagsterInvariantViolationError(
-            "Cannot set group_name parameter on dbt_cloud_assets if one or more of the "
-            "dbt Cloud asset specs have a group_name defined."
+            f"Cannot set group_name parameter on dbt_cloud_assets for dbt Cloud workspace with account "
+            f"{workspace.account_name}, project {workspace.project_name} and environment {workspace.environment_name} -"
+            f" one or more of the dbt Cloud asset specs have a group_name defined."
         )
 
     return multi_asset(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/conftest.py
@@ -802,6 +802,21 @@ def fetch_workspace_data_api_mocks_fixture(
 
 
 @pytest.fixture(
+    name="asset_decorator_group_name_api_mocks",
+)
+def asset_decorator_group_name_api_mocks_fixture(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> Iterator[responses.RequestsMock]:
+    fetch_workspace_data_api_mocks.add(
+        method=responses.GET,
+        url=f"{TEST_REST_API_BASE_URL}",
+        json=SAMPLE_ACCOUNT_RESPONSE,
+        status=200,
+    )
+    yield fetch_workspace_data_api_mocks
+
+
+@pytest.fixture(
     name="sensor_builder_api_mocks",
 )
 def sensor_builder_api_mocks_fixture(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_asset_decorator.py
@@ -80,7 +80,7 @@ class MyCustomTranslatorWithGroupName(DagsterDbtTranslator):
 
 def test_translator_invariant_group_name_with_asset_decorator(
     workspace: DbtCloudWorkspace,
-    fetch_workspace_data_api_mocks: responses.RequestsMock,
+    asset_decorator_group_name_api_mocks: responses.RequestsMock,
 ) -> None:
     with pytest.raises(
         DagsterInvariantViolationError,


### PR DESCRIPTION
## Summary & Motivation

As title - add the workspace info to help user find the faulty assets def.


