### PR TITLE
[record] Use @record for PartitionMappings, update __eq__ and __ne__

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -1040,3 +1040,33 @@ def test_invalid_mappings_with_asset_deps():
                 assets=[daily_partitioned_asset, static_mapped_asset],
             )
         )
+
+
+@pytest.mark.parametrize(
+    ["a", "b", "equal"],
+    [
+        (IdentityPartitionMapping(), LastPartitionMapping(), False),
+        (LastPartitionMapping(), AllPartitionMapping(), False),
+        (IdentityPartitionMapping(), IdentityPartitionMapping(), True),
+        (
+            IdentityPartitionMapping(),
+            TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            False,
+        ),
+        (
+            TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            True,
+        ),
+        (
+            TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            TimeWindowPartitionMapping(start_offset=-2, end_offset=-2),
+            False,
+        ),
+    ],
+)
+def test_partition_mapping_equality(a: PartitionMapping, b: PartitionMapping, equal: bool) -> None:
+    if equal:
+        assert a == b
+    else:
+        assert a != b

--- a/python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py
@@ -159,6 +159,8 @@ def _namedtuple_record_transform(
         _ORIGINAL_CLASS_FIELD: cls,
         _KW_ONLY_FIELD: kw_only,
         "__reduce__": _reduce,
+        "__eq__": _eq,
+        "__ne__": _ne,
         # functools doesn't work, so manually update_wrapper
         "__module__": cls.__module__,
         "__qualname__": cls.__qualname__,
@@ -574,6 +576,14 @@ def _from_reduce(cls, kwargs):
 def _reduce(self):
     # pickle support
     return _from_reduce, (self.__class__, as_dict_for_new(self))
+
+
+def _eq(self, other):
+    return type(self) == type(other) and self._fields == other._fields
+
+
+def _ne(self, other):
+    return not _eq(self, other)
 
 
 def _repr(self) -> str:


### PR DESCRIPTION
## Summary & Motivation

Slightly spicy as `@record` shares the same `__eq__` method as namedtuples, I needed to update it to take types into account.

The core of the issue is that things like `LastPartitionMapping()` and `AllPartitionMapping()` are just empty tuples and so are (by default) considered to be equal. This updates the record class to take the type into account

## How I Tested These Changes

## Changelog

NOCHANGELOG
