### PR TITLE
[ui] Repair live updating for materializing from asset graph

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThreadManager.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThreadManager.tsx
@@ -132,8 +132,13 @@ export class LiveDataThreadManager<T> {
    * so that the keys are re-eligible for fetching again despite the pollRate.
    */
   public invalidateCache(keys?: string[]) {
-    (keys ?? Object.keys(this.lastFetchedOrRequested)).forEach((key) => {
+    const keysToReset = keys ?? Object.keys(this.lastFetchedOrRequested);
+    keysToReset.forEach((key) => {
       delete this.lastFetchedOrRequested[key];
+
+      // After removing a key from the cache, we need to mark it as "unfetched" again
+      // to ensure that it will be included by `determineKeysToFetch`.
+      this.unfetchedKeys.add(key);
     });
   }
 


### PR DESCRIPTION
## Summary & Motivation

It appears that as of https://github.com/dagster-io/dagster/pull/29658, asset statuses are not reliably live-updating when materialized.

This appears to be due to the invalidation of the cache in `LiveDataThreadManager`, which removes the key from the list of `lastFetchedOrRequested` keys but does not re-add the keys to the `unfetchedKeys` list. They are then skipped by `determineKeysToFetch`, and not requested for updates.

Fix this by re-adding the keys to `unfetchedKeys` when invalidating the cache, thus allowing them to be fetched again.

## How I Tested These Changes

Load the app locally, view an asset. Materialize it from the lineage view, verify that the materialization status updates live, including to successful completion of the materialization.

## Changelog

[ui] Fix live updating of asset materialization statuses in asset graph.
