### PR TITLE
Remove strict typer pin

### DIFF
--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -42,16 +42,14 @@ setup(
         "jsonschema",
         "PyYAML>=5.1",
         "rich",
-        "watchdog",
+        "watchdog<7",
         # Unfortunately mcp package is not available for python 3.9
         "mcp; python_version >= '3.10'",
         "yaspin",
         "setuptools",  # Needed to parse setup.cfg
         "packaging",
         "python-dotenv",
-        # We use some private APIs of typer so we hard-pin here. This shouldn't need to be
-        # frequently updated since is designed to be used from an isolated environment.
-        "typer==0.15.1",
+        "typer<0.16.0",
         f"dagster-shared{pin}",
         f"dagster-cloud-cli{pin}",
     ],


### PR DESCRIPTION
Summary:
Sending this out for discussion - if dagster-dg is going to be installable in proejct venvs and not just globally, this pin will likely be too restrictive. Is there more information on these private typer APIs that we are using somehwere? For now I changed this to `<0.16.0`.

Also pre-emptively added a watchdog pin since they are unafraid to release breaking changes.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
