### PR TITLE
Eliminate global component load context

### DIFF
--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -31,7 +31,7 @@ from dagster._utils.pydantic_yaml import (
 from dagster.components.component.component import Component
 from dagster.components.component.component_loader import is_component_loader
 from dagster.components.component.template_vars import find_inline_template_vars_in_module
-from dagster.components.core.context import ComponentLoadContext, use_component_load_context
+from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.package_entry import load_package_object
 from dagster.components.definitions import LazyDefinitions
 from dagster.components.resolved.base import Resolvable
@@ -220,9 +220,7 @@ class DefsFolderComponent(Component):
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         child_defs = []
         for path, child in self.children.items():
-            sub_ctx = context.for_path(path)
-            with use_component_load_context(sub_ctx):
-                child_defs.append(child.build_defs(sub_ctx))
+            child_defs.append(child.build_defs(context.for_path(path)))
         defs = Definitions.merge(*child_defs)
         for post_processor in self.asset_post_processors or []:
             defs = post_processor(defs)
@@ -269,11 +267,9 @@ def find_components_from_context(context: ComponentLoadContext) -> Mapping[Path,
         relative_subpath = subpath.relative_to(context.path)
         if any(relative_subpath.match(pattern) for pattern in EXPLICITLY_IGNORED_GLOB_PATTERNS):
             continue
-        sub_ctx = context.for_path(subpath)
-        with use_component_load_context(sub_ctx):
-            component = get_component(sub_ctx)
-            if component:
-                found[subpath] = component
+        component = get_component(context.for_path(subpath))
+        if component:
+            found[subpath] = component
     return found
 
 

--- a/python_modules/dagster/dagster/components/core/load_defs.py
+++ b/python_modules/dagster/dagster/components/core/load_defs.py
@@ -9,7 +9,7 @@ from dagster._annotations import deprecated, preview, public
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._utils.warnings import suppress_dagster_warnings
-from dagster.components.core.context import ComponentLoadContext, use_component_load_context
+from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.tree import ComponentTree
 
 PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY = "plugin_component_types_json"
@@ -87,25 +87,24 @@ def load_defs(
     context = ComponentLoadContext.for_module(
         defs_root, project_root, terminate_autoloading_on_keyword_files
     )
-    with use_component_load_context(context):
-        # Despite the argument being named defs_root, load_defs supports loading arbitrary components
-        # directly, so use get_component instead of DefsFolderComponent.get
-        root_component = get_component(context)
-        if root_component is None:
-            raise DagsterInvalidDefinitionError("Could not resolve root module to a component.")
+    # Despite the argument being named defs_root, load_defs supports loading arbitrary components
+    # directly, so use get_component instead of DefsFolderComponent.get
+    root_component = get_component(context)
+    if root_component is None:
+        raise DagsterInvalidDefinitionError("Could not resolve root module to a component.")
 
-        tree = None
-        # If we did get a folder component back, assume its the root tree
-        if isinstance(root_component, DefsFolderComponent):
-            tree = ComponentTree(
-                defs_module=defs_root,
-                project_root=project_root,
-            )
-
-        return Definitions.merge(
-            root_component.build_defs(context),
-            get_library_json_enriched_defs(tree),
+    tree = None
+    # If we did get a folder component back, assume its the root tree
+    if isinstance(root_component, DefsFolderComponent):
+        tree = ComponentTree(
+            defs_module=defs_root,
+            project_root=project_root,
         )
+
+    return Definitions.merge(
+        root_component.build_defs(context),
+        get_library_json_enriched_defs(tree),
+    )
 
 
 def get_library_json_enriched_defs(tree: Optional[ComponentTree]) -> Definitions:

--- a/python_modules/dagster/dagster/components/core/tree.py
+++ b/python_modules/dagster/dagster/components/core/tree.py
@@ -8,7 +8,7 @@ from typing_extensions import TypeVar
 
 from dagster._core.definitions.definitions_class import Definitions
 from dagster.components.component.component import Component
-from dagster.components.core.context import ComponentLoadContext, use_component_load_context
+from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.defs_module import DefsFolderComponent
 
 PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY = "plugin_component_types_json"
@@ -52,19 +52,16 @@ class ComponentTree:
     def load_defs(self) -> Definitions:
         from dagster.components.core.load_defs import get_library_json_enriched_defs
 
-        with use_component_load_context(self.load_context):
-            return Definitions.merge(
-                self.root.build_defs(self.load_context),
-                get_library_json_enriched_defs(self),
-            )
+        return Definitions.merge(
+            self.root.build_defs(self.load_context),
+            get_library_json_enriched_defs(self),
+        )
 
     def load_defs_at_path(self, defs_path: Path) -> Definitions:
         # impl to be fleshed out to flexibly handle different path types (str, list[str], ...)
         for cp, c in self.root.iterate_path_component_pairs():
             if cp.file_path.relative_to(self.root.path) == defs_path:
-                ctx = self.load_context.for_path(cp.file_path)
-                with use_component_load_context(ctx):
-                    return c.build_defs(ctx)
+                return c.build_defs(self.load_context.for_path(cp.file_path))
 
         raise Exception(f"No component found for path {defs_path}")
 

--- a/python_modules/dagster/dagster/components/core/tree.py
+++ b/python_modules/dagster/dagster/components/core/tree.py
@@ -41,8 +41,7 @@ class ComponentTree:
     @cached_property
     def load_context(self):
         return ComponentLoadContext.for_module(
-            defs_module=self.defs_module,
-            project_root=self.project_root,
+            defs_module=self.defs_module, project_root=self.project_root
         )
 
     @cached_property

--- a/python_modules/dagster/dagster/components/resolved/context.py
+++ b/python_modules/dagster/dagster/components/resolved/context.py
@@ -41,7 +41,9 @@ class ResolutionContext:
     scope: Mapping[str, Any]
     path: list[Union[str, int]] = []
     source_position_tree: Optional[SourcePositionTree] = None
-    # dictionay where you can stash arbitrary objects. Used to store references to ComponentLoadContext
+    # dict where you can stash arbitrary objects. Used to store references to ComponentLoadContext
+    # We are structuring this way to make it easier to use Resolved outside of the context of
+    # the component system in the future
     stash: dict[str, Any] = {}
 
     def at_path(self, path_part: Union[str, int]):

--- a/python_modules/dagster/dagster/components/resolved/context.py
+++ b/python_modules/dagster/dagster/components/resolved/context.py
@@ -41,6 +41,8 @@ class ResolutionContext:
     scope: Mapping[str, Any]
     path: list[Union[str, int]] = []
     source_position_tree: Optional[SourcePositionTree] = None
+    # dictionay where you can stash arbitrary objects. Used to store references to ComponentLoadContext
+    stash: dict[str, Any] = {}
 
     def at_path(self, path_part: Union[str, int]):
         return copy(self, path=[*self.path, path_part])
@@ -51,6 +53,9 @@ class ResolutionContext:
             scope={"env": env_scope, "automation_condition": automation_condition_scope()},
             source_position_tree=source_position_tree,
         )
+
+    def with_stashed_value(self, key: str, value: Any) -> "ResolutionContext":
+        return copy(self, stash={**self.stash, key: value})
 
     def with_scope(self, **additional_scope) -> "ResolutionContext":
         return copy(self, scope={**self.scope, **additional_scope})

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
@@ -1,10 +1,6 @@
-from typing import TYPE_CHECKING, cast
-
 import dagster as dg
 from dagster.components.core.context import ComponentLoadContext
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
+from dagster_shared import check
 
 
 @dg.definitions
@@ -12,10 +8,7 @@ def defs(context: ComponentLoadContext) -> dg.Definitions:
     from component_component_deps.defs import my_python_defs  # type:ignore
 
     @dg.asset(
-        deps=cast(
-            "Sequence[dg.AssetsDefinition]",
-            context.load_defs(my_python_defs).assets,
-        )
+        deps=check.is_list(context.load_defs(my_python_defs).assets, of_type=dg.AssetsDefinition)
     )
     def downstream_of_all_my_python_defs(): ...
 

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
@@ -1,22 +1,22 @@
 from typing import TYPE_CHECKING, cast
 
 import dagster as dg
-from component_component_deps.defs import my_python_defs  # type:ignore
 from dagster.components.core.context import ComponentLoadContext
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from dagster._core.definitions.assets import AssetsDefinition
 
-ctx = ComponentLoadContext.current()
+@dg.definitions
+def defs(context: ComponentLoadContext) -> dg.Definitions:
+    from component_component_deps.defs import my_python_defs  # type:ignore
 
-
-@dg.asset(
-    deps=cast(
-        "Sequence[AssetsDefinition]",
-        ctx.load_defs(my_python_defs).assets,
+    @dg.asset(
+        deps=cast(
+            "Sequence[dg.AssetsDefinition]",
+            context.load_defs(my_python_defs).assets,
+        )
     )
-)
-def downstream_of_all_my_python_defs():
-    pass
+    def downstream_of_all_my_python_defs(): ...
+
+    return dg.Definitions(assets=[downstream_of_all_my_python_defs])

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/dependency_on_dbt_project_location/defs/depends_on_dbt/definitions.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/dependency_on_dbt_project_location/defs/depends_on_dbt/definitions.py
@@ -1,11 +1,14 @@
 import dagster as dg
 from dagster.components.core.context import ComponentLoadContext
 from dagster_dbt.components.dbt_project.component import get_asset_key_for_model_from_module
-from dependency_on_dbt_project_location.defs import jaffle_shop_dbt  # type: ignore
-
-ctx = ComponentLoadContext.current()
 
 
-@dg.asset(deps={get_asset_key_for_model_from_module(ctx, jaffle_shop_dbt, "customers")})
-def downstream_of_customers():
-    pass
+@dg.definitions
+def defs(context: ComponentLoadContext) -> dg.Definitions:
+    from dependency_on_dbt_project_location.defs import jaffle_shop_dbt  # type: ignore
+
+    @dg.asset(deps={get_asset_key_for_model_from_module(context, jaffle_shop_dbt, "customers")})
+    def downstream_of_customers():
+        pass
+
+    return dg.Definitions(assets=[downstream_of_customers])

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
@@ -25,14 +25,14 @@ if TYPE_CHECKING:
 TranslationFn: TypeAlias = Callable[[AssetSpec, DltResourceTranslatorData], AssetSpec]
 
 
-def _load_object_from_python_path(path: str):
+def _load_object_from_python_path(resolution_context: ResolutionContext, path: str):
     """Loads a Python object from the given import path, accepting
     relative paths.
 
     For example, '.foo_module.bar_object' will find the relative module
     'foo_module' and return 'bar_object'.
     """
-    context = ComponentLoadContext.current()
+    context = ComponentLoadContext.from_resolution_context(resolution_context)
 
     if path.startswith("."):
         path = f"{context.defs_relative_module_name(context.path)}{path}"
@@ -93,12 +93,12 @@ class DltLoadSpecModel(Resolvable):
 
     pipeline: Annotated[
         Pipeline,
-        Resolver(lambda ctx, path: _load_object_from_python_path(path), model_field_type=str),
+        Resolver(lambda ctx, path: _load_object_from_python_path(ctx, path), model_field_type=str),
     ]
     source: Annotated[
         DltSource,
         Resolver(
-            lambda ctx, path: _load_object_from_python_path(path),
+            lambda ctx, path: _load_object_from_python_path(ctx, path),
             model_field_type=str,
         ),
     ]

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -21,7 +21,6 @@ from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path, pushd
 from dagster._utils.env import environ
 from dagster.components.cli import cli
-from dagster.components.core.context import use_component_load_context
 from dagster_dg_core.utils import ensure_dagster_dg_tests_import
 from dagster_dlt import DagsterDltResource, DltLoadCollectionComponent
 from dagster_dlt.components.dlt_load_collection.component import DltLoadSpecModel
@@ -79,10 +78,9 @@ def setup_dlt_component(
         project_root = Path.cwd()
 
         context = ComponentLoadContext.for_module(defs_root, project_root)
-        with use_component_load_context(context):
-            component = get_underlying_component(context)
-            assert isinstance(component, DltLoadCollectionComponent)
-            yield component, component.build_defs(context)
+        component = get_underlying_component(context)
+        assert isinstance(component, DltLoadCollectionComponent)
+        yield component, component.build_defs(context)
 
 
 def github_load():
@@ -372,10 +370,9 @@ def test_scaffold_bare_component():
         project_root = Path.cwd()
 
         context = ComponentLoadContext.for_module(defs_root, project_root)
-        with use_component_load_context(context):
-            component = get_underlying_component(context)
-            assert isinstance(component, DltLoadCollectionComponent)
-            defs = component.build_defs(context)
+        component = get_underlying_component(context)
+        assert isinstance(component, DltLoadCollectionComponent)
+        defs = component.build_defs(context)
 
         assert len(component.loads) == 1
         assert defs.get_asset_graph().get_all_asset_keys() == {
@@ -416,9 +413,8 @@ def test_scaffold_component_with_source_and_destination(source: str, destination
         project_root = Path.cwd()
 
         context = ComponentLoadContext.for_module(defs_root, project_root)
-        with use_component_load_context(context):
-            component = get_underlying_component(context)
-            assert isinstance(component, DltLoadCollectionComponent)
+        component = get_underlying_component(context)
+        assert isinstance(component, DltLoadCollectionComponent)
 
         # scaffolder generates a silly sample load right now because the complex parsing logic is flaky
         assert len(component.loads) == 1

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -18,7 +18,6 @@ from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
 from dagster._utils.env import environ
 from dagster.components.cli import cli
-from dagster.components.core.context import use_component_load_context
 from dagster_fivetran.components.workspace_component.component import FivetranAccountComponent
 from dagster_fivetran.resources import FivetranWorkspace
 from dagster_fivetran.translator import FivetranConnector
@@ -71,10 +70,9 @@ def setup_fivetran_component(
         project_root = Path.cwd()
 
         context = ComponentLoadContext.for_module(defs_root, project_root)
-        with use_component_load_context(context):
-            component = get_underlying_component(context)
-            assert isinstance(component, FivetranAccountComponent)
-            yield component, component.build_defs(context)
+        component = get_underlying_component(context)
+        assert isinstance(component, FivetranAccountComponent)
+        yield component, component.build_defs(context)
 
 
 BASIC_FIVETRAN_COMPONENT_BODY = {


### PR DESCRIPTION
## Summary & Motivation

While writing testing utilities and other code I've noted that we have a global context variable to store a ComponentLoadContext. I think this is easier to screw up and unnecessary. The system will be better, more testable, and more modular if we can get away with not having it.

Two things in order to accomplish this

* If you need access to the context, you have to do in a `@definitions` callback or a `build_defs`. I think the users will thank us for pushing more compute out of the import path
* In another case, I added a stash dictionary to the `ResolutionContext`. I think this is the right thing to do, as it solidfies as ResolutionContext as "lower" in the stack than Components. The component load context is only retrieved from the stash when we know we are dealing with components code. I still want to preserve the option value to use Resolved outside of components contexts.

This resolves is a net negative LOC PR, which is good, and the lines we remove are easy ones to miss. Wouldn't be surprised if we already miss callsites.

## How I Tested These Changes

BK
