### PR TITLE
Add description to ExecutableComponent

### DIFF
--- a/python_modules/dagster/dagster/components/lib/executable_component/component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/component.py
@@ -83,6 +83,7 @@ class ExecutableComponent(Component, Resolvable, Model):
 
     # inferred from the function name if not provided
     name: Optional[str] = None
+    description: Optional[str] = None
     tags: Optional[dict[str, Any]] = None
     partitions_def: Optional[ResolvedPartitionDefinition] = None
     assets: Optional[list[ResolvedAssetSpec]] = None
@@ -99,6 +100,7 @@ class ExecutableComponent(Component, Resolvable, Model):
             @multi_asset(
                 name=self.name or self.execute_fn.__name__,
                 op_tags=self.tags,
+                description=self.description,
                 specs=self.assets,
                 check_specs=self.checks,
                 partitions_def=self.partitions_def,
@@ -114,6 +116,7 @@ class ExecutableComponent(Component, Resolvable, Model):
                 name=self.name or self.execute_fn.__name__,
                 op_tags=self.tags,
                 specs=self.checks,
+                description=self.description,
                 required_resource_keys=self.resource_keys,
             )
             def _asset_check_def(context: AssetCheckExecutionContext, **kwargs):

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_asset_check_only.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_asset_check_only.py
@@ -170,11 +170,12 @@ def test_standalone_asset_check_with_resources() -> None:
     }
 
 
-def test_op_tags() -> None:
+def test_trivial_properties() -> None:
     component_only_assets = ExecutableComponent.from_attributes_dict(
         attributes={
             "name": "op_name",
             "execute_fn": "dagster_tests.components_tests.executable_component_tests.test_asset_check_only.only_asset_execute_fn",
+            "description": "op_description",
             "tags": {"op_tag": "op_tag_value"},
             "assets": [
                 {
@@ -189,6 +190,7 @@ def test_op_tags() -> None:
     component_only_asset_checks = ExecutableComponent.from_attributes_dict(
         attributes={
             "name": "op_name",
+            "description": "op_description",
             "execute_fn": "dagster_tests.components_tests.executable_component_tests.test_asset_check_only.only_asset_check_execute_fn",
             "tags": {"op_tag": "op_tag_value"},
             "checks": [
@@ -200,6 +202,6 @@ def test_op_tags() -> None:
         }
     )
 
-    assert component_only_asset_checks.build_underlying_assets_def().op.tags == {
-        "op_tag": "op_tag_value"
-    }
+    for component in [component_only_assets, component_only_asset_checks]:
+        assert component.build_underlying_assets_def().op.tags == {"op_tag": "op_tag_value"}
+        assert component.build_underlying_assets_def().op.description == "op_description"


### PR DESCRIPTION
## Summary & Motivation

Now that we have some common test cases, easy to add description to ExecutableComponent. Again this becomes the op description.

## How I Tested These Changes

BK

