### PR TITLE
 @template_var

### DIFF
--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -100,7 +100,7 @@ class Component(ABC):
         return None
 
     @classmethod
-    def get_additional_scope(cls) -> dict[str, Any]:
+    def get_additional_scope(cls) -> Mapping[str, Any]:
         return get_static_template_vars(cls)
 
     @abstractmethod

--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -15,6 +15,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.metadata.source_code import CodeReference, LocalFileCodeReference
 from dagster._core.definitions.utils import validate_component_owner
 from dagster.components.component.component_scaffolder import DefaultComponentScaffolder
+from dagster.components.component.template_vars import get_static_template_vars
 from dagster.components.resolved.base import Resolvable
 from dagster.components.scaffold.scaffold import scaffold_with
 
@@ -99,8 +100,8 @@ class Component(ABC):
         return None
 
     @classmethod
-    def get_additional_scope(cls) -> Mapping[str, Any]:
-        return {}
+    def get_additional_scope(cls) -> dict[str, Any]:
+        return get_static_template_vars(cls)
 
     @abstractmethod
     def build_defs(self, context: "ComponentLoadContext") -> Definitions: ...

--- a/python_modules/dagster/dagster/components/component/template_vars.py
+++ b/python_modules/dagster/dagster/components/component/template_vars.py
@@ -71,11 +71,10 @@ def is_staticmethod(cls, method):
 
 
 def get_static_template_vars(cls: type) -> dict[str, TemplateVarFn]:
-    """Find all staticmethods in a class that pass a predicate function.
+    """Find all staticmethods in a class that can be used as template variables.
 
     Args:
         cls: The class to search through
-        predicate: A function that takes a callable and returns a boolean
 
     Returns:
         A dictionary mapping method names to their callable functions for each matching staticmethod

--- a/python_modules/dagster/dagster/components/component/template_vars.py
+++ b/python_modules/dagster/dagster/components/component/template_vars.py
@@ -3,9 +3,7 @@ from typing import Any, Callable, Optional, Union, overload
 
 from typing_extensions import TypeAlias
 
-from dagster.components.core.context import ComponentLoadContext
-
-TemplateVarFn: TypeAlias = Callable[[ComponentLoadContext], Any]
+TemplateVarFn: TypeAlias = Callable[..., Any]
 
 TEMPLATE_VAR_ATTR = "__dagster_template_var"
 
@@ -35,7 +33,7 @@ def is_template_var(obj: Any) -> bool:
     return getattr(obj, TEMPLATE_VAR_ATTR, False)
 
 
-def find_template_vars_in_module(module: Any) -> dict[str, TemplateVarFn]:
+def find_inline_template_vars_in_module(module: Any) -> dict[str, TemplateVarFn]:
     """Finds all template functions in the given module.
 
     Args:
@@ -45,3 +43,51 @@ def find_template_vars_in_module(module: Any) -> dict[str, TemplateVarFn]:
         dict[str, TemplateVarFn]: A dictionary of template variable functions indexed by name
     """
     return {name: obj for name, obj in inspect.getmembers(module, is_template_var)}
+
+
+def is_staticmethod(cls, method):
+    """Check if a method is a static method by examining the class descriptor.
+
+    Args:
+        cls: The class where the method is defined
+        method: The method reference (e.g., cls.method_name)
+
+    Returns:
+        bool: True if the method is a static method, False otherwise
+    """
+    # Get the method name from the method reference
+    if not hasattr(method, "__name__"):
+        return False
+
+    method_name = method.__name__
+
+    # Check the class hierarchy to find where this method is defined
+    for base_cls in inspect.getmro(cls):
+        if method_name in base_cls.__dict__:
+            method_descriptor = base_cls.__dict__[method_name]
+            return isinstance(method_descriptor, staticmethod)
+
+    return False
+
+
+def get_static_template_vars(cls: type) -> dict[str, TemplateVarFn]:
+    """Find all staticmethods in a class that pass a predicate function.
+
+    Args:
+        cls: The class to search through
+        predicate: A function that takes a callable and returns a boolean
+
+    Returns:
+        A dictionary mapping method names to their callable functions for each matching staticmethod
+    """
+    results = {}
+    for name, method in cls.__dict__.items():
+        if is_staticmethod(cls, method):
+            # Get the actual function from the staticmethod wrapper
+            func = method.__get__(None, cls)
+            if is_template_var(func):
+                if len(inspect.signature(func).parameters) > 0:
+                    raise ValueError(f"Static template var {name} must not take any arguments")
+                results[name] = func()
+
+    return results

