### PR TITLE
Fix fivetran BK

### DIFF
--- a/python_modules/libraries/dagster-fivetran/tox.ini
+++ b/python_modules/libraries/dagster-fivetran/tox.ini
@@ -16,6 +16,7 @@ deps =
   -e ../dagster-shared
   -e ../dagster-managed-elements
   -e ../dagster-dg[test]
+  -e ../create-dagster
   -e ../dagster-cloud-cli
   -e ../../dagster-graphql
   -e .[test]


### PR DESCRIPTION
## Summary & Motivation
dagster-dg[test] depends on create-dagster now
