### PR TITLE
[dg] Implement `dg scaffold defs` (BUILD-1213)

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/adding-attributes-to-assets/1-scaffold-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/adding-attributes-to-assets/1-scaffold-project.txt
@@ -1,5 +1,5 @@
 dg scaffold project my-project \
     && cd my-project/src \
-    && dg scaffold dagster.asset team_a/subproject/a.py \
-    && dg scaffold dagster.asset team_a/b.py \
-    && dg scaffold dagster.asset team_b/c.py
+    && dg scaffold defs dagster.asset team_a/subproject/a.py \
+    && dg scaffold defs dagster.asset team_a/b.py \
+    && dg scaffold defs dagster.asset team_b/c.py

--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/1-scaffold-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/1-scaffold-project.txt
@@ -1,4 +1,4 @@
 dg scaffold project my-project \
     && cd my-project/src \
     && uv add dagster-sling \
-    && dg scaffold dagster_sling.SlingReplicationCollectionComponent my_sling_sync
+    && dg scaffold defs dagster_sling.SlingReplicationCollectionComponent my_sling_sync

--- a/examples/docs_snippets/docs_snippets/guides/components/index/1-help.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/1-help.txt
@@ -24,6 +24,6 @@ Usage: dg [OPTIONS] COMMAND [ARGS]...
 │ docs       Commands for generating docs from your Dagster code.                                                      │
 │ launch     Launch a Dagster run.                                                                                     │
 │ list       Commands for listing Dagster entities.                                                                    │
-│ scaffold   Commands for scaffolding Dagster code.                                                                    │
+│ scaffold   Commands for scaffolding Dagster entities.                                                                │
 │ utils      Assorted utility commands.                                                                                │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/examples/docs_snippets/docs_snippets/guides/components/index/10-dg-scaffold-sling-replication.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/10-dg-scaffold-sling-replication.txt
@@ -1,1 +1,1 @@
-dg scaffold 'dagster_sling.SlingReplicationCollectionComponent' ingest_files
+dg scaffold defs 'dagster_sling.SlingReplicationCollectionComponent' ingest_files

--- a/examples/docs_snippets/docs_snippets/guides/components/index/20-dg-scaffold-jdbt.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/20-dg-scaffold-jdbt.txt
@@ -1,1 +1,1 @@
-dg scaffold dagster_dbt.DbtProjectComponent jdbt --project-path dbt/jdbt
+dg scaffold defs dagster_dbt.DbtProjectComponent jdbt --project-path dbt/jdbt

--- a/examples/docs_snippets/docs_snippets/guides/components/index/30-scaffold-jaffle-dashboard.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/30-scaffold-jaffle-dashboard.txt
@@ -1,1 +1,1 @@
-dg scaffold dagster_evidence.EvidenceProject jaffle_dashboard
+dg scaffold defs dagster_evidence.EvidenceProject jaffle_dashboard

--- a/examples/docs_snippets/docs_snippets/guides/components/index/35-scaffold-daily-jaffle.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/35-scaffold-daily-jaffle.txt
@@ -1,1 +1,1 @@
-dg scaffold dagster.schedule daily_jaffle.py
+dg scaffold defs dagster.schedule daily_jaffle.py

--- a/examples/docs_snippets/docs_snippets/guides/components/integrations/dlt-component/3-scaffold-dlt-component.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/integrations/dlt-component/3-scaffold-dlt-component.txt
@@ -1,2 +1,2 @@
-dg scaffold dagster_dlt.DltLoadCollectionComponent github_snowflake_ingest \
+dg scaffold defs dagster_dlt.DltLoadCollectionComponent github_snowflake_ingest \
   --source github --destination snowflake

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/4-scaffold-instance-of-component.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/4-scaffold-instance-of-component.txt
@@ -1,3 +1,3 @@
-dg scaffold 'my_component_library.components.ShellCommand' my_shell_command
+dg scaffold defs 'my_component_library.components.ShellCommand' my_shell_command
 
 Creating a component at /.../my-component-library/src/my_component_library/defs/my_shell_command.

