### PR TITLE
Fix telemetry tests on windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,16 @@ jobs:
             PYTHON_VERSION: "${{ py_version }}"
     variables:
       PYTHONUTF8: "1"
+      # Different APIs when running Python in windows will sometimes generate different paths for
+      # the same file. In particular, "C:\Users\VssAdministrator" and "C:\Users\VSSADM~1" actually
+      # refer to the same directory, but different APIs will return one of these two variants.
+      # Tempdir commands can return the shorter "VSSADM~1" form. This can break our code when it
+      # does lexical comparison of paths to ensure one path is a subdirectory of another. Lexical
+      # comparisons are unaware of the underlying equality of the short and long paths.
+      # 
+      # To avoid this, we set the TEMP and TMP enivironment variables to ensure tempdir APIs always
+      # return the long path.
+      LONG_TEMP: '$(USERPROFILE)\AppData\Local\Temp'
     # Use PowerShell (`powershell`) instead of cmd shell (`script`) for better UTF-8 support.
     steps:
       - task: UsePythonVersion@0
@@ -57,6 +67,10 @@ jobs:
           tox -e $env:TOX_ENV
           cd $env:PATH_BACK_TO_REPO_ROOT
         displayName: "Run tests"
+        env:
+          # See note in the `variables` section above.
+          TEMP: "$(LONG_TEMP)"
+          TMP: "$(LONG_TEMP)"
       - task: PublishTestResults@2
         inputs:
           testResultsFiles: "**/test_results.xml"

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -162,7 +162,7 @@ def dev_command_impl(
         )
 
     os.environ["DAGSTER_IS_DEV_CLI"] = "1"
-    os.environ["DAGSTER_verbose"] = "1" if verbose else ""
+    os.environ["DAGSTER_VERBOSE"] = "1" if verbose else "0"
 
     configure_loggers(formatter=log_format, log_level=log_level.upper())
     logger = logging.getLogger("dagster")

--- a/python_modules/dagster/dagster/_utils/env.py
+++ b/python_modules/dagster/dagster/_utils/env.py
@@ -8,4 +8,4 @@ def using_dagster_dev() -> bool:
 
 
 def use_verbose() -> bool:
-    return bool(os.getenv("DAGSTER_verbose", "1"))
+    return os.getenv("DAGSTER_VERBOSE", "1") == "1"

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 from difflib import SequenceMatcher
+from pathlib import Path
 from typing import Any
 from unittest import mock
 
@@ -84,8 +85,9 @@ def telemetry_caplog(caplog):
     cleanup_telemetry_logger()
 
 
-def path_to_file(path):
-    return script_relative_path(os.path.join("./", path))
+def path_to_file(path: str) -> str:
+    str_path = script_relative_path(os.path.join("./", path))
+    return str(Path(str_path))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary & Motivation

Make sure we're using platform-normalized paths in telemetry tests to fix windows tests.

## How I Tested These Changes

Existing test suite.