### PR TITLE
[asset health] handle computing health data for assets with no definition

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -300,6 +300,7 @@ const AssetViewImpl = ({assetKey, headerBreadcrumbs, writeAssetVisit, currentPat
         headerBreadcrumbs={headerBreadcrumbs}
         tags={
           <AssetViewPageHeaderTags
+            assetKey={assetKey}
             definition={cachedOrLiveDefinition}
             liveData={liveData}
             onShowUpstream={() => setParams({...params, view: 'lineage', lineageScope: 'upstream'})}
@@ -544,10 +545,12 @@ const HistoricalViewAlert = ({asOf, hasDefinition}: {asOf: string; hasDefinition
 };
 
 const AssetViewPageHeaderTags = ({
+  assetKey,
   definition,
   liveData,
   onShowUpstream,
 }: {
+  assetKey: AssetKey;
   definition: AssetViewDefinitionNodeFragment | AssetTableDefinitionFragment | null | undefined;
   liveData?: LiveDataForNodeWithStaleData;
   onShowUpstream: () => void;
@@ -556,20 +559,22 @@ const AssetViewPageHeaderTags = ({
   // When the old code below is removed, some of these components may no longer be used.
   return (
     <>
-      {definition ? (
-        <Box flex={{direction: 'row', gap: 6, alignItems: 'center'}}>
-          <AssetHealthSummary assetKey={definition.assetKey} />
-          <StaleReasonsTag
-            liveData={liveData}
-            assetKey={definition.assetKey}
-            onClick={onShowUpstream}
-          />
-          <ChangedReasonsTag
-            changedReasons={definition.changedReasons}
-            assetKey={definition.assetKey}
-          />
-        </Box>
-      ) : null}
+      <Box flex={{direction: 'row', gap: 6, alignItems: 'center'}}>
+        <AssetHealthSummary assetKey={assetKey} />
+        {definition ? (
+          <Box>
+            <StaleReasonsTag
+              liveData={liveData}
+              assetKey={definition.assetKey}
+              onClick={onShowUpstream}
+            />
+            <ChangedReasonsTag
+              changedReasons={definition.changedReasons}
+              assetKey={definition.assetKey}
+            />
+          </Box>
+        ) : null}
+      </Box>
       {!definition?.isMaterializable ? <Tag>External Asset</Tag> : undefined}
     </>
   );

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -184,8 +184,7 @@ async def get_materialization_status_and_metadata(
                 meta = GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta(
                     failedRunId=run_id,
                 )
-                if is_currently_failed:
-                    return GrapheneAssetHealthStatus.DEGRADED, meta
+                return GrapheneAssetHealthStatus.DEGRADED, meta
             if has_ever_materialized:
                 return GrapheneAssetHealthStatus.HEALTHY, None
             else:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -42,6 +42,10 @@ async def get_asset_check_status_and_metadata(
         )
     # captures streamline disabled or consumer state doesn't exist
     if asset_check_health_state is None:
+        # Note - this will only compute check health if there is a definition for the asset and checks in the
+        # asset graph. If check results are reported for assets or checks that are not in the asset graph, those
+        # results will not be picked up. If we add storage methods to get all check results for an asset by
+        # asset key, rather than by check keys, we could compute check health for the asset in this case.
         remote_check_nodes = graphene_info.context.asset_graph.get_checks_for_asset(asset_key)
         asset_check_health_state = await AssetCheckHealthState.compute_for_asset_checks(
             {remote_check_node.asset_check.key for remote_check_node in remote_check_nodes},

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_health.py
@@ -7,7 +7,10 @@ from dagster._core.storage.event_log.base import AssetRecord
 from dagster._streamline.asset_check_health import AssetCheckHealthState
 from dagster._streamline.asset_freshness_health import AssetFreshnessHealthState
 from dagster._streamline.asset_health import AssetHealthStatus
-from dagster._streamline.asset_materialization_health import AssetMaterializationHealthState
+from dagster._streamline.asset_materialization_health import (
+    AssetMaterializationHealthState,
+    _get_is_currently_failed_and_latest_terminal_run_id,
+)
 
 if TYPE_CHECKING:
     from dagster_graphql.schema.asset_health import (
@@ -32,14 +35,13 @@ async def get_asset_check_status_and_metadata(
         GrapheneAssetHealthStatus,
     )
 
+    asset_check_health_state = None
     if graphene_info.context.instance.streamline_read_asset_health_supported():
         asset_check_health_state = (
             graphene_info.context.instance.get_asset_check_health_state_for_asset(asset_key)
         )
-        if asset_check_health_state is None:
-            # asset_check_health_state_for is only None if no checks are defined on the asset
-            return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
-    else:
+    # captures streamline disabled or consumer state doesn't exist
+    if asset_check_health_state is None:
         remote_check_nodes = graphene_info.context.asset_graph.get_checks_for_asset(asset_key)
         asset_check_health_state = await AssetCheckHealthState.compute_for_asset_checks(
             {remote_check_node.asset_check.key for remote_check_node in remote_check_nodes},
@@ -104,7 +106,10 @@ async def get_freshness_status_and_metadata(
     if (
         asset_freshness_health_state is None
     ):  # if streamline reads are off or no streamline state exists for the asset compute it from the DB
-        if graphene_info.context.asset_graph.get(asset_key).internal_freshness_policy is None:
+        if (
+            not graphene_info.context.asset_graph.has(asset_key)
+            or graphene_info.context.asset_graph.get(asset_key).internal_freshness_policy is None
+        ):
             return GrapheneAssetHealthStatus.NOT_APPLICABLE, None
         asset_freshness_health_state = AssetFreshnessHealthState.compute_for_asset(
             asset_key,
@@ -163,8 +168,31 @@ async def get_materialization_status_and_metadata(
                 asset_key
             )
         )
-    # captures streamline disabled or consumer state doesn't exist (because it's an observable source asset)
+    # captures streamline disabled or consumer state doesn't exist
     if asset_materialization_health_state is None:
+        if not graphene_info.context.asset_graph.has(asset_key):
+            # if the asset is not in the asset graph, it could be because materializations are reported by
+            # an external system, determine the status as best we can based on the asset record
+            asset_record = await AssetRecord.gen(graphene_info.context, asset_key)
+            if asset_record is None:
+                return GrapheneAssetHealthStatus.UNKNOWN, None
+            has_ever_materialized = asset_record.asset_entry.last_materialization is not None
+            is_currently_failed, run_id = await _get_is_currently_failed_and_latest_terminal_run_id(
+                graphene_info.context, asset_record
+            )
+            if is_currently_failed:
+                meta = GrapheneAssetHealthMaterializationDegradedNotPartitionedMeta(
+                    failedRunId=run_id,
+                )
+                if is_currently_failed:
+                    return GrapheneAssetHealthStatus.DEGRADED, meta
+            if has_ever_materialized:
+                return GrapheneAssetHealthStatus.HEALTHY, None
+            else:
+                if asset_record.asset_entry.last_observation is not None:
+                    return GrapheneAssetHealthStatus.HEALTHY, None
+                return GrapheneAssetHealthStatus.UNKNOWN, None
+
         node_snap = graphene_info.context.asset_graph.get(asset_key)
         if node_snap.is_observable and not node_snap.is_materializable:  # observable source asset
             # get the asset record to see if there is an observation event

--- a/python_modules/dagster-test/dagster_test/toys/asset_health.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_health.py
@@ -34,9 +34,9 @@ def random_3(context, random_1):
     return 1
 
 
-@dg.asset
-def always_materializes():
-    return 1
+# @dg.asset
+# def always_materializes():
+#     return 1
 
 
 @dg.asset
@@ -97,20 +97,20 @@ def random_2_check_sometimes_errors(context):
         return dg.AssetCheckResult(passed=True)
 
 
-@dg.asset_check(asset=always_materializes)
-def always_materializes_check_sometimes_warns(context):
-    if should_fail(context.log):
-        return dg.AssetCheckResult(passed=False, severity=dg.AssetCheckSeverity.WARN)
-    else:
-        return dg.AssetCheckResult(passed=True)
+# @dg.asset_check(asset=always_materializes)
+# def always_materializes_check_sometimes_warns(context):
+#     if should_fail(context.log):
+#         return dg.AssetCheckResult(passed=False, severity=dg.AssetCheckSeverity.WARN)
+#     else:
+#         return dg.AssetCheckResult(passed=True)
 
 
-@dg.asset_check(asset=always_materializes)
-def always_materializes_check_sometimes_errors(context):
-    if should_fail(context.log):
-        return dg.AssetCheckResult(passed=False, severity=dg.AssetCheckSeverity.ERROR)
-    else:
-        return dg.AssetCheckResult(passed=True)
+# @dg.asset_check(asset=always_materializes)
+# def always_materializes_check_sometimes_errors(context):
+#     if should_fail(context.log):
+#         return dg.AssetCheckResult(passed=False, severity=dg.AssetCheckSeverity.ERROR)
+#     else:
+#         return dg.AssetCheckResult(passed=True)
 
 
 @dg.observable_source_asset
@@ -163,7 +163,7 @@ def get_assets_and_checks():
         random_1,
         random_2,
         random_3,
-        always_materializes,
+        # always_materializes,
         always_fails,
         random_failure_partitioned_asset,
         random_1_check_always_warns,
@@ -171,8 +171,8 @@ def get_assets_and_checks():
         random_1_check_always_execution_fails,
         random_2_check_sometimes_warns,
         random_2_check_sometimes_errors,
-        always_materializes_check_sometimes_warns,
-        always_materializes_check_sometimes_errors,
+        # always_materializes_check_sometimes_warns,
+        # always_materializes_check_sometimes_errors,
         observable_source_asset_always_observes,
         observable_source_asset_execution_error,
         observable_source_asset_random_execution_error,


### PR DESCRIPTION
## Summary & Motivation
Some assets have no node on the asset graph (for example, you can report an asset materialization for a key that otherwise has no references in the asset graph, see the new examples added to the toys repo to see an example)

Computing the health for an asset sometimes required getting the node for an asset from the asset graph, this would fail for the kinds of assets described above since there is no node in the asset graph. This PR fixes that by adding a different path for each health component if the asset has no node in the graph. For materialization, we are able to compute some information based on the record in the DB (this falls short if the reported materializations have partitions associated with them, but we don't handle this perfectly in other parts of the UI right now, so i think the current behavior is fine as a starting place). 

For asset checks and freshness, we return NOT_APPLICABLE results if the asset has no definition. Technically you can report check results for an asset that has no definition, but we don't have storage methods to get these check results (you can only fetch results if you have the check key, and you can only get the check keys for an asset via the asset graph), so we don't display them anywhere in the UI right now. A future improvement would be to add these storage methods to allow us to display the check results throughout the UI and compute health based on them.

If streamline is enabled, we are able to report on the check events that are reported for assets that don't have nodes in the asset graph since we can build up the data needed to report health as the events come in and then fetch that data by asset key, rather than needing the check keys


In this screenshot `no_def_observable` and `no_def_materializable` are assets with no definition, but there are jobs the emit observation/materialization events for assets with this these keys. We are now able to show results for them in the UI 
<img width="1900" alt="Screenshot 2025-05-29 at 10 24 01 AM" src="https://github.com/user-attachments/assets/727f54cf-0511-46a1-abea-c78ba5405cd5" />

Also updates the UI so that we show the health status report card on the asset details page for all assets, even if they don't have a definition
<img width="767" alt="Screenshot 2025-05-29 at 11 55 54 AM" src="https://github.com/user-attachments/assets/252643b7-0982-4c8e-93b6-8b2a188dd71a" />

## How I Tested These Changes
new unit tests in https://github.com/dagster-io/internal/pull/16021
