### PR TITLE
Introduce `CronFreshnessPolicy`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -2,15 +2,16 @@ from abc import ABC
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from dagster_shared.serdes.utils import SerializableTimeDelta
 
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._record import IHaveNew, record, record_custom
 from dagster._serdes import deserialize_value, whitelist_for_serdes
+from dagster._time import get_timezone
 from dagster._utils import check
-from dagster._utils.schedules import is_valid_cron_string
+from dagster._utils.schedules import get_smallest_cron_interval, is_valid_cron_string
 
 
 @whitelist_for_serdes
@@ -94,7 +95,11 @@ class TimeWindowFreshnessPolicy(InternalFreshnessPolicy, IHaveNew):
 
 
 @whitelist_for_serdes
-@record_custom
+@record_custom(
+    field_to_new_mapping={
+        "serializable_lower_bound_delta": "lower_bound_delta",
+    }
+)
 class CronFreshnessPolicy(InternalFreshnessPolicy, IHaveNew):
     """Defines a cron schedule on which the asset is expected to materialize.
 
@@ -124,25 +129,52 @@ class CronFreshnessPolicy(InternalFreshnessPolicy, IHaveNew):
     """
 
     deadline_cron: str
-    lower_bound_delta: SerializableTimeDelta
+    serializable_lower_bound_delta: SerializableTimeDelta
     timezone: str
 
-    def __new__(cls, deadline_cron: str, lower_bound_delta: timedelta, timezone: str = "UTC"):
+    def __new__(
+        cls,
+        deadline_cron: str,
+        lower_bound_delta: Union[timedelta, SerializableTimeDelta],
+        timezone: str = "UTC",
+    ):
         check.str_param(deadline_cron, "deadline_cron")
         check.invariant(is_valid_cron_string(deadline_cron), "Invalid cron string.")
 
-        # TODO validate lower bound delta fits within the cron
-        # This will require a method to find the minimum cycle length of the cron schedule
+        # Handle both construction (with timedelta) and deserialization (with SerializableTimeDelta)
+        if isinstance(lower_bound_delta, SerializableTimeDelta):
+            # During deserialization, we already have a SerializableTimeDelta
+            serializable_lower_bound_delta = lower_bound_delta
+            actual_lower_bound_delta = lower_bound_delta.to_timedelta()
+        else:
+            # During normal construction, we have a timedelta and need to convert it
+            actual_lower_bound_delta = lower_bound_delta
+            serializable_lower_bound_delta = SerializableTimeDelta.from_timedelta(lower_bound_delta)
 
+        check.invariant(
+            actual_lower_bound_delta >= timedelta(minutes=1)
+            or actual_lower_bound_delta == timedelta(seconds=0),
+            "Lower bound delta must either be 0 or at least 1 minute.",
+        )
+        check.invariant(
+            actual_lower_bound_delta <= get_smallest_cron_interval(deadline_cron),
+            "Lower bound delta must fit within the cron schedule.",
+        )
+
+        try:
+            get_timezone(timezone)
+        except:
+            raise check.CheckError(f"Invalid timezone: {timezone}")
         return super().__new__(
             cls,
             deadline_cron=deadline_cron,
-            lower_bound_delta=SerializableTimeDelta.from_timedelta(lower_bound_delta),
+            serializable_lower_bound_delta=serializable_lower_bound_delta,
             timezone=timezone,
         )
 
-    def get_lower_bound_delta(self) -> timedelta:
-        return SerializableTimeDelta.to_timedelta(self.lower_bound_delta)
+    @property
+    def lower_bound_delta(self) -> timedelta:
+        return SerializableTimeDelta.to_timedelta(self.serializable_lower_bound_delta)
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -4,7 +4,7 @@ import functools
 import math
 import re
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, Union
 
 import dagster._check as check
 from dagster._core.definitions.partition import ScheduleType
@@ -12,9 +12,6 @@ from dagster._time import get_current_datetime, get_timezone
 from dagster._vendored.croniter import croniter as _croniter
 from dagster._vendored.dateutil.relativedelta import relativedelta
 from dagster._vendored.dateutil.tz import datetime_ambiguous, datetime_exists
-
-if TYPE_CHECKING:
-    from dagster._core.definitions.partition import ScheduleType
 
 # Monthly schedules with 29-31 won't reliably run every month
 MAX_DAY_OF_MONTH_WITH_GUARANTEED_MONTHLY_INTERVAL = 28
@@ -363,15 +360,13 @@ def _find_schedule_time(
     hour: Optional[int],
     day_of_month: Optional[int],
     day_of_week: Optional[int],
-    schedule_type: "ScheduleType",
+    schedule_type: ScheduleType,
     date: datetime.datetime,
     ascending: bool,
     # lets us skip slow work to find the starting point if we know that
     # we are already on the boundary of the cron interval
     already_on_boundary: bool,
 ) -> datetime.datetime:
