### PR TITLE
[dbt] fix components cli option

### DIFF
--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -199,10 +199,13 @@ class DefsFolderComponent(Component):
 
     def iterate_components(self) -> Iterator[Component]:
         for component in self.children.values():
+            yield component
+
             if isinstance(component, DefsFolderComponent):
                 yield from component.iterate_components()
 
-            yield component
+            if isinstance(component, CompositeYamlComponent):
+                yield from component.components
 
 
 EXPLICITLY_IGNORED_GLOB_PATTERNS = [

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -140,6 +140,9 @@ def test_project_prepare_cli(dbt_path: Path) -> None:
         assert result.exit_code == 0
 
         projects = get_projects_from_dbt_component(p)
+
+        assert projects
+
         for p in projects:
             assert p.manifest_path.exists()
 


### PR DESCRIPTION
This was broken when we introduced `CompositeYamlComponent` since the test was missing a crucial assert given how its written

## How I Tested These Changes

add assert to test

## Changelog

[dagster-dbt] the `dagster-dbt` cli flag `--components` flag now correcty finds `DbtProjectComponent` again 
