### PR TITLE
[fix] fix map_asset_specs call on non-spec types in CompositeYamlComponent

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -751,6 +751,18 @@ class Definitions(IHaveNew):
                 )
 
         """
+        return self.map_asset_specs_inner(
+            func=func,
+            selection=selection,
+            _ignore_non_spec_asset_types=False,
+        )
+
+    def map_asset_specs_inner(
+        self,
+        func: Callable[[AssetSpec], AssetSpec],
+        selection: Optional[CoercibleToAssetSelection],
+        _ignore_non_spec_asset_types: bool,
+    ) -> "Definitions":
         target_keys = None
         if selection:
             if isinstance(selection, str):

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -754,14 +754,14 @@ class Definitions(IHaveNew):
         return self.map_asset_specs_inner(
             func=func,
             selection=selection,
-            _ignore_non_spec_asset_types=False,
+            ignore_non_spec_asset_types=False,
         )
 
     def map_asset_specs_inner(
         self,
         func: Callable[[AssetSpec], AssetSpec],
         selection: Optional[CoercibleToAssetSelection],
-        _ignore_non_spec_asset_types: bool,
+        ignore_non_spec_asset_types: bool,
     ) -> "Definitions":
         target_keys = None
         if selection:
@@ -773,7 +773,7 @@ class Definitions(IHaveNew):
         non_spec_asset_types = {
             type(d) for d in self.assets or [] if not isinstance(d, (AssetsDefinition, AssetSpec))
         }
-        if non_spec_asset_types:
+        if non_spec_asset_types and not ignore_non_spec_asset_types:
             raise DagsterInvariantViolationError(
                 "Can only map over AssetSpec or AssetsDefinition objects. "
                 "Received objects of types: "

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -103,7 +103,7 @@ class CompositeYamlComponent(Component):
                         asset_spec=spec,
                     ),
                     selection=None,
-                    _ignore_non_spec_asset_types=True,
+                    ignore_non_spec_asset_types=True,
                 )
                 for component, source_position in zip(self.components, self.source_positions)
             )

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -94,14 +94,16 @@ class CompositeYamlComponent(Component):
 
         return Definitions.merge(
             *(
-                component.build_defs(context).map_asset_specs(
+                component.build_defs(context).map_asset_specs_inner(
                     func=lambda spec: _add_defs_yaml_code_reference_to_spec(
                         component_yaml_path=component_yaml,
                         load_context=context,
                         component=component,
                         source_position=source_position,
                         asset_spec=spec,
-                    )
+                    ),
+                    selection=None,
+                    _ignore_non_spec_asset_types=True,
                 )
                 for component, source_position in zip(self.components, self.source_positions)
             )

--- a/python_modules/dagster/dagster_tests/components_tests/test_code_references.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_code_references.py
@@ -1,0 +1,54 @@
+import tempfile
+from pathlib import Path
+
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
+from dagster._core.definitions.decorators.asset_decorator import asset
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.test_utils import new_cwd
+from dagster.components.component.component import Component
+from dagster.components.core.context import ComponentLoadContext
+from dagster.components.core.defs_module import CompositeYamlComponent
+from dagster_shared.yaml_utils.source_position import LineCol, SourcePosition
+
+
+class MyCacheableAssetsDefinition(CacheableAssetsDefinition):
+    def compute_cacheable_data(self):
+        return []
+
+    def build_definitions(self, data):
+        @asset
+        def my_asset():
+            return 1
+
+        return [my_asset]
+
+
+class CustomComponent(Component):
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        return Definitions(
+            assets=[AssetSpec(key="asset1"), MyCacheableAssetsDefinition(unique_id="my_asset")]
+        )
+
+
+def test_composite_yaml_component_code_references():
+    with tempfile.TemporaryDirectory() as tmpdir, new_cwd(tmpdir):
+        (Path(tmpdir) / "defs.yaml").touch()
+
+        component = CompositeYamlComponent(
+            components=[CustomComponent()],
+            source_positions=[
+                SourcePosition(
+                    filename="test.py", start=LineCol(line=1, col=1), end=LineCol(line=1, col=1)
+                )
+            ],
+        )
+
+        defs = component.build_defs(ComponentLoadContext.for_test())
+        assets = list(defs.assets or [])
+        assert len(assets) == 2
+        spec = next(a for a in assets if isinstance(a, AssetSpec))
+        assert isinstance(spec, AssetSpec)
+        assert "dagster/code_references" in spec.metadata
+        cacheable_asset = next(a for a in assets if isinstance(a, MyCacheableAssetsDefinition))
+        assert isinstance(cacheable_asset, MyCacheableAssetsDefinition)


### PR DESCRIPTION
## Summary

Ignore non `AssetsDefinition`, `AssetSpec` types (cacheable assets, source assets) when mapping over specs to attach code reference info.
