### PR TITLE
Introduce `build_asset_check_context`

### DIFF
--- a/docs/sphinx/sections/api/apidocs/dagster/execution.rst
+++ b/docs/sphinx/sections/api/apidocs/dagster/execution.rst
@@ -80,6 +80,12 @@ Contexts
 
 .. autofunction:: build_asset_context
 
+.. autoclass:: AssetCheckExecutionContext
+  :members:
+  :inherited-members:
+
+.. autofunction:: build_asset_check_context
+
 .. autoclass:: TypeCheckContext
   :members:
   :inherited-members:

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -512,6 +512,7 @@ from dagster._core.execution.context.input import (
     build_input_context as build_input_context,
 )
 from dagster._core.execution.context.invocation import (
+    build_asset_check_context as build_asset_check_context,
     build_asset_context as build_asset_context,
     build_op_context as build_op_context,
 )


### PR DESCRIPTION
## Summary

Prompted by user request, introduces `build_asset_check_context`, a peer fn to `build_asset_context` for asset check executions.

## Test Plan

New unit tests.

## Changelog

> Introduced `build_asset_check_context`, which can be used to build asset check contexts for direct invocation:
> ```python
> @asset_check(asset=...)
> def my_check1(context: AssetCheckExecutionContext): ...
> 
> my_check1(build_asset_check_context())
> ```