### PR TITLE
[Helm] Add backfill daemon configuration

### DIFF
--- a/docs/docs/deployment/oss/dagster-yaml.md
+++ b/docs/docs/deployment/oss/dagster-yaml.md
@@ -151,6 +151,10 @@ schedules:
   use_threads: true
   num_workers: 8
 
+backfills:
+  use_threads: true
+  num_workers: 8
+
 auto_materialize:
   enabled: true
   minimum_interval_seconds: 3600
@@ -295,6 +299,16 @@ Configures how schedules are evaluated.
 
 ```yaml
 schedules:
+  use_threads: true
+  num_workers: 8
+```
+
+### `backfills`
+
+Configures how backfills are submitted.
+
+```yaml
+backfills:
   use_threads: true
   num_workers: 8
 ```

--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -72,6 +72,12 @@ class Schedules(BaseModel):
     numSubmitWorkers: Optional[int] = None
 
 
+class Backfills(BaseModel):
+    useThreads: bool
+    numWorkers: Optional[int] = None
+    numSubmitWorkers: Optional[int] = None
+
+
 class RunRetries(BaseModel):
     enabled: bool
     maxRetries: Optional[int] = None
@@ -103,6 +109,7 @@ class Daemon(BaseModel, extra="forbid"):
     runRetries: RunRetries
     sensors: Sensors
     schedules: Schedules
+    backfills: Backfills
     schedulerName: Optional[str] = None
     volumeMounts: Optional[list[kubernetes.VolumeMount]] = None
     volumes: Optional[list[kubernetes.Volume]] = None

--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -109,7 +109,7 @@ class Daemon(BaseModel, extra="forbid"):
     runRetries: RunRetries
     sensors: Sensors
     schedules: Schedules
