### PR TITLE
Don't propagate the telemetry logger to the root logger

### DIFF
--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -13,7 +13,6 @@ For local development:
 import datetime
 import hashlib
 import inspect
-import logging
 import os
 import uuid
 from collections.abc import Mapping, Sequence
@@ -199,18 +198,6 @@ def _check_telemetry_instance_param(
             DagsterInstance,
             f"'instance' argument at position {instance_index} must be a DagsterInstance",
         )
-
-
-# For use in test teardown
-def cleanup_telemetry_logger() -> None:
-    logger = logging.getLogger("dagster_telemetry_logger")
-    if len(logger.handlers) == 0:
-        return
-
-    check.invariant(len(logger.handlers) == 1)
-    handler = next(iter(logger.handlers))
-    handler.close()
-    logger.removeHandler(handler)
 
 
 def _get_instance_telemetry_info(

--- a/python_modules/dagster/dagster_tests/core_tests/test_telemetry_upload.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_telemetry_upload.py
@@ -6,10 +6,10 @@ import pytest
 import responses
 from click.testing import CliRunner
 from dagster._cli.job import job_execute_command
-from dagster._core.telemetry import cleanup_telemetry_logger
 from dagster._core.telemetry_upload import get_dagster_telemetry_url, upload_logs
 from dagster._core.test_utils import environ, instance_for_test
 from dagster._utils import pushd, script_relative_path
+from dagster_shared.telemetry import cleanup_telemetry_logger
 
 
 def path_to_file(path):


### PR DESCRIPTION
## Summary & Motivation
Without this, if anybody adjusts the log level of the root logger, this logger might also write to stdout.

## How I Tested These Changes
With dbt installed, dg list defs no longer prints telemetry logger output

## Changelog
Fixed an issue where `dg` commands would sometimes output extra dagster_telemetry_logger ines to stdout at the end of commands.
