### PR TITLE
Make catalog group link to asset table without cross code location filter.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/util.tsx
@@ -8,7 +8,7 @@ import {useAssetsHealthData} from '../../asset-data/AssetHealthDataProvider';
 import {AssetHealthStatus} from '../../graphql/types';
 import {
   linkToAssetTableWithAssetOwnerFilter,
-  linkToAssetTableWithGroupFilter,
+  linkToAssetTableWithCrossCodeLocationGroupFilter,
   linkToAssetTableWithKindFilter,
   linkToAssetTableWithTagFilter,
   linkToCodeLocationInCatalog,
@@ -60,11 +60,7 @@ export function getGroupedAssets(assets: AssetTableFragment[]) {
         acc.groupName[groupName] = acc.groupName[groupName] || {
           assets: [],
           label: groupName,
-          link: linkToAssetTableWithGroupFilter({
-            groupName,
-            repositoryLocationName: repository?.location.name,
-            repositoryName: repository?.name,
-          }),
+          link: linkToAssetTableWithCrossCodeLocationGroupFilter(groupName),
         };
         acc.groupName[groupName]!.assets.push(asset);
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/search/links.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/links.tsx
@@ -12,6 +12,12 @@ export const linkToAssetTableWithGroupFilter = (groupMetadata: GroupMetadata) =>
   })}`;
 };
 
+export const linkToAssetTableWithCrossCodeLocationGroupFilter = (groupName: string) => {
+  return `/assets?${qs.stringify({
+    'asset-selection': `group:"${groupName}"`,
+  })}`;
+};
+
 export const linkToAssetTableWithKindFilter = (kind: string) => {
   return `/assets?${qs.stringify({
     'asset-selection': `kind:"${kind}"`,


### PR DESCRIPTION
## Summary & Motivation

Historically groups have been tied to a specific code location but we want to move to making them cross code location. More info on that here: https://github.com/dagster-io/internal/discussions/12935

## How I Tested These Changes

clicked on a group tile and saw the selection input doesnt include a code locatioin filter
<img width="1005" alt="Screenshot 2025-05-22 at 4 40 54 PM" src="https://github.com/user-attachments/assets/e88adb97-98b6-4ba9-bf1b-4bfaac3c5a5f" />

