### PR TITLE
feat(backfill_daemon): make default use_threads=True, num_workers=4

### DIFF
--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -354,8 +354,10 @@ class BackfillDaemon(DagsterDaemon):
         self._threadpool_executor: Optional[InheritContextThreadPoolExecutor] = None
         self._submit_threadpool_executor: Optional[InheritContextThreadPoolExecutor] = None
 
-        if settings.get("use_threads"):
-            num_workers = settings.get("num_workers")
+        # Backfill daemon is enabled by default for reasons explained at:
+        # https://github.com/dagster-io/dagster/pull/30189#issuecomment-2930805760
+        if settings.get("use_threads", True):
+            num_workers = settings.get("num_workers", 4)
             if num_workers:
                 self._threadpool_executor = self._exit_stack.enter_context(
                     InheritContextThreadPoolExecutor(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_dagster_daemon.py
@@ -117,6 +117,14 @@ def test_backfill_threadpool():
     with instance_for_test() as instance:
         with daemon_from_instance(instance, "BACKFILL") as backfill_daemon:
             assert isinstance(backfill_daemon, BackfillDaemon)
+            assert backfill_daemon._threadpool_executor  # noqa: SLF001
+            assert not backfill_daemon._submit_threadpool_executor  # noqa: SLF001
+
+    with instance_for_test(
+        overrides={"backfills": {"use_threads": False, "num_workers": 4, "num_submit_workers": 4}}
+    ) as instance:
+        with daemon_from_instance(instance, "BACKFILL") as backfill_daemon:
+            assert isinstance(backfill_daemon, BackfillDaemon)
             assert not backfill_daemon._threadpool_executor  # noqa: SLF001
             assert not backfill_daemon._submit_threadpool_executor  # noqa: SLF001
 
@@ -133,8 +141,8 @@ def test_backfill_threadpool():
     ) as instance:
         with daemon_from_instance(instance, "BACKFILL") as backfill_daemon:
             assert isinstance(backfill_daemon, BackfillDaemon)
-            assert not backfill_daemon._threadpool_executor  # noqa: SLF001
-            assert not backfill_daemon._submit_threadpool_executor  # noqa: SLF001
+            assert backfill_daemon._threadpool_executor  # noqa: SLF001
+            assert backfill_daemon._submit_threadpool_executor  # noqa: SLF001
 
     with instance_for_test(
         overrides={"backfills": {"use_threads": True, "num_workers": 4}}
@@ -149,5 +157,5 @@ def test_backfill_threadpool():
     ) as instance:
         with daemon_from_instance(instance, "BACKFILL") as backfill_daemon:
             assert isinstance(backfill_daemon, BackfillDaemon)
-            assert not backfill_daemon._threadpool_executor  # noqa: SLF001
+            assert backfill_daemon._threadpool_executor  # noqa: SLF001
             assert backfill_daemon._submit_threadpool_executor  # noqa: SLF001


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/pull/30189#issuecomment-2930805760

## How I Tested These Changes
```
python -m pytest python_modules/dagster/dagster_tests -k backfill
```
## Changelog

> feat(backfill_daemon): make default use_threads=True, num_workers=4
