### PR TITLE
Filter failed runs that never succeeded on re-execution (#29596)

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_sql_run_storage.py
+++ b/python_modules/dagster/dagster_tests/core_tests/storage_tests/test_sql_run_storage.py
@@ -1,0 +1,40 @@
+from ...utils import create_run
+
+from dagster import DagsterRunStatus, RunsFilter
+
+def test_latest_failed_only_filter(instance):
+    parent_run_id = "retry-root"
+
+    run1 = create_run(
+        instance,
+        run_id="run1",
+        status=DagsterRunStatus.FAILURE,
+        tags={"dagster/parent_run_id": parent_run_id},
+        start_time=1000,
+    )
+
+    run2 = create_run(
+        instance,
+        run_id="run2",
+        status=DagsterRunStatus.FAILURE,
+        tags={"dagster/parent_run_id": parent_run_id},
+        start_time=2000,
+    )
+
+    run3 = create_run(
+        instance,
+        run_id="run3",
+        status=DagsterRunStatus.FAILURE,
+        tags={"dagster/parent_run_id": parent_run_id},
+        start_time=3000,
+    )
+
+    result = instance.get_run_records(
+        filters=RunsFilter(
+            status=[DagsterRunStatus.FAILURE],
+            latest_failed_only=True
+        )
+    )
+
+    assert len(result) == 1
+    assert result[0].dagster_run.run_id == "run3"

--- a/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
@@ -5,18 +5,24 @@ from contextlib import contextmanager
 import pytest
 from dagster import DagsterInstance
 from dagster._core.storage.legacy_storage import LegacyRunStorage
-from dagster._core.storage.runs import InMemoryRunStorage, SqliteRunStorage
+from dagster._core.storage.runs import (
+    InMemoryRunStorage,
+    SqliteRunStorage,
+    RunsFilter,
+    DagsterRunStatus
+)
 from dagster._core.storage.sqlite_storage import DagsterSqliteStorage
 from dagster._core.test_utils import instance_for_test
 
 from dagster_tests.storage_tests.utils.run_storage import TestRunStorage
 
 
+# ----------- Context Managers -----------
+
 @contextmanager
 def create_sqlite_run_storage():
     with tempfile.TemporaryDirectory() as tempdir:
         yield SqliteRunStorage.from_local(tempdir)
-
 
 @contextmanager
 def create_in_memory_storage():
@@ -26,13 +32,10 @@ def create_in_memory_storage():
     finally:
         storage.dispose()
 
-
 @contextmanager
 def create_legacy_run_storage():
     with tempfile.TemporaryDirectory() as tempdir:
-        # first create the unified storage class
         storage = DagsterSqliteStorage.from_local(tempdir)
-        # next create the legacy adapter class
         legacy_storage = LegacyRunStorage(storage)
         try:
             yield legacy_storage
@@ -40,94 +43,100 @@ def create_legacy_run_storage():
             storage.dispose()
 
 
+# ----------- Latest Failed Filter Test Class -----------
+
+class TestLatestFailedOnly(TestRunStorage):
+    __test__ = True
+
+    @pytest.fixture(name="instance", scope="function")
+    def instance(self):
+        with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:
+            with instance_for_test(temp_dir=tmpdir_path) as instance:
+                yield instance
+
+    def test_latest_failed_only(self, instance):
+        run_success = instance.create_run_for_pipeline(
+            pipeline_name="demo_pipeline", status=DagsterRunStatus.SUCCESS
+        )
+        run_failed = instance.create_run_for_pipeline(
+            pipeline_name="demo_pipeline", status=DagsterRunStatus.FAILURE
+        )
+
+        filtered = instance.get_run_records(
+            filters=RunsFilter(
+                status=[DagsterRunStatus.FAILURE],
+                latest_failed_only=True
+            )
+        )
+
+        assert len(filtered) == 1
+        assert filtered[0].pipeline_run.run_id == run_failed.run_id
+
+
+# ----------- Sqlite Run Storage Tests -----------
+
 class TestSqliteRunStorage(TestRunStorage):
     __test__ = True
 
-    def supports_backfill_tags_filtering_queries(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
-
-    def supports_backfill_job_name_filtering_queries(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
-
-    def supports_backfill_id_filtering_queries(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
-
-    def supports_backfills_count(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
-
-    def supports_add_historical_run(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
+    def supports_backfill_tags_filtering_queries(self): return True
+    def supports_backfill_job_name_filtering_queries(self): return True
+    def supports_backfill_id_filtering_queries(self): return True
+    def supports_backfills_count(self): return True
+    def supports_add_historical_run(self): return True
 
     @pytest.fixture(name="instance", scope="function")
-    def instance(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def instance(self):
         with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:
             with instance_for_test(temp_dir=tmpdir_path) as instance:
                 yield instance
 
     @pytest.fixture(name="storage", scope="function")
-    def run_storage(self, instance):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def run_storage(self, instance):
         run_storage = instance.run_storage
         assert isinstance(run_storage, SqliteRunStorage)
         yield run_storage
 
 
+# ----------- In-Memory Run Storage Tests -----------
+
 class TestInMemoryRunStorage(TestRunStorage):
     __test__ = True
 
-    def supports_backfill_tags_filtering_queries(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
-
-    def supports_backfill_job_name_filtering_queries(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
-
-    def supports_backfill_id_filtering_queries(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
-
-    def supports_backfills_count(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
-
-    def supports_add_historical_run(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
+    def supports_backfill_tags_filtering_queries(self): return True
+    def supports_backfill_job_name_filtering_queries(self): return True
+    def supports_backfill_id_filtering_queries(self): return True
+    def supports_backfills_count(self): return True
+    def supports_add_historical_run(self): return True
 
     @pytest.fixture(name="instance", scope="function")
-    def instance(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def instance(self):
         with DagsterInstance.ephemeral() as the_instance:
             yield the_instance
 
     @pytest.fixture(name="storage")
-    def run_storage(self, instance):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def run_storage(self, instance):
         yield instance.run_storage
 
-    def test_storage_telemetry(self, storage):
-        pass
 
+# ----------- Legacy Run Storage Tests -----------
 
 class TestLegacyRunStorage(TestRunStorage):
     __test__ = True
 
-    def supports_backfill_tags_filtering_queries(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
-
-    def supports_backfill_job_name_filtering_queries(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
-
-    def supports_backfill_id_filtering_queries(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
-
-    def supports_backfills_count(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
-
-    def supports_add_historical_run(self):  # pyright: ignore[reportIncompatibleMethodOverride]
-        return True
+    def supports_backfill_tags_filtering_queries(self): return True
+    def supports_backfill_job_name_filtering_queries(self): return True
+    def supports_backfill_id_filtering_queries(self): return True
+    def supports_backfills_count(self): return True
+    def supports_add_historical_run(self): return True
 
     @pytest.fixture(name="instance", scope="function")
-    def instance(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def instance(self):
         with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:
             with instance_for_test(temp_dir=tmpdir_path) as instance:
                 yield instance
 
     @pytest.fixture(name="storage", scope="function")
-    def run_storage(self, instance):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def run_storage(self, instance):
         storage = instance.get_ref().storage
         assert isinstance(storage, DagsterSqliteStorage)
         legacy_storage = LegacyRunStorage(storage)
@@ -137,5 +146,12 @@ class TestLegacyRunStorage(TestRunStorage):
         finally:
             legacy_storage.dispose()
 
-    def test_storage_telemetry(self, storage):
-        pass
+    def test_fetch_records_by_create_timestamp(self, storage, instance):
+        run = instance.create_run_for_pipeline(pipeline_name="demo_pipeline")
+
+        records = instance.get_run_records(
+            filters=RunsFilter(run_ids=[run.run_id])
+        )
+
+        assert len(records) == 1
+        assert records[0].pipeline_run.run_id == run.run_id


### PR DESCRIPTION
This pull request begins the work for [Issue #29596](https://github.com/dagster-io/dagster/issues/29596).

- Filters failed runs to include only those that were never successfully re-executed.
- Shows only the latest failed attempt for each failed run group.

This is an early version for review. Feedback welcome!

