### PR TITLE
Rename get_all_job_defs and get_implicit_global_asset_job_def

### DIFF
--- a/examples/assets_pandas_type_metadata/assets_pandas_type_metadata_tests/test_defs.py
+++ b/examples/assets_pandas_type_metadata/assets_pandas_type_metadata_tests/test_defs.py
@@ -1,5 +1,8 @@
+from dagster._core.definitions.definitions_class import Definitions
+
 from assets_pandas_type_metadata.definitions import defs
 
 
-def test_defs_can_load():
-    assert defs.get_all_job_defs()
+def test_defs_can_load() -> None:
+    assert isinstance(defs, Definitions)
+    assert defs.resolve_all_job_defs()

--- a/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_config.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/migrating_to_python_resources_and_config/migrating_config.py
@@ -18,7 +18,7 @@ def old_config() -> None:
 
     defs = Definitions(assets=[an_asset, upstream_asset])
 
-    job_def = defs.get_implicit_global_asset_job_def()
+    job_def = defs.resolve_implicit_global_asset_job_def()
 
     result = job_def.execute_in_process(
         run_config={"ops": {"an_asset": {"config": {"conn_string": "foo", "port": 1}}}}
@@ -44,7 +44,7 @@ def new_config_schema() -> None:
 
     defs = Definitions(assets=[an_asset, upstream_asset])
 
-    job_def = defs.get_implicit_global_asset_job_def()
+    job_def = defs.resolve_implicit_global_asset_job_def()
 
     # code to launch/execute jobs is unchanged
     result = job_def.execute_in_process(
@@ -70,7 +70,7 @@ def new_config_schema_and_typed_run_config() -> None:
 
     defs = Definitions(assets=[an_asset, upstream_asset])
 
-    job_def = defs.get_implicit_global_asset_job_def()
+    job_def = defs.resolve_implicit_global_asset_job_def()
 
     # begin_new_config_schema_and_typed_run_config
 

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_checks.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_checks.py
@@ -98,9 +98,13 @@ def mock_fetch_last_updated_timestamps():
 
 
 def test_source_data_freshness(mock_fetch_last_updated_timestamps: None):
-    job_def = source_data_freshness_in_pieces_defs.get_implicit_global_asset_job_def()
+    job_def = (
+        source_data_freshness_in_pieces_defs.resolve_implicit_global_asset_job_def()
+    )
     result = job_def.execute_in_process(resources={"snowflake": MagicMock()})
     assert result.success
-    job_def = source_data_freshness_complete_defs.get_implicit_global_asset_job_def()
+    job_def = (
+        source_data_freshness_complete_defs.resolve_implicit_global_asset_job_def()
+    )
     result = job_def.execute_in_process(resources={"snowflake": MagicMock()})
     assert result.success

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/external_asset_tests/test_external_assets_decls.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/external_asset_tests/test_external_assets_decls.py
@@ -37,7 +37,7 @@ def test_docs_snippets_normal_assets_dep_on_external() -> None:
     }
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(asset_selection=[al_key])
         .success
     )

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_pythonic_resources.py
@@ -32,7 +32,7 @@ def test_new_resources_assets_defs() -> None:
     with mock.patch("requests.get", return_value=RequestsResponse()):
         defs = new_resources_assets_defs()
 
-        res = defs.get_implicit_global_asset_job_def().execute_in_process()
+        res = defs.resolve_implicit_global_asset_job_def().execute_in_process()
         assert res.success
         assert res.output_for_node("data_from_url") == {"foo": "bar"}
 
@@ -49,7 +49,7 @@ def test_new_resources_configurable_defs() -> None:
     with mock.patch("requests.get", return_value=RequestsResponse()):
         defs = new_resources_configurable_defs()
 
-        res = defs.get_implicit_global_asset_job_def().execute_in_process()
+        res = defs.resolve_implicit_global_asset_job_def().execute_in_process()
         assert res.success
         assert res.output_for_node("data_from_service") == {"foo": "bar"}
 
@@ -63,9 +63,9 @@ def test_new_resource_runtime() -> None:
         DagsterInvalidConfigError,
         match='Missing required config entry "resources" at the root.',
     ):
-        res = defs.get_implicit_global_asset_job_def().execute_in_process()
+        res = defs.resolve_implicit_global_asset_job_def().execute_in_process()
 
