### PR TITLE
remote populate-cache argument from scaffold_project

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -727,13 +727,6 @@ def scaffold_github_actions_command(git_root: Optional[Path], **global_options: 
 )
 @click.argument("path", type=Path)
 @click.option(
-    "--populate-cache/--no-populate-cache",
-    is_flag=True,
-    default=True,
-    help="Whether to automatically populate the component type cache for the project.",
-    hidden=True,
-)
-@click.option(
     "--python-environment",
     default="active",
     type=click.Choice(get_args(DgProjectPythonEnvironmentFlag)),
@@ -752,7 +745,6 @@ def scaffold_github_actions_command(git_root: Optional[Path], **global_options: 
 @cli_telemetry_wrapper
 def scaffold_project_command(
     path: Path,
-    populate_cache: bool,
     use_editable_dagster: Optional[str],
     python_environment: DgProjectPythonEnvironmentFlag,
     uv_sync: Optional[bool],
@@ -820,7 +812,6 @@ def scaffold_project_command(
         abs_path,
         dg_context,
         use_editable_dagster=use_editable_dagster,
-        populate_cache=populate_cache,
         python_environment=DgProjectPythonEnvironment.from_flag(python_environment),
     )
 

--- a/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/scaffold.py
@@ -9,7 +9,6 @@ import click
 from packaging.version import Version
 from typing_extensions import TypeAlias
 
-from dagster_dg.component import RemotePluginRegistry
 from dagster_dg.config import (
     DgProjectPythonEnvironment,
     DgRawWorkspaceConfig,
@@ -79,7 +78,6 @@ def scaffold_project(
     path: Path,
     dg_context: DgContext,
     use_editable_dagster: Optional[str],
-    populate_cache: bool = True,
     python_environment: Optional[DgProjectPythonEnvironment] = None,
 ) -> None:
     import tomlkit
@@ -146,8 +144,6 @@ def scaffold_project(
     cl_dg_context = dg_context.with_root_path(path)
     if cl_dg_context.use_dg_managed_environment:
         cl_dg_context.ensure_uv_lock()
-        if populate_cache:
-            RemotePluginRegistry.from_dg_context(cl_dg_context)  # Populate the cache
 
     # Update pyproject.toml
     if cl_dg_context.is_workspace:

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_deploy_command.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/plus_tests/test_plus_deploy_command.py
@@ -151,7 +151,6 @@ def project_setup_path(runner):
                 "project",
                 "foo-bar-2",
                 *["--python-environment", "uv_managed"],
-                *(["--no-populate-cache"]),
             ]
 
             result = runner.invoke(*args)

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_scaffold_commands.py
@@ -356,37 +356,6 @@ def test_scaffold_project_use_editable_dagster_env_var_succeeds(monkeypatch) -> 
             )
 
 
-def test_scaffold_project_no_populate_cache_success(monkeypatch) -> None:
-    dagster_git_repo_dir = discover_git_root(Path(__file__))
-    monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))
-    with ProxyRunner.test() as runner, runner.isolated_filesystem():
-        result = runner.invoke(
-            "scaffold",
-            "project",
-            "foo-bar",
-            "--no-populate-cache",
-            "--python-environment",
-            "uv_managed",
-            "--use-editable-dagster",
-        )
-        assert_runner_result(result)
-        assert Path("foo-bar").exists()
-        assert Path("foo-bar/src/foo_bar").exists()
-        assert Path("foo-bar/src/foo_bar/components").exists()
-        assert Path("foo-bar/src/foo_bar/defs").exists()
-        assert Path("foo-bar/tests").exists()
-        assert Path("foo-bar/pyproject.toml").exists()
-
-        # Check venv created
-        assert Path("foo-bar/.venv").exists()
-        assert Path("foo-bar/uv.lock").exists()
-
-        with pushd("foo-bar"):
-            result = runner.invoke("list", "plugin-modules", "--verbose")
-            assert_runner_result(result)
-            assert "CACHE [miss]" in result.output
-
-
 def test_scaffold_project_python_environment_uv_managed_success(monkeypatch) -> None:
     dagster_git_repo_dir = discover_git_root(Path(__file__))
     monkeypatch.setenv("DAGSTER_GIT_REPO_DIR", str(dagster_git_repo_dir))

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/test_cache.py
@@ -14,11 +14,8 @@ from dagster_dg_tests.utils import (
     isolated_example_project_foo_bar,
 )
 
-# For all cache tests, avoid setting up venv in example project so we do not prepopulate the
-# cache (which is part of the venv setup routine).
 example_project = partial(
     isolated_example_project_foo_bar,
-    populate_cache=False,
     python_environment="uv_managed",
 )
 cache_runner_args = {"verbose": True}

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/utils.py
@@ -217,7 +217,6 @@ _MIN_DAGSTER_COMPONENTS_MERGED_VERSION = Version("1.10.8")
 def isolated_example_project_foo_bar(
     runner: Union[CliRunner, "ProxyRunner"],
     in_workspace: bool = True,
-    populate_cache: bool = False,
     component_dirs: Sequence[Path] = [],
     config_file_type: ConfigFileType = "pyproject.toml",
     package_layout: PackageLayoutType = "src",
@@ -271,7 +270,6 @@ def isolated_example_project_foo_bar(
             "foo-bar",
             *uv_sync_args,
             *["--python-environment", python_environment],
-            *(["--no-populate-cache"] if not populate_cache else []),
             *(["--use-editable-dagster", dagster_git_repo_dir] if use_editable_dagster else []),
         ]
         result = runner.invoke(*args)


### PR DESCRIPTION
## Summary & Motivation
Now that populating the cache happens in process rather than over IPC, it is not safe to do this when scaffolding a project - it will populate the cache with the plugins in the global environment rather than the plugins in the venv.

Incidentally the same thing happens if you accidentally run dg list plugins in the wrong venv now while in a project. Do we need to do anything more proactive to detect and prevent that?

## How I Tested These Changes
BK
