### PR TITLE
scaffold_defs_sandbox utility for testing custom component types

### DIFF
--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -1,13 +1,33 @@
+import importlib
+import secrets
+import shutil
+import string
+import sys
+
+import yaml
+from dagster_shared import check
+
 """Testing utilities for components."""
 
-from collections.abc import Mapping
+import json
+import tempfile
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._utils import alter_sys_path
 from dagster.components.component.component import Component
+from dagster.components.component_scaffolding import scaffold_object
 from dagster.components.core.context import ComponentLoadContext
-from dagster.components.core.defs_module import load_yaml_component_from_path
+from dagster.components.core.defs_module import (
+    CompositeYamlComponent,
+    get_component,
+    load_yaml_component_from_path,
+)
+from dagster.components.scaffold.scaffold import ScaffoldFormatOptions
 
 
 def component_defs(
@@ -54,3 +74,235 @@ def defs_from_component_yaml_path(
     context = context or ComponentLoadContext.for_test()
     component = load_yaml_component_from_path(context=context, component_def_path=component_yaml)
     return component_defs(component=component, resources=resources, context=context)
+
+
+def get_original_module_name(cls):
+    """Returns the fully qualified module name where a class was originally declared.
+
+    Args:
+        cls: A class object (not an instance)
+
+    Returns:
+        str: The fully qualified module name (e.g., 'foo.bar.SomeClass')
+
+    Raises:
+        TypeError: If the input is not a class
+        AttributeError: If the class doesn't have proper module information
+    """
+    if not isinstance(cls, type):
+        raise TypeError("Input must be a class, not an instance")
+
+    # Get the module name where the class is defined
+    module_name = cls.__module__
+
+    # Get the class name
+    class_name = cls.__qualname__  # Use __qualname__ to handle nested classes properly
+
+    if not module_name:
+        raise AttributeError(f"Class {cls} has no module name")
+
+    # Combine them to get the fully qualified name
+    return f"{module_name}.{class_name}"
+
+
+def get_underlying_component(context: ComponentLoadContext) -> Optional[Component]:
+    """Loads a component from the given context, resolving the underlying component if
+    it is a CompositeYamlComponent.
+    """
+    component = get_component(context)
+    if isinstance(component, CompositeYamlComponent):
+        assert len(component.components) == 1
+        return component.components[0]
+    return component
+
+
+def random_importable_name(length: int = 8) -> str:
+    """Generate a random string that's guaranteed to be importable as a Python symbol."""
+    # Ensure it starts with a letter (not underscore to avoid special meanings)
+    first_char = secrets.choice(string.ascii_letters)
+
+    # Use only letters and digits for the rest (no underscores for cleaner names)
+    remaining_chars = string.ascii_letters + string.digits
+    remaining = "".join(secrets.choice(remaining_chars) for _ in range(length - 1))
+
+    return "sandbox_module_" + first_char + remaining
+
+
+@dataclass
+class DefsPathSandbox:
+    project_root: Path
+    defs_folder_path: Path
+    component_path: Path
+    project_name: str
+    component_format: ScaffoldFormatOptions
+
+    @contextmanager
+    def swap_defs_file(self, defs_path: Path, component_body: Optional[dict[str, Any]]):
+        check.invariant(
+            defs_path.suffix == ".yaml",
+            "Attributes are only supported for yaml components",
+        )
+        check.invariant(defs_path.exists(), "defs.yaml must exist")
+
+        # no need to override there is no component body
+        if component_body is None:
+            yield
+            return
+
+        temp_dir = Path(tempfile.mkdtemp())
+        temp_path = temp_dir / defs_path.name
+
+        try:
+            shutil.copy2(defs_path, temp_path)
+
+            defs_path.write_text(yaml.safe_dump(component_body))
+
+            yield
+
+        finally:
+            if temp_path.exists():
+                defs_path.unlink(missing_ok=True)
+                shutil.copy2(temp_path, defs_path)
+            shutil.rmtree(temp_dir)
+
+    @contextmanager
+    def load(
+        self, component_body: Optional[dict[str, Any]] = None
+    ) -> Iterator[tuple["Component", "Definitions"]]:
+        defs_path = self.defs_folder_path / "defs.yaml"
+
+        with self.swap_defs_file(defs_path, component_body):
+            with self.load_instance(0) as (component, defs):
+                yield component, defs
+
+    @contextmanager
+    def load_instance(
+        self, instance_key: Union[int, str]
+    ) -> Iterator[tuple[Component, Definitions]]:
+        assert isinstance(instance_key, int)  # only int for now
+        with self.load_all() as components:
+            yield components[instance_key][0], components[instance_key][1]
+
+    @contextmanager
+    def load_all(self) -> Iterator[list[tuple[Component, Definitions]]]:
+        with alter_sys_path(to_add=[str(self.project_root / "src")], to_remove=[]):
+            module_path = f"{self.project_name}.defs.{self.component_path}"
+
+            try:
+                module = importlib.import_module(module_path)
+                context = ComponentLoadContext.for_module(
+                    defs_module=module,
+                    project_root=self.project_root,
+                    terminate_autoloading_on_keyword_files=False,
+                )
+                components = self.flatten_components(get_component(context))
+                yield [(component, component.build_defs(context)) for component in components]
+
+            finally:
+                modules_to_remove = [name for name in sys.modules if name.startswith(module_path)]
+                for name in modules_to_remove:
+                    del sys.modules[name]
+
+    def flatten_components(self, parent_component: Optional[Component]) -> list[Component]:
+        if isinstance(parent_component, CompositeYamlComponent):
+            return list(parent_component.components)
+        elif isinstance(parent_component, Component):
+            return [parent_component]
+        else:
+            return []
+
+
+@contextmanager
+def scaffold_defs_sandbox(
+    *,
+    component_cls: type,
+    component_path: Optional[Union[Path, str]] = None,
+    scaffold_params: Optional[dict[str, Any]] = None,
+    scaffold_format: ScaffoldFormatOptions = "yaml",
+    project_name: Optional[str] = None,
+) -> Iterator[DefsPathSandbox]:
+    """Create a lightweight sandbox to scaffold and instantiate a component. Useful
+    for those authoring component types.
+
+    Scaffold defs sandbox creates a temporary project that mimics the defs folder portion
+    of a real dagster project.
+
+    It then invokes the scaffolder on the component class that produces. After
+    scaffold_defs_sandbox yields a DefsPathSandbox object.
+
+    DefsPathSandbox has a few properties useful for different types of tests:
+
+    * defs_folder_path: The absolute path to the defs folder where the component
+      is scaffolded. The user can inspect and load files that the scaffolder has produced.
+      e.g. (defs_folder_path / "defs.yaml").exists()
+
+    * component_path: The relative path to the component within the defs folder. If not
+      provided, a random name is generated.
+
+    * project_name: If not provided, a random name is generated.
+
+    Once the sandbox is created the user has the option to load the definitions produced
+    by the component using the load method on DefsPathSandbox.
+
+    By default it will produce the component based on the persisted `defs.yaml` file. You
+    can also supply a component body to the load method to override the defs.yaml file with
+    an in-memory component body.
+
+    This sandbox does not provide complete environmental isolation, but does provide some isolation guarantees
+    to do its best to isolate the test from and restore the environment after the test.
+
+    * A file structure like this is created: <<temp folder>> / src / <<project_name>> / defs / <<component_path>>
+    * <<temp folder>> / src is placed in sys.path during the loading process
+    * The last element of the component path is loaded as a namespace package
+    * Any modules loaded during the process that descend from defs module are evicted from sys.modules on cleanup.
+
+    Args:
+        component_cls: The component class to scaffold
+        component_path: Optional path where the component should be scaffolded. It is relative to the defs folder. Defaults to a random name at the root of the defs folder.
+        scaffold_params: Optional parameters to pass to the scaffolder in dictionary form. E.g. if you scaffold a component with dg scaffold defs MyComponent --param-one value-one the scaffold_params should be {"param_one": "value-one"}.
+        scaffold_format: Format to use for scaffolding (default: "yaml"). Can also be "python".
+        project_name: Optional name for the project (default: random name).
+
+    Returns:
+        Iterator[DefsPathSandbox]: A context manager that yields a DefsPathSandbox
+
+    Example:
+
+    .. code-block:: python
+
+        with scaffold_defs_sandbox(component_cls=MyComponent) as sandbox:
+            assert (sandbox.defs_folder_path / "defs.yaml").exists()
+            assert (sandbox.defs_folder_path / "my_component_config_file.yaml").exists()  # produced by MyComponentScaffolder
+
+        with scaffold_defs_sandbox(component_cls=MyComponent, scaffold_params={"asset_key": "my_asset"}) as sandbox:
+            with sandbox.load() as (component, defs):
+                assert isinstance(component, MyComponent)
+                assert defs.get_asset_def("my_asset").key == AssetKey("my_asset")
+
+        with scaffold_defs_sandbox(component_cls=MyComponent) as sandbox:
+            with sandbox.load(component_body={"type": "MyComponent", "attributes": {"asset_key": "different_asset_key"}}) as (component, defs):
+                assert isinstance(component, MyComponent)
+                assert defs.get_asset_def("different_asset_key").key == AssetKey("different_asset_key")
+    """
+    project_name = project_name or random_importable_name()
+    component_path = component_path or random_importable_name()
+    typename = get_original_module_name(component_cls)
+    with tempfile.TemporaryDirectory() as project_root_str:
+        project_root = Path(project_root_str)
+        defs_folder_path = project_root / "src" / project_name / "defs" / component_path
+        defs_folder_path.mkdir(parents=True, exist_ok=True)
+        scaffold_object(
+            path=defs_folder_path,
+            # obj=component_cls,
+            typename=typename,
+            json_params=json.dumps(scaffold_params) if scaffold_params else None,
+            scaffold_format=scaffold_format,
+            project_root=project_root,
+        )
+        yield DefsPathSandbox(
+            project_root=project_root,
+            defs_folder_path=defs_folder_path,
+            project_name=project_name,
+            component_path=Path(component_path),
+            component_format=scaffold_format,
+        )

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
@@ -7,6 +7,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._utils.env import environ
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.defs_module import CompositeYamlComponent, DefsFolderComponent
+from dagster.components.testing import get_underlying_component
 from dagster_shared import check
 from pydantic import ValidationError
 
@@ -14,10 +15,7 @@ from dagster_tests.components_tests.integration_tests.component_loader import (
     chdir as chdir,
     sync_load_test_component_defs,
 )
-from dagster_tests.components_tests.utils import (
-    create_project_from_components,
-    get_underlying_component,
-)
+from dagster_tests.components_tests.utils import create_project_from_components
 
 
 @pytest.mark.parametrize("defs", ["definitions/explicit_file_relative_imports"], indirect=True)

--- a/python_modules/dagster/dagster_tests/components_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/components_tests/utils.py
@@ -16,11 +16,7 @@ from click.testing import Result
 from dagster import Component, ComponentLoadContext, Definitions
 from dagster._utils import alter_sys_path, pushd
 from dagster._utils.pydantic_yaml import enrich_validation_errors_with_source_position
-from dagster.components.core.defs_module import (
-    CompositeYamlComponent,
-    context_with_injected_scope,
-    get_component,
-)
+from dagster.components.core.defs_module import context_with_injected_scope
 from dagster.components.utils import ensure_loadable_path
 from dagster_shared import check
 from dagster_shared.yaml_utils import parse_yaml_with_source_position
@@ -249,14 +245,3 @@ def set_toml_value(doc: tomlkit.TOMLDocument, path: Iterable[str], value: object
     path_list = list(path)
     inner_dict = get_toml_value(doc, path_list[:-1], dict)
     inner_dict[path_list[-1]] = value
-
-
-def get_underlying_component(context: ComponentLoadContext) -> Optional[Component]:
-    """Loads a component from the given context, resolving the underlying component if
-    it is a CompositeYamlComponent.
-    """
-    component = get_component(context)
-    if isinstance(component, CompositeYamlComponent):
-        assert len(component.components) == 1
-        return component.components[0]
-    return component

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -1,7 +1,6 @@
 # ruff: noqa: F841 TID252
 
 import copy
-import importlib
 import inspect
 import subprocess
 import textwrap
@@ -11,17 +10,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import pytest
-import yaml
-from click.testing import CliRunner
 from dagster import AssetKey, ComponentLoadContext
 from dagster._core.definitions import materialize
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.test_utils import ensure_dagster_tests_import
-from dagster._utils import alter_sys_path, pushd
+from dagster._utils import pushd
 from dagster._utils.env import environ
-from dagster_dg_cli.cli import cli
-from dagster_dg_core.utils import ensure_dagster_dg_tests_import
+from dagster.components.testing import scaffold_defs_sandbox
 from dagster_dlt import DagsterDltResource, DltLoadCollectionComponent
 from dagster_dlt.components.dlt_load_collection.component import DltLoadSpecModel
 
@@ -29,16 +24,9 @@ if TYPE_CHECKING:
     from dagster._core.definitions.assets import AssetsDefinition
 
 
-ensure_dagster_tests_import()
-from dagster_tests.components_tests.utils import get_underlying_component
 from dlt import Pipeline
 
 from dagster_dlt_tests.dlt_test_sources.duckdb_with_transformer import pipeline as dlt_source
-
-ensure_dagster_tests_import()
-ensure_dagster_dg_tests_import()
-
-from dagster_dg_core_tests.utils import ProxyRunner, isolated_example_project_foo_bar
 
 
 def dlt_init(source: str, dest: str) -> None:
@@ -47,40 +35,29 @@ def dlt_init(source: str, dest: str) -> None:
 
 
 @contextmanager
-def setup_dlt_ready_project() -> Iterator[None]:
-    with (
-        ProxyRunner.test(use_fixed_test_components=True) as runner,
-        isolated_example_project_foo_bar(runner, in_workspace=False),
-        alter_sys_path(to_add=[str(Path.cwd() / "src")], to_remove=[]),
-    ):
-        yield
-
-
-@contextmanager
 def setup_dlt_component(
-    load_py_contents: Callable, component_body: dict[str, Any], setup_dlt_sources: Callable
+    load_py_contents: Callable,
+    component_body: dict[str, Any],
+    setup_dlt_sources: Callable,
+    project_name: Optional[str] = None,
 ) -> Iterator[tuple[DltLoadCollectionComponent, Definitions]]:
     """Sets up a components project with a dlt component based on provided params."""
-    with setup_dlt_ready_project():
-        defs_path = Path.cwd() / "src" / "foo_bar" / "defs"
-        component_path = defs_path / "ingest"
-        component_path.mkdir(parents=True, exist_ok=True)
-
-        with pushd(str(component_path)):
+    with scaffold_defs_sandbox(
+        component_cls=DltLoadCollectionComponent,
+        scaffold_params={"source": "github", "destination": "snowflake"},
+        component_path="ingest",
+        project_name=project_name,
+    ) as defs_sandbox:
+        with pushd(str(defs_sandbox.defs_folder_path)):
             setup_dlt_sources()
 
-        Path(component_path / "load.py").write_text(
+        Path(defs_sandbox.defs_folder_path / "load.py").write_text(
             textwrap.dedent("\n".join(inspect.getsource(load_py_contents).split("\n")[1:]))
         )
-        (component_path / "defs.yaml").write_text(yaml.safe_dump(component_body))
 
-        defs_root = importlib.import_module("foo_bar.defs.ingest")
-        project_root = Path.cwd()
-
-        context = ComponentLoadContext.for_module(defs_root, project_root)
-        component = get_underlying_component(context)
-        assert isinstance(component, DltLoadCollectionComponent)
-        yield component, component.build_defs(context)
+        with defs_sandbox.load(component_body=component_body) as (component, defs):
+            assert isinstance(component, DltLoadCollectionComponent)
+            yield component, defs
 
 
 def github_load():
@@ -152,6 +129,7 @@ def test_component_load_abs_path_load_py() -> None:
             load_py_contents=github_load,
             component_body=GITHUB_COMPONENT_BODY_WITH_ABSOLUTE_PATH,
             setup_dlt_sources=lambda: dlt_init("github", "snowflake"),
+            project_name="foo_bar",
         ) as (
             component,
             defs,
@@ -347,38 +325,22 @@ def test_python_interface(dlt_pipeline: Pipeline):
     }
 
 
-def test_scaffold_bare_component():
-    runner = CliRunner()
+def test_scaffold_bare_component() -> None:
+    with scaffold_defs_sandbox(component_cls=DltLoadCollectionComponent) as defs_sandbox:
+        assert defs_sandbox.defs_folder_path.exists()
+        assert (defs_sandbox.defs_folder_path / "defs.yaml").exists()
+        assert (defs_sandbox.defs_folder_path / "loads.py").exists()
 
-    with setup_dlt_ready_project() as project_path:
-        result = runner.invoke(
-            cli,
-            [
-                "scaffold",
-                "defs",
-                "dagster_dlt.DltLoadCollectionComponent",
-                "my_barebones_dlt_component",
-                "--format",
-                "yaml",
-            ],
-        )
-        assert result.exit_code == 0
-        assert Path("src/foo_bar/defs/my_barebones_dlt_component/loads.py").exists()
-        assert Path("src/foo_bar/defs/my_barebones_dlt_component/defs.yaml").exists()
+        with defs_sandbox.load() as (component, defs):
+            assert isinstance(component, DltLoadCollectionComponent)
+            assert len(component.loads) == 1
+            assert defs.resolve_asset_graph().get_all_asset_keys() == {
+                AssetKey(["example", "hello_world"]),
+                AssetKey(["my_source_hello_world"]),
+            }
 
-        defs_root = importlib.import_module("foo_bar.defs.my_barebones_dlt_component")
-        project_root = Path.cwd()
 
-        context = ComponentLoadContext.for_module(defs_root, project_root)
-        component = get_underlying_component(context)
-        assert isinstance(component, DltLoadCollectionComponent)
-        defs = component.build_defs(context)
-
-        assert len(component.loads) == 1
-        assert defs.resolve_asset_graph().get_all_asset_keys() == {
-            AssetKey(["example", "hello_world"]),
-            AssetKey(["my_source_hello_world"]),
-        }
+# >>>>>>> 1dbdf22ea8 (Scaffolding infrastructure)
 
 
 @pytest.mark.parametrize(
@@ -388,36 +350,22 @@ def test_scaffold_bare_component():
         ("sql_database", "duckdb"),
     ],
 )
-def test_scaffold_component_with_source_and_destination(source: str, destination: str):
-    runner = CliRunner()
+def test_scaffold_component_with_source_and_destination(source: str, destination: str) -> None:
+    with (
+        scaffold_defs_sandbox(
+            component_cls=DltLoadCollectionComponent,
+            scaffold_params={"source": source, "destination": destination},
+        ) as defs_sandbox,
+        environ({"SOURCES__ACCESS_TOKEN": "fake"}),
+    ):
+        assert defs_sandbox.defs_folder_path.exists()
+        assert (defs_sandbox.defs_folder_path / "defs.yaml").exists()
+        assert (defs_sandbox.defs_folder_path / "loads.py").exists()
 
-    with setup_dlt_ready_project() as project_path, environ({"SOURCES__ACCESS_TOKEN": "fake"}):
-        result = runner.invoke(
-            cli,
-            [
-                "scaffold",
-                "defs",
-                "dagster_dlt.DltLoadCollectionComponent",
-                "my_barebones_dlt_component",
-                "--format",
-                "yaml",
-                "--json-params",
-                f'{{"source": "{source}", "destination": "{destination}"}}',
-            ],
-        )
-        assert result.exit_code == 0, result.output
-        assert Path("src/foo_bar/defs/my_barebones_dlt_component/loads.py").exists()
-        assert Path("src/foo_bar/defs/my_barebones_dlt_component/defs.yaml").exists()
-
-        defs_root = importlib.import_module("foo_bar.defs.my_barebones_dlt_component")
-        project_root = Path.cwd()
-
-        context = ComponentLoadContext.for_module(defs_root, project_root)
-        component = get_underlying_component(context)
-        assert isinstance(component, DltLoadCollectionComponent)
-
-        # scaffolder generates a silly sample load right now because the complex parsing logic is flaky
-        assert len(component.loads) == 1
+        with defs_sandbox.load() as (component, defs):
+            assert isinstance(component, DltLoadCollectionComponent)
+            # scaffolder generates a silly sample load right now because the complex parsing logic is flaky
+            assert len(component.loads) == 1
 
 
 def test_execute_component(dlt_pipeline: Pipeline):

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -340,9 +340,6 @@ def test_scaffold_bare_component() -> None:
             }
 
 
-# >>>>>>> 1dbdf22ea8 (Scaffolding infrastructure)
-
-
 @pytest.mark.parametrize(
     "source, destination",
     [

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import pytest
 import yaml
-from click.testing import CliRunner
 from dagster import AssetKey, ComponentLoadContext
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
@@ -26,17 +25,13 @@ from dagster._utils import alter_sys_path
 from dagster._utils.env import environ
 from dagster.components.resolved.context import ResolutionException
 from dagster.components.resolved.core_models import AssetAttributesModel
-from dagster_dg_cli.cli import cli
+from dagster.components.testing import get_underlying_component, scaffold_defs_sandbox
 from dagster_shared import check
 from dagster_sling import SlingReplicationCollectionComponent, SlingResource
 
 ensure_dagster_tests_import()
 
-from dagster_tests.components_tests.utils import (
-    build_component_defs_for_test,
-    get_underlying_component,
-    temp_code_location_bar,
-)
+from dagster_tests.components_tests.utils import build_component_defs_for_test
 
 if TYPE_CHECKING:
     from dagster._core.definitions.assets import AssetsDefinition
@@ -296,24 +291,32 @@ def test_translation_is_comprehensive():
 
 
 def test_scaffold_sling():
-    runner = CliRunner()
+    # <<<<<<< HEAD
+    #     runner = CliRunner()
 
-    with temp_code_location_bar():
-        result = runner.invoke(
-            cli,
-            [
-                "scaffold",
-                "defs",
-                "dagster_sling.SlingReplicationCollectionComponent",
-                "qux",
-                "--format",
-                "yaml",
-            ],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0
-        assert Path("bar/defs/qux/replication.yaml").exists()
-        assert Path("bar/defs/qux/defs.yaml").exists()
+    #     with temp_code_location_bar():
+    #         result = runner.invoke(
+    #             cli,
+    #             [
+    #                 "scaffold",
+    #                 "defs",
+    #                 "dagster_sling.SlingReplicationCollectionComponent",
+    #                 "qux",
+    #                 "--format",
+    #                 "yaml",
+    #             ],
+    #             catch_exceptions=False,
+    #         )
+    #         assert result.exit_code == 0
+    #         assert Path("bar/defs/qux/replication.yaml").exists()
+    #         assert Path("bar/defs/qux/defs.yaml").exists()
+    # =======
+    with scaffold_defs_sandbox(component_cls=SlingReplicationCollectionComponent) as defs_sandbox:
+        assert (defs_sandbox.defs_folder_path / "defs.yaml").exists()
+        assert (defs_sandbox.defs_folder_path / "replication.yaml").exists()
+
+
+# >>>>>>> 1dbdf22ea8 (Scaffolding infrastructure)
 
 
 def test_spec_is_available_in_scope() -> None:

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -291,32 +291,9 @@ def test_translation_is_comprehensive():
 
 
 def test_scaffold_sling():
-    # <<<<<<< HEAD
-    #     runner = CliRunner()
-
-    #     with temp_code_location_bar():
-    #         result = runner.invoke(
-    #             cli,
-    #             [
-    #                 "scaffold",
-    #                 "defs",
-    #                 "dagster_sling.SlingReplicationCollectionComponent",
-    #                 "qux",
-    #                 "--format",
-    #                 "yaml",
-    #             ],
-    #             catch_exceptions=False,
-    #         )
-    #         assert result.exit_code == 0
-    #         assert Path("bar/defs/qux/replication.yaml").exists()
-    #         assert Path("bar/defs/qux/defs.yaml").exists()
-    # =======
     with scaffold_defs_sandbox(component_cls=SlingReplicationCollectionComponent) as defs_sandbox:
         assert (defs_sandbox.defs_folder_path / "defs.yaml").exists()
         assert (defs_sandbox.defs_folder_path / "replication.yaml").exists()
-
-
-# >>>>>>> 1dbdf22ea8 (Scaffolding infrastructure)
 
 
 def test_spec_is_available_in_scope() -> None:


### PR DESCRIPTION
## Summary & Motivation

Testing scaffolding and loading definitions is a pain point, but for our own development as well as our users. We write bespoke, brittle, and slow tests that are no fun to write and debug.

This proposes a new approach based on lightweight sandboxing. Instead of creating entire projects (or entire virtual environments God forbid) we create just a temporary folder and rely on our context and request objects to provide isolation.

You can see them applies to our dlt, fivetran, and sling tests here. I think it provides a nice degree of flexibility that can handle a variety of use cases (e.g. the dlt test harness, which is a beast) while minimizing boilerplate.

Docblock:

```python
@contextmanager
def scaffold_defs_sandbox(
    *,
    component_cls: type,
    component_path: Optional[Union[Path, str]] = None,
    scaffold_params: Optional[dict[str, Any]] = None,
    scaffold_format: ScaffoldFormatOptions = "yaml",
    project_name: Optional[str] = None,
) -> Iterator[DefsPathSandbox]:
    """Create a lightweight sandbox to scaffold and instantiate a component. Useful
    for those authoring component types.

    Scaffold defs sandbox creates a temporary project that mimics the defs folder portion
    of a real dagster project.

    It then invokes the scaffolder on the component class that produces. After
    scaffold_defs_sandbox yields a DefsPathSandbox object.

    DefsPathSandbox has a few properties useful for different types of tests:

    * defs_folder_path: The absolute path to the defs folder where the component
      is scaffolded. The user can inspect and load files that the scaffolder has produced.
      e.g. (defs_folder_path / "defs.yaml").exists()

    * component_path: The relative path to the component within the defs folder. If not
      provided, a random name is generated.

    * project_name: If not provided, a random name is generated.

    Once the sandbox is created the user has the option to load the definitions produced
    by the component using the load method on DefsPathSandbox.

    By default it will produce the component based on the persisted `defs.yaml` file. You
    can also supply a component body to the load method to override the defs.yaml file with
    an in-memory component body.

    This sandbox does not provide complete environmental isolation, but does provide some isolation guarantees
    to do its best to isolate the test from and restore the environment after the test.

    * A file structure like this is created: <<temp folder>> / src / <<project_name>> / defs / <<component_path>>
    * <<temp folder>> / src is placed in sys.path during the loading process
    * The last element of the component path is loaded as a namespace package
    * Any modules loaded during the process that descend from defs module are evicted from sys.modules on cleanup.

    Args:
        component_cls: The component class to scaffold
        component_path: Optional path where the component should be scaffolded. It is relative to the defs folder. Defaults to a random name at the root of the defs folder.
        scaffold_params: Optional parameters to pass to the scaffolder in dictionary form. E.g. if you scaffold a component with dg scaffold defs MyComponent --param-one value-one the scaffold_params should be {"param_one": "value-one"}.
        scaffold_format: Format to use for scaffolding (default: "yaml"). Can also be "python".
        project_name: Optional name for the project (default: random name).

    Returns:
        Iterator[DefsPathSandbox]: A context manager that yields a DefsPathSandbox

    Example:

    .. code-block:: python

        with scaffold_defs_sandbox(component_cls=MyComponent) as sandbox:
            assert (sandbox.defs_folder_path / "defs.yaml").exists()
            assert (sandbox.defs_folder_path / "my_component_config_file.yaml").exists()  # produced by MyComponentScaffolder

        with scaffold_defs_sandbox(component_cls=MyComponent, scaffold_params={"asset_key": "my_asset"}) as sandbox:
            with sandbox.load() as (component, defs):
                assert isinstance(component, MyComponent)
                assert defs.get_asset_def("my_asset").key == AssetKey("my_asset")

        with scaffold_defs_sandbox(component_cls=MyComponent) as sandbox:
            with sandbox.load(component_body={"type": "MyComponent", "attributes": {"asset_key": "different_asset_key"}}) as (component, defs):
                assert isinstance(component, MyComponent)
                assert defs.get_asset_def("different_asset_key").key == AssetKey("different_asset_key")
    """
```

## How I Tested These Changes

BK
