### PR TITLE
Move components CLI invocations to be direct function calls

### DIFF
--- a/python_modules/dagster/dagster/components/cli/list.py
+++ b/python_modules/dagster/dagster/components/cli/list.py
@@ -1,9 +1,10 @@
 import json
 import logging
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 from traceback import TracebackException
-from typing import Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import click
 from dagster_shared.error import SerializableErrorInfo, remove_system_frames_from_error
@@ -48,21 +49,25 @@ def list_cli():
 @list_cli.command(name="plugins")
 @click.option("--entry-points/--no-entry-points", is_flag=True, default=True)
 @click.argument("extra_modules", nargs=-1, type=str)
-def list_plugins_command(entry_points: bool, extra_modules: tuple[str, ...]) -> None:
+def list_plugins_command(entry_points: bool, extra_modules: tuple[str]) -> None:
     """List registered plugin objects."""
+    click.echo(serialize_value(list_plugins(entry_points, list(extra_modules))))
+
+
+def list_plugins(
+    entry_points: bool, extra_modules: Sequence[str]
+) -> Union[PluginManifest, SerializableErrorInfo]:
     modules = [*(ep.value for ep in get_plugin_entry_points()), *extra_modules]
     try:
         plugin_objects = _load_plugin_objects(entry_points, extra_modules)
         object_snaps = [get_package_entry_snap(key, obj) for key, obj in plugin_objects.items()]
