### PR TITLE
[ui] Widen suggest component for compute log op selection

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
@@ -175,7 +175,8 @@ export const ComputeLogToolbar = ({
           <div style={{width: 200}}>
             <Suggest
               resetOnClose
-              inputProps={{placeholder: 'Select a step…'}}
+              inputProps={{placeholder: 'Select a step…', style: {width: 500}}}
+              popoverProps={{matchTargetWidth: true}}
               activeItem={computeLogFileKey}
               selectedItem={computeLogFileKey}
               disabled={!steps.length}
@@ -193,6 +194,7 @@ export const ComputeLogToolbar = ({
                   key={item}
                 />
               )}
+              menuWidth={500}
               onItemSelect={(fileKey) => {
                 onSetComputeLogKey(fileKey);
               }}


### PR DESCRIPTION
## Summary & Motivation

The op selection `Suggest` in the compute logs on the Run page is susceptible to cutting off long step names, which can also make it hard to disambiguate different attempts of the same step. To alleviate this, make the input and menu wider.

There is also an open issue to fix selecting a repeated step from the Gantt chart, which currently just (incorrectly) selects the first attempt of the step. That will require a more substantial fix, so I'm trying to make the workaround a little more palatable in the meantime.

<img width="568" alt="Screenshot 2025-05-28 at 14 15 56" src="https://github.com/user-attachments/assets/5da37840-b979-4a25-902b-6831c09deef6" />

## How I Tested These Changes

Execute a run that repeats a step attempt. Verify that the menu is wider.