### PR TITLE
Add an mcp extra to dagster-dg

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -504,7 +504,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "python_modules/libraries/dagster-dg-cli",
-        pytest_tox_factors=["general", "docs", "plus"],
+        pytest_tox_factors=["general", "docs", "plus", "mcp"],
     ),
     PackageSpec(
         "python_modules/libraries/dagster-aws",

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/mcp_server.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/mcp_server.py
@@ -18,6 +18,14 @@ def serve_command():
             "The MCP server is only supported on Python 3.10 and above. "
             "Please upgrade your Python version and reinstall `dagster-dg-cli`.",
         )
+
+    try:
+        import mcp.server.fastmcp
+    except ImportError:
+        raise ImportError(
+            "dagster-dg-cli must be installed with the mcp extra to use `dg mcp` commands."
+        )
+
     from dagster_dg_core.mcp.server import mcp
 
     mcp.run(transport="stdio")

--- a/python_modules/libraries/dagster-dg-cli/setup.py
+++ b/python_modules/libraries/dagster-dg-cli/setup.py
@@ -42,5 +42,10 @@ setup(
             "dg = dagster_dg_cli.cli:main",
         ]
     },
+    extras_require={
+        "mcp": [
+            "mcp",
+        ],
+    },
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-dg-cli/tox.ini
+++ b/python_modules/libraries/dagster-dg-cli/tox.ini
@@ -26,6 +26,7 @@ deps =
   plus: -e ../../../python_modules/libraries/dagster-aws
   plus: -e ../../../python_modules/libraries/dagster-k8s
   plus: -e ../../../python_modules/libraries/dagster-docker
+  mcp: -e .[mcp]
   -e .
 allowlist_externals =
   /bin/bash
@@ -37,4 +38,5 @@ commands =
   docs: pytest ./dagster_dg_cli_tests/cli_tests/test_docs_commands.py -vv --durations 10 {posargs}
   plus: npm install -g @action-validator/core @action-validator/cli --save-dev
   plus: pytest ./dagster_dg_cli_tests/cli_tests/plus_tests -vv --durations 10 {posargs}
-  general: pytest ./dagster_dg_cli_tests -vv --durations 10 {posargs} --ignore=./dagster_dg_cli_tests/cli_tests/test_docs_commands.py --ignore=./dagster_dg_cli_tests/cli_tests/plus_tests
+  mcp: pytest ./dagster_dg_cli_tests/cli_tests/mcp_tests -vv --durations 10 {posargs}
+  general: pytest ./dagster_dg_cli_tests -vv --durations 10 {posargs} --ignore=./dagster_dg_cli_tests/cli_tests/test_docs_commands.py --ignore=./dagster_dg_cli_tests/cli_tests/plus_tests --ignore=./dagster_dg_cli_tests/cli_tests/mcp_tests

--- a/python_modules/libraries/dagster-dg-core/setup.py
+++ b/python_modules/libraries/dagster-dg-core/setup.py
@@ -45,8 +45,6 @@ setup(
         "PyYAML>=5.1",
         "rich",
         "watchdog",
-        # Unfortunately mcp package is not available for python 3.9
-        "mcp; python_version >= '3.10'",
         "yaspin",
         "setuptools",  # Needed to parse setup.cfg
         "packaging",


### PR DESCRIPTION
## Summary & Motivation
As we likely move away from dagster-dg being only installed in an isolated global environment, we have to be a bit stricter about what we bring in. In that light, make mcp a separate extra while it's still an experimental feature.

## How I Tested These Changes
`dagster mcp serve` with and without the relevant extra installed
