### PR TITLE
[airlift] update docs examples

### DIFF
--- a/docs/docs/guides/labs/airlift/represent-airflow-dags-in-dagster.md
+++ b/docs/docs/guides/labs/airlift/represent-airflow-dags-in-dagster.md
@@ -11,6 +11,18 @@ import AirliftPrereqs from '@site/docs/partials/\_AirliftPrereqs.md';
 
 TK - conceptual info here
 
+once you have represented your airflow instance in dagster using the airflow instance component, you may want to represent the graph of asset dependencies produced by that dag as well. this is easy to do in your component configuration.
+
+## Manually mapping assets to Airflow tasks
+
+You can manually define which assets are produced by a given airflow dag by editing your component's yaml configuration:
+
+<CodeExample path="docs_snippets/docs_snippets/integrations/airlift_v2/represent_airflow_dags_in_dagster/component_dag_mappings.yaml" />
+
+If you have a more specific mapping from a task within the dag to a set of assets, you can also set these mappings at the task level:
+
+<CodeExample path="docs_snippets/docs_snippets/integrations/airlift_v2/represent_airflow_dags_in_dagster/component_task_mappings.yaml" />
+
 ## Prerequisites
 
 <AirliftPrereqs />

--- a/docs/docs/guides/labs/airlift/setup.md
+++ b/docs/docs/guides/labs/airlift/setup.md
@@ -16,17 +16,33 @@ To install `dg`, follow the [`dg` installation guide](https://docs.dagster.io/gu
 
 To create a components-ready project, follow the [project creation guide](https://docs.dagster.io/guides/labs/dg/creating-a-project).
 
-## Add the Airlift component to your project
 
-Add the Airlift component type to your environment:
-
-```
-uv add dagster-airlift
-```
-
-Create a new instance of the Airlift component:
+### Add the Airlift component type to your environment
 
 ```
-dg scaffold dagster_airlift.core.AirflowInstanceComponent airlift_migrate
+uv add dagster-airlift[core]
 ```
-{/* TODO replace above with name of Airlift component */}
+
+
+### Create a new instance of the Airlift component
+
+Currently dagster-airlift only supports basic authentication against an Airflow instance. You can scaffold a new component into your project using the `dg scaffold` command:
+
+<CliInvocationExample path="docs_snippets/docs_snippets/integrations/airlift_v2/setup/basic_auth/1-scaffold.txt" />
+
+This will create a new component definition in your project under the `defs/airflow` directory.
+
+<CliInvocationExample path="docs_snippets/docs_snippets/integrations/airlift_v2/setup/basic_auth/2-tree.txt" />
+
+By default, the component pulls values from environment variables (`AIRFLOW_WEBSERVER_URL`, `AIRFLOW_USERNAME`, and `AIRFLOW_PASSWORD`). While you should never include your password directly in this file, you can update the generated file to hard code the values for the webserver url and username if desired.
+
+<CliInvocationExample path="docs_snippets/docs_snippets/integrations/airlift_v2/setup/basic_auth/3-cat.txt" />
+
+Once this is done, Dagster will do a few things:
+
+1. All of your airflow dags will be automatically represented in dagster in the "jobs" page. Any jobs pulled from airflow will have an airflow icon to distinguish them
+2. Any airflow datasets will be automatically represented in dagster as assets 
+2. Any time an airflow dag executes, that run will be represented 
+
+
+(maybe explain the fact that it creates a sensor called `your_airlift_instance__airflow_monitoring_job_sensor` that will be responsible for looking for runs in your airflow instance and pulling them in to dagster)

--- a/examples/docs_snippets/docs_snippets/integrations/airlift_v2/represent_airflow_dags_in_dagster/component_dag_mappings.yaml
+++ b/examples/docs_snippets/docs_snippets/integrations/airlift_v2/represent_airflow_dags_in_dagster/component_dag_mappings.yaml
@@ -1,0 +1,21 @@
+type: dagster_airlift.core.components.AirflowInstanceComponent
+
+attributes:
+  name: my_airflow
+  auth:
+    type: basic_auth
+    webserver_url: '{{ env("AIRFLOW_WEBSERVER_URL") }}'
+    username: '{{ env("AIRFLOW_USERNAME") }}'
+    password: '{{ env("AIRFLOW_PASSWORD") }}'
+# highlight-start 
+  mappings:
+  - dag_id: upload_source_data 
+    assets:
+      - spec: 
+          key: order_data
+      - spec: 
+          key: activity_data
+      - spec:
+          key: aggregated_user_data
+          deps: [order_data, activity_data]
+# highlight-end

--- a/examples/docs_snippets/docs_snippets/integrations/airlift_v2/represent_airflow_dags_in_dagster/component_task_mappings.yaml
+++ b/examples/docs_snippets/docs_snippets/integrations/airlift_v2/represent_airflow_dags_in_dagster/component_task_mappings.yaml
@@ -1,0 +1,27 @@
+type: dagster_airlift.core.components.AirflowInstanceComponent
+
+attributes:
+  name: my_airflow
+  auth:
+    type: basic_auth
+    webserver_url: '{{ env("AIRFLOW_WEBSERVER_URL") }}'
+    username: '{{ env("AIRFLOW_USERNAME") }}'
+    password: '{{ env("AIRFLOW_PASSWORD") }}'
+# highlight-start 
+  mappings:
+  - dag_id: upload_source_data 
+    task_mappings:
+      - task_id: upload_orders
+        assets:
+          - spec: 
+              key: order_data
+      - task_id: upload_activity
+        assets:
+          - spec: 
+              key: activity_data
+      - task_id: aggregate_user_data
+        assets:
+          - spec: 
+              key: aggregated_user_data
+              deps: [order_data, activity_data]
+# highlight-end

--- a/examples/docs_snippets/docs_snippets/integrations/airlift_v2/setup/basic_auth/1-scaffold.txt
+++ b/examples/docs_snippets/docs_snippets/integrations/airlift_v2/setup/basic_auth/1-scaffold.txt
@@ -1,0 +1,1 @@
+dg scaffold dagster_airlift.core.components.AirflowInstanceComponent airflow --name my_airflow --auth-type basic_auth

--- a/examples/docs_snippets/docs_snippets/integrations/airlift_v2/setup/basic_auth/2-tree.txt
+++ b/examples/docs_snippets/docs_snippets/integrations/airlift_v2/setup/basic_auth/2-tree.txt
@@ -1,0 +1,8 @@
+tree src/my_project/defs
+
+src/my_project/defs
+├── __init__.py
+└── airflow
+    └── component.yaml
+
+2 directories, 2 files

--- a/examples/docs_snippets/docs_snippets/integrations/airlift_v2/setup/basic_auth/3-cat.txt
+++ b/examples/docs_snippets/docs_snippets/integrations/airlift_v2/setup/basic_auth/3-cat.txt
@@ -1,0 +1,11 @@
+cat src/my_project/defs/airflow/component.yaml
+
+type: dagster_airlift.core.components.AirflowInstanceComponent
+
+attributes:
+  name: my_airflow
+  auth:
+    type: basic_auth
+    webserver_url: '{{ env("AIRFLOW_WEBSERVER_URL") }}'
+    username: '{{ env("AIRFLOW_USERNAME") }}'
+    password: '{{ env("AIRFLOW_PASSWORD") }}'

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/labs/airlift_v2/test_setup.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/labs/airlift_v2/test_setup.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+
+import pytest
+
+from dagster._utils.env import environ
+from docs_snippets_tests.snippet_checks.guides.components.utils import (
+    DAGSTER_ROOT,
+    EDITABLE_DIR,
+    MASK_PLUGIN_CACHE_REBUILD,
+    format_multiline,
+    isolated_snippet_generation_environment,
+)
+from docs_snippets_tests.snippet_checks.utils import (
+    _run_command,
+    compare_tree_output,
+    create_file,
+    run_command_and_snippet_output,
+)
+
+MASK_MY_PROJECT = (r" \/.*?\/my-project", " /.../my-project")
+MASK_VENV = (r"Using.*\.venv.*", "")
+
+
+SNIPPETS_DIR = (
+    DAGSTER_ROOT
+    / "examples"
+    / "docs_snippets"
+    / "docs_snippets"
+    / "integrations"
+    / "airlift_v2"
+)
+
+
+def test_setup_basic_auth(update_snippets: bool) -> None:
+    with isolated_snippet_generation_environment() as get_next_snip_number:
+        _run_command(
+            cmd=f"dg scaffold project my-project --python-environment uv_managed --use-editable-dagster && cd my-project && uv add --editable {EDITABLE_DIR / 'dagster-airlift[core]'}",
+        )
+
+        run_command_and_snippet_output(
+            cmd="dg scaffold dagster_airlift.core.components.AirflowInstanceComponent airflow --name my_airflow --auth-type basic_auth",
+            snippet_path=SNIPPETS_DIR
+            / "setup"
+            / "basic_auth"
+            / f"{get_next_snip_number()}-scaffold.txt",
+            update_snippets=update_snippets,
+            snippet_replace_regex=[
+                MASK_MY_PROJECT,
+                MASK_PLUGIN_CACHE_REBUILD,
+                MASK_VENV,
+            ],
+        )
+
+        _run_command(r"find . -type d -name __pycache__ -exec rm -r {} \+")
+        _run_command(r"find . -type d -name my_project.egg-info -exec rm -r {} \+")
+        run_command_and_snippet_output(
+            cmd="tree src/my_project/defs",
+            snippet_path=SNIPPETS_DIR
+            / "setup"
+            / "basic_auth"
+            / f"{get_next_snip_number()}-tree.txt",
+            update_snippets=update_snippets,
+            custom_comparison_fn=compare_tree_output,
+        )
+
+        run_command_and_snippet_output(
+            cmd="cat src/my_project/defs/airflow/component.yaml",
+            snippet_path=SNIPPETS_DIR
+            / "setup"
+            / "basic_auth"
+            / f"{get_next_snip_number()}-cat.txt",
+            update_snippets=update_snippets,
+        )
+
+        _run_command("dg check yaml --no-validate-requirements")
+
+
+def test_component_files() -> None:
+    """Ensures that our example component yaml files have valid syntax.
+    Really this should be pytest parametrized but I wanted to reuse the environment and I was too lazy to create a fixture.
+    """
+    with isolated_snippet_generation_environment():
+        _run_command(
+            cmd=f"dg scaffold project my-project --python-environment uv_managed --use-editable-dagster && cd my-project && uv add --editable {EDITABLE_DIR / 'dagster-airlift[core]'}",
+        )
+        _run_command(
+            cmd="dg scaffold dagster_airlift.core.components.AirflowInstanceComponent airflow --name my_airflow --auth-type basic_auth",
+        )
+
+        component_yaml_path = (
+            Path.cwd() / "src" / "my_project" / "defs" / "airflow" / "component.yaml"
+        )
+
+        for path in [
+            SNIPPETS_DIR
+            / "represent_airflow_dags_in_dagster"
+            / "component_dag_mappings.yaml",
+            SNIPPETS_DIR
+            / "represent_airflow_dags_in_dagster"
+            / "component_task_mappings.yaml",
+        ]:
+            content = path.read_text()
+            component_yaml_path.write_text(content)
+            _run_command("dg check yaml --no-validate-requirements")

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/__init__.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/__init__.py
@@ -1,0 +1,3 @@
+from dagster_airlift.core.components.airflow_instance.component import (
+    AirflowInstanceComponent as AirflowInstanceComponent,
+)

--- a/python_modules/libraries/dagster-airlift/setup.py
+++ b/python_modules/libraries/dagster-airlift/setup.py
@@ -91,7 +91,10 @@ setup(
     entry_points={
         "console_scripts": [
             "dagster-airlift = dagster_airlift.cli:cli",
-        ]
+        ],
+        "dagster_dg.plugin": [
+            "dagster_airlift.core.components = dagster_airlift.core.components",
+        ],
     },
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary & Motivation

This just adds basic information on setting up the dagster-airlift component with basic auth

Right now, authenticating with mwaa is not supported in the component, but once it is, I was imagining this would be a tab sorta deal, where the user would first select if they want to use basic auth or authenticate against mwaa and then we'd tailor the examples for them, hence me setting up the subfolders this way.

## How I Tested These Changes

