### PR TITLE
[dg] only set DAGSTER_IS_DEV_CLI in dev and list defs

### DIFF
--- a/python_modules/dagster/dagster/components/cli/list.py
+++ b/python_modules/dagster/dagster/components/cli/list.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import sys
 from collections.abc import Sequence
 from pathlib import Path
@@ -136,6 +137,9 @@ def list_definitions_impl(
     location: Optional[str],
     **other_opts: object,
 ) -> list[DgDefinitionMetadata]:
+    # consider list defs a dev cli
+    os.environ["DAGSTER_IS_DEV_CLI"] = "1"
+
     python_pointer_opts = PythonPointerOpts.extract_from_cli_options(other_opts)
     assert_no_remaining_opts(other_opts)
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/__init__.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/__init__.py
@@ -62,8 +62,6 @@ def create_dg_cli():
         **global_options: object,
     ):
         """CLI for managing Dagster projects."""
-        os.environ["DAGSTER_IS_DEV_CLI"] = "1"
-
         context = click.get_current_context()
         if install_completion:
             import dagster_dg_core.completion


### PR DESCRIPTION
Setting it globally has the consequence of causing every execution subprocess of a `launch` command thinking its a dev cli and do things like dbt rebuilds.

Instead of unsetting it in those cases lets just narrow when we do set it. 

`dg dev` is handled by https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_cli/dev.py#L164

so just add it to `list defs` 

## How I Tested These Changes

existing coverage

## Changelog

[dg] the `DAGSTER_IS_DEV_CLI` environment variable is not set more narrowly just in `dg dev` and `dg list defs`