-        output = PluginManifest(
+        return PluginManifest(
             modules=modules,
             objects=object_snaps,
         )
     except ComponentsEntryPointLoadError as e:
         tb = TracebackException.from_exception(e)
-        output = SerializableErrorInfo.from_traceback(tb)
-
-    click.echo(serialize_value(output))
+        return SerializableErrorInfo.from_traceback(tb)
 
 
 @list_cli.command(name="all-components-schema")
@@ -72,8 +77,13 @@ def list_all_components_schema_command(entry_points: bool, extra_modules: tuple[
     """Builds a JSON schema which ORs the schema for a component
     file for all component types available in the current code location.
     """
-    component_types = _load_component_types(entry_points, extra_modules)
+    click.echo(json.dumps(list_all_components_schema(entry_points, extra_modules)))
 
+
+def list_all_components_schema(
+    entry_points: bool, extra_modules: tuple[str, ...]
+) -> dict[str, Any]:
+    component_types = _load_component_types(entry_points, extra_modules)
     model_cls_list = []
     for key in sorted(component_types.keys(), key=lambda k: k.to_typename()):
         component_type = component_types[key]
@@ -91,7 +101,7 @@ def list_all_components_schema_command(entry_points: bool, extra_modules: tuple[
                 )
             )
     union_type = Union[tuple(model_cls_list)]  # type: ignore
-    click.echo(json.dumps(TypeAdapter(union_type).json_schema()))
+    return TypeAdapter(union_type).json_schema()
 
 
 @list_cli.command(name="definitions")
@@ -211,7 +221,7 @@ def list_definitions_impl(
 
 
 def _load_plugin_objects(
-    entry_points: bool, extra_modules: tuple[str, ...]
+    entry_points: bool, extra_modules: Sequence[str]
 ) -> dict[PluginObjectKey, object]:
     objects = {}
     if entry_points:
@@ -222,7 +232,7 @@ def _load_plugin_objects(
 
 
 def _load_component_types(
-    entry_points: bool, extra_modules: tuple[str, ...]
+    entry_points: bool, extra_modules: Sequence[str]
 ) -> dict[PluginObjectKey, type[Component]]:
     return {
         key: obj

--- a/python_modules/dagster/dagster/components/cli/scaffold.py
+++ b/python_modules/dagster/dagster/components/cli/scaffold.py
@@ -32,6 +32,16 @@ def scaffold_object_command(
     scaffold_format: str,
     project_root: Optional[Path],
 ) -> None:
+    scaffold_object_command_impl(typename, path, json_params, scaffold_format, project_root)
+
+
+def scaffold_object_command_impl(
+    typename: str,
+    path: Path,
+    json_params: Optional[str],
+    scaffold_format: str,
+    project_root: Optional[Path],
+) -> None:
     key = PluginObjectKey.from_typename(typename)
     obj = load_package_object(key)
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/component.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/component.py
@@ -1,5 +1,4 @@
 import copy
-import json
 import re
 import sys
 from collections.abc import Iterable, Mapping, Sequence, Set
@@ -11,11 +10,12 @@ from dagster_shared.error import (
     make_simple_frames_removed_hint,
     remove_system_frames_from_error,
 )
-from dagster_shared.serdes import deserialize_value, serialize_value
+from dagster_shared.serdes import serialize_value
 from dagster_shared.serdes.objects import PluginObjectKey, PluginObjectSnap
 from dagster_shared.serdes.objects.package_entry import PluginManifest, PluginObjectFeature
 from packaging.version import Version
 
+from dagster_dg.utils import validate_dagster_availability
 from dagster_dg.utils.warnings import emit_warning
 
 if TYPE_CHECKING:
@@ -127,10 +127,11 @@ def all_components_schema_from_dg_context(dg_context: "DgContext") -> Mapping[st
     if schema is None:
         if dg_context.has_cache:
             print("Component schema cache is invalidated or empty. Building cache...")  # noqa: T201
-        schema_raw = dg_context.in_process_dagster_components_cli_command(
-            ["list", "all-components-schema"]
-        )
-        schema = json.loads(schema_raw)
+
+        validate_dagster_availability()
+        from dagster.components.cli.list import list_all_components_schema
+
+        schema = list_all_components_schema(entry_points=True, extra_modules=())
 
     return schema
 
@@ -155,7 +156,7 @@ def _load_entry_point_components(
     if not plugin_manifest:
         if dg_context.is_plugin_cache_enabled:
             sys.stderr.write("Plugin object cache is invalidated or empty. Building cache...\n")
-        plugin_manifest = _fetch_plugin_manifest(dg_context, [])
+        plugin_manifest = _fetch_plugin_manifest(entry_points=True, extra_modules=[])
         if dg_context.is_plugin_cache_enabled and cache_key:
             dg_context.cache.set(cache_key, serialize_value(plugin_manifest))
     return plugin_manifest
@@ -178,7 +179,7 @@ def _load_module_library_objects(dg_context: "DgContext", modules: Sequence[str]
                 f"Plugin object cache is invalidated or empty for modules: [{modules_to_fetch}]. Building cache...\n"
             )
         plugin_manifest = _fetch_plugin_manifest(
-            dg_context, ["--no-entry-points", *modules_to_fetch]
+            entry_points=False, extra_modules=list(modules_to_fetch)
         )
         for module in modules_to_fetch:
             objects_for_module = [
@@ -198,12 +199,15 @@ def _load_module_library_objects(dg_context: "DgContext", modules: Sequence[str]
 # PluginManifest. This function handles normalizing the output across versions. We can compute a
 # PluginManifest from the list[PluginObjectSnap], but it won't include any modules that register an
 # entry point but don't expose any plugin objects.
-def _fetch_plugin_manifest(context: "DgContext", args: list[str]) -> PluginManifest:
+def _fetch_plugin_manifest(entry_points: bool, extra_modules: Sequence[str]) -> PluginManifest:
     from rich.console import Console
     from rich.panel import Panel
 
-    result = context.in_process_dagster_components_cli_command(["list", "plugins", *args])
-    result = deserialize_value(result, as_type=Union[SerializableErrorInfo, PluginManifest])
+    validate_dagster_availability()
+    from dagster.components.cli.list import list_plugins
+
+    result = list_plugins(entry_points=entry_points, extra_modules=extra_modules)
+
     if isinstance(result, SerializableErrorInfo):
         clean_result = remove_system_frames_from_error(
             result.cause,

--- a/python_modules/libraries/dagster-dg/dagster_dg/context.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/context.py
@@ -5,13 +5,11 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 from collections.abc import Iterable, Mapping
 from functools import cached_property
 from pathlib import Path
 from typing import Any, Final, Optional, Union
 
-from click.testing import CliRunner
 from dagster_shared.libraries import DagsterPyPiAccessError, get_published_pypi_versions
 from dagster_shared.record import record
 from dagster_shared.serdes.serdes import serialize_value, whitelist_for_serdes
@@ -617,23 +615,6 @@ class DgContext:
     # ########################
     # ##### HELPERS
     # ########################
-
-    def in_process_dagster_components_cli_command(
-        self,
-        command: list[str],
-    ) -> str:
-        validate_dagster_availability()
-        from dagster.components.cli import cli
-
-        result = CliRunner().invoke(
-            cli,
-            command,
-            catch_exceptions=False,
-        )
-        if result.exit_code != 0:
-            sys.exit(result.exit_code)
-
-        return result.stdout
 
     @property
     def has_uv_lock(self) -> bool:


### PR DESCRIPTION
## Summary & Motivation
After https://app.graphite.dev/github/pr/dagster-io/dagster/30127 these dagster-components invocations happen in-process, but still wrap a CLI invocation using CliRunner.

CliRunner is bad (it's intended for testing, doesn't stream, etc.). Move to direct function invocations instead.

## How I Tested These Changes
BK
