### PR TITLE
add exclusion support for time window partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window.py
@@ -158,6 +158,7 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
                 " TimeWindowPartitionsDefinition."
             )
 
+        cleaned_exclusions: Optional[set[Union[str, TimestampWithTimezone]]] = None
         if exclusions:
             check.set_param(
                 exclusions,
@@ -176,7 +177,7 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
                     " argument for a TimeWindowPartitionsDefinition. Expected a set of valid cron"
                     " strings and datetime objects."
                 )
-            cleaned_exclusions: set[Union[str, TimestampWithTimezone]] = set()
+            cleaned_exclusions = set()
             for exclusion_part in exclusions:
                 if isinstance(exclusion_part, datetime):
                     dt = exclusion_part.replace(tzinfo=get_timezone(timezone))
@@ -192,7 +193,7 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
             fmt=fmt,
             end_offset=end_offset,
             cron_schedule=cron_schedule,
-            exclusions=cleaned_exclusions if exclusions else None,
+            exclusions=cleaned_exclusions if cleaned_exclusions else None,
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window_subclasses.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window_subclasses.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from datetime import datetime
 from typing import Optional, Union
 
@@ -39,6 +40,10 @@ class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
             passed. If end_offset is 0 (the default), the last partition ends before the current
             time. If end_offset is 1, the second-to-last partition ends before the current time,
             and so on.
+        exclusions (Optional[Sequence[Union[str, datetime]]]): Specifies a sequence of cron strings
+            or datetime objects that should be excluded from the partition set. Every tick of the
+            cron schedule that matches an excluded datetime or matches the tick of an excluded
+            cron string will be excluded from the partition set.
 
     .. code-block:: python
 
@@ -69,7 +74,7 @@ class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
         timezone: Optional[str] = None,
         fmt: Optional[str] = None,
         end_offset: int = 0,
-        exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
+        exclusions: Optional[Sequence[Union[str, datetime, TimestampWithTimezone]]] = None,
         **kwargs,
     ):
         _fmt = fmt or DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
@@ -119,6 +124,10 @@ class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
             passed. If end_offset is 0 (the default), the last partition ends before the current
             time. If end_offset is 1, the second-to-last partition ends before the current time,
             and so on.
+        exclusions (Optional[Sequence[Union[str, datetime]]]): Specifies a sequence of cron strings
+            or datetime objects that should be excluded from the partition set. Every tick of the
+            cron schedule that matches an excluded datetime or matches the tick of an excluded
+            cron string will be excluded from the partition set.
 
     .. code-block:: python
 
@@ -144,7 +153,7 @@ class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
         timezone: Optional[str] = None,
         fmt: Optional[str] = None,
         end_offset: int = 0,
-        exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
+        exclusions: Optional[Sequence[Union[str, datetime, TimestampWithTimezone]]] = None,
         **kwargs,
     ):
         _fmt = fmt or DEFAULT_DATE_FORMAT
@@ -199,6 +208,10 @@ class WeeklyPartitionsDefinition(TimeWindowPartitionsDefinition):
             passed. If end_offset is 0 (the default), the last partition ends before the current
             time. If end_offset is 1, the second-to-last partition ends before the current time,
             and so on.
+        exclusions (Optional[Sequence[Union[str, datetime]]]): Specifies a sequence of cron strings
+            or datetime objects that should be excluded from the partition set. Every tick of the
+            cron schedule that matches an excluded datetime or matches the tick of an excluded
+            cron string will be excluded from the partition set.
 
     .. code-block:: python
 
@@ -225,7 +238,7 @@ class WeeklyPartitionsDefinition(TimeWindowPartitionsDefinition):
         timezone: Optional[str] = None,
         fmt: Optional[str] = None,
         end_offset: int = 0,
-        exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
+        exclusions: Optional[Sequence[Union[str, datetime, TimestampWithTimezone]]] = None,
         **kwargs,
     ):
         _fmt = fmt or DEFAULT_DATE_FORMAT
@@ -279,6 +292,10 @@ class MonthlyPartitionsDefinition(TimeWindowPartitionsDefinition):
             passed. If end_offset is 0 (the default), the last partition ends before the current
             time. If end_offset is 1, the second-to-last partition ends before the current time,
             and so on.
+        exclusions (Optional[Sequence[Union[str, datetime]]]): Specifies a sequence of cron strings
+            or datetime objects that should be excluded from the partition set. Every tick of the
+            cron schedule that matches an excluded datetime or matches the tick of an excluded
+            cron string will be excluded from the partition set.
 
     .. code-block:: python
 
@@ -305,7 +322,7 @@ class MonthlyPartitionsDefinition(TimeWindowPartitionsDefinition):
         timezone: Optional[str] = None,
         fmt: Optional[str] = None,
         end_offset: int = 0,
-        exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
+        exclusions: Optional[Sequence[Union[str, datetime, TimestampWithTimezone]]] = None,
         **kwargs,
     ):
         _fmt = fmt or DEFAULT_DATE_FORMAT

--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window_subclasses.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window_subclasses.py
@@ -7,6 +7,7 @@ from dagster._core.definitions.partitions.definition.time_window import (
     TimeWindowPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.schedule_type import ScheduleType
+from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._utils.partitions import DEFAULT_DATE_FORMAT, DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 
 
@@ -68,6 +69,7 @@ class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
         timezone: Optional[str] = None,
         fmt: Optional[str] = None,
         end_offset: int = 0,
+        exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
         **kwargs,
     ):
         _fmt = fmt or DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
@@ -88,6 +90,7 @@ class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
             fmt=_fmt,
             end_offset=end_offset,
             cron_schedule=cron_schedule,
+            exclusions=exclusions,
         )
 
 
@@ -141,6 +144,7 @@ class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
         timezone: Optional[str] = None,
         fmt: Optional[str] = None,
         end_offset: int = 0,
+        exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
         **kwargs,
     ):
         _fmt = fmt or DEFAULT_DATE_FORMAT
@@ -163,6 +167,7 @@ class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
             fmt=_fmt,
             end_offset=end_offset,
             cron_schedule=cron_schedule,
+            exclusions=exclusions,
         )
 
 
@@ -220,6 +225,7 @@ class WeeklyPartitionsDefinition(TimeWindowPartitionsDefinition):
         timezone: Optional[str] = None,
         fmt: Optional[str] = None,
         end_offset: int = 0,
+        exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
         **kwargs,
     ):
         _fmt = fmt or DEFAULT_DATE_FORMAT
@@ -241,6 +247,7 @@ class WeeklyPartitionsDefinition(TimeWindowPartitionsDefinition):
             fmt=_fmt,
             end_offset=end_offset,
             cron_schedule=cron_schedule,
+            exclusions=exclusions,
         )
 
 
@@ -298,6 +305,7 @@ class MonthlyPartitionsDefinition(TimeWindowPartitionsDefinition):
         timezone: Optional[str] = None,
         fmt: Optional[str] = None,
         end_offset: int = 0,
+        exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
         **kwargs,
     ):
         _fmt = fmt or DEFAULT_DATE_FORMAT
@@ -325,4 +333,5 @@ class MonthlyPartitionsDefinition(TimeWindowPartitionsDefinition):
             fmt=_fmt,
             end_offset=end_offset,
             cron_schedule=cron_schedule,
+            exclusions=exclusions,
         )

--- a/python_modules/dagster/dagster/_core/definitions/partitions/partitioned_config/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/partitioned_config/time_window.py
@@ -14,6 +14,7 @@ from dagster._core.definitions.partitions.definition.time_window_subclasses impo
     WeeklyPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
