### PR TITLE
@component -> @component_instance. Allow multiple instances in file

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -643,7 +643,7 @@ from dagster.components.component.component import (
     Component as Component,
     ComponentTypeSpec as ComponentTypeSpec,
 )
-from dagster.components.component.component_loader import component as component
+from dagster.components.component.component_loader import component_instance as component_instance
 from dagster.components.component_scaffolding import scaffold_component as scaffold_component
 from dagster.components.components import (
     DefinitionsComponent as DefinitionsComponent,  # back-compat

--- a/python_modules/dagster/dagster/components/__init__.py
+++ b/python_modules/dagster/dagster/components/__init__.py
@@ -2,7 +2,7 @@ from dagster.components.component.component import (
     Component as Component,
     ComponentTypeSpec as ComponentTypeSpec,
 )
-from dagster.components.component.component_loader import component as component
+from dagster.components.component.component_loader import component_instance as component_instance
 from dagster.components.component_scaffolding import scaffold_component as scaffold_component
 from dagster.components.components import (
     DefinitionsComponent as DefinitionsComponent,  # back-compat

--- a/python_modules/dagster/dagster/components/component/component_loader.py
+++ b/python_modules/dagster/dagster/components/component/component_loader.py
@@ -13,8 +13,18 @@ T_Component = TypeVar("T_Component", bound="Component")
 
 
 @public
-@preview(emit_runtime_warning=False)
 def component(
+    fn: Callable[["ComponentLoadContext"], T_Component],
+) -> Callable[["ComponentLoadContext"], T_Component]:
+    """Decorator for a function to be used to load an instance of a Component.
+    This is used when instantiating components in python instead of via yaml.
+    """
+    return component_instance(fn)
+
+
+@public
+@preview(emit_runtime_warning=False)
+def component_instance(
     fn: Callable[["ComponentLoadContext"], T_Component],
 ) -> Callable[["ComponentLoadContext"], T_Component]:
     """Decorator for a function to be used to load an instance of a Component.

--- a/python_modules/dagster/dagster/components/component/component_loader.py
+++ b/python_modules/dagster/dagster/components/component/component_loader.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
-from dagster._annotations import preview, public
+from dagster._annotations import preview, public, superseded
 
 if TYPE_CHECKING:
     from dagster.components.component.component import Component
@@ -13,6 +13,7 @@ T_Component = TypeVar("T_Component", bound="Component")
 
 
 @public
+@superseded(additional_warn_text="Use `component_instance` instead.")
 def component(
     fn: Callable[["ComponentLoadContext"], T_Component],
 ) -> Callable[["ComponentLoadContext"], T_Component]:

--- a/python_modules/dagster/dagster/components/component_scaffolding.py
+++ b/python_modules/dagster/dagster/components/component_scaffolding.py
@@ -54,7 +54,7 @@ def scaffold_component(
                         from dagster import component, ComponentLoadContext
                         from {module_path} import {class_name}
 
-                        @component
+                        @component_instance
                         def load(context: ComponentLoadContext) -> {class_name}: ...
                 """
                 ).lstrip()

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -108,6 +108,14 @@ class CompositeYamlComponent(Component):
         )
 
 
