### PR TITLE
[record] Explicitly error when attaching pydantic.Field to @record

### DIFF
--- a/python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py
@@ -41,6 +41,8 @@ def _get_field_set_and_defaults(
     cls: type,
     kw_only: bool,
 ) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    from pydantic.fields import FieldInfo
+
     field_set = getattr(cls, "__annotations__", {})
     defaults = {}
 
@@ -62,6 +64,12 @@ def _get_field_set_and_defaults(
                     f"Conflicting function for field {name} on record {cls.__name__}. "
                     "If you are trying to set a function as a default value "
                     "you will have to override __new__.",
+                )
+                check.invariant(
+                    not isinstance(attr_val, FieldInfo),
+                    "pydantic.Field is not supported as a default value for @record fields."
+                    " For Resolved subclasses, you may provide additional field metadata"
+                    " through the Resolver: Annotated[..., Resolver.default(description=...)].",
                 )
                 defaults[name] = attr_val
                 last_defaulted_field = name

--- a/python_modules/libraries/dagster-shared/dagster_shared_tests/test_record.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared_tests/test_record.py
@@ -22,7 +22,7 @@ from dagster_shared.record import (
 from dagster_shared.serdes.serdes import deserialize_value, serialize_value, whitelist_for_serdes
 from dagster_shared.utils.cached_method import cached_method
 from dagster_shared.utils.hash import hash_collection
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, Field, TypeAdapter
 
 if TYPE_CHECKING:
     from dagster_shared.utils.test import TestType
@@ -920,3 +920,14 @@ def test_pydantic() -> None:
         optional_custom_list_mapping={"c": [c]},
     )
     assert TypeAdapter(CustomHolder).validate_python(holder)
+
+
+def test_runtime_typecheck_pydantic_field() -> None:
+    with pytest.raises(
+        CheckError, match="pydantic.Field is not supported as a default value for @record fields.*"
+    ):
+
+        @record
+        class MyClass:
+            foo: str = Field(default="foo")
+            bar: Optional[int] = Field(default=None)


### PR DESCRIPTION
## Summary

Alternative to #30232. Points users to use BaseModel instead of @record if trying to attach pydantic.Field metadata to a resolved model field.