-    backfills: Backfills
+    backfills: Optional[Backfills] = None
     schedulerName: Optional[str] = None
     volumeMounts: Optional[list[kubernetes.VolumeMount]] = None
     volumes: Optional[list[kubernetes.Volume]] = None

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -322,7 +322,7 @@ def test_run_monitoring_set_max_runtime_seconds(
     assert instance["run_monitoring"]["max_runtime_seconds"] == 2
 
 
-def test_sensor_schedule_threading_default(
+def test_sensor_schedule_backfill_threading_default(
     instance_template: HelmTemplate,
 ):
     helm_values = DagsterHelmValues.construct(dagsterDaemon=Daemon.construct())
@@ -338,8 +338,8 @@ def test_sensor_schedule_threading_default(
 
     assert instance["schedules"]["use_threads"] is True
     assert instance["schedules"]["num_workers"] == 4
-    assert instance["backfills"]["use_threads"] is True
-    assert instance["backfills"]["num_workers"] == 4
+
+    assert "backfills" not in instance
 
 
 def test_schedule_threading_disabled(
@@ -357,8 +357,6 @@ def test_schedule_threading_disabled(
 
     assert instance["sensors"]["use_threads"] is True
     assert instance["sensors"]["num_workers"] == 4
-    assert instance["backfills"]["use_threads"] is True
-    assert instance["backfills"]["num_workers"] == 4
 
     assert "schedules" not in instance
 
@@ -377,8 +375,6 @@ def test_sensor_threading_disabled(
 
     assert instance["schedules"]["use_threads"] is True
     assert instance["schedules"]["num_workers"] == 4
-    assert instance["backfills"]["use_threads"] is True
-    assert instance["backfills"]["num_workers"] == 4
 
     assert "sensors" not in instance
 
@@ -401,7 +397,7 @@ def test_backfill_threading_disabled(
     assert instance["schedules"]["use_threads"] is True
     assert instance["schedules"]["num_workers"] == 4
 
-    assert "backfills" not in instance
+    assert instance["backfills"]["use_threads"] is False
 
 
 def test_run_retries_default(

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -144,6 +144,18 @@ data:
       num_submit_workers: {{ $schedules.numSubmitWorkers }}
       {{- end }}
     {{- end }}
+    
+    {{- $backfills := .Values.dagsterDaemon.backfills }}
+    {{- if and (.Values.dagsterDaemon.enabled) ($backfills.useThreads) }}
+    backfills:
+      use_threads: {{ $backfills.useThreads }}
+      {{- if $backfills.numWorkers }}
+      num_workers: {{ $backfills.numWorkers }}
+      {{- end }}
+      {{- if $backfills.numSubmitWorkers }}
+      num_submit_workers: {{ $backfills.numSubmitWorkers }}
+      {{- end }}
+    {{- end }}
 
     telemetry:
       enabled: {{ .Values.telemetry.enabled }}

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -146,7 +146,7 @@ data:
     {{- end }}
     
     {{- $backfills := .Values.dagsterDaemon.backfills }}
-    {{- if and (.Values.dagsterDaemon.enabled) ($backfills.useThreads) }}
+    {{- if and (.Values.dagsterDaemon.enabled) ($backfills) }}
     backfills:
       use_threads: {{ $backfills.useThreads }}
       {{- if $backfills.numWorkers }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -138,6 +138,43 @@
             "title": "AzureBlobComputeLogManager",
             "type": "object"
         },
+        "Backfills": {
+            "properties": {
+                "useThreads": {
+                    "title": "Usethreads",
+                    "type": "boolean"
+                },
+                "numWorkers": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Numworkers"
+                },
+                "numSubmitWorkers": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Numsubmitworkers"
+                }
+            },
+            "required": [
+                "useThreads"
+            ],
+            "title": "Backfills",
+            "type": "object"
+        },
         "BlockOpConcurrencyLimitedRuns": {
             "properties": {
                 "enabled": {
@@ -753,6 +790,9 @@
                 "schedules": {
                     "$ref": "#/$defs/Schedules"
                 },
+                "backfills": {
+                    "$ref": "#/$defs/Backfills"
+                },
                 "schedulerName": {
                     "anyOf": [
                         {
@@ -860,7 +900,8 @@
                 "runMonitoring",
                 "runRetries",
                 "sensors",
-                "schedules"
+                "schedules",
+                "backfills"
             ],
             "title": "Daemon",
             "type": "object"

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -791,7 +791,15 @@
                     "$ref": "#/$defs/Schedules"
                 },
                 "backfills": {
-                    "$ref": "#/$defs/Backfills"
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Backfills"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
                 },
                 "schedulerName": {
                     "anyOf": [

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -900,8 +900,7 @@
                 "runMonitoring",
                 "runRetries",
                 "sensors",
-                "schedules",
-                "backfills"
+                "schedules"
             ],
             "title": "Daemon",
             "type": "object"

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1188,6 +1188,18 @@ dagsterDaemon:
     # used to decrease latency when a schedule emits multiple run requests within a single tick.
     # numSubmitWorkers: 4
 
+  backfills:
+    # Whether to submit backfills using an asynchronous thread pool, allowing backfill runs
+    # to be enqueued in parallel
+    useThreads: true
+    # The max number of worker threads to use when submitting backfills. Can be tuned
+    # to allow more backfills to run in parallel, but may require allocating more resources to the
+    # daemon.
+    numWorkers: 4
+    # Uncomment to use a threadpool to submit runs from backfills in parallel. Can be
+    # used to decrease latency when a backfill enqueues many run requests.
+    # numSubmitWorkers: 4
+
   # Additional environment variables to set.
   # These will be directly applied to the daemon container. See
   # https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1188,17 +1188,20 @@ dagsterDaemon:
     # used to decrease latency when a schedule emits multiple run requests within a single tick.
     # numSubmitWorkers: 4
 
-  backfills:
-    # Whether to submit backfills using an asynchronous thread pool, allowing backfill runs
-    # to be enqueued in parallel
-    useThreads: true
-    # The max number of worker threads to use when submitting backfills. Can be tuned
-    # to allow more backfills to run in parallel, but may require allocating more resources to the
-    # daemon.
-    numWorkers: 4
-    # Uncomment to use a threadpool to submit runs from backfills in parallel. Can be
-    # used to decrease latency when a backfill enqueues many run requests.
-    # numSubmitWorkers: 4
+    # Uncomment to configure the backfill daemon.
+    # Warning: Code deployments with version before 1.9.7 don't support this configuration and might fail.
+    # More details: https://github.com/dagster-io/dagster/pull/30189#issuecomment-2930805760
+    # backfills:
+    #   Whether to submit backfills using an asynchronous thread pool, allowing backfill runs
+    #   to be enqueued in parallel
+    #   useThreads: true
+    #   The max number of worker threads to use when submitting backfills. Can be tuned
+    #   to allow more backfills to run in parallel, but may require allocating more resources to the
+    #   daemon.
+    #   numWorkers: 4
+    #   Uncomment to use a threadpool to submit runs from backfills in parallel. Can be
+    #   used to decrease latency when a backfill enqueues many run requests.
+    #   numSubmitWorkers: 4
 
   # Additional environment variables to set.
   # These will be directly applied to the daemon container. See


### PR DESCRIPTION
## Summary & Motivation
Backfill daemon supports parallel processing using threadpool executor.
Until now, the configuration was available only via `dagster.yaml`, but not via helm values.

## How I Tested These Changes
`helm template .` + Deployed Dagster controller using Helm chart with validation to ArgoCD. 

## Changelog

> [Helm] Add backfill daemon configuration
