### PR TITLE
[dagster] feat: Add `is_root_executable` automation condition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -734,6 +734,17 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
 
         return AnyDownstreamConditionsCondition()
 
+    @public
+    @beta
+    @staticmethod
+    def is_root_executable() -> "BuiltinAutomationCondition":
+        """Returns an AutomationCondition that is true if the asset is a root executable asset."""
+        from dagster._core.definitions.declarative_automation.operands.operands import (
+            IsRootExecutableCondition,
+        )
+
+        return IsRootExecutableCondition()
+
 
 @record
 class BuiltinAutomationCondition(AutomationCondition[T_EntityKey]):

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
@@ -356,3 +356,20 @@ class CheckResultCondition(SubsetAutomationCondition[AssetCheckKey]):
         return await context.asset_graph_view.compute_subset_with_status(
             key=context.key, status=target_status
         )
+
+
+@whitelist_for_serdes
+@record
+class IsRootExecutableCondition(BuiltinAutomationCondition):
+    @property
+    def name(self) -> str:
+        return "is_root_executable"
+
+    def evaluate(self, context):
+        root_keys = context.asset_graph.root_executable_asset_keys
+        key = context.key
+        if key in root_keys:
+            true_subset = context.candidate_subset
+        else:
+            true_subset = context.get_empty_subset()
+        return AutomationResult(context, true_subset)

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_is_root_executable.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_is_root_executable.py
@@ -1,0 +1,56 @@
+import pytest
+from dagster import AutomationCondition
+
+from dagster_tests.declarative_automation_tests.scenario_utils.automation_condition_scenario import (
+    AutomationConditionScenarioState,
+)
+from dagster_tests.declarative_automation_tests.scenario_utils.scenario_specs import (
+    one_asset,
+    one_asset_depends_on_two,
+    two_assets_depend_on_one,
+)
+
+
+@pytest.mark.asyncio
+async def test_is_root_executable_single_asset() -> None:
+    state = AutomationConditionScenarioState(
+        one_asset, automation_condition=AutomationCondition.is_root_executable()
+    )
+
+    # The only asset should be root executable
+    state, result = await state.evaluate("A")
+    assert result.true_subset.size == 1
+
+
+@pytest.mark.asyncio
+async def test_is_root_executable_in_graph() -> None:
+    state = AutomationConditionScenarioState(
+        one_asset_depends_on_two, automation_condition=AutomationCondition.is_root_executable()
+    )
+
+    # In this graph, A and B are roots, C is not
+    state, result = await state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    state, result = await state.evaluate("B")
+    assert result.true_subset.size == 1
+
+    state, result = await state.evaluate("C")
+    assert result.true_subset.size == 0
+
+
+@pytest.mark.asyncio
+async def test_is_root_executable_observable() -> None:
+    state = AutomationConditionScenarioState(
+        two_assets_depend_on_one, automation_condition=AutomationCondition.is_root_executable()
+    )
+
+    # In this graph, A is not executable, B is root executable
+    state, result = await state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    state, result = await state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    state, result = await state.evaluate("C")
+    assert result.true_subset.size == 0


### PR DESCRIPTION
Closes #30140 

Adds a new `is_root_executable` automation condition that checks if an asset is a root executable asset. This condition can be used in declarative automation policies to trigger actions based on whether an asset is a root.

This commit includes:

- Implementation of the `IsRootExecutableCondition` class.
- Addition of the `is_root_executable` static method to the `AutomationCondition` class.
- Unit tests for the new condition.

## Summary & Motivation
#30140 

## How I Tested These Changes
New unit test

## Changelog

> Added a new `AutomationCondition.is_root_executable()` condition that makes it possible to filter for assets that are root executable.