--- a/python_modules/dagster/dagster/components/component/template_vars.py
+++ b/python_modules/dagster/dagster/components/component/template_vars.py
@@ -1,0 +1,47 @@
+import inspect
+from typing import Any, Callable, Optional, Union, overload
+
+from typing_extensions import TypeAlias
+
+from dagster.components.core.context import ComponentLoadContext
+
+TemplateVarFn: TypeAlias = Callable[[ComponentLoadContext], Any]
+
+TEMPLATE_VAR_ATTR = "__dagster_template_var"
+
+
+@overload
+def template_var(fn: TemplateVarFn) -> TemplateVarFn: ...
+
+
+@overload
+def template_var() -> Callable[[TemplateVarFn], TemplateVarFn]: ...
+
+
+def template_var(
+    fn: Optional[TemplateVarFn] = None,
+) -> Union[TemplateVarFn, Callable[[TemplateVarFn], TemplateVarFn]]:
+    def decorator(func: TemplateVarFn) -> TemplateVarFn:
+        setattr(func, TEMPLATE_VAR_ATTR, True)
+        return func
+
+    if fn is None:
+        return decorator
+    else:
+        return decorator(fn)
+
+
+def is_template_var(obj: Any) -> bool:
+    return getattr(obj, TEMPLATE_VAR_ATTR, False)
+
+
+def find_template_vars_in_module(module: Any) -> dict[str, TemplateVarFn]:
+    """Finds all template functions in the given module.
+
+    Args:
+        module: The module to search for template functions
+
+    Returns:
+        dict[str, TemplateVarFn]: A dictionary of template variable functions indexed by name
+    """
+    return {name: obj for name, obj in inspect.getmembers(module, is_template_var)}

--- a/python_modules/dagster/dagster_tests/components_tests/template_vars_tests/template_vars.py
+++ b/python_modules/dagster/dagster_tests/components_tests/template_vars_tests/template_vars.py
@@ -1,0 +1,18 @@
+from typing import Callable
+
+from dagster.components.component.template_vars import template_var
+
+
+@template_var
+def foo(context) -> str:
+    return "value_for_foo"
+
+
+@template_var
+def a_udf(context) -> Callable:
+    return lambda: "a_udf_value"
+
+
+@template_var
+def a_udf_with_args(context) -> Callable:
+    return lambda x: f"a_udf_value_{x}"

