### PR TITLE
[dg] Add support for autodefs_module_name in workspace loading

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -756,6 +756,7 @@ def grpc_command(
             python_pointer_opts.module_name,
             python_pointer_opts.package_name,
             python_pointer_opts.python_file,
+            python_pointer_opts.autoload_defs_module_name,
             empty_working_directory,
         ]
     ):
@@ -772,6 +773,7 @@ def grpc_command(
             module_name=python_pointer_opts.module_name,
             python_file=python_pointer_opts.python_file,
             package_name=python_pointer_opts.package_name,
+            autoload_defs_module_name=python_pointer_opts.autoload_defs_module_name,
         )
 
     code_desc = " "

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -220,6 +220,7 @@ def start_command(
         module_name=python_pointer_opts.module_name,
         python_file=python_pointer_opts.python_file,
         package_name=python_pointer_opts.package_name,
+        autoload_defs_module_name=python_pointer_opts.autoload_defs_module_name,
     )
 
     code_desc = " "

--- a/python_modules/dagster/dagster/_cli/utils.py
+++ b/python_modules/dagster/dagster/_cli/utils.py
@@ -28,7 +28,8 @@ def has_pyproject_dagster_block(path: str) -> bool:
         data = tomli.load(f)
         if not isinstance(data, dict):
             return False
-        return "dagster" in data.get("tool", {})
+
+        return "dagster" in data.get("tool", {}) or "dg" in data.get("tool", {})
 
 
 @contextmanager

--- a/python_modules/dagster/dagster/_core/code_pointer.py
+++ b/python_modules/dagster/dagster/_core/code_pointer.py
@@ -285,3 +285,19 @@ class CustomPointer(CodePointer, IHaveNew, LegacyNamedTupleMixin):
                 self,  # type: ignore
             )
         return self._hash
+
+
+@whitelist_for_serdes
+@record
+class AutoloadDefsModuleCodePointer(CodePointer):
+    module: str
+    working_directory: Optional[str]
+
+    def load_target(self) -> object:
+        from dagster.components.core.load_defs import load_defs
+
+        module = load_python_module(self.module, self.working_directory)
+        return load_defs(module)
+
+    def describe(self) -> str:
+        return f"autoload from {self.module}"

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -48,15 +48,16 @@ def _assign_grpc_location_name(port, socket, host):
 def _assign_loadable_target_origin_name(loadable_target_origin: LoadableTargetOrigin) -> str:
     check.inst_param(loadable_target_origin, "loadable_target_origin", LoadableTargetOrigin)
 
