### PR TITLE
Remove partitions_def from ExecutableComponent

### DIFF
--- a/python_modules/dagster/dagster/components/lib/executable_component/component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/component.py
@@ -1,7 +1,7 @@
 import importlib
 import inspect
 from functools import cached_property
-from typing import Annotated, Any, Callable, Literal, Optional, Union
+from typing import Annotated, Any, Callable, Optional, Union
 
 from dagster_shared import check
 from typing_extensions import TypeAlias
@@ -11,7 +11,6 @@ from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.decorators.asset_check_decorator import multi_asset_check
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition
 from dagster._core.execution.context.asset_check_execution_context import AssetCheckExecutionContext
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster.components.component.component import Component
@@ -20,30 +19,6 @@ from dagster.components.resolved.base import Resolvable
 from dagster.components.resolved.context import ResolutionContext
 from dagster.components.resolved.core_models import ResolvedAssetCheckSpec, ResolvedAssetSpec
 from dagster.components.resolved.model import Model, Resolver
-
-
-class DailyPartitionDefinitionModel(Resolvable, Model):
-    type: Literal["daily"] = "daily"
-    start_date: str
-    end_offset: int = 0
-
-
-def resolve_partition_definition(
-    context: ResolutionContext, model: DailyPartitionDefinitionModel
-) -> DailyPartitionsDefinition:
-    return DailyPartitionsDefinition(
-        start_date=model.start_date,
-        end_offset=model.end_offset,
-    )
-
-
-ResolvedPartitionDefinition: TypeAlias = Annotated[
-    DailyPartitionsDefinition,
-    Resolver(
-        resolve_partition_definition,
-        model_field_type=DailyPartitionDefinitionModel,
-    ),
-]
 
 
 def resolve_callable(context: ResolutionContext, model: str) -> Callable:
@@ -85,7 +60,6 @@ class ExecutableComponent(Component, Resolvable, Model):
     name: Optional[str] = None
     description: Optional[str] = None
     tags: Optional[dict[str, Any]] = None
-    partitions_def: Optional[ResolvedPartitionDefinition] = None
     assets: Optional[list[ResolvedAssetSpec]] = None
     checks: Optional[list[ResolvedAssetCheckSpec]] = None
     execute_fn: ResolvableCallable
@@ -103,7 +77,6 @@ class ExecutableComponent(Component, Resolvable, Model):
                 description=self.description,
                 specs=self.assets,
                 check_specs=self.checks,
-                partitions_def=self.partitions_def,
                 required_resource_keys=self.resource_keys,
             )
             def _assets_def(context: AssetExecutionContext, **kwargs):


### PR DESCRIPTION
## Summary & Motivation

In the spirit of only having one way of doing things, I'm going to pull partitions definition of the Executable Component, and rely on it in `AssetSpec` only. Worthy of discussion. If we do this we probably want some group assignment primitive as there are a few properties like this.

## How I Tested These Changes

BK
