### PR TITLE
Support tags in both the asset and asset check use case

### DIFF
--- a/python_modules/dagster/dagster/components/lib/executable_component/component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/component.py
@@ -6,6 +6,8 @@ from typing import Annotated, Any, Callable, Literal, Optional, Union
 from dagster_shared import check
 from typing_extensions import TypeAlias
 
+from dagster._core.definitions.asset_checks import AssetChecksDefinition
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.decorators.asset_check_decorator import multi_asset_check
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.definitions_class import Definitions
@@ -81,6 +83,7 @@ class ExecutableComponent(Component, Resolvable, Model):
 
     # inferred from the function name if not provided
     name: Optional[str] = None
+    tags: Optional[dict[str, Any]] = None
     partitions_def: Optional[ResolvedPartitionDefinition] = None
     assets: Optional[list[ResolvedAssetSpec]] = None
     checks: Optional[list[ResolvedAssetCheckSpec]] = None
@@ -90,11 +93,12 @@ class ExecutableComponent(Component, Resolvable, Model):
     def resource_keys(self) -> set[str]:
         return set(get_resources_from_callable(self.execute_fn))
 
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+    def build_underlying_assets_def(self) -> AssetsDefinition:
         if self.assets:
 
             @multi_asset(
                 name=self.name or self.execute_fn.__name__,
+                op_tags=self.tags,
                 specs=self.assets,
                 check_specs=self.checks,
                 partitions_def=self.partitions_def,
@@ -103,20 +107,28 @@ class ExecutableComponent(Component, Resolvable, Model):
             def _assets_def(context: AssetExecutionContext, **kwargs):
                 return self.invoke_execute_fn(context)
 
-            return Definitions(assets=[_assets_def])
+            return _assets_def
         elif self.checks:
 
             @multi_asset_check(
                 name=self.name or self.execute_fn.__name__,
+                op_tags=self.tags,
                 specs=self.checks,
                 required_resource_keys=self.resource_keys,
             )
             def _asset_check_def(context: AssetCheckExecutionContext, **kwargs):
                 return self.invoke_execute_fn(context)
 
-            return Definitions(asset_checks=[_asset_check_def])
+            return _asset_check_def
+
+        check.failed("No assets or checks provided")
+
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        assets_def = self.build_underlying_assets_def()
+        if isinstance(assets_def, AssetChecksDefinition):
+            return Definitions(asset_checks=[assets_def])
         else:
-            check.failed("No assets or checks provided")
+            return Definitions(assets=[assets_def])
 
     def invoke_execute_fn(
         self, context: Union[AssetExecutionContext, AssetCheckExecutionContext]

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_asset_check_only.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_asset_check_only.py
@@ -164,3 +164,38 @@ def test_standalone_asset_check_with_resources() -> None:
     assert asset_check_evaluations[0].metadata == {
         "resource_one": TextMetadataValue("resource_value")
     }
+
+
+def test_op_tags() -> None:
+    component_only_assets = ExecutableComponent.from_attributes_dict(
+        attributes={
+            "name": "op_name",
+            "execute_fn": "dagster_tests.components_tests.executable_component_tests.test_asset_check_only.only_asset_check_execute_fn",
+            "tags": {"op_tag": "op_tag_value"},
+            "assets": [
+                {
+                    "key": "asset",
+                }
+            ],
+        }
+    )
+
+    assert component_only_assets.build_underlying_assets_def().op.tags == {"op_tag": "op_tag_value"}
+
+    component_only_asset_checks = ExecutableComponent.from_attributes_dict(
+        attributes={
+            "name": "op_name",
+            "execute_fn": "dagster_tests.components_tests.executable_component_tests.test_asset_check_only.only_asset_check_execute_fn",
+            "tags": {"op_tag": "op_tag_value"},
+            "checks": [
+                {
+                    "asset": "asset",
+                    "name": "check_name",
+                }
+            ],
+        }
+    )
+
+    assert component_only_asset_checks.build_underlying_assets_def().op.tags == {
+        "op_tag": "op_tag_value"
+    }

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_asset_check_only.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_asset_check_only.py
@@ -15,6 +15,10 @@ from dagster.components.lib.executable_component.component import ExecutableComp
 from dagster_shared import check
 
 
+def only_asset_execute_fn(context):
+    return MaterializeResult()
+
+
 def only_asset_check_execute_fn(context):
     return AssetCheckResult(passed=True)
 
@@ -170,7 +174,7 @@ def test_op_tags() -> None:
     component_only_assets = ExecutableComponent.from_attributes_dict(
         attributes={
             "name": "op_name",
-            "execute_fn": "dagster_tests.components_tests.executable_component_tests.test_asset_check_only.only_asset_check_execute_fn",
+            "execute_fn": "dagster_tests.components_tests.executable_component_tests.test_asset_check_only.only_asset_execute_fn",
             "tags": {"op_tag": "op_tag_value"},
             "assets": [
                 {


### PR DESCRIPTION
## Summary & Motivation

Adding support for `tags` on `ExecutableComponent`, which ends up getting assigned to the underlying `op`. This is fairly critical decision, actually, because we are deciding whether or not to _hide_ ops (which this does) or to be transparent (by having the schema to op: name: foo).

## How I Tested These Changes

BK
