### PR TITLE
[docs] add clarification on use of multi_asset in shell script component

### DIFF
--- a/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
+++ b/docs/docs/guides/labs/components/creating-new-component-types/creating-and-registering-a-component-type.md
@@ -85,7 +85,11 @@ Next, you'll need to define how to turn the component parameters into a `Definit
 
 To do so, you will need to update the `build_defs` method, which is responsible for returning a `Definitions` object containing all definitions related to the component.
 
-In this example, the `build_defs` method creates a single `@asset` that executes the provided shell script. By convention, the code to execute this asset is placed inside of a function called `execute`, which will make it easier for future developers to create subclasses of this component:
+In this example, the `build_defs` method creates a `@multi_asset` that executes the provided shell script. By convention, the code to execute this asset is placed inside of a function called `execute`, which will make it easier for future developers to create subclasses of this component:
+
+:::note
+The `@multi_asset` decorator is used to provide the flexibility of assigning multiple assets using `asset_spec` to a single shell script execution as our shell script may produce more than one object.
+:::
 
 <CodeExample
   path="docs_snippets/docs_snippets/guides/components/shell-script-component/with-build-defs.py"


### PR DESCRIPTION
## Summary & Motivation

Closes DOC-1117.

Addresses feedback:
> In the docs it says Our build_defs method will create a single @asset that executes the provided shell script.
> yet the example uses multi_asset Is there a reason why a single asset needs multi asset?

## How I Tested These Changes

## Changelog

NOCHANGELOG
