### PR TITLE
defer structllog imports

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -5,9 +5,6 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from fsspec import AbstractFileSystem
-from fsspec.implementations.local import LocalFileSystem
-
 from dagster import (
     InputContext,
     MetadataValue,
@@ -18,6 +15,7 @@ from dagster import (
 from dagster._core.storage.io_manager import IOManager
 
 if TYPE_CHECKING:
+    from fsspec import AbstractFileSystem
     from upath import UPath
 
 
@@ -91,13 +89,15 @@ class UPathIOManager(IOManager):
             return objs
 
     @property
-    def fs(self) -> AbstractFileSystem:
+    def fs(self) -> "AbstractFileSystem":
         """Utility function to get the IOManager filesystem.
 
         Returns:
             AbstractFileSystem: fsspec filesystem.
 
         """
+        # Deferred for import perf
+        from fsspec.implementations.local import LocalFileSystem
         from upath import UPath
 
         if isinstance(self._base_path, UPath):

--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, Union
 
 import coloredlogs
 import dagster_shared.seven as seven
-import structlog
 from typing_extensions import TypeAlias
 
 import dagster._check as check
@@ -18,6 +17,8 @@ from dagster._core.definitions.logger_definition import LoggerDefinition, logger
 from dagster._core.utils import coerce_valid_log_level
 
 if TYPE_CHECKING:
+    import structlog
+
     from dagster._core.execution.context.logger import InitLoggerContext
 
 
@@ -213,6 +214,9 @@ def define_default_formatter() -> logging.Formatter:
 
 
 def get_structlog_shared_processors():
+    # Deferred for import perf
+    import structlog
+
     timestamper = structlog.processors.TimeStamper(fmt="iso", utc=True)
 
     shared_processors = [
@@ -226,7 +230,10 @@ def get_structlog_shared_processors():
     return shared_processors
 
 
-def get_structlog_json_formatter() -> structlog.stdlib.ProcessorFormatter:
+def get_structlog_json_formatter() -> "structlog.stdlib.ProcessorFormatter":
+    # Deferred for import perf
+    import structlog
+
     return structlog.stdlib.ProcessorFormatter(
         foreign_pre_chain=get_structlog_shared_processors(),
         processors=[
@@ -244,6 +251,9 @@ def get_structlog_json_formatter() -> structlog.stdlib.ProcessorFormatter:
 def configure_loggers(
     handler: str = "default", formatter: str = "colored", log_level: Union[str, int] = "INFO"
 ) -> None:
+    # Deferred for import perf
+    import structlog
+
     # It's possible that structlog has already been configured by either the user or a controlling
     # process. If so, we don't want to override that configuration.
     if not structlog.is_configured():

--- a/python_modules/dagster/dagster_tests/general_tests/test_import.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_import.py
@@ -27,6 +27,8 @@ def test_import_perf():
         "grpc",
         "sqlalchemy",
         "upath.",  # don't conflate with import of upath_io_manager
+        "structlog",
+        "fsspec",
     ]
     expensive_imports = [f"`{lib}`" for lib in expensive_library if lib in import_profile]
 


### PR DESCRIPTION
Summary:
This is maybe 40ms of import time that can be defered.

Test Plan:
New test case, compare import microbenchmarks

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
