### PR TITLE
[docs] hide version dropdown on media queries 996px -> 1200px

### DIFF
--- a/docs/src/styles/custom.scss
+++ b/docs/src/styles/custom.scss
@@ -39,6 +39,10 @@ hr {
     display: none;
   }
 
+  .feedback-nav-link {
+    display: none;
+  }
+
   // reduce navbar item margins on smaller sizes
   .navbar__item {
     margin-right: 8px;

--- a/docs/src/styles/custom.scss
+++ b/docs/src/styles/custom.scss
@@ -28,6 +28,10 @@ hr {
   height: 1px;
 }
 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                             Navbar                                             //
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 .navbar {
   box-shadow: none;
   border-bottom: 1px solid var(--theme-color-keyline);
@@ -84,23 +88,6 @@ hr {
   }
 }
 
-/* Main content */
-.theme-doc-markdown {
-  margin: 0 auto;
-  margin-top: 1rem;
-
-  img {
-    border: 1px solid var(--theme-color-keyline);
-    border-radius: 8px;
-    overflow: hidden;
-  }
-}
-
-/* Custom code for PyObject */
-a.pyobject {
-  color: var(--theme-color-text-default);
-}
-
 .navbar {
   &--dark {
     --ifm-navbar-link-color: var(--theme-color-text-default);
@@ -130,6 +117,16 @@ a.pyobject {
   }
 }
 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                             Search                                             //
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+@media screen and (min-width: 996px) and (max-width: 1200px) {
+  .navbar__search {
+    display: none;
+  }
+}
+
 .DocSearch-Button {
   border-radius: 8px !important;
   background: var(--theme-color-background-default) !important;
@@ -147,6 +144,7 @@ a.pyobject {
     border: 1px solid var(--theme-color-text-lighter) !important;
   }
 }
+
 .DocSearch-Hit-source {
   color: var(--theme-color-text-light) !important;
 }
@@ -162,6 +160,26 @@ a.pyobject {
 
 .DocSearch-Cancel {
   color: var(--theme-color-text-light) !important;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                          Main Content                                          //
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+.theme-doc-markdown {
+  margin: 0 auto;
+  margin-top: 1rem;
+
+  img {
+    border: 1px solid var(--theme-color-keyline);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+}
+
+/* Custom code for PyObject */
+a.pyobject {
+  color: var(--theme-color-text-default);
 }
 
 .footer {
@@ -466,11 +484,8 @@ table {
   color: var(--theme-color-text-light);
 }
 
-@media (max-width: 950px) {
-  .navbar__items .navbar__brand {
-    margin: 0 auto;
-  }
-
+@media (max-width: 996px) {
+  // center logo on smaller displays
   .navbar__items .navbar__brand {
     margin: 0 auto;
   }

--- a/docs/src/styles/custom.scss
+++ b/docs/src/styles/custom.scss
@@ -32,6 +32,24 @@ hr {
 //                                             Navbar                                             //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+
+@media screen and (min-width: 996px) and (max-width: 1272px) {
+  // hide version dropdown on smaller sizes
+  .dropdown--right {
+    display: none;
+  }
+
+  // reduce navbar item margins on smaller sizes
+  .navbar__item {
+    margin-right: 8px;
+  }
+
+  // reduce search bar width on smaller sizes
+  .navbar__search-input {
+    width: 8rem;
+  }
+}
+
 .navbar {
   box-shadow: none;
   border-bottom: 1px solid var(--theme-color-keyline);
@@ -120,12 +138,6 @@ hr {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                             Search                                             //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-
-@media screen and (min-width: 996px) and (max-width: 1200px) {
-  .navbar__search {
-    display: none;
-  }
-}
 
 .DocSearch-Button {
   border-radius: 8px !important;


### PR DESCRIPTION
## Summary & Motivation

Closes DOC-1199.

Hides the version dropdown on pages between 996px and 1200px, this is to resolve an issue with text overlap.

Note, we may prefer to hide a different navigation element, but changing the media query breakpoints themselves is not an easy task.
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/bf6633f3-a387-4476-9426-64a0d5df52f0" />


Before:
<img width="1088" alt="image" src="https://github.com/user-attachments/assets/0325a081-0236-42cd-ae44-6d6c2ee81298" />


## How I Tested These Changes

`yarn start`

## Changelog

NOCHANGELOG
