### PR TITLE
[api lifecycle update] move BackfillPolicy from Beta to GA

### DIFF
--- a/docs/docs/guides/build/partitions-and-backfills/backfilling-data.md
+++ b/docs/docs/guides/build/partitions-and-backfills/backfilling-data.md
@@ -24,9 +24,6 @@ To observe the progress of an asset backfill, navigate to the **Runs details** p
 
 ## Launching single-run backfills using backfill policies
 
-import Beta from '@site/docs/partials/\_Beta.md';
-
-<Beta />
 
 By default, if you launch a backfill that covers `N` partitions, Dagster will launch `N` separate runs, one for each partition. This approach can help avoid overwhelming Dagster or resources with large amounts of data. However, if you're using a parallel-processing engine like Spark and Snowflake, you often don't need Dagster to help with parallelism, so splitting up the backfill into multiple runs just adds extra overhead.
 

--- a/python_modules/dagster/dagster/_core/definitions/backfill_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/backfill_policy.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import NamedTuple, Optional
 
 import dagster._check as check
-from dagster._annotations import beta, public
+from dagster._annotations import public
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.warnings import disable_dagster_warnings
 
@@ -13,7 +13,6 @@ class BackfillPolicyType(Enum):
     MULTI_RUN = "MULTI_RUN"
 
 
-@beta
 @whitelist_for_serdes
 class BackfillPolicy(
     NamedTuple(


### PR DESCRIPTION
## Summary & Motivation
Per offline discussion, we have sufficient user validation to declare the API stable, as well as usage by large-scale customers confirming the feature’s scalability.

Note: Typically, we’d make this type of change in a 1.x.0 release. However, since there hasn’t been recent active development and the current status is causing confusion around the feature’s stability, I’m opening this PR to propose promoting it to GA earlier.

## How I Tested These Changes

| [Before](https://docs.dagster.io/guides/build/partitions-and-backfills/backfilling-data#launching-single-run-backfills-using-backfill-policies)  | [After](https://05-21-api-lifecycle-update-move-backfillpolicy-from-beta-to-ga.archive.dagster-docs.io/guides/build/partitions-and-backfills/backfilling-data#launching-single-run-backfills-using-backfill-policies) |
| ------------- | ------------- |
| ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/UJKUC8TkY94NXkl6T0es/1e099b1e-2d57-450d-9fe0-8d1952a3de9e.png) | ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/UJKUC8TkY94NXkl6T0es/63583fc1-f19b-4311-956f-09303f5e11f3.png)  |


| [Before](https://docs.dagster.io/api/dagster/partitions#dagster.BackfillPolicy)  | [After](https://05-21-api-lifecycle-update-move-backfillpolicy-from-beta-to-ga.archive.dagster-docs.io/api/dagster/partitions#dagster.BackfillPolicy) |
| ------------- | ------------- |
| ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/UJKUC8TkY94NXkl6T0es/cfae0a9b-826d-453f-8301-6005185255a9.png) | ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/UJKUC8TkY94NXkl6T0es/dd3e7fbd-f168-457a-95a1-61856350a3f2.png) |

## Changelog

`BackfillPolicy` is now marked as generally available (GA).
