### PR TITLE
Remove rendering ConfigTypeSchema conditionally on any

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarResourcesSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarResourcesSection.tsx
@@ -31,7 +31,7 @@ export const SidebarResourcesSection = ({
             <div>
               <ContextResourceHeader>{resource.name}</ContextResourceHeader>
               <Description description={resource.description || NO_DESCRIPTION} />
-              {resource.configField && (
+              {resource.configField && resource.configField.configType.key !== 'Any' && (
                 <ConfigTypeSchema
                   type={resource.configField.configType}
                   typesInScope={resource.configField.configType.recursiveConfigTypes}


### PR DESCRIPTION
## Summary & Motivation
This pull request updates the behavior of the `SidebarResourcesSection` component in the `dagster-ui` package to improve how resource configurations are displayed. The most important change ensures that the `ConfigTypeSchema` component is only rendered if the `configField` exists and its `configType.key` is not `'Any'`.


## How I Tested These Changes
Changes tested manually by running dagster ui from examples. 
## Changelog

> ### Updates to resource configuration rendering:

* [`js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarResourcesSection.tsx`](diffhunk://#diff-963bc59b16ee4da61d2be1fd0d547cebca56efbe52a4d7dd6e0b7467d5294f08L34-R34): Modified the conditional rendering logic for the `ConfigTypeSchema` component to exclude cases where `configType.key` is `'Any'`. This prevents unnecessary rendering for resources with a generic configuration type.
