### PR TITLE
Add multiple ssh key types

### DIFF
--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -31,7 +31,7 @@ def key_from_str(key_str):
         key_str (str): A string containing the private key data.
 
     Returns:
-        paramiko.RSAKey: An RSA key object created from the provided string.
+        paramiko.PKey: A key object created from the provided string.
 
     Raises:
         ValueError: If the key string is invalid or cannot be parsed.
@@ -40,9 +40,18 @@ def key_from_str(key_str):
 
     # py2 StringIO doesn't support with
     key_file = StringIO(key_str)
-    result = paramiko.RSAKey.from_private_key(key_file)
-    key_file.close()
-    return result
+    try:
+        # Try parsing with different key types
+        for key_class in [paramiko.RSAKey, paramiko.Ed25519Key, paramiko.ECDSAKey, paramiko.DSSKey]:
+            try:
+                result = key_class.from_private_key(key_file)
+                key_file.close()
+                return result
+            except:
+                key_file.seek(0)  # Reset file pointer for next attempt
+        raise ValueError("Unable to parse the key with any known key type")
+    finally:
+        key_file.close()
 
 
 @beta

--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -45,11 +45,10 @@ def key_from_str(key_str):
         for key_class in [paramiko.RSAKey, paramiko.Ed25519Key, paramiko.ECDSAKey, paramiko.DSSKey]:
             try:
                 result = key_class.from_private_key(key_file)
-                key_file.close()
                 return result
-            except:
+            except paramiko.ssh_exception.SSHException:
                 key_file.seek(0)  # Reset file pointer for next attempt
-        raise ValueError("Unable to parse the key with any known key type")
+        raise paramiko.ssh_exception.SSHException("Unable to parse the key with any known key type")
     finally:
         key_file.close()
 


### PR DESCRIPTION
## Summary & Motivation
Currently `dagster-ssh` only supports RSA key type, while the underlying `paramiko` provides 4 keys.

This PR iterates over the key classes and attempts to instantiate a class. If it fails, we try the next one. If it succeeds, we return!

## How I Tested These Changes

Yet to test them!

## Changelog

> Add support for ed25519, ECDSA, DSS keys in `dagster-ssh`
