### PR TITLE
Fix logspew in dg dev / dg check defs in a workspace context due to attempting to check yaml

### DIFF
--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -73,7 +73,7 @@ def definitions_validate_command(
     definitions_validate_command_impl(
         log_level=log_level,
         log_format=log_format,
-        load_with_grpc=load_with_grpc,
+        allow_in_process=not load_with_grpc,
         verbose=verbose,
         **other_opts,
     )
@@ -82,7 +82,7 @@ def definitions_validate_command(
 def definitions_validate_command_impl(
     log_level: str,
     log_format: str,
-    load_with_grpc: bool,
+    allow_in_process: bool,
     verbose: bool,
     **other_opts: object,
 ):
@@ -108,7 +108,7 @@ def definitions_validate_command_impl(
             instance=instance,
             version=dagster_version,
             workspace_opts=workspace_opts,
-            allow_in_process=not load_with_grpc,
+            allow_in_process=allow_in_process,
             log_level=log_level,
         ) as workspace:
             if logger.parent:

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/check.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/check.py
@@ -1,12 +1,18 @@
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import click
 from dagster_dg_core.config import normalize_cli_config
 from dagster_dg_core.context import DgContext
 from dagster_dg_core.shared_options import dg_global_options, dg_path_options
-from dagster_dg_core.utils import DgClickCommand, DgClickGroup, pushd, validate_dagster_availability
+from dagster_dg_core.utils import (
+    DgClickCommand,
+    DgClickGroup,
+    exit_with_error,
+    pushd,
+    validate_dagster_availability,
+)
 from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
 
 from dagster_dg_cli.cli.utils import create_temp_workspace_file
@@ -95,8 +101,8 @@ def check_yaml_command(
 @click.option(
     "--check-yaml/--no-check-yaml",
     flag_value=True,
-    default=True,
     help="Whether to schema-check defs.yaml files for the project before loading and checking all definitions.",
+    default=None,
 )
 @dg_path_options
 @dg_global_options
@@ -108,6 +114,7 @@ def check_definitions_command(
     log_format: str,
     verbose: bool,
     target_path: Path,
+    check_yaml: Optional[bool],
     **global_options: Mapping[str, object],
 ) -> None:
     """Loads and validates your Dagster definitions using a Dagster instance.
@@ -130,11 +137,17 @@ def check_definitions_command(
 
     validate_dagster_availability()
 
+    if check_yaml is True and not dg_context.is_project:
+        exit_with_error("--check-yaml is not currently supported in a workspace context")
+
+    if check_yaml is None:
+        check_yaml = dg_context.is_project
+
     with (
         pushd(dg_context.root_path),
         create_temp_workspace_file(dg_context) as workspace_file,
     ):
-        if check_yaml_fn:
+        if check_yaml:
             overall_check_result = True
             project_dirs = (
                 [dg_context.root_path]
@@ -156,7 +169,7 @@ def check_definitions_command(
         definitions_validate_command_impl(
             log_level=log_level,
             log_format=log_format,
-            load_with_grpc=False,
+            allow_in_process=True,
             verbose=verbose,
             workspace=[workspace_file],
         )

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/dev.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/dev.py
@@ -8,7 +8,12 @@ import click
 from dagster_dg_core.config import normalize_cli_config
 from dagster_dg_core.context import DgContext
 from dagster_dg_core.shared_options import dg_global_options, dg_path_options
-from dagster_dg_core.utils import DgClickCommand, pushd, validate_dagster_availability
+from dagster_dg_core.utils import (
+    DgClickCommand,
+    exit_with_error,
+    pushd,
+    validate_dagster_availability,
+)
 from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
 from dagster_shared.cli import WorkspaceOpts, dg_workspace_options
 
@@ -65,8 +70,8 @@ T = TypeVar("T")
 @click.option(
     "--check-yaml/--no-check-yaml",
     flag_value=True,
-    default=True,
     help="Whether to schema-check defs.yaml files for the project before starting the dev server.",
+    default=None,
 )
 @dg_path_options
 @dg_global_options
@@ -79,7 +84,7 @@ def dev_command(
     port: Optional[int],
     host: Optional[str],
     live_data_poll_rate: int,
-    check_yaml: bool,
+    check_yaml: Optional[bool],
     target_path: Path,
     **other_options: Mapping[str, object],
 ) -> None:
@@ -119,6 +124,9 @@ def dev_command(
         os.environ["DAGSTER_PROJECT_ENV_FILE_PATHS"] = json.dumps(
             {dg_context.code_location_name: str(dg_context.root_path)}
         )
+        if check_yaml is None:
+            # default to checking yaml in a project context
+            check_yaml = True
     else:
         os.environ["DAGSTER_PROJECT_ENV_FILE_PATHS"] = json.dumps(
             {
@@ -128,6 +136,9 @@ def dev_command(
                 for project in dg_context.project_specs
             }
         )
+        if check_yaml is True:
+            exit_with_error("--check-yaml is not currently supported in a workspace context")
+        check_yaml = False
 
     with (
         pushd(dg_context.root_path),

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_check_defs_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_check_defs_command.py
@@ -67,7 +67,7 @@ def test_check_defs_project_context_failure():
         assert result.exit_code == 1
 
 
-def test_implicit_yaml_check_from_dg_check_defs() -> None:
+def test_implicit_yaml_check_from_dg_check_defs_in_project_context() -> None:
     with (
         ProxyRunner.test() as runner,
         create_project_from_components(
@@ -75,29 +75,83 @@ def test_implicit_yaml_check_from_dg_check_defs() -> None:
             BASIC_MISSING_VALUE.component_path,
             BASIC_INVALID_VALUE.component_path,
             local_component_defn_to_inject=BASIC_MISSING_VALUE.component_type_filepath,
+            in_workspace=False,
         ) as tmpdir,
     ):
         with pushd(str(tmpdir)):
-            result = runner.invoke("check", "defs")
+            result = runner.invoke("check", "defs", catch_exceptions=False)
             assert result.exit_code != 0, str(result.stdout)
 
             assert BASIC_INVALID_VALUE.check_error_msg and BASIC_MISSING_VALUE.check_error_msg
             BASIC_INVALID_VALUE.check_error_msg(str(result.stdout))
             BASIC_MISSING_VALUE.check_error_msg(str(result.stdout))
 
+            # didn't make it to defs check
+            assert "Validation failed for code location foo-bar" not in str(result.stdout)
 
-def test_implicit_yaml_check_from_dg_check_defs_workspace() -> None:
+
+def test_implicit_yaml_check_disabled_in_project_context() -> None:
     with (
         ProxyRunner.test() as runner,
         create_project_from_components(
             runner,
             BASIC_MISSING_VALUE.component_path,
+            BASIC_INVALID_VALUE.component_path,
             local_component_defn_to_inject=BASIC_MISSING_VALUE.component_type_filepath,
+            in_workspace=False,
         ) as tmpdir,
     ):
-        with pushd(str(Path(tmpdir).parent)):
-            result = runner.invoke("dev")
+        with pushd(str(tmpdir)):
+            result = runner.invoke("check", "defs", "--no-check-yaml", catch_exceptions=False)
             assert result.exit_code != 0, str(result.stdout)
 
-            assert BASIC_MISSING_VALUE.check_error_msg
+            # yaml check was skipped, defs check failed
+            assert "Validation failed for code location foo-bar" in str(result.stdout)
+
+
+def test_no_implicit_yaml_check_from_dg_check_defs_in_workspace_context() -> None:
+    with (
+        ProxyRunner.test() as runner,
+        create_project_from_components(
+            runner,
+            BASIC_MISSING_VALUE.component_path,
+            BASIC_INVALID_VALUE.component_path,
+            local_component_defn_to_inject=BASIC_MISSING_VALUE.component_type_filepath,
+            in_workspace=True,
+        ) as tmpdir,
+    ):
+        with pushd(Path(tmpdir).parent):
+            result = runner.invoke("check", "defs", catch_exceptions=False)
+            assert result.exit_code != 0, str(result.stdout)
+
+            # yaml check was skipped, defs check failed
+            assert "Validation failed for code location foo-bar" in str(result.stdout)
+
+
+def test_implicit_yaml_check_from_dg_check_defs_disallowed_in_workspace_context() -> None:
+    with (
+        ProxyRunner.test() as runner,
+        create_project_from_components(
+            runner,
+            BASIC_MISSING_VALUE.component_path,
+            BASIC_INVALID_VALUE.component_path,
+            local_component_defn_to_inject=BASIC_MISSING_VALUE.component_type_filepath,
+            in_workspace=True,
+        ) as tmpdir,
+    ):
+        with pushd(Path(tmpdir).parent):
+            result = runner.invoke("check", "defs", "--check-yaml", catch_exceptions=False)
+            assert result.exit_code != 0, str(result.stdout)
+
+            assert "--check-yaml is not currently supported in a workspace context" in str(
+                result.stdout
+            )
+
+        # It is supported and is the default in a project context within a workspace
+        with pushd(tmpdir):
+            result = runner.invoke("check", "defs", "--check-yaml", catch_exceptions=False)
+            assert result.exit_code != 0, str(result.stdout)
+
+            assert BASIC_INVALID_VALUE.check_error_msg and BASIC_MISSING_VALUE.check_error_msg
+            BASIC_INVALID_VALUE.check_error_msg(str(result.stdout))
             BASIC_MISSING_VALUE.check_error_msg(str(result.stdout))

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/utils.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/utils.py
@@ -733,6 +733,7 @@ def create_project_from_components(
     *src_paths: str,
     local_component_defn_to_inject: Optional[Path] = None,
     python_environment: DgProjectPythonEnvironmentFlag = "active",
+    in_workspace: bool = True,
 ) -> Iterator[Path]:
     """Scaffolds a project with the given components in a temporary directory,
     injecting the provided local component defn into each component's __init__.py.
@@ -742,6 +743,7 @@ def create_project_from_components(
         runner,
         component_dirs=origin_paths,
         python_environment=python_environment,
+        in_workspace=in_workspace,
     ):
         for src_path in src_paths:
             components_dir = Path.cwd() / "src" / "foo_bar" / "defs" / src_path.split("/")[-1]


### PR DESCRIPTION
Summary:
This regressed a bit when we moved dg to in process - before you could check yaml over the IPC boundary, now you can't. Resolve by temporarily disabling checking yaml in a workspace context. Longer term we can add a gRPC method for checking YAML and use that (which is why check defs still works even after the change, it has always used gRPC).

Test Plan:
dg dev and dg check defs in a workspace using a uv venv now doesn't spew at you
