### PR TITLE
Make Definitions.get_job_def much simpler

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -452,6 +452,18 @@ class Definitions(IHaveNew):
         (return value of :py:func:`define_asset_job`) it will be resolved to a :py:class:`JobDefinition` when returned
         from this function, with all resource dependencies fully resolved.
         """
+        for job in self.jobs or []:
+            if job.name == name:
+                if isinstance(job, JobDefinition):
+                    return job
+
+        warnings.warn(
+            f"JobDefinition with name {name} directly passed to Definitions not found, "
+            "will attempt to resolve to a JobDefinition. "
+            "This will be an error in a future release and will require a call to "
+            "resolve_job_def in dagster 1.11. "
+        )
+
         return self.resolve_job_def(name)
 
     def resolve_job_def(self, name: str) -> JobDefinition:

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_object.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_object.py
@@ -64,9 +64,6 @@ def test_resolve_direct_asset_job() -> None:
     ensure_resolve_job_succeeds(defs, "asset_job")
 
 
-@pytest.mark.skip(
-    reason="This is a bug in the implementation of get_job_def"
-)  # schrockn 2025-06-02
 def test_get_direct_asset_job_fails() -> None:
     @asset
     def _asset(_context): ...
@@ -92,9 +89,6 @@ def test_sensor_target_job_resolve_succeeds() -> None:
     ensure_resolve_job_succeeds(defs, "asset_job")
 
 
-@pytest.mark.skip(
-    reason="This is a bug in the implementation of get_job_def"
-)  # schrockn 2025-06-02
 def test_sensor_target_job_get_fails() -> None:
     @asset
     def _asset(_context): ...
@@ -122,7 +116,7 @@ def test_sensor_get_direct_job_succeeds() -> None:
 
     defs = Definitions(sensors=[my_sensor])
 
-    ensure_get_direct_job_def_succeeds(defs, direct_job)
+    ensure_get_job_def_warns(defs, direct_job.name)
 
 
 def test_schedule_target_job_resolve_succeeds() -> None:
@@ -139,9 +133,6 @@ def test_schedule_target_job_resolve_succeeds() -> None:
     ensure_resolve_job_succeeds(defs, "asset_job")
 
 
-@pytest.mark.skip(
-    reason="This is a bug in the implementation of get_job_def"
-)  # schrockn 2025-06-02
 def test_schedule_target_job_get_fails() -> None:
     @asset
     def _asset(_context): ...
@@ -169,7 +160,7 @@ def test_schedule_get_direct_job_succeeds() -> None:
 
     defs = Definitions(schedules=[my_schedule])
 
-    ensure_get_direct_job_def_succeeds(defs, direct_job)
+    ensure_get_job_def_warns(defs, direct_job.name)
 
 
 def test_get_sensor_def_warns() -> None:


### PR DESCRIPTION
## Summary & Motivation

This is take two at a simpler `get_job_def`, but this one is even simpler. It only gets the job definitions passed directly to the `jobs` parameter. Anything "smarter" than that will be left to `resolve_job_def`.

## How I Tested These Changes

BK
