### PR TITLE
Fix dagster-plus/alerts redirects

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -3052,11 +3052,11 @@
     },
     {
       "source": "/dagster-plus/features/alerts",
-      "destination": "/guides/monitor/insights"
+      "destination": "/guides/monitor/alerts"
     },
     {
       "source": "/dagster-plus/features/alerts/:path*",
-      "destination": "/guides/monitor/insights/:path*"
+      "destination": "/guides/monitor/alerts/:path*"
     },
     {
       "source": "/dagster-plus/features//dagster-plus/features/authentication-and-access-control",


### PR DESCRIPTION
## Summary & Motivation

Fixes redirects from /dagster-plus/alerts paths

## How I Tested These Changes

Checked redirects in preview links.

## Changelog

> Insert changelog entry or delete this section.
