### PR TITLE
allow multiple @definitions

### DIFF
--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -291,10 +291,7 @@ class DagsterDefsComponent(Component):
             return lazy_def(context)
 
         if len(lazy_def_objects) > 1:
-            raise DagsterInvalidDefinitionError(
-                f"Found multiple @definitions-decorated functions in {self.path}. At most one "
-                "@definitions-decorated function may be specified per module."
-            )
+            return Definitions.merge(*[lazy_def(context) for lazy_def in lazy_def_objects])
 
         return load_definitions_from_module(module)
 

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/multiple_definitions_calls/defs.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/multiple_definitions_calls/defs.py
@@ -1,0 +1,11 @@
+from dagster import AssetSpec, Definitions, definitions
+
+
+@definitions
+def defs_one():
+    return Definitions(assets=[AssetSpec(key="from_defs_one")])
+
+
+@definitions
+def defs_two():
+    return Definitions(assets=[AssetSpec(key="from_defs_two")])

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
@@ -30,6 +30,8 @@ def test_load_from_path() -> None:
         AssetKey("bar"),
         AssetKey("foo_def_py"),
         AssetKey("bar_def_py"),
+        AssetKey("from_defs_one"),
+        AssetKey("from_defs_two"),
     }
 
 


### PR DESCRIPTION
## Summary & Motivation

This PR proposes allowing multiple `@definitions` declarations in files in the `defs` hierarchy and automatically merging them together.

This can risk adding duplicative definitions to a project, most likely when importing a `@definitions`-decorated function from one module to another. 

However I do think this is a fairly arbitrary limitation that users would expect to "just work."

## How I Tested These Changes

Manually tested on a scaffolded project

## Changelog

* Can define multiple `@definitions`-decorated functions in a single module in the `defs` hierarchy and they are automatically merged and incorporated into the project.