### PR TITLE
[components] Add flag to disable special autoload handling for definitions.py, component.py

### DIFF
--- a/python_modules/dagster/dagster/components/core/context.py
+++ b/python_modules/dagster/dagster/components/core/context.py
@@ -29,6 +29,7 @@ class ComponentLoadContext:
     defs_module_path: PublicAttr[Path]
     defs_module_name: PublicAttr[str]
     resolution_context: PublicAttr[ResolutionContext]
+    terminate_autoloading_on_keyword_files: bool
 
     @staticmethod
     def current() -> "ComponentLoadContext":
@@ -40,7 +41,11 @@ class ComponentLoadContext:
         return context
 
     @staticmethod
-    def for_module(defs_module: ModuleType, project_root: Path) -> "ComponentLoadContext":
+    def for_module(
+        defs_module: ModuleType,
+        project_root: Path,
+        terminate_autoloading_on_keyword_files: bool = True,
+    ) -> "ComponentLoadContext":
         path = get_path_from_module(defs_module)
         return ComponentLoadContext(
             path=path,
@@ -48,6 +53,7 @@ class ComponentLoadContext:
             defs_module_path=path,
             defs_module_name=defs_module.__name__,
             resolution_context=ResolutionContext.default(),
+            terminate_autoloading_on_keyword_files=terminate_autoloading_on_keyword_files,
         )
 
     @staticmethod
@@ -58,6 +64,7 @@ class ComponentLoadContext:
             defs_module_path=Path.cwd(),
             defs_module_name="test",
             resolution_context=ResolutionContext.default(),
+            terminate_autoloading_on_keyword_files=True,
         )
 
     def _with_resolution_context(

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -130,10 +130,15 @@ def get_component(context: ComponentLoadContext) -> Optional[Component]:
     if _find_defs_or_component_yaml(context.path):
         return load_yaml_component(context)
     # pythonic component
-    elif (context.path / "component.py").exists():
+    elif (
+        context.terminate_autoloading_on_keyword_files and (context.path / "component.py").exists()
+    ):
         return load_pythonic_component(context)
     # defs
-    elif (context.path / "definitions.py").exists():
+    elif (
+        context.terminate_autoloading_on_keyword_files
+        and (context.path / "definitions.py").exists()
+    ):
         return DagsterDefsComponent(path=context.path / "definitions.py")
     elif context.path.suffix == ".py":
         return DagsterDefsComponent(path=context.path)

--- a/python_modules/dagster/dagster/components/core/load_defs.py
+++ b/python_modules/dagster/dagster/components/core/load_defs.py
@@ -65,19 +65,28 @@ def get_project_root(defs_root: ModuleType) -> Path:
 @public
 @preview(emit_runtime_warning=False)
 @suppress_dagster_warnings
-def load_defs(defs_root: ModuleType, project_root: Optional[Path] = None) -> Definitions:
+def load_defs(
+    defs_root: ModuleType,
+    project_root: Optional[Path] = None,
+    terminate_autoloading_on_keyword_files: bool = True,
+) -> Definitions:
     """Constructs a Definitions object, loading all Dagster defs in the given module.
 
     Args:
         defs_root (Path): The path to the defs root, typically `package.defs`.
         project_root (Optional[Path]): path to the project root directory.
+        terminate_autoloading_on_keyword_files (bool): Whether to terminate the defs
+            autoloading process when encountering a definitions.py or component.py file.
+            Defaults to True.
     """
     from dagster.components.core.defs_module import DefsFolderComponent, get_component
 
     project_root = project_root if project_root else get_project_root(defs_root)
 
     # create a top-level DefsModule component from the root module
-    context = ComponentLoadContext.for_module(defs_root, project_root)
+    context = ComponentLoadContext.for_module(
+        defs_root, project_root, terminate_autoloading_on_keyword_files
+    )
     with use_component_load_context(context):
         # Despite the argument being named defs_root, load_defs supports loading arbitrary components
         # directly, so use get_component instead of DefsFolderComponent.get

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/folder_with_component_py/asset.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/folder_with_component_py/asset.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def asset_only_in_asset_py_with_component_py() -> None: ...

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/folder_with_component_py/component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/folder_with_component_py/component.py
@@ -1,0 +1,19 @@
+from dagster import Component, ComponentLoadContext, component
+from dagster._core.definitions.decorators.asset_decorator import asset
+from dagster._core.definitions.definitions_class import Definitions
+
+
+class AComponent(Component):
+    """A simple component class for demonstration purposes."""
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        @asset
+        def asset_in_component_py() -> None: ...
+
+        return Definitions(assets=[asset_in_component_py])
+
+
+@component
+def load(context: ComponentLoadContext) -> Component:
+    """A component that loads a component from the same module."""
+    return AComponent()

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/folder_with_component_py/component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/folder_with_component_py/component.py
@@ -1,4 +1,4 @@
-from dagster import Component, ComponentLoadContext, component
+from dagster import Component, ComponentLoadContext, component_instance
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 
@@ -13,7 +13,7 @@ class AComponent(Component):
         return Definitions(assets=[asset_in_component_py])
 
 
-@component
+@component_instance
 def load(context: ComponentLoadContext) -> Component:
     """A component that loads a component from the same module."""
     return AComponent()

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/folder_with_definitions_py/asset.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/folder_with_definitions_py/asset.py
@@ -1,0 +1,9 @@
+import dagster as dg
+
+
+@dg.asset
+def defs_obj_outer() -> None: ...
+
+
+@dg.asset
+def not_included() -> None: ...

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/folder_with_definitions_py/definitions.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/folder_with_definitions_py/definitions.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def asset_in_definitions_py() -> None: ...

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/folder_with_definitions_py/inner/asset.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/folder_with_definitions_py/inner/asset.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def asset_in_inner() -> None: ...

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/top_level.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/special_names_at_levels/top_level.py
@@ -1,0 +1,5 @@
+import dagster as dg
+
+
+@dg.asset
+def top_level() -> None: ...


### PR DESCRIPTION
## Summary

Moves us to a world where autoloading behavior is more straightforward by adding a flag that turns off the `definitions.py` and `component.py` special branching behavior. These files are treated as normal Python source files if the flag is set. Defaults to off.


```python
    defs = load_defs(
        module,
        project_root=Path(__file__).parent,
        terminate_autoloading_on_keyword_files=False,
    )
```
## Test Plan

New unit test.