### PR TITLE
move dagster.components exports to top level

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -639,7 +639,44 @@ from dagster._utils.warnings import (
     PreviewWarning as PreviewWarning,
     SupersessionWarning as SupersessionWarning,
 )
+from dagster.components.component.component import (
+    Component as Component,
+    ComponentTypeSpec as ComponentTypeSpec,
+)
+from dagster.components.component.component_loader import component as component
+from dagster.components.component_scaffolding import scaffold_component as scaffold_component
+from dagster.components.components import (
+    DefinitionsComponent as DefinitionsComponent,  # back-compat
+    DefsFolderComponent as DefsFolderComponent,
+    PipesSubprocessScriptCollectionComponent as PipesSubprocessScriptCollectionComponent,
+)
+from dagster.components.core.context import ComponentLoadContext as ComponentLoadContext
+from dagster.components.core.load_defs import (
+    build_component_defs as build_component_defs,
+    load_defs as load_defs,
+)
+from dagster.components.definitions import definitions as definitions
 from dagster.components.lib.shim_components.resources import resources as resources
+from dagster.components.resolved.base import Resolvable as Resolvable
+from dagster.components.resolved.context import ResolutionContext as ResolutionContext
+from dagster.components.resolved.core_models import (
+    AssetAttributesModel as AssetAttributesModel,
+    AssetPostProcessorModel as AssetPostProcessorModel,
+    ResolvedAssetCheckSpec as ResolvedAssetCheckSpec,
+    ResolvedAssetKey as ResolvedAssetKey,
+    ResolvedAssetSpec as ResolvedAssetSpec,
+)
+from dagster.components.resolved.model import (
+    Injectable as Injectable,
+    Injected as Injected,
+    Model as Model,
+    Resolver as Resolver,
+)
+from dagster.components.scaffold.scaffold import (
+    Scaffolder as Scaffolder,
+    ScaffoldRequest as ScaffoldRequest,
+    scaffold_with as scaffold_with,
+)
 from dagster.version import __version__ as __version__
 
 DagsterLibraryRegistry.register("dagster", __version__)

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_object_relative_imports/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_object_relative_imports/defs.yaml
@@ -1,4 +1,4 @@
-type: dagster.components.DefinitionsComponent
+type: dagster.DefinitionsComponent
 
 attributes:
   path: definitions_other_name.py

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/validation/basic_component_extra_value_in_a_subfolder/subfolder/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/validation/basic_component_extra_value_in_a_subfolder/subfolder/defs.yaml
@@ -1,4 +1,4 @@
-type: dagster.components.DefinitionsComponent
+type: dagster.DefinitionsComponent
 
 attributes:
   path: {}

--- a/python_modules/dagster/dagster_tests/components_tests/registry_tests/test_registry.py
+++ b/python_modules/dagster/dagster_tests/components_tests/registry_tests/test_registry.py
@@ -114,19 +114,19 @@ def test_components_from_dagster():
         ]
     ) as python_executable:
         component_types = _get_component_types_in_python_environment(python_executable)
-        assert "dagster.components.PipesSubprocessScriptCollectionComponent" in component_types
+        assert "dagster.PipesSubprocessScriptCollectionComponent" in component_types
         assert "dagster_dbt.DbtProjectComponent" not in component_types
         assert "dagster_sling.SlingReplicationCollectionComponent" not in component_types
 
     with _temp_venv([*common_deps, "-e", dbt_root]) as python_executable:
         component_types = _get_component_types_in_python_environment(python_executable)
-        assert "dagster.components.PipesSubprocessScriptCollectionComponent" in component_types
+        assert "dagster.PipesSubprocessScriptCollectionComponent" in component_types
         assert "dagster_dbt.DbtProjectComponent" in component_types
         assert "dagster_sling.SlingReplicationCollectionComponent" not in component_types
 
     with _temp_venv([*common_deps, "-e", sling_root]) as python_executable:
         component_types = _get_component_types_in_python_environment(python_executable)
