### PR TITLE
Refactor map_resolved_asset_specs to eliminate boolean flag

### DIFF
--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -97,7 +97,7 @@ class CompositeYamlComponent(Component):
 
         return Definitions.merge(
             *(
-                component.build_defs(context).map_resolved_asset_specs_inner(
+                component.build_defs(context).permissive_map_resolved_asset_specs(
                     func=lambda spec: _add_defs_yaml_code_reference_to_spec(
                         component_yaml_path=component_yaml,
                         load_context=context,

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -106,7 +106,6 @@ class CompositeYamlComponent(Component):
                         asset_spec=spec,
                     ),
                     selection=None,
-                    ignore_non_spec_asset_types=True,
                 )
                 for component, source_position in zip(self.components, self.source_positions)
             )


### PR DESCRIPTION
## Summary & Motivation

In certain code paths (that are constrained in certain ways) we allow SourceAssets and CacheableAssetsDefinitions to be mapped. This refactors the inner function that allows that to not use a boolean argument. To use a fancy term this reduces the cyclomatic complexity of the code path, making it easier to understand. 

## How I Tested These Changes

BK
