### PR TITLE
[dagster-dbt] Support --selector for build_schedule_from_dbt_selection

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -299,6 +299,7 @@ def build_schedule_from_dbt_selection(
     cron_schedule: str,
     dbt_select: str = DBT_DEFAULT_SELECT,
     dbt_exclude: Optional[str] = DBT_DEFAULT_EXCLUDE,
+    dbt_selector: str = DBT_DEFAULT_SELECTOR,
     schedule_name: Optional[str] = None,
     tags: Optional[Mapping[str, str]] = None,
     config: Optional[RunConfig] = None,
@@ -315,6 +316,7 @@ def build_schedule_from_dbt_selection(
         cron_schedule (str): The cron schedule to define the schedule.
         dbt_select (str): A dbt selection string to specify a set of dbt resources.
         dbt_exclude (Optional[str]): A dbt selection string to exclude a set of dbt resources.
+        dbt_selector (str): A dbt selector to select resources to materialize.
         schedule_name (Optional[str]): The name of the dbt schedule to create.
         tags (Optional[Mapping[str, str]]): A dictionary of tags (string key-value pairs) to attach
             to the scheduled runs.
@@ -351,6 +353,7 @@ def build_schedule_from_dbt_selection(
                 dbt_assets,
                 dbt_select=dbt_select,
                 dbt_exclude=dbt_exclude or DBT_DEFAULT_EXCLUDE,
+                dbt_selector=dbt_selector,
             ),
             config=config,
             tags=tags,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
@@ -14,6 +14,7 @@ from dagster_dbt import DbtManifestAssetSelection, build_schedule_from_dbt_selec
         "cron_schedule",
         "dbt_select",
         "dbt_exclude",
+        "dbt_selector",
         "schedule_name",
         "tags",
         "config",
@@ -26,6 +27,7 @@ from dagster_dbt import DbtManifestAssetSelection, build_schedule_from_dbt_selec
             "0 0 * * *",
             "fqn:*",
             "",
+            "",
             None,
             None,
             None,
@@ -37,6 +39,19 @@ from dagster_dbt import DbtManifestAssetSelection, build_schedule_from_dbt_selec
             "0 * * * *",
             "fqn:*",
             "fqn:staging.*",
+            "",
+            "my_custom_schedule",
+            {"my": "tag"},
+            RunConfig(ops={"my_op": {"config": "value"}}),
+            "America/Vancouver",
+            DefaultScheduleStatus.RUNNING,
+        ),
+        (
+            "test_job",
+            "0 * * * *",
+            "fqn:*",
+            "",
+            "raw_customer_child_models",
             "my_custom_schedule",
             {"my": "tag"},
             RunConfig(ops={"my_op": {"config": "value"}}),
@@ -51,6 +66,7 @@ def test_dbt_build_schedule(
     cron_schedule: str,
     dbt_select: str,
     dbt_exclude: str,
+    dbt_selector: str,
     schedule_name: Optional[str],
     tags: Optional[Mapping[str, str]],
     config: Optional[RunConfig],
@@ -67,6 +83,7 @@ def test_dbt_build_schedule(
         dbt_select=dbt_select,
         schedule_name=schedule_name,
         dbt_exclude=dbt_exclude,
+        dbt_selector=dbt_selector,
         tags=tags,
         config=config,
         execution_timezone=execution_timezone,
@@ -92,5 +109,7 @@ def test_dbt_build_schedule(
     )
     assert dbt_assets_selection.select == "fqn:*"
     assert dbt_assets_selection.exclude == ""
+    assert dbt_assets_selection.selector == ""
     assert job_selection.select == (dbt_select or "fqn:*")
     assert job_selection.exclude == (dbt_exclude or "")
+    assert job_selection.selector == (dbt_selector or "")


### PR DESCRIPTION
## Summary & Motivation

Like we did in https://github.com/dagster-io/dagster/pull/29554 but for dbt schedules

## How I Tested These Changes

Update tests with BK

## Changelog

[dagster-dbt] `build_schedule_from_dbt_selection` now supports a `selector` argument, allowing you to use yaml-based selectors.