-        assert "dagster.components.PipesSubprocessScriptCollectionComponent" in component_types
+        assert "dagster.PipesSubprocessScriptCollectionComponent" in component_types
         assert "dagster_dbt.DbtProjectComponent" not in component_types
         assert "dagster_sling.SlingReplicationCollectionComponent" in component_types
 

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -174,7 +174,6 @@ setup(
         ],
         "dagster_dg.plugin": [
             "dagster = dagster",
-            "dagster.components = dagster.components",
         ],
     },
 )

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/mcp_tests/test_mcp_serve.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/mcp_tests/test_mcp_serve.py
@@ -51,7 +51,7 @@ async def test_list_dagster_components():
             assert not response.isError
             assert len(response.content) == 1
             text_content = cast("TextContent", response.content[0])
-            assert "dagster.components.DefinitionsComponent" in text_content.text
+            assert "dagster.DefinitionsComponent" in text_content.text
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="no mcp support on 3.9")
@@ -63,7 +63,7 @@ async def test_scaffold_dagster_component_and_check_yaml():
                 "scaffold_dagster_component",
                 {
                     "project_path": ".",
-                    "component_type": "dagster.components.DefinitionsComponent",
+                    "component_type": "dagster.DefinitionsComponent",
                     "component_name": "my_defs",
                     "component_arguments": [],
                 },

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/mcp_tests/test_mcp_serve.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/mcp_tests/test_mcp_serve.py
@@ -81,7 +81,7 @@ async def test_scaffold_dagster_component_and_check_yaml():
             assert response.isError
 
             assert (Path.cwd() / "src" / "foo_bar/" / "defs" / "my_defs" / "defs.yaml").write_text(
-                "type: dagster.components.DefinitionsComponent\n\nattributes:\n  path: test.py"
+                "type: dagster.DefinitionsComponent\n\nattributes:\n  path: test.py"
             )
 
             response = await session.call_tool(

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_launch_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_launch_commands.py
@@ -46,7 +46,7 @@ def test_launch_assets() -> None:
     ):
         with activate_venv(project_dir / ".venv"):
             subprocess.run(
-                ["dg", "scaffold", "defs", "dagster.components.DefsFolderComponent", "mydefs"],
+                ["dg", "scaffold", "defs", "dagster.DefsFolderComponent", "mydefs"],
                 check=True,
             )
 
@@ -132,7 +132,7 @@ def test_launch_assets_config_files(capfd) -> None:
         activate_venv(project_dir / ".venv"),
     ):
         result = subprocess.run(
-            ["dg", "scaffold", "defs", "dagster.components.DefsFolderComponent", "mydefs"],
+            ["dg", "scaffold", "defs", "dagster.DefsFolderComponent", "mydefs"],
             check=True,
         )
         assert result.returncode == 0

--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_list_commands.py
@@ -308,7 +308,7 @@ def test_list_defs_succeeds(use_json: bool):
     ):
         with activate_venv(project_dir / ".venv"):
             result = subprocess.run(
-                ["dg", "scaffold", "defs", "dagster.components.DefsFolderComponent", "mydefs"],
+                ["dg", "scaffold", "defs", "dagster.DefsFolderComponent", "mydefs"],
                 check=True,
             )
 
@@ -395,7 +395,7 @@ def test_list_defs_complex_assets_succeeds():
     ):
         with activate_venv(project_dir / ".venv"):
             subprocess.run(
-                ["dg", "scaffold", "defs", "dagster.components.DefsFolderComponent", "mydefs"],
+                ["dg", "scaffold", "defs", "dagster.DefsFolderComponent", "mydefs"],
                 check=True,
             )
 
@@ -476,7 +476,7 @@ def test_list_defs_with_env_file_succeeds():
     ):
         with activate_venv(project_dir / ".venv"):
             subprocess.run(
-                ["dg", "scaffold", "defs", "dagster.components.DefsFolderComponent", "mydefs"],
+                ["dg", "scaffold", "defs", "dagster.DefsFolderComponent", "mydefs"],
                 check=True,
             )
 
@@ -526,7 +526,7 @@ def test_list_defs_fails_compact(capture_stderr_from_components_cli_invocations)
     ):
         with activate_venv(project_dir / ".venv"):
             subprocess.run(
-                ["dg", "scaffold", "defs", "dagster.components.DefsFolderComponent", "mydefs"],
+                ["dg", "scaffold", "defs", "dagster.DefsFolderComponent", "mydefs"],
                 check=True,
             )
 


### PR DESCRIPTION
## Summary

In advance of release, moves top-level symbols from dagster.components to dagster module

## Changelog

> [components] Exports from dagster.components are now available in the top-level dagster module