### PR TITLE
[dagster-k8s] include dagster/deployment-id label on pods

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -37,6 +37,7 @@ from dagster_k8s.job import (
     get_user_defined_k8s_config,
 )
 from dagster_k8s.launcher import K8sRunLauncher
+from dagster_k8s.utils import get_deployment_id_label
 
 _K8S_EXECUTOR_CONFIG_SCHEMA = merge_dicts(
     DagsterK8sJobConfig.config_type_job(),
@@ -297,6 +298,9 @@ class K8sStepHandler(StepHandler):
             labels["dagster/code-location"] = (
                 run.remote_job_origin.repository_origin.code_location_origin.location_name
             )
+        deployment_name_env_var = get_deployment_id_label(container_context.run_k8s_config)
+        if deployment_name_env_var:
+            labels["dagster/deployment-id"] = deployment_name_env_var
         job = construct_dagster_k8s_job(
             job_config=job_config,
             args=args,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -300,7 +300,7 @@ class K8sStepHandler(StepHandler):
             )
         deployment_name_env_var = get_deployment_id_label(container_context.run_k8s_config)
         if deployment_name_env_var:
-            labels["dagster/deployment-id"] = deployment_name_env_var
+            labels["dagster/deployment-name"] = deployment_name_env_var
         job = construct_dagster_k8s_job(
             job_config=job_config,
             args=args,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -18,6 +18,7 @@ from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster_k8s.client import DagsterKubernetesClient
 from dagster_k8s.container_context import K8sContainerContext
 from dagster_k8s.job import DagsterK8sJobConfig, construct_dagster_k8s_job, get_job_name_from_run_id
+from dagster_k8s.utils import get_deployment_id_label
 
 
 class K8sRunLauncher(RunLauncher, ConfigurableClass):
@@ -231,6 +232,9 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             "dagster/job": job_origin.job_name,
             "dagster/run-id": run.run_id,
         }
+        deployment_name_env_var = get_deployment_id_label(user_defined_k8s_config)
+        if deployment_name_env_var:
+            labels["dagster/deployment-id"] = deployment_name_env_var
         if run.remote_job_origin:
             labels["dagster/code-location"] = (
                 run.remote_job_origin.repository_origin.code_location_origin.location_name

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -234,7 +234,7 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         }
         deployment_name_env_var = get_deployment_id_label(user_defined_k8s_config)
         if deployment_name_env_var:
-            labels["dagster/deployment-id"] = deployment_name_env_var
+            labels["dagster/deployment-name"] = deployment_name_env_var
         if run.remote_job_origin:
             labels["dagster/code-location"] = (
                 run.remote_job_origin.repository_origin.code_location_origin.location_name

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -320,7 +320,7 @@ def execute_k8s_job(
         else None
     )
     if deployment_name_env_var:
-        labels["dagster/deployment-id"] = deployment_name_env_var["value"]
+        labels["dagster/deployment-name"] = deployment_name_env_var["value"]
 
     job = construct_dagster_k8s_job(
         job_config=k8s_job_config,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -313,6 +313,14 @@ def execute_k8s_job(
         labels["dagster/code-location"] = (
             context.dagster_run.remote_job_origin.repository_origin.code_location_origin.location_name
         )
+    env = user_defined_k8s_config.container_config.get("env")
+    deployment_name_env_var = (
+        next((entry for entry in env if entry["name"] == "DAGSTER_CLOUD_DEPLOYMENT_NAME"), None)
+        if env
+        else None
+    )
+    if deployment_name_env_var:
+        labels["dagster/deployment-id"] = deployment_name_env_var["value"]
 
     job = construct_dagster_k8s_job(
         job_config=k8s_job_config,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/utils.py
@@ -1,6 +1,10 @@
 import re
+from typing import TYPE_CHECKING
 
 from dagster import __version__ as dagster_version
+
+if TYPE_CHECKING:
+    from dagster_k8s.job import UserDefinedDagsterK8sConfig
 
 
 def sanitize_k8s_label(label_name: str):
@@ -18,3 +22,13 @@ def get_common_labels():
         "app.kubernetes.io/version": sanitize_k8s_label(dagster_version),
         "app.kubernetes.io/part-of": "dagster",
     }
+
+
+def get_deployment_id_label(user_defined_k8s_config: "UserDefinedDagsterK8sConfig"):
+    env = user_defined_k8s_config.container_config.get("env")
+    deployment_name_env_var = (
+        next((entry for entry in env if entry["name"] == "DAGSTER_CLOUD_DEPLOYMENT_NAME"), None)
+        if env
+        else None
+    )
+    return deployment_name_env_var["value"] if deployment_name_env_var else None

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -518,7 +518,7 @@ def test_step_handler(kubeconfig_file, k8s_instance, deployment_name: str):
     assert labels["dagster/code-location"] == "in_process"
     assert labels["dagster/job"] == "bar"
     assert labels["dagster/run-id"] == run.run_id
-    assert labels.get("dagster/deployment-id") == deployment_name
+    assert labels.get("dagster/deployment-name") == deployment_name
 
 
 def test_step_handler_user_defined_config(kubeconfig_file, k8s_instance):

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -389,7 +389,7 @@ def test_launcher_with_k8s_config(kubeconfig_file, deployment_name: str):
         assert labels["dagster/code-location"] == "in_process"
         assert labels["dagster/job"] == "fake_job"
         assert labels["dagster/run-id"] == run.run_id
-        assert labels.get("dagster/deployment-id") == deployment_name
+        assert labels.get("dagster/deployment-name") == deployment_name
 
 
 def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):


### PR DESCRIPTION
## Summary

If the `DAGSTER_CLOUD_DEPLOYMENT_NAME` env var is set on container context, propagate this info into pod labels for the k8s run launcher and k8s executor, since tracking down a run just by ID on a multi-deployment organization can be quite tricky.

## Test Plan

New unit tests.

## Changelog

> [dagster-k8s] Pods created by the Kubernetes run launcher and executor from Dagster Plus now include the  `dagster/deployment-name` label.