### PR TITLE
[dg launch] Add --config param to load config from file

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/launch.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/launch.py
@@ -22,7 +22,6 @@ from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 @click.option(
     "--config-json", type=click.STRING, help="JSON string of config to use for the launched run."
 )
-
 @click.option(
     "--config",
     "-c",
@@ -33,7 +32,6 @@ from dagster_dg.utils.telemetry import cli_telemetry_wrapper
     ),
     multiple=True,
 )
-
 @dg_path_options
 @dg_global_options
 @cli_telemetry_wrapper

--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/launch.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/launch.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Optional
 
@@ -22,6 +22,18 @@ from dagster_dg.utils.telemetry import cli_telemetry_wrapper
 @click.option(
     "--config-json", type=click.STRING, help="JSON string of config to use for the launched run."
 )
+
+@click.option(
+    "--config",
+    "-c",
+    type=click.Path(exists=True, dir_okay=False, file_okay=True),
+    help=(
+        "Specify one or more run config files. These can also be file patterns."
+        " If more than one run config file is captured then those files are merged. Files listed first take precedence."
+    ),
+    multiple=True,
+)
+
 @dg_path_options
 @dg_global_options
 @cli_telemetry_wrapper
@@ -30,6 +42,7 @@ def launch_command(
     partition: Optional[str],
     partition_range: Optional[str],
     config_json: Optional[str],
+    config: Sequence[str],
     path: Path,
     **global_options: Mapping[str, object],
 ):
@@ -53,7 +66,7 @@ def launch_command(
         select=assets,
         partition=partition,
         partition_range=partition_range,
-        config=(),
+        config=tuple(config),
         config_json=config_json,
         working_directory=str(dg_context.root_path),
         module_name=dg_context.code_location_target_module_name,

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_launch_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_launch_commands.py
@@ -1,8 +1,10 @@
 import inspect
+import json
 import subprocess
 import textwrap
 from pathlib import Path
 
+import yaml
 from dagster_dg.utils import ensure_dagster_dg_tests_import
 
 ensure_dagster_dg_tests_import()
@@ -116,3 +118,52 @@ def test_launch_assets() -> None:
             assert result.returncode != 0
 
             assert "no AssetsDefinition objects supply these keys" in result.stderr.decode("utf-8")
+
+
+def test_launch_assets_config_files(capfd) -> None:
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(
+            runner,
+            in_workspace=False,
+            python_environment="uv_managed",
+        ) as project_dir,
+        activate_venv(project_dir / ".venv"),
+    ):
+        result = subprocess.run(
+            ["dg", "scaffold", "dagster.components.DefsFolderComponent", "mydefs"], check=True
+        )
+        assert result.returncode == 0
+
+        with Path("src/foo_bar/defs/mydefs/definitions.py").open("w") as f:
+            defs_source = textwrap.dedent(inspect.getsource(_sample_defs).split("\n", 1)[1])
+            f.write(defs_source)
+
+        Path("config.json").write_text(json.dumps({"ops": {"my_asset_3": {"config": {"foo": 7}}}}))
+
+        result = subprocess.run(
+            ["dg", "launch", "--assets", "my_asset_3", "--config", "config.json"], check=True
+        )
+        assert result.returncode == 0
+
+        captured = capfd.readouterr()
+        assert "CONFIG: 7" in captured.err
+
+        Path("config.yaml").write_text(yaml.dump({"ops": {"my_asset_3": {"config": {"foo": 3}}}}))
+        result = subprocess.run(
+            ["dg", "launch", "--assets", "my_asset_3", "-c", "config.yaml"], check=True
+        )
+        assert result.returncode == 0
+
+        captured = capfd.readouterr()
+        assert "CONFIG: 3" in captured.err
+
+        Path("config.yaml").write_text(yaml.dump({"ops": {"my_asset_3": {"config": {"foo": 3}}}}))
+        result = subprocess.run(
+            ["dg", "launch", "--assets", "my_asset_3", "-c", "config.yaml", "-c", "config.json"],
+            check=True,
+        )
+        assert result.returncode == 0
+
+        captured = capfd.readouterr()
+        assert "CONFIG: 7" in captured.err


### PR DESCRIPTION
## Summary

Supports the `--config/-c` parameter to pass config files to `dg launch`.

## Test Plan

New unit test.

## Changelog

> [dg] `dg launch` now supports passing config files through `--config/-c`.