### PR TITLE
remove grpc dependency from api import flow

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -41,9 +41,7 @@ from dagster._core.storage.tags import (
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import FuturesAwareThreadPoolExecutor
-from dagster._grpc import DagsterGrpcClient, DagsterGrpcServer
 from dagster._grpc.impl import core_execute_run
-from dagster._grpc.server import DagsterApiServer
 from dagster._grpc.types import ExecuteRunArgs, ExecuteStepArgs, ResumeRunArgs
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._utils.error import serializable_error_info_from_exc_info
@@ -721,6 +719,9 @@ def grpc_command(
     enable_metrics: bool = False,
     **other_opts: Any,
 ) -> None:
+    # deferring for import perf
+    from dagster._grpc.server import DagsterApiServer, DagsterGrpcServer
+
     python_pointer_opts = PythonPointerOpts.extract_from_cli_options(other_opts)
     assert_no_remaining_opts(other_opts)
 
@@ -868,6 +869,9 @@ def grpc_command(
 def grpc_health_check_command(
     port: Optional[int], socket: Optional[str], host: str, use_ssl: bool
 ) -> None:
+    # deferring for import perf
+    from dagster._grpc.client import DagsterGrpcClient
+
     if seven.IS_WINDOWS and port is None:
         raise click.UsageError(
             "You must pass a valid --port/-p on Windows: --socket/-s not supported."

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -190,8 +190,9 @@ def start_command(
     instance_ref: Optional[str],
     **other_opts,
 ):
-    from dagster._grpc import DagsterGrpcServer
+    # deferring for import perf
     from dagster._grpc.proxy_server import DagsterProxyApiServicer
+    from dagster._grpc.server import DagsterGrpcServer
 
     python_pointer_opts = PythonPointerOpts.extract_from_cli_options(other_opts)
     assert_no_remaining_opts(other_opts)

--- a/python_modules/dagster/dagster/_cli/proxy_server_manager.py
+++ b/python_modules/dagster/dagster/_cli/proxy_server_manager.py
@@ -3,7 +3,7 @@ import os
 import threading
 from collections.abc import Mapping, Sequence
 from contextlib import AbstractContextManager, ExitStack
-from typing import Any, Union, cast
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from typing_extensions import Self
 
@@ -20,11 +20,10 @@ from dagster._core.remote_representation.origin import (
 )
 from dagster._core.workspace.context import WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
-from dagster._grpc.server import (
-    INCREASE_TIMEOUT_DAGSTER_YAML_MSG,
-    GrpcServerCommand,
-    GrpcServerProcess,
-)
+from dagster._grpc.constants import INCREASE_TIMEOUT_DAGSTER_YAML_MSG, GrpcServerCommand
+
+if TYPE_CHECKING:
+    from dagster._grpc.server import GrpcServerProcess
 
 
 def get_auto_restart_code_server_interval() -> int:
@@ -82,7 +81,7 @@ class ProxyServerManager(AbstractContextManager):
                     monitoring_thread.start()
                     self._process_monitoring_threads.append(monitoring_thread)
 
-    def _process_monitoring_thread(self, process_entry: GrpcServerProcess) -> None:
+    def _process_monitoring_thread(self, process_entry: "GrpcServerProcess") -> None:
         """Thread responsible for monitoring the code server processes.
         - If the proxy servers exit unexpectedly, restarts them.
         - Heartbeats the proxy servers to let them know that the caller process is still alive.

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -4,7 +4,6 @@ from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, NoReturn, Optional, cast
 
-import grpc
 from dagster_shared.record import IHaveNew, NamedTupleAdapter, record, record_custom
 
 import dagster._check as check
@@ -250,7 +249,7 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(
         from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
         from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
         from dagster._core.workspace.context import WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL
-        from dagster._grpc.server import GrpcServerCommand
+        from dagster._grpc.constants import GrpcServerCommand
 
         with GrpcServerRegistry(
             instance_ref=instance.get_ref(),
@@ -328,6 +327,9 @@ class GrpcServerCodeLocationOrigin(
         return {key: value for key, value in metadata.items() if value is not None}
 
     def reload_location(self, instance: "DagsterInstance") -> "GrpcServerCodeLocation":
+        # deferred for import perf
+        import grpc
+
         from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
 
         try:

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -68,7 +68,7 @@ from dagster._core.workspace.workspace import (
     CurrentWorkspace,
     location_status_from_location_entry,
 )
-from dagster._grpc.server import INCREASE_TIMEOUT_DAGSTER_YAML_MSG, GrpcServerCommand
+from dagster._grpc.constants import INCREASE_TIMEOUT_DAGSTER_YAML_MSG, GrpcServerCommand
 from dagster._time import get_current_timestamp
 from dagster._utils.aiodataloader import DataLoader
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -27,7 +27,7 @@ from dagster._daemon.daemon import (
 )
 from dagster._daemon.run_coordinator.queued_run_coordinator_daemon import QueuedRunCoordinatorDaemon
 from dagster._daemon.types import DaemonHeartbeat, DaemonStatus
-from dagster._grpc.server import INCREASE_TIMEOUT_DAGSTER_YAML_MSG, GrpcServerCommand
+from dagster._grpc.constants import INCREASE_TIMEOUT_DAGSTER_YAML_MSG, GrpcServerCommand
 from dagster._time import get_current_datetime, get_current_timestamp
 from dagster._utils.interrupts import raise_interrupts_as
 from dagster._utils.log import configure_loggers

--- a/python_modules/dagster/dagster/_grpc/__init__.py
+++ b/python_modules/dagster/dagster/_grpc/__init__.py
@@ -8,16 +8,9 @@ The GRPC layer is not intended to supplant the dagster-graphql layer, which shou
 drive web frontends like the Dagster UI.
 """
 
-from dagster._grpc.client import (
-    DagsterGrpcClient as DagsterGrpcClient,
-    client_heartbeat_thread as client_heartbeat_thread,
-    ephemeral_grpc_api_client as ephemeral_grpc_api_client,
-)
-from dagster._grpc.impl import core_execute_run as core_execute_run
-from dagster._grpc.server import (
-    DagsterGrpcServer as DagsterGrpcServer,
-    GrpcServerProcess as GrpcServerProcess,
-)
+# Prevents dagster._core => dagster._grpc.types => dagster._api => dagster._grpc.types circular imports
+import dagster._core.remote_representation.external_data  # noqa
+
 from dagster._grpc.types import (
     CanCancelExecutionRequest as CanCancelExecutionRequest,
     CanCancelExecutionResult as CanCancelExecutionResult,

--- a/python_modules/dagster/dagster/_grpc/constants.py
+++ b/python_modules/dagster/dagster/_grpc/constants.py
@@ -1,0 +1,22 @@
+from collections.abc import Sequence
+from enum import Enum
+
+INCREASE_TIMEOUT_DAGSTER_YAML_MSG = """To increase the timeout, add the following to a dagster.yaml file, located in your $DAGSTER_HOME folder or the folder where you are running `dagster dev`:
+
+code_servers:
+  local_startup_timeout: <timeout value>
+
+"""
+
+
+class GrpcServerCommand(Enum):
+    API_GRPC = "api_grpc"
+    CODE_SERVER_START = "code_server_start"
+
+    @property
+    def server_command(self) -> Sequence[str]:
+        return (
+            ["api", "grpc", "--lazy-load-user-code"]
+            if self == GrpcServerCommand.API_GRPC
+            else ["code-server", "start"]
+        )

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -13,7 +13,7 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.__generated__ import dagster_api_pb2
 from dagster._grpc.__generated__.dagster_api_pb2_grpc import DagsterApiServicer
 from dagster._grpc.client import DEFAULT_GRPC_TIMEOUT
-from dagster._grpc.server import GrpcServerCommand
+from dagster._grpc.constants import GrpcServerCommand
 from dagster._grpc.types import (
     CancelExecutionRequest,
     CancelExecutionResult,

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -12,7 +12,6 @@ import uuid
 import warnings
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import ExitStack
-from enum import Enum
 from functools import update_wrapper
 from threading import Event as ThreadingEventType
 from time import sleep
@@ -63,6 +62,7 @@ from dagster._grpc.__generated__.dagster_api_pb2_grpc import (
     DagsterApiServicer,
     add_DagsterApiServicer_to_server,
 )
+from dagster._grpc.constants import GrpcServerCommand
 from dagster._grpc.impl import (
     IPCErrorMessage,
     RunInSubprocessComplete,
@@ -1356,14 +1356,6 @@ class CouldNotStartServerProcess(Exception):
         )
 
 
-INCREASE_TIMEOUT_DAGSTER_YAML_MSG = """To increase the timeout, add the following to a dagster.yaml file, located in your $DAGSTER_HOME folder or the folder where you are running `dagster dev`:
-
-code_servers:
-  local_startup_timeout: <timeout value>
-
-"""
-
-
 def wait_for_grpc_server(
     server_process: subprocess.Popen,
     client: "DagsterGrpcClient",
@@ -1395,19 +1387,6 @@ def wait_for_grpc_server(
             )
 
         sleep(0.1)
-
-
-class GrpcServerCommand(Enum):
-    API_GRPC = "api_grpc"
-    CODE_SERVER_START = "code_server_start"
-
-    @property
-    def server_command(self) -> Sequence[str]:
-        return (
-            ["api", "grpc", "--lazy-load-user-code"]
-            if self == GrpcServerCommand.API_GRPC
-            else ["code-server", "start"]
-        )
 
 
 def open_server_process(

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
@@ -18,7 +18,8 @@ from dagster._core.remote_representation.origin import (
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.load_target import PythonFileTarget
-from dagster._grpc.server import GrpcServerCommand, GrpcServerProcess
+from dagster._grpc.constants import GrpcServerCommand
+from dagster._grpc.server import GrpcServerProcess
 from dagster._utils import get_terminate_signal
 from dagster._utils.env import environ
 

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -24,12 +24,8 @@ from dagster._core.test_utils import (
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.client import DagsterGrpcClient
-from dagster._grpc.server import (
-    ExecuteExternalJobArgs,
-    GrpcServerCommand,
-    open_server_process,
-    wait_for_grpc_server,
-)
+from dagster._grpc.constants import GrpcServerCommand
+from dagster._grpc.server import ExecuteExternalJobArgs, open_server_process, wait_for_grpc_server
 from dagster._grpc.types import (
     JobSubsetSnapshotArgs,
     ListRepositoriesResponse,

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
@@ -13,10 +13,11 @@ import pytest
 from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.test_utils import instance_for_test
 from dagster._core.utils import FuturesAwareThreadPoolExecutor
-from dagster._grpc import DagsterGrpcClient, DagsterGrpcServer, ephemeral_grpc_api_client
+from dagster._grpc.client import DagsterGrpcClient, ephemeral_grpc_api_client
+from dagster._grpc.constants import GrpcServerCommand
 from dagster._grpc.server import (
     DagsterCodeServerUtilizationMetrics,
-    GrpcServerCommand,
+    DagsterGrpcServer,
     GrpcServerProcess,
     open_server_process,
 )

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_watch_server.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_watch_server.py
@@ -3,7 +3,8 @@ import time
 import pytest
 from dagster._core.test_utils import instance_for_test
 from dagster._grpc.client import DagsterGrpcClient
-from dagster._grpc.server import GrpcServerCommand, open_server_process
+from dagster._grpc.constants import GrpcServerCommand
+from dagster._grpc.server import open_server_process
 from dagster._grpc.server_watcher import create_grpc_watch_thread
 from dagster._utils import find_free_port
 from dagster_shared.ipc import interrupt_ipc_subprocess_pid

--- a/python_modules/dagster/dagster_tests/general_tests/import_cli.py
+++ b/python_modules/dagster/dagster_tests/general_tests/import_cli.py
@@ -1,0 +1,1 @@
+import dagster._cli  # noqa

--- a/python_modules/dagster/dagster_tests/general_tests/test_import.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_import.py
@@ -6,6 +6,49 @@ from dagster_shared.seven import IS_WINDOWS
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="fails on windows, unix coverage sufficient")
+def test_import_cli_perf():
+    py_file = file_relative_path(__file__, "import_cli.py")
+
+    # import cost profiling output in stderr via "-X importtime"
+    result = subprocess.run(
+        [
+            "python",
+            "-X",
+            "importtime",
+            py_file,
+        ],
+        check=True,
+        capture_output=True,
+    )
+    import_profile = result.stderr.decode("utf-8")
+
+    import_profile_lines = import_profile.split("\n")
+    import_names = [line.split("|")[-1].strip() for line in import_profile_lines]
+
+    # ensure expensive libraries which should not be needed for basic definitions are not imported
+    expensive_library = [
+        "grpc",
+        "sqlalchemy",
+        "upath.",  # don't conflate with import of upath_io_manager
+        "structlog",
+        "fsspec",
+    ]
+    expensive_imports = [
+        f"`{lib}`"
+        for lib in expensive_library
+        if any(import_name.startswith(lib) for import_name in import_names)
+    ]
+    # if `tuna` output is unfriendly, another way to debug imports is to open `/tmp/import.txt`
+    # using https://kmichel.github.io/python-importtime-graph/
+    assert not expensive_imports, (
+        "The following expensive libraries were imported with the top-level `dagster` module, "
+        f"slowing down any process that imports Dagster: {', '.join(expensive_imports)}; to debug, "
+        "`pip install tuna`, then run "
+        "`python -X importtime python_modules/dagster/dagster_tests/general_tests/import_cli.py &> /tmp/import.txt && tuna /tmp/import.txt`."
+    )
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="fails on windows, unix coverage sufficient")
 def test_import_perf():
     py_file = file_relative_path(__file__, "simple.py")
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -63,7 +63,8 @@ from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import EmptyWorkspaceTarget, ModuleTarget
 from dagster._daemon import get_default_daemon_logger
 from dagster._grpc.client import DagsterGrpcClient
-from dagster._grpc.server import GrpcServerCommand, open_server_process
+from dagster._grpc.constants import GrpcServerCommand
+from dagster._grpc.server import open_server_process
 from dagster._record import copy
 from dagster._scheduler.scheduler import (
     RETAIN_ORPHANED_STATE_INTERVAL_SECONDS,

--- a/python_modules/libraries/dagster-celery/dagster_celery/launcher.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/launcher.py
@@ -19,7 +19,7 @@ from dagster._core.launcher import (
     RunLauncher,
     WorkerStatus,
 )
-from dagster._grpc import ExecuteRunArgs, ResumeRunArgs
+from dagster._grpc.types import ExecuteRunArgs, ResumeRunArgs
 from dagster._serdes import ConfigurableClass, ConfigurableClassData, pack_value
 from typing_extensions import Self, override
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/import_perf_tests/test_import_perf.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/import_perf_tests/test_import_perf.py
@@ -22,8 +22,6 @@ def test_import_perf():
         capture_output=True,
     )
     import_profile = result.stderr.decode("utf-8")
-
-    import_profile = result.stderr.decode("utf-8")
     import_profile_lines = import_profile.split("\n")
     import_names = [line.split("|")[-1].strip() for line in import_profile_lines]
 


### PR DESCRIPTION
## Summary & Motivation
grpc was not in the core dagster import but still popped in if you import an API command. Fix that.

## How I Tested These Changes
New test case

