### PR TITLE
Add pool to executable component

### DIFF
--- a/python_modules/dagster/dagster/components/lib/executable_component/component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/component.py
@@ -62,6 +62,7 @@ class ExecutableComponent(Component, Resolvable, Model):
     name: Optional[str] = None
     description: Optional[str] = None
     tags: Optional[dict[str, Any]] = None
+    pool: Optional[str] = None
     assets: Optional[list[ResolvedAssetSpec]] = None
     checks: Optional[list[ResolvedAssetCheckSpec]] = None
     execute_fn: ResolvableCallable
@@ -84,6 +85,7 @@ class ExecutableComponent(Component, Resolvable, Model):
                 specs=self.assets,
                 check_specs=self.checks,
                 required_resource_keys=self.resource_keys,
+                pool=self.pool,
             )
             def _assets_def(context: AssetExecutionContext, **kwargs):
                 return self.invoke_execute_fn(context)
@@ -97,6 +99,7 @@ class ExecutableComponent(Component, Resolvable, Model):
                 specs=self.checks,
                 description=self.description,
                 required_resource_keys=self.resource_keys,
+                pool=self.pool,
             )
             def _asset_check_def(context: AssetCheckExecutionContext, **kwargs):
                 return self.invoke_execute_fn(context)

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_asset_check_only.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_asset_check_only.py
@@ -178,6 +178,7 @@ def test_trivial_properties() -> None:
             "execute_fn": "dagster_tests.components_tests.executable_component_tests.test_asset_check_only.only_asset_execute_fn",
             "description": "op_description",
             "tags": {"op_tag": "op_tag_value"},
+            "pool": "op_pool",
             "assets": [
                 {
                     "key": "asset",
@@ -194,6 +195,7 @@ def test_trivial_properties() -> None:
             "description": "op_description",
             "execute_fn": "dagster_tests.components_tests.executable_component_tests.test_asset_check_only.only_asset_check_execute_fn",
             "tags": {"op_tag": "op_tag_value"},
+            "pool": "op_pool",
             "checks": [
                 {
                     "asset": "asset",
@@ -206,3 +208,4 @@ def test_trivial_properties() -> None:
     for component in [component_only_assets, component_only_asset_checks]:
         assert component.build_underlying_assets_def().op.tags == {"op_tag": "op_tag_value"}
         assert component.build_underlying_assets_def().op.description == "op_description"
+        assert component.build_underlying_assets_def().op.pool == "op_pool"


### PR DESCRIPTION
## Summary & Motivation

Adds a `pool` argument to `ExecutableComponent` which gets passed down to the underlying `multi_asset` and `multi_asset_check`

## How I Tested These Changes

BK
