### PR TITLE
bring create-dagster workspace args in line with create-dagster project args

### DIFF
--- a/python_modules/libraries/create-dagster/create_dagster/cli/scaffold.py
+++ b/python_modules/libraries/create-dagster/create_dagster/cli/scaffold.py
@@ -8,6 +8,7 @@ from dagster_dg_core.config import (
     DgProjectPythonEnvironmentFlag,
     DgRawWorkspaceConfig,
     DgWorkspaceScaffoldProjectOptions,
+    discover_workspace_root,
     normalize_cli_config,
 )
 from dagster_dg_core.context import DgContext
@@ -25,8 +26,6 @@ from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
 from typing_extensions import get_args
 
 from create_dagster.scaffold import scaffold_project, scaffold_workspace
-
-DEFAULT_WORKSPACE_NAME = "dagster-workspace"
 
 
 def _print_package_install_warning_message() -> None:
@@ -201,12 +200,12 @@ def scaffold_project_command(
     cls=DgClickCommand,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
-@click.argument("name", type=str, default=DEFAULT_WORKSPACE_NAME)
+@click.argument("path", type=Path)
 @dg_editable_dagster_options
 @dg_global_options
 @cli_telemetry_wrapper
 def scaffold_workspace_command(
-    name: str,
+    path: Path,
     use_editable_dagster: Optional[str],
     **global_options: object,
 ):
@@ -232,4 +231,17 @@ def scaffold_workspace_command(
             use_editable_dagster,
         )
     )
-    scaffold_workspace(name, workspace_config)
+
+    abs_path = path.resolve()
+
+    existing_workspace_path = discover_workspace_root(path)
+    if existing_workspace_path:
+        exit_with_error(
+            f"Workspace already exists at {existing_workspace_path}.  Run `create-dagster project` to add a new project to that workspace."
+        )
+    elif str(path) != "." and path.exists():
+        exit_with_error(f"Folder already exists at {path}.")
+
+    click.echo(f"Creating a Dagster workspace at {path}.")
+
+    scaffold_workspace(abs_path, workspace_config)

--- a/python_modules/libraries/create-dagster/create_dagster/scaffold.py
+++ b/python_modules/libraries/create-dagster/create_dagster/scaffold.py
@@ -9,7 +9,6 @@ from dagster_dg_core.config import (
     DgProjectPythonEnvironment,
     DgRawWorkspaceConfig,
     DgWorkspaceScaffoldProjectOptions,
-    discover_workspace_root,
     modify_dg_toml_config,
 )
 from dagster_dg_core.context import DgContext
@@ -19,41 +18,30 @@ from dagster_shared.scaffold import scaffold_subtree
 
 
 def scaffold_workspace(
-    dirname: str,
+    path: Path,
     workspace_config: Optional[DgRawWorkspaceConfig] = None,
-) -> Path:
+) -> None:
     # Can't create a workspace that is a child of another workspace
     import tomlkit
     import tomlkit.items
 
-    new_workspace_path = Path.cwd() if dirname == "." else Path.cwd() / dirname
-    existing_workspace_path = discover_workspace_root(new_workspace_path)
-    if existing_workspace_path:
-        exit_with_error(
-            f"Workspace already exists at {existing_workspace_path}.  Run `create-dagster project` to add a new project to that workspace."
-        )
-    elif dirname != "." and new_workspace_path.exists():
-        exit_with_error(f"Folder already exists at {new_workspace_path}.")
-
     scaffold_subtree(
-        path=new_workspace_path,
+        path=path,
         name_placeholder="WORKSPACE_NAME_PLACEHOLDER",
         project_template_path=Path(
             os.path.join(os.path.dirname(__file__), "templates", "WORKSPACE_NAME_PLACEHOLDER")
         ),
-        project_name=dirname,
     )
 
     if workspace_config is not None:
-        with modify_dg_toml_config(new_workspace_path / "dg.toml") as toml:
+        with modify_dg_toml_config(path / "dg.toml") as toml:
             for k, v in workspace_config.items():
                 # Ignore empty collections and None, but not False
                 if v != {} and v != [] and v is not None:
                     get_toml_node(toml, ("workspace",), (tomlkit.items.Table)).add(tomlkit.nl())
                     set_toml_node(toml, ("workspace", k), v)
 
-    click.echo(f"Scaffolded files for Dagster workspace at {new_workspace_path}.")
-    return new_workspace_path
+    click.echo(f"Scaffolded files for Dagster workspace at {path}.")
 
 
 def scaffold_project(

--- a/python_modules/libraries/create-dagster/create_dagster_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/create-dagster/create_dagster_tests/test_scaffold_commands.py
@@ -36,12 +36,10 @@ from dagster_dg_core_tests.utils import (
 @pytest.mark.parametrize(
     "cli_args",
     [
-        tuple(),
         ("helloworld",),
         (".",),
     ],
     ids=[
-        "no_args",
         "with_name",
         "with_cwd",
     ],
@@ -76,8 +74,8 @@ def test_scaffold_workspace_already_exists_failure(monkeypatch) -> None:
         os.mkdir("dagster-workspace")
         result = runner.invoke_create_dagster(
             "workspace",
-            "--use-editable-dagster",
             "dagster-workspace",
+            "--use-editable-dagster",
         )
         assert_runner_result(result, exit_0=False)
         assert "already exists" in result.output


### PR DESCRIPTION
## Summary & Motivation
The project and workspace scaffold arguments were different in subtle and unneeded ways. Use the same path argument and the same behavior, and drop the 'dagster-workspace' default, which always surprises me during testing.

## How I Tested These Changes
BK, scaffold a workspace locally

## Changelog
[create-dagster] The `create-dagster workspace` command now accepts the same required path argument as the `create-dagster project` command, instead of defaulting to a `dagster-workspace` subfolder of the current working directory.

> Insert changelog entry or delete this section.
