### PR TITLE
Add UnauthorizedError to the accepted types from the update code location mutation

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/gql.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/gql.py
@@ -197,6 +197,9 @@ mutation CliAddOrUpdateLocation($document: GenericScalar!) {
         ... on InvalidLocationError {
             errors
         }
+        ... on UnauthorizedError {
+            message
+        }
     }
 }
 """


### PR DESCRIPTION
Summary:
Without this an auth failure fails with an inscrutable "key not found" error instead of an "Authorization failed" error.

Test Plan:
Do a dagster-cloud deploy call with a viewer token, clearer error message

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