--- a/python_modules/dagster/dagster_tests/components_tests/template_vars_tests/test_basic_template_vars.py
+++ b/python_modules/dagster/dagster_tests/components_tests/template_vars_tests/test_basic_template_vars.py
@@ -1,0 +1,91 @@
+from typing import Any
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster.components.component.component import Component
+from dagster.components.core.context import ComponentLoadContext
+from dagster.components.resolved.base import Resolvable
+from dagster.components.resolved.model import Model
+
+from dagster_tests.components_tests.utils import load_context_and_component_for_test
+
+
+class ComponentWithAdditionalScope(Component, Resolvable, Model):
+    value: str
+
+    @classmethod
+    def get_additional_scope(cls) -> dict[str, Any]:
+        return {
+            "foo": "value_for_foo",
+            "a_udf": lambda: "a_udf_value",
+            "a_udf_with_args": lambda x: f"a_udf_value_{x}",
+        }
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions: ...
+
+
+def test_basic_additional_scope_hardcoded_value():
+    load_context, component = load_context_and_component_for_test(
+        ComponentWithAdditionalScope, {"value": "a_value"}
+    )
+
+    assert component.value == "a_value"
+
+
+def test_basic_additional_scope_scope_var():
+    load_context, component = load_context_and_component_for_test(
+        ComponentWithAdditionalScope, {"value": "{{ foo }}"}
+    )
+
+    assert component.value == "value_for_foo"
+
+
+def test_basic_additional_scope_scope_udf_no_args():
+    load_context, component = load_context_and_component_for_test(
+        ComponentWithAdditionalScope, {"value": "{{ a_udf() }}"}
+    )
+
+    assert component.value == "a_udf_value"
+
+
+def test_basic_additional_scope_scope_udf_with_args():
+    load_context, component = load_context_and_component_for_test(
+        ComponentWithAdditionalScope, {"value": "{{ a_udf_with_args('1') }}"}
+    )
+
+    assert component.value == "a_udf_value_1"
+
+
+class ComponentWithInjectedScope(Component, Resolvable, Model):
+    value: str
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions: ...
+
+
+def test_basic_injected_scope_var():
+    load_context, component = load_context_and_component_for_test(
+        ComponentWithInjectedScope,
+        {"value": "{{ foo }}"},
+        injectables_module="dagster_tests.components_tests.template_vars_tests.template_vars",
+    )
+
+    assert component.value == "value_for_foo"
+
+
+def test_basic_scope_udf_no_args():
+    load_context, component = load_context_and_component_for_test(
+        ComponentWithInjectedScope,
+        {"value": "{{ a_udf() }}"},
+        injectables_module="dagster_tests.components_tests.template_vars_tests.template_vars",
+    )
+
+    assert component.value == "a_udf_value"
+
+
+def test_basic_scope_udf_with_args():
+    load_context, component = load_context_and_component_for_test(
+        ComponentWithInjectedScope,
+        {"value": "{{ a_udf_with_args('1') }}"},
+        injectables_module="dagster_tests.components_tests.template_vars_tests.template_vars",
+    )
+
+    assert component.value == "a_udf_value_1"

--- a/python_modules/dagster/dagster_tests/components_tests/template_vars_tests/test_basic_template_vars.py
+++ b/python_modules/dagster/dagster_tests/components_tests/template_vars_tests/test_basic_template_vars.py
@@ -1,24 +1,32 @@
-from typing import Any
+from collections.abc import Callable
 
 from dagster._core.definitions.definitions_class import Definitions
 from dagster.components.component.component import Component
+from dagster.components.component.template_vars import template_var
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.resolved.base import Resolvable
-from dagster.components.resolved.model import Model
+from dagster.components.resolved.model import Injectable, Model
 
 from dagster_tests.components_tests.utils import load_context_and_component_for_test
 
 
 class ComponentWithAdditionalScope(Component, Resolvable, Model):
-    value: str
+    value: Injectable[str]
 
-    @classmethod
-    def get_additional_scope(cls) -> dict[str, Any]:
-        return {
-            "foo": "value_for_foo",
-            "a_udf": lambda: "a_udf_value",
-            "a_udf_with_args": lambda x: f"a_udf_value_{x}",
-        }
+    @staticmethod
+    @template_var
+    def foo() -> str:
+        return "value_for_foo"
+
+    @staticmethod
+    @template_var
+    def a_udf() -> Callable:
+        return lambda: "a_udf_value"
+
+    @staticmethod
+    @template_var
+    def a_udf_with_args() -> Callable:
+        return lambda x: f"a_udf_value_{x}"
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions: ...
 

--- a/python_modules/dagster/dagster_tests/components_tests/template_vars_tests/test_basic_template_vars.py
+++ b/python_modules/dagster/dagster_tests/components_tests/template_vars_tests/test_basic_template_vars.py
@@ -73,7 +73,7 @@ def test_basic_injected_scope_var():
     load_context, component = load_context_and_component_for_test(
         ComponentWithInjectedScope,
         {"value": "{{ foo }}"},
-        injectables_module="dagster_tests.components_tests.template_vars_tests.template_vars",
+        template_vars_module="dagster_tests.components_tests.template_vars_tests.template_vars",
     )
 
     assert component.value == "value_for_foo"
