### PR TITLE
[Asset Graph] Hide non SDAs again

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -13,7 +13,7 @@ import {featureEnabled} from '../app/Flags';
 import {GraphQueryItem} from '../app/GraphQueryImpl';
 import {indexedDBAsyncMemoize} from '../app/Util';
 import {AssetKey} from '../assets/types';
-import {useAllAssets, useAllAssetsNodes} from '../assets/useAllAssets';
+import {useAllAssetsNodes} from '../assets/useAllAssets';
 import {AssetGroupSelector, PipelineSelector} from '../graphql/types';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {hashObject} from '../util/hashObject';
@@ -120,16 +120,16 @@ const INITIAL_STATE: GraphDataState = {
  * uses this option to implement the "3 of 4 repositories" picker.
  */
 export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScope) {
-  const {assets, loading: assetsLoading} = useAllAssets();
+  const {assets, loading: assetsLoading} = useAllAssetsNodes();
+
+  const externalAssetNodes = useMemo(
+    () => (options.externalAssets ?? []).map((a) => buildExternalAssetQueryItem(a)),
+    [options.externalAssets],
+  );
+
   const allNodes = useMemo(
-    () =>
-      assets.map((a) => {
-        if (!a.definition) {
-          return buildExternalAssetQueryItem(a);
-        }
-        return a.definition;
-      }),
-    [assets],
+    () => [...(assets ?? []), ...externalAssetNodes],
+    [assets, externalAssetNodes],
   );
 
   const {pipelineSelector, groupSelector, hideNodesMatching} = options;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAllAssets.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAllAssets.tsx
@@ -28,6 +28,12 @@ const RETRY_INTERVAL = 1000; // 1 second
 
 const DEFAULT_BATCH_LIMIT = 1000;
 
+export function useAllAssetsNodes() {
+  const {allRepos, loading: workspaceLoading} = useContext(WorkspaceContext);
+  const allAssetNodes = useMemo(() => getAllAssetNodes(allRepos), [allRepos]);
+  return {assets: allAssetNodes, loading: workspaceLoading};
+}
+
 export function useAllAssets({
   groupSelector,
   batchLimit = DEFAULT_BATCH_LIMIT,
@@ -61,8 +67,7 @@ export function useAllAssets({
     };
   }, [manager, batchLimit]);
 
-  const {allRepos, loading: workspaceLoading} = useContext(WorkspaceContext);
-  const allAssetNodes = useMemo(() => getAllAssetNodes(allRepos), [allRepos]);
+  const {assets: allAssetNodes, loading: allAssetNodesLoading} = useAllAssetsNodes();
 
   const allAssetNodesByKey = useMemo(() => getAllAssetNodesByKey(allAssetNodes), [allAssetNodes]);
 
@@ -75,7 +80,7 @@ export function useAllAssets({
 
   return {
     assets,
-    loading: loading || workspaceLoading,
+    loading: loading || allAssetNodesLoading,
     query: manager.fetchAssets,
     assetsByAssetKey,
     error,


### PR DESCRIPTION
## Summary & Motivation

in https://github.com/dagster-io/dagster/pull/30179 I included a change to back `useAssetGraphData` by `useAllAssets` which includes external assets. This was a change in behavior and led to asset graphs including non SDAs. Instead we should go back to relying on the `options.externalAssets` prop so that we only include external assets in the asset selection input (which uses this hook and passes this prop) .

## How I Tested These Changes

Checked that asset graphs no longer include external assets
