### PR TITLE
Require proper resources on the execute_fn

### DIFF
--- a/python_modules/dagster/dagster/components/lib/executable_component/component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/component.py
@@ -67,12 +67,12 @@ class ExecutableComponent(Component, Resolvable, Model):
     execute_fn: ResolvableCallable
 
     @cached_property
-    def invoker(self) -> "ExecuteInvoker":
-        return ExecuteInvoker(self.execute_fn)
+    def execute_fn_metadata(self) -> "ExecuteFnMetadata":
+        return ExecuteFnMetadata(self.execute_fn)
 
     @cached_property
     def resource_keys(self) -> set[str]:
-        return self.invoker.resource_keys
+        return self.execute_fn_metadata.resource_keys
 
     def build_underlying_assets_def(self) -> AssetsDefinition:
         if self.assets:
@@ -86,7 +86,7 @@ class ExecutableComponent(Component, Resolvable, Model):
                 required_resource_keys=self.resource_keys,
             )
             def _assets_def(context: AssetExecutionContext, **kwargs):
-                return self.invoker.invoke(context)
+                return self.invoke_execute_fn(context)
 
             return _assets_def
         elif self.checks:
@@ -99,7 +99,7 @@ class ExecutableComponent(Component, Resolvable, Model):
                 required_resource_keys=self.resource_keys,
             )
             def _asset_check_def(context: AssetCheckExecutionContext, **kwargs):
-                return self.invoker.invoke(context)
+                return self.invoke_execute_fn(context)
 
             return _asset_check_def
 
@@ -121,7 +121,7 @@ class ExecutableComponent(Component, Resolvable, Model):
         return self.execute_fn(context, **to_pass)
 
 
-class ExecuteInvoker:
+class ExecuteFnMetadata:
     def __init__(self, execute_fn: Callable):
         self.execute_fn = execute_fn
         found_args = {"context"} | self.resource_keys
@@ -139,9 +139,3 @@ class ExecuteInvoker:
     @cached_property
     def function_params_names(self) -> set[str]:
         return {arg.name for arg in get_function_params(self.execute_fn)}
-
-    def invoke(self, context: Union[AssetExecutionContext, AssetCheckExecutionContext]) -> Any:
-        rd = context.resources.original_resource_dict
-        to_pass = {k: v for k, v in rd.items() if k in self.resource_keys}
-        check.invariant(set(to_pass.keys()) == self.resource_keys, "Resource keys mismatch")
-        return self.execute_fn(context, **to_pass)

--- a/python_modules/dagster/dagster/components/lib/executable_component/component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/component.py
@@ -6,11 +6,13 @@ from typing import Annotated, Any, Callable, Optional, Union
 from dagster_shared import check
 from typing_extensions import TypeAlias
 
+from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.decorators.asset_check_decorator import multi_asset_check
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.execution.context.asset_check_execution_context import AssetCheckExecutionContext
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster.components.component.component import Component
@@ -65,8 +67,12 @@ class ExecutableComponent(Component, Resolvable, Model):
     execute_fn: ResolvableCallable
 
     @cached_property
+    def invoker(self) -> "ExecuteInvoker":
+        return ExecuteInvoker(self.execute_fn)
+
+    @cached_property
     def resource_keys(self) -> set[str]:
-        return set(get_resources_from_callable(self.execute_fn))
+        return self.invoker.resource_keys
 
     def build_underlying_assets_def(self) -> AssetsDefinition:
         if self.assets:
@@ -80,7 +86,7 @@ class ExecutableComponent(Component, Resolvable, Model):
                 required_resource_keys=self.resource_keys,
             )
             def _assets_def(context: AssetExecutionContext, **kwargs):
-                return self.invoke_execute_fn(context)
+                return self.invoker.invoke(context)
 
             return _assets_def
         elif self.checks:
@@ -93,7 +99,7 @@ class ExecutableComponent(Component, Resolvable, Model):
                 required_resource_keys=self.resource_keys,
             )
             def _asset_check_def(context: AssetCheckExecutionContext, **kwargs):
-                return self.invoke_execute_fn(context)
+                return self.invoker.invoke(context)
 
             return _asset_check_def
 
@@ -109,6 +115,32 @@ class ExecutableComponent(Component, Resolvable, Model):
     def invoke_execute_fn(
         self, context: Union[AssetExecutionContext, AssetCheckExecutionContext]
     ) -> Any:
