### PR TITLE
[dg] dev options that align with dagster dev

### DIFF
--- a/docs/sphinx/_ext/sphinx-click/sphinx_click/ext.py
+++ b/docs/sphinx/_ext/sphinx-click/sphinx_click/ext.py
@@ -198,7 +198,6 @@ def _format_options(ctx: click.Context) -> ty.Generator[str, None, None]:
         for param in ctx.command.params
         if isinstance(param, click.core.Option) and not getattr(param, "hidden", False)
     ]
-
     for param in params:
         yield from _format_option(ctx, param)
         yield ""
@@ -260,7 +259,7 @@ def _format_envvars(ctx: click.Context) -> ty.Generator[str, None, None]:
                 param.envvar = f"{auto_envvar_prefix}_{param.name.upper()}"
             params.append(param)
     else:
-        params = [x for x in ctx.command.params if x.envvar]
+        params = [x for x in ctx.command.params if x.envvar and not getattr(x, "hidden", False)]
 
     for param in params:
         yield ".. _{command_name}-{param_name}-{envvar}:".format(

--- a/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_cli_invocations.py
+++ b/examples/docs_snippets/docs_snippets_tests/intro_tutorial_tests/test_cli_invocations.py
@@ -6,7 +6,10 @@ import pytest
 from dagster_webserver.app import create_app_from_workspace_process_context
 from starlette.testclient import TestClient
 
-from dagster._cli.workspace.cli_target import WorkspaceOpts
+from dagster._cli.workspace.cli_target import (
+    WorkspaceOpts,
+    workspace_opts_to_load_target,
+)
 from dagster._core.test_utils import instance_for_test
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._utils import check_script, pushd, script_relative_path
@@ -108,7 +111,7 @@ def load_dagster_webserver_for_workspace_cli_args(
             instance,
             version="",
             read_only=False,
-            workspace_load_target=workspace_opts.to_load_target(),
+            workspace_load_target=workspace_opts_to_load_target(workspace_opts),
         ) as workspace_process_context:
             client = TestClient(
                 create_app_from_workspace_process_context(workspace_process_context)

--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -15,12 +15,12 @@ from dagster._cli.utils import (
 )
 from dagster._cli.workspace.cli_target import (
     WORKSPACE_TARGET_WARNING,
-    WorkspaceOpts,
-    workspace_options,
+    workspace_opts_to_load_target,
 )
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._utils import DEFAULT_WORKSPACE_YAML_FILENAME
 from dagster._utils.log import get_stack_trace_array
+from dagster_shared.cli import WorkspaceOpts, workspace_options
 
 from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
 from dagster_graphql.schema import create_schema
@@ -225,7 +225,7 @@ def ui(
                 instance=instance,
                 version=__version__,
                 read_only=False,
-                workspace_load_target=workspace_opts.to_load_target(),
+                workspace_load_target=workspace_opts_to_load_target(workspace_opts),
             ) as workspace_process_context:
                 execute_query_from_cli(
                     workspace_process_context,

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -15,7 +15,7 @@ from dagster._cli.utils import assert_no_remaining_opts, get_possibly_temporary_
 from dagster._cli.workspace.cli_target import (
     WORKSPACE_TARGET_WARNING,
     WorkspaceOpts,
-    workspace_options,
+    workspace_opts_to_load_target,
 )
 from dagster._core.instance import InstanceRef
 from dagster._core.telemetry import START_DAGSTER_WEBSERVER, log_action
@@ -25,6 +25,7 @@ from dagster._serdes import deserialize_value
 from dagster._utils import DEFAULT_WORKSPACE_YAML_FILENAME, find_free_port, is_port_in_use
 from dagster._utils.interrupts import setup_interrupt_handlers
 from dagster._utils.log import configure_loggers
+from dagster_shared.cli import workspace_options
 from dagster_shared.ipc import interrupt_on_ipc_shutdown_message
 
 from dagster_webserver.app import create_app_from_workspace_process_context
@@ -255,7 +256,7 @@ def dagster_webserver(
             instance,
             version=__version__,
             read_only=read_only,
-            workspace_load_target=workspace_opts.to_load_target(),
+            workspace_load_target=workspace_opts_to_load_target(workspace_opts),
             code_server_log_level=code_server_log_level,
         ) as workspace_process_context:
             host_dagster_ui_with_workspace_process_context(

--- a/python_modules/dagster-webserver/dagster_webserver_tests/test_smoke.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/test_smoke.py
@@ -1,5 +1,5 @@
 import pytest
-from dagster._cli.workspace.cli_target import WorkspaceOpts
+from dagster._cli.workspace.cli_target import WorkspaceOpts, workspace_opts_to_load_target
 from dagster._core.test_utils import instance_for_test
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster_webserver import app
@@ -34,9 +34,9 @@ def test_smoke_app(gen_instance):
             instance,
             version="",
             read_only=False,
-            workspace_load_target=WorkspaceOpts(
-                module_name=("dagster_webserver_tests.toy.bar_repo",)
-            ).to_load_target(),
+            workspace_load_target=workspace_opts_to_load_target(
+                WorkspaceOpts(module_name=("dagster_webserver_tests.toy.bar_repo",))
+            ),
         ) as workspace_process_context:
             asgi_app = app.create_app_from_workspace_process_context(workspace_process_context)
             client = TestClient(asgi_app)

--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/conftest.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from dagster import DagsterInstance, __version__
-from dagster._cli.workspace.cli_target import WorkspaceOpts
+from dagster._cli.workspace.cli_target import WorkspaceOpts, workspace_opts_to_load_target
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster_webserver.webserver import DagsterWebserver
 from starlette.requests import Request
@@ -34,7 +34,9 @@ def test_client(instance):
         instance=instance,
         version=__version__,
         read_only=False,
-        workspace_load_target=WorkspaceOpts(empty_workspace=True).to_load_target(),
+        workspace_load_target=workspace_opts_to_load_target(
+            WorkspaceOpts(empty_workspace=True),
+        ),
     )
 
     app = TestDagsterWebserver(process_context).create_asgi_app(debug=True)

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -10,10 +10,11 @@ from typing import Any, Callable, Optional, cast
 
 import click
 import dagster_shared.seven as seven
+from dagster_shared.cli import python_pointer_options
 
 import dagster._check as check
 from dagster._cli.utils import assert_no_remaining_opts, get_instance_for_cli
-from dagster._cli.workspace.cli_target import PythonPointerOpts, python_pointer_options
+from dagster._cli.workspace.cli_target import PythonPointerOpts
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.errors import DagsterExecutionInterruptedError
 from dagster._core.events import DagsterEvent, DagsterEventType, EngineEventData

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import click
+from dagster_shared.cli import python_pointer_options
 
 import dagster._check as check
 from dagster._cli.job import get_run_config_from_cli_opts
@@ -12,7 +13,6 @@ from dagster._cli.utils import (
 from dagster._cli.workspace.cli_target import (
     PythonPointerOpts,
     get_repository_python_origin_from_cli_opts,
-    python_pointer_options,
     run_config_option,
 )
 from dagster._core.definitions.asset_selection import AssetSelection

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -7,9 +7,10 @@ from typing import Optional
 
 import click
 import dagster_shared.seven as seven
+from dagster_shared.cli import python_pointer_options
 
 from dagster._cli.utils import assert_no_remaining_opts
-from dagster._cli.workspace.cli_target import PythonPointerOpts, python_pointer_options
+from dagster._cli.workspace.cli_target import PythonPointerOpts
 from dagster._core.instance import InstanceRef
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import FuturesAwareThreadPoolExecutor

--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -3,15 +3,12 @@ import os
 import sys
 
 import click
+from dagster_shared.cli import workspace_options
 from dagster_shared.error import remove_system_frames_from_error
 
 from dagster import __version__ as dagster_version
 from dagster._cli.utils import assert_no_remaining_opts, get_possibly_temporary_instance_for_cli
-from dagster._cli.workspace.cli_target import (
-    WorkspaceOpts,
-    get_workspace_from_cli_opts,
-    workspace_options,
-)
+from dagster._cli.workspace.cli_target import WorkspaceOpts, get_workspace_from_cli_opts
 from dagster._utils.error import unwrap_user_code_error
 from dagster._utils.log import configure_loggers
 

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from typing import Any, Callable, Optional, TypeVar
 
 import click
+from dagster_shared.cli import python_pointer_options, workspace_options
 from dagster_shared.seven import IS_WINDOWS, JSONDecodeError, json
 from dagster_shared.yaml_utils import dump_run_config_yaml
 
@@ -33,11 +34,9 @@ from dagster._cli.workspace.cli_target import (
     get_run_config_from_cli_opts,
     get_workspace_from_cli_opts,
     job_name_option,
-    python_pointer_options,
     repository_name_option,
     repository_options,
     run_config_option,
-    workspace_options,
 )
 from dagster._core.definitions import JobDefinition
 from dagster._core.definitions.backfill_policy import BackfillPolicyType

--- a/python_modules/dagster/dagster/_cli/run.py
+++ b/python_modules/dagster/dagster/_cli/run.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import click
+from dagster_shared.cli import workspace_options
 from tqdm import tqdm
 
 from dagster import __version__ as dagster_version
@@ -11,7 +12,6 @@ from dagster._cli.workspace.cli_target import (
     get_job_from_cli_opts,
     job_name_option,
     repository_options,
-    workspace_options,
 )
 
 

--- a/python_modules/dagster/dagster/_cli/schedule.py
+++ b/python_modules/dagster/dagster/_cli/schedule.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import Callable, Optional
 
 import click
+from dagster_shared.cli import workspace_options
 
 from dagster import (
     DagsterInvariantViolationError,
@@ -21,7 +22,6 @@ from dagster._cli.workspace.cli_target import (
     WorkspaceOpts,
     get_repository_from_cli_opts,
     repository_options,
-    workspace_options,
 )
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import Optional
 
 import click
+from dagster_shared.cli import workspace_options
 from dagster_shared.yaml_utils import dump_run_config_yaml
 
 from dagster import (
@@ -25,7 +26,6 @@ from dagster._cli.workspace.cli_target import (
     get_repository_from_cli_opts,
     get_workspace_from_cli_opts,
     repository_options,
-    workspace_options,
 )
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster/dagster/_cli/utils.py
+++ b/python_modules/dagster/dagster/_cli/utils.py
@@ -28,7 +28,6 @@ def has_pyproject_dagster_block(path: str) -> bool:
         data = tomli.load(f)
         if not isinstance(data, dict):
             return False
-
         return "dagster" in data.get("tool", {})
 
 

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -1,15 +1,16 @@
 import logging
 import os
 import sys
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from typing import Any, Callable, Optional, TypeVar, cast
 
 import click
 from click import UsageError
+from dagster_shared.cli import ClickOption, WorkspaceOpts, apply_click_params
 from dagster_shared.seven import JSONDecodeError, json
 from dagster_shared.yaml_utils import load_yaml_from_glob_list
-from typing_extensions import Never, Self, TypeAlias
+from typing_extensions import Never, Self
 
 import dagster._check as check
 from dagster import __version__ as dagster_version
@@ -68,7 +69,7 @@ WORKSPACE_CLI_ARGS = (
 def _get_workspace_load_target_from_cli_opts(
     workspace_opts: "WorkspaceOpts",
 ) -> WorkspaceLoadTarget:
-    if _are_attrs_falsey(workspace_opts, *WORKSPACE_CLI_ARGS):
+    if not workspace_opts.specifies_target():
         if workspace_opts.empty_workspace:
             return EmptyWorkspaceTarget()
         elif has_pyproject_dagster_block("pyproject.toml"):
@@ -236,7 +237,7 @@ def get_workspace_from_cli_opts(
     allow_in_process: bool = False,
     log_level: str = "INFO",
 ) -> Iterator[WorkspaceRequestContext]:
-    load_target = workspace_opts.to_load_target(allow_in_process)
+    load_target = workspace_opts_to_load_target(workspace_opts, allow_in_process)
     if isinstance(load_target, InProcessWorkspaceLoadTarget):
         logger.debug("Loading workspace in-process")
     else:
@@ -324,65 +325,31 @@ class PythonPointerOpts:
         )
 
 
-@record
-class WorkspaceOpts:
-    empty_workspace: bool = False
-    workspace: Optional[Sequence[str]] = None
+def workspace_opts_to_load_target(
+    opts: WorkspaceOpts, allow_in_process: bool = False
+) -> WorkspaceLoadTarget:
+    load_target = _get_workspace_load_target_from_cli_opts(opts)
+    origins = load_target.create_origins()
 
-    # Like PythonPointerParams but multiple files/modules/packages are allowed
-    python_file: Optional[Sequence[str]] = None
-    module_name: Optional[Sequence[str]] = None
-    package_name: Optional[Sequence[str]] = None
-    working_directory: Optional[str] = None
-    attribute: Optional[str] = None
-
-    # For gRPC server
-    grpc_port: Optional[int] = None
-    grpc_socket: Optional[str] = None
-    grpc_host: Optional[str] = None
-    use_ssl: bool = False
-
-    @classmethod
-    def extract_from_cli_options(cls, cli_options: dict[str, Any]) -> Self:
-        # This is expected to always be called from a click entry point, so all options should be
-        # present in the dictionary. We rely on `@record` for type-checking.
-        return cls(
-            empty_workspace=cli_options.pop("empty_workspace", False),
-            workspace=cli_options.pop("workspace", None),
-            python_file=cli_options.pop("python_file", None),
-            module_name=cli_options.pop("module_name", None),
-            package_name=cli_options.pop("package_name", None),
-            working_directory=cli_options.pop("working_directory", None),
-            attribute=cli_options.pop("attribute", None),
-            grpc_port=cli_options.pop("grpc_port", None),
-            grpc_socket=cli_options.pop("grpc_socket", None),
-            grpc_host=cli_options.pop("grpc_host", None),
-            use_ssl=cli_options.pop("use_ssl", False),
+    # We can load a workspace in-process if there is only one origin and the python executable is
+    # unspecified or matches that of the current process.
+    origins = load_target.create_origins()
+    can_load_in_process = len(origins) == 1 and _origin_executable_matches_current_process(
+        origins[0]
+    )
+    if allow_in_process and can_load_in_process:
+        origin = origins[0]
+        return InProcessWorkspaceLoadTarget(
+            [
+                InProcessCodeLocationOrigin(
+                    origin.loadable_target_origin,
+                    container_image=None,
+                    location_name=origin.location_name,
+                )
+            ]
         )
-
-    def to_load_target(self, allow_in_process: bool = False) -> WorkspaceLoadTarget:
-        load_target = _get_workspace_load_target_from_cli_opts(self)
-        origins = load_target.create_origins()
-
-        # We can load a workspace in-process if there is only one origin and the python executable is
-        # unspecified or matches that of the current process.
-        origins = load_target.create_origins()
-        can_load_in_process = len(origins) == 1 and _origin_executable_matches_current_process(
-            origins[0]
-        )
-        if allow_in_process and can_load_in_process:
-            origin = origins[0]
-            return InProcessWorkspaceLoadTarget(
-                [
-                    InProcessCodeLocationOrigin(
-                        origin.loadable_target_origin,
-                        container_image=None,
-                        location_name=origin.location_name,
-                    )
-                ]
-            )
-        else:
-            return load_target
+    else:
+        return load_target
 
 
 def _origin_executable_matches_current_process(origin: CodeLocationOrigin) -> bool:
@@ -416,7 +383,7 @@ class RepositoryOpts:
 
 def run_config_option(*, name: str, command_name: str) -> Callable[[T_Callable], T_Callable]:
     def wrap(f: T_Callable) -> T_Callable:
-        return _apply_click_params(f, _generate_run_config_option(name, command_name))
+        return apply_click_params(f, _generate_run_config_option(name, command_name))
 
     return wrap
 
@@ -425,39 +392,22 @@ def job_name_option(f: Optional[T_Callable] = None, *, name: str) -> T_Callable:
     if f is None:
         return lambda f: job_name_option(f, name=name)  # type: ignore
     else:
-        return _apply_click_params(f, _generate_job_name_option(name))
+        return apply_click_params(f, _generate_job_name_option(name))
 
 
 def repository_name_option(f: Optional[T_Callable] = None, *, name: str) -> T_Callable:
     if f is None:
         return lambda f: repository_name_option(f, name=name)  # type: ignore
     else:
-        return _apply_click_params(f, _generate_repository_name_option(name))
-
-
-def workspace_options(f: T_Callable) -> T_Callable:
-    return _apply_click_params(f, *_generate_workspace_options())
-
-
-def python_pointer_options(f: T_Callable) -> T_Callable:
-    return _apply_click_params(f, *_generate_python_pointer_options(allow_multiple=False))
+        return apply_click_params(f, _generate_repository_name_option(name))
 
 
 def repository_options(f: T_Callable) -> T_Callable:
-    return _apply_click_params(
+    return apply_click_params(
         f,
         _generate_repository_name_option("repository"),
         _generate_code_location_name_option("location"),
     )
-
-
-ClickOption: TypeAlias = Callable[[T_Callable], T_Callable]
-
-
-def _apply_click_params(command: T_Callable, *click_params: ClickOption) -> T_Callable:
-    for click_param in click_params:
-        command = click_param(command)
-    return command
 
 
 # ########################
@@ -521,109 +471,6 @@ def _generate_run_config_option(name: str, command_name: str) -> ClickOption:
             "-c pandas_hello_world/ops.yaml -c pandas_hello_world/env.yaml"
         ),
     )
-
-
-def _generate_python_pointer_options(allow_multiple: bool) -> Sequence[ClickOption]:
-    return [
-        click.option(
-            "--working-directory",
-            "-d",
-            help="Specify working directory to use when loading the repository or job",
-            envvar="DAGSTER_WORKING_DIRECTORY",
-        ),
-        click.option(
-            "--python-file",
-            "-f",
-            # Checks that the path actually exists lower in the stack, where we
-            # are better equipped to surface errors
-            type=click.Path(exists=False),
-            multiple=allow_multiple,
-            help=(
-                "Specify python file "
-                + ("or files (flag can be used multiple times) " if allow_multiple else "")
-                + "where dagster definitions reside as top-level symbols/variables and load "
-                + ("each" if allow_multiple else "the")
-                + " file as a code location in the current python environment."
-            ),
-            envvar="DAGSTER_PYTHON_FILE",
-        ),
-        click.option(
-            "--module-name",
-            "-m",
-            multiple=allow_multiple,
-            help=(
-                "Specify module "
-                + ("or modules (flag can be used multiple times) " if allow_multiple else "")
-                + "where dagster definitions reside as top-level symbols/variables and load "
-                + ("each" if allow_multiple else "the")
-                + " module as a code location in the current python environment."
-            ),
-            envvar="DAGSTER_MODULE_NAME",
-        ),
-        click.option(
-            "--package-name",
-            multiple=allow_multiple,
-            help="Specify Python package where repository or job function lives",
-            envvar="DAGSTER_PACKAGE_NAME",
-        ),
-        click.option(
-            "--attribute",
-            "-a",
-            help=(
-                "Attribute that is either a 1) repository or job or "
-                "2) a function that returns a repository or job"
-            ),
-            envvar="DAGSTER_ATTRIBUTE",
-        ),
-    ]
-
-
-def _generate_grpc_server_options(hidden=False) -> Sequence[ClickOption]:
-    return [
-        click.option(
-            "--grpc-port",
-            type=click.INT,
-            required=False,
-            help="Port to use to connect to gRPC server",
-            hidden=hidden,
-        ),
-        click.option(
-            "--grpc-socket",
-            type=click.Path(),
-            required=False,
-            help="Named socket to use to connect to gRPC server",
-            hidden=hidden,
-        ),
-        click.option(
-            "--grpc-host",
-            type=click.STRING,
-            required=False,
-            help="Host to use to connect to gRPC server, defaults to localhost",
-            hidden=hidden,
-        ),
-        click.option(
-            "--use-ssl",
-            is_flag=True,
-            default=False,
-            help="Use a secure channel when connecting to the gRPC server",
-            hidden=hidden,
-        ),
-    ]
-
-
-def _generate_workspace_options() -> Sequence[ClickOption]:
-    return [
-        click.option("--empty-workspace", is_flag=True, help="Allow an empty workspace"),
-        click.option(
-            "--workspace",
-            "-w",
-            multiple=True,
-            type=click.Path(exists=True),
-            help="Path to workspace file. Argument can be provided multiple times.",
-        ),
-        *_generate_python_pointer_options(allow_multiple=True),
-        *_generate_grpc_server_options(),
-    ]
 
 
 def _get_code_pointer_dict_from_python_pointer_opts(

--- a/python_modules/dagster/dagster/_daemon/cli/__init__.py
+++ b/python_modules/dagster/dagster/_daemon/cli/__init__.py
@@ -4,11 +4,12 @@ from contextlib import ExitStack
 from typing import Optional
 
 import click
+from dagster_shared.cli import WorkspaceOpts, workspace_options
 from dagster_shared.ipc import interrupt_on_ipc_shutdown_message
 
 from dagster import __version__ as dagster_version
 from dagster._cli.utils import assert_no_remaining_opts, get_instance_for_cli
-from dagster._cli.workspace.cli_target import WorkspaceOpts, workspace_options
+from dagster._cli.workspace.cli_target import workspace_opts_to_load_target
 from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.telemetry import telemetry_wrapper
 from dagster._daemon.controller import (
@@ -111,7 +112,7 @@ def _daemon_run_command(
 ) -> None:
     with daemon_controller_from_instance(
         instance,
-        workspace_load_target=workspace_opts.to_load_target(),
+        workspace_load_target=workspace_opts_to_load_target(workspace_opts),
         heartbeat_tolerance_seconds=_get_heartbeat_tolerance(),
         log_level=log_level,
         code_server_log_level=code_server_log_level,

--- a/python_modules/dagster/dagster/components/cli/list.py
+++ b/python_modules/dagster/dagster/components/cli/list.py
@@ -7,6 +7,7 @@ from traceback import TracebackException
 from typing import Any, Literal, Optional, Union
 
 import click
+from dagster_shared.cli import python_pointer_options
 from dagster_shared.error import SerializableErrorInfo, remove_system_frames_from_error
 from dagster_shared.serdes.objects import PluginObjectKey
 from dagster_shared.serdes.objects.definition_metadata import (
@@ -26,7 +27,6 @@ from dagster._cli.utils import assert_no_remaining_opts, get_possibly_temporary_
 from dagster._cli.workspace.cli_target import (
     PythonPointerOpts,
     get_repository_python_origin_from_cli_opts,
-    python_pointer_options,
 )
 from dagster._config.pythonic_config.resource import get_resource_type_name
 from dagster._core.definitions.asset_job import is_reserved_asset_job_name

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_job_load.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_job_load.py
@@ -3,16 +3,15 @@ import pytest
 from click.testing import CliRunner
 from dagster._cli.workspace.cli_target import (
     RepositoryOpts,
-    WorkspaceOpts,
     get_job_from_cli_opts,
     job_name_option,
     repository_options,
-    workspace_options,
 )
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import RemoteJob
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import file_relative_path
+from dagster_shared.cli import WorkspaceOpts, workspace_options
 
 
 def load_pipeline_via_cli_runner(cli_args):

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_repository_load.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_repository_load.py
@@ -4,17 +4,16 @@ from click.testing import CliRunner
 from dagster._cli.utils import assert_no_remaining_opts
 from dagster._cli.workspace.cli_target import (
     RepositoryOpts,
-    WorkspaceOpts,
     get_repository_from_cli_opts,
     get_workspace_from_cli_opts,
     repository_options,
-    workspace_options,
 )
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import RemoteRepository
 from dagster._core.test_utils import instance_for_test
 from dagster._core.workspace.context import WorkspaceRequestContext
 from dagster._utils import file_relative_path
+from dagster_shared.cli import WorkspaceOpts, workspace_options
 
 
 def load_repository_via_cli_runner(cli_args, repo_assert_fn=None):

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_graphql.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_graphql.py
@@ -1,4 +1,4 @@
-from dagster._cli.workspace.cli_target import WorkspaceOpts
+from dagster._cli.workspace.cli_target import WorkspaceOpts, workspace_opts_to_load_target
 from dagster._core.test_utils import instance_for_test
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._utils import file_relative_path
@@ -16,10 +16,12 @@ def test_execute_hammer_through_webserver():
             instance,
             version="",
             read_only=False,
-            workspace_load_target=WorkspaceOpts(
-                python_file=(file_relative_path(__file__, "hammer_job.py"),),
-                attribute="hammer_job",
-            ).to_load_target(),
+            workspace_load_target=workspace_opts_to_load_target(
+                WorkspaceOpts(
+                    python_file=(file_relative_path(__file__, "hammer_job.py"),),
+                    attribute="hammer_job",
+                )
+            ),
         ) as workspace_process_context:
             context = workspace_process_context.create_request_context()
             selector = infer_job_selector(context, "hammer_job")

--- a/python_modules/libraries/dagster-shared/dagster_shared/cli/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/cli/__init__.py
@@ -1,0 +1,198 @@
+from collections.abc import Sequence
+from typing import Any, Callable, Optional, TypeVar
+
+import click
+from typing_extensions import Self, TypeAlias
+
+from dagster_shared.record import as_dict, record
+
+T_Callable = TypeVar("T_Callable", bound=Callable[..., Any])
+
+ClickOption: TypeAlias = Callable[[T_Callable], T_Callable]
+
+
+def apply_click_params(command: T_Callable, *click_params: ClickOption) -> T_Callable:
+    for click_param in click_params:
+        command = click_param(command)
+    return command
+
+
+def python_pointer_options(f: T_Callable) -> T_Callable:
+    return apply_click_params(
+        f,
+        *generate_python_pointer_options(
+            allow_multiple=False,
+            hide_legacy_options=False,
+        ),
+    )
+
+
+def generate_python_pointer_options(
+    *,
+    allow_multiple: bool,
+    hide_legacy_options: bool,
+) -> Sequence[ClickOption]:
+    return [
+        click.option(
+            "--working-directory",
+            "-d",
+            help="Specify working directory to use when loading the repository or job",
+            envvar="DAGSTER_WORKING_DIRECTORY",
+        ),
+        click.option(
+            "--python-file",
+            "-f",
+            # Checks that the path actually exists lower in the stack, where we
+            # are better equipped to surface errors
+            type=click.Path(exists=False),
+            multiple=allow_multiple,
+            help=(
+                "Specify python file "
+                + ("or files (flag can be used multiple times) " if allow_multiple else "")
+                + "where dagster definitions reside as top-level symbols/variables and load "
+                + ("each" if allow_multiple else "the")
+                + " file as a code location in the current python environment."
+            ),
+            envvar="DAGSTER_PYTHON_FILE",
+        ),
+        click.option(
+            "--module-name",
+            "-m",
+            multiple=allow_multiple,
+            help=(
+                "Specify module "
+                + ("or modules (flag can be used multiple times) " if allow_multiple else "")
+                + "where dagster definitions reside as top-level symbols/variables and load "
+                + ("each" if allow_multiple else "the")
+                + " module as a code location in the current python environment."
+            ),
+            envvar="DAGSTER_MODULE_NAME",
+        ),
+        click.option(
+            "--package-name",
+            multiple=allow_multiple,
+            help="Specify Python package where repository or job function lives",
+            envvar="DAGSTER_PACKAGE_NAME",
+            hidden=hide_legacy_options,
+        ),
+        click.option(
+            "--attribute",
+            "-a",
+            help=(
+                "Attribute that is either a 1) repository or job or "
+                "2) a function that returns a repository or job"
+            ),
+            envvar="DAGSTER_ATTRIBUTE",
+            hidden=hide_legacy_options,
+        ),
+    ]
+
+
+def generate_grpc_server_options() -> Sequence[ClickOption]:
+    return []
+
+
+def generate_workspace_options(*, hide_uncommon_options: bool) -> Sequence[ClickOption]:
+    return [
+        click.option("--empty-workspace", is_flag=True, help="Allow an empty workspace"),
+        click.option(
+            "--workspace",
+            "-w",
+            multiple=True,
+            type=click.Path(exists=True),
+            help="Path to workspace file. Argument can be provided multiple times.",
+        ),
+        *generate_python_pointer_options(
+            allow_multiple=True,
+            hide_legacy_options=hide_uncommon_options,
+        ),
+        click.option(
+            "--grpc-port",
+            type=click.INT,
+            required=False,
+            help="Port to use to connect to gRPC server",
+            hidden=hide_uncommon_options,
+        ),
+        click.option(
+            "--grpc-socket",
+            type=click.Path(),
+            required=False,
+            help="Named socket to use to connect to gRPC server",
+            hidden=hide_uncommon_options,
+        ),
+        click.option(
+            "--grpc-host",
+            type=click.STRING,
+            required=False,
+            help="Host to use to connect to gRPC server, defaults to localhost",
+            hidden=hide_uncommon_options,
+        ),
+        click.option(
+            "--use-ssl",
+            is_flag=True,
+            default=False,
+            help="Use a secure channel when connecting to the gRPC server",
+            hidden=hide_uncommon_options,
+        ),
+    ]
+
+
+def dg_workspace_options(f: T_Callable) -> T_Callable:
+    return apply_click_params(
+        f,
+        *generate_workspace_options(
+            hide_uncommon_options=True,  # dg as a newer cli hides deprecated and rarely used options
+        ),
+    )
+
+
+def workspace_options(f: T_Callable) -> T_Callable:
+    return apply_click_params(
+        f,
+        *generate_workspace_options(
+            hide_uncommon_options=False,
+        ),
+    )
+
+
+@record
+class WorkspaceOpts:
+    empty_workspace: bool = False
+    workspace: Optional[Sequence[str]] = None
+
+    # Like PythonPointerParams but multiple files/modules/packages are allowed
+    python_file: Optional[Sequence[str]] = None
+    module_name: Optional[Sequence[str]] = None
+    package_name: Optional[Sequence[str]] = None
+    working_directory: Optional[str] = None
+    attribute: Optional[str] = None
+
+    # For gRPC server
+    grpc_port: Optional[int] = None
+    grpc_socket: Optional[str] = None
+    grpc_host: Optional[str] = None
+    use_ssl: bool = False
+
+    @classmethod
+    def extract_from_cli_options(cls, cli_options: dict[str, Any]) -> Self:
+        # This is expected to always be called from a click entry point, so all options should be
+        # present in the dictionary. We rely on `@record` for type-checking.
+        return cls(
+            empty_workspace=cli_options.pop("empty_workspace", False),
+            workspace=cli_options.pop("workspace", None),
+            python_file=cli_options.pop("python_file", None),
+            module_name=cli_options.pop("module_name", None),
+            package_name=cli_options.pop("package_name", None),
+            working_directory=cli_options.pop("working_directory", None),
+            attribute=cli_options.pop("attribute", None),
+            grpc_port=cli_options.pop("grpc_port", None),
+            grpc_socket=cli_options.pop("grpc_socket", None),
+            grpc_host=cli_options.pop("grpc_host", None),
+            use_ssl=cli_options.pop("use_ssl", False),
+        )
+
+    def specifies_target(self) -> bool:
+        set_args = [
+            k for k, v in as_dict(self).items() if v and (k not in {"empty_workspace", "use_ssl"})
+        ]
+        return bool(set_args)

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/cli.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/cli.py
@@ -4,7 +4,6 @@ from dagster._cli.utils import assert_no_remaining_opts
 from dagster._cli.workspace.cli_target import (
     PythonPointerOpts,
     get_repository_python_origin_from_cli_opts,
-    python_pointer_options,
 )
 from dagster._core.definitions.definitions_load_context import (
     DefinitionsLoadContext,
@@ -14,6 +13,7 @@ from dagster._core.definitions.repository_definition.repository_definition impor
 from dagster._utils.env import environ
 from dagster._utils.hosted_user_process import recon_repository_from_origin
 from dagster._utils.warnings import beta_warning
+from dagster_shared.cli import python_pointer_options
 from dagster_shared.serdes.utils import serialize_value
 
 SNAPSHOT_ENV_VAR_NAME = "DAGSTER_SIGMA_IS_GENERATING_SNAPSHOT"


### PR DESCRIPTION
support the options that `dagster dev` does for targeting specific things to load from `dg dev` by moving the definition of the click options and some related utilities out to `dagster_shared`

## How I Tested These Changes

`dg dev -f sample.py`

