### PR TITLE
Fix Slack Hooks: slack_on_success and slack_on_failure

### DIFF
--- a/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/hooks.py
@@ -72,7 +72,7 @@ def slack_on_failure(
         if webserver_base_url:
             text += f"\n<{webserver_base_url}/runs/{context.run_id}|View in Dagster UI>"
 
-        context.resources.slack.chat_postMessage(channel=channel, text=text)
+        context.resources.slack.get_client().chat_postMessage(channel=channel, text=text)
 
     return _hook
 
@@ -131,6 +131,6 @@ def slack_on_success(
         if webserver_base_url:
             text += f"\n<{webserver_base_url}/runs/{context.run_id}|View in Dagster UI>"
 
-        context.resources.slack.chat_postMessage(channel=channel, text=text)
+        context.resources.slack.get_client().chat_postMessage(channel=channel, text=text)
 
     return _hook


### PR DESCRIPTION
fixes #22052

## Summary & Motivation
Current implementation will not work and throw an exception.

```
AttributeError: 'SlackResource' object has no attribute 'chat_postMessage'
```

## How I Tested These Changes
Ran it locally.

## Changelog
Add `get_client()` to slack resource.

> Insert changelog entry or delete this section.
