### PR TITLE
[dagster-fivetran] Use connector name as fivetran_assets name in Fivetran asset factory

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -800,18 +800,21 @@ def build_fivetran_assets_definitions(
         connector_selector_fn=connector_selector_fn,
     )
 
-    connector_ids = {
-        check.not_none(FivetranMetadataSet.extract(spec.metadata).connector_id)
+    connectors = {
+        (
+            check.not_none(FivetranMetadataSet.extract(spec.metadata).connector_id),
+            check.not_none(FivetranMetadataSet.extract(spec.metadata).connector_name),
+        )
         for spec in all_asset_specs
     }
 
     _asset_fns = []
-    for connector_id in connector_ids:
+    for connector_id, connector_name in connectors:
 
         @fivetran_assets(
             connector_id=connector_id,
             workspace=workspace,
-            name=connector_id,
+            name=connector_name,
             dagster_fivetran_translator=dagster_fivetran_translator,
             connector_selector_fn=connector_selector_fn,
         )


### PR DESCRIPTION
## Summary & Motivation

Update how we name fivetran assets in the Fivetran asset factory - we use the connector name instead of the connector ID to ease discoverability when looking at a run.