+        rd = context.resources.original_resource_dict
+        to_pass = {k: v for k, v in rd.items() if k in self.resource_keys}
+        check.invariant(set(to_pass.keys()) == self.resource_keys, "Resource keys mismatch")
+        return self.execute_fn(context, **to_pass)
+
+
+class ExecuteInvoker:
+    def __init__(self, execute_fn: Callable):
+        self.execute_fn = execute_fn
+        found_args = {"context"} | self.resource_keys
+        extra_args = self.function_params_names - found_args
+        if extra_args:
+            check.failed(
+                f"Found extra arguments in execute_fn: {extra_args}. "
+                "Arguments must be valid resource params or annotated with Upstream"
+            )
+
+    @cached_property
+    def resource_keys(self) -> set[str]:
+        return {arg.name for arg in get_resource_args(self.execute_fn)}
+
+    @cached_property
+    def function_params_names(self) -> set[str]:
+        return {arg.name for arg in get_function_params(self.execute_fn)}
+
+    def invoke(self, context: Union[AssetExecutionContext, AssetCheckExecutionContext]) -> Any:
         rd = context.resources.original_resource_dict
         to_pass = {k: v for k, v in rd.items() if k in self.resource_keys}
         check.invariant(set(to_pass.keys()) == self.resource_keys, "Resource keys mismatch")

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_asset_check_only.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_asset_check_only.py
@@ -8,6 +8,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.materialize import materialize
 from dagster._core.definitions.metadata.metadata_value import TextMetadataValue
+from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster.components.core.context import ComponentLoadContext
@@ -131,7 +132,7 @@ def test_standalone_asset_check() -> None:
     assert asset_check_evaluations[0].passed is True
 
 
-def asset_check_execute_fn_with_resources(context, resource_one):
+def asset_check_execute_fn_with_resources(context, resource_one: ResourceParam[str]):
     return AssetCheckResult(passed=True, metadata={"resource_one": resource_one})
 
 

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_executable_component_in_memory.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_executable_component_in_memory.py
@@ -6,6 +6,7 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.materialize import materialize
 from dagster._core.definitions.metadata.metadata_value import TextMetadataValue
+from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.definitions.result import MaterializeResult
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.lib.executable_component.component import ExecutableComponent
@@ -73,7 +74,7 @@ def test_basic_singular_asset_from_yaml() -> None:
 
 
 def test_resource_usage() -> None:
-    def _execute_fn(context, some_resource) -> MaterializeResult:
+    def _execute_fn(context, some_resource: ResourceParam[str]) -> MaterializeResult:
         return MaterializeResult(metadata={"foo": some_resource})
 
     component = ExecutableComponent(

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_execute_fn_params.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_execute_fn_params.py
@@ -1,0 +1,27 @@
+import pytest
+from dagster._core.definitions.resource_annotation import ResourceParam
+from dagster.components.lib.executable_component.component import ExecuteInvoker
+from dagster_shared.check import CheckError
+
+
+def test_execute_fn_with_ok() -> None:
+    def execute_fn_no_args(context): ...
+
+    invoker = ExecuteInvoker(execute_fn_no_args)
+    assert invoker.resource_keys == set()
+    assert invoker.function_params_names == {"context"}
+
+
+def test_execute_fn_no_annotations() -> None:
+    def execute_fn(context, no_annotation): ...
+
+    with pytest.raises(CheckError, match="Found extra arguments in execute_fn: {'no_annotation'}"):
+        ExecuteInvoker(execute_fn)
+
+
+def test_execute_fn_with_resource_param() -> None:
+    def execute_fn(context, some_resource: ResourceParam[str]): ...
+
+    invoker = ExecuteInvoker(execute_fn)
+    assert invoker.resource_keys == {"some_resource"}
+    assert invoker.function_params_names == {"context", "some_resource"}

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_execute_fn_params.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_execute_fn_params.py
@@ -1,13 +1,13 @@
 import pytest
 from dagster._core.definitions.resource_annotation import ResourceParam
-from dagster.components.lib.executable_component.component import ExecuteInvoker
+from dagster.components.lib.executable_component.component import ExecuteFnMetadata
 from dagster_shared.check import CheckError
 
 
 def test_execute_fn_with_ok() -> None:
     def execute_fn_no_args(context): ...
 
-    invoker = ExecuteInvoker(execute_fn_no_args)
+    invoker = ExecuteFnMetadata(execute_fn_no_args)
     assert invoker.resource_keys == set()
     assert invoker.function_params_names == {"context"}
 
@@ -16,12 +16,12 @@ def test_execute_fn_no_annotations() -> None:
     def execute_fn(context, no_annotation): ...
 
     with pytest.raises(CheckError, match="Found extra arguments in execute_fn: {'no_annotation'}"):
-        ExecuteInvoker(execute_fn)
+        ExecuteFnMetadata(execute_fn)
 
 
 def test_execute_fn_with_resource_param() -> None:
     def execute_fn(context, some_resource: ResourceParam[str]): ...
 
-    invoker = ExecuteInvoker(execute_fn)
+    invoker = ExecuteFnMetadata(execute_fn)
     assert invoker.resource_keys == {"some_resource"}
     assert invoker.function_params_names == {"context", "some_resource"}


### PR DESCRIPTION
## Summary & Motivation

This PR enforces more strict rules on the parameters of execute_fn of an ExecutableComponent in preparation for supporting parameter passing. Instead of blindly grabbing parameter names we now reuse the logic to handle `ResourceParam`, resource subtypes, and so forth.

## How I Tested These Changes

BK