@@ -83,7 +83,7 @@ def test_basic_scope_udf_no_args():
     load_context, component = load_context_and_component_for_test(
         ComponentWithInjectedScope,
         {"value": "{{ a_udf() }}"},
-        injectables_module="dagster_tests.components_tests.template_vars_tests.template_vars",
+        template_vars_module="dagster_tests.components_tests.template_vars_tests.template_vars",
     )
 
     assert component.value == "a_udf_value"
@@ -93,7 +93,7 @@ def test_basic_scope_udf_with_args():
     load_context, component = load_context_and_component_for_test(
         ComponentWithInjectedScope,
         {"value": "{{ a_udf_with_args('1') }}"},
-        injectables_module="dagster_tests.components_tests.template_vars_tests.template_vars",
+        template_vars_module="dagster_tests.components_tests.template_vars_tests.template_vars",
     )
 
     assert component.value == "a_udf_value_1"

--- a/python_modules/dagster/dagster_tests/components_tests/template_vars_tests/test_fn_decorators.py
+++ b/python_modules/dagster/dagster_tests/components_tests/template_vars_tests/test_fn_decorators.py
@@ -1,0 +1,84 @@
+from typing import Callable
+
+from dagster.components.component.template_vars import is_template_var, template_var
+from dagster.components.core.context import ComponentLoadContext
+
+
+def test_template_udf_decorator():
+    @template_var
+    def my_udf(context: ComponentLoadContext) -> Callable[[str], str]:
+        return lambda x: f"udf_{x}"
+
+    assert is_template_var(my_udf)
+    assert my_udf(ComponentLoadContext.for_test())("test") == "udf_test"
+
+
+def test_template_udf_decorator_with_parens():
+    @template_var()
+    def my_udf(context: ComponentLoadContext) -> Callable[[str], str]:
+        return lambda x: f"udf_{x}"
+
+    assert is_template_var(my_udf)
+    assert my_udf(ComponentLoadContext.for_test())("test") == "udf_test"
+
+
+def test_template_udf_decorator_preserves_function_metadata():
+    @template_var
+    def my_udf(context: ComponentLoadContext) -> Callable[[str], str]:
+        """Test docstring."""
+        return lambda x: f"udf_{x}"
+
+    assert my_udf.__name__ == "my_udf"
+    assert my_udf.__doc__ == "Test docstring."
+
+
+def test_is_template_udf():
+    def regular_fn() -> Callable[[str], str]:
+        return lambda x: f"regular_{x}"
+
+    @template_var
+    def udf_fn(context: ComponentLoadContext) -> Callable[[str], str]:
+        return lambda x: f"udf_{x}"
+
+    assert not is_template_var(regular_fn)
+    assert is_template_var(udf_fn)
+
+
+def test_template_var_decorator():
+    @template_var
+    def my_var(context: ComponentLoadContext) -> str:
+        return "var_value"
+
+    assert is_template_var(my_var)
+    assert my_var(ComponentLoadContext.for_test()) == "var_value"
+
+
+def test_template_var_decorator_with_parens():
+    @template_var()
+    def my_var(context: ComponentLoadContext) -> str:
+        return "var_value"
+
+    assert is_template_var(my_var)
+    assert my_var(ComponentLoadContext.for_test()) == "var_value"
+
+
+def test_template_var_decorator_preserves_function_metadata():
+    @template_var
+    def my_var(context: ComponentLoadContext) -> str:
+        """Test docstring."""
+        return "var_value"
+
+    assert my_var.__name__ == "my_var"
+    assert my_var.__doc__ == "Test docstring."
+
+
+def test_is_template_var():
+    def regular_fn() -> str:
+        return "regular_value"
+
+    @template_var
+    def var_fn(context: ComponentLoadContext) -> str:
+        return "var_value"
+
+    assert not is_template_var(regular_fn)
+    assert is_template_var(var_fn)

