### PR TITLE
Temporarily pin deltalake < 1.0

### DIFF
--- a/python_modules/libraries/dagster-deltalake/setup.py
+++ b/python_modules/libraries/dagster-deltalake/setup.py
@@ -32,7 +32,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.9,<3.13",
     install_requires=[
-        "deltalake>=0.25.0",
+        "deltalake>=0.25.0,<1",
         f"dagster{pin}",
     ],
     extras_require={


### PR DESCRIPTION
Latest release breaks some of the build. Pinning while we investigate support.