### PR TITLE
Defer expensive dg import time dependencies

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/config/jinja_template_loader.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/config/jinja_template_loader.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from jinja2 import Environment, FileSystemLoader
 
 
 class JinjaTemplateLoader:
@@ -32,6 +31,9 @@ class JinjaTemplateLoader:
         return getenv(name, default)
 
     def render(self, filepath: str, context: Mapping[str, Any]) -> str:
+        # defer for import performance
+        from jinja2 import Environment, FileSystemLoader
+
         path = Path(filepath)
         template_path = path.resolve().parent
         filename = path.name

--- a/python_modules/libraries/dagster-dg/dagster_dg/check.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/check.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
 import click
 from dagster_shared.serdes.objects import PluginObjectKey
@@ -11,12 +11,14 @@ from dagster_shared.yaml_utils.source_position import (
     SourcePositionTree,
     ValueAndSourcePositionTree,
 )
-from jsonschema import Draft202012Validator, ValidationError
 from yaml.scanner import ScannerError
 
 from dagster_dg.cli.check_utils import error_dict_to_formatted_error
 from dagster_dg.component import RemotePluginRegistry, get_specified_env_var_deps, get_used_env_vars
 from dagster_dg.context import DgContext
+
+if TYPE_CHECKING:  # defer for import performance
+    from jsonschema import ValidationError
 
 COMPONENT_FILE_SCHEMA = {
     "type": "object",
@@ -49,7 +51,7 @@ def _scaffold_value_and_source_position_tree(
 
 class ErrorInput(NamedTuple):
     object_key: Optional[PluginObjectKey]
-    error: ValidationError
+    error: "ValidationError"
     source_position_tree: ValueAndSourcePositionTree
 
 
@@ -58,6 +60,9 @@ def check_yaml(
     resolved_paths: Sequence[Path],
     validate_requirements: bool,
 ) -> bool:
+    # defer for import performance
+    from jsonschema import Draft202012Validator, ValidationError
+
     top_level_component_validator = Draft202012Validator(schema=COMPONENT_FILE_SCHEMA)
 
     validation_errors: list[ErrorInput] = []

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/check_utils.py
@@ -1,12 +1,14 @@
 import re
 from collections.abc import Sequence
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import click
 import typer
 from dagster_shared.serdes.objects import PluginObjectKey
 from dagster_shared.yaml_utils.source_position import SourcePositionTree
-from jsonschema import ValidationError
+
+if TYPE_CHECKING:  # defer for import performance
+    from jsonschema import ValidationError
 
 
 @click.group(name="check")
@@ -26,7 +28,7 @@ ADDITIONAL_PROPERTIES_ERROR_MESSAGE = (
 )
 
 
-def augment_error_path(error_details: ValidationError) -> Sequence[Union[str, int]]:
+def augment_error_path(error_details: "ValidationError") -> Sequence[Union[str, int]]:
     """Augment the error location (e.g. key) for certain error messages.
 
     In particular, for extra properties, returns the location of the extra property instead
@@ -40,7 +42,7 @@ def augment_error_path(error_details: ValidationError) -> Sequence[Union[str, in
 
 def error_dict_to_formatted_error(
     key: Optional[PluginObjectKey],
-    error_details: ValidationError,
+    error_details: "ValidationError",
     source_position_tree: SourcePositionTree,
     prefix: Sequence[str] = (),
 ) -> str:

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/__init__.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any, Literal, Optional, TypeVar, Union, overload
 
 import click
-import jinja2
 import tomlkit
 from click_aliases import ClickAliasedGroup
 from typer.rich_utils import rich_format_help
@@ -204,6 +203,9 @@ def scaffold_subtree(
     **other_template_vars: Any,
 ):
     """Renders templates for Dagster project."""
+    # defer for import performance
+    import jinja2
+
     excludes = (
         DEFAULT_FILE_EXCLUDE_PATTERNS if not excludes else DEFAULT_FILE_EXCLUDE_PATTERNS + excludes
     )

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/build.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Optional
 
 import click
-import jinja2
 from dagster_shared import check
 from dagster_shared.plus.config import DagsterPlusCliConfig
 
@@ -75,6 +74,9 @@ def get_agent_type(cli_config: Optional[DagsterPlusCliConfig] = None) -> DgPlusA
 
 
 def create_deploy_dockerfile(dst_path: Path, python_version: str, use_editable_dagster: bool):
+    # defer for import performance
+    import jinja2
+
     dockerfile_template_path = (
         Path(__file__).parent.parent.parent
         / "templates"

--- a/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql_client.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/utils/plus/gql_client.py
@@ -3,8 +3,6 @@ from typing import Any, Optional
 
 import click
 from dagster_shared.plus.config import DagsterPlusCliConfig
-from gql import Client, gql
-from gql.transport.requests import RequestsHTTPTransport
 
 
 class DagsterPlusUnauthorizedError(click.ClickException):
@@ -13,6 +11,10 @@ class DagsterPlusUnauthorizedError(click.ClickException):
 
 class DagsterPlusGraphQLClient:
     def __init__(self, url: str, headers: Mapping[str, str]):
+        # defer for import performance
+        from gql import Client
+        from gql.transport.requests import RequestsHTTPTransport
+
         self.client = Client(
             transport=RequestsHTTPTransport(url=url, use_json=True, headers=dict(headers))
         )
@@ -33,6 +35,9 @@ class DagsterPlusGraphQLClient:
         )
 
     def execute(self, query: str, variables: Optional[Mapping[str, Any]] = None):
+        # defer for import performance
+        from gql import gql
+
         result = self.client.execute(gql(query), variable_values=dict(variables or {}))
         value = next(iter(result.values()))
         if isinstance(value, Mapping):

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/import_perf_tests/simple_import.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/import_perf_tests/simple_import.py
@@ -1,0 +1,1 @@
+from dagster_dg.cli.launch import launch_command  # noqa

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/import_perf_tests/test_import_perf.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/import_perf_tests/test_import_perf.py
@@ -1,0 +1,54 @@
+import subprocess
+
+import pytest
+from dagster._utils import file_relative_path
+from dagster_shared.seven import IS_WINDOWS
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="fails on windows, unix coverage sufficient")
+def test_import_perf():
+    py_file = file_relative_path(__file__, "simple_import.py")
+
+    # import cost profiling output in stderr via "-X importtime"
+    result = subprocess.run(
+        [
+            "python",
+            "-X",
+            "importtime",
+            py_file,
+        ],
+        check=True,
+        capture_output=True,
+    )
+    import_profile = result.stderr.decode("utf-8")
+
+    import_profile = result.stderr.decode("utf-8")
+    import_profile_lines = import_profile.split("\n")
+    import_names = [line.split("|")[-1].strip() for line in import_profile_lines]
+
+    # ensure expensive libraries which should not be needed for basic definitions are not imported
+    expensive_library = [
+        "grpc",
+        "sqlalchemy",
+        "upath.",  # don't conflate with import of upath_io_manager
+        "structlog",
+        "fsspec",
+        "gql",
+        "jinja2",
+        "jsonschema",
+        "requests",
+    ]
+    expensive_imports = [
+        f"`{lib}`"
+        for lib in expensive_library
+        if any(import_name.startswith(lib) for import_name in import_names)
+    ]
+
+    # if `tuna` output is unfriendly, another way to debug imports is to open `/tmp/import.txt`
+    # using https://kmichel.github.io/python-importtime-graph/
+    assert not expensive_imports, (
+        "The following expensive libraries were imported with the top-level `dagster` module, "
+        f"slowing down any process that imports Dagster: {', '.join(expensive_imports)}; to debug, "
+        "`pip install tuna`, then run "
+        "`python -X importtime python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/import_perf_tests/simple_import.py &> /tmp/import.txt && tuna /tmp/import.txt`."
+    )


### PR DESCRIPTION
## Summary & Motivation
Building off of alex's execellent past work speeding up import times in dagster core, defer relatively expensive imports until they are actually used in a command rather than at import time, with a test to keep them from sneaking back in. There's some additional juice to squeeze here but these are the easy ones.

## How I Tested These Changes
New test case, manual trials (lowers import time from ~0.5356 seconds to ~0.317 seconds)