-    file_or_module = (
-        loadable_target_origin.package_name
-        if loadable_target_origin.package_name
-        else (
-            loadable_target_origin.module_name
-            if loadable_target_origin.module_name
-            else os.path.basename(cast("str", loadable_target_origin.python_file))
-        )
-    )
+    if loadable_target_origin.package_name:
+        file_or_module = loadable_target_origin.package_name
+    elif loadable_target_origin.module_name:
+        file_or_module = loadable_target_origin.module_name
+    elif loadable_target_origin.autoload_defs_module_name:
+        file_or_module = loadable_target_origin.autoload_defs_module_name
+    elif loadable_target_origin.python_file:
+        file_or_module = os.path.basename(loadable_target_origin.python_file)
+    else:
+        check.failed(f"Unexpected LoadableTargetOrigin structure: {loadable_target_origin}")
 
     return (
         f"{file_or_module}:{loadable_target_origin.attribute}"
@@ -216,6 +217,7 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(IHaveNew, LegacyNamedTupleMixin, Co
         metadata = {
             "python_file": self.loadable_target_origin.python_file,
             "module_name": self.loadable_target_origin.module_name,
+            "autoload_defs_module_name": self.loadable_target_origin.autoload_defs_module_name,
             "working_directory": self.loadable_target_origin.working_directory,
             "attribute": self.loadable_target_origin.attribute,
             "package_name": self.loadable_target_origin.package_name,

--- a/python_modules/dagster/dagster/_core/types/loadable_target_origin.py
+++ b/python_modules/dagster/dagster/_core/types/loadable_target_origin.py
@@ -7,7 +7,11 @@ from dagster._serdes import whitelist_for_serdes
 from dagster_shared.record import LegacyNamedTupleMixin, record, as_dict
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(
+    # This object is included in code location origin hashing used to identify schedule/sensor so
+    # ensure new fields are not included when they are not used which would change the hash.
+    skip_when_none_fields={"autoload_defs_module_name"},
+)
 @record
 class LoadableTargetOrigin(LegacyNamedTupleMixin):
     executable_path: Optional[str] = None
@@ -16,6 +20,7 @@ class LoadableTargetOrigin(LegacyNamedTupleMixin):
     working_directory: Optional[str] = None
     attribute: Optional[str] = None
     package_name: Optional[str] = None
+    autoload_defs_module_name: Optional[str] = None
 
     def get_cli_args(self) -> Sequence[str]:
         args = (
@@ -24,6 +29,11 @@ class LoadableTargetOrigin(LegacyNamedTupleMixin):
             + (["-d", self.working_directory] if self.working_directory else [])
             + (["-a", self.attribute] if self.attribute else [])
             + (["--package-name", self.package_name] if self.package_name else [])
+            + (
+                ["--autoload-defs-module-name", self.autoload_defs_module_name]
+                if self.autoload_defs_module_name
+                else []
+            )
         )
 
         return args

--- a/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
+++ b/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
@@ -132,3 +132,14 @@ def _loadable_targets_of_type(
             loadable_targets.append(LoadableTarget(name, value))
 
     return loadable_targets
+
+
+def autodefs_module_target(autoload_defs_module_name: str, working_directory: Optional[str]):
+    from dagster.components import load_defs
+
+    module = load_python_module(autoload_defs_module_name, working_directory)
+    defs = load_defs(module)
+    return LoadableTarget(
+        attribute="",
+        target_definition=defs,
+    )

--- a/python_modules/dagster/dagster/_core/workspace/config_schema.py
+++ b/python_modules/dagster/dagster/_core/workspace/config_schema.py
@@ -73,6 +73,15 @@ def _get_target_config() -> Mapping[str, ScalarUnion]:
                 "executable_path": Field(StringSource, is_required=False),
             },
         ),
+        "autoload_defs_module": ScalarUnion(
+            scalar_type=str,
+            non_scalar_schema={
+                "module_name": StringSource,
+                "working_directory": Field(StringSource, is_required=False),
+                "location_name": Field(StringSource, is_required=False),
+                "executable_path": Field(StringSource, is_required=False),
+            },
+        ),
     }
 
 

--- a/python_modules/dagster/dagster/_core/workspace/load.py
+++ b/python_modules/dagster/dagster/_core/workspace/load.py
@@ -101,6 +101,29 @@ def _get_module_config_data(
     )
 
 
+def _location_origin_from_autoload_config(
+    python_module_config: Union[str, Mapping[str, str]],
+) -> ManagedGrpcPythonEnvCodeLocationOrigin:
+    (
+        module_name,
+        _,
+        working_directory,
+        location_name,
+        executable_path,
+    ) = _get_module_config_data(python_module_config)
+
+    loadable_target_origin = LoadableTargetOrigin(
+        executable_path=executable_path,
+        python_file=None,
+        autoload_defs_module_name=module_name,
+        working_directory=working_directory,
+        attribute=None,
+        package_name=None,
+    )
+
+    return _create_python_env_location_origin(loadable_target_origin, location_name)
+
+
 def _create_python_env_location_origin(
     loadable_target_origin: LoadableTargetOrigin, location_name: Optional[str]
 ) -> ManagedGrpcPythonEnvCodeLocationOrigin:
@@ -126,6 +149,25 @@ def location_origin_from_module_name(
         working_directory=working_directory,
         attribute=attribute,
         package_name=None,
+    )
+
+    return _create_python_env_location_origin(loadable_target_origin, location_name)
+
+
+def location_origin_from_autoload_defs_module_name(
+    autoload_defs_module_name: str,
+    working_directory: Optional[str],
+    location_name: Optional[str] = None,
+    executable_path: Optional[str] = None,
+) -> ManagedGrpcPythonEnvCodeLocationOrigin:
+    loadable_target_origin = LoadableTargetOrigin(
+        executable_path=executable_path,
+        python_file=None,
+        module_name=None,
+        working_directory=working_directory,
+        attribute=None,
+        package_name=None,
+        autoload_defs_module_name=autoload_defs_module_name,
     )
 
     return _create_python_env_location_origin(loadable_target_origin, location_name)
@@ -315,6 +357,7 @@ def is_target_config(potential_target_config: object) -> bool:
         potential_target_config.get("python_file")
         or potential_target_config.get("python_module")
         or potential_target_config.get("python_package")
+        or potential_target_config.get("autoload_defs_module")
     )
 
 
