### PR TITLE
Retry exit code 128

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -40,8 +40,10 @@ class CommandStepBuilder:
             "timeout_in_minutes": timeout_in_minutes,
             "retry": {
                 "automatic": [
+                    # https://buildkite.com/docs/agent/v3#exit-codes
                     {"exit_status": -1, "limit": 2},  # agent lost
                     {"exit_status": 125, "limit": 2},  # docker daemon error
+                    {"exit_status": 128, "limit": 2},  # k8s git clone error
                     {"exit_status": 143, "limit": 2},  # agent lost
                     {"exit_status": 2, "limit": 2},  # often a uv read timeout
                     {"exit_status": 255, "limit": 2},  # agent forced shut down


### PR DESCRIPTION
In theory we're not supposed to get 128 directly and instead are supposed to get 128 + the actual signal. But one came through here:

https://buildkite.com/dagster/internal/builds/108176#0196f93e-d87a-462c-adb4-7d05a409157e

```
Cloning into '/workspace/build/buildkite/dagster/internal/../dagster'...
fatal: unable to access 'https://github.com/dagster-io/dagster.git/': Could not resolve host: github.com
🚨 Error: The command exited with status 128
```

Which seems totally safe and preferred to just retry our way around.