### PR TITLE
[ui] Ensure that lineage fullscreen works for new nav

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/App.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/App.oss.tsx
@@ -1,10 +1,11 @@
 import clsx from 'clsx';
 import {CSSProperties, useCallback, useContext} from 'react';
-import {useRecoilValue} from 'recoil';
+import {useLocation} from 'react-router-dom';
+import {useRecoilState} from 'recoil';
 
 import {LayoutContext} from './LayoutProvider';
 import {LEFT_NAV_WIDTH, LeftNav} from '../nav/LeftNav';
-import {isFullScreenAtom} from './AppTopNav/AppTopNavContext';
+import {canForceFullScreen, isFullScreenAtom} from './AppTopNav/AppTopNavContext';
 import styles from './css/App.module.css';
 
 interface Props {
@@ -21,7 +22,9 @@ export const App = ({banner, children}: Props) => {
     }
   }, [nav]);
 
-  const isFullScreen = useRecoilValue(isFullScreenAtom);
+  const location = useLocation();
+  const [enabledFullScreen] = useRecoilState(isFullScreenAtom);
+  const isFullScreen = enabledFullScreen && canForceFullScreen(location);
 
   return (
     <div

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavContext.tsx
@@ -1,6 +1,13 @@
+import {useLocation} from 'react-router-dom';
 import {atom} from 'recoil';
 
 export const isFullScreenAtom = atom<boolean>({
   key: 'isFullScreenAtom',
   default: false,
 });
+
+export const canForceFullScreen = (location: ReturnType<typeof useLocation>): boolean => {
+  const {pathname, search} = location;
+  const searchParams = new URLSearchParams(search);
+  return pathname.startsWith('/selection/') && searchParams.get('selectedTab') === 'lineage';
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsCatalog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsCatalog.tsx
@@ -1,11 +1,11 @@
 import {Box} from '@dagster-io/ui-components';
 import React, {useEffect} from 'react';
-import {useRouteMatch} from 'react-router-dom';
+import {useLocation, useRouteMatch} from 'react-router-dom';
 import {useRecoilState, useSetRecoilState} from 'recoil';
 import {ViewBreadcrumb} from 'shared/assets/ViewBreadcrumb.oss';
 
 import {AssetCatalogTableV2} from './AssetCatalogTableV2';
-import {isFullScreenAtom} from '../../app/AppTopNav/AppTopNavContext';
+import {canForceFullScreen, isFullScreenAtom} from '../../app/AppTopNav/AppTopNavContext';
 import {currentPageAtom} from '../../app/analytics';
 
 export const AssetsCatalog = React.memo(() => {
@@ -15,7 +15,9 @@ export const AssetsCatalog = React.memo(() => {
     setCurrentPage(({specificPath}) => ({specificPath, path: `${path}?view=AssetCatalogTableV2`}));
   }, [path, setCurrentPage]);
 
-  const [isFullScreen, setIsFullScreen] = useRecoilState(isFullScreenAtom);
+  const location = useLocation();
+  const [enabledFullScreen, setEnableFullScreen] = useRecoilState(isFullScreenAtom);
+  const isFullScreen = enabledFullScreen && canForceFullScreen(location);
 
   return (
     <div
@@ -35,7 +37,7 @@ export const AssetsCatalog = React.memo(() => {
       </Box>
       <AssetCatalogTableV2
         isFullScreen={isFullScreen}
-        toggleFullScreen={() => setIsFullScreen(!isFullScreen)}
+        toggleFullScreen={() => setEnableFullScreen(!enabledFullScreen)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary & Motivation

Check the pathname and search values to determine whether fullscreen behavior should be enabled for the app. Used by https://github.com/dagster-io/internal/pull/15848 to determine whether to hide the new nav.

## How I Tested These Changes

View app, navigate to asset selection, then lineage. Toggle fullscreen, verify that the top nav is hidden.