+class CompositeComponent(Component):
+    def __init__(self, components: Sequence[Component]):
+        self.components = components
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        return Definitions.merge(*[component.build_defs(context) for component in self.components])
+
+
 def get_component(context: ComponentLoadContext) -> Optional[Component]:
     """Attempts to load a component from the given context. Iterates through potential component
     type matches, prioritizing more specific types: YAML, Python, plain Dagster defs, and component
@@ -302,8 +310,8 @@ def load_pythonic_component(context: ComponentLoadContext) -> Component:
         _, component_loader = component_loaders[0]
         return component_loader(context)
     else:
-        raise DagsterInvalidDefinitionError(
-            f"Multiple component loaders found in module: {component_loaders}"
+        return CompositeComponent(
+            [component_loader(context) for _, component_loader in component_loaders]
         )
 
 

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/multiple_component_instances/component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/multiple_component_instances/component.py
@@ -1,0 +1,40 @@
+from dagster import AssetSpec, AutomationCondition
+from dagster.components import ComponentLoadContext, component_instance
+from dagster.components.lib.pipes_subprocess_script_collection import (
+    PipesSubprocessScript,
+    PipesSubprocessScriptCollectionComponent,
+)
+
+
+@component_instance
+def foo(context: ComponentLoadContext) -> PipesSubprocessScriptCollectionComponent:
+    return PipesSubprocessScriptCollectionComponent(
+        scripts=[
+            PipesSubprocessScript(
+                path="cool_script.py",
+                assets=[
+                    AssetSpec(
+                        key="foo",
+                        automation_condition=AutomationCondition.eager(),
+                    )
+                ],
+            )
+        ]
+    )
+
+
+@component_instance
+def bar(context: ComponentLoadContext) -> PipesSubprocessScriptCollectionComponent:
+    return PipesSubprocessScriptCollectionComponent(
+        scripts=[
+            PipesSubprocessScript(
+                path="cool_script.py",
+                assets=[
+                    AssetSpec(
+                        key="bar",
+                        automation_condition=AutomationCondition.eager(),
+                    )
+                ],
+            )
+        ]
+    )

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/multiple_component_instances_defs_py/component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/multiple_component_instances_defs_py/component.py
@@ -1,0 +1,40 @@
+from dagster import AssetSpec, AutomationCondition
+from dagster.components import ComponentLoadContext, component_instance
+from dagster.components.lib.pipes_subprocess_script_collection import (
+    PipesSubprocessScript,
+    PipesSubprocessScriptCollectionComponent,
+)
+
+
+@component_instance
+def foo(context: ComponentLoadContext) -> PipesSubprocessScriptCollectionComponent:
+    return PipesSubprocessScriptCollectionComponent(
+        scripts=[
+            PipesSubprocessScript(
+                path="cool_script.py",
+                assets=[
+                    AssetSpec(
+                        key="foo_def_py",
+                        automation_condition=AutomationCondition.eager(),
+                    )
+                ],
+            )
+        ]
+    )
+
+
+@component_instance
+def bar(context: ComponentLoadContext) -> PipesSubprocessScriptCollectionComponent:
+    return PipesSubprocessScriptCollectionComponent(
+        scripts=[
+            PipesSubprocessScript(
+                path="cool_script.py",
+                assets=[
+                    AssetSpec(
+                        key="bar_def_py",
+                        automation_condition=AutomationCondition.eager(),
+                    )
+                ],
+            )
+        ]
+    )

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/script_python_decl/component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/script_python_decl/component.py
@@ -1,11 +1,11 @@
-from dagster import AssetSpec, AutomationCondition, ComponentLoadContext, component
+from dagster import AssetSpec, AutomationCondition, ComponentLoadContext, component_instance
 from dagster.components.lib.pipes_subprocess_script_collection import (
     PipesSubprocessScript,
     PipesSubprocessScriptCollectionComponent,
 )
 
 
-@component
+@component_instance
 def load(context: ComponentLoadContext) -> PipesSubprocessScriptCollectionComponent:
     return PipesSubprocessScriptCollectionComponent(
         scripts=[

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/pythonic_components/relative_import/component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/pythonic_components/relative_import/component.py
@@ -1,4 +1,4 @@
-from dagster import Component, ComponentLoadContext, component
+from dagster import Component, ComponentLoadContext, component_instance
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 
@@ -18,7 +18,7 @@ class AComponent(Component):
         return Definitions(assets=[an_asset])
 
 
-@component
+@component_instance
 def load(context: ComponentLoadContext) -> Component:
     """A component that loads a component from the same module."""
     return AComponent()

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
@@ -26,6 +26,10 @@ def test_load_from_path() -> None:
         AssetKey("up1_dash"),
         AssetKey("up2_dash"),
         AssetKey("override_key_dash"),
+        AssetKey("foo"),
+        AssetKey("bar"),
+        AssetKey("foo_def_py"),
+        AssetKey("bar_def_py"),
     }
 
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
@@ -151,7 +151,7 @@ def test_scaffold_airlift_python():
                 """from dagster import component, ComponentLoadContext
 from dagster_airlift.core.components.airflow_instance.component import AirflowInstanceComponent
 
-@component
+@component_instance
 def load(context: ComponentLoadContext) -> AirflowInstanceComponent: ...
 """
             )


### PR DESCRIPTION
## Summary & Motivation

Rename `@component` to `@component_instance`. Allow multiple declaration of `component_instance` in the same file.

## How I Tested These Changes

BK and manual project scaffolding.

## Changelog

* Added `@component_instance` to replace `@component` and allows multiple component instances in a python file.