-    from dagster._core.definitions.partition import ScheduleType
-
     if schedule_type == ScheduleType.HOURLY:
         return _find_hourly_schedule_time(
             check.not_none(minutes), date, ascending, already_on_boundary
@@ -629,8 +624,6 @@ def cron_string_iterator(
     start_offset: int = 0,
 ) -> Iterator[datetime.datetime]:
     """Generator of datetimes >= start_timestamp for the given cron string."""
-    from dagster._core.definitions.partition import ScheduleType
-
     # leap day special casing
     if cron_string.endswith(" 29 2 *"):
         min_hour, _ = cron_string.split(" 29 2 *")

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -4,7 +4,7 @@ import functools
 import math
 import re
 from collections.abc import Iterator, Sequence
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import dagster._check as check
 from dagster._core.definitions.partition import ScheduleType
@@ -12,6 +12,9 @@ from dagster._time import get_current_datetime, get_timezone
 from dagster._vendored.croniter import croniter as _croniter
 from dagster._vendored.dateutil.relativedelta import relativedelta
 from dagster._vendored.dateutil.tz import datetime_ambiguous, datetime_exists
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.partition import ScheduleType
 
 # Monthly schedules with 29-31 won't reliably run every month
 MAX_DAY_OF_MONTH_WITH_GUARANTEED_MONTHLY_INTERVAL = 28
@@ -360,13 +363,15 @@ def _find_schedule_time(
     hour: Optional[int],
     day_of_month: Optional[int],
     day_of_week: Optional[int],
-    schedule_type: ScheduleType,
+    schedule_type: "ScheduleType",
     date: datetime.datetime,
     ascending: bool,
     # lets us skip slow work to find the starting point if we know that
     # we are already on the boundary of the cron interval
     already_on_boundary: bool,
 ) -> datetime.datetime:
+    from dagster._core.definitions.partition import ScheduleType
+
     if schedule_type == ScheduleType.HOURLY:
         return _find_hourly_schedule_time(
             check.not_none(minutes), date, ascending, already_on_boundary
@@ -624,6 +629,8 @@ def cron_string_iterator(
     start_offset: int = 0,
 ) -> Iterator[datetime.datetime]:
     """Generator of datetimes >= start_timestamp for the given cron string."""
+    from dagster._core.definitions.partition import ScheduleType
+
     # leap day special casing
     if cron_string.endswith(" 29 2 *"):
         min_hour, _ = cron_string.split(" 29 2 *")

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -4,14 +4,16 @@ import functools
 import math
 import re
 from collections.abc import Iterator, Sequence
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import dagster._check as check
-from dagster._core.definitions.partition import ScheduleType
 from dagster._time import get_current_datetime, get_timezone
 from dagster._vendored.croniter import croniter as _croniter
 from dagster._vendored.dateutil.relativedelta import relativedelta
 from dagster._vendored.dateutil.tz import datetime_ambiguous, datetime_exists
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.partition import ScheduleType
 
 # Monthly schedules with 29-31 won't reliably run every month
 MAX_DAY_OF_MONTH_WITH_GUARANTEED_MONTHLY_INTERVAL = 28
@@ -360,13 +362,15 @@ def _find_schedule_time(
     hour: Optional[int],
     day_of_month: Optional[int],
     day_of_week: Optional[int],
-    schedule_type: ScheduleType,
+    schedule_type: "ScheduleType",
     date: datetime.datetime,
     ascending: bool,
     # lets us skip slow work to find the starting point if we know that
     # we are already on the boundary of the cron interval
     already_on_boundary: bool,
 ) -> datetime.datetime:
+    from dagster._core.definitions.partition import ScheduleType
+
     if schedule_type == ScheduleType.HOURLY:
         return _find_hourly_schedule_time(
             check.not_none(minutes), date, ascending, already_on_boundary
@@ -624,6 +628,8 @@ def cron_string_iterator(
     start_offset: int = 0,
 ) -> Iterator[datetime.datetime]:
     """Generator of datetimes >= start_timestamp for the given cron string."""
+    from dagster._core.definitions.partition import ScheduleType
+
     # leap day special casing
     if cron_string.endswith(" 29 2 *"):
         min_hour, _ = cron_string.split(" 29 2 *")

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
@@ -174,29 +174,29 @@ def test_internal_freshness_policy_cron_policy_validation() -> None:
     # Valid cron string and lookback, daily
     policy = InternalFreshnessPolicy.cron(
         deadline_cron="0 10 * * *",
-        lookback_window=timedelta(hours=1),
+        lower_bound_delta=timedelta(hours=1),
     )
     assert isinstance(policy, CronFreshnessPolicy)
     assert policy.deadline_cron == "0 10 * * *"
-    assert policy.lookback_window == SerializableTimeDelta.from_timedelta(timedelta(hours=1))
+    assert policy.lower_bound_delta == SerializableTimeDelta.from_timedelta(timedelta(hours=1))
     assert policy.timezone == "UTC"
 
     # Valid cron string and lookback and timezone
     policy = InternalFreshnessPolicy.cron(
         deadline_cron="0 10 * * *",
-        lookback_window=timedelta(hours=1),
+        lower_bound_delta=timedelta(hours=1),
         timezone="America/New_York",
     )
     assert isinstance(policy, CronFreshnessPolicy)
     assert policy.deadline_cron == "0 10 * * *"
-    assert policy.lookback_window == SerializableTimeDelta.from_timedelta(timedelta(hours=1))
+    assert policy.lower_bound_delta == SerializableTimeDelta.from_timedelta(timedelta(hours=1))
     assert policy.timezone == "America/New_York"
 
     # Invalid cron string
     with pytest.raises(CheckError):
         InternalFreshnessPolicy.cron(
             deadline_cron="0 10 * * * *",  # we don't support seconds resolution in the cron
-            lookback_window=timedelta(hours=1),
+            lower_bound_delta=timedelta(hours=1),
         )
 
 
@@ -246,7 +246,7 @@ def test_internal_freshness_policy_apply_to_asset() -> None:
     @asset(
         internal_freshness_policy=InternalFreshnessPolicy.cron(
             deadline_cron="0 10 * * *",
-            lookback_window=timedelta(hours=1),
+            lower_bound_delta=timedelta(hours=1),
             timezone="UTC",
         )
     )
@@ -259,7 +259,9 @@ def test_internal_freshness_policy_apply_to_asset() -> None:
     deserialized = deserialize_value(policy)
     assert isinstance(deserialized, CronFreshnessPolicy)
     assert deserialized.deadline_cron == "0 10 * * *"
-    assert deserialized.lookback_window == SerializableTimeDelta.from_timedelta(timedelta(hours=1))
+    assert deserialized.lower_bound_delta == SerializableTimeDelta.from_timedelta(
+        timedelta(hours=1)
+    )
     assert deserialized.timezone == "UTC"
 
 
@@ -268,15 +270,14 @@ def test_internal_freshness_policy_apply_to_asset_spec() -> None:
         key="foo",
         internal_freshness_policy=InternalFreshnessPolicy.cron(
             deadline_cron="0 10 * * *",
-            lookback_window=timedelta(hours=1),
-            timezone="UTC",
+            lower_bound_delta=timedelta(hours=1),
         ),
     )
     asset_spec = attach_internal_freshness_policy(
         asset_spec,
         InternalFreshnessPolicy.cron(
             deadline_cron="0 10 * * *",
-            lookback_window=timedelta(hours=1),
+            lower_bound_delta=timedelta(hours=1),
             timezone="UTC",
         ),
     )
@@ -284,5 +285,7 @@ def test_internal_freshness_policy_apply_to_asset_spec() -> None:
     deserialized = deserialize_value(asset_spec.metadata[INTERNAL_FRESHNESS_POLICY_METADATA_KEY])
     assert isinstance(deserialized, CronFreshnessPolicy)
     assert deserialized.deadline_cron == "0 10 * * *"
-    assert deserialized.lookback_window == SerializableTimeDelta.from_timedelta(timedelta(hours=1))
+    assert deserialized.lower_bound_delta == SerializableTimeDelta.from_timedelta(
+        timedelta(hours=1)
+    )
     assert deserialized.timezone == "UTC"

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
@@ -19,273 +19,274 @@ from dagster_tests.core_tests.host_representation_tests.test_external_data impor
 )
 
 
-def test_asset_decorator_with_internal_freshness_policy() -> None:
-    """Can we define an asset from decorator with an internal freshness policy?"""
+class TestTimeWindowFreshnessPolicy:
+    def test_asset_decorator_with_time_window_freshness_policy(self) -> None:
+        """Can we define an asset from decorator with a time window freshness policy?"""
 
-    @asset(
-        internal_freshness_policy=TimeWindowFreshnessPolicy.from_timedeltas(
-            fail_window=timedelta(minutes=10), warn_window=timedelta(minutes=5)
+        @asset(
+            internal_freshness_policy=TimeWindowFreshnessPolicy.from_timedeltas(
+                fail_window=timedelta(minutes=10), warn_window=timedelta(minutes=5)
+            )
         )
-    )
-    def asset_with_internal_freshness_policy():
-        pass
+        def asset_with_internal_freshness_policy():
+            pass
 
-    spec = asset_with_internal_freshness_policy.get_asset_spec()
-    policy = spec.metadata.get(INTERNAL_FRESHNESS_POLICY_METADATA_KEY)
-    assert policy is not None
-    deserialized = deserialize_value(policy)
-    assert isinstance(deserialized, TimeWindowFreshnessPolicy)
-    assert deserialized.fail_window == SerializableTimeDelta.from_timedelta(timedelta(minutes=10))
-    assert deserialized.warn_window == SerializableTimeDelta.from_timedelta(timedelta(minutes=5))
-
-
-def test_asset_spec_with_internal_freshness_policy() -> None:
-    """Can we define an asset spec with an internal freshness policy?"""
-
-    def create_spec_and_verify_policy(asset_key: str, fail_window: timedelta, warn_window=None):
-        asset = AssetSpec(
-            key=AssetKey(asset_key),
-            internal_freshness_policy=InternalFreshnessPolicy.time_window(
-                fail_window=fail_window, warn_window=warn_window
-            ),
-        )
-
-        asset_node_snaps = _get_asset_node_snaps_from_definitions(Definitions(assets=[asset]))
-        snap = asset_node_snaps[0]
-        policy = snap.internal_freshness_policy
-        assert isinstance(policy, TimeWindowFreshnessPolicy)
-        assert policy.fail_window == SerializableTimeDelta.from_timedelta(fail_window)
-        if warn_window:
-            assert policy.warn_window == SerializableTimeDelta.from_timedelta(warn_window)
-        else:
-            assert policy.warn_window is None
-
-    # Test without warn window
-    create_spec_and_verify_policy("asset1", fail_window=timedelta(minutes=10))
-
-    # Test with optional warn window
-    create_spec_and_verify_policy(
-        "asset2", fail_window=timedelta(minutes=10), warn_window=timedelta(minutes=5)
-    )
-
-
-def test_attach_internal_freshness_policy() -> None:
-    """Can we attach an internal freshness policy to an asset spec?"""
-
-    def assert_freshness_policy(spec, expected_fail_window, expected_warn_window=None):
-        metadata = spec.metadata
-        assert INTERNAL_FRESHNESS_POLICY_METADATA_KEY in metadata
-        deserialized = deserialize_value(metadata[INTERNAL_FRESHNESS_POLICY_METADATA_KEY])
+        spec = asset_with_internal_freshness_policy.get_asset_spec()
+        policy = spec.metadata.get(INTERNAL_FRESHNESS_POLICY_METADATA_KEY)
+        assert policy is not None
+        deserialized = deserialize_value(policy)
         assert isinstance(deserialized, TimeWindowFreshnessPolicy)
         assert deserialized.fail_window == SerializableTimeDelta.from_timedelta(
-            expected_fail_window
+            timedelta(minutes=10)
         )
-        if expected_warn_window:
-            assert deserialized.warn_window == SerializableTimeDelta.from_timedelta(
-                expected_warn_window
+        assert deserialized.warn_window == SerializableTimeDelta.from_timedelta(
+            timedelta(minutes=5)
+        )
+
+    def test_asset_spec_with_time_window_freshness_policy(self) -> None:
+        """Can we define an asset spec with a time window freshness policy?"""
+
+        def create_spec_and_verify_policy(asset_key: str, fail_window: timedelta, warn_window=None):
+            asset = AssetSpec(
+                key=AssetKey(asset_key),
+                internal_freshness_policy=InternalFreshnessPolicy.time_window(
+                    fail_window=fail_window, warn_window=warn_window
+                ),
             )
-        else:
-            assert deserialized.warn_window is None
 
-    asset_spec = AssetSpec(key="foo")
-    asset_spec = attach_internal_freshness_policy(
-        asset_spec,
-        InternalFreshnessPolicy.time_window(
+            asset_node_snaps = _get_asset_node_snaps_from_definitions(Definitions(assets=[asset]))
+            snap = asset_node_snaps[0]
+            policy = snap.internal_freshness_policy
+            assert isinstance(policy, TimeWindowFreshnessPolicy)
+            assert policy.fail_window == SerializableTimeDelta.from_timedelta(fail_window)
+            if warn_window:
+                assert policy.warn_window == SerializableTimeDelta.from_timedelta(warn_window)
+            else:
+                assert policy.warn_window is None
+
+        # Test without warn window
+        create_spec_and_verify_policy("asset1", fail_window=timedelta(minutes=10))
+
+        # Test with optional warn window
+        create_spec_and_verify_policy(
+            "asset2", fail_window=timedelta(minutes=10), warn_window=timedelta(minutes=5)
+        )
+
+    def test_attach_time_window_freshness_policy(self) -> None:
+        """Can we attach an internal freshness policy to an asset spec?"""
+
+        def assert_freshness_policy(spec, expected_fail_window, expected_warn_window=None):
+            metadata = spec.metadata
+            assert INTERNAL_FRESHNESS_POLICY_METADATA_KEY in metadata
+            deserialized = deserialize_value(metadata[INTERNAL_FRESHNESS_POLICY_METADATA_KEY])
+            assert isinstance(deserialized, TimeWindowFreshnessPolicy)
+            assert deserialized.fail_window == SerializableTimeDelta.from_timedelta(
+                expected_fail_window
+            )
+            if expected_warn_window:
+                assert deserialized.warn_window == SerializableTimeDelta.from_timedelta(
+                    expected_warn_window
+                )
+            else:
+                assert deserialized.warn_window is None
+
+        asset_spec = AssetSpec(key="foo")
+        asset_spec = attach_internal_freshness_policy(
+            asset_spec,
+            InternalFreshnessPolicy.time_window(
+                fail_window=timedelta(minutes=10), warn_window=timedelta(minutes=5)
+            ),
+        )
+        assert_freshness_policy(
+            asset_spec,
+            expected_fail_window=timedelta(minutes=10),
+            expected_warn_window=timedelta(minutes=5),
+        )
+
+        # Overwrite the policy with a new one
+        asset_spec = attach_internal_freshness_policy(
+            asset_spec, InternalFreshnessPolicy.time_window(fail_window=timedelta(minutes=60))
+        )
+        assert_freshness_policy(asset_spec, expected_fail_window=timedelta(minutes=60))
+
+        # Don't overwrite existing metadata
+        spec_with_metadata = AssetSpec(key="bar", metadata={"existing": "metadata"})
+        spec_with_metadata = attach_internal_freshness_policy(
+            spec_with_metadata,
+            InternalFreshnessPolicy.time_window(fail_window=timedelta(minutes=60)),
+        )
+        assert spec_with_metadata.metadata.get("existing") == "metadata"
+        assert_freshness_policy(
+            spec_with_metadata,
+            expected_fail_window=timedelta(minutes=60),
+            expected_warn_window=None,
+        )
+
+    def test_map_asset_specs_attach_time_window_freshness_policy(self) -> None:
+        """Can we map attach_internal_freshness_policy over a selection of assets and asset specs?"""
+
+        @asset
+        def foo_asset():
+            pass
+
+        asset_specs = [foo_asset, AssetSpec(key="bar"), AssetSpec(key="baz")]
+        defs: Definitions = Definitions(assets=asset_specs)
+
+        freshness_policy = TimeWindowFreshnessPolicy.from_timedeltas(
             fail_window=timedelta(minutes=10), warn_window=timedelta(minutes=5)
-        ),
-    )
-    assert_freshness_policy(
-        asset_spec,
-        expected_fail_window=timedelta(minutes=10),
-        expected_warn_window=timedelta(minutes=5),
-    )
-
-    # Overwrite the policy with a new one
-    asset_spec = attach_internal_freshness_policy(
-        asset_spec, InternalFreshnessPolicy.time_window(fail_window=timedelta(minutes=60))
-    )
-    assert_freshness_policy(asset_spec, expected_fail_window=timedelta(minutes=60))
-
-    # Don't overwrite existing metadata
-    spec_with_metadata = AssetSpec(key="bar", metadata={"existing": "metadata"})
-    spec_with_metadata = attach_internal_freshness_policy(
-        spec_with_metadata,
-        InternalFreshnessPolicy.time_window(fail_window=timedelta(minutes=60)),
-    )
-    assert spec_with_metadata.metadata.get("existing") == "metadata"
-    assert_freshness_policy(
-        spec_with_metadata,
-        expected_fail_window=timedelta(minutes=60),
-        expected_warn_window=None,
-    )
-
-
-def test_map_asset_specs_attach_internal_freshness_policy() -> None:
-    """Can we map attach_internal_freshness_policy over a selection of assets and asset specs?"""
-
-    @asset
-    def foo_asset():
-        pass
-
-    asset_specs = [foo_asset, AssetSpec(key="bar"), AssetSpec(key="baz")]
-    defs: Definitions = Definitions(assets=asset_specs)
-
-    freshness_policy = TimeWindowFreshnessPolicy.from_timedeltas(
-        fail_window=timedelta(minutes=10), warn_window=timedelta(minutes=5)
-    )
-    mapped_defs = defs.map_resolved_asset_specs(
-        func=lambda spec: attach_internal_freshness_policy(spec, freshness_policy)
-    )
-
-    assets_and_specs = mapped_defs.assets
-    assert assets_and_specs is not None
-    for asset_or_spec in assets_and_specs:
-        assert isinstance(asset_or_spec, (AssetsDefinition, AssetSpec))
-        spec = (
-            asset_or_spec.get_asset_spec()
-            if isinstance(asset_or_spec, AssetsDefinition)
-            else asset_or_spec
         )
-        assert INTERNAL_FRESHNESS_POLICY_METADATA_KEY in spec.metadata
-        policy = deserialize_value(spec.metadata[INTERNAL_FRESHNESS_POLICY_METADATA_KEY])
-        assert isinstance(policy, TimeWindowFreshnessPolicy)
-        assert policy.fail_window == SerializableTimeDelta.from_timedelta(timedelta(minutes=10))
-        assert policy.warn_window == SerializableTimeDelta.from_timedelta(timedelta(minutes=5))
+        mapped_defs = defs.map_resolved_asset_specs(
+            func=lambda spec: attach_internal_freshness_policy(spec, freshness_policy)
+        )
 
+        assets_and_specs = mapped_defs.assets
+        assert assets_and_specs is not None
+        for asset_or_spec in assets_and_specs:
+            assert isinstance(asset_or_spec, (AssetsDefinition, AssetSpec))
+            spec = (
+                asset_or_spec.get_asset_spec()
+                if isinstance(asset_or_spec, AssetsDefinition)
+                else asset_or_spec
+            )
+            assert INTERNAL_FRESHNESS_POLICY_METADATA_KEY in spec.metadata
+            policy = deserialize_value(spec.metadata[INTERNAL_FRESHNESS_POLICY_METADATA_KEY])
+            assert isinstance(policy, TimeWindowFreshnessPolicy)
+            assert policy.fail_window == SerializableTimeDelta.from_timedelta(timedelta(minutes=10))
+            assert policy.warn_window == SerializableTimeDelta.from_timedelta(timedelta(minutes=5))
 
-def test_internal_freshness_policy_fail_window_validation() -> None:
-    with pytest.raises(CheckError):
-        InternalFreshnessPolicy.time_window(fail_window=timedelta(seconds=59))
+    def test_time_window_freshness_policy_fail_window_validation(self) -> None:
+        with pytest.raises(CheckError):
+            InternalFreshnessPolicy.time_window(fail_window=timedelta(seconds=59))
 
-    with pytest.raises(CheckError):
+        with pytest.raises(CheckError):
+            InternalFreshnessPolicy.time_window(
+                fail_window=timedelta(seconds=59), warn_window=timedelta(seconds=59)
+            )
+
+        # exactly 1 minute is ok
+        InternalFreshnessPolicy.time_window(fail_window=timedelta(seconds=60))
         InternalFreshnessPolicy.time_window(
-            fail_window=timedelta(seconds=59), warn_window=timedelta(seconds=59)
+            fail_window=timedelta(seconds=61), warn_window=timedelta(minutes=1)
+        )
+    
+    def test_attach_time_window_freshness_policy_overwrite_existing() -> None:
+        """Does overwrite_existing respect existing freshness policy on an asset?"""
+
+        @asset
+        def asset_no_policy():
+            pass
+
+        @asset(
+            internal_freshness_policy=InternalFreshnessPolicy.time_window(
+                fail_window=timedelta(hours=24)
+            )
+        )
+        def asset_with_policy():
+            pass
+
+        defs = Definitions(assets=[asset_no_policy, asset_with_policy])
+
+        # If no policy is attached, overwrite with new policy containing fail window of 10 minutes
+        mapped_defs = defs.map_asset_specs(
+            func=lambda spec: attach_internal_freshness_policy(
+                spec,
+                InternalFreshnessPolicy.time_window(fail_window=timedelta(minutes=10)),
+                overwrite_existing=False,
+            )
         )
 
-    # exactly 1 minute is ok
-    InternalFreshnessPolicy.time_window(fail_window=timedelta(seconds=60))
-    InternalFreshnessPolicy.time_window(
-        fail_window=timedelta(seconds=61), warn_window=timedelta(minutes=1)
-    )
+        specs = mapped_defs.get_all_asset_specs()
 
+        # Should see new policy applied to asset without existing policy
+        spec_no_policy = next(spec for spec in specs if spec.key == AssetKey("asset_no_policy"))
+        assert spec_no_policy.metadata.get(INTERNAL_FRESHNESS_POLICY_METADATA_KEY) is not None
+        assert spec_no_policy.metadata[INTERNAL_FRESHNESS_POLICY_METADATA_KEY] == serialize_value(
+            InternalFreshnessPolicy.time_window(fail_window=timedelta(minutes=10))
+        )
 
-def test_internal_freshness_policy_cron_policy_validation() -> None:
-    """Can we define a cron freshness policy?"""
-    # Valid cron string and lookback, daily
-    policy = InternalFreshnessPolicy.cron(
-        deadline_cron="0 10 * * *",
-        lower_bound_delta=timedelta(hours=1),
-    )
-    assert isinstance(policy, CronFreshnessPolicy)
-    assert policy.deadline_cron == "0 10 * * *"
-    assert policy.lower_bound_delta == SerializableTimeDelta.from_timedelta(timedelta(hours=1))
-    assert policy.timezone == "UTC"
-
-    # Valid cron string and lookback and timezone
-    policy = InternalFreshnessPolicy.cron(
-        deadline_cron="0 10 * * *",
-        lower_bound_delta=timedelta(hours=1),
-        timezone="America/New_York",
-    )
-    assert isinstance(policy, CronFreshnessPolicy)
-    assert policy.deadline_cron == "0 10 * * *"
-    assert policy.lower_bound_delta == SerializableTimeDelta.from_timedelta(timedelta(hours=1))
-    assert policy.timezone == "America/New_York"
-
-    # Invalid cron string
-    with pytest.raises(CheckError):
-        InternalFreshnessPolicy.cron(
-            deadline_cron="0 10 * * * *",  # we don't support seconds resolution in the cron
-            lower_bound_delta=timedelta(hours=1),
+        spec_with_policy = next(spec for spec in specs if spec.key == AssetKey("asset_with_policy"))
+        assert spec_with_policy.metadata.get(INTERNAL_FRESHNESS_POLICY_METADATA_KEY) is not None
+        assert spec_with_policy.metadata[INTERNAL_FRESHNESS_POLICY_METADATA_KEY] == serialize_value(
+            InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))
         )
 
 
-def test_attach_internal_freshness_policy_overwrite_existing() -> None:
-    """Does overwrite_existing respect existing freshness policy on an asset?"""
-
-    @asset
-    def asset_no_policy():
-        pass
-
-    @asset(
-        internal_freshness_policy=InternalFreshnessPolicy.time_window(
-            fail_window=timedelta(hours=24)
-        )
-    )
-    def asset_with_policy():
-        pass
-
-    defs = Definitions(assets=[asset_no_policy, asset_with_policy])
-
-    # If no policy is attached, overwrite with new policy containing fail window of 10 minutes
-    mapped_defs = defs.map_asset_specs(
-        func=lambda spec: attach_internal_freshness_policy(
-            spec,
-            InternalFreshnessPolicy.time_window(fail_window=timedelta(minutes=10)),
-            overwrite_existing=False,
-        )
-    )
-
-    specs = mapped_defs.get_all_asset_specs()
-
-    # Should see new policy applied to asset without existing policy
-    spec_no_policy = next(spec for spec in specs if spec.key == AssetKey("asset_no_policy"))
-    assert spec_no_policy.metadata.get(INTERNAL_FRESHNESS_POLICY_METADATA_KEY) is not None
-    assert spec_no_policy.metadata[INTERNAL_FRESHNESS_POLICY_METADATA_KEY] == serialize_value(
-        InternalFreshnessPolicy.time_window(fail_window=timedelta(minutes=10))
-    )
-
-    spec_with_policy = next(spec for spec in specs if spec.key == AssetKey("asset_with_policy"))
-    assert spec_with_policy.metadata.get(INTERNAL_FRESHNESS_POLICY_METADATA_KEY) is not None
-    assert spec_with_policy.metadata[INTERNAL_FRESHNESS_POLICY_METADATA_KEY] == serialize_value(
-        InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))
-    )
-
-
-def test_internal_freshness_policy_apply_to_asset() -> None:
-    @asset(
-        internal_freshness_policy=InternalFreshnessPolicy.cron(
+class TestCronFreshnessPolicy:
+    def test_internal_freshness_policy_cron_policy_validation(self) -> None:
+        """Can we define a cron freshness policy?"""
+        # Valid cron string and lookback, daily
+        policy = InternalFreshnessPolicy.cron(
             deadline_cron="0 10 * * *",
             lower_bound_delta=timedelta(hours=1),
-            timezone="UTC",
         )
-    )
-    def asset_with_internal_freshness_policy():
-        pass
+        assert isinstance(policy, CronFreshnessPolicy)
+        assert policy.deadline_cron == "0 10 * * *"
+        assert policy.lower_bound_delta == SerializableTimeDelta.from_timedelta(timedelta(hours=1))
+        assert policy.timezone == "UTC"
 
-    asset_spec = asset_with_internal_freshness_policy.get_asset_spec()
-    policy = asset_spec.metadata.get(INTERNAL_FRESHNESS_POLICY_METADATA_KEY)
-    assert policy is not None
-    deserialized = deserialize_value(policy)
-    assert isinstance(deserialized, CronFreshnessPolicy)
-    assert deserialized.deadline_cron == "0 10 * * *"
-    assert deserialized.lower_bound_delta == SerializableTimeDelta.from_timedelta(
-        timedelta(hours=1)
-    )
-    assert deserialized.timezone == "UTC"
-
-
-def test_internal_freshness_policy_apply_to_asset_spec() -> None:
-    asset_spec = AssetSpec(
-        key="foo",
-        internal_freshness_policy=InternalFreshnessPolicy.cron(
+        # Valid cron string and lookback and timezone
+        policy = InternalFreshnessPolicy.cron(
             deadline_cron="0 10 * * *",
             lower_bound_delta=timedelta(hours=1),
-        ),
-    )
-    asset_spec = attach_internal_freshness_policy(
-        asset_spec,
-        InternalFreshnessPolicy.cron(
-            deadline_cron="0 10 * * *",
-            lower_bound_delta=timedelta(hours=1),
-            timezone="UTC",
-        ),
-    )
-    assert asset_spec.metadata.get(INTERNAL_FRESHNESS_POLICY_METADATA_KEY) is not None
-    deserialized = deserialize_value(asset_spec.metadata[INTERNAL_FRESHNESS_POLICY_METADATA_KEY])
-    assert isinstance(deserialized, CronFreshnessPolicy)
-    assert deserialized.deadline_cron == "0 10 * * *"
-    assert deserialized.lower_bound_delta == SerializableTimeDelta.from_timedelta(
-        timedelta(hours=1)
-    )
-    assert deserialized.timezone == "UTC"
+            timezone="America/New_York",
+        )
+        assert isinstance(policy, CronFreshnessPolicy)
+        assert policy.deadline_cron == "0 10 * * *"
+        assert policy.lower_bound_delta == SerializableTimeDelta.from_timedelta(timedelta(hours=1))
+        assert policy.timezone == "America/New_York"
+
+        # Invalid cron string
+        with pytest.raises(CheckError):
+            InternalFreshnessPolicy.cron(
+                deadline_cron="0 10 * * * *",  # we don't support seconds resolution in the cron
+                lower_bound_delta=timedelta(hours=1),
+            )
+
+    def test_internal_freshness_policy_apply_to_asset(self) -> None:
+        @asset(
+            internal_freshness_policy=InternalFreshnessPolicy.cron(
+                deadline_cron="0 10 * * *",
+                lower_bound_delta=timedelta(hours=1),
+                timezone="UTC",
+            )
+        )
+        def asset_with_internal_freshness_policy():
+            pass
+
+        asset_spec = asset_with_internal_freshness_policy.get_asset_spec()
+        policy = asset_spec.metadata.get(INTERNAL_FRESHNESS_POLICY_METADATA_KEY)
+        assert policy is not None
+        deserialized = deserialize_value(policy)
+        assert isinstance(deserialized, CronFreshnessPolicy)
+        assert deserialized.deadline_cron == "0 10 * * *"
+        assert deserialized.lower_bound_delta == SerializableTimeDelta.from_timedelta(
+            timedelta(hours=1)
+        )
+        assert deserialized.timezone == "UTC"
+
+    def test_internal_freshness_policy_apply_to_asset_spec(self) -> None:
+        asset_spec = AssetSpec(
+            key="foo",
+            internal_freshness_policy=InternalFreshnessPolicy.cron(
+                deadline_cron="0 10 * * *",
+                lower_bound_delta=timedelta(hours=1),
+            ),
+        )
+        asset_spec = attach_internal_freshness_policy(
+            asset_spec,
+            InternalFreshnessPolicy.cron(
+                deadline_cron="0 10 * * *",
+                lower_bound_delta=timedelta(hours=1),
+                timezone="UTC",
+            ),
+        )
+        assert asset_spec.metadata.get(INTERNAL_FRESHNESS_POLICY_METADATA_KEY) is not None
+        deserialized = deserialize_value(
+            asset_spec.metadata[INTERNAL_FRESHNESS_POLICY_METADATA_KEY]
+        )
+        assert isinstance(deserialized, CronFreshnessPolicy)
+        assert deserialized.deadline_cron == "0 10 * * *"
+        assert deserialized.lower_bound_delta == SerializableTimeDelta.from_timedelta(
+            timedelta(hours=1)
+        )
+        assert deserialized.timezone == "UTC"

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
@@ -168,8 +168,8 @@ class TestTimeWindowFreshnessPolicy:
         InternalFreshnessPolicy.time_window(
             fail_window=timedelta(seconds=61), warn_window=timedelta(minutes=1)
         )
-    
-    def test_attach_time_window_freshness_policy_overwrite_existing() -> None:
+
+    def test_attach_time_window_freshness_policy_overwrite_existing(self) -> None:
         """Does overwrite_existing respect existing freshness policy on an asset?"""
 
         @asset


### PR DESCRIPTION
## Summary & Motivation
Introduce a new freshness policy type `CronFreshnessPolicy`.

This is very similar in behavior to the cron-based portion of last updated freshness checks.

Evaluation code for this policy will initially be implemented in cloud only (https://github.com/dagster-io/internal/pull/16104), and then ported over to OSS along with `TimeWindowFreshnessPolicy`.

## How I Tested These Changes
unit tests
## Changelog

> Insert changelog entry or delete this section.
