### PR TITLE
[ui] Show relative time for runs in timeline hover list

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
@@ -13,6 +13,8 @@ import {
   useViewport,
 } from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
 import * as React from 'react';
 import {useMemo} from 'react';
 import {Link} from 'react-router-dom';
@@ -38,6 +40,8 @@ import {RepoRow} from '../workspace/VirtualizedWorkspaceTable';
 import {repoAddressAsURLString} from '../workspace/repoAddressAsString';
 import {repoAddressFromPath} from '../workspace/repoAddressFromPath';
 import {RepoAddress} from '../workspace/types';
+
+dayjs.extend(relativeTime);
 
 const ROW_HEIGHT = 32;
 const TIME_HEADER_HEIGHT = 32;
@@ -809,7 +813,7 @@ interface RunHoverContentProps {
   batch: RunBatch<TimelineRun>;
 }
 
-const RunHoverContent = (props: RunHoverContentProps) => {
+export const RunHoverContent = (props: RunHoverContentProps) => {
   const {row, batch} = props;
   const count = batch.runs.length;
   const parentRef = React.useRef<HTMLDivElement | null>(null);
@@ -826,7 +830,7 @@ const RunHoverContent = (props: RunHoverContentProps) => {
   const height = Math.min(count * ROW_HEIGHT, 240);
 
   return (
-    <Box style={{width: '260px'}}>
+    <Box style={{width: '300px'}}>
       <Box padding={12} border="bottom" flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
         <RunTimelineRowIcon type={row.runs[0]?.externalJobSource ? 'airflow' : row.type} />
         <HoverContentRowName>{row.name}</HoverContentRowName>
@@ -849,21 +853,21 @@ const RunHoverContent = (props: RunHoverContentProps) => {
                       {run.status === 'SCHEDULED' ? (
                         'Scheduled'
                       ) : (
-                        <Link to={`/runs/${run.id}`}>
-                          <Mono>{run.id.slice(0, 8)}</Mono>
-                        </Link>
+                        <Link to={`/runs/${run.id}`}>{dayjs(run.startTime).fromNow()}</Link>
                       )}
                     </Box>
-                    <Mono>
+                    <div>
                       {run.status === 'SCHEDULED' ? (
                         <TimestampDisplay timestamp={run.startTime / 1000} />
                       ) : (
-                        <TimeElapsed
-                          startUnix={run.startTime / 1000}
-                          endUnix={run.endTime / 1000}
-                        />
+                        <Mono>
+                          <TimeElapsed
+                            startUnix={run.startTime / 1000}
+                            endUnix={run.endTime / 1000}
+                          />
+                        </Mono>
                       )}
-                    </Mono>
+                    </div>
                   </Box>
                 </Row>
               );


### PR DESCRIPTION
## Summary & Motivation

On the run timeline, when hovering over a run chunk, show the relative time of the runs instead of the sliced run ID. This should hopefully help provide better context about the order of the runs in the list.

<img width="347" alt="Screenshot 2025-05-29 at 14 13 35" src="https://github.com/user-attachments/assets/6afe7811-3cad-40a1-9fa2-befc901a47f2" />


## How I Tested These Changes

Hover on run timeline, verify that relative time is displayed instead of the run ID.

## Changelog

[ui] Show relative start time on runs in run timeline hover lists.