@@ -336,6 +379,10 @@ def _location_origin_from_target_config(
     elif "python_package" in target_config:
         python_package_config = cast("Union[str, dict]", target_config["python_package"])
         return _location_origin_from_package_config(python_package_config)
+
+    elif "autoload_defs_module" in target_config:
+        autoload_cfg = cast("Union[str, dict]", target_config["autoload_defs_module"])
+        return _location_origin_from_autoload_config(autoload_cfg)
 
     else:
         check.failed("invalid target_config")

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -26,7 +26,7 @@ from dagster_shared.utils import find_free_port
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 
 import dagster._check as check
-from dagster._core.code_pointer import CodePointer
+from dagster._core.code_pointer import AutoloadDefsModuleCodePointer, CodePointer
 from dagster._core.definitions.definitions_load_context import (
     DefinitionsLoadContext,
     DefinitionsLoadType,
@@ -267,11 +267,12 @@ class LoadedRepositories:
                 ),
             ):
                 loadable_targets = get_loadable_targets(
-                    loadable_target_origin.python_file,
-                    loadable_target_origin.module_name,
-                    loadable_target_origin.package_name,
-                    loadable_target_origin.working_directory,
-                    loadable_target_origin.attribute,
+                    python_file=loadable_target_origin.python_file,
+                    module_name=loadable_target_origin.module_name,
+                    package_name=loadable_target_origin.package_name,
+                    working_directory=loadable_target_origin.working_directory,
+                    attribute=loadable_target_origin.attribute,
+                    autoload_defs_module_name=loadable_target_origin.autoload_defs_module_name,
                 )
             for loadable_target in loadable_targets:
                 pointer = _get_code_pointer(loadable_target_origin, loadable_target)
@@ -341,6 +342,11 @@ def _get_code_pointer(
             loadable_target_origin.module_name,
             loadable_repository_symbol.attribute,
             loadable_target_origin.working_directory,
+        )
+    elif loadable_target_origin.autoload_defs_module_name:
+        return AutoloadDefsModuleCodePointer(
+            module=loadable_target_origin.autoload_defs_module_name,
+            working_directory=loadable_target_origin.working_directory,
         )
     else:
         check.failed("Invalid loadable target origin")