--- a/python_modules/dagster/dagster_tests/components_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/components_tests/utils.py
@@ -33,14 +33,14 @@ T_Component = TypeVar("T_Component", bound=Component)
 def load_context_and_component_for_test(
     component_type: type[T_Component],
     attrs: Union[str, dict[str, Any]],
-    injectables_module: Optional[str] = None,
+    template_vars_module: Optional[str] = None,
 ) -> tuple[ComponentLoadContext, T_Component]:
     context = ComponentLoadContext.for_test()
     model_cls = check.not_none(
         component_type.get_model_cls(), "Component must have schema for direct test"
     )
 
-    context = context_with_injected_scope(context, component_type, injectables_module)
+    context = context_with_injected_scope(context, component_type, template_vars_module)
 
     if isinstance(attrs, str):
         source_positions = parse_yaml_with_source_position(attrs)

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/check.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/check.py
@@ -34,6 +34,7 @@ COMPONENT_FILE_SCHEMA = {
             "properties": {"env": {"type": "array", "items": {"type": "string"}}},
             "additionalProperties": False,
         },
+        "scope": {"type": "string"},
     },
     "additionalProperties": False,
 }

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/check.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/check.py
@@ -34,7 +34,7 @@ COMPONENT_FILE_SCHEMA = {
             "properties": {"env": {"type": "array", "items": {"type": "string"}}},
             "additionalProperties": False,
         },
-        "scope": {"type": "string"},
+        "template_vars_module": {"type": "string"},
     },
     "additionalProperties": False,
 }


### PR DESCRIPTION
## Summary & Motivation

Right now the only way to inject additional scope in the Component templating engine is create a distinct component subtype and override the class method `get_additional_scope`.


In dogfooding Components DOP –– especially to `ExecutableComponent` –– I found I was making trivial subclasses whose only purpose was to define additional scope for udfs.

Scope is an overloaded, very generic term. So this PR proposes the use of the term "template var" instead of scope.

This PR makes it so that you no need to override `get_additional_scope` to define a template variable. Instead they are defined in two different ways:

1. Annotate a `@staticmethod` on a class. This associates the template variable with the _class_, and this is introspectable when the class is imported. This is known as a _static_ template variable function in internal nomenclature.

2. Annotate a freestanding function in a module. This associates the template variable with a particular path in the `defs` hierarchy. A freestanding, or _inline_ template var, optionall accepts a `ComponentLoadContext` and is only known  when the component hierarchy is loaded.

Inline template variables, combined with @alangenfeld 's change to make resolved fields injectable by default, enable a ton of flexibility over something like `ExecutableComponent`. 

As a norm, inline template variables would be defined in `template_vars.py` adjacent to `defs.yaml` for simple use cases.

However it is logical to allow for more flexibility that, so we don't hardcode that norm in any way. 


### Static Template Vars ###

```python
class NewComponent(Component):

   @staticmethod
   @template_var
   def foo() -> str:
        return "value_for_foo"


   @staticmethod
   @template_var
    def a_udf() -> Callable:
        return lambda: "a_udf_value"


   @staticmethod
   @template_var
    def a_udf_with_args(context) -> Callable:
        return lambda x: f"a_udf_value_{x}"
```

### Inline Template Vars ###

```yaml
# defs.yaml
type: test_new_scope.components.ExistingComponent

attributes:
  value: "{{ foo }}"

template_vars_module: .template_vars
```

```python
from typing import Callable

from dagster.components.component.template_vars import template_var


@template_var
def foo(context) -> str:
    return "value_for_foo"


@template_var
def a_udf(context) -> Callable:
    return lambda: "a_udf_value"


@template_var
def a_udf_with_args(context) -> Callable:
    return lambda x: f"a_udf_value_{x}"
```

There will probably be more extensions to this, including some notion of dynamic scoping (the ability for all subchildren in the defs hierarchy to access a scope variable, for example) but I'm defaulting to YAGNI in this case. 

## How I Tested These Changes

BK. Manual testing with a project.

## Changelog

* Added `@template_var` as an alternative approach for defining variables in a templating context with associated with a component type, or only available at a particular path in the defs hierarchy.
