### PR TITLE
[docs] add note about Org Admin role requirement for using Connect to Github/Gitlab buttons

### DIFF
--- a/docs/docs/dagster-plus/deployment/deployment-types/serverless/ci-cd-in-serverless.md
+++ b/docs/docs/dagster-plus/deployment/deployment-types/serverless/ci-cd-in-serverless.md
@@ -6,6 +6,11 @@ title: CI/CD in Serverless
 
 If you're a GitHub or GitLab user, you can use our predefined workflows to seamlessly deploy and synchronize your code to Dagster+. You can also use other Git providers or a local Git repository with our [dagster-cloud CLI](/dagster-plus/deployment/management/dagster-cloud-cli) to run your own CI/CD process.
 
+:::note
+Using the `Connect to Github` or `Connect to Gitlab` buttons in Dagster+ to configure a Git repository requires the Organization Admin role so that the system can provision an agent token.
+
+:::
+
 <Tabs groupId="method">
 <TabItem value="GitHub" label="With GitHub">
 

--- a/docs/docs/dagster-plus/deployment/deployment-types/serverless/ci-cd-in-serverless.md
+++ b/docs/docs/dagster-plus/deployment/deployment-types/serverless/ci-cd-in-serverless.md
@@ -7,7 +7,7 @@ title: CI/CD in Serverless
 If you're a GitHub or GitLab user, you can use our predefined workflows to seamlessly deploy and synchronize your code to Dagster+. You can also use other Git providers or a local Git repository with our [dagster-cloud CLI](/dagster-plus/deployment/management/dagster-cloud-cli) to run your own CI/CD process.
 
 :::note
-Using the `Connect to Github` or `Connect to Gitlab` buttons in Dagster+ to configure a Git repository requires the Organization Admin role so that the system can provision an agent token.
+Using the `Connect to GitHub` or `Connect to GitLab` buttons in Dagster+ to configure a Git repository requires the Organization Admin role so that the system can provision an agent token.
 
 :::
 


### PR DESCRIPTION
## Summary & Motivation
Resolves [DSE-107](https://linear.app/dagster-labs/issue/DSE-107/ib-document-using-connect-to-githubgitlab-buttons-for-import-a-dagster)

URL to the page the buttons are on: {org_name}.dagster.cloud/prod/serverless/add-code-location?tab=import_existing_project

The buttons require the Organization Admin role and users without this role will encounter an `Error (401) Unauthorized` page.

## How I Tested These Changes
👀