+from dagster._core.definitions.timestamp import TimestampWithTimezone
 
 
 def wrap_time_window_tags_fn(
@@ -50,6 +51,7 @@ def hourly_partitioned_config(
     fmt: Optional[str] = None,
     end_offset: int = 0,
     tags_for_partition_fn: Optional[Callable[[datetime, datetime], Mapping[str, str]]] = None,
+    exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
 ) -> Callable[
     [Callable[[datetime, datetime], Mapping[str, Any]]],
     PartitionedConfig[HourlyPartitionsDefinition],
@@ -111,6 +113,7 @@ def hourly_partitioned_config(
             timezone=timezone,
             fmt=fmt,
             end_offset=end_offset,
+            exclusions=exclusions,
         )
         return PartitionedConfig(
             run_config_for_partition_key_fn=wrap_time_window_run_config_fn(fn, partitions_def),
@@ -133,6 +136,7 @@ def daily_partitioned_config(
     fmt: Optional[str] = None,
     end_offset: int = 0,
     tags_for_partition_fn: Optional[Callable[[datetime, datetime], Mapping[str, str]]] = None,
+    exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
 ) -> Callable[
     [Callable[[datetime, datetime], Mapping[str, Any]]],
     PartitionedConfig[DailyPartitionsDefinition],
@@ -196,6 +200,7 @@ def daily_partitioned_config(
             timezone=timezone,
             fmt=fmt,
             end_offset=end_offset,
+            exclusions=exclusions,
         )
 
         return PartitionedConfig(
@@ -220,6 +225,7 @@ def weekly_partitioned_config(
     fmt: Optional[str] = None,
     end_offset: int = 0,
     tags_for_partition_fn: Optional[Callable[[datetime, datetime], Mapping[str, str]]] = None,
+    exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
 ) -> Callable[
     [Callable[[datetime, datetime], Mapping[str, Any]]],
     PartitionedConfig[WeeklyPartitionsDefinition],
@@ -288,6 +294,7 @@ def weekly_partitioned_config(
             timezone=timezone,
             fmt=fmt,
             end_offset=end_offset,
+            exclusions=exclusions,
         )
         return PartitionedConfig(
             run_config_for_partition_key_fn=wrap_time_window_run_config_fn(fn, partitions_def),
@@ -311,6 +318,7 @@ def monthly_partitioned_config(
     fmt: Optional[str] = None,
     end_offset: int = 0,
     tags_for_partition_fn: Optional[Callable[[datetime, datetime], Mapping[str, str]]] = None,
+    exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
 ) -> Callable[
     [Callable[[datetime, datetime], Mapping[str, Any]]],
     PartitionedConfig[MonthlyPartitionsDefinition],
@@ -378,6 +386,7 @@ def monthly_partitioned_config(
             timezone=timezone,
             fmt=fmt,
             end_offset=end_offset,
+            exclusions=exclusions,
         )
 
         return PartitionedConfig(

--- a/python_modules/dagster/dagster/_core/definitions/partitions/partitioned_config/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/partitioned_config/time_window.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any, Callable, Optional, Union
 
@@ -51,7 +51,7 @@ def hourly_partitioned_config(
     fmt: Optional[str] = None,
     end_offset: int = 0,
     tags_for_partition_fn: Optional[Callable[[datetime, datetime], Mapping[str, str]]] = None,
-    exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
+    exclusions: Optional[Sequence[Union[str, datetime, TimestampWithTimezone]]] = None,
 ) -> Callable[
     [Callable[[datetime, datetime], Mapping[str, Any]]],
     PartitionedConfig[HourlyPartitionsDefinition],
@@ -85,6 +85,10 @@ def hourly_partitioned_config(
         tags_for_partition_fn (Optional[Callable[[str], Mapping[str, str]]]): A function that
             accepts a partition time window and returns a dictionary of tags to attach to runs for
             that partition.
+        exclusions (Optional[Sequence[Union[str, datetime]]]): Specifies a sequence of cron strings
+            or datetime objects that should be excluded from the partition set. Every tick of the
+            cron schedule that matches an excluded datetime or matches the tick of an excluded
+            cron string will be excluded from the partition set.
 
     .. code-block:: python
 
@@ -136,7 +140,7 @@ def daily_partitioned_config(
     fmt: Optional[str] = None,
     end_offset: int = 0,
     tags_for_partition_fn: Optional[Callable[[datetime, datetime], Mapping[str, str]]] = None,
-    exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
+    exclusions: Optional[Sequence[Union[str, datetime, TimestampWithTimezone]]] = None,
 ) -> Callable[
     [Callable[[datetime, datetime], Mapping[str, Any]]],
     PartitionedConfig[DailyPartitionsDefinition],
@@ -171,6 +175,10 @@ def daily_partitioned_config(
         tags_for_partition_fn (Optional[Callable[[str], Mapping[str, str]]]): A function that
             accepts a partition time window and returns a dictionary of tags to attach to runs for
             that partition.
+        exclusions (Optional[Sequence[Union[str, datetime]]]): Specifies a sequence of cron strings
+            or datetime objects that should be excluded from the partition set. Every tick of the
+            cron schedule that matches an excluded datetime or matches the tick of an excluded
+            cron string will be excluded from the partition set.
 
     .. code-block:: python
 
@@ -225,7 +233,7 @@ def weekly_partitioned_config(
     fmt: Optional[str] = None,
     end_offset: int = 0,
     tags_for_partition_fn: Optional[Callable[[datetime, datetime], Mapping[str, str]]] = None,
-    exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
+    exclusions: Optional[Sequence[Union[str, datetime, TimestampWithTimezone]]] = None,
 ) -> Callable[
     [Callable[[datetime, datetime], Mapping[str, Any]]],
     PartitionedConfig[WeeklyPartitionsDefinition],
@@ -264,6 +272,10 @@ def weekly_partitioned_config(
         tags_for_partition_fn (Optional[Callable[[str], Mapping[str, str]]]): A function that
             accepts a partition time window and returns a dictionary of tags to attach to runs for
             that partition.
+        exclusions (Optional[Sequence[Union[str, datetime]]]): Specifies a sequence of cron strings
+            or datetime objects that should be excluded from the partition set. Every tick of the
+            cron schedule that matches an excluded datetime or matches the tick of an excluded
+            cron string will be excluded from the partition set.
 
     .. code-block:: python
 
@@ -318,7 +330,7 @@ def monthly_partitioned_config(
     fmt: Optional[str] = None,
     end_offset: int = 0,
     tags_for_partition_fn: Optional[Callable[[datetime, datetime], Mapping[str, str]]] = None,
-    exclusions: Optional[set[Union[str, datetime, TimestampWithTimezone]]] = None,
+    exclusions: Optional[Sequence[Union[str, datetime, TimestampWithTimezone]]] = None,
 ) -> Callable[
     [Callable[[datetime, datetime], Mapping[str, Any]]],
     PartitionedConfig[MonthlyPartitionsDefinition],
@@ -356,6 +368,10 @@ def monthly_partitioned_config(
         tags_for_partition_fn (Optional[Callable[[str], Mapping[str, str]]]): A function that
             accepts a partition time window and returns a dictionary of tags to attach to runs for
             that partition.
+        exclusions (Optional[Sequence[Union[str, datetime]]]): Specifies a sequence of cron strings
+            or datetime objects that should be excluded from the partition set. Every tick of the
+            cron schedule that matches an excluded datetime or matches the tick of an excluded
+            cron string will be excluded from the partition set.
 
     .. code-block:: python
 

--- a/python_modules/dagster/dagster/_core/definitions/partitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/partitioned_schedule.py
@@ -212,9 +212,7 @@ def build_schedule_from_partitioned_job(
                         if context.instance_ref is not None
                         else None,
                     ):
-                        window = time_partitions_def.get_last_partition_window(
-                            ignore_exclusions=True
-                        )
+                        window = time_partitions_def.get_last_partition_window_ignoring_exclusions()
                         if not window:
                             return True
                         return not time_partitions_def.is_window_start_excluded(window.start)

--- a/python_modules/dagster/dagster/_core/definitions/partitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/partitioned_schedule.py
@@ -191,6 +191,7 @@ def build_schedule_from_partitioned_job(
                 cron_schedule,
                 "Creating a schedule from a static partitions definition requires a cron schedule",
             )
+            should_execute = None
         else:
             if cron_schedule or execution_timezone:
                 check.failed(
@@ -202,6 +203,25 @@ def build_schedule_from_partitioned_job(
                 minute_of_hour, hour_of_day, day_of_week, day_of_month
             )
             execution_timezone = time_partitions_def.timezone
+            if time_partitions_def.exclusions:
+
+                def _should_execute(context: ScheduleEvaluationContext) -> bool:
+                    with partition_loading_context(
+                        effective_dt=context.scheduled_execution_time,
+                        dynamic_partitions_store=context.instance
+                        if context.instance_ref is not None
+                        else None,
+                    ):
+                        window = time_partitions_def.get_last_partition_window(
+                            ignore_exclusions=True
+                        )
+                        if not window:
+                            return True
+                        return not time_partitions_def.is_window_start_excluded(window.start)
+
+                should_execute = _should_execute
+            else:
+                should_execute = None
 
         return schedule(
             cron_schedule=cron_schedule,  # type: ignore[arg-type]
@@ -210,6 +230,7 @@ def build_schedule_from_partitioned_job(
             execution_timezone=execution_timezone,
             name=check.opt_str_param(name, "name", f"{job.name}_schedule"),
             description=check.opt_str_param(description, "description"),
+            should_execute=should_execute,
         )(_get_schedule_evaluation_fn(partitions_def, job, tags))
 
 

--- a/python_modules/dagster/dagster/_core/definitions/partitions/snap/snap.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/snap/snap.py
@@ -6,7 +6,8 @@ for that.
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Optional
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional, Union
 
 from typing_extensions import Self
 
@@ -64,6 +65,7 @@ class TimeWindowPartitionsSnap(PartitionsSnap):
     end_offset: int
     end: Optional[float] = None
     cron_schedule: Optional[str] = None
+    exclusions: Optional[set[Union[str, datetime]]] = None
     # superseded by cron_schedule, but kept around for backcompat
     schedule_type: Optional[ScheduleType] = None
     # superseded by cron_schedule, but kept around for backcompat
@@ -85,6 +87,7 @@ class TimeWindowPartitionsSnap(PartitionsSnap):
             timezone=partitions_def.timezone,
             fmt=partitions_def.fmt,
             end_offset=partitions_def.end_offset,
+            exclusions=partitions_def.exclusions,
         )
 
     def get_partitions_definition(self):
@@ -98,6 +101,7 @@ class TimeWindowPartitionsSnap(PartitionsSnap):
                 fmt=self.fmt,
                 end_offset=self.end_offset,
                 end=(datetime_from_timestamp(self.end, tz=self.timezone) if self.end else None),  # pyright: ignore[reportArgumentType]
+                exclusions=self.exclusions,
             )
         else:
             # backcompat case
@@ -111,6 +115,7 @@ class TimeWindowPartitionsSnap(PartitionsSnap):
                 minute_offset=self.minute_offset,
                 hour_offset=self.hour_offset,
                 day_offset=self.day_offset,
+                exclusions=self.exclusions,
             )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/partitions/snap/snap.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/snap/snap.py
@@ -67,7 +67,7 @@ class TimeWindowPartitionsSnap(PartitionsSnap):
     end: Optional[float] = None
     cron_schedule: Optional[str] = None
     exclusions: Optional[
-        set[
+        Sequence[
             Union[
                 str,
                 Annotated[
@@ -97,7 +97,7 @@ class TimeWindowPartitionsSnap(PartitionsSnap):
             timezone=partitions_def.timezone,
             fmt=partitions_def.fmt,
             end_offset=partitions_def.end_offset,
-            exclusions=set(partitions_def.exclusions) if partitions_def.exclusions else None,
+            exclusions=partitions_def.exclusions if partitions_def.exclusions else None,
         )
 
     def get_partitions_definition(self):
@@ -111,7 +111,7 @@ class TimeWindowPartitionsSnap(PartitionsSnap):
                 fmt=self.fmt,
                 end_offset=self.end_offset,
                 end=(datetime_from_timestamp(self.end, tz=self.timezone) if self.end else None),  # pyright: ignore[reportArgumentType]
-                exclusions=set(self.exclusions) if self.exclusions else None,
+                exclusions=self.exclusions if self.exclusions else None,
             )
         else:
             # backcompat case
@@ -125,7 +125,7 @@ class TimeWindowPartitionsSnap(PartitionsSnap):
                 minute_offset=self.minute_offset,
                 hour_offset=self.hour_offset,
                 day_offset=self.day_offset,
-                exclusions=set(self.exclusions) if self.exclusions else None,
+                exclusions=self.exclusions if self.exclusions else None,
             )
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -1019,3 +1019,49 @@ def test_invalid_mappings_with_asset_deps():
                 assets=[daily_partitioned_asset, static_mapped_asset],
             )
         )
+
+
+def test_time_window_partition_mapping_with_exclusions():
+    """Test that TimeWindowPartitionMapping correctly handles excluded partitions with datetime exclusions."""
+    excluded_partition_dts = {
+        datetime(2023, 1, 7),  # Saturday
+        datetime(2023, 1, 8),  # Sunday
+        datetime(2023, 1, 14),  # Saturday
+        datetime(2023, 1, 15),  # Sunday
+    }
+    partitions_def_with_exclusions = dg.TimeWindowPartitionsDefinition(
+        cron_schedule="@daily",
+        start="2023-01-01",
+        fmt="%Y-%m-%d",
+        exclusions=set(excluded_partition_dts),
+    )
+
+    @dg.asset(partitions_def=partitions_def_with_exclusions)
+    def upstream():
+        return
+
+    @dg.asset(
+        partitions_def=partitions_def_with_exclusions,
+        deps=[
+            dg.AssetDep(
+                upstream,
+                partition_mapping=dg.TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            )
+        ],
+    )
+    def downstream(context: AssetExecutionContext):
+        upstream_partition_dt = datetime.strptime(
+            context.asset_partition_key_for_input("upstream"), "%Y-%m-%d"
+        )
+        current_partition_dt = datetime.strptime(context.partition_key, "%Y-%m-%d")
+        assert upstream_partition_dt not in excluded_partition_dts
+        assert current_partition_dt not in excluded_partition_dts
+        assert current_partition_dt - upstream_partition_dt > timedelta(days=1)
+
+    result = dg.materialize(assets=[upstream, downstream], partition_key="2023-01-09")
+
+    assert_namedtuple_lists_equal(
+        result.asset_materializations_for_node("downstream"),
+        [dg.AssetMaterialization(dg.AssetKey(["downstream"]), partition="2023-01-09")],
+        exclude_fields=["tags"],
+    )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -1023,17 +1023,17 @@ def test_invalid_mappings_with_asset_deps():
 
 def test_time_window_partition_mapping_with_exclusions():
     """Test that TimeWindowPartitionMapping correctly handles excluded partitions with datetime exclusions."""
-    excluded_partition_dts = {
+    excluded_partition_dts = [
         datetime(2023, 1, 7),  # Saturday
         datetime(2023, 1, 8),  # Sunday
         datetime(2023, 1, 14),  # Saturday
         datetime(2023, 1, 15),  # Sunday
-    }
+    ]
     partitions_def_with_exclusions = dg.TimeWindowPartitionsDefinition(
         cron_schedule="@daily",
         start="2023-01-01",
         fmt="%Y-%m-%d",
-        exclusions=set(excluded_partition_dts),
+        exclusions=excluded_partition_dts,
     )
 
     @dg.asset(partitions_def=partitions_def_with_exclusions)

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -137,6 +137,7 @@ def test_asset_with_multi_run_backfill_policy():
         timezone="US/Central",
         fmt=DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE,
         end_offset=1,
+        exclusions=set(),
     )
     partitions_def = partitions_snap.get_partitions_definition()
 

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -137,7 +137,6 @@ def test_asset_with_multi_run_backfill_policy():
         timezone="US/Central",
         fmt=DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE,
         end_offset=1,
-        exclusions=set(),
     )
     partitions_def = partitions_snap.get_partitions_definition()
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
@@ -1142,6 +1142,9 @@
           "day_offset": null,
           "end": null,
           "end_offset": 0,
+          "exclusions": {
+            "__set__": []
+          },
           "fmt": "%Y-%m-%d",
           "hour_offset": null,
           "minute_offset": null,

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
@@ -1142,9 +1142,7 @@
           "day_offset": null,
           "end": null,
           "end_offset": 0,
-          "exclusions": {
-            "__set__": []
-          },
+          "exclusions": null,
           "fmt": "%Y-%m-%d",
           "hour_offset": null,
           "minute_offset": null,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
@@ -557,7 +557,7 @@ def test_dynamic_multipartitioned_job_schedule():
 
 
 def test_daily_exclusion_schedule():
-    @dg.daily_partitioned_config(start_date="2021-05-05", exclusions={datetime(2021, 5, 6)})
+    @dg.daily_partitioned_config(start_date="2021-05-05", exclusions=[datetime(2021, 5, 6)])
     def my_partitioned_config(start, end):
         return {"start": start.isoformat(), "end": end.isoformat()}
 
@@ -585,7 +585,7 @@ def test_daily_exclusion_schedule():
 
 def test_daily_exclusion_schedule_with_end_offsets():
     @dg.daily_partitioned_config(
-        start_date="2021-05-05", exclusions={datetime(2021, 5, 6)}, end_offset=1
+        start_date="2021-05-05", exclusions=[datetime(2021, 5, 6)], end_offset=1
     )
     def my_partitioned_config(start, end):
         return {"start": start.isoformat(), "end": end.isoformat()}
@@ -606,7 +606,6 @@ def test_daily_exclusion_schedule_with_end_offsets():
     run_request = my_schedule.evaluate_tick(  # pyright: ignore[reportOptionalSubscript,reportAttributeAccessIssue]
         dg.build_schedule_context(scheduled_execution_time=datetime(2021, 5, 7))
     ).run_requests[0]
-    assert tick.run_requests == []
     assert run_request.run_config == {
         "start": "2021-05-07T00:00:00+00:00",
         "end": "2021-05-08T00:00:00+00:00",

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
@@ -554,3 +554,37 @@ def test_dynamic_multipartitioned_job_schedule():
             "2020-01-01|c",
             "2020-01-01|d",
         }
+
+
+def test_daily_exclusion_schedule():
+    @dg.daily_partitioned_config(start_date="2021-05-05", exclusions={datetime(2021, 5, 6)})
+    def my_partitioned_config(start, end):
+        return {"start": start.isoformat(), "end": end.isoformat()}
+
+    keys = my_partitioned_config.get_partition_keys()
+
+    assert keys[0] == "2021-05-05"
+    assert keys[1] == "2021-05-07"
+
+    my_schedule = schedule_for_partitioned_config(
+        my_partitioned_config, hour_of_day=9, minute_of_hour=30
+    )
+    assert my_schedule.cron_schedule == "30 9 * * *"  # pyright: ignore[reportAttributeAccessIssue]
+
+    # tick on excluded date will skip
+    tick = my_schedule.evaluate_tick(  # pyright: ignore[reportAttributeAccessIssue]
+        dg.build_schedule_context(scheduled_execution_time=datetime(2021, 5, 7, 9, 30))
+    )
+    assert tick.run_requests == []
+
+    run_request = my_schedule.evaluate_tick(  # pyright: ignore[reportOptionalSubscript,reportAttributeAccessIssue]
+        dg.build_schedule_context(scheduled_execution_time=datetime(2021, 5, 8, 9, 30))
+    ).run_requests[0]
+    assert run_request.run_config == {
+        "start": "2021-05-07T00:00:00+00:00",
+        "end": "2021-05-08T00:00:00+00:00",
+    }
+
+    @dg.repository
+    def _repo():
+        return [my_schedule]

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -2330,19 +2330,19 @@ def test_exclusions():
         end="2026-01-01",
         fmt="%Y-%m-%d",
         cron_schedule="0 0 * * *",
-        exclusions={
+        exclusions=[
             "0 0 * * 6-7",  # exclude weekends
-        },
+        ],
     )
     dagsterlabs_calendar = TimeWindowPartitionsDefinition(
         start="2025-01-01",
         end="2026-01-01",
         fmt="%Y-%m-%d",
         cron_schedule="0 0 * * *",  # weekdays only
-        exclusions={
+        exclusions=[
             "0 0 * * 6-7",  # exclude weekends
             *company_holidays,  # exclude company holidays
-        },
+        ],
     )
 
     assert daily_calendar.get_first_partition_key() == "2025-01-01"
@@ -2404,9 +2404,9 @@ def test_exclusions_with_end_offset():
     partitions_def = dg.DailyPartitionsDefinition(
         start_date="2021-05-05",
         end_offset=2,
-        exclusions={
+        exclusions=[
             datetime.strptime("2021-06-04", DATE_FORMAT),
-        },
+        ],
     )
     current_time = datetime.strptime("2021-06-05", DATE_FORMAT)
     partition_context = PartitionLoadingContext(
@@ -2434,9 +2434,9 @@ def test_exclusions_with_negative_end_offset():
     partitions_def = dg.DailyPartitionsDefinition(
         start_date="2021-05-05",
         end_offset=-2,
-        exclusions={
+        exclusions=[
             datetime.strptime("2021-06-01", DATE_FORMAT),
-        },
+        ],
     )
     current_time = datetime.strptime("2021-06-05", DATE_FORMAT)
     partition_context = PartitionLoadingContext(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1,7 +1,7 @@
 import pickle
 import random
 from collections.abc import Sequence
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, cast
 
 import dagster as dg
@@ -2303,3 +2303,80 @@ def test_reverse_pagination_negative_end_offset():
     assert get_paginated_partition_keys(
         partitions_def, current_time=current_time, ascending=False
     ) == list(reversed(all_keys))
+
+
+def test_exclusions():
+    company_holidays = [
+        create_datetime(2025, 1, 1),
+        create_datetime(2025, 1, 20),
+        create_datetime(2025, 2, 17),
+        create_datetime(2025, 5, 26),
+        create_datetime(2025, 6, 19),
+        create_datetime(2025, 7, 4),
+        create_datetime(2025, 9, 1),
+        create_datetime(2025, 11, 27),
+        create_datetime(2025, 11, 28),
+        create_datetime(2025, 12, 24),
+        create_datetime(2025, 12, 25),
+    ]
+    daily_calendar = TimeWindowPartitionsDefinition(
+        start="2025-01-01",
+        end="2026-01-01",
+        fmt="%Y-%m-%d",
+        cron_schedule="0 0 * * *",
+    )
+    weekday_calendar = TimeWindowPartitionsDefinition(
+        start="2025-01-01",
+        end="2026-01-01",
+        fmt="%Y-%m-%d",
+        cron_schedule="0 0 * * *",
+        exclusions={
+            "0 0 * * 6-7",  # exclude weekends
+        },
+    )
+    dagsterlabs_calendar = TimeWindowPartitionsDefinition(
+        start="2025-01-01",
+        end="2026-01-01",
+        fmt="%Y-%m-%d",
+        cron_schedule="0 0 * * *",  # weekdays only
+        exclusions={
+            "0 0 * * 6-7",  # exclude weekends
+            *company_holidays,  # exclude company holidays
+        },
+    )
+
+    assert daily_calendar.get_first_partition_key() == "2025-01-01"
+    assert weekday_calendar.get_first_partition_key() == "2025-01-01"
+    assert dagsterlabs_calendar.get_first_partition_key() == "2025-01-02"
+
+    # normal weekday
+    assert dagsterlabs_calendar.get_next_partition_key("2025-01-09") == "2025-01-10"
+    # respects weekends
+    assert dagsterlabs_calendar.get_next_partition_key("2025-01-10") == "2025-01-13"
+    # respects holiday weekends
+    assert dagsterlabs_calendar.get_next_partition_key("2025-01-17") == "2025-01-21"
+    all_keys = set(dagsterlabs_calendar.get_partition_keys())
+    assert all_keys.intersection(company_holidays) == set()
+
+    next_year = datetime.strptime("2026-01-01", "%Y-%m-%d")
+    with partition_loading_context(effective_dt=next_year):
+        assert daily_calendar.get_num_partitions() == 365
+        assert weekday_calendar.get_num_partitions() == 261
+        assert dagsterlabs_calendar.get_num_partitions() == 250
+
+    # get the time window for a Friday
+    monday = datetime.strptime("2025-01-13", "%Y-%m-%d")
+    window = weekday_calendar.get_prev_partition_window(monday)
+    assert window
+    assert window.start == datetime.strptime("2025-01-10", "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    assert window.end == datetime.strptime("2025-01-11", "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+    # get the time window for the day before a holiday
+    with partition_loading_context(effective_dt=next_year):
+        assert dagsterlabs_calendar.get_next_partition_key("2025-12-23") == "2025-12-26"
+
+    after_christmas = datetime.strptime("2025-12-26", "%Y-%m-%d")
+    window = dagsterlabs_calendar.get_prev_partition_window(after_christmas)
+    assert window
+    assert window.start == datetime.strptime("2025-12-23", "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    assert window.end == datetime.strptime("2025-12-24", "%Y-%m-%d").replace(tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary & Motivation
This PR handles exclusions by omitting them from the set of defined partition keys.

## How I Tested These Changes
BK

## Changelog
- Adds a param `exclusions` to time window partition definitions to support custom calendars