### PR TITLE
[dg] Add [local] extra to dagster-dg-cli with dagster dependency (BUILD-1241)

### DIFF
--- a/python_modules/libraries/create-dagster/create_dagster/scaffold.py
+++ b/python_modules/libraries/create-dagster/create_dagster/scaffold.py
@@ -189,7 +189,7 @@ EDITABLE_DAGSTER_DEV_DEPENDENCIES = [
 PYPI_DAGSTER_DEPENDENCIES = ["dagster"]
 PYPI_DAGSTER_DEV_DEPENDENCIES = [
     "dagster-webserver",
-    "dagster-dg-cli",
+    "dagster-dg-cli[local]",
 ]
 
 

--- a/python_modules/libraries/create-dagster/create_dagster_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/create-dagster/create_dagster_tests/test_scaffold_commands.py
@@ -363,7 +363,7 @@ def validate_published_pyproject_toml(
     ) == {
         "dev": [
             f"dagster-webserver=={version}",
-            f"dagster-dg-cli=={version}",
+            f"dagster-dg-cli[local]=={version}",
         ]
     }
 

--- a/python_modules/libraries/dagster-dg-cli/setup.py
+++ b/python_modules/libraries/dagster-dg-cli/setup.py
@@ -43,6 +43,9 @@ setup(
         ]
     },
     extras_require={
+        "local": [
+            f"dagster=={ver}",
+        ],
         "mcp": [
             "mcp",
         ],


### PR DESCRIPTION
## Summary & Motivation

- Add a `[local] extra to `dagster-dg-cli`, that installs `dagster` as a pinned dependency
- Change scaffolded deps to install `dagster-dg-cli[local]` for the dev dependency group

## How I Tested These Changes

Existing test suite