### PR TITLE
Make AssetCheckSpec a @record_custom

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -34,7 +34,7 @@ class AssetCheckSeverity(Enum):
 
 LazyAutomationCondition: TypeAlias = Annotated[
     "AutomationCondition",
-    "AutomationCondition",  # Ideally this would be AutomationCondition[AssetCheckKey] if record was updated to handle it
+    ImportFrom("dagster._core.definitions.declarative_automation.automation_condition"),
 ]
 
 LazyAssetDep: TypeAlias = Annotated["AssetDep", ImportFrom("dagster._core.definitions.asset_dep")]

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -1,7 +1,8 @@
 from collections.abc import Iterable, Mapping
 from enum import Enum
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
+from dagster_shared.record import IHaveNew, LegacyNamedTupleMixin, record_custom
 from dagster_shared.serdes import whitelist_for_serdes
 
 import dagster._check as check
@@ -31,23 +32,18 @@ class AssetCheckSeverity(Enum):
     ERROR = "ERROR"
 
 
-class AssetCheckSpec(
-    NamedTuple(
-        "_AssetCheckSpec",
-        [
-            ("name", PublicAttr[str]),
-            ("asset_key", PublicAttr[AssetKey]),
-            ("description", PublicAttr[Optional[str]]),
-            ("additional_deps", PublicAttr[Iterable["AssetDep"]]),
-            (
-                "blocking",  # intentionally not public, see https://github.com/dagster-io/dagster/issues/20659
-                bool,
-            ),
-            ("metadata", PublicAttr[Optional[Mapping[str, Any]]]),
-            ("automation_condition", Optional["AutomationCondition[AssetCheckKey]"]),
-        ],
+@record_custom
+class AssetCheckSpec(IHaveNew, LegacyNamedTupleMixin):
+    name: PublicAttr[str]
+    asset_key: PublicAttr[AssetKey]
+    description: PublicAttr[Optional[str]]
+    additional_deps: PublicAttr[Iterable["AssetDep"]]
+    blocking: (
+        bool  # intentionally not public, see https://github.com/dagster-io/dagster/issues/20659
     )
-):
+    metadata: PublicAttr[Optional[Mapping[str, Any]]]
+    automation_condition: PublicAttr[Optional["AutomationCondition[AssetCheckKey]"]]
+
     """Defines information about an asset check, except how to execute it.
 
     AssetCheckSpec is often used as an argument to decorators that decorator a function that can

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -49,7 +49,7 @@ class AssetCheckSpec(IHaveNew, LegacyNamedTupleMixin):
     blocking: (
         bool  # intentionally not public, see https://github.com/dagster-io/dagster/issues/20659
     )
-    metadata: PublicAttr[Optional[Mapping[str, Any]]]
+    metadata: PublicAttr[Mapping[str, Any]]
     automation_condition: PublicAttr[Optional[LazyAutomationCondition]]
 
     """Defines information about an asset check, except how to execute it.
@@ -104,7 +104,7 @@ class AssetCheckSpec(IHaveNew, LegacyNamedTupleMixin):
             description=description,
             additional_deps=additional_asset_deps,
             blocking=blocking,
-            metadata=metadata,
+            metadata=metadata or {},
             automation_condition=automation_condition,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -1,9 +1,10 @@
 from collections.abc import Iterable, Mapping
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Any, Optional, Union
 
-from dagster_shared.record import IHaveNew, LegacyNamedTupleMixin, record_custom
+from dagster_shared.record import IHaveNew, ImportFrom, LegacyNamedTupleMixin, record_custom
 from dagster_shared.serdes import whitelist_for_serdes
+from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._annotations import PublicAttr
@@ -32,17 +33,25 @@ class AssetCheckSeverity(Enum):
     ERROR = "ERROR"
 
 
+LazyAutomationCondition: TypeAlias = Annotated[
+    "AutomationCondition",
+    ImportFrom("dagster._core.definitions.declarative_automation.automation_condition"),
+]
+
+LazyAssetDep: TypeAlias = Annotated["AssetDep", ImportFrom("dagster._core.definitions.asset_dep")]
+
+
 @record_custom
 class AssetCheckSpec(IHaveNew, LegacyNamedTupleMixin):
     name: PublicAttr[str]
     asset_key: PublicAttr[AssetKey]
     description: PublicAttr[Optional[str]]
-    additional_deps: PublicAttr[Iterable["AssetDep"]]
+    additional_deps: PublicAttr[Iterable[LazyAssetDep]]
     blocking: (
         bool  # intentionally not public, see https://github.com/dagster-io/dagster/issues/20659
     )
     metadata: PublicAttr[Optional[Mapping[str, Any]]]
-    automation_condition: PublicAttr[Optional["AutomationCondition[AssetCheckKey]"]]
+    automation_condition: PublicAttr[Optional[LazyAutomationCondition]]
 
     """Defines information about an asset check, except how to execute it.
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -33,7 +33,7 @@ class AssetCheckSeverity(Enum):
 
 
 LazyAutomationCondition: TypeAlias = Annotated[
-    "AutomationCondition",
+    "AutomationCondition",  # Ideally this would be AutomationCondition[AssetCheckKey] if record was updated to handle it
     ImportFrom("dagster._core.definitions.declarative_automation.automation_condition"),
 ]
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -34,7 +34,7 @@ class AssetCheckSeverity(Enum):
 
 LazyAutomationCondition: TypeAlias = Annotated[
     "AutomationCondition",
-    ImportFrom("dagster._core.definitions.declarative_automation.automation_condition"),
+    "AutomationCondition",  # Ideally this would be AutomationCondition[AssetCheckKey] if record was updated to handle it
 ]
 
 LazyAssetDep: TypeAlias = Annotated["AssetDep", ImportFrom("dagster._core.definitions.asset_dep")]

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -6,7 +6,6 @@ from dagster_shared.record import IHaveNew, ImportFrom, LegacyNamedTupleMixin, r
 from dagster_shared.serdes import whitelist_for_serdes
 from typing_extensions import TypeAlias
 
-import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey, CoercibleToAssetKey
 
@@ -84,9 +83,6 @@ class AssetCheckSpec(IHaveNew, LegacyNamedTupleMixin):
         automation_condition: Optional["AutomationCondition[AssetCheckKey]"] = None,
     ):
         from dagster._core.definitions.asset_dep import coerce_to_deps_and_check_duplicates
-        from dagster._core.definitions.declarative_automation.automation_condition import (
-            AutomationCondition,
-        )
 
         asset_key = AssetKey.from_coercible_or_definition(asset)
 
@@ -103,15 +99,13 @@ class AssetCheckSpec(IHaveNew, LegacyNamedTupleMixin):
 
         return super().__new__(
             cls,
-            name=check.str_param(name, "name"),
+            name=name,
             asset_key=asset_key,
-            description=check.opt_str_param(description, "description"),
+            description=description,
             additional_deps=additional_asset_deps,
-            blocking=check.bool_param(blocking, "blocking"),
-            metadata=check.opt_mapping_param(metadata, "metadata", key_type=str),
-            automation_condition=check.opt_inst_param(
-                automation_condition, "automation_condition", AutomationCondition
-            ),
+            blocking=blocking,
+            metadata=metadata,
+            automation_condition=automation_condition,
         )
 
     def get_python_identifier(self) -> str:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_spec.py
@@ -36,4 +36,4 @@ def test_unserializable_metadata():
 
     obj = SomeObject()
 
-    assert AssetCheckSpec(asset="foo", name="check1", metadata={"foo": obj}).metadata["foo"] == obj  # pyright: ignore[reportOptionalSubscript]
+    assert AssetCheckSpec(asset="foo", name="check1", metadata={"foo": obj}).metadata["foo"] == obj

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_freshness_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_freshness_checks.py
@@ -106,7 +106,7 @@ def test_last_update_multiple_assets_defs(
     assert len(orders_checks) == 1
     customers_check = next(iter(customers_checks))
     orders_check = next(iter(orders_checks))
-    assert customers_check.check_specs_by_output_name["customers_freshness_check"].metadata[  # type: ignore[attr-defined]
+    assert customers_check.check_specs_by_output_name["customers_freshness_check"].metadata[
         FRESHNESS_PARAMS_METADATA_KEY
     ] == JsonMetadataValue(
         {
@@ -115,7 +115,7 @@ def test_last_update_multiple_assets_defs(
             DEADLINE_CRON_PARAM_KEY: "0 0 * * *",
         }
     )
-    assert orders_check.check_specs_by_output_name["orders_freshness_check"].metadata[  # type: ignore[attr-defined]
+    assert orders_check.check_specs_by_output_name["orders_freshness_check"].metadata[
         FRESHNESS_PARAMS_METADATA_KEY
     ] == JsonMetadataValue(
         {
@@ -163,7 +163,7 @@ def test_time_partition_multiple_assets_defs(
     assert len(orders_checks) == 1
     customers_check = next(iter(customers_checks))
     orders_check = next(iter(orders_checks))
-    assert customers_check.check_specs_by_output_name["customers_freshness_check"].metadata[  # type: ignore[attr-defined]
+    assert customers_check.check_specs_by_output_name["customers_freshness_check"].metadata[
         FRESHNESS_PARAMS_METADATA_KEY
     ] == JsonMetadataValue(
         {
@@ -171,7 +171,7 @@ def test_time_partition_multiple_assets_defs(
             DEADLINE_CRON_PARAM_KEY: "0 0 * * *",
         }
     )
-    assert orders_check.check_specs_by_output_name["orders_freshness_check"].metadata[  # type: ignore[attr-defined]
+    assert orders_check.check_specs_by_output_name["orders_freshness_check"].metadata[
         FRESHNESS_PARAMS_METADATA_KEY
     ] == JsonMetadataValue(
         {
@@ -214,7 +214,7 @@ def test_mixed_freshness(test_dagster_dbt_mixed_freshness_manifest: dict[str, An
     assert len(orders_checks) == 1
     customers_check = next(iter(customers_checks))
     orders_check = next(iter(orders_checks))
-    assert customers_check.check_specs_by_output_name["customers_freshness_check"].metadata[  # type: ignore[attr-defined]
+    assert customers_check.check_specs_by_output_name["customers_freshness_check"].metadata[
         FRESHNESS_PARAMS_METADATA_KEY
     ] == JsonMetadataValue(
         {
@@ -223,7 +223,7 @@ def test_mixed_freshness(test_dagster_dbt_mixed_freshness_manifest: dict[str, An
             DEADLINE_CRON_PARAM_KEY: "0 0 * * *",
         }
     )
-    assert orders_check.check_specs_by_output_name["orders_freshness_check"].metadata[  # type: ignore[attr-defined]
+    assert orders_check.check_specs_by_output_name["orders_freshness_check"].metadata[
         FRESHNESS_PARAMS_METADATA_KEY
     ] == JsonMetadataValue(
         {


### PR DESCRIPTION
## Summary & Motivation

Making `AssetCheckSpec` a `@record_custom` in order to make it play nicer with pydantic.

Note that `ImportFrom` does not play nicely with generics so this loosens type safety by changing the typing from "AutomationCondition[AssetCheckKey]" to "AutomationCondition" on AssetCheckSpec.automation_condition/

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG