### PR TITLE
[record] enable @record to play nice with pydantic.Field

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -121,6 +121,8 @@ def derive_model_type(
             field_infos = []
             if annotation_info.field_info:
                 field_infos.append(annotation_info.field_info)
+            if isinstance(annotation_info.default, FieldInfo):
+                field_infos.append(annotation_info.default)
 
             if annotation_info.has_default:
                 # if the annotation has a serializable default

--- a/python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py
@@ -16,7 +16,6 @@ from typing import (
     overload,
 )
 
-import pydantic
 from pydantic.fields import FieldInfo
 from typing_extensions import Self, dataclass_transform
 

--- a/python_modules/libraries/dagster-shared/dagster_shared_tests/test_record.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared_tests/test_record.py
@@ -22,7 +22,7 @@ from dagster_shared.record import (
 from dagster_shared.serdes.serdes import deserialize_value, serialize_value, whitelist_for_serdes
 from dagster_shared.utils.cached_method import cached_method
 from dagster_shared.utils.hash import hash_collection
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, Field, TypeAdapter
 
 if TYPE_CHECKING:
     from dagster_shared.utils.test import TestType
@@ -920,3 +920,21 @@ def test_pydantic() -> None:
         optional_custom_list_mapping={"c": [c]},
     )
     assert TypeAdapter(CustomHolder).validate_python(holder)
+
+
+def test_runtime_typecheck_pydantic_field() -> None:
+    @record
+    class MyClass:
+        foo: str = Field(default="foo")
+        bar: Optional[int] = Field(default=None)
+
+    MyClass()
+
+
+def test_pydantic_field_annotation():
+    @record
+    class MyClass:
+        foo: Annotated[str, Field(description="foo")] = "foo"
+        bar: Annotated[Optional[int], Field(description="bar")] = None
+
+    MyClass()


### PR DESCRIPTION
## Summary

`pydantic.Field` encodes some nice information which `dataclass.field` cannot, namely description. We pass this information through to the component docs in the case that you are annotating a `pydantic.BaseModel` with this field-level info. However, if your resolved class is instead a `@record`, some odd behavior results:

- any `Field(default=...)` set on the field is ignored by the record `__new__` implementation, see https://dagsterlabs.slack.com/archives/C06U59R0N4A/p1748022067192079 
- if the `@record` is a `Resolvable`, the `Field` info is discarded as part of the model transformation

This PR addresses this by transposing the `Field` as part of `@record` conversion to a `NamedTuple` - the `Field` is moved from the default position to an annotation on the field itself:
```python
@record
class MyRecord:
    my_field: str = Field(default="foo", description="My field")
```

becomes

```python
class MyRecord(NamedTuple):
    my_field: Annotated[str, Field(default="foo", description="My field")] = "foo"
```

## Test Plan

New unit tests.

## Changelog

> [dagster-shared] @record now supports `pydantic.Field` annotations
