### PR TITLE
[dg] Add classnames as aliases to scaffold defs subcommands (BUILD-1225)

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg/cli/scaffold.py
@@ -116,7 +116,7 @@ class ScaffoldDefsGroup(DgClickGroup):
 
         registry = RemotePluginRegistry.from_dg_context(dg_context)
 
-        # Keys where the actual class name is not sharde with any other key will use the class name
+        # Keys where the actual class name is not shared with any other key will use the class name
         # as a command alias.
         keys_by_name: dict[str, set[PluginObjectKey]] = {}
         for key in registry.keys():


### PR DESCRIPTION
## Summary & Motivation

This adds class names as command aliases for `dg scaffold defs` subcommands when those class names are unique. For example, if I have a component `some_lib.FooComponent`, and that is the only component named `FooComponent`, then I can just do:

```
$ dg scaffold defs FooComponent ...
```

And it will work as if I typed the fully-qualified name. However, if `some_other_lib.FooComponent` is also in scope, the alias is not added and the other above command will fall back to the substring match menu.

## How I Tested These Changes

New unit tests.

## Changelog

When component classnames are unique, you can now use just the classname as an alias for the fully qualified name when running `dg scaffold defs <component>`.
