### PR TITLE
Make @sensor loadable after scaffolding

### DIFF
--- a/python_modules/dagster/dagster/components/lib/shim_components/sensor.py
+++ b/python_modules/dagster/dagster/components/lib/shim_components/sensor.py
@@ -5,11 +5,11 @@ from dagster.components.scaffold.scaffold import ScaffoldRequest, scaffold_with
 
 class SensorScaffolder(ShimScaffolder):
     def get_text(self, request: ScaffoldRequest) -> str:
-        return f"""# import dagster as dg
-#
-#
-# @dg.sensor(target=...)
-# def {request.target_path.stem}(context: dg.SensorEvaluationContext): ...
+        return f"""import dagster as dg
+
+
+@dg.sensor(target=None)
+def {request.target_path.stem}(context: dg.SensorEvaluationContext): ...
 """
 
 

--- a/python_modules/dagster/dagster/components/lib/shim_components/sensor.py
+++ b/python_modules/dagster/dagster/components/lib/shim_components/sensor.py
@@ -9,7 +9,8 @@ class SensorScaffolder(ShimScaffolder):
 
 
 @dg.sensor(target=None)
-def {request.target_path.stem}(context: dg.SensorEvaluationContext): ...
+def {request.target_path.stem}(context: dg.SensorEvaluationContext) -> dg.SensorResult:
+    return dg.SensorResult()
 """
 
 

--- a/python_modules/dagster/dagster_tests/components_tests/shim_components/test_sensor.py
+++ b/python_modules/dagster/dagster_tests/components_tests/shim_components/test_sensor.py
@@ -1,7 +1,9 @@
+from dagster._core.definitions.sensor_definition import SensorDefinition
 from dagster.components.lib.shim_components.sensor import SensorScaffolder
 
 from dagster_tests.components_tests.shim_components.shim_test_utils import (
     execute_ruff_compliance_test,
+    execute_scaffolder_and_get_symbol,
     make_test_scaffold_request,
 )
 
@@ -14,6 +16,10 @@ def test_sensor_scaffolder():
     assert isinstance(code, str)
     assert "sensor" in code
     assert "SensorEvaluationContext" in code
+
+    sensor_fn = execute_scaffolder_and_get_symbol(scaffolder, "my_sensor")
+    assert isinstance(sensor_fn, SensorDefinition)
+    assert sensor_fn.name == "my_sensor"
 
 
 def test_sensor_scaffolder_ruff_compliance():


### PR DESCRIPTION
## Summary & Motivation

Make a scaffolded sensor "list-able" by default

## How I Tested These Changes

BK and manual testing

## Changelog

* In `dg` a scaffolded sensor is now loadable and listable by default.