### PR TITLE
[Catalog] Add `isFullScreenEnabled` atom to control whether a view is full page screenable

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/App.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/App.oss.tsx
@@ -3,7 +3,7 @@ import {CSSProperties, useCallback, useContext} from 'react';
 
 import {LayoutContext} from './LayoutProvider';
 import {LEFT_NAV_WIDTH, LeftNav} from '../nav/LeftNav';
-import {useFullscreen} from './AppTopNav/AppTopNavContext';
+import {useFullScreen} from './AppTopNav/AppTopNavContext';
 import styles from './css/App.module.css';
 
 interface Props {
@@ -20,7 +20,7 @@ export const App = ({banner, children}: Props) => {
     }
   }, [nav]);
 
-  const {isFullScreen} = useFullscreen();
+  const {isFullScreen} = useFullScreen();
 
   return (
     <div

--- a/js_modules/dagster-ui/packages/ui-core/src/app/App.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/App.oss.tsx
@@ -3,7 +3,7 @@ import {CSSProperties, useCallback, useContext} from 'react';
 
 import {LayoutContext} from './LayoutProvider';
 import {LEFT_NAV_WIDTH, LeftNav} from '../nav/LeftNav';
-import {useIsFullScreenEnabled} from './AppTopNav/AppTopNavContext';
+import {useFullscreen} from './AppTopNav/AppTopNavContext';
 import styles from './css/App.module.css';
 
 interface Props {
@@ -20,7 +20,7 @@ export const App = ({banner, children}: Props) => {
     }
   }, [nav]);
 
-  const isFullScreen = useIsFullScreenEnabled();
+  const {isFullScreen} = useFullscreen();
 
   return (
     <div

--- a/js_modules/dagster-ui/packages/ui-core/src/app/App.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/App.oss.tsx
@@ -1,10 +1,9 @@
 import clsx from 'clsx';
 import {CSSProperties, useCallback, useContext} from 'react';
-import {useRecoilValue} from 'recoil';
 
 import {LayoutContext} from './LayoutProvider';
 import {LEFT_NAV_WIDTH, LeftNav} from '../nav/LeftNav';
-import {isFullScreenAtom} from './AppTopNav/AppTopNavContext';
+import {useIsFullScreenEnabled} from './AppTopNav/AppTopNavContext';
 import styles from './css/App.module.css';
 
 interface Props {
@@ -21,7 +20,7 @@ export const App = ({banner, children}: Props) => {
     }
   }, [nav]);
 