--- a/python_modules/dagster/dagster/_grpc/utils.py
+++ b/python_modules/dagster/dagster/_grpc/utils.py
@@ -17,14 +17,17 @@ _DEFAULT_REPOSITORY_TIMEOUT_IF_NO_ENV_VAR_SET = 180
 
 
 def get_loadable_targets(
+    *,
     python_file: Optional[str],
     module_name: Optional[str],
     package_name: Optional[str],
+    autoload_defs_module_name: Optional[str],
     working_directory: Optional[str],
     attribute: Optional[str],
 ) -> Sequence["LoadableTarget"]:
     from dagster._core.workspace.autodiscovery import (
         LoadableTarget,
+        autodefs_module_target,
         loadable_targets_from_python_file,
         loadable_targets_from_python_module,
         loadable_targets_from_python_package,
@@ -60,6 +63,8 @@ def get_loadable_targets(
             if attribute
             else loadable_targets_from_python_package(package_name, working_directory)
         )
+    elif autoload_defs_module_name:
+        return [autodefs_module_target(autoload_defs_module_name, working_directory)]
     else:
         check.failed("invalid")
 

--- a/python_modules/dagster/dagster_tests/cli_tests/test_workspace_config_schema.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_workspace_config_schema.py
@@ -254,3 +254,23 @@ def test_load_from_grpc_server_env():
     """
 
         assert _validate_yaml_contents(valid_socket_yaml).success
+
+
+def test_autoload_module():
+    terse_workspace_yaml = """
+load_from:
+    - autoload_defs_module: foo.defs
+"""
+
+    assert _validate_yaml_contents(terse_workspace_yaml).success
+
+
+def test_autoload_module_obj():
+    terse_workspace_yaml = """
+load_from:
+    - autoload_defs_module:
+        module_name: foo.defs
+        working_directory: baz
+"""
+
+    assert _validate_yaml_contents(terse_workspace_yaml).success

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
@@ -49,6 +49,35 @@ def test_load_python_module_from_dg_toml():
         assert origins[0].loadable_target_origin.module_name == "baaz.other_definitions"
 
 
+def test_autodefs_module_from_dg_toml():
+    with NamedTemporaryFile("w") as f:
+        f.write(
+            textwrap.dedent("""
+                [tool.dg.project]
+                root_module = "baaz"
+                autoload_defs = true
+            """).strip()
+        )
+        f.flush()
+        origins = get_origins_from_toml(f.name)
+        assert len(origins) == 1
+        assert origins[0].loadable_target_origin.autoload_defs_module_name == "baaz.defs"
+
+    with NamedTemporaryFile("w") as f:
+        f.write(
+            textwrap.dedent("""
+                [tool.dg.project]
+                root_module = "baaz"
+                autoload_defs = true
+                defs_module = "boo.bar"
+            """).strip()
+        )
+        f.flush()
+        origins = get_origins_from_toml(f.name)
+        assert len(origins) == 1
+        assert origins[0].loadable_target_origin.autoload_defs_module_name == "boo.bar"
+
+
 def test_load_empty_toml():
     assert get_origins_from_toml(file_relative_path(__file__, "empty.toml")) == []
 

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/workspace/__init__.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/workspace/__init__.py
@@ -342,6 +342,10 @@ def format_workspace_config(workspace_config) -> dict[str, Any]:
                 new_location["code_source"]["package_name"] = location["package_name"]
             if "module_name" in location:
                 new_location["code_source"]["module_name"] = location["module_name"]
+            if "autodefs_module_name" in location:
+                new_location["code_source"]["autodefs_module_name"] = location[
+                    "autodefs_module_name"
+                ]
 
             new_location["location_name"] = name
             updated_locations.append(new_location)

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/config_utils.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/config_utils.py
@@ -362,6 +362,14 @@ DEPLOYMENT_METADATA_OPTIONS = {
         str,
         Option(None, "--module-name", "-m", help="Python module where repositories live"),
     ),
+    "autoload_defs_module_name": (
+        str,
+        Option(
+            None,
+            "--autoload-defs-module-name",
+            help="Python module to recurse over and automatically load Definitions from",
+        ),
+    ),
     "executable_path": (
         str,
         Option(
@@ -474,6 +482,7 @@ def get_location_document(name: Optional[str], kwargs: dict[str, Any]) -> dict[s
                 "python_file": python_file_str,
                 "module_name": kwargs.get("module_name"),
                 "package_name": kwargs.get("package_name"),
+                "autoload_defs_module_name": kwargs.get("autoload_defs_module_name"),
             },
             "working_directory": kwargs.get("working_directory"),
             "image": kwargs.get("image"),

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/launch.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/launch.py
@@ -74,8 +74,7 @@ def launch_command(
             partition_range=partition_range,
             config=tuple(config),
             config_json=config_json,
-            working_directory=str(dg_context.root_path),
-            module_name=dg_context.code_location_target_module_name,
+            **dg_context.target_args,
         )
     elif job:
         from dagster._cli.job import job_execute_command_impl
@@ -84,11 +83,10 @@ def launch_command(
             job_name=job,
             config=tuple(config),
             config_json=config_json,
-            working_directory=str(dg_context.root_path),
-            module_name=dg_context.code_location_target_module_name,
             repository=SINGLETON_REPOSITORY_NAME,
             tags=None,
             op_selection=None,
             partition=partition,
             partition_range=partition_range,
+            **dg_context.target_args,
         )

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/list.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/list.py
@@ -307,7 +307,7 @@ def list_defs_command(output_json: bool, path: Path, **global_options: object) -
     with capture_stdout():
         definitions = list_definitions_impl(
             location=dg_context.code_location_name,
-            module_name=dg_context.code_location_target_module_name,
+            **dg_context.target_args,
         )
 
     # JSON

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/config.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/config.py
@@ -309,6 +309,7 @@ def merge_container_context_configs(
 class DgProjectConfig:
     root_module: str
     defs_module: Optional[str] = None
+    autoload_defs: bool = False
     code_location_target_module: Optional[str] = None
     code_location_name: Optional[str] = None
     python_environment: DgProjectPythonEnvironment = field(
@@ -319,6 +320,7 @@ class DgProjectConfig:
     def from_raw(cls, raw: "DgRawProjectConfig") -> Self:
         return cls(
             root_module=raw["root_module"],
+            autoload_defs=raw.get("autoload_defs", DgProjectConfig.autoload_defs),
             defs_module=raw.get("defs_module", DgProjectConfig.defs_module),
             code_location_name=raw.get("code_location_name", DgProjectConfig.code_location_name),
             code_location_target_module=raw.get(
@@ -335,6 +337,7 @@ class DgProjectConfig:
 
 class DgRawProjectConfig(TypedDict):
     root_module: Required[str]
+    autoload_defs: NotRequired[bool]
     defs_module: NotRequired[str]
     code_location_target_module: NotRequired[str]
     code_location_name: NotRequired[str]

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/context.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/context.py
@@ -490,10 +490,24 @@ class DgContext:
         return (self.defs_path / name).is_dir()
 
     @property
+    def target_args(self) -> Mapping[str, str]:
+        if not self.config.project:
+            raise DgError("`target_args` are only available in a Dagster project context")
+
+        if self.config.project.autoload_defs:
+            return {"autoload_defs_module_name": self.defs_module_name}
+
+        return {"module_name": self.code_location_target_module_name}
+
+    @property
     def code_location_target_module_name(self) -> str:
         if not self.config.project:
             raise DgError(
                 "`code_location_target_module_name` is only available in a Dagster project context"
+            )
+        if self.config.project.autoload_defs:
+            raise DgError(
+                "`code_location_target_module_name` is not valid when autoload_defs is enabled"
             )
         return (
             self.config.project.code_location_target_module

--- a/python_modules/libraries/dagster-shared/dagster_shared/cli/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/cli/__init__.py
@@ -69,6 +69,11 @@ def generate_python_pointer_options(
             envvar="DAGSTER_MODULE_NAME",
         ),
         click.option(
+            "--autoload-defs-module-name",
+            help=("A module to import and recursively search through for definitions."),
+            envvar="DAGSTER_autoload_defs_module_name",
+        ),
+        click.option(
             "--package-name",
             multiple=allow_multiple,
             help="Specify Python package where repository or job function lives",
@@ -167,6 +172,8 @@ class WorkspaceOpts:
     working_directory: Optional[str] = None
     attribute: Optional[str] = None
 
+    autoload_defs_module_name: Optional[str] = None
+
     # For gRPC server
     grpc_port: Optional[int] = None
     grpc_socket: Optional[str] = None
@@ -185,6 +192,7 @@ class WorkspaceOpts:
             package_name=cli_options.pop("package_name", None),
             working_directory=cli_options.pop("working_directory", None),
             attribute=cli_options.pop("attribute", None),
+            autoload_defs_module_name=cli_options.pop("autoload_defs_module_name", None),
             grpc_port=cli_options.pop("grpc_port", None),
             grpc_socket=cli_options.pop("grpc_socket", None),
             grpc_host=cli_options.pop("grpc_host", None),


### PR DESCRIPTION
Adds a new `CodePointer` and associated cli options for targeting an "autodefs module" which will do a components root load at that target. This removes the need for a manual `definitions.py` 

Moving to this is done via a new tool section entry `autodefs_module` which takes the module to start crawling at.


## How I Tested These Changes

removed the root definitions.py in dagster open platform and added the `autoload` value to `pyproject.toml`
