### PR TITLE
Make dagster-dg typer pin less strict

### DIFF
--- a/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg/dagster_dg_tests/cli_tests/test_custom_help_format.py
@@ -80,12 +80,14 @@ def test_root_help_message():
     with fixed_panel_width():
         result = runner.invoke(root, ["--help"])
     assert_runner_result(result)
+
     assert match_terminal_box_output(
         result.output.strip(),
         textwrap.dedent("""
              Usage: root [OPTIONS] COMMAND [ARGS]...
 
              Root group.
+
 
             ╭─ Options ────────────────────────────────────────────────────────────────────╮
             │ --root-opt        TEXT  Root option.                                         │
@@ -114,6 +116,7 @@ def test_sub_group_with_option_help_message():
 
              Sub-group.
 
+
             ╭─ Options ────────────────────────────────────────────────────────────────────╮
             │ --sub-group-opt        TEXT  Sub-group option.                               │
             │ --help                       Show this message and exit.                     │
@@ -140,6 +143,7 @@ def test_sub_group_command_with_option_help_message():
 
              Sub-group-command.
 
+
             ╭─ Options ────────────────────────────────────────────────────────────────────╮
             │ --sub-group-command-opt        TEXT  Sub-group-command option.               │
             │ --help                               Show this message and exit.             │
@@ -162,6 +166,7 @@ def test_sub_command_with_option_help_message():
              Usage: root sub-command [OPTIONS] COMMAND [ARGS]...
 
              Sub-command.
+
 
             ╭─ Options ────────────────────────────────────────────────────────────────────╮
             │ --sub-command-opt        TEXT  Sub-command option.                           │

--- a/python_modules/libraries/dagster-dg/setup.py
+++ b/python_modules/libraries/dagster-dg/setup.py
@@ -49,9 +49,7 @@ setup(
         "setuptools",  # Needed to parse setup.cfg
         "packaging",
         "python-dotenv",
-        # We use some private APIs of typer so we hard-pin here. This shouldn't need to be
-        # frequently updated since is designed to be used from an isolated environment.
-        "typer==0.15.1",
+        "typer<0.17.0",
         f"dagster-shared{pin}",
         f"dagster-cloud-cli{pin}",
     ],


### PR DESCRIPTION
Summary:
Now that dg is in-environment during development, this pin is more onerous than it should be. Add an upper bound limit instead (since typer does do breaking changes from time to time).

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
