### PR TITLE
[1.11] error on conflicting AssetSpec

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -347,7 +347,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         self._specs_by_key = {}
         for spec in normalized_specs:
             if spec.key in self._specs_by_key and self._specs_by_key[spec.key] != spec:
-                warnings.warn(
+                raise DagsterInvalidDefinitionError(
                     "Received conflicting AssetSpecs with the same key:\n"
                     f"{self._specs_by_key[spec.key]}\n"
                     f"{spec}\n"

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
@@ -420,8 +420,8 @@ def test_definitions_spec_collision():
     dg.AssetsDefinition(specs=[first, first])
     assert dg.Definitions(assets=[first, first]).get_all_asset_specs() == [first]
 
-    with pytest.warns(match="conflicting AssetSpec"):
+    with pytest.raises(DagsterInvalidDefinitionError, match="conflicting AssetSpec"):
         dg.AssetsDefinition(specs=[first, second])
 
-    with pytest.warns(match="conflicting AssetSpec"):
+    with pytest.raises(DagsterInvalidDefinitionError, match="conflicting AssetSpec"):
         dg.Definitions(assets=[first, second]).get_all_asset_specs()


### PR DESCRIPTION
promote warning to error in next version bump

## How I Tested These Changes

updated test

## Changelog

[breaking change] `Definitions` and `AssetsDefinition` will now error if they get different `AssetSpec`s with the same key
