### PR TITLE
[dg launch] Add support for workspace options

### DIFF
--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Optional, TypeVar, cast
 
 import click
 from click import UsageError
-from dagster_shared.cli import ClickOption, WorkspaceOpts, apply_click_params
+from dagster_shared.cli import ClickOption, PythonPointerOpts, WorkspaceOpts, apply_click_params
 from dagster_shared.seven import JSONDecodeError, json
 from dagster_shared.yaml_utils import load_yaml_from_glob_list
 from typing_extensions import Never, Self
@@ -293,41 +293,6 @@ def get_job_from_cli_opts(
 # of these decorators is used, the resulting options should be immediately parsed into the
 # corresponding value object at the top of the click command body, by calling
 # `extract_from_cli_options`.
-
-
-@record
-class PythonPointerOpts:
-    python_file: Optional[str] = None
-    module_name: Optional[str] = None
-    package_name: Optional[str] = None
-    working_directory: Optional[str] = None
-    attribute: Optional[str] = None
-    autoload_defs_module_name: Optional[str] = None
-
-    @classmethod
-    def extract_from_cli_options(cls, cli_options: dict[str, Any]) -> Self:
-        # This is expected to always be called from a click entry point, so all options should be
-        # present in the dictionary. We rely on `@record` for type-checking.
-        return cls(
-            python_file=cli_options.pop("python_file", None),
-            module_name=cli_options.pop("module_name", None),
-            package_name=cli_options.pop("package_name", None),
-            working_directory=cli_options.pop("working_directory", None),
-            attribute=cli_options.pop("attribute", None),
-            autoload_defs_module_name=cli_options.pop("autoload_defs_module_name", None),
-        )
-
-    def to_workspace_opts(self) -> "WorkspaceOpts":
-        return WorkspaceOpts(
-            python_file=(self.python_file,) if self.python_file else None,
-            module_name=(self.module_name,) if self.module_name else None,
-            package_name=(self.package_name,) if self.package_name else None,
-            autoload_defs_module_name=self.autoload_defs_module_name
-            if self.autoload_defs_module_name
-            else None,
-            working_directory=self.working_directory,
-            attribute=self.attribute,
-        )
 
 
 def workspace_opts_to_load_target(

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/launch.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/launch.py
@@ -71,10 +71,7 @@ def launch_command(
     else:
         cli_config = normalize_cli_config(other_options, click.get_current_context())
         dg_context = DgContext.for_project_environment(path, cli_config)
-        extra_workspace_opts = {
-            "working_directory": str(dg_context.root_path),
-            "module_name": dg_context.code_location_target_module_name,
-        }
+        extra_workspace_opts = dg_context.target_args
 
     if assets:
         from dagster._cli.asset import asset_materialize_command_impl

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/launch.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/launch.py
@@ -15,20 +15,6 @@ from dagster_shared.cli import WorkspaceOpts, dg_workspace_options
 SINGLETON_REPOSITORY_NAME = "__repository__"
 
 
-OPTIONS_NOT_TO_PASS_ON = {
-    "use_component_modules",
-    "verbose",
-    "disable_cache",
-    "cache_dir",
-    "use_ssl",
-    "grpc_host",
-    "grpc_socket",
-    "grpc_port",
-    "workspace",
-    "empty_workspace",
-}
-
-
 def _args_from_workspace_opts(workspace_opts: WorkspaceOpts) -> dict[str, str]:
     """Converts WorkspaceOpts to a dictionary of arguments of the type that
     dagster job launch or dagster asset materialize expects.

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_launch_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_launch_commands.py
@@ -403,7 +403,7 @@ def test_launch_job_point_to_module_explicitly() -> None:
         assert result.returncode == 0
 
         with Path("src/foo_bar/defs/mydefs/definitions.py").open("w") as f:
-            defs_source = textwrap.dedent(inspect.getsource(_sample_job).split("\n", 1)[1])
+            defs_source = textwrap.dedent(inspect.getsource(_sample_single_job).split("\n", 1)[1])
             f.write(defs_source)
 
         result = subprocess.run(
@@ -411,9 +411,9 @@ def test_launch_job_point_to_module_explicitly() -> None:
                 "dg",
                 "launch",
                 "--module-name",
-                "foo_bar.definitions",
+                "foo_bar.defs.mydefs.definitions",
                 "--job",
-                "my_partitioned_job",
+                "my_job",
             ],
             check=True,
         )
@@ -445,7 +445,7 @@ def test_launch_assets_point_to_module_explicitly() -> None:
                 "dg",
                 "launch",
                 "--module-name",
-                "foo_bar.definitions",
+                "foo_bar.defs.mydefs.definitions",
                 "--assets",
                 "my_asset_1",
             ],

--- a/python_modules/libraries/dagster-shared/dagster_shared/cli/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/cli/__init__.py
@@ -204,3 +204,41 @@ class WorkspaceOpts:
             k for k, v in as_dict(self).items() if v and (k not in {"empty_workspace", "use_ssl"})
         ]
         return bool(set_args)
+
+
+@record
+class PythonPointerOpts:
+    python_file: Optional[str] = None
+    module_name: Optional[str] = None
+    package_name: Optional[str] = None
+    working_directory: Optional[str] = None
+    attribute: Optional[str] = None
+    autoload_defs_module_name: Optional[str] = None
+
+    @classmethod
+    def extract_from_cli_options(cls, cli_options: dict[str, Any]) -> Self:
+        # This is expected to always be called from a click entry point, so all options should be
+        # present in the dictionary. We rely on `@record` for type-checking.
+        return cls(
+            python_file=cli_options.pop("python_file", None),
+            module_name=cli_options.pop("module_name", None),
+            package_name=cli_options.pop("package_name", None),
+            working_directory=cli_options.pop("working_directory", None),
+            attribute=cli_options.pop("attribute", None),
+            autoload_defs_module_name=cli_options.pop("autoload_defs_module_name", None),
+        )
+
+    def to_workspace_opts(self) -> "WorkspaceOpts":
+        return WorkspaceOpts(
+            python_file=(self.python_file,) if self.python_file else None,
+            module_name=(self.module_name,) if self.module_name else None,
+            package_name=(self.package_name,) if self.package_name else None,
+            autoload_defs_module_name=self.autoload_defs_module_name
+            if self.autoload_defs_module_name
+            else None,
+            working_directory=self.working_directory,
+            attribute=self.attribute,
+        )
+
+    def specifies_target(self) -> bool:
+        return bool(self.python_file or self.module_name or self.package_name)


### PR DESCRIPTION
## Summary

Patterned after #30226, adds `dg launch` options which pattern after those available for `dagster job launch` etc which point to code by its path/module/package.

## Test Plan

New unit tests.