-    res = defs.get_implicit_global_asset_job_def().execute_in_process(
+    res = defs.resolve_implicit_global_asset_job_def().execute_in_process(
         run_config={
             "resources": {
                 "db_conn": {

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/dagster_pipes_tests/test_subprocess.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/dagster_pipes_tests/test_subprocess.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dagster import Definitions
 from docs_snippets.guides.dagster.dagster_pipes.subprocess.custom_messages.dagster_code import (
     defs as custom_msg_defs,
 )
@@ -43,8 +44,8 @@ from docs_snippets.guides.dagster.dagster_pipes.subprocess.with_multi_asset.dags
         custom_msg_defs,
     ],
 )
-def test_execute(defs):
-    job_defs = defs.get_all_job_defs()
+def test_execute(defs: Definitions) -> None:
+    job_defs = defs.resolve_all_job_defs()
     for job_def in job_defs:
         result = job_def.execute_in_process()
         assert result.success

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/migrating_to_python_resources_and_config_tests/test_migrating_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/migrating_to_python_resources_and_config_tests/test_migrating_resources.py
@@ -13,7 +13,7 @@ from docs_snippets.guides.dagster.migrating_to_python_resources_and_config.migra
 
 def test_initial_code_base() -> None:
     defs = initial_code_base()
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
 
 
 def test_convert_resource() -> None:
@@ -30,17 +30,17 @@ def test_new_style_resource_on_param() -> None:
 
 def test_old_third_party_resource() -> None:
     defs = old_third_party_resource()
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
 
 
 def test_old_resource_code_contextmanager() -> None:
     defs = old_resource_code_contextmanager()
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
 
 
 def test_new_resource_code_contextmanager() -> None:
     defs = new_resource_code_contextmanager()
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
 
 
 def test_new_third_party_resource_old_code_broken() -> None:

--- a/python_modules/dagster-test/dagster_test_tests/toys_tests/asset_reconciliation_tests/test_eager_reconciliation.py
+++ b/python_modules/dagster-test/dagster_test_tests/toys_tests/asset_reconciliation_tests/test_eager_reconciliation.py
@@ -3,6 +3,6 @@ from dagster_test.toys.asset_reconciliation.eager_reconciliation import defs
 
 
 def test_assets():
-    defs.get_implicit_global_asset_job_def().execute_in_process(
+    defs.resolve_implicit_global_asset_job_def().execute_in_process(
         resources={"io_manager": mem_io_manager}
     )

--- a/python_modules/dagster-test/dagster_test_tests/toys_tests/partitioned_assets_tests/test_hourly_and_daily_and_unpartitioned.py
+++ b/python_modules/dagster-test/dagster_test_tests/toys_tests/partitioned_assets_tests/test_hourly_and_daily_and_unpartitioned.py
@@ -5,7 +5,7 @@ from dagster_test.toys.partitioned_assets import hourly_and_daily_and_unpartitio
 
 def test_assets():
     defs = Definitions(assets=load_assets_from_modules([hourly_and_daily_and_unpartitioned]))
-    job_def = defs.get_implicit_global_asset_job_def()
+    job_def = defs.resolve_implicit_global_asset_job_def()
 
     assert job_def.execute_in_process(
         asset_selection=[

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -591,7 +591,7 @@ class Definitions(IHaveNew):
             instance=instance,
         )
 
-    def get_all_job_defs(self) -> Sequence[JobDefinition]:
+    def resolve_all_job_defs(self) -> Sequence[JobDefinition]:
         """Get all the Job definitions in the code location.
         This includes both jobs passed into the Definitions object and any implicit jobs created.
         All jobs returned from this function will have all resource dependencies resolved.
@@ -602,6 +602,12 @@ class Definitions(IHaveNew):
         return self.get_repository_def().has_implicit_global_asset_job_def()
 
     def get_implicit_global_asset_job_def(self) -> JobDefinition:
+        warnings.warn(
+            "This will be renamed to resolve_implicit_global_asset_job_def in dagster 1.11"
+        )
+        return self.get_repository_def().get_implicit_global_asset_job_def()
+
+    def resolve_implicit_global_asset_job_def(self) -> JobDefinition:
         """A useful conveninence method when there is a single defined global asset job.
         This occurs when all assets in the code location use a single partitioning scheme.
         If there are multiple partitioning schemes you must use get_implicit_job_def_for_assets
@@ -609,7 +615,7 @@ class Definitions(IHaveNew):
         """
         return self.get_repository_def().get_implicit_global_asset_job_def()
 
-    def get_implicit_job_def_for_assets(
+    def resolve_implicit_job_def_def_for_assets(
         self, asset_keys: Iterable[AssetKey]
     ) -> Optional[JobDefinition]:
         return self.get_repository_def().get_implicit_job_def_for_assets(asset_keys)

--- a/python_modules/dagster/dagster/_core/definitions/materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/materialize.py
@@ -99,7 +99,7 @@ def materialize(
     )
 
     # validate input asset graph and resources
-    defs.get_all_job_defs()
+    defs.resolve_all_job_defs()
 
     return check.not_none(
         defs.resolve_job_def(EPHEMERAL_JOB_NAME),

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -930,7 +930,7 @@ def test_multi_asset_with_many_specs():
     defs = Definitions(assets=[my_multi_asset_with_many_specs])
 
     start_time = time.time()
-    defs.get_all_job_defs()
+    defs.resolve_all_job_defs()
 
     end_time = time.time()
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
@@ -2263,7 +2263,7 @@ def test_build_subset_job_errors(job_selection, use_multi, expected_error):
     if expected_error:
         expected_class, expected_message = expected_error
         with pytest.raises(expected_class, match=expected_message):
-            Definitions(assets=assets, jobs=[asset_job]).get_all_job_defs()
+            Definitions(assets=assets, jobs=[asset_job]).resolve_all_job_defs()
     else:
         Definitions(assets=assets, jobs=[asset_job])
 
@@ -2315,7 +2315,7 @@ def test_simple_graph_backed_asset_subset(
         resources={"asset_io_manager": io_manager_def},
     )
     # materialize all assets once so values exist to load from
-    defs.get_implicit_global_asset_job_def().execute_in_process()
+    defs.resolve_implicit_global_asset_job_def().execute_in_process()
 
     # now build the subset job
     job = defs.resolve_job_def("assets_job")
@@ -2383,7 +2383,7 @@ def test_asset_group_build_subset_job(job_selection, expected_assets, use_multi,
     )
 
     # materialize all assets once so values exist to load from
-    defs.get_implicit_global_asset_job_def().execute_in_process()
+    defs.resolve_implicit_global_asset_job_def().execute_in_process()
 
     # now build the subset job
     job = defs.resolve_job_def("assets_job")
@@ -2527,7 +2527,7 @@ def test_subset_cycle_resolution_embed_assets_in_complex_graph():
     job = Definitions(
         assets=[foo, x, y],
         resources={"io_manager": io_manager_def},
-    ).get_implicit_global_asset_job_def()
+    ).resolve_implicit_global_asset_job_def()
 
     # should produce a job with foo(a,b,c,d,f) -> x -> foo(e,g) -> y -> foo(h)
     assert len(list(job.graph.iterate_op_defs())) == 5
@@ -2599,7 +2599,7 @@ def test_subset_cycle_resolution_complex():
     job = Definitions(
         assets=[foo, x, y],
         resources={"io_manager": io_manager_def},
-    ).get_implicit_global_asset_job_def()
+    ).resolve_implicit_global_asset_job_def()
 
     # should produce a job with foo -> x -> foo -> y -> foo
     assert len(list(job.graph.iterate_op_defs())) == 5
@@ -2660,7 +2660,7 @@ def test_subset_cycle_resolution_basic():
     job = Definitions(
         assets=[foo, foo_prime, s],
         resources={"io_manager": io_manager_def},
-    ).get_implicit_global_asset_job_def()
+    ).resolve_implicit_global_asset_job_def()
 
     # should produce a job with foo -> foo_prime -> foo_2 -> foo_prime_2
     assert len(list(job.graph.iterate_op_defs())) == 4
@@ -2712,7 +2712,7 @@ def test_subset_cycle_resolution_with_checks():
 
     Definitions.validate_loadable(defs)
 
-    job = defs.get_implicit_global_asset_job_def()
+    job = defs.resolve_implicit_global_asset_job_def()
 
     # should produce a job with foo -> foo_prime -> foo_2 -> foo_prime_2
     assert len(list(job.graph.iterate_op_defs())) == 4
@@ -2767,7 +2767,7 @@ def test_subset_cycle_resolution_asset_result():
     job = Definitions(
         assets=[foo, foo_prime, s],
         resources={"io_manager": io_manager_def},
-    ).get_implicit_global_asset_job_def()
+    ).resolve_implicit_global_asset_job_def()
 
     # should produce a job with foo -> foo_prime -> foo_2 -> foo_prime_2
     assert len(list(job.graph.iterate_op_defs())) == 4
@@ -2836,7 +2836,7 @@ def test_subset_cycle_resolution_with_asset_check():
         assets=[foo, foo_prime, s],
         asset_checks=[check_a_prime],
         resources={"io_manager": io_manager_def},
-    ).get_implicit_global_asset_job_def()
+    ).resolve_implicit_global_asset_job_def()
 
     # should produce a job with foo -> foo_prime -> foo_2 -> foo_prime_2
     assert len(list(job.graph.iterate_op_defs())) == 5
@@ -2896,7 +2896,7 @@ def test_subset_cycle_dependencies():
         assets=[foo, python],
         resources={"io_manager": io_manager_def},
     )
-    job = defs.get_implicit_global_asset_job_def()
+    job = defs.resolve_implicit_global_asset_job_def()
 
     # should produce a job with foo -> python -> foo_2
     assert len(list(job.graph.iterate_op_defs())) == 3
@@ -2955,7 +2955,7 @@ def test_subset_recongeal() -> None:
     def b() -> None: ...
 
     defs = dg.Definitions(assets=[acd, b])
-    all_job = defs.get_implicit_global_asset_job_def()
+    all_job = defs.resolve_implicit_global_asset_job_def()
     subset_job = all_job.get_subset(asset_selection={dg.AssetKey("a"), dg.AssetKey("c")})
     assert len(list(subset_job.graph.iterate_op_defs())) == 1
     assert all_job.graph.dependencies == {

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1679,7 +1679,7 @@ def test_asset_takes_bare_resource():
         executed["yes"] = True
 
     defs = Definitions(assets=[blah])
-    defs.get_implicit_global_asset_job_def().execute_in_process()
+    defs.resolve_implicit_global_asset_job_def().execute_in_process()
     assert executed["yes"]
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -74,7 +74,9 @@ def test_partitioned_observable_source_asset():
         return 1
 
     with instance_for_test() as instance:
-        job_def = Definitions(assets=[foo, bar, baz]).get_implicit_job_def_for_assets([foo.key])
+        job_def = Definitions(assets=[foo, bar, baz]).resolve_implicit_job_def_def_for_assets(
+            [foo.key]
+        )
 
         # If the asset selection contains any materializable assets, source assets observations will not run
         job_def.execute_in_process(partition_key="A", instance=instance)  # pyright: ignore[reportOptionalMemberAccess]

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
@@ -88,7 +88,7 @@ def test_str_env_var() -> None:
     defs = Definitions(assets=[a_string_asset])
 
     with environ({"A_STR": "foo"}):
-        defs.get_implicit_global_asset_job_def().execute_in_process(
+        defs.resolve_implicit_global_asset_job_def().execute_in_process(
             run_config=RunConfig(ops={"a_string_asset": AStringConfig(a_str=EnvVar("A_STR"))})
         )
     assert executed["a_string_asset"]
@@ -111,7 +111,7 @@ def test_str_env_var_nested() -> None:
     defs = Definitions(assets=[a_string_asset])
 
     with environ({"A_STR": "bar"}):
-        defs.get_implicit_global_asset_job_def().execute_in_process(
+        defs.resolve_implicit_global_asset_job_def().execute_in_process(
             run_config=RunConfig(
                 ops={"a_string_asset": AnOuterConfig(inner=AStringConfig(a_str=EnvVar("A_STR")))}
             )
@@ -133,7 +133,7 @@ def test_int_env_var() -> None:
     defs = Definitions(assets=[an_int_asset])
 
     with environ({"AN_INT": "5"}):
-        defs.get_implicit_global_asset_job_def().execute_in_process(
+        defs.resolve_implicit_global_asset_job_def().execute_in_process(
             run_config=RunConfig(ops={"an_int_asset": AnIntConfig(an_int=EnvVar.int("AN_INT"))})
         )
     assert executed["an_int_asset"]
@@ -156,7 +156,7 @@ def test_int_env_var_nested() -> None:
     defs = Definitions(assets=[a_int_asset])
 
     with environ({"AN_INT": "10"}):
-        defs.get_implicit_global_asset_job_def().execute_in_process(
+        defs.resolve_implicit_global_asset_job_def().execute_in_process(
             run_config=RunConfig(
                 ops={"a_int_asset": AnOuterConfig(inner=AnIntConfig(a_int=EnvVar.int("AN_INT")))}
             )
@@ -184,7 +184,7 @@ def test_int_env_var_non_int_value() -> None:
                 'Value "NOT_AN_INT" stored in env variable "AN_INT" cannot be coerced into an int.'
             ),
         ):
-            defs.get_implicit_global_asset_job_def().execute_in_process(
+            defs.resolve_implicit_global_asset_job_def().execute_in_process(
                 run_config=RunConfig(ops={"an_int_asset": AnIntConfig(an_int=EnvVar.int("AN_INT"))})
             )
     assert len(executed) == 0
@@ -204,7 +204,7 @@ def test_str_env_var_default() -> None:
     defs = Definitions(assets=[a_string_asset])
 
     with environ({"A_STR": "foo"}):
-        defs.get_implicit_global_asset_job_def().execute_in_process(
+        defs.resolve_implicit_global_asset_job_def().execute_in_process(
             run_config=RunConfig(ops={"a_string_asset": AStringConfig()})
         )
     assert executed["a_string_asset"]
@@ -224,7 +224,7 @@ def test_int_env_var_default() -> None:
     defs = Definitions(assets=[an_int_asset])
 
     with environ({"AN_INT": "55"}):
-        defs.get_implicit_global_asset_job_def().execute_in_process(
+        defs.resolve_implicit_global_asset_job_def().execute_in_process(
             run_config=RunConfig(ops={"an_int_asset": AnIntConfig()})
         )
     assert executed["an_int_asset"]

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -663,7 +663,7 @@ def test_nested_discriminated_resource_instantiation() -> None:
         assets=[my_asset_uses_resource],
         resources={"resource_with_union": resource_with_union},
     )
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert executed["yes"]
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_binding.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_binding.py
@@ -458,12 +458,14 @@ def test_override_default_value_in_asset_config() -> None:
     defs = Definitions([my_asset])
 
     assert (
-        defs.get_implicit_global_asset_job_def().execute_in_process().output_for_node("my_asset")
+        defs.resolve_implicit_global_asset_job_def()
+        .execute_in_process()
+        .output_for_node("my_asset")
         == "a_default_value"
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(run_config={"ops": {"my_asset": {"config": {"str_field": "override"}}}})
         .output_for_node("my_asset")
         == "override"
@@ -487,7 +489,9 @@ def test_override_default_value_in_ctor() -> None:
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def().execute_in_process().output_for_node("my_asset")
+        defs.resolve_implicit_global_asset_job_def()
+        .execute_in_process()
+        .output_for_node("my_asset")
         == "value_set_in_ctor"
     )
 
@@ -498,7 +502,7 @@ def test_override_default_value_in_ctor() -> None:
     assert "yes" not in executed
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(
             run_config={"resources": {"my_resource": {"config": {"str_field": "overriden"}}}}
         )
@@ -523,7 +527,9 @@ def test_override_default_field_value_in_resources() -> None:
     defs = Definitions([my_asset], resources={"my_resource": MyResourceWithDefault()})
 
     assert (
-        defs.get_implicit_global_asset_job_def().execute_in_process().output_for_node("my_asset")
+        defs.resolve_implicit_global_asset_job_def()
+        .execute_in_process()
+        .output_for_node("my_asset")
         == "value_set_in_default_field_decl"
     )
 
@@ -534,7 +540,7 @@ def test_override_default_field_value_in_resources() -> None:
     assert "yes" not in executed
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(
             run_config={"resources": {"my_resource": {"config": {"str_field": "overriden"}}}}
         )
@@ -561,7 +567,9 @@ def test_override_default_field_value_in_resources_using_configure_at_launch() -
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def().execute_in_process().output_for_node("my_asset")
+        defs.resolve_implicit_global_asset_job_def()
+        .execute_in_process()
+        .output_for_node("my_asset")
         == "value_set_in_default_field_decl"
     )
 
@@ -572,7 +580,7 @@ def test_override_default_field_value_in_resources_using_configure_at_launch() -
     assert "yes" not in executed
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(
             run_config={"resources": {"my_resource": {"config": {"str_field": "overriden"}}}}
         )
@@ -603,7 +611,9 @@ def test_bind_with_string_annotation():
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def().execute_in_process().output_for_node("my_asset")
+        defs.resolve_implicit_global_asset_job_def()
+        .execute_in_process()
+        .output_for_node("my_asset")
         == str_field_value
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_env_vars.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_env_vars.py
@@ -34,7 +34,7 @@ def test_env_var() -> None:
             },
         )
 
-        assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+        assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
         assert executed["yes"]
 
 
@@ -75,7 +75,7 @@ def test_env_var_data_structure() -> None:
             },
         )
 
-        assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+        assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
         assert executed["yes"]
 
 
@@ -99,12 +99,12 @@ def test_runtime_config_env_var() -> None:
 
     with environ({"MY_PREFIX_FOR_TEST": "greeting: "}):
         with pytest.raises(DagsterInvalidConfigError):
-            defs.get_implicit_global_asset_job_def().execute_in_process(
+            defs.resolve_implicit_global_asset_job_def().execute_in_process(
                 {"resources": {"writer": {"config": {"prefix": EnvVar("MY_PREFIX_FOR_TEST")}}}}
             )
 
         # Ensure fully unstructured run config option works
-        result = defs.get_implicit_global_asset_job_def().execute_in_process(
+        result = defs.resolve_implicit_global_asset_job_def().execute_in_process(
             {"resources": {"writer": {"config": {"prefix": {"env": "MY_PREFIX_FOR_TEST"}}}}}
         )
         assert result.success
@@ -137,7 +137,7 @@ def test_env_var_err() -> None:
             'You have attempted to fetch the environment variable "UNSET_ENV_VAR" which is not set.'
         ),
     ):
-        defs.get_implicit_global_asset_job_def().execute_in_process()
+        defs.resolve_implicit_global_asset_job_def().execute_in_process()
 
     # Test using runtime configuration of the resource
     defs = Definitions(
@@ -148,7 +148,7 @@ def test_env_var_err() -> None:
         DagsterInvalidConfigError,
         match="Invalid use of environment variable wrapper.",
     ):
-        defs.get_implicit_global_asset_job_def().execute_in_process(
+        defs.resolve_implicit_global_asset_job_def().execute_in_process(
             {"resources": {"a_resource": {"config": {"a_str": EnvVar("UNSET_ENV_VAR_RUNTIME")}}}}
         )
 
@@ -183,7 +183,7 @@ def test_env_var_nested_resources() -> None:
             "ENV_VARIABLE_FOR_TEST": "SOME_VALUE",
         }
     ):
-        assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+        assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
         assert executed["yes"]
 
 
@@ -217,7 +217,7 @@ def test_env_var_nested_config() -> None:
             "ENV_VARIABLE_FOR_TEST": "SOME_VALUE",
         }
     ):
-        assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+        assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
         assert executed["yes"]
 
 
@@ -253,14 +253,14 @@ def test_env_var_alongside_enum() -> None:
             "ENV_VARIABLE_FOR_TEST": "SOME_VALUE",
         }
     ):
-        result = defs.get_implicit_global_asset_job_def().execute_in_process()
+        result = defs.resolve_implicit_global_asset_job_def().execute_in_process()
         assert result.output_for_node("an_asset") == ("FOO", "SOME_VALUE")
         assert executed["yes"]
 
     executed.clear()
 
     # Case: I'm using the default value provided by resource instantiation to the enum, and then using a value specified at runtime for the string.
-    result = defs.get_implicit_global_asset_job_def().execute_in_process(
+    result = defs.resolve_implicit_global_asset_job_def().execute_in_process(
         run_config={"resources": {"a_resource": {"config": {"a_str": "foo", "my_enum": "BAR"}}}}
     )
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
@@ -87,7 +87,7 @@ def test_basic_structured_resource_assets() -> None:
         resources={"writer": WriterResource(prefix="greeting: ")},
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert out_txt == ["greeting: hello, world!"]
 
 
@@ -280,7 +280,7 @@ def test_migration_attach_bare_object_to_context() -> None:
         resources={"my_client": MyClientResource()},
     )
 
-    asset_job = defs.get_implicit_global_asset_job_def()
+    asset_job = defs.resolve_implicit_global_asset_job_def()
     assert asset_job
     assert asset_job.execute_in_process().success
     assert executed["unmigrated"]
@@ -321,7 +321,7 @@ def test_io_manager_adapter():
         assets=[an_asset],
         resources={"io_manager": AdapterForIOManager(a_config_value="passed-in-configured")},
     )
-    defs.get_implicit_global_asset_job_def().execute_in_process()
+    defs.resolve_implicit_global_asset_job_def().execute_in_process()
 
     assert executed["yes"]
 
@@ -346,7 +346,7 @@ def test_io_manager_factory_class():
         assets=[another_asset],
         resources={"io_manager": AnIOManagerFactory(a_config_value="passed-in-factory")},
     )
-    defs.get_implicit_global_asset_job_def().execute_in_process()
+    defs.resolve_implicit_global_asset_job_def().execute_in_process()
 
     assert executed["yes"]
 
@@ -370,7 +370,7 @@ def test_structured_resource_runtime_config():
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process({"resources": {"writer": {"config": {"prefix": ""}}}})
         .success
     )
@@ -379,7 +379,7 @@ def test_structured_resource_runtime_config():
     out_txt.clear()
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process({"resources": {"writer": {"config": {"prefix": "greeting: "}}}})
         .success
     )
@@ -408,7 +408,7 @@ def test_runtime_config_run_config_obj():
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(RunConfig(resources={"writer": WriterResource(prefix="greeting: ")}))
         .success
     )
@@ -515,7 +515,7 @@ def test_resources_which_return():
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert completed["yes"]
 
     str_resource_partial = StringResource.configure_at_launch()
@@ -530,7 +530,7 @@ def test_resources_which_return():
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(
             {
                 "resources": {
@@ -581,7 +581,7 @@ def test_nested_config_class() -> None:
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert executed["yes"]
 
 
@@ -647,7 +647,7 @@ def test_using_enum_simple() -> None:
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert executed["yes"]
     executed.clear()
 
@@ -659,7 +659,7 @@ def test_using_enum_simple() -> None:
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(
             {"resources": {"my_resource": {"config": {"an_enum": SimpleEnum.FOO.name}}}}
         )
@@ -694,7 +694,7 @@ def test_using_enum_complex() -> None:
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert executed["yes"]
     executed.clear()
 
@@ -713,7 +713,7 @@ def test_resource_defs_on_asset() -> None:
     defs = Definitions(
         assets=[an_asset],
     )
-    defs.get_implicit_global_asset_job_def().execute_in_process()
+    defs.resolve_implicit_global_asset_job_def().execute_in_process()
 
     assert executed["yes"]
 
@@ -776,7 +776,7 @@ def test_extending_resource_nesting() -> None:
         assets=[an_asset],
         resources={"writer": ExtendingResource(a_str="foo", nested=NestedResource(a_str="baz"))},
     )
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
 
     assert executed["yes"]
     executed.clear()
@@ -790,7 +790,7 @@ def test_extending_resource_nesting() -> None:
         },
     )
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(
             run_config={"resources": {"nested_deferred": {"config": {"a_str": "baz"}}}}
         )
@@ -960,7 +960,7 @@ def test_context_on_resource_basic() -> None:
         resources={"context_using": ContextUsingResource()},
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert executed["yes"]
 
 
@@ -1006,7 +1006,7 @@ def test_context_on_resource_use_instance() -> None:
             resources={"output_dir": OutputDirResource()},
         )
 
-        assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+        assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
         assert executed["yes"]
 
 
@@ -1040,7 +1040,7 @@ def test_context_on_resource_runtime_config() -> None:
         )
 
         assert (
-            defs.get_implicit_global_asset_job_def()
+            defs.resolve_implicit_global_asset_job_def()
             .execute_in_process(
                 run_config={"resources": {"output_dir": {"config": {"output_dir": None}}}}
             )
@@ -1088,7 +1088,7 @@ def test_context_on_resource_nested() -> None:
             resources={"wrapper": OutputDirWrapperResource(output_dir=OutputDirResource())},
         )
 
-        assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+        assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
         assert executed["yes"]
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -63,7 +63,7 @@ def test_nested_resources() -> None:
                 "writer": json_writer_resource,
             },
         )
-        .get_implicit_global_asset_job_def()
+        .resolve_implicit_global_asset_job_def()
         .execute_in_process()
         .success
     )
@@ -84,7 +84,7 @@ def test_nested_resources() -> None:
                 "writer": prefixed_json_writer_resource,
             },
         )
-        .get_implicit_global_asset_job_def()
+        .resolve_implicit_global_asset_job_def()
         .execute_in_process()
         .success
     )
@@ -126,7 +126,7 @@ def test_nested_resources_multiuse() -> None:
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert completed["yes"]
 
 
@@ -169,7 +169,7 @@ def test_nested_resources_runtime_config() -> None:
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(
             {
                 "resources": {
@@ -247,7 +247,7 @@ def test_nested_resources_runtime_config_complex() -> None:
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(
             {
                 "resources": {
@@ -283,7 +283,7 @@ def test_nested_resources_runtime_config_complex() -> None:
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(
             {
                 "resources": {
@@ -333,7 +333,7 @@ def test_nested_function_resource() -> None:
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert out_txt == ["foo!", "bar!"]
 
 
@@ -371,7 +371,7 @@ def test_nested_function_resource_configured() -> None:
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert out_txt == ["foo!", "bar!"]
 
     out_txt.clear()
@@ -385,7 +385,7 @@ def test_nested_function_resource_configured() -> None:
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert out_txt == ["msg: foo!", "msg: bar!"]
 
 
@@ -440,7 +440,7 @@ def test_nested_function_resource_runtime_config() -> None:
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(
             {
                 "resources": {
@@ -478,7 +478,7 @@ def test_nested_resource_raw_value() -> None:
             "my_resource": MyResourceWithDep(a_string=string_resource),
         },
     )
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert executed["yes"]
 
     executed.clear()
@@ -487,7 +487,7 @@ def test_nested_resource_raw_value() -> None:
         assets=[my_asset],
         resources={"my_resource": MyResourceWithDep(a_string="foo")},
     )
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert executed["yes"]
 
 
@@ -547,7 +547,7 @@ def test_nested_resource_raw_value_io_manager() -> None:
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert log == [
         "ConfigIOManager handle_output base/my_asset",
         "RawIOManager handle_output my_asset",
@@ -581,7 +581,7 @@ def test_enum_nested_resource_no_run_config() -> None:
         },
     )
 
-    a_job = defs.get_implicit_global_asset_job_def()
+    a_job = defs.resolve_implicit_global_asset_job_def()
 
     result = a_job.execute_in_process()
     assert result.success
@@ -614,7 +614,7 @@ def test_enum_nested_resource_run_config_override() -> None:
         },
     )
 
-    a_job = defs.get_implicit_global_asset_job_def()
+    a_job = defs.resolve_implicit_global_asset_job_def()
 
     # Case: I'm re-specifying the nested enum at runtime - expect the runtime config to override the resource config
     result = a_job.execute_in_process(
@@ -692,7 +692,7 @@ def test_nested_resource_raw_value_io_manager_with_setup_teardown() -> None:
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert log == [
         "ConfigIOManager setup_for_execution",
         "MyMultiwriteIOManager setup_for_execution",
@@ -781,7 +781,7 @@ def test_nested_resource_raw_value_io_manager_with_cm_setup_teardown() -> None:
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert log == [
         "ConfigIOManager cm setup",
         "RawIOManager cm setup",
@@ -819,7 +819,7 @@ def test_multiple_nested_optional_resources() -> None:
             assets=[expects_none_asset],
             resources={"main": MainResource(outer=None)},
         )
-        .get_implicit_global_asset_job_def()
+        .resolve_implicit_global_asset_job_def()
         .execute_in_process()
         .success
     )
@@ -835,7 +835,7 @@ def test_multiple_nested_optional_resources() -> None:
             assets=[hello_world_asset],
             resources={"main": MainResource(outer=OuterResource(inner=InnerResource()))},
         )
-        .get_implicit_global_asset_job_def()
+        .resolve_implicit_global_asset_job_def()
         .execute_in_process()
         .success
     )
@@ -874,7 +874,7 @@ def test_multiple_nested_optional_resources_complex() -> None:
                 assets=[my_asset],
                 resources={"main": main_resource},
             )
-            .get_implicit_global_asset_job_def()
+            .resolve_implicit_global_asset_job_def()
             .execute_in_process()
             .success
         )
@@ -889,7 +889,7 @@ def test_multiple_nested_optional_resources_complex() -> None:
             assets=[my_asset],
             resources={"main": main_resource},
         )
-        .get_implicit_global_asset_job_def()
+        .resolve_implicit_global_asset_job_def()
         .execute_in_process()
         .success
     )
@@ -924,7 +924,7 @@ def test_nested_resource_setup_teardown_inner() -> None:
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert log == [
         "SetupTeardownInnerResource setup_for_execution",
         "my_asset",
@@ -959,7 +959,7 @@ def test_nested_resource_yield_inner() -> None:
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert log == [
         "SetupTeardownInnerResource yield_for_execution",
         "my_asset",
@@ -1008,7 +1008,7 @@ def test_nested_resources_runtime_config_fully_populated() -> None:
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process(
             {
                 "resources": {

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
@@ -612,7 +612,7 @@ def test_bare_resource_on_with_resources():
 
     bound_assets = with_resources([blah], {"bare_resource": BareObjectResource()})
     defs = Definitions(assets=bound_assets)
-    defs.get_implicit_global_asset_job_def().execute_in_process()
+    defs.resolve_implicit_global_asset_job_def().execute_in_process()
     assert executed["yes"]
 
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_check_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_check_condition.py
@@ -157,7 +157,7 @@ def test_all_deps_blocking_checks_passed_condition(real_check: bool) -> None:
 
     def _emit_check(checks: Set[AssetCheckKey], passed: bool):
         if real_check:
-            defs.get_implicit_global_asset_job_def().get_subset(
+            defs.resolve_implicit_global_asset_job_def().get_subset(
                 asset_check_selection=checks
             ).execute_in_process(
                 tags={"passed": ""} if passed else None, instance=instance, raise_on_error=passed
@@ -314,21 +314,21 @@ def test_check_selection(condition: AutomationCondition) -> None:
     assert result.total_requested == 0
 
     # ignore_check fails, but it's ignored
-    defs.get_implicit_global_asset_job_def().get_subset(
+    defs.resolve_implicit_global_asset_job_def().get_subset(
         asset_check_selection={ignore_check.check_key}
     ).execute_in_process(instance=instance)
     result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
     assert result.total_requested == 0
 
     # allow_check fails, not ignored
-    defs.get_implicit_global_asset_job_def().get_subset(
+    defs.resolve_implicit_global_asset_job_def().get_subset(
         asset_check_selection={allow_check.check_key}
     ).execute_in_process(instance=instance, raise_on_error=False)
     result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
     assert result.total_requested == 1
 
     # allow_check passes, now back to normal
-    defs.get_implicit_global_asset_job_def().get_subset(
+    defs.resolve_implicit_global_asset_job_def().get_subset(
         asset_check_selection={allow_check.check_key}
     ).execute_in_process(tags={"passed": ""}, instance=instance)
     result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_check_passed_failed_conditions.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_check_passed_failed_conditions.py
@@ -24,7 +24,7 @@ def test_check_result_conditions(passed: bool) -> None:
 
     defs = Definitions(assets=[A], asset_checks=[foo_check])
     instance = DagsterInstance.ephemeral()
-    check_job = defs.get_implicit_global_asset_job_def().get_subset(
+    check_job = defs.resolve_implicit_global_asset_job_def().get_subset(
         asset_check_selection={foo_check.check_key}
     )
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_eager_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_eager_condition.py
@@ -194,7 +194,7 @@ def test_eager_self_dependency() -> None:
     assert result.total_requested == 0
 
     # now previous partition of A exists, so request
-    defs.get_implicit_global_asset_job_def().execute_in_process(
+    defs.resolve_implicit_global_asset_job_def().execute_in_process(
         instance=instance, asset_selection=[root.key, A.key], partition_key="2024-08-14"
     )
     result = evaluate_automation_conditions(
@@ -209,7 +209,7 @@ def test_eager_self_dependency() -> None:
     assert result.total_requested == 0
 
     # now materialize the previous partition again, kick off again
-    defs.get_implicit_global_asset_job_def().execute_in_process(
+    defs.resolve_implicit_global_asset_job_def().execute_in_process(
         instance=instance, asset_selection=[A.key], partition_key="2024-08-14"
     )
     result = evaluate_automation_conditions(
@@ -343,7 +343,7 @@ def test_eager_partial_run(b_result: str) -> None:
     assert result.total_requested == 0
 
     # now simulate the above run, B / C will not be materialized
-    defs.get_implicit_global_asset_job_def().execute_in_process(
+    defs.resolve_implicit_global_asset_job_def().execute_in_process(
         instance=instance, asset_selection=[A.key, B.key, C.key], raise_on_error=False
     )
     result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
@@ -351,7 +351,7 @@ def test_eager_partial_run(b_result: str) -> None:
     assert result.total_requested == 0
 
     # A gets materialized on its own, do kick off B and C
-    defs.get_implicit_global_asset_job_def().execute_in_process(
+    defs.resolve_implicit_global_asset_job_def().execute_in_process(
         instance=instance, asset_selection=[A.key]
     )
     result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_executed_with_tags_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_executed_with_tags_condition.py
@@ -41,7 +41,7 @@ def test_executed_with_tag_keys() -> None:
 
     defs = Definitions(assets=[A])
     instance = DagsterInstance.ephemeral()
-    job = defs.get_implicit_global_asset_job_def()
+    job = defs.resolve_implicit_global_asset_job_def()
 
     # hasn't newly updated
     result = evaluate_automation_conditions(defs=defs, instance=instance)
@@ -92,7 +92,7 @@ def test_executed_with_tag_values() -> None:
 
     defs = Definitions(assets=[A])
     instance = DagsterInstance.ephemeral()
-    job = defs.get_implicit_global_asset_job_def()
+    job = defs.resolve_implicit_global_asset_job_def()
 
     # hasn't newly updated
     result = evaluate_automation_conditions(defs=defs, instance=instance)

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_in_progress_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_in_progress_condition.py
@@ -95,7 +95,7 @@ def test_unpartitioned() -> None:
 
     defs = Definitions(assets=[A, B])
     instance = DagsterInstance.ephemeral()
-    job = defs.get_implicit_job_def_for_assets([A.key, B.key])
+    job = defs.resolve_implicit_job_def_def_for_assets([A.key, B.key])
     assert job is not None
 
     result = evaluate_automation_conditions(defs=defs, instance=instance)

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_updated_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_updated_condition.py
@@ -108,7 +108,7 @@ def test_newly_updated_on_asset_check() -> None:
 
     defs = Definitions(assets=[A], asset_checks=[foo_check])
     instance = DagsterInstance.ephemeral()
-    check_job = defs.get_implicit_global_asset_job_def().get_subset(
+    check_job = defs.resolve_implicit_global_asset_job_def().get_subset(
         asset_check_selection={foo_check.check_key}
     )
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_cron_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_cron_condition.py
@@ -269,7 +269,7 @@ def test_asset_order_change_doesnt_reset_cursor_state() -> None:
     instance = DagsterInstance.ephemeral()
 
     def _emit_check(defs: Definitions, checks: Set[AssetCheckKey], passed: bool):
-        defs.get_implicit_global_asset_job_def().get_subset(
+        defs.resolve_implicit_global_asset_job_def().get_subset(
             asset_check_selection=checks
         ).execute_in_process(
             tags={"passed": ""} if passed else None, instance=instance, raise_on_error=passed

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/perf_tests/test_perf.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/perf_tests/test_perf.py
@@ -31,7 +31,7 @@ def run_declarative_automation_perf_simulation(instance: DagsterInstance) -> Non
         & AutomationCondition.all_deps_blocking_checks_passed(),
     )
     defs = Definitions(assets=assets)
-    asset_job = defs.get_implicit_global_asset_job_def()
+    asset_job = defs.resolve_implicit_global_asset_job_def()
 
     cursor = None
     start = time.time()

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -169,7 +169,9 @@ class AssetDaemonScenarioState(ScenarioState):
         # make sure these run requests are available on the instance
         for request in new_run_requests:
             asset_selection = check.not_none(request.asset_selection)
-            job_def = self.scenario_spec.defs.get_implicit_job_def_for_assets(asset_selection)
+            job_def = self.scenario_spec.defs.resolve_implicit_job_def_def_for_assets(
+                asset_selection
+            )
             self.instance.create_run_for_job(
                 job_def=check.not_none(job_def),
                 asset_selection=set(asset_selection),

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/scenario_state.py
@@ -303,7 +303,7 @@ class ScenarioState:
     ) -> Self:
         run_id = make_new_run_id()
         with freeze_time(self.current_time):
-            job_def = self.scenario_spec.defs.get_implicit_job_def_for_assets(
+            job_def = self.scenario_spec.defs.resolve_implicit_job_def_def_for_assets(
                 asset_keys=list(asset_keys)
             )
             assert job_def

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset_decorator.py
@@ -141,6 +141,6 @@ def test_op_tags_forwarded_to_execution_step() -> None:
 
     # Create a job that includes the source asset
     defs = Definitions(assets=[tagged_source_asset])
-    global_job = defs.get_implicit_global_asset_job_def()
+    global_job = defs.resolve_implicit_global_asset_job_def()
     assert len(global_job.nodes) == 1
     assert global_job.nodes[0].tags == op_tags

--- a/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/test_load_asset_checks_from_modules.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/test_load_asset_checks_from_modules.py
@@ -115,4 +115,4 @@ def test_load_asset_checks_from_package(load_fns):
     assets = assets_load_fn(checks_module, key_prefix="foo")
     assert len(assets) == 1
 
-    Definitions(assets=assets, asset_checks=checks).get_all_job_defs()
+    Definitions(assets=assets, asset_checks=checks).resolve_all_job_defs()

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
@@ -173,7 +173,7 @@ def test_how_source_assets_are_backwards_compatible() -> None:
 
     instance = DagsterInstance.ephemeral()
 
-    result_one = defs_with_source.get_implicit_global_asset_job_def().execute_in_process(
+    result_one = defs_with_source.resolve_implicit_global_asset_job_def().execute_in_process(
         instance=instance
     )
 
@@ -186,7 +186,7 @@ def test_how_source_assets_are_backwards_compatible() -> None:
 
     assert isinstance(defs_with_shim.resolve_assets_def("source_asset"), AssetsDefinition)
 
-    result_two = defs_with_shim.get_implicit_global_asset_job_def().execute_in_process(
+    result_two = defs_with_shim.resolve_implicit_global_asset_job_def().execute_in_process(
         instance=instance,
         # currently we have to explicitly select the asset to exclude the source from execution
         asset_selection=[AssetKey("an_asset")],
@@ -197,7 +197,9 @@ def test_how_source_assets_are_backwards_compatible() -> None:
 
 
 def get_job_for_assets(defs: Definitions, *coercibles_or_defs) -> JobDefinition:
-    job_def = defs.get_implicit_job_def_for_assets(set_from_coercibles_or_defs(coercibles_or_defs))
+    job_def = defs.resolve_implicit_job_def_def_for_assets(
+        set_from_coercibles_or_defs(coercibles_or_defs)
+    )
     assert job_def, "Expected to find a job def"
     return job_def
 
@@ -276,7 +278,7 @@ def test_observable_source_asset_decorator() -> None:
     defs = Definitions(assets=[assets_def])
 
     instance = DagsterInstance.ephemeral()
-    result = defs.get_implicit_global_asset_job_def().execute_in_process(instance=instance)
+    result = defs.resolve_implicit_global_asset_job_def().execute_in_process(instance=instance)
 
     assert result.success
     assert result.output_for_node("an_observable_source_asset") is None
@@ -305,7 +307,7 @@ def test_external_assets_with_dependencies_manual_construction() -> None:
     defs = Definitions(assets=[_upstream_def, _downstream_asset])
     assert defs
 
-    assert defs.get_implicit_global_asset_job_def().asset_layer.asset_graph.get(
+    assert defs.resolve_implicit_global_asset_job_def().asset_layer.asset_graph.get(
         AssetKey("downstream_asset")
     ).parent_keys == {AssetKey("upstream_asset")}
 

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_context.py
@@ -327,7 +327,7 @@ def test_context_provided_to_asset_check():
 
     def execute_assets_and_checks(assets=None, asset_checks=None, raise_on_error: bool = True):
         defs = Definitions(assets=assets, asset_checks=asset_checks)
-        job_def = defs.get_implicit_global_asset_job_def()
+        job_def = defs.resolve_implicit_global_asset_job_def()
         return job_def.execute_in_process(raise_on_error=raise_on_error, instance=instance)
 
     @asset

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_metadata.py
@@ -388,5 +388,5 @@ def test_snapshot_arbitrary_metadata():
         pass
 
     assert build_node_defs_snapshot(
-        Definitions(assets=[foo_asset]).get_implicit_global_asset_job_def()
+        Definitions(assets=[foo_asset]).resolve_implicit_global_asset_job_def()
     )

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
@@ -28,7 +28,7 @@ from dagster_tests.execution_tests.pipes_tests.in_process_client import InProces
 def execute_asset_through_def(assets_def, resources) -> ExecuteInProcessResult:
     return (
         Definitions(assets=[assets_def], resources={"inprocess_client": InProcessPipesClient()})
-        .get_implicit_global_asset_job_def()
+        .resolve_implicit_global_asset_job_def()
         .execute_in_process()
     )
 
@@ -374,7 +374,7 @@ def test_get_asset_check_result() -> None:
             asset_checks=[an_asset_check],
             resources={"inprocess_client": InProcessPipesClient()},
         )
-        .get_implicit_global_asset_job_def()
+        .resolve_implicit_global_asset_job_def()
         .execute_in_process()
     )
     assert result.success

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
@@ -35,7 +35,7 @@ class DefinitionsRunner:
 
     def materialize_all_assets(self, partition_key: Optional[str] = None) -> ExecuteInProcessResult:
         all_keys = list(self.defs.get_repository_def().asset_graph.get_all_asset_keys())
-        job_def = self.defs.get_implicit_job_def_for_assets(all_keys)
+        job_def = self.defs.resolve_implicit_job_def_def_for_assets(all_keys)
         assert job_def
         return job_def.execute_in_process(instance=self.instance, partition_key=partition_key)
 
@@ -43,7 +43,7 @@ class DefinitionsRunner:
         self, asset_selection: Sequence[CoercibleToAssetKey], partition_key: Optional[str] = None
     ) -> ExecuteInProcessResult:
         asset_keys = [AssetKey.from_coercible(asset_key) for asset_key in asset_selection]
-        job_def = self.defs.get_implicit_job_def_for_assets(asset_keys)
+        job_def = self.defs.resolve_implicit_job_def_def_for_assets(asset_keys)
         assert job_def
         return job_def.execute_in_process(
             instance=self.instance,

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_checks.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_checks.py
@@ -35,7 +35,7 @@ def test_get_asset_check_summary_records(instance: DagsterInstance):
     assert summary_record.asset_check_key == next(iter(the_asset_check.check_keys))
     assert summary_record.last_check_execution_record is None
     assert summary_record.last_run_id is None
-    implicit_job = defs.get_all_job_defs()[0]
+    implicit_job = defs.resolve_all_job_defs()[0]
     result = implicit_job.execute_in_process(instance=instance)
     assert result.success
     records = instance.event_log_storage.get_asset_check_summary_records(

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
@@ -158,7 +158,7 @@ def test_asset_materialization_accessors():
 
     with DagsterInstance.ephemeral() as instance:
         defs = Definitions(assets=[return_one])
-        defs.get_implicit_global_asset_job_def().execute_in_process(instance=instance)
+        defs.resolve_implicit_global_asset_job_def().execute_in_process(instance=instance)
 
         log_entry = instance.get_latest_materialization_event(AssetKey("return_one"))
         assert log_entry

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -195,7 +195,7 @@ def get_assets_job(io_manager_def, partitions_def=None):
     return Definitions(
         assets=[asset1, asset2],
         resources={"io_manager": io_manager_def},
-    ).get_implicit_job_def_for_assets([asset1.key, asset2.key])
+    ).resolve_implicit_job_def_def_for_assets([asset1.key, asset2.key])
 
 
 def test_fs_io_manager_handles_assets():

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -1097,7 +1097,7 @@ def test_instance_set_on_asset_loader():
             assets=[an_asset, another_asset],
             resources={"io_manager": AssertingContextInputOnLoadInputIOManager()},
         )
-        defs.get_implicit_global_asset_job_def().execute_in_process(
+        defs.resolve_implicit_global_asset_job_def().execute_in_process(
             asset_selection=[AssetKey("an_asset")], instance=instance
         )
         # load_input not called when asset does not have any inputs

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_managers_pythonic_config.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_managers_pythonic_config.py
@@ -91,7 +91,7 @@ def test_runtime_config():
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process({"resources": {"io_manager": {"config": {"prefix": ""}}}})
         .success
     )
@@ -100,7 +100,7 @@ def test_runtime_config():
     out_txt.clear()
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process({"resources": {"io_manager": {"config": {"prefix": "greeting: "}}}})
         .success
     )
@@ -133,7 +133,7 @@ def test_nested_resources():
         },
     )
 
-    assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
     assert out_txt == ["greeting: hello, world!"]
 
 
@@ -167,7 +167,7 @@ def test_nested_resources_runtime_config():
     )
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process({"resources": {"io_config": {"config": {"prefix": ""}}}})
         .success
     )
@@ -176,7 +176,7 @@ def test_nested_resources_runtime_config():
     out_txt.clear()
 
     assert (
-        defs.get_implicit_global_asset_job_def()
+        defs.resolve_implicit_global_asset_job_def()
         .execute_in_process({"resources": {"io_config": {"config": {"prefix": "greeting: "}}}})
         .success
     )
@@ -196,7 +196,7 @@ def test_pythonic_fs_io_manager() -> None:
         )
 
         assert not os.path.exists(os.path.join(tmpdir_path, "hello_world_asset"))
-        assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+        assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
         assert os.path.exists(os.path.join(tmpdir_path, "hello_world_asset"))
 
 
@@ -214,7 +214,7 @@ def test_pythonic_fs_io_manager_runtime_config() -> None:
 
         assert not os.path.exists(os.path.join(tmpdir_path, "hello_world_asset"))
         assert (
-            defs.get_implicit_global_asset_job_def()
+            defs.resolve_implicit_global_asset_job_def()
             .execute_in_process(
                 run_config=RunConfig(
                     resources={"io_manager": FilesystemIOManager(base_dir=tmpdir_path)}
@@ -445,7 +445,7 @@ def test_io_manager_def() -> None:
         )
 
         assert not os.path.exists(os.path.join(tmpdir_path, "hello_world_asset"))
-        assert defs.get_implicit_global_asset_job_def().execute_in_process().success
+        assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
         assert os.path.exists(os.path.join(tmpdir_path, "hello_world_asset"))
 
 
@@ -486,7 +486,7 @@ def test_observable_source_asset_io_manager_def() -> None:
             assets=[my_observable_asset, my_downstream_asset],
         )
 
-        result = defs.get_implicit_global_asset_job_def().execute_in_process()
+        result = defs.resolve_implicit_global_asset_job_def().execute_in_process()
         assert result.success
         assert result.output_for_node("my_downstream_asset") == "foobar"
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -302,7 +302,7 @@ def _synthesize_events(
             loggers=_default_loggers(_append_event),
             resources=_default_resources(),
             executor=in_process_executor,
-        ).get_implicit_job_def_for_assets([k for a in ops_fn_or_assets for k in a.keys])
+        ).resolve_implicit_job_def_def_for_assets([k for a in ops_fn_or_assets for k in a.keys])
         assert job_def
         a_job = job_def
     else:  # op_fn
@@ -1406,7 +1406,7 @@ class TestEventLogStorage:
 
         asset_job = Definitions(
             assets=[asset_one, never_runs_asset],
-        ).get_implicit_global_asset_job_def()
+        ).resolve_implicit_global_asset_job_def()
 
         # test with only one asset selected
         result = asset_job.execute_in_process(
@@ -1432,7 +1432,7 @@ class TestEventLogStorage:
 
         asset_job = Definitions(
             assets=[asset_one, never_runs_asset],
-        ).get_implicit_global_asset_job_def()
+        ).resolve_implicit_global_asset_job_def()
 
         result = asset_job.execute_in_process(instance=instance, raise_on_error=False)
         run_id = result.run_id
@@ -4581,7 +4581,7 @@ class TestEventLogStorage:
         asset_key = AssetKey("never_materializes_asset")
         never_materializes_job = Definitions(
             assets=[never_materializes_asset],
-        ).get_implicit_global_asset_job_def()
+        ).resolve_implicit_global_asset_job_def()
 
         result = _execute_job_and_store_events(
             instance, storage, never_materializes_job, run_id=run_id_1

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -241,7 +241,7 @@ def _get_snapshot_id(manifest, _):
     )
     def my_dbt_assets(): ...
 
-    job = Definitions(assets=[my_dbt_assets]).get_implicit_global_asset_job_def()
+    job = Definitions(assets=[my_dbt_assets]).resolve_implicit_global_asset_job_def()
     return job.get_job_snapshot_id()
 
 
@@ -1092,7 +1092,7 @@ def test_dbt_with_python_interleaving(
         assets=[my_dbt_assets, python_augmented_customers],
         resources={"dbt": DbtCliResource(project_dir=os.fspath(test_dbt_python_interleaving_path))},
     )
-    global_job = defs.get_implicit_global_asset_job_def()
+    global_job = defs.resolve_implicit_global_asset_job_def()
     # my_dbt_assets gets split up
     assert global_job.dependencies == {
         # no dependencies for the first invocation of my_dbt_assets

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -120,7 +120,7 @@ def test_io_manager_asset_metadata(tmp_path) -> None:
         },
     )
 
-    res = defs.get_implicit_global_asset_job_def().execute_in_process()
+    res = defs.resolve_implicit_global_asset_job_def().execute_in_process()
     assert res.success
 
     mats = res.get_asset_materialization_events()

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -75,7 +75,7 @@ def test_io_manager_asset_metadata() -> None:
             assets=[my_pandas_df], resources={"io_manager": pythonic_bigquery_io_manager}
         )
 
-        res = defs.get_implicit_global_asset_job_def().execute_in_process()
+        res = defs.resolve_implicit_global_asset_job_def().execute_in_process()
         assert res.success
 
         mats = res.get_asset_materialization_events()

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -228,7 +228,7 @@ def test_io_manager_asset_metadata() -> None:
             assets=[my_pandas_df], resources={"io_manager": pythonic_snowflake_io_manager}
         )
 
-        res = defs.get_implicit_global_asset_job_def().execute_in_process()
+        res = defs.resolve_implicit_global_asset_job_def().execute_in_process()
         assert res.success
 
         mats = res.get_asset_materialization_events()

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -205,7 +205,7 @@ def test_io_manager_asset_metadata(spark) -> None:
             assets=[my_spark_df], resources={"io_manager": pythonic_snowflake_io_manager}
         )
 
-        res = defs.get_implicit_global_asset_job_def().execute_in_process()
+        res = defs.resolve_implicit_global_asset_job_def().execute_in_process()
         assert res.success
 
         mats = res.get_asset_materialization_events()


### PR DESCRIPTION
## Summary & Motivation

* get_all_job_defs --> resolve_all_job_defs
* get_implicit_global_asset_job_def --> resolve_implicit_global_asset_job_def
* Warn on get_implicit_global_asset_job_def

## How I Tested These Changes

BK

## Changelog

* Added warning to Definitions.get_implicit_global_asset_job_def to use Definitions.resolve_implicit_global_asset_job_def instead
