### PR TITLE
updated docs for create-dagster and dg separation

### DIFF
--- a/docs/docs/guides/labs/components/components-etl-pipeline-tutorial.md
+++ b/docs/docs/guides/labs/components/components-etl-pipeline-tutorial.md
@@ -43,9 +43,9 @@ See the [`duckdb`](https://duckdb.org/docs/installation/?version=stable&environm
 
 :::
 
-### 2. Install `dg`
+### 2. Install `create-dagster`
 
-Next, follow the [`dg` installation steps](/guides/labs/dg) to install the `dg` command line tool. `dg` allows you to quickly create a components-ready Dagster project.
+The `create-dagster` CLI allows you to quickly create a components-ready Dagster project. We recommend using `uv`, which allows you to run `uvx create-dagster` without a separate installation step. If you're not using `uv`, follow the [`create-dagster` installation steps](/guides/labs/dg#installing-the-create-dagster-cli) to install the `create-dagster` command line tool.
 
 ### 3. Create a new Dagster project
 
@@ -69,12 +69,11 @@ After installing dependencies, create a components-ready Dagster project. The st
         :::
     </TabItem>
     <TabItem value="pip" label="pip">
-        Because `pip` does not support global installations, you will need to install `dg` inside your Dagster project virtual environment. To do so, follow the commands below to create and enter a Dagster project directory, initialize and activate a virtual environment, and install the `dagster-dg` package into it:
+        First initialize and activate a virtual environment:
         <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/2-a-pip-scaffold.txt" />
         <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/2-b-pip-scaffold.txt" />
         <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/2-c-pip-scaffold.txt" />
-        <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/2-d-pip-scaffold.txt" />
-        Next, run `dg scaffold project .` to create a new Dagster project in the current directory:
+        Next, run `create-dagster project .` to create a new Dagster project in the current directory:
         <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/2-e-pip-scaffold.txt" />
         Finally, install the newly created project package into the virtual environment as an [editable install](https://setuptools.pypa.io/en/latest/userguide/development_mode.html):
         <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/index/2-f-pip-scaffold.txt" />
@@ -82,7 +81,7 @@ After installing dependencies, create a components-ready Dagster project. The st
 
 </Tabs>
 
-To learn more about the files, directories, and default settings in a project created with `dg scaffold project`, see "[Creating a project with components](/guides/labs/dg/creating-a-project#project-structure)".
+To learn more about the files, directories, and default settings in a project created with `create-dagster project`, see "[Creating a project with components](/guides/labs/dg/creating-a-project#project-structure)".
 
 ## Ingest data
 

--- a/docs/docs/guides/labs/components/creating-new-component-types/creating-dg-plugin.md
+++ b/docs/docs/guides/labs/components/creating-new-component-types/creating-dg-plugin.md
@@ -16,16 +16,16 @@ commands.
 
 Any Python package can be made into a `dg` plugin by declaring an [entry
 point](https://packaging.python.org/en/latest/specifications/entry-points/)
-under the `dagster_dg.plugin` group in its package metadata:
+under the `dagster_dg_cli.plugin` group in its package metadata:
 
 ```toml
 [project.entry-points]
-"dagster_dg.plugin" = { my_package = "my_package"}
+"dagster_dg_cli.plugin" = { my_package = "my_package"}
 ```
 
 The entry point indicates a module within the package that contains references
 to plugin objects. As you can see, an entry points is defined as a key-value pair
-of strings. For `dagster_dg.plugin` entry points:
+of strings. For `dagster_dg_cli.plugin` entry points:
 
 - The entry point value must be the name of a Python module containing plugin
   object references. By convention, this is usually the top-level module name of
@@ -35,7 +35,7 @@ of strings. For `dagster_dg.plugin` entry points:
   (i.e. the module name).
 
 :::note
-New projects scaffolded by `dg` include a `dagster_dg.plugin` entry point,
+New projects scaffolded by `dg` include a `dagster_dg_cli.plugin` entry point,
 and therefore are `dg` plugins out of the box. This allows a project to define
 project-scoped component types etc.
 :::
@@ -45,7 +45,7 @@ project-scoped component types etc.
 Let's step through the process of converting an existing Python package into a `dg` plugin. We'll:
 
 - Define a custom component type in the package
-- Add a `dagster_dg.plugin` entry point to the package metadata
+- Add a `dagster_dg_cli.plugin` entry point to the package metadata
 - Confirm that the custom component type is available to `dg` commands
 
 Let's start with a basic package called `my_library`. `my_library` is intended
@@ -63,7 +63,7 @@ Since the focus of this guide is on exposing rather than authoring plugin object
   title="src/my_library/empty_component.py"
 />
 
-Now we'll add the `dagster_dg.plugin` entry point to the package metadata.
+Now we'll add the `dagster_dg_cli.plugin` entry point to the package metadata.
 
 Following convention, we add the following entry point to the package metadata:
 
@@ -98,7 +98,7 @@ module.
 :::note
 Python entry points are registered at package installation time. If you are
 developing a library that has already been installed as an editable, and you
-add a `dagster_dg.plugin` entry point to it, the entry point will not be
+add a `dagster_dg_cli.plugin` entry point to it, the entry point will not be
 detected by `dg` until the package is reinstalled with `pip install -e
 path/to/my_library`, `uv pip install path/to/my_library`, or an equivalent command.
 :::

--- a/docs/docs/guides/labs/dg/creating-a-project.md
+++ b/docs/docs/guides/labs/dg/creating-a-project.md
@@ -1,6 +1,6 @@
 ---
-title: 'Creating a project with dg'
-description: Dagster dg allows you to create a special type of Python package, called a project, that defines a Dagster code location.
+title: 'Creating a dg project'
+description: dg allows you to create a special type of Python package, called a project, that defines a Dagster code location.
 sidebar_label: 'Creating a project'
 sidebar_position: 100
 ---
@@ -10,32 +10,26 @@ import InstallUv from '@site/docs/partials/\_InstallUv.md';
 
 <DgComponentsPreview />
 
-`dg` allows you to create a special type of Python package, called a _project_, that defines a [Dagster code location](/deployment/code-locations/managing-code-locations-with-definitions).
-
-:::note
-
-Dagster projects created with `dg` are compatible with Dagster Components. For more information, see the [Dagster Components documentation](/guides/labs/components).
-
-:::
+The `create-dagster` CLI allows you to create a special type of Python package, called a _project_, that defines a [Dagster code location](/deployment/code-locations/managing-code-locations-with-definitions).
 
 ## Prerequisites
 
-Before creating a project with `dg`, you must [install `dg`](/guides/labs/dg#installation).
+Before creating a project, you must [install `create-dagster`](/guides/labs/dg#installing-the-create-dagster-cli). If you're using `uv`, you can run `create-dagster` using `uvx`, without needing to install it first.
 
 ## Creating a project
 
 <Tabs>
   <TabItem value="uv" label="uv">
-    ``` dg scaffold project my-project ```
+    ``` uvx create-dagster project my-project ```
   </TabItem>
-  <TabItem value="pip" label="pip">
-    ``` dg scaffold project my-project ```
+  <TabItem value="non-uv" label="Homebrew, curl, or pip">
+    ``` create-dagster project my-project ```
   </TabItem>
 </Tabs>
 
 ## Project structure
 
-The `dg scaffold project` command creates a directory with a standard Python package structure with some additions:
+The `create-dagster project` command creates a directory with a standard Python package structure with some additions:
 
 <Tabs groupId="package-manager">
   <TabItem value="uv" label="uv">

--- a/docs/docs/guides/labs/dg/incrementally-adopting-dg/migrating-project.md
+++ b/docs/docs/guides/labs/dg/incrementally-adopting-dg/migrating-project.md
@@ -22,12 +22,6 @@ both a case where we have been using [uv](https://docs.astral.sh/uv/) with `pypr
   </TabItem>
 </Tabs>
 
-`dg` needs to be able to resolve a Python environment for your project. This
-environment must include an installation of your project package. By default,
-a project's environment will resolve to whatever virtual environment is
-currently activated in the shell, or system Python if no virtual environment is
-activated.
-
 Before proceeding, we'll make sure we have an activated and up-to-date virtual
 environment in the project root. Having the virtual environment located in the
 project root is recommended (particularly when using `uv`) but not required.
@@ -51,19 +45,13 @@ project root is recommended (particularly when using `uv`) but not required.
 
 ## Install dependencies
 
-### Install the `dg` command line tool
+### Install the `dg` command line tool into your project virtual environment.
 
 <Tabs groupId="package-manager">
   <TabItem value="uv" label="uv">
-    We'll [install `dg` globally](/guides/labs/dg) as a `uv` tool:
     <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/migrating-project/3-uv-install-dg.txt" />
-    This installs `dg` into a hidden, isolated Python environment separate from your project virtual environment. The
-    `dg` executable is always available in the user's `$PATH`, regardless of any virtual environment activation in the
-    shell. This is the recommended way to work with `dg` if you are using `uv`.
   </TabItem>
   <TabItem value="pip" label="pip">
-    Let's install `dg` into your project virtual environment. This is the recommended way to work with `dg` if you are
-    using `pip`.
     <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/migrating-project/3-pip-install-dg.txt" />
   </TabItem>
 </Tabs>
@@ -100,7 +88,7 @@ Now that these settings are in place, you can interact with your project using `
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/migrating-project/5-list-defs.txt" />
 
-### Add a `dagster_dg.plugin` entry point
+### Add a `dagster_dg_cli.plugin` entry point
 
 We're not quite done adding configuration. `dg` uses the Python [entry
 point](https://packaging.python.org/en/latest/specifications/entry-points/) API
@@ -116,7 +104,7 @@ Let's create this submodule now:
 See the [plugin guide](/guides/labs/components/creating-new-component-types/creating-dg-plugin) for more on `dg` plugins.
 :::
 
-We'll need to add a `dagster_dg.plugin` entry point to our project and then
+We'll need to add a `dagster_dg_cli.plugin` entry point to our project and then
 reinstall the project package into our virtual environment. The reinstallation
 step is crucial. Python entry points are registered at package installation
 time, so if you simply add a new entry point to an existing editable-installed

--- a/docs/docs/guides/labs/dg/index.md
+++ b/docs/docs/guides/labs/dg/index.md
@@ -9,17 +9,12 @@ import DgComponentsPreview from '@site/docs/partials/\_DgComponentsPreview.md';
 
 <DgComponentsPreview />
 
-`dg` is a new command line interface that provides a streamlined Dagster development experience. It is a drop-in replacement for the Dagster CLI that can be [used in existing projects](/guides/labs/dg/incrementally-adopting-dg/migrating-project) or used to [scaffold new Dagster projects](/guides/labs/dg/creating-a-project). Once a project is set up to use `dg`, you can list, check, and scaffold Dagster definitions and [components](/guides/labs/components/) with ease.
+`dg` is a new command line interface that provides a streamlined Dagster development experience. It is a drop-in replacement for the Dagster CLI that can be [used in existing projects](/guides/labs/dg/incrementally-adopting-dg/migrating-project) or in [new Dagster projects](/guides/labs/dg/creating-a-project) created with the `create-dagster` CLI. Once a project is set up to use `dg`, you can list, check, and scaffold Dagster definitions and [components](/guides/labs/components/) with ease.
 
-:::note
 
-`dg` is designed to be usable from an isolated environment and has no dependency on `dagster` itself.
+## Installing the create-dagster CLI
 
-:::
-
-## Installation
-
-You can install `dg` with `uv` or `pip`.
+New projects can be created using the `create-dagster` CLI. You can install `create-dagster` from a package manager or via `curl` with our standalone installer script.
 
 <Tabs>
 <TabItem value="uv" label="uv">
@@ -28,37 +23,38 @@ First, install the Python package manager [`uv`](https://docs.astral.sh/uv/) if 
 
 <InstallUv />
 
-Next, use `uv` to install `dg` as a globally available tool:
+We recommend running `create-dagster` using [uvx](https://docs.astral.sh/uv/guides/tools/):
 
-<CliInvocationExample contents="uv tool install dagster-dg" />
+<CliInvocationExample contents="uvx create-dagster project my-project" />
 
-This installs `dg` into a hidden, isolated Python environment. The `dg` executable is always available in your `$PATH`, regardless of any virtual environment activation in the shell.
+This runs `create-dagster` in a temporary, isolated Python environment.
 
-While it is possible to create a virtual environment and install `dagster-dg` into it with `uv`, we recommend a global installation for most users, since it only needs to be done once, and better supports multiple Python projects.
-
-</TabItem>
-<TabItem value="pip" label="pip">
-
-If you are starting a project from scratch, run the following:
-
-```
-mkdir my_project && cd my_project
-```
-
-```
-python -m venv .venv && source .venv/bin/activate
-```
-
-If you are not starting a new project, first activate your desired virtual
-environment, then install `dagster-dg`:
-
-```
-pip install dagster-dg
-```
+While it is also possible to create a virtual environment and install `create-dagster` into it with `uv`, using `uvx` better supports multiple Python projects and doesn't require an explicit install step.
 
 </TabItem>
+
+<TabItem value="brew" label="Homebrew">
+
+`create-dagster` is available in a Homebrew tap:
+
+<CliInvocationExample contents="brew install dagster-io/tap/create-dagster" />
+
+</TabItem>
+
+<TabItem value="curl" label="curl">
+
+Use `curl` to download a standalone installation script and execute it with `sh`:
+
+<CliInvocationExample contents="curl -LsSf https://dagster.io/create-dagster/install.sh | sh" />
+
+Request a specific version by including it in the URL:
+
+<CliInvocationExample contents="curl -LsSf https://dagster.io/create-dagster/1.10.18/install.sh | sh" />
+
+`create-dagster` is available starting at version 1.10.18.
+
+</TabItem>
+
 </Tabs>
 
-## `dg` CLI reference
-
-Once you've installed `dg`, you can run `dg --help` on the command line to see all the commands, or check out the [`dg` CLI documentation](/guides/labs/dg/dagster-dg-cli).
+Once you have `create-dagster` installed (or available to run via `uvx`), see the [creating a new project guide](/guides/labs/dg/creating-a-project) to use it to create `dg` projects.

--- a/docs/docs/guides/labs/dg/multiple-projects.md
+++ b/docs/docs/guides/labs/dg/multiple-projects.md
@@ -2,7 +2,7 @@
 title: 'Managing multiple projects with dg'
 sidebar_label: 'Managing multiple projects'
 sidebar_position: 300
-description: Manage multiple isolated Dagster projects using dg, each with unique environments, by creating a workspace directory with dg scaffold project.
+description: Manage multiple isolated Dagster projects using dg, each with unique environments, by creating a workspace directory with create-dagster project.
 ---
 
 import DgComponentsPreview from '@site/docs/partials/\_DgComponentsPreview.md';
@@ -27,11 +27,11 @@ A workspace does not define a Python environment by default. Instead, Python env
 
 ## Scaffold a new workspace and first project
 
-To scaffold a new workspace called `dagster-workspace`, run `dg scaffold workspace`:
+To scaffold a new workspace called `dagster-workspace`, run `uvx create-dagster workspace`:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/workspace/1-dg-scaffold-workspace.txt" />
 
-Now we'll create a project inside our workspace called `project-1`. Run `dg scaffold project` with the `--python-environment uv_managed` option. You will be prompted for the name of the project:
+Now we'll create a project inside our workspace called `project-1`. Run `uvx create-dagster project` with the `--python-environment uv_managed` option. You will be prompted for the name of the project:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/workspace/2-dg-scaffold-project.txt" />
 

--- a/docs/docs/guides/labs/dg/python-environment-management-and-uv-integration.md
+++ b/docs/docs/guides/labs/dg/python-environment-management-and-uv-integration.md
@@ -42,7 +42,7 @@ The Python environment used for a project is determined by the `tool.dg.project.
   </TabItem>
 </Tabs>
 
-If the setting is `active` (the default), then it is up to the user to manage their own Python environments. If individual project-scoped environments are desired, the user must create them, and ensure the appropriate one is activated when running `dg` commands against that project. We try to guide users in this direction when they run `dg scaffold project`. After a project is scaffolded by `dg scaffold project`, we prompt the user for permission to automatically run `uv sync`, and recommend they immediately activate the newly created virtual environment.
+If the setting is `active` (the default), then it is up to the user to manage their own Python environments. If individual project-scoped environments are desired, the user must create them, and ensure the appropriate one is activated when running `dg` commands against that project. We try to guide users in this direction when they run `create-dagster project`. After a project is scaffolded by `create-dagster project`, we prompt the user for permission to automatically run `uv sync`, and recommend they immediately activate the newly created virtual environment.
 
 If the setting is `uv_managed`, then `dg` will ignore any activated virtual environments. Subprocesses will be launched using `uv run`, which handles resolution of the project-scoped `.venv` environment and ensures subprocesses are launched in that environment. It also ensures that the environment is up to date with the project's specified dependencies before launching a subprocess.
 

--- a/examples/docs_snippets/docs_snippets/guides/components/adding-attributes-to-assets/1-scaffold-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/adding-attributes-to-assets/1-scaffold-project.txt
@@ -1,4 +1,4 @@
-dg scaffold project my-project \
+uvx create-dagster project my-project \
     && cd my-project/src \
     && dg scaffold defs dagster.asset team_a/subproject/a.py \
     && dg scaffold defs dagster.asset team_a/b.py \

--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/1-scaffold-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/1-scaffold-project.txt
@@ -1,4 +1,4 @@
-dg scaffold project my-project \
+uvx create-dagster project my-project \
     && cd my-project/src \
     && uv add dagster-sling \
     && dg scaffold defs dagster_sling.SlingReplicationCollectionComponent my_sling_sync

--- a/examples/docs_snippets/docs_snippets/guides/components/index/2-a-uv-scaffold.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/2-a-uv-scaffold.txt
@@ -1,1 +1,1 @@
-dg scaffold project jaffle-platform
+uvx create-dagster project jaffle-platform

--- a/examples/docs_snippets/docs_snippets/guides/components/index/2-d-pip-scaffold.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/2-d-pip-scaffold.txt
@@ -1,1 +1,1 @@
-pip install dagster-dg
+pip install dagster-dg-cli

--- a/examples/docs_snippets/docs_snippets/guides/components/index/2-e-pip-scaffold.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/2-e-pip-scaffold.txt
@@ -1,1 +1,1 @@
-dg scaffold project .
+create-dagster project .

--- a/examples/docs_snippets/docs_snippets/guides/components/integrations/dlt-component/1-scaffold-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/integrations/dlt-component/1-scaffold-project.txt
@@ -1,1 +1,1 @@
-dg scaffold project my-project && cd my-project/src
+uvx create-dagster project my-project && cd my-project/src

--- a/examples/docs_snippets/docs_snippets/guides/components/integrations/elt-component/1-scaffold-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/integrations/elt-component/1-scaffold-project.txt
@@ -1,4 +1,4 @@
-dg scaffold project my-project --python-environment uv_managed --use-editable-dagster && cd my-project/src
+uvx create-dagster project my-project --python-environment uv_managed --use-editable-dagster && cd my-project/src
 
 Creating a Dagster project at /private/var/folders/bc/4npnrqyd46l4vbbkdsdsw3_h0000gn/T/tmpmqnnt_3b/my-project.
 Scaffolded files for Dagster project at /private/var/folders/bc/4npnrqyd46l4vbbkdsdsw3_h0000gn/T/tmpmqnnt_3b/my-project.

--- a/examples/docs_snippets/docs_snippets/guides/components/integrations/fivetran-component/1-scaffold-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/integrations/fivetran-component/1-scaffold-project.txt
@@ -1,1 +1,1 @@
-dg scaffold project my-project && cd my-project/src
+uvx create-dagster project my-project && cd my-project/src

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/3-pip-install-dg.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/3-pip-install-dg.txt
@@ -1,1 +1,1 @@
-pip install dagster-dg
+pip install dagster-dg-cli

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/3-uv-install-dg.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/3-uv-install-dg.txt
@@ -1,1 +1,1 @@
-uv tool install dagster-dg
+uv add dagster-dg-cli

--- a/examples/docs_snippets/docs_snippets/guides/dg/scaffolding-project/1-scaffolding-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/scaffolding-project/1-scaffolding-project.txt
@@ -1,4 +1,4 @@
-dg scaffold project my-project
+uvx create-dagster project my-project
 
 Creating a Dagster project at /.../my-project.
 Scaffolded files for Dagster project at /.../my-project.

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/1-dg-init.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/1-dg-init.txt
@@ -1,1 +1,1 @@
-dg scaffold project ingestion
+uvx create-dagster project ingestion

--- a/examples/docs_snippets/docs_snippets/guides/dg/workspace/1-dg-scaffold-workspace.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/workspace/1-dg-scaffold-workspace.txt
@@ -1,3 +1,3 @@
-dg scaffold workspace dagster-workspace && cd dagster-workspace
+uvx create-dagster workspace dagster-workspace && cd dagster-workspace
 
 Scaffolded files for Dagster workspace at /.../dagster-workspace.

--- a/examples/docs_snippets/docs_snippets/guides/dg/workspace/2-dg-scaffold-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/workspace/2-dg-scaffold-project.txt
@@ -1,4 +1,4 @@
-dg scaffold project --python-environment uv_managed projects/project-1
+uvx create-dagster project --python-environment uv_managed projects/project-1
 
 Creating a Dagster project at /.../dagster-workspace/projects/project-1.
 Scaffolded files for Dagster project at /.../dagster-workspace/projects/project-1.

--- a/examples/docs_snippets/docs_snippets/guides/dg/workspace/2-dg-scaffold-workspace.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/workspace/2-dg-scaffold-workspace.txt
@@ -1,4 +1,4 @@
-dg scaffold project --python-environment uv_managed projects/project-1
+uvx create-dagster project --python-environment uv_managed projects/project-1
 
 Creating a Dagster project at /.../dagster-workspace/projects/project-1.
 Scaffolded files for Dagster project at /.../dagster-workspace/projects/project-1.

--- a/examples/docs_snippets/docs_snippets/guides/dg/workspace/5-scaffold-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/workspace/5-scaffold-project.txt
@@ -1,4 +1,4 @@
-dg scaffold project projects/project-2 --python-environment uv_managed
+uvx create-dagster project projects/project-2 --python-environment uv_managed
 
 Creating a Dagster project at /.../dagster-workspace/projects/project-2.
 Scaffolded files for Dagster project at /.../dagster-workspace/projects/project-2.

--- a/examples/docs_snippets/docs_snippets/guides/dg/workspace/6-scaffold-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/workspace/6-scaffold-project.txt
@@ -1,4 +1,4 @@
-dg scaffold project projects/project-2 --python-environment uv_managed
+uvx create-dagster project projects/project-2 --python-environment uv_managed
 
 Creating a Dagster project at /.../dagster-workspace/projects/project-2.
 Scaffolded files for Dagster project at /.../dagster-workspace/projects/project-2.

--- a/python_modules/libraries/create-dagster/create_dagster/cli/scaffold.py
+++ b/python_modules/libraries/create-dagster/create_dagster/cli/scaffold.py
@@ -119,10 +119,10 @@ def scaffold_project_command(
     "." may be passed as PATH to create the new project inside the existing working directory.
 
     Examples:
-        dagster-create project PROJECT_NAME
+        create-dagster project PROJECT_NAME
             Scaffold a new project in new directory PROJECT_NAME. Automatically creates directory
             and parent directories.
-        dagster-create project .
+        create-dagster project .
             Scaffold a new project in the CWD. The project name is taken from the last component of the CWD.
 
     Created projects will have the following structure:
@@ -213,10 +213,10 @@ def scaffold_workspace_command(
     """Initialize a new Dagster workspace.
 
     Examples:
-        dagster-create workspace WORKSPACE_NAME
+        create-dagster workspace WORKSPACE_NAME
             Scaffold a new workspace in new directory WORKSPACE_NAME. Automatically creates directory
             and parent directories.
-        dagster-create workspace .
+        create-dagster workspace .
             Scaffold a new workspace in the CWD. The workspace name is the last component of the CWD.
 
     The scaffolded workspace folder has the following structure:

--- a/python_modules/libraries/create-dagster/create_dagster/scaffold.py
+++ b/python_modules/libraries/create-dagster/create_dagster/scaffold.py
@@ -30,7 +30,7 @@ def scaffold_workspace(
     existing_workspace_path = discover_workspace_root(new_workspace_path)
     if existing_workspace_path:
         exit_with_error(
-            f"Workspace already exists at {existing_workspace_path}.  Run `dg scaffold project` to add a new project to that workspace."
+            f"Workspace already exists at {existing_workspace_path}.  Run `create-dagster project` to add a new project to that workspace."
         )
     elif dirname != "." and new_workspace_path.exists():
         exit_with_error(f"Folder already exists at {new_workspace_path}.")

--- a/python_modules/libraries/create-dagster/create_dagster_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/create-dagster/create_dagster_tests/test_scaffold_commands.py
@@ -90,7 +90,7 @@ def test_scaffold_workspace_already_exists_failure(monkeypatch) -> None:
 # At this time all of our tests are against an editable install of dagster. The reason
 # for this is that this package should always be tested against the corresponding version of
 # dagster (i.e. from the same commit), and the only way to achieve this right now is
-# using the editable install variant of `dg scaffold project`.
+# using the editable install variant of `create-dagster project`.
 #
 # Ideally we would have a way to still use the matching dagster-components without using the
 # editable install variant, but this will require somehow configuring uv to ensure that it builds


### PR DESCRIPTION
## Summary & Motivation
The install docs become just how to install create-dagster. Things get a little hairy since everytime you run create-dagster it can now either be vanilla `create-dagster` or `uvx create-dagster` if you're using uv.
