### PR TITLE
fix dg docs env test

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_using_env.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_using_env.py
@@ -226,7 +226,7 @@ def test_component_docs_using_env(
         ExitStack() as stack,
     ):
         run_command_and_snippet_output(
-            cmd="dg scaffold project ingestion",
+            cmd="dg scaffold project ingestion --use-editable-dagster",
             snippet_path=SNIPPETS_DIR / f"{get_next_snip_number()}-dg-init.txt",
             update_snippets=update_snippets,
             snippet_replace_regex=[


### PR DESCRIPTION
## Summary

Fix failing test on master which is due to a latent version mismatch between editable `dagster-sling` and non-editable `dagster` in this test specifically. A forward compat change was introduced and now this test is broken.

Updates to use editable for both.