--- a/examples/docs_snippets/docs_snippets/guides/dg/dagster-definitions/1-scaffold.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/dagster-definitions/1-scaffold.txt
@@ -1,3 +1,3 @@
-dg scaffold dagster.asset assets/my_asset.py
+dg scaffold defs dagster.asset assets/my_asset.py
 
 Creating a component at /.../my-project/src/my_project/defs/assets/my_asset.py.

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/5-dg-scaffold-sling.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/5-dg-scaffold-sling.txt
@@ -1,3 +1,3 @@
-dg scaffold dagster_sling.SlingReplicationCollectionComponent ingest_to_snowflake
+dg scaffold defs dagster_sling.SlingReplicationCollectionComponent ingest_to_snowflake
 
 Creating a component at /.../ingestion/src/ingestion/defs/ingest_to_snowflake.

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_dlt_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_dlt_component.py
@@ -71,7 +71,7 @@ def test_dlt_components_docs_adding_attributes_to_assets(
 
         # scaffold dlt component
         context.run_command_and_snippet_output(
-            cmd="dg scaffold dagster_dlt.DltLoadCollectionComponent github_snowflake_ingest \\\n  --source github --destination snowflake",
+            cmd="dg scaffold defs dagster_dlt.DltLoadCollectionComponent github_snowflake_ingest \\\n  --source github --destination snowflake",
             snippet_path=SNIPPETS_DIR
             / f"{context.get_next_snip_number()}-scaffold-dlt-component.txt",
             ignore_output=True,

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_component_docs_adding_attributes_to_assets.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_component_docs_adding_attributes_to_assets.py
@@ -50,9 +50,9 @@ def test_components_docs_adding_attributes_to_assets(
                 dg scaffold project my-project --python-environment uv_managed --use-editable-dagster \\
                     && source my-project/.venv/bin/activate \\
                     && cd my-project/src \\
-                    && dg scaffold dagster.asset team_a/subproject/a.py \\
-                    && dg scaffold dagster.asset team_a/b.py \\
-                    && dg scaffold dagster.asset team_b/c.py\
+                    && dg scaffold defs dagster.asset team_a/subproject/a.py \\
+                    && dg scaffold defs dagster.asset team_a/b.py \\
+                    && dg scaffold defs dagster.asset team_b/c.py\
                 """
             ),
             snippet_path=f"{context.get_next_snip_number()}-scaffold-project.txt",

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -201,7 +201,7 @@ def test_components_docs_index(
 
         # Scaffold new ingestion, validate new files
         context.run_command_and_snippet_output(
-            cmd="dg scaffold 'dagster_sling.SlingReplicationCollectionComponent' ingest_files",
+            cmd="dg scaffold defs 'dagster_sling.SlingReplicationCollectionComponent' ingest_files",
             snippet_path=f"{next_snip_no()}-dg-scaffold-sling-replication.txt",
             # TODO turn output back on when we figure out how to handle multiple
             # "Using ..." messages from multiple dagster-components calls under the hood (when
@@ -322,7 +322,7 @@ def test_components_docs_index(
 
             # Scaffold dbt project components
             context.run_command_and_snippet_output(
-                cmd="dg scaffold dagster_dbt.DbtProjectComponent jdbt --project-path dbt/jdbt",
+                cmd="dg scaffold defs dagster_dbt.DbtProjectComponent jdbt --project-path dbt/jdbt",
                 snippet_path=f"{next_snip_no()}-dg-scaffold-jdbt.txt",
                 # TODO turn output back on when we figure out how to handle multiple
                 # "Using ..." messages from multiple dagster-components calls under the hood
@@ -399,7 +399,7 @@ def test_components_docs_index(
             )
 
             context.run_command_and_snippet_output(
-                cmd="dg scaffold dagster_evidence.EvidenceProject jaffle_dashboard",
+                cmd="dg scaffold defs dagster_evidence.EvidenceProject jaffle_dashboard",
                 snippet_path=f"{next_snip_no()}-scaffold-jaffle-dashboard.txt",
                 # TODO turn output back on when we figure out how to handle multiple
                 # "Using ..." messages from multiple dagster-components calls under the hood
@@ -453,7 +453,7 @@ def test_components_docs_index(
 
             # Schedule
             context.run_command_and_snippet_output(
-                cmd="dg scaffold dagster.schedule daily_jaffle.py",
+                cmd="dg scaffold defs dagster.schedule daily_jaffle.py",
                 snippet_path=f"{next_snip_no()}-scaffold-daily-jaffle.txt",
                 # TODO turn output back on when we figure out how to handle multiple
                 # "Using ..." messages from multiple dagster-components calls under the hood (when

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
@@ -135,7 +135,7 @@ def test_creating_a_component(
             contents=(COMPONENTS_SNIPPETS_DIR / "with-scaffolder.py").read_text(),
         )
         context.run_command_and_snippet_output(
-            cmd="dg scaffold 'my_component_library.components.ShellCommand' my_shell_command",
+            cmd="dg scaffold defs 'my_component_library.components.ShellCommand' my_shell_command",
             snippet_path=f"{context.get_next_snip_number()}-scaffold-instance-of-component.txt",
         )
 

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_customizing_existing_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_customizing_existing_component.py
@@ -62,7 +62,7 @@ def test_components_docs_adding_attributes_to_assets(
                     && source my-project/.venv/bin/activate \\
                     && cd my-project/src \\
                     && uv add --editable {EDITABLE_DIR / "dagster-sling"} \\
-                    && dg scaffold dagster_sling.SlingReplicationCollectionComponent my_sling_sync\
+                    && dg scaffold defs dagster_sling.SlingReplicationCollectionComponent my_sling_sync\
                 """
             ),
             snippet_path=SNIPPETS_DIR

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_dagster_definitions.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_dagster_definitions.py
@@ -46,7 +46,7 @@ def test_dagster_definitions(update_snippets: bool) -> None:
 
         with activate_venv(".venv") as venv_path:
             context.run_command_and_snippet_output(
-                cmd="dg scaffold dagster.asset assets/my_asset.py",
+                cmd="dg scaffold defs dagster.asset assets/my_asset.py",
                 snippet_path=SNIPPETS_DIR
                 / f"{context.get_next_snip_number()}-scaffold.txt",
             )

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_using_env.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_using_env.py
@@ -270,7 +270,7 @@ def test_component_docs_using_env(
 
             # Scaffold dbt project components
             context.run_command_and_snippet_output(
-                cmd="dg scaffold dagster_sling.SlingReplicationCollectionComponent ingest_to_snowflake",
+                cmd="dg scaffold defs dagster_sling.SlingReplicationCollectionComponent ingest_to_snowflake",
                 snippet_path=SNIPPETS_DIR
                 / f"{context.get_next_snip_number()}-dg-scaffold-sling.txt",
             )

--- a/python_modules/libraries/dagster-dg/dagster_dg/mcp/server.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/mcp/server.py
@@ -107,7 +107,7 @@ async def scaffold_dagster_component_help(
         The help for scaffolding a specific component_type.
     """
     return _subprocess(
-        ["uv", "run", "dg", "--verbose", "scaffold", component_type, "--help"],
+        ["uv", "run", "dg", "--verbose", "scaffold", "defs", component_type, "--help"],
         cwd=project_path,
     )
 
@@ -136,6 +136,7 @@ async def scaffold_dagster_component(
             "dg",
             "--verbose",
             "scaffold",
+            "defs",
             component_type,
             component_name,
             *component_arguments,

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/conftest.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/conftest.py
@@ -7,6 +7,6 @@ def clear_defined_commands():
     to ensure the cache of scaffold subcommands is cleared. This isn't an issue outside
     of tests because we're not reusing a Python process between different dg venvs.
     """
-    from dagster_dg.cli.scaffold import scaffold_group
+    from dagster_dg.cli.scaffold import scaffold_defs_group
 
-    scaffold_group._commands_defined = False  # noqa: SLF001
+    scaffold_defs_group._commands_defined = False  # noqa: SLF001  # type: ignore

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_list_env_plus.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_list_env_plus.py
@@ -105,7 +105,10 @@ def test_list_env_succeeds(dg_plus_cli_config):
         )
 
         result = runner.invoke(
-            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "subfolder/mydefs"
+            "scaffold",
+            "defs",
+            "dagster_test.components.AllMetadataEmptyComponent",
+            "subfolder/mydefs",
         )
         assert_runner_result(result)
         Path("src/foo_bar/defs/subfolder/mydefs/defs.yaml").write_text(

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -181,28 +181,28 @@ def test_dynamic_subcommand_help_message():
     ):
         with fixed_panel_width(width=120):
             result = runner.invoke(
-                "scaffold", "dagster_test.components.SimplePipesScriptComponent", "--help"
+                "scaffold", "defs", "dagster_test.components.SimplePipesScriptComponent", "--help"
             )
             assert_runner_result(result)
             assert match_terminal_box_output(
                 result.output.strip(),
                 textwrap.dedent("""
-Usage: dg scaffold [GLOBAL OPTIONS] dagster_test.components.SimplePipesScriptComponent [OPTIONS] INSTANCE_NAME
+                Usage: dg scaffold defs [GLOBAL OPTIONS] dagster_test.components.SimplePipesScriptComponent [OPTIONS] INSTANCE_NAME
 
-╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ *    instance_name      TEXT  [required]                                                                             │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --json-params          TEXT           JSON string of component parameters.                                           │
-│ --format               [yaml|python]  Format of the component configuration (yaml or python)                         │
-│ --asset-key            TEXT           asset_key                                                                      │
-│ --filename             TEXT           filename                                                                       │
-│ --help         -h                     Show this message and exit.                                                    │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Global options ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --cache-dir            TEXT  Specify a directory to use for the cache.                                               │
-│ --disable-cache              Disable the cache..                                                                     │
-│ --verbose                    Enable verbose output for debugging.                                                    │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-                            """).strip(),
+                ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+                │ *    instance_name      TEXT  [required]                                                                             │
+                ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+                ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+                │ --json-params          TEXT           JSON string of component parameters.                                           │
+                │ --format               [yaml|python]  Format of the component configuration (yaml or python)                         │
+                │ --asset-key            TEXT           asset_key                                                                      │
+                │ --filename             TEXT           filename                                                                       │
+                │ --help         -h                     Show this message and exit.                                                    │
+                ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+                ╭─ Global options ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
+                │ --cache-dir            TEXT  Specify a directory to use for the cache.                                               │
+                │ --disable-cache              Disable the cache..                                                                     │
+                │ --verbose                    Enable verbose output for debugging.                                                    │
+                ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+                """).strip(),
             )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_environment_validation.py
@@ -40,10 +40,10 @@ NO_REQUIRED_CONTEXT_COMMANDS = [
     CommandSpec(("scaffold",), "project"),
     CommandSpec(("scaffold", "project"), "foo"),
     CommandSpec(("scaffold", "workspace"), "foo"),
-    CommandSpec(("scaffold", "dagster.asset"), "foo"),
-    CommandSpec(("scaffold", "dagster.asset_check"), "foo"),
-    CommandSpec(("scaffold", "dagster.schedule"), "foo"),
-    CommandSpec(("scaffold", "dagster.sensor"), "foo"),
+    CommandSpec(("scaffold", "defs", "dagster.asset"), "foo"),
+    CommandSpec(("scaffold", "defs", "dagster.asset_check"), "foo"),
+    CommandSpec(("scaffold", "defs", "dagster.schedule"), "foo"),
+    CommandSpec(("scaffold", "defs", "dagster.sensor"), "foo"),
     CommandSpec(("plus", "login")),
 ]
 
@@ -68,7 +68,7 @@ PROJECT_CONTEXT_COMMANDS = [
     CommandSpec(("check", "yaml")),
     CommandSpec(("list", "defs")),
     CommandSpec(("list", "env")),
-    CommandSpec(("scaffold", DEFAULT_COMPONENT_TYPE, "foot")),
+    CommandSpec(("scaffold", "defs", DEFAULT_COMPONENT_TYPE, "foot")),
 ]
 
 WORKSPACE_CONTEXT_COMMANDS = [

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_launch_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_launch_commands.py
@@ -44,7 +44,8 @@ def test_launch_assets() -> None:
     ):
         with activate_venv(project_dir / ".venv"):
             subprocess.run(
-                ["dg", "scaffold", "dagster.components.DefsFolderComponent", "mydefs"], check=True
+                ["dg", "scaffold", "defs", "dagster.components.DefsFolderComponent", "mydefs"],
+                check=True,
             )
 
             with Path("src/foo_bar/defs/mydefs/definitions.py").open("w") as f:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -299,7 +299,7 @@ def test_list_defs_succeeds(use_json: bool):
     ):
         with activate_venv(project_dir / ".venv"):
             result = subprocess.run(
-                ["dg", "scaffold", "dagster.components.DefsFolderComponent", "mydefs"],
+                ["dg", "scaffold", "defs", "dagster.components.DefsFolderComponent", "mydefs"],
                 check=True,
             )
 
@@ -375,7 +375,8 @@ def test_list_defs_complex_assets_succeeds():
     ):
         with activate_venv(project_dir / ".venv"):
             subprocess.run(
-                ["dg", "scaffold", "dagster.components.DefsFolderComponent", "mydefs"], check=True
+                ["dg", "scaffold", "defs", "dagster.components.DefsFolderComponent", "mydefs"],
+                check=True,
             )
 
             result = subprocess.run(["dg", "list", "defs"], check=True, capture_output=True)
@@ -455,7 +456,8 @@ def test_list_defs_with_env_file_succeeds():
     ):
         with activate_venv(project_dir / ".venv"):
             subprocess.run(
-                ["dg", "scaffold", "dagster.components.DefsFolderComponent", "mydefs"], check=True
+                ["dg", "scaffold", "defs", "dagster.components.DefsFolderComponent", "mydefs"],
+                check=True,
             )
 
             with Path("src/foo_bar/defs/mydefs/definitions.py").open("w") as f:
@@ -504,7 +506,8 @@ def test_list_defs_fails_compact(capture_stderr_from_components_cli_invocations)
     ):
         with activate_venv(project_dir / ".venv"):
             subprocess.run(
-                ["dg", "scaffold", "dagster.components.DefsFolderComponent", "mydefs"], check=True
+                ["dg", "scaffold", "defs", "dagster.components.DefsFolderComponent", "mydefs"],
+                check=True,
             )
 
             with Path("src/foo_bar/defs/mydefs/definitions.py").open("w") as f:
@@ -566,7 +569,10 @@ def test_list_env_succeeds(monkeypatch):
         )
 
         result = runner.invoke(
-            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "subfolder/mydefs"
+            "scaffold",
+            "defs",
+            "dagster_test.components.AllMetadataEmptyComponent",
+            "subfolder/mydefs",
         )
         assert_runner_result(result)
         Path("src/foo_bar/defs/subfolder/mydefs/defs.yaml").write_text(

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -401,23 +401,22 @@ def test_scaffold_project_non_editable_dagster_dagster_components_executable_exi
 
 
 # ########################
-# ##### COMPONENT
+# ##### DEFS
 # ########################
 
 
-def test_scaffold_component_dynamic_subcommand_generation() -> None:
+def test_scaffold_defs_dynamic_subcommand_generation() -> None:
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("scaffold", "--help")
+        result = runner.invoke("scaffold", "defs", "--help")
         assert_runner_result(result)
 
         normalized_output = standardize_box_characters(result.output)
         # These are wrapped in a table so it's hard to check exact output.
         for line in [
             "╭─ Commands",
-            "│ project",
             "│ dagster_test.components.AllMetadataEmptyComponent",
             "│ dagster_test.components.ComplexAssetComponent",
             "│ dagster_test.components.SimpleAssetComponent",
@@ -427,13 +426,13 @@ def test_scaffold_component_dynamic_subcommand_generation() -> None:
 
 
 @pytest.mark.parametrize("in_workspace", [True, False])
-def test_scaffold_component_no_params_success(in_workspace: bool) -> None:
+def test_scaffold_defs_component_no_params_success(in_workspace: bool) -> None:
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner, in_workspace),
     ):
         result = runner.invoke(
-            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
+            "scaffold", "defs", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result)
         assert Path("src/foo_bar/defs/qux").exists()
@@ -445,13 +444,14 @@ def test_scaffold_component_no_params_success(in_workspace: bool) -> None:
 
 
 @pytest.mark.parametrize("in_workspace", [True, False])
-def test_scaffold_component_json_params_success(in_workspace: bool) -> None:
+def test_scaffold_defs_component_json_params_success(in_workspace: bool) -> None:
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner, in_workspace),
     ):
         result = runner.invoke(
             "scaffold",
+            "defs",
             "dagster_test.components.SimplePipesScriptComponent",
             "qux",
             "--json-params",
@@ -468,13 +468,14 @@ def test_scaffold_component_json_params_success(in_workspace: bool) -> None:
 
 
 @pytest.mark.parametrize("in_workspace", [True, False])
-def test_scaffold_component_key_value_params_success(in_workspace: bool) -> None:
+def test_scaffold_defs_component_key_value_params_success(in_workspace: bool) -> None:
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner, in_workspace),
     ):
         result = runner.invoke(
             "scaffold",
+            "defs",
             "dagster_test.components.SimplePipesScriptComponent",
             "qux",
             "--asset-key=foo",
@@ -490,13 +491,14 @@ def test_scaffold_component_key_value_params_success(in_workspace: bool) -> None
         )
 
 
-def test_scaffold_component_json_params_and_key_value_params_fails() -> None:
+def test_scaffold_defs_component_json_params_and_key_value_params_fails() -> None:
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner),
     ):
         result = runner.invoke(
             "scaffold",
+            "defs",
             "dagster_test.components.SimplePipesScriptComponent",
             "qux",
             "--json-params",
@@ -509,14 +511,14 @@ def test_scaffold_component_json_params_and_key_value_params_fails() -> None:
         )
 
 
-def test_scaffold_component_undefined_component_type_fails() -> None:
+def test_scaffold_defs_component_undefined_component_type_fails() -> None:
     with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):
-        result = runner.invoke("scaffold", "fake.Fake", "qux")
+        result = runner.invoke("scaffold", "defs", "fake.Fake", "qux")
         assert_runner_result(result, exit_0=False)
         assert "No plugin object `fake.Fake` is registered" in result.output
 
 
-def test_scaffold_component_command_with_non_matching_module_name():
+def test_scaffold_defs_component_command_with_non_matching_module_name():
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner),
@@ -526,30 +528,30 @@ def test_scaffold_component_command_with_non_matching_module_name():
         python_module.rename("module_not_same_as_project")
 
         result = runner.invoke(
-            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
+            "scaffold", "defs", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result, exit_0=False)
         assert "Cannot find module `foo_bar" in result.output
 
 
 @pytest.mark.parametrize("in_workspace", [True, False])
-def test_scaffold_component_already_exists_fails(in_workspace: bool) -> None:
+def test_scaffold_defs_component_already_exists_fails(in_workspace: bool) -> None:
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner, in_workspace),
     ):
         result = runner.invoke(
-            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
+            "scaffold", "defs", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result)
         result = runner.invoke(
-            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
+            "scaffold", "defs", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result, exit_0=False)
         assert "already exists" in result.output
 
 
-def test_scaffold_component_succeeds_non_default_defs_module() -> None:
+def test_scaffold_defs_component_succeeds_non_default_defs_module() -> None:
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner),
@@ -559,7 +561,7 @@ def test_scaffold_component_succeeds_non_default_defs_module() -> None:
         with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
             create_toml_node(toml_dict, ("tool", "dg", "project", "defs_module"), "foo_bar._defs")
         result = runner.invoke(
-            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
+            "scaffold", "defs", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result)
         assert Path("src/foo_bar/_defs/qux").exists()
@@ -570,7 +572,7 @@ def test_scaffold_component_succeeds_non_default_defs_module() -> None:
         )
 
 
-def test_scaffold_component_fails_defs_module_does_not_exist() -> None:
+def test_scaffold_defs_component_fails_defs_module_does_not_exist() -> None:
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(runner),
@@ -578,13 +580,13 @@ def test_scaffold_component_fails_defs_module_does_not_exist() -> None:
         with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
             create_toml_node(toml_dict, ("tool", "dg", "project", "defs_module"), "foo_bar._defs")
         result = runner.invoke(
-            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
+            "scaffold", "defs", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result, exit_0=False)
         assert "Cannot find module `foo_bar._defs`" in result.output
 
 
-def test_scaffold_component_succeeds_scaffolded_component_type() -> None:
+def test_scaffold_defs_component_succeeds_scaffolded_component_type() -> None:
     with (
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(
@@ -597,7 +599,7 @@ def test_scaffold_component_succeeds_scaffolded_component_type() -> None:
             subprocess.run(["dg", "scaffold", "component", "Baz"], check=True)
             assert Path("src/foo_bar/components/baz.py").exists()
 
-            subprocess.run(["dg", "scaffold", "foo_bar.components.Baz", "qux"], check=True)
+            subprocess.run(["dg", "scaffold", "defs", "foo_bar.components.Baz", "qux"], check=True)
             assert Path("src/foo_bar/defs/qux").exists()
             defs_yaml_path = Path("src/foo_bar/defs/qux/defs.yaml")
             assert defs_yaml_path.exists()
@@ -607,31 +609,35 @@ def test_scaffold_component_succeeds_scaffolded_component_type() -> None:
 # ##### SHIMS
 
 
-def test_scaffold_asset() -> None:
+def test_scaffold_defs_asset() -> None:
     with (
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("scaffold", "dagster.asset", "assets/foo.py")
+        result = runner.invoke("scaffold", "defs", "dagster.asset", "assets/foo.py")
         assert_runner_result(result)
         assert Path("src/foo_bar/defs/assets/foo.py").exists()
         assert Path("src/foo_bar/defs/assets/foo.py").read_text().startswith("import dagster as dg")
         assert not Path("src/foo_bar/defs/assets/foo.py").is_dir()
         assert not Path("src/foo_bar/defs/assets/defs.yaml").exists()
 
-        result = runner.invoke("scaffold", "dagster.asset", "assets/bar.py")
+        result = runner.invoke("scaffold", "defs", "dagster.asset", "assets/bar.py")
         assert_runner_result(result)
         assert Path("src/foo_bar/defs/assets/bar.py").exists()
         assert not Path("src/foo_bar/defs/assets/defs.yaml").exists()
 
 
-def test_scaffold_asset_check_with_key() -> None:
+def test_scaffold_defs_asset_check_with_key() -> None:
     with (
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
     ):
         result = runner.invoke(
-            "scaffold", "dagster.asset_check", "asset_checks/my_check.py", "--asset-key=my/key"
+            "scaffold",
+            "defs",
+            "dagster.asset_check",
+            "asset_checks/my_check.py",
+            "--asset-key=my/key",
         )
         assert_runner_result(result)
         assert Path("src/foo_bar/defs/asset_checks/my_check.py").exists()
@@ -653,21 +659,23 @@ def test_scaffold_asset_check_with_key() -> None:
         assert "my_check" in result.output
 
 
-def test_scaffold_bad_extension() -> None:
+def test_scaffold_defs_bad_extension() -> None:
     with (
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("scaffold", "dagster.asset", "assets/foo")
+        result = runner.invoke("scaffold", "defs", "dagster.asset", "assets/foo")
         assert_runner_result(result, exit_0=False)
 
 
-def test_scaffold_multi_asset_basic() -> None:
+def test_scaffold_defs_multi_asset_basic() -> None:
     with (
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("scaffold", "dagster.multi_asset", "multi_assets/composite.py")
+        result = runner.invoke(
+            "scaffold", "defs", "dagster.multi_asset", "multi_assets/composite.py"
+        )
         assert_runner_result(result)
         assert Path("src/foo_bar/defs/multi_assets/composite.py").exists()
         assert (
@@ -689,7 +697,7 @@ def test_scaffold_multi_asset_basic() -> None:
         assert "composite/second_asset" in output
 
 
-def test_scaffold_multi_asset_params() -> None:
+def test_scaffold_defs_multi_asset_params() -> None:
     with (
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
@@ -697,6 +705,7 @@ def test_scaffold_multi_asset_params() -> None:
         # First, try scaffolding with multiple options using --asset-key
         result = runner.invoke(
             "scaffold",
+            "defs",
             "dagster.multi_asset",
             "multi_assets/custom_keys.py",
             "--asset-key",
@@ -719,6 +728,7 @@ def test_scaffold_multi_asset_params() -> None:
         # Next, try more complex keys with --json-params
         result = runner.invoke(
             "scaffold",
+            "defs",
             "dagster.multi_asset",
             "multi_assets/with_nested_keys.py",
             "--json-params",
@@ -737,12 +747,12 @@ def test_scaffold_multi_asset_params() -> None:
         assert "baz/qux" in output
 
 
-def test_scaffold_job() -> None:
+def test_scaffold_defs_job() -> None:
     with (
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("scaffold", "dagster.job", "jobs/my_pipeline.py")
+        result = runner.invoke("scaffold", "defs", "dagster.job", "jobs/my_pipeline.py")
         assert_runner_result(result)
         assert Path("src/foo_bar/defs/jobs/my_pipeline.py").exists()
         assert (
@@ -758,17 +768,17 @@ def test_scaffold_job() -> None:
         assert not Path("src/foo_bar/defs/jobs/defs.yaml").exists()
 
         # Create another job file to verify it works consistently
-        result = runner.invoke("scaffold", "dagster.job", "jobs/another_job.py")
+        result = runner.invoke("scaffold", "defs", "dagster.job", "jobs/another_job.py")
         assert_runner_result(result)
         assert Path("src/foo_bar/defs/jobs/another_job.py").exists()
 
 
-def test_scaffold_sensor() -> None:
+def test_scaffold_defs_sensor() -> None:
     with (
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner),
     ):
-        result = runner.invoke("scaffold", "dagster.sensor", "my_sensor.py")
+        result = runner.invoke("scaffold", "defs", "dagster.sensor", "my_sensor.py")
         assert_runner_result(result)
         assert Path("src/foo_bar/defs/my_sensor.py").exists()
         assert not Path("src/foo_bar/defs/defs.yaml").exists()
@@ -802,7 +812,14 @@ def test_scaffold_dbt_project_instance(params) -> None:
 
         with activate_venv(project_path / ".venv"):
             subprocess.run(
-                ["dg", "scaffold", "dagster_dbt.DbtProjectComponent", "my_project", *params],
+                [
+                    "dg",
+                    "scaffold",
+                    "defs",
+                    "dagster_dbt.DbtProjectComponent",
+                    "my_project",
+                    *params,
+                ],
                 check=True,
             )
             assert Path("src/foo_bar/defs/my_project").exists()
@@ -817,7 +834,7 @@ def test_scaffold_dbt_project_instance(params) -> None:
 
 
 # ########################
-# ##### COMPONENT TYPE
+# ##### COMPONENT
 # ########################
 
 

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_telemetry.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_telemetry.py
@@ -149,7 +149,7 @@ def test_telemetry_scaffold_component(caplog: pytest.LogCaptureFixture) -> None:
     ):
         caplog.clear()
         result = runner.invoke(
-            "scaffold", "dagster_test.components.AllMetadataEmptyComponent", "qux"
+            "scaffold", "defs", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert result.exit_code == 0, result.output + " " + str(result.exception)
         assert Path("foo_bar/defs/qux").exists()

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -678,8 +678,8 @@ class ProxyRunner:
         # We need to find the right spot to inject global options. For the `dg scaffold`
         # command, we need to inject the global options before the final subcommand. For everything
         # else they can be appended at the end of the options.
-        if args[0] == "scaffold":
-            index = 1
+        if args[0] == "scaffold" and args[1] == "defs":
+            index = 2
         elif "--help" in args:
             index = args.index("--help")
         elif "--" in args:


### PR DESCRIPTION
## Summary & Motivation

Break all defs scaffolders into a new command group under `dg scaffold defs`.

## How I Tested These Changes

Modified existing tests.

## Changelog

Definitions and component instances are now scaffolded with `dg scaffold defs <scaffolder>` instead of ` dg scaffold <scaffolder>`.