### PR TITLE
[core] allow configuring table via output metadata in DbIOManager

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -263,7 +263,11 @@ class DbIOManager(IOManager):
                         )
                     )
         else:
-            table = output_context.name
+            if "table" in output_context_metadata:
+                table = check.str_param(output_context_metadata["table"], "table")
+            else:
+                table = output_context.name
+
             if output_context_metadata.get("schema"):
                 schema = cast("str", output_context_metadata["schema"])
             elif self._schema:


### PR DESCRIPTION
## Summary & Motivation

Currently the target table always matches the last part of the asset key path.
I feel like it should be possible to configure the table name via metadata instead, just like schema is already configurable. 

## How I Tested These Changes

Added a test

## Changelog

[core] the database table used by the `DbIOManager` is now configurable via `"table"` output (asset) metadata key