### PR TITLE
added per-partition config support to job-based backfills

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -126,6 +126,8 @@ def create_and_launch_partition_backfill(
 
     tags = {**tags, **graphene_info.context.get_viewer_tags()}
 
+    partition_configs = backfill_params.get("partitionConfigs", {})
+
     title = check_valid_title(backfill_params.get("title"))
 
     if backfill_params.get("selector") is not None:  # job backfill
@@ -184,6 +186,7 @@ def create_and_launch_partition_backfill(
             asset_selection=asset_selection,
             title=title,
             description=backfill_params.get("description"),
+            partition_configs=partition_configs,
         )
         assert_valid_job_partition_backfill(
             graphene_info,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -197,6 +197,7 @@ class GrapheneAssetBackfillPreviewParams(graphene.InputObjectType):
 
 class GrapheneLaunchBackfillParams(graphene.InputObjectType):
     selector = graphene.InputField(GraphenePartitionSetSelector)
+    partitionConfigs = graphene.JSONString()
     partitionNames = graphene.List(graphene.NonNull(graphene.String))
     partitionsByAssets = graphene.List(GraphenePartitionsByAssetSelector)
     reexecutionSteps = graphene.List(graphene.NonNull(graphene.String))
@@ -319,7 +320,6 @@ class GrapheneExecutionParams(graphene.InputObjectType):
 
 
 class GrapheneReexecutionStrategy(graphene.Enum):
-    FROM_ASSET_FAILURE = "FROM_ASSET_FAILURE"
     FROM_FAILURE = "FROM_FAILURE"
     ALL_STEPS = "ALL_STEPS"
 

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -118,6 +118,7 @@ class PartitionBackfill(
             ("submitting_run_requests", Sequence[RunRequest]),
             ("reserved_run_ids", Sequence[str]),
             ("backfill_end_timestamp", Optional[float]),
+            ("partition_configs", Optional[dict[str, str]]),
         ],
     ),
 ):
@@ -142,6 +143,7 @@ class PartitionBackfill(
         submitting_run_requests: Optional[Sequence[RunRequest]] = None,
         reserved_run_ids: Optional[Sequence[str]] = None,
         backfill_end_timestamp: Optional[float] = None,
+        partition_configs: Optional[dict[str, str]] = None,
     ):
         check.invariant(
             not (asset_selection and reexecution_steps),
@@ -194,6 +196,9 @@ class PartitionBackfill(
             ),
             backfill_end_timestamp=check.opt_float_param(
                 backfill_end_timestamp, "backfill_end_timestamp"
+            ),
+            partition_configs=check.opt_dict_param(
+                partition_configs, "partition_configs", key_type=str, value_type=str
             ),
         )
 


### PR DESCRIPTION
Draft PR: This is a capstone project deliverable and represents a foundational implementation toward resolving [#10079](https://github.com/dagster-io/dagster/issues/10079). While we welcome any feedback on the approach or direction, please note that due to the end of our academic sprint, we may not be able to make significant additional changes moving forward.

## Summary & Motivation
This PR introduces support for per-partition configuration in job-based backfills. Previously, all selected partitions in a backfill shared the same run config. With this enhancement, users can now define unique configuration values for each partition directly in the backfill UI.

This feature was implemented to improve user efficiency when managing large backfills, especially in workflows where each partition requires different input parameters (e.g., varying asset keys, model hyperparameters, or custom filters).

This change is in support of GitHub issue [#10079](https://github.com/dagster-io/dagster/issues/10079) and the request discussed in [Discussion #19463](https://github.com/dagster-io/dagster/discussions/19463), and was developed as part of our college capstone project.

## How I Tested These Changes
✅ Manual testing through the Dagster UI (backfill dialog).

✅ Launched multiple backfills with partition-specific config to confirm correct propagation.

✅ Verified that the config is serialized in GraphQL, stored in PartitionBackfill, and injected into run requests via submit_backfill_runs.

✅ Added debug logging to trace config merge at execution time.

❌ No unit tests added due to sprint time constraints, but all existing tests continue to pass.

## Changelog
- Added: New per-partition config section in backfill UI
- Added: Support for `partitionConfigs` in LaunchBackfillParams (GraphQL)
- Added: New logic to parse and merge user configs per partition in the backfill daemon
- Removed: Deprecated BackfillRunRequest abstraction in favor of direct config/tag mapping

## Additional Information
- This is not a breaking change.
- Asset backfills are not yet supported — this implementation applies only to job-based backfills (partition_set_origin path).
- Others contributors: @Gene7Him @DPJProgramming