### PR TITLE
Optionally truncate cloud compute logs

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/cloud_storage_compute_log_manager.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import tempfile
 import threading
 import time
 from abc import abstractmethod
@@ -21,15 +22,47 @@ from dagster._core.storage.local_compute_log_manager import (
     IO_TYPE_EXTENSION,
     LocalComputeLogManager,
 )
+from dagster._utils import ensure_file
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 SUBSCRIPTION_POLLING_INTERVAL = 5
+
+
+@contextmanager
+def _truncate_file(path, max_bytes: int) -> Iterator[str]:
+    dest = tempfile.NamedTemporaryFile(mode="w+b", delete=False)
+    try:
+        with open(path, "rb") as src:
+            remaining = max_bytes
+            bufsize = 64 * 1024
+
+            while remaining:
+                chunk = src.read(min(bufsize, remaining))
+                if not chunk:
+                    break
+                dest.write(chunk)
+                remaining -= len(chunk)
+
+            dest.flush()
+            dest.close()
+
+            yield dest.name
+
+    finally:
+        try:
+            os.remove(dest.name)
+        except FileNotFoundError:
+            pass
 
 
 class CloudStorageComputeLogManager(ComputeLogManager[T_DagsterInstance]):
     """Abstract class that uses the local compute log manager to capture logs and stores them in
     remote cloud storage.
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._truncated = set()
 
     @property
     @abstractmethod
@@ -62,10 +95,31 @@ class CloudStorageComputeLogManager(ComputeLogManager[T_DagsterInstance]):
         """Returns whether the cloud storage contains logs for a given log key."""
 
     @abstractmethod
+    def _upload_file_obj(
+        self, data: IO[bytes], log_key: Sequence[str], io_type: ComputeIOType, partial=False
+    ):
+        pass
+
     def upload_to_cloud_storage(
         self, log_key: Sequence[str], io_type: ComputeIOType, partial: bool = False
     ) -> None:
         """Uploads the logs for a given log key from local storage to cloud storage."""
+        # We've already truncated
+        if (tuple(log_key), io_type) in self._truncated:
+            return
+
+        path = self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
+        ensure_file(path)
+
+        max_bytes = int(os.environ.get("DAGSTER_TRUNCATE_COMPUTE_LOGS_UPLOAD_BYTES", "0"))
+        if max_bytes and os.stat(path).st_size >= max_bytes:
+            self._truncated.add((tuple(log_key), io_type))
+            with _truncate_file(path, max_bytes=max_bytes) as truncated_path:
+                with open(truncated_path, "rb") as data:
+                    self._upload_file_obj(data, log_key, io_type, partial)
+        else:
+            with open(path, "rb") as data:
+                self._upload_file_obj(data, log_key, io_type, partial)
 
     def download_from_cloud_storage(
         self, log_key: Sequence[str], io_type: ComputeIOType, partial: bool = False

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/compute_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/compute_log_manager.py
@@ -6,6 +6,7 @@ import time
 import pytest
 from dagster._core.execution.compute_logs import should_disable_io_stream_redirect
 from dagster._core.storage.compute_log_manager import ComputeIOType
+from dagster._core.test_utils import environ
 from dagster._time import get_current_datetime
 
 
@@ -129,6 +130,25 @@ class TestComputeLogManager:
             assert not read_manager.cloud_storage_has_logs(log_key, ComputeIOType.STDOUT)
             assert read_manager.cloud_storage_has_logs(log_key, ComputeIOType.STDERR, partial=True)
             assert read_manager.cloud_storage_has_logs(log_key, ComputeIOType.STDERR, partial=True)
+
+    def test_truncation(self, write_manager, read_manager):
+        from dagster._core.storage.cloud_storage_compute_log_manager import (
+            CloudStorageComputeLogManager,
+        )
+
+        if not isinstance(write_manager, CloudStorageComputeLogManager) or not isinstance(
+            read_manager, CloudStorageComputeLogManager
+        ):
+            pytest.skip("does not support truncation")
+        with environ({"DAGSTER_TRUNCATE_COMPUTE_LOGS_UPLOAD_BYTES": "5"}):
+            now = get_current_datetime()
+            log_key = ["truncating", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
+            with write_manager.capture_logs(log_key):
+                print("hello stdout")  # noqa: T201
+                print("hello stderr", file=sys.stderr)  # noqa: T201
+            log_data = read_manager.get_log_data(log_key)
+            assert log_data.stdout == b"hello"
+            assert log_data.stderr == b"hello"
 
     @pytest.mark.skipif(
         should_disable_io_stream_redirect(), reason="compute logs disabled for win / py3.6+"

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
@@ -1,7 +1,7 @@
 import os
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from typing import Any, Optional
+from typing import IO, Any, Optional
 
 import boto3
 import dagster_shared.seven as seven
@@ -23,7 +23,7 @@ from dagster._core.storage.local_compute_log_manager import (
     LocalComputeLogManager,
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
-from dagster._utils import ensure_dir, ensure_file
+from dagster._utils import ensure_dir
 from typing_extensions import Self
 
 POLLING_INTERVAL = 5
@@ -114,6 +114,7 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
             self._region = self._s3_session.meta.region_name
         else:
             self._region = region
+        super().__init__()
 
     @property
     def inst_data(self):
@@ -234,22 +235,19 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
             return False
         return True
 
-    def upload_to_cloud_storage(
-        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
+    def _upload_file_obj(
+        self, data: IO[bytes], log_key: Sequence[str], io_type: ComputeIOType, partial=False
     ):
         path = self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
-        ensure_file(path)
-
         if (self._skip_empty_files or partial) and os.stat(path).st_size == 0:
             return
 
         s3_key = self._s3_key(log_key, io_type, partial=partial)
-        with open(path, "rb") as data:
-            extra_args = {
-                "ContentType": "text/plain",
-                **(self._upload_extra_args if self._upload_extra_args else {}),
-            }
-            self._s3_session.upload_fileobj(data, self._s3_bucket, s3_key, ExtraArgs=extra_args)
+        extra_args = {
+            "ContentType": "text/plain",
+            **(self._upload_extra_args if self._upload_extra_args else {}),
+        }
+        self._s3_session.upload_fileobj(data, self._s3_bucket, s3_key, ExtraArgs=extra_args)
 
     def download_from_cloud_storage(
         self, log_key: Sequence[str], io_type: ComputeIOType, partial=False

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/compute_log_manager.py
@@ -2,7 +2,7 @@ import os
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import IO, Any, Optional
 
 import dagster_shared.seven as seven
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
@@ -29,7 +29,7 @@ from dagster._core.storage.local_compute_log_manager import (
     LocalComputeLogManager,
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
-from dagster._utils import ensure_dir, ensure_file
+from dagster._utils import ensure_dir
 from typing_extensions import Self
 
 from dagster_azure.blob.utils import create_blob_client, generate_blob_sas
@@ -160,6 +160,7 @@ class AzureBlobComputeLogManager(CloudStorageComputeLogManager, ConfigurableClas
         self._subscription_manager = PollingComputeLogSubscriptionManager(self)
         self._upload_interval = check.opt_int_param(upload_interval, "upload_interval")
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
+        super().__init__()
 
     @property
     def inst_data(self) -> Optional[ConfigurableClassData]:
@@ -347,15 +348,12 @@ class AzureBlobComputeLogManager(CloudStorageComputeLogManager, ConfigurableClas
         exact_matches = [blob for blob in blob_objects if blob.name == blob_key]
         return len(exact_matches) > 0
 
-    def upload_to_cloud_storage(
-        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
+    def _upload_file_obj(
+        self, data: IO[bytes], log_key: Sequence[str], io_type: ComputeIOType, partial=False
     ):
-        path = self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
-        ensure_file(path)
         blob_key = self._blob_key(log_key, io_type, partial=partial)
-        with open(path, "rb") as data:
-            blob = self._container_client.get_blob_client(blob_key)
-            blob.upload_blob(data, **{"overwrite": partial})  # type: ignore
+        blob = self._container_client.get_blob_client(blob_key)
+        blob.upload_blob(data, **{"overwrite": partial})  # type: ignore
 
     def download_from_cloud_storage(
         self, log_key: Sequence[str], io_type: ComputeIOType, partial=False

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
@@ -3,7 +3,7 @@ import json
 import os
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from typing import Any, Optional
+from typing import IO, Any, Optional
 
 import dagster_shared.seven as seven
 from dagster import (
@@ -22,7 +22,7 @@ from dagster._core.storage.local_compute_log_manager import (
     LocalComputeLogManager,
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
-from dagster._utils import ensure_dir, ensure_file
+from dagster._utils import ensure_dir
 from google.cloud import storage
 from typing_extensions import Self
 
@@ -206,18 +206,16 @@ class GCSComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         gcs_key = self._gcs_key(log_key, io_type, partial)
         return self._bucket.blob(gcs_key).exists()
 
-    def upload_to_cloud_storage(
-        self, log_key: Sequence[str], io_type: ComputeIOType, partial=False
+    def _upload_file_obj(
+        self, data: IO[bytes], log_key: Sequence[str], io_type: ComputeIOType, partial=False
     ):
         path = self.local_manager.get_captured_local_path(log_key, IO_TYPE_EXTENSION[io_type])
-        ensure_file(path)
 
         if partial and os.stat(path).st_size == 0:
             return
 
         gcs_key = self._gcs_key(log_key, io_type, partial=partial)
-        with open(path, "rb") as data:
-            self._bucket.blob(gcs_key).upload_from_file(data)
+        self._bucket.blob(gcs_key).upload_from_file(data)
 
     def download_from_cloud_storage(
         self, log_key: Sequence[str], io_type: ComputeIOType, partial=False


### PR DESCRIPTION
We have a longstanding issue with our cloud compute logs where we rewrite the same key over and over again as the file grows because each time we upload, we upload the entire locally captured file.

We should address that - presumably by either mirroring stdout/stderr to chunked files or by writing some sort of chunk reader that can iterate over the full local file.

This stops a step short by providing an env var that can be set to truncate the max file size to upload. The implementation is pretty naive. It maintains current behavior up until the limit. Once the local file is larger than our truncation limit, it writes a truncated temp file, uploads that one, and sets a flat to no longer upload anything else.