### PR TITLE
Add new service discovery error to list of transient task failures for retry purposes

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
@@ -160,4 +160,7 @@ def is_transient_task_stopped_reason(stopped_reason: str) -> bool:
     ):
         return True
 
+    if "The Service Discovery instance could not be registered" in stopped_reason:
+        return True
+
     return False


### PR DESCRIPTION
## Summary & Motivation
Once we verify that this error that failed a task startup (seemingly transiently) is expected, add it to the list of errors that are automatically retried.
