### PR TITLE
Adjust asset decorator overload order to ease wrapping

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -58,13 +58,6 @@ from dagster._utils.warnings import disable_dagster_warnings
 
 @overload
 def asset(
-    compute_fn: Callable[..., Any],
-    **kwargs,
-) -> AssetsDefinition: ...
-
-
-@overload
-def asset(
     *,
     name: Optional[str] = ...,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
@@ -94,6 +87,13 @@ def asset(
     pool: Optional[str] = ...,
     **kwargs,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]: ...
+
+
+@overload
+def asset(
+    compute_fn: Callable[..., Any],
+    **kwargs,
+) -> AssetsDefinition: ...
 
 
 def _validate_hidden_non_argument_dep_param(


### PR DESCRIPTION
This commit modifies the order of the overload definitions for the asset decorator to ease the creation of custom wrapper that wrap this decorator. Prior to this commit the overload ordering meant that wrapping the asset decorator would result in type checker errors due to the way in which type checkers select which overload definition to use as described here:

https://typing.python.org/en/latest/spec/overload.html#overload-call-evaluation

## Summary & Motivation

It is often useful to modify the `asset` decorator to enforce some sort of local policy. For example, locally I need to ensure that `key_prefix` always contains an environment variable. To do that, I would use the following approach:

```python
import functools
from collections.abc import Callable
from typing import Any, cast

import dagster


def wrap[**P, T](
    wrapped: Callable[P, T],
) -> Callable[[Callable[..., Any]], Callable[P, T]]:
    def wrapper(func: Callable[..., Any]) -> Callable[P, T]:
        return cast("Callable[P, T]", functools.wraps(wrapped)(func))

    return wrapper


@wrap(dagster.asset)
def asset(fn, **kwargs):
    # Do something here with kwargs, e.g. adding an extra item to key_prefix
    return dagster.asset(fn, **kwargs)


@asset(name="my_asset_with_key_prefix_adjusted") # error: Argument missing for parameter "compute_fn" (reportCallIssue)
def my_asset(a: int) -> None: ...
```

Running pyright on this yields:
```
test.py
  test.py:23:2 - error: Argument missing for parameter "compute_fn" (reportCallIssue)
1 error, 0 warnings, 0 informations
```
and similarly mypy reports:
```
test.py:23: error: Missing positional argument "compute_fn" in call to "asset"  [call-arg]
Found 1 error in 1 file (checked 1 source file)
```

The reason for this is that `dagster.asset` has an overloaded definition, and type checkers follow [these rules](https://typing.python.org/en/latest/spec/overload.html#overload-call-evaluation) when type checking against an overloaded function. Those results end up in the signature of the first overload definition being used, which is the wrong signature. Simply switching the overload order fixes this problem, which is what this PR does. 

## How I Tested These Changes

See the above reproducer of the original problem. Applying the change in the PR fixes this.

## Changelog

> Optimize ordering of the asset decorator overload definitions to ease third party wrapping of this decorator.
