### PR TITLE
errorred -> errored - aligning with spelling in rest of repo

### DIFF
--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -991,7 +991,7 @@ def _handle_run_reactions(
         origin_run_id = check.not_none(run_reaction.dagster_run).run_id
         if run_reaction.error:
             context.logger.warning(
-                f"Got a reaction request for run {origin_run_id} but execution errorred:"
+                f"Got a reaction request for run {origin_run_id} but execution errored:"
                 f" {run_reaction.error}"
             )
             context.update_state(


### PR DESCRIPTION
It is spelled "errored" in many other places in the repository.

Also, see https://english.stackexchange.com/questions/244410/how-is-the-past-tense-of-error-spelt-in-british-english for a discussion of this spelling.

## Summary & Motivation
This spelling, which appears in an error message, was a bit jarring for me.

## How I Tested These Changes
Text-only change.

## Changelog
> Improved spelling.
