### PR TITLE
[docs] Add docstring for missing `required_resource_keys` param in @sensor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -81,6 +81,7 @@ def sensor(
         asset_selection (Optional[Union[str, Sequence[str], Sequence[AssetKey], Sequence[Union[AssetsDefinition, SourceAsset]], AssetSelection]]):
             An asset selection to launch a run for if the sensor condition is met.
             This can be provided instead of specifying a job.
+        required_resource_keys (Optional[set[str]]): A set of resource keys that must be available on the context when the sensor evaluation function runs. Use this to specify resources your sensor function depends on.
         tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
             be used for searching and filtering in the UI.
         metadata (Optional[Mapping[str, object]]): A set of metadata entries that annotate the


### PR DESCRIPTION
## Summary & Motivation
Missing docstring for the `required_resource_keys` param

## How I Tested These Changes
N/A
