### PR TITLE
[dg list defs] Update dg list defs --path to additionally support  relative path to defs folder

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/list.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/list.py
@@ -265,7 +265,7 @@ def _get_sensors_table(sensors: Sequence[DgSensorMetadata]) -> "Table":
     "--path",
     "-p",
     type=click.Path(
-        resolve_path=True,
+        resolve_path=False,
         path_type=Path,
     ),
     help="Path to the definitions to list.",
@@ -274,7 +274,7 @@ def _get_sensors_table(sensors: Sequence[DgSensorMetadata]) -> "Table":
 @dg_path_options
 @cli_telemetry_wrapper
 def list_defs_command(
-    output_json: bool, target_path: Path, path: Path, **global_options: object
+    output_json: bool, target_path: Path, path: Optional[Path], **global_options: object
 ) -> None:
     """List registered Dagster definitions in the current project environment."""
     from rich.console import Console

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
@@ -354,6 +354,8 @@ def _asset_3():
     "path,should_error,expected_assets,not_expected_assets",
     [
         ("src/foo_bar/defs", False, ["my_asset_1", "my_asset_2", "my_asset_3"], []),
+        # Accepts either relative to cwd or relative to defs
+        ("asset1.py", False, ["my_asset_1"], ["my_asset_2", "my_asset_3"]),
         ("src/foo_bar/defs/asset1.py", False, ["my_asset_1"], ["my_asset_2", "my_asset_3"]),
         (
             "src/foo_bar/defs/subfolder/asset2.py",


### PR DESCRIPTION
## Summary

Updates `dg list defs --path` logic to first check if the path exists, as an absolute path or relative to the CWD. If not, interprets it as a relative path to the `defs` folder. 

## Test Plan

Update unit test.
