### PR TITLE
[dagster-fivetran] Fix asset key translation & customization with legacy Fivetran APIs

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/conftest.py
@@ -688,7 +688,12 @@ def all_api_mocks_fixture(
 
 @pytest.fixture(name="sync_and_poll")
 def sync_and_poll_fixture():
-    with patch("dagster_fivetran.resources.FivetranClient.sync_and_poll") as mocked_function:
+    with (
+        patch("dagster_fivetran.resources.FivetranClient.sync_and_poll") as mocked_function,
+        patch(
+            "dagster_fivetran.resources.FivetranResource.sync_and_poll"
+        ) as mocked_sync_and_poll_legacy_resource,
+    ):
         # Fivetran output where all sync'd tables match the workspace data that was used to create the assets def
         expected_fivetran_output = FivetranOutput(
             connector_details=get_sample_connection_details(
@@ -707,6 +712,11 @@ def sync_and_poll_fixture():
         # sync_and_poll returns None if the connector is paused
         paused_connector_output = None
         mocked_function.side_effect = [
+            expected_fivetran_output,
+            unexpected_fivetran_output,
+            paused_connector_output,
+        ]
+        mocked_sync_and_poll_legacy_resource.side_effect = [
             expected_fivetran_output,
             unexpected_fivetran_output,
             paused_connector_output,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/deprecated/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/deprecated/test_asset_defs.py
@@ -171,7 +171,7 @@ def test_fivetran_asset_run(tables, infer_missing_tables, should_error, schema_p
 
 
 class MyCustomTranslator(DagsterFivetranTranslator):
-    def get_asset_spec(self, props: FivetranConnectorTableProps) -> AssetSpec:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def get_asset_spec(self, props: FivetranConnectorTableProps) -> AssetSpec:
         default_spec = super().get_asset_spec(props)
         return default_spec.replace_attributes(
             key=default_spec.key.with_prefix("prefix"),
@@ -180,7 +180,7 @@ class MyCustomTranslator(DagsterFivetranTranslator):
 
 
 class MyCustomTranslatorWackyKeys(DagsterFivetranTranslator):
-    def get_asset_spec(self, props: FivetranConnectorTableProps) -> AssetSpec:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def get_asset_spec(self, props: FivetranConnectorTableProps) -> AssetSpec:
         default_spec = super().get_asset_spec(props)
         return default_spec.replace_attributes(
             key=["wacky", *["".join(reversed(item)) for item in default_spec.key.path], "wow"],

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/deprecated/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/deprecated/test_asset_defs.py
@@ -1,15 +1,25 @@
+from unittest.mock import MagicMock
+
 import pytest
 import responses
 from dagster import AssetKey, DagsterStepOutputNotFoundError
-from dagster._core.definitions.materialize import materialize
-from dagster_fivetran import fivetran_resource
-from dagster_fivetran.asset_defs import build_fivetran_assets
+from dagster._core.definitions import materialize
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.test_utils import environ
+from dagster_fivetran import (
+    DagsterFivetranTranslator,
+    FivetranConnectorTableProps,
+    fivetran_resource,
+)
+from dagster_fivetran.asset_defs import build_fivetran_assets, load_assets_from_fivetran_instance
 from dagster_fivetran.resources import (
     FIVETRAN_API_BASE,
     FIVETRAN_API_VERSION_PATH,
     FIVETRAN_CONNECTOR_PATH,
+    FivetranResource,
 )
 
+from dagster_fivetran_tests.conftest import TEST_API_KEY, TEST_API_SECRET, TEST_CONNECTOR_ID
 from dagster_fivetran_tests.deprecated.utils import (
     DEFAULT_CONNECTOR_ID,
     get_sample_columns_response,
@@ -158,3 +168,74 @@ def test_fivetran_asset_run(tables, infer_missing_tables, should_error, schema_p
                     AssetKey(["schema1", "untracked"]),
                     AssetKey(["schema2", "tracked"]),
                 } | ({AssetKey(["does", "not_exist"])} if infer_missing_tables else set())
+
+
+class MyCustomTranslator(DagsterFivetranTranslator):
+    def get_asset_spec(self, props: FivetranConnectorTableProps) -> AssetSpec:  # pyright: ignore[reportIncompatibleMethodOverride]
+        default_spec = super().get_asset_spec(props)
+        return default_spec.replace_attributes(
+            key=default_spec.key.with_prefix("prefix"),
+            metadata={**default_spec.metadata, "custom": "metadata"},
+        )
+
+
+class MyCustomTranslatorWackyKeys(DagsterFivetranTranslator):
+    def get_asset_spec(self, props: FivetranConnectorTableProps) -> AssetSpec:  # pyright: ignore[reportIncompatibleMethodOverride]
+        default_spec = super().get_asset_spec(props)
+        return default_spec.replace_attributes(
+            key=["wacky", *["".join(reversed(item)) for item in default_spec.key.path], "wow"],
+        )
+
+
+@pytest.mark.parametrize(
+    "translator, expected_key",
+    [
+        (
+            MyCustomTranslator,
+            AssetKey(["prefix", "schema_name_in_destination_1", "table_name_in_destination_1"]),
+        ),
+        (
+            MyCustomTranslatorWackyKeys,
+            AssetKey(
+                ["wacky", "1_noitanitsed_ni_eman_amehcs", "1_noitanitsed_ni_eman_elbat", "wow"]
+            ),
+        ),
+    ],
+    ids=["custom_translator", "custom_translator_wacky_keys"],
+)
+def test_translator_custom_metadata_materialize(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+    sync_and_poll: MagicMock,
+    translator: type[DagsterFivetranTranslator],
+    expected_key: AssetKey,
+) -> None:
+    with environ({"FIVETRAN_API_KEY": TEST_API_KEY, "FIVETRAN_API_SECRET": TEST_API_SECRET}):
+        resource = FivetranResource(api_key=TEST_API_KEY, api_secret=TEST_API_SECRET)
+        my_cacheable_fivetran_assets = load_assets_from_fivetran_instance(
+            fivetran=resource, fetch_column_metadata=False, translator=translator
+        )
+        my_fivetran_assets = my_cacheable_fivetran_assets.build_definitions(
+            my_cacheable_fivetran_assets.compute_cacheable_data()
+        )
+        my_fivetran_assets_def = next(
+            assets_def
+            for assets_def in my_fivetran_assets
+            if TEST_CONNECTOR_ID in assets_def.op.name
+        )
+        result = materialize(
+            [my_fivetran_assets_def],
+        )
+
+        assert result.success
+        asset_materializations = [
+            event
+            for event in result.all_events
+            if event.event_type_value == "ASSET_MATERIALIZATION"
+        ]
+        assert len(asset_materializations) == 4
+        materialized_asset_keys = {
+            asset_materialization.asset_key for asset_materialization in asset_materializations
+        }
+        assert len(materialized_asset_keys) == 4
+        assert my_fivetran_assets_def.keys == materialized_asset_keys
+        assert expected_key in materialized_asset_keys

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_specs.py
@@ -240,7 +240,7 @@ def test_cached_load_spec_with_asset_factory(
 
 
 class MyCustomTranslator(DagsterFivetranTranslator):
-    def get_asset_spec(self, props: FivetranConnectorTableProps) -> AssetSpec:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def get_asset_spec(self, props: FivetranConnectorTableProps) -> AssetSpec:
         default_spec = super().get_asset_spec(props)
         return default_spec.replace_attributes(
             key=default_spec.key.with_prefix("prefix"),
@@ -274,7 +274,7 @@ def test_translator_custom_metadata(
 
 
 class MyCustomTranslatorWackyKeys(DagsterFivetranTranslator):
-    def get_asset_spec(self, props: FivetranConnectorTableProps) -> AssetSpec:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def get_asset_spec(self, props: FivetranConnectorTableProps) -> AssetSpec:
         default_spec = super().get_asset_spec(props)
         return default_spec.replace_attributes(
             key=["wacky", *["".join(reversed(item)) for item in default_spec.key.path], "wow"],


### PR DESCRIPTION
## Summary

Fixes a subtle issue which arises with the legacy Fivetran integration APIs when materializing connections whose asset keys are customized by a user-provided translator.

This codepath was not under test (we never materialized these customized assets, just checked the properties of the specs themselves) - added a new test which tests both legacy and modern APIs with translators which manipulate asset keys in varying ways.

## Changelog

> [dagster-fivetran] Fixed an issue with `load_assets_from_fivetran_instance` legacy apis where assets whose asset keys have been customized using a Fivetran translator would lead to an exception.
