### PR TITLE
schedule decorator executable

### DIFF
--- a/python_modules/dagster/dagster/components/lib/shim_components/schedule.py
+++ b/python_modules/dagster/dagster/components/lib/shim_components/schedule.py
@@ -6,6 +6,7 @@ from dagster.components.scaffold.scaffold import ScaffoldRequest, scaffold_with
 class ScheduleScaffolder(ShimScaffolder):
     def get_text(self, request: ScaffoldRequest) -> str:
         return f"""from typing import Union
+
 import dagster as dg
 
 

--- a/python_modules/dagster/dagster/components/lib/shim_components/schedule.py
+++ b/python_modules/dagster/dagster/components/lib/shim_components/schedule.py
@@ -5,12 +5,12 @@ from dagster.components.scaffold.scaffold import ScaffoldRequest, scaffold_with
 
 class ScheduleScaffolder(ShimScaffolder):
     def get_text(self, request: ScaffoldRequest) -> str:
-        return f"""# import dagster as dg
-#
-#
-# @dg.schedule(cron_schedule=..., target=...)
-# def {request.target_path.stem}(context: dg.ScheduleEvaluationContext):
-#     return dg.RunRequest()
+        return f"""import dagster as dg
+
+
+@dg.schedule(cron_schedule="@daily", target="*")
+def {request.target_path.stem}(context: dg.ScheduleEvaluationContext) -> dg.RunRequest:
+    return dg.RunRequest()
 """
 
 

--- a/python_modules/dagster/dagster/components/lib/shim_components/schedule.py
+++ b/python_modules/dagster/dagster/components/lib/shim_components/schedule.py
@@ -5,12 +5,13 @@ from dagster.components.scaffold.scaffold import ScaffoldRequest, scaffold_with
 
 class ScheduleScaffolder(ShimScaffolder):
     def get_text(self, request: ScaffoldRequest) -> str:
-        return f"""import dagster as dg
+        return f"""from typing import Union
+import dagster as dg
 
 
 @dg.schedule(cron_schedule="@daily", target="*")
-def {request.target_path.stem}(context: dg.ScheduleEvaluationContext) -> dg.RunRequest:
-    return dg.RunRequest()
+def {request.target_path.stem}(context: dg.ScheduleEvaluationContext) -> Union[dg.RunRequest, dg.SkipReason]:
+    return dg.SkipReason("Skipping. Change this to return a RunRequest to launch a run.")
 """
 
 

--- a/python_modules/dagster/dagster_tests/components_tests/shim_components/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/components_tests/shim_components/test_schedule.py
@@ -1,7 +1,9 @@
+from dagster._core.definitions.schedule_definition import ScheduleDefinition
 from dagster.components.lib.shim_components.schedule import ScheduleScaffolder
 
 from dagster_tests.components_tests.shim_components.shim_test_utils import (
     execute_ruff_compliance_test,
+    execute_scaffolder_and_get_symbol,
     make_test_scaffold_request,
 )
 
@@ -15,6 +17,10 @@ def test_schedule_scaffolder():
     assert "schedule" in code
     assert "ScheduleEvaluationContext" in code
     assert "RunRequest" in code
+
+    schedule_fn = execute_scaffolder_and_get_symbol(scaffolder, "my_schedule")
+    assert isinstance(schedule_fn, ScheduleDefinition)
+    assert schedule_fn.name == "my_schedule"
 
 
 def test_schedule_scaffolder_ruff_compliance():


### PR DESCRIPTION
## Summary & Motivation

Make a scaffolded schedule list-able and executable by default

## How I Tested These Changes

BK and manual test

## Changelog

* Scaffolded schedules in `dg` are now loadable by default.