### PR TITLE
[Definitions] detect conflicting AssetSpecs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -344,7 +344,16 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
 
         _validate_self_deps(normalized_specs)
 
-        self._specs_by_key = {spec.key: spec for spec in normalized_specs}
+        self._specs_by_key = {}
+        for spec in normalized_specs:
+            if spec.key in self._specs_by_key and self._specs_by_key[spec.key] != spec:
+                warnings.warn(
+                    "Received conflicting AssetSpecs with the same key:\n"
+                    f"{self._specs_by_key[spec.key]}\n"
+                    f"{spec}\n"
+                    "This warning will become an exception in version 1.11"
+                )
+            self._specs_by_key[spec.key] = spec
 
         self._partition_mappings = get_partition_mappings_from_deps(
             {},

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
@@ -411,3 +411,17 @@ def test_pydantic_spec() -> None:
 
     holder = SpecHolder(spec=AssetSpec(key="foo"), spec_list=[AssetSpec(key="bar")])
     assert TypeAdapter(SpecHolder).validate_python(holder)
+
+
+def test_definitions_spec_collision():
+    first = AssetSpec("a", group_name="first")
+    second = AssetSpec("a", group_name="second")
+
+    dg.AssetsDefinition(specs=[first, first])
+    assert dg.Definitions(assets=[first, first]).get_all_asset_specs() == [first]
+
+    with pytest.warns(match="conflicting AssetSpec"):
+        dg.AssetsDefinition(specs=[first, second])
+
+    with pytest.warns(match="conflicting AssetSpec"):
+        dg.Definitions(assets=[first, second]).get_all_asset_specs()


### PR DESCRIPTION
silent last write wins seems bad 

## How I Tested These Changes

added test 

## Changelog

[bugfix] `Definitions` and `AssetDefinition` will now warn if they get different `AssetSpec`s with the same key. This will become an exception in 1.11. 