-  const isFullScreen = useRecoilValue(isFullScreenAtom);
+  const isFullScreen = useIsFullScreenEnabled();
 
   return (
     <div

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNav.tsx
@@ -1,7 +1,6 @@
 import {Box, Colors, Icon, IconWrapper} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {NavLink} from 'react-router-dom';
-import {useRecoilValue} from 'recoil';
 import {AppTopNavRightOfLogo} from 'shared/app/AppTopNav/AppTopNavRightOfLogo.oss';
 import styled from 'styled-components';
 
@@ -15,7 +14,7 @@ import {
 } from '../../nav/useRepositoryLocationReload';
 import {LayoutContext} from '../LayoutProvider';
 import {ShortcutHandler} from '../ShortcutHandler';
-import {isFullScreenAtom} from './AppTopNavContext';
+import {useFullscreen} from './AppTopNavContext';
 
 interface Props {
   children?: React.ReactNode;
@@ -24,7 +23,7 @@ interface Props {
 }
 
 export const AppTopNav = ({children, allowGlobalReload = false}: Props) => {
-  const isFullScreen = useRecoilValue(isFullScreenAtom);
+  const {isFullScreen} = useFullscreen();
   return isFullScreen ? null : (
     <AppTopNavImpl allowGlobalReload={allowGlobalReload}>{children}</AppTopNavImpl>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNav.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../nav/useRepositoryLocationReload';
 import {LayoutContext} from '../LayoutProvider';
 import {ShortcutHandler} from '../ShortcutHandler';
-import {useFullscreen} from './AppTopNavContext';
+import {useFullScreen} from './AppTopNavContext';
 
 interface Props {
   children?: React.ReactNode;
@@ -23,7 +23,7 @@ interface Props {
 }
 
 export const AppTopNav = ({children, allowGlobalReload = false}: Props) => {
-  const {isFullScreen} = useFullscreen();
+  const {isFullScreen} = useFullScreen();
   return isFullScreen ? null : (
     <AppTopNavImpl allowGlobalReload={allowGlobalReload}>{children}</AppTopNavImpl>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavContext.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useLayoutEffect} from 'react';
-import {atom, useRecoilState, useSetRecoilState} from 'recoil';
+import {atom, useRecoilState, useRecoilValue, useSetRecoilState} from 'recoil';
 
 export const isFullScreenAtom = atom<boolean>({
   key: 'isFullScreenAtom',
@@ -11,14 +11,16 @@ export const isFullScreenAllowedAtom = atom<boolean>({
   default: false,
 });
 
-export const useFullscreen = () => {
+export const useFullScreen = () => {
+  // FullScreen causes the navigation to be hidden to create more room.
   const [isFullScreen, setIsFullScreen] = useRecoilState(isFullScreenAtom);
-  const [isFullScreenEnabled, setIsFullScreenEnabled] = useRecoilState(isFullScreenAllowedAtom);
+
+  // Not every page supports full screen mode, a page can use the useFullScreenAllowedView hook to enable it.
+  const isFullScreenAllowed = useRecoilValue(isFullScreenAllowedAtom);
 
   return {
-    isFullScreen: isFullScreen && isFullScreenEnabled,
+    isFullScreen: isFullScreen && isFullScreenAllowed,
     setIsFullScreen,
-    setIsFullScreenEnabled,
     toggleFullScreen: useCallback(
       () => setIsFullScreen((isFullScreen) => !isFullScreen),
       [setIsFullScreen],
@@ -26,10 +28,10 @@ export const useFullscreen = () => {
   };
 };
 
-export const useFullScreenEnabledView = () => {
-  const setIsFullScreenEnabled = useSetRecoilState(isFullScreenAllowedAtom);
+export const useFullScreenAllowedView = () => {
+  const setIsFullScreenAllowed = useSetRecoilState(isFullScreenAllowedAtom);
   useLayoutEffect(() => {
-    setIsFullScreenEnabled(true);
-    return () => setIsFullScreenEnabled(false);
-  }, [setIsFullScreenEnabled]);
+    setIsFullScreenAllowed(true);
+    return () => setIsFullScreenAllowed(false);
+  }, [setIsFullScreenAllowed]);
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavContext.tsx
@@ -1,6 +1,35 @@
-import {atom} from 'recoil';
+import {useCallback, useLayoutEffect} from 'react';
+import {atom, useRecoilState, useSetRecoilState} from 'recoil';
 
 export const isFullScreenAtom = atom<boolean>({
   key: 'isFullScreenAtom',
   default: false,
 });
+
+export const isFullScreenAllowedAtom = atom<boolean>({
+  key: 'isFullScreenAllowedAtom',
+  default: false,
+});
+
+export const useFullscreen = () => {
+  const [isFullScreen, setIsFullScreen] = useRecoilState(isFullScreenAtom);
+  const [isFullScreenEnabled, setIsFullScreenEnabled] = useRecoilState(isFullScreenAllowedAtom);
+
+  return {
+    isFullScreen: isFullScreen && isFullScreenEnabled,
+    setIsFullScreen,
+    setIsFullScreenEnabled,
+    toggleFullScreen: useCallback(
+      () => setIsFullScreen((isFullScreen) => !isFullScreen),
+      [setIsFullScreen],
+    ),
+  };
+};
+
+export const useFullScreenEnabledView = () => {
+  const setIsFullScreenEnabled = useSetRecoilState(isFullScreenAllowedAtom);
+  useLayoutEffect(() => {
+    setIsFullScreenEnabled(true);
+    return () => setIsFullScreenEnabled(false);
+  }, [setIsFullScreenEnabled]);
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
@@ -172,7 +172,7 @@ describe('AssetCatalogTableV2', () => {
               >
                 <WorkspaceProvider>
                   <AssetLiveDataProvider>
-                    <AssetCatalogTableV2 isFullScreen={false} toggleFullScreen={() => {}} />
+                    <AssetCatalogTableV2 />
                   </AssetLiveDataProvider>
                 </WorkspaceProvider>
               </MockedProvider>
@@ -232,7 +232,7 @@ describe('AssetCatalogTableV2', () => {
               >
                 <WorkspaceProvider>
                   <AssetLiveDataProvider>
-                    <AssetCatalogTableV2 isFullScreen={false} toggleFullScreen={() => {}} />
+                    <AssetCatalogTableV2 />
                   </AssetLiveDataProvider>
                 </WorkspaceProvider>
               </MockedProvider>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogAssetGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogAssetGraph.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useMemo, useState} from 'react';
 import {useHistory} from 'react-router';
 import {useFavoriteAssets} from 'shared/assets/useFavoriteAssets.oss';
 
-import {useFullScreenEnabledView, useFullscreen} from '../../app/AppTopNav/AppTopNavContext';
+import {useFullScreen, useFullScreenAllowedView} from '../../app/AppTopNav/AppTopNavContext';
 import {AssetGraphExplorer} from '../../asset-graph/AssetGraphExplorer';
 import {AssetGraphViewType, tokenForAssetKey} from '../../asset-graph/Utils';
 import {AssetLocation} from '../../asset-graph/useFindAssetLocation';
@@ -22,9 +22,9 @@ export const AssetCatalogAssetGraph = React.memo(
     onChangeSelection: (selection: string) => void;
     tabs: React.ReactNode;
   }) => {
-    useFullScreenEnabledView();
+    useFullScreenAllowedView();
 
-    const {isFullScreen, toggleFullScreen} = useFullscreen();
+    const {isFullScreen, toggleFullScreen} = useFullScreen();
 
     const history = useHistory();
     const openInNewTab = useOpenInNewTab();

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogAssetGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogAssetGraph.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useMemo, useState} from 'react';
 import {useHistory} from 'react-router';
 import {useFavoriteAssets} from 'shared/assets/useFavoriteAssets.oss';
 
+import {useFullScreenEnabledView, useFullscreen} from '../../app/AppTopNav/AppTopNavContext';
 import {AssetGraphExplorer} from '../../asset-graph/AssetGraphExplorer';
 import {AssetGraphViewType, tokenForAssetKey} from '../../asset-graph/Utils';
 import {AssetLocation} from '../../asset-graph/useFindAssetLocation';
@@ -15,16 +16,16 @@ export const AssetCatalogAssetGraph = React.memo(
   ({
     selection,
     onChangeSelection,
-    isFullScreen,
-    toggleFullScreen,
     tabs,
   }: {
     selection: string;
     onChangeSelection: (selection: string) => void;
-    isFullScreen: boolean;
-    toggleFullScreen: () => void;
     tabs: React.ReactNode;
   }) => {
+    useFullScreenEnabledView();
+
+    const {isFullScreen, toggleFullScreen} = useFullscreen();
+
     const history = useHistory();
     const openInNewTab = useOpenInNewTab();
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -25,7 +25,7 @@ import {useFavoriteAssets} from 'shared/assets/useFavoriteAssets.oss';
 
 import {AssetCatalogAssetGraph} from './AssetCatalogAssetGraph';
 import {AssetCatalogV2VirtualizedTable} from './AssetCatalogV2VirtualizedTable';
-import {useFullscreen} from '../../app/AppTopNav/AppTopNavContext';
+import {useFullScreen} from '../../app/AppTopNav/AppTopNavContext';
 import {PythonErrorInfo} from '../../app/PythonErrorInfo';
 import {COMMON_COLLATOR, assertUnreachable} from '../../app/Util';
 import {currentPageAtom} from '../../app/analytics';
@@ -163,7 +163,7 @@ export const AssetCatalogTableV2 = React.memo(() => {
     }));
   }, [path, setCurrentPage, selectedTab]);
 
-  const {isFullScreen} = useFullscreen();
+  const {isFullScreen} = useFullScreen();
 
   const tabs = useMemo(
     () => (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -25,6 +25,7 @@ import {useFavoriteAssets} from 'shared/assets/useFavoriteAssets.oss';
 
 import {AssetCatalogAssetGraph} from './AssetCatalogAssetGraph';
 import {AssetCatalogV2VirtualizedTable} from './AssetCatalogV2VirtualizedTable';
+import {useFullscreen} from '../../app/AppTopNav/AppTopNavContext';
 import {PythonErrorInfo} from '../../app/PythonErrorInfo';
 import {COMMON_COLLATOR, assertUnreachable} from '../../app/Util';
 import {currentPageAtom} from '../../app/analytics';
@@ -50,229 +51,225 @@ import {AssetTableFragment} from '../types/AssetTableFragment.types';
 dayjs.extend(relativeTime);
 dayjs.extend(updateLocale);
 
-export const AssetCatalogTableV2 = React.memo(
-  ({isFullScreen, toggleFullScreen}: {isFullScreen: boolean; toggleFullScreen: () => void}) => {
-    const {assets, loading: assetsLoading, error} = useAllAssets();
-    useBlockTraceUntilTrue('useAllAssets', !!assets?.length && !assetsLoading);
+export const AssetCatalogTableV2 = React.memo(() => {
+  const {assets, loading: assetsLoading, error} = useAllAssets();
+  useBlockTraceUntilTrue('useAllAssets', !!assets?.length && !assetsLoading);
 
-    const {favorites, loading: favoritesLoading} = useFavoriteAssets();
+  const {favorites, loading: favoritesLoading} = useFavoriteAssets();
 
-    const penultimateAssets = useMemo(() => {
-      if (!favorites) {
-        return assets ?? [];
-      }
-      return (assets ?? []).filter((asset: AssetTableFragment) =>
-        favorites.has(tokenForAssetKey(asset.key)),
-      );
-    }, [favorites, assets]);
+  const penultimateAssets = useMemo(() => {
+    if (!favorites) {
+      return assets ?? [];
+    }
+    return (assets ?? []).filter((asset: AssetTableFragment) =>
+      favorites.has(tokenForAssetKey(asset.key)),
+    );
+  }, [favorites, assets]);
 
-    const [errorState, setErrorState] = useState<SyntaxError[]>([]);
+  const [errorState, setErrorState] = useState<SyntaxError[]>([]);
 
-    const {
-      filterInput,
-      filtered,
-      loading: selectionLoading,
-      setAssetSelection,
-      assetSelection,
-    } = useAssetSelectionInput<AssetTableFragment>({
-      assets: penultimateAssets,
-      assetsLoading: !assets && (assetsLoading || favoritesLoading),
-      onErrorStateChange: useCallback(
-        (errors: SyntaxError[]) => {
-          if (errors !== errorState) {
-            setErrorState(errors);
-          }
-        },
-        [errorState],
-      ),
-    });
-
-    const loading = selectionLoading && !filtered.length;
-
-    const [sortBy, setSortBy] = useStateWithStorage<(typeof SORT_ITEMS)[number]['key']>(
-      usePrefixedCacheKey('catalog-sortBy'),
-      (json) => {
-        if (['materialization_asc', 'materialization_desc', 'key_asc', 'key_desc'].includes(json)) {
-          return json;
+  const {
+    filterInput,
+    filtered,
+    loading: selectionLoading,
+    setAssetSelection,
+    assetSelection,
+  } = useAssetSelectionInput<AssetTableFragment>({
+    assets: penultimateAssets,
+    assetsLoading: !assets && (assetsLoading || favoritesLoading),
+    onErrorStateChange: useCallback(
+      (errors: SyntaxError[]) => {
+        if (errors !== errorState) {
+          setErrorState(errors);
         }
-        return 'materialization_asc';
       },
-    );
+      [errorState],
+    ),
+  });
 
-    const {liveDataByNode} = useAssetsHealthData(
-      useMemo(() => filtered.map((asset) => asAssetKeyInput(asset.key)), [filtered]),
-    );
+  const loading = selectionLoading && !filtered.length;
 
-    const healthDataLoading = useMemo(() => {
-      return Object.values(liveDataByNode).length !== filtered.length;
-    }, [liveDataByNode, filtered]);
-
-    const groupedByStatus = useMemo(() => {
-      const byStatus: Record<AssetHealthStatusString, (typeof liveDataByNode)[string][]> = {
-        Degraded: [],
-        Warning: [],
-        Healthy: [],
-        Unknown: [],
-      };
-      Object.values(liveDataByNode).forEach((asset) => {
-        const status =
-          statusToIconAndColor[asset.assetHealth?.assetHealth ?? AssetHealthStatus.UNKNOWN].text;
-        byStatus[status].push(asset);
-      });
-      let sortFn;
-      switch (sortBy) {
-        case 'materialization_asc':
-          sortFn = (a: AssetHealthFragment, b: AssetHealthFragment) =>
-            sortAssetsByMaterializationTimestamp(a, b);
-          break;
-        case 'materialization_desc':
-          sortFn = (a: AssetHealthFragment, b: AssetHealthFragment) =>
-            sortAssetsByMaterializationTimestamp(b, a);
-          break;
-        case 'key_asc':
-          sortFn = (a: AssetHealthFragment, b: AssetHealthFragment) =>
-            COMMON_COLLATOR.compare(tokenForAssetKey(a.key), tokenForAssetKey(b.key));
-          break;
-        case 'key_desc':
-          sortFn = (a: AssetHealthFragment, b: AssetHealthFragment) =>
-            COMMON_COLLATOR.compare(tokenForAssetKey(b.key), tokenForAssetKey(a.key));
-          break;
-        default:
-          assertUnreachable(sortBy);
+  const [sortBy, setSortBy] = useStateWithStorage<(typeof SORT_ITEMS)[number]['key']>(
+    usePrefixedCacheKey('catalog-sortBy'),
+    (json) => {
+      if (['materialization_asc', 'materialization_desc', 'key_asc', 'key_desc'].includes(json)) {
+        return json;
       }
-      Object.values(byStatus).forEach((assets) => {
-        assets.sort(sortFn);
-      });
-      return byStatus;
-    }, [liveDataByNode, sortBy]);
+      return 'materialization_asc';
+    },
+  );
 
-    const [selectedTab, setSelectedTab] = useQueryPersistedState<string>({
-      queryKey: 'selectedTab',
-      defaults: {selectedTab: 'assets'},
-      decode: (qs) =>
-        qs.selectedTab && typeof qs.selectedTab === 'string' ? qs.selectedTab : 'assets',
-      encode: (b) => ({selectedTab: b || 'assets'}),
+  const {liveDataByNode} = useAssetsHealthData(
+    useMemo(() => filtered.map((asset) => asAssetKeyInput(asset.key)), [filtered]),
+  );
+
+  const healthDataLoading = useMemo(() => {
+    return Object.values(liveDataByNode).length !== filtered.length;
+  }, [liveDataByNode, filtered]);
+
+  const groupedByStatus = useMemo(() => {
+    const byStatus: Record<AssetHealthStatusString, (typeof liveDataByNode)[string][]> = {
+      Degraded: [],
+      Warning: [],
+      Healthy: [],
+      Unknown: [],
+    };
+    Object.values(liveDataByNode).forEach((asset) => {
+      const status =
+        statusToIconAndColor[asset.assetHealth?.assetHealth ?? AssetHealthStatus.UNKNOWN].text;
+      byStatus[status].push(asset);
     });
+    let sortFn;
+    switch (sortBy) {
+      case 'materialization_asc':
+        sortFn = (a: AssetHealthFragment, b: AssetHealthFragment) =>
+          sortAssetsByMaterializationTimestamp(a, b);
+        break;
+      case 'materialization_desc':
+        sortFn = (a: AssetHealthFragment, b: AssetHealthFragment) =>
+          sortAssetsByMaterializationTimestamp(b, a);
+        break;
+      case 'key_asc':
+        sortFn = (a: AssetHealthFragment, b: AssetHealthFragment) =>
+          COMMON_COLLATOR.compare(tokenForAssetKey(a.key), tokenForAssetKey(b.key));
+        break;
+      case 'key_desc':
+        sortFn = (a: AssetHealthFragment, b: AssetHealthFragment) =>
+          COMMON_COLLATOR.compare(tokenForAssetKey(b.key), tokenForAssetKey(a.key));
+        break;
+      default:
+        assertUnreachable(sortBy);
+    }
+    Object.values(byStatus).forEach((assets) => {
+      assets.sort(sortFn);
+    });
+    return byStatus;
+  }, [liveDataByNode, sortBy]);
 
-    const setCurrentPage = useSetRecoilState(currentPageAtom);
-    const {path} = useRouteMatch();
-    useEffect(() => {
-      setCurrentPage(({specificPath}) => ({
-        specificPath,
-        path: `${path}?view=AssetCatalogTableV2&selected_tab=${selectedTab}`,
-      }));
-    }, [path, setCurrentPage, selectedTab]);
+  const [selectedTab, setSelectedTab] = useQueryPersistedState<string>({
+    queryKey: 'selectedTab',
+    defaults: {selectedTab: 'assets'},
+    decode: (qs) =>
+      qs.selectedTab && typeof qs.selectedTab === 'string' ? qs.selectedTab : 'assets',
+    encode: (b) => ({selectedTab: b || 'assets'}),
+  });
 
-    const tabs = useMemo(
-      () => (
-        <Box border="bottom">
-          {isFullScreen ? null : (
-            <Tabs
-              onChange={setSelectedTab}
-              selectedTabId={selectedTab}
-              style={{marginLeft: 24, marginRight: 24}}
-            >
-              <Tab id="assets" title="Assets" />
-              <Tab id="lineage" title="Lineage" />
-              <Tab id="insights" title="Insights" />
-            </Tabs>
-          )}
-        </Box>
-      ),
-      [isFullScreen, selectedTab, setSelectedTab],
-    );
+  const setCurrentPage = useSetRecoilState(currentPageAtom);
+  const {path} = useRouteMatch();
+  useEffect(() => {
+    setCurrentPage(({specificPath}) => ({
+      specificPath,
+      path: `${path}?view=AssetCatalogTableV2&selected_tab=${selectedTab}`,
+    }));
+  }, [path, setCurrentPage, selectedTab]);
 
-    const content = useMemo(() => {
-      if (error) {
-        return <PythonErrorInfo error={error} />;
-      }
+  const {isFullScreen} = useFullscreen();
 
-      if (!assets?.length && !loading) {
-        return (
-          <Box padding={{vertical: 64}}>
-            <AssetsEmptyState />
-          </Box>
-        );
-      }
-      if (favorites && filtered.length === 0 && !loading) {
-        return (
-          <Box padding={24}>
-            <NonIdealState
-              icon="star"
-              title="No favorite assets"
-              description="To add one, click the star in the asset view or choose 'Add to favorites' from the asset menu in the catalog."
-            />
-          </Box>
-        );
-      }
-      switch (selectedTab) {
-        case 'lineage':
-          return (
-            <AssetCatalogAssetGraph
-              selection={assetSelection}
-              onChangeSelection={setAssetSelection}
-              isFullScreen={isFullScreen}
-              toggleFullScreen={toggleFullScreen}
-              tabs={tabs}
-            />
-          );
-        case 'insights':
-          return <AssetCatalogInsights assets={filtered} selection={assetSelection} tabs={tabs} />;
-        default:
-          return (
-            <Table
-              assets={filtered}
-              groupedByStatus={groupedByStatus}
-              loading={loading}
-              healthDataLoading={healthDataLoading}
-              tabs={tabs}
-              sortBy={sortBy}
-              setSortBy={setSortBy}
-            />
-          );
-      }
-    }, [
-      error,
-      assets?.length,
-      loading,
-      selectedTab,
-      assetSelection,
-      setAssetSelection,
-      isFullScreen,
-      toggleFullScreen,
-      filtered,
-      groupedByStatus,
-      favorites,
-      healthDataLoading,
-      tabs,
-      sortBy,
-      setSortBy,
-    ]);
-
-    const extraStyles =
-      selectedTab === 'lineage'
-        ? {
-            gridTemplateColumns: 'minmax(500px, 1fr)',
-            display: 'grid',
-            gridTemplateRows: 'repeat(2, auto) minmax(0, 1fr)',
-          }
-        : {};
-    return (
-      <Box flex={{direction: 'column'}} style={{height: '100%', minHeight: 600, ...extraStyles}}>
-        <Box
-          flex={{direction: 'row', alignItems: 'center', gap: 8}}
-          padding={{vertical: 12, horizontal: 24}}
-          border={['insights', 'lineage'].includes(selectedTab) ? 'bottom' : undefined}
-        >
-          <Box flex={{grow: 1, shrink: 1}}>{filterInput}</Box>
-          <CreateCatalogViewButton />
-        </Box>
-        {/* Lineage and Insights render their own loading bars */}
-        {content}
+  const tabs = useMemo(
+    () => (
+      <Box border="bottom">
+        {isFullScreen ? null : (
+          <Tabs
+            onChange={setSelectedTab}
+            selectedTabId={selectedTab}
+            style={{marginLeft: 24, marginRight: 24}}
+          >
+            <Tab id="assets" title="Assets" />
+            <Tab id="lineage" title="Lineage" />
+            <Tab id="insights" title="Insights" />
+          </Tabs>
+        )}
       </Box>
-    );
-  },
-);
+    ),
+    [isFullScreen, selectedTab, setSelectedTab],
+  );
+
+  const content = useMemo(() => {
+    if (error) {
+      return <PythonErrorInfo error={error} />;
+    }
+
+    if (!assets?.length && !loading) {
+      return (
+        <Box padding={{vertical: 64}}>
+          <AssetsEmptyState />
+        </Box>
+      );
+    }
+    if (favorites && filtered.length === 0 && !loading) {
+      return (
+        <Box padding={24}>
+          <NonIdealState
+            icon="star"
+            title="No favorite assets"
+            description="To add one, click the star in the asset view or choose 'Add to favorites' from the asset menu in the catalog."
+          />
+        </Box>
+      );
+    }
+    switch (selectedTab) {
+      case 'lineage':
+        return (
+          <AssetCatalogAssetGraph
+            selection={assetSelection}
+            onChangeSelection={setAssetSelection}
+            tabs={tabs}
+          />
+        );
+      case 'insights':
+        return <AssetCatalogInsights assets={filtered} selection={assetSelection} tabs={tabs} />;
+      default:
+        return (
+          <Table
+            assets={filtered}
+            groupedByStatus={groupedByStatus}
+            loading={loading}
+            healthDataLoading={healthDataLoading}
+            tabs={tabs}
+            sortBy={sortBy}
+            setSortBy={setSortBy}
+          />
+        );
+    }
+  }, [
+    error,
+    assets?.length,
+    loading,
+    selectedTab,
+    assetSelection,
+    setAssetSelection,
+    filtered,
+    groupedByStatus,
+    favorites,
+    healthDataLoading,
+    tabs,
+    sortBy,
+    setSortBy,
+  ]);
+
+  const extraStyles =
+    selectedTab === 'lineage'
+      ? {
+          gridTemplateColumns: 'minmax(500px, 1fr)',
+          display: 'grid',
+          gridTemplateRows: 'repeat(2, auto) minmax(0, 1fr)',
+        }
+      : {};
+  return (
+    <Box flex={{direction: 'column'}} style={{height: '100%', minHeight: 600, ...extraStyles}}>
+      <Box
+        flex={{direction: 'row', alignItems: 'center', gap: 8}}
+        padding={{vertical: 12, horizontal: 24}}
+        border={['insights', 'lineage'].includes(selectedTab) ? 'bottom' : undefined}
+      >
+        <Box flex={{grow: 1, shrink: 1}}>{filterInput}</Box>
+        <CreateCatalogViewButton />
+      </Box>
+      {/* Lineage and Insights render their own loading bars */}
+      {content}
+    </Box>
+  );
+});
 
 AssetCatalogTableV2.displayName = 'AssetCatalogTableV2';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsCatalog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsCatalog.tsx
@@ -1,11 +1,11 @@
 import {Box} from '@dagster-io/ui-components';
 import React, {useEffect} from 'react';
 import {useRouteMatch} from 'react-router-dom';
-import {useRecoilState, useSetRecoilState} from 'recoil';
+import {useSetRecoilState} from 'recoil';
 import {ViewBreadcrumb} from 'shared/assets/ViewBreadcrumb.oss';
 
 import {AssetCatalogTableV2} from './AssetCatalogTableV2';
-import {isFullScreenAtom} from '../../app/AppTopNav/AppTopNavContext';
+import {useFullscreen} from '../../app/AppTopNav/AppTopNavContext';
 import {currentPageAtom} from '../../app/analytics';
 
 export const AssetsCatalog = React.memo(() => {
@@ -15,7 +15,7 @@ export const AssetsCatalog = React.memo(() => {
     setCurrentPage(({specificPath}) => ({specificPath, path: `${path}?view=AssetCatalogTableV2`}));
   }, [path, setCurrentPage]);
 
-  const [isFullScreen, setIsFullScreen] = useRecoilState(isFullScreenAtom);
+  const {isFullScreen, setIsFullScreen} = useFullscreen();
 
   return (
     <div
@@ -35,7 +35,7 @@ export const AssetsCatalog = React.memo(() => {
       </Box>
       <AssetCatalogTableV2
         isFullScreen={isFullScreen}
-        toggleFullScreen={() => setIsFullScreen(!isFullScreen)}
+        toggleFullScreen={() => setIsFullScreen((isFullScreen) => !isFullScreen)}
       />
     </div>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsCatalog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsCatalog.tsx
@@ -5,7 +5,6 @@ import {useSetRecoilState} from 'recoil';
 import {ViewBreadcrumb} from 'shared/assets/ViewBreadcrumb.oss';
 
 import {AssetCatalogTableV2} from './AssetCatalogTableV2';
-import {useFullscreen} from '../../app/AppTopNav/AppTopNavContext';
 import {currentPageAtom} from '../../app/analytics';
 
 export const AssetsCatalog = React.memo(() => {
@@ -14,8 +13,6 @@ export const AssetsCatalog = React.memo(() => {
   useEffect(() => {
     setCurrentPage(({specificPath}) => ({specificPath, path: `${path}?view=AssetCatalogTableV2`}));
   }, [path, setCurrentPage]);
-
-  const {isFullScreen, setIsFullScreen} = useFullscreen();
 
   return (
     <div
@@ -33,10 +30,7 @@ export const AssetsCatalog = React.memo(() => {
       >
         <ViewBreadcrumb full />
       </Box>
-      <AssetCatalogTableV2
-        isFullScreen={isFullScreen}
-        toggleFullScreen={() => setIsFullScreen((isFullScreen) => !isFullScreen)}
-      />
+      <AssetCatalogTableV2 />
     </div>
   );
 });


### PR DESCRIPTION
## Summary & Motivation
"Full screen" mode causes the page's navigation to disappear. It is intended for use by the lineage page in the catalog. 

Currently if you turn fullscreen mode on, and navigate away by clicking a link from the asset graph's right sidebar (eg. "View in catalog" link for an asset) then fullscreen mode stays on and there's no way to turn it off to see the page's navigation. To fix this I'm adding a second atom `isFullScreenEnabled` and a hook `useFullScreenEnabledView`

## How I Tested These Changes

https://github.com/user-attachments/assets/cc2962fd-4ac4-4159-b7d6-20626a8b1937
