### PR TITLE
Add setuptools as dagster-cloud-cli dependency

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/setup.py
+++ b/python_modules/libraries/dagster-cloud-cli/setup.py
@@ -43,6 +43,7 @@ setup(
         "PyYAML>=5.1",
         "github3.py",
         "Jinja2",
+        "setuptools",
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Summary:
This is needed to build some PEX files on python 3.12 (in other versions it is automatically included).

Deploy a PEX file on python 3.12 in github

Fixed an issue where the dagster-cloud cli failed to deploy PEX projects on python 3.12 in certain environments without setuptools already installed.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
