### PR TITLE
[dg] Project plugin registry

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/3-scaffold-component.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/3-scaffold-component.txt
@@ -1,4 +1,4 @@
 dg scaffold component CustomSlingReplicationComponent
 
-Creating a Dagster component type at /.../my-project/src/my_project/components/custom_sling_replication_component.py.
-Scaffolded files for Dagster component type at /.../my-project/src/my_project/components/custom_sling_replication_component.py.
+Creating module at: /.../my-project/src/my_project/components
+Scaffolded Dagster component at /.../my-project/src/my_project/components/custom_sling_replication_component.py.

--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/6-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/6-defs.yaml
@@ -1,4 +1,4 @@
-type: my_project.components.CustomSlingReplicationComponent
+type: my_project.components.custom_sling_replication_component.CustomSlingReplicationComponent
 
 attributes:
   replications:

--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/9-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/9-defs.yaml
@@ -1,4 +1,4 @@
-type: my_project.components.CustomSlingReplicationComponent
+type: my_project.components.custom_sling_replication_component.CustomSlingReplicationComponent
 
 attributes:
   replications:

--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/4-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/4-tree.txt
@@ -2,8 +2,6 @@ tree my_project
 
 my_project
 ├── __init__.py
-├── components
-│   └── __init__.py
 └── defs
     ├── __init__.py
     └── my_sling_sync
@@ -11,4 +9,4 @@ my_project
         ├── defs.yaml
         └── replication.yaml
 
-4 directories, 6 files
+3 directories, 5 files

--- a/examples/docs_snippets/docs_snippets/guides/components/index/3-pip-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/3-pip-tree.txt
@@ -5,11 +5,9 @@ tree
 ├── src
 │   └── jaffle_platform
 │       ├── __init__.py
-│       ├── components
-│       │   └── __init__.py
 │       └── defs
 │           └── __init__.py
 └── tests
     └── __init__.py
 
-6 directories, 5 files
+5 directories, 4 files

--- a/examples/docs_snippets/docs_snippets/guides/components/index/3-uv-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/3-uv-tree.txt
@@ -5,12 +5,10 @@ tree
 ├── src
 │   └── jaffle_platform
 │       ├── __init__.py
-│       ├── components
-│       │   └── __init__.py
 │       └── defs
 │           └── __init__.py
 ├── tests
 │   └── __init__.py
 └── uv.lock
 
-6 directories, 6 files
+5 directories, 5 files

--- a/examples/docs_snippets/docs_snippets/guides/components/index/8-tree-jaffle-platform.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/8-tree-jaffle-platform.txt
@@ -2,12 +2,10 @@ tree src/jaffle_platform
 
 src/jaffle_platform
 ├── __init__.py
-├── components
-│   └── __init__.py
 └── defs
     ├── __init__.py
     └── ingest_files
         ├── defs.yaml
         └── replication.yaml
 
-4 directories, 5 files
+3 directories, 4 files

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/1-dg-scaffold-shell-command.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/1-dg-scaffold-shell-command.txt
@@ -1,4 +1,4 @@
 dg scaffold component ShellCommand
 
-Creating a Dagster component type at /.../my-component-library/src/my_component_library/components/shell_command.py.
-Scaffolded files for Dagster component type at /.../my-component-library/src/my_component_library/components/shell_command.py.
+Creating module at: /.../my-component-library/src/my_component_library/components
+Scaffolded Dagster component at /.../my-component-library/src/my_component_library/components/shell_command.py.

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-components.txt
@@ -1,15 +1,15 @@
 dg list components
 
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Key                                              ┃ Summary                                                           ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ dagster.DefinitionsComponent                     │ An arbitrary set of dagster definitions.                          │
-├──────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
-│ dagster.DefsFolderComponent                      │ A folder which may contain multiple submodules, each              │
-│                                                  │ which define components.                                          │
-├──────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
-│ dagster.PipesSubprocessScriptCollectionComponent │ Assets that wrap Python scripts executed with Dagster's           │
-│                                                  │ PipesSubprocessClient.                                            │
-├──────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
-│ my_component_library.components.ShellCommand     │ Models a shell script as a Dagster asset.                         │
-└──────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Key                                                        ┃ Summary                                                 ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster.DefinitionsComponent                               │ An arbitrary set of dagster definitions.                │
+├────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────┤
+│ dagster.DefsFolderComponent                                │ A folder which may contain multiple submodules, each    │
+│                                                            │ which define components.                                │
+├────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────┤
+│ dagster.PipesSubprocessScriptCollectionComponent           │ Assets that wrap Python scripts executed with Dagster's │
+│                                                            │ PipesSubprocessClient.                                  │
+├────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────┤
+│ my_component_library.components.shell_command.ShellCommand │ Models a shell script as a Dagster asset.               │
+└────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────┘

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/4-scaffold-instance-of-component.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/4-scaffold-instance-of-component.txt
@@ -1,3 +1,3 @@
-dg scaffold defs 'my_component_library.components.ShellCommand' my_shell_command
+dg scaffold defs 'my_component_library.components.shell_command.ShellCommand' my_shell_command
 
 Creating a component at /.../my-component-library/src/my_component_library/defs/my_shell_command.

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/5-scaffolded-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/5-scaffolded-defs.yaml
@@ -1,4 +1,4 @@
-type: my_component_library.components.ShellCommand
+type: my_component_library.components.shell_command.ShellCommand
 
 attributes:
   script_path: script.sh

--- a/examples/docs_snippets/docs_snippets/guides/dg/dagster-definitions/2-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/dagster-definitions/2-tree.txt
@@ -5,8 +5,6 @@ tree
 ├── src
 │   └── my_project
 │       ├── __init__.py
-│       ├── components
-│       │   └── __init__.py
 │       └── defs
 │           ├── __init__.py
 │           └── assets
@@ -15,4 +13,4 @@ tree
 │   └── __init__.py
 └── uv.lock
 
-7 directories, 7 files
+6 directories, 6 files

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/10-scaffold-component-type.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/10-scaffold-component-type.txt
@@ -1,4 +1,3 @@
 dg scaffold component Foo
 
-Creating a Dagster component type at /.../my-existing-project/my_existing_project/components/foo.py.
-Scaffolded files for Dagster component type at /.../my-existing-project/my_existing_project/components/foo.py.
+Scaffolded Dagster component at /.../my-existing-project/my_existing_project/components/foo.py.

--- a/examples/docs_snippets/docs_snippets/guides/dg/scaffolding-project/2-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/scaffolding-project/2-tree.txt
@@ -6,12 +6,10 @@ tree
     ├── src
     │   └── my_project
     │       ├── __init__.py
-    │       ├── components
-    │       │   └── __init__.py
     │       └── defs
     │           └── __init__.py
     ├── tests
     │   └── __init__.py
     └── uv.lock
 
-7 directories, 6 files
+6 directories, 5 files

--- a/examples/docs_snippets/docs_snippets/guides/dg/workspace/3-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/workspace/3-tree.txt
@@ -8,8 +8,6 @@ tree
         ├── src
         │   └── project_1
         │       ├── __init__.py
-        │       ├── components
-        │       │   └── __init__.py
         │       └── defs
         │           └── __init__.py
         ├── tests

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
@@ -135,7 +135,7 @@ def test_creating_a_component(
             contents=(COMPONENTS_SNIPPETS_DIR / "with-scaffolder.py").read_text(),
         )
         context.run_command_and_snippet_output(
-            cmd="dg scaffold defs 'my_component_library.components.ShellCommand' my_shell_command",
+            cmd="dg scaffold defs 'my_component_library.components.shell_command.ShellCommand' my_shell_command",
             snippet_path=f"{context.get_next_snip_number()}-scaffold-instance-of-component.txt",
         )
 

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_customizing_existing_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_customizing_existing_component.py
@@ -155,7 +155,7 @@ def test_components_docs_adding_attributes_to_assets(
                 .read_text()
                 .replace(
                     "dagster_sling.SlingReplicationCollectionComponent",
-                    "my_project.components.CustomSlingReplicationComponent",
+                    "my_project.components.custom_sling_replication_component.CustomSlingReplicationComponent",
                 ),
                 snippet_path=SNIPPETS_DIR
                 / component_type

--- a/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
+++ b/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
@@ -4,9 +4,6 @@ requires-python = ">=3.9,<3.13"
 version = "0.1.0"
 {{ dependencies }}
 
-[project.entry-points]
-"dagster_dg_cli.registry_modules" = { {{ project_name }} = "{{ project_name }}.components"}
-
 [dependency-groups]
 {{ dev_dependencies }}
 

--- a/python_modules/libraries/create-dagster/create_dagster_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/create-dagster/create_dagster_tests/test_scaffold_commands.py
@@ -150,7 +150,6 @@ def test_scaffold_project_success(
 
         assert Path("foo-bar").exists()
         assert Path("foo-bar/src/foo_bar").exists()
-        assert Path("foo-bar/src/foo_bar/components").exists()
         assert Path("foo-bar/src/foo_bar/defs").exists()
         assert Path("foo-bar/tests").exists()
         assert Path("foo-bar/pyproject.toml").exists()
@@ -184,7 +183,6 @@ def test_scaffold_project_inside_workspace_success(monkeypatch) -> None:
         assert_runner_result(result)
         assert Path("projects/foo-bar").exists()
         assert Path("projects/foo-bar/src/foo_bar").exists()
-        assert Path("projects/foo-bar/src/foo_bar/components").exists()
         assert Path("projects/foo-bar/src/foo_bar/defs").exists()
         assert Path("projects/foo-bar/tests").exists()
         assert Path("projects/foo-bar/pyproject.toml").exists()
@@ -400,7 +398,6 @@ def test_scaffold_project_python_environment_uv_managed_success(monkeypatch) -> 
         assert_runner_result(result)
         assert Path("foo-bar").exists()
         assert Path("foo-bar/src/foo_bar").exists()
-        assert Path("foo-bar/src/foo_bar/components").exists()
         assert Path("foo-bar/src/foo_bar/defs").exists()
         assert Path("foo-bar/tests").exists()
         assert Path("foo-bar/pyproject.toml").exists()

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold.py
@@ -884,7 +884,7 @@ def _core_scaffold(
 
 
 # ########################
-# ##### COMPONENT TYPE
+# ##### COMPONENT
 # ########################
 
 
@@ -916,11 +916,41 @@ def scaffold_component_command(
     dg_context = DgContext.for_component_library_environment(target_path, cli_config)
     registry = RemotePluginRegistry.from_dg_context(dg_context)
 
-    module_name = snakecase(name)
-    component_key = PluginObjectKey(
-        name=name, namespace=dg_context.default_registry_root_module_name
-    )
-    if registry.has(component_key):
-        exit_with_error(f"Component type`{component_key.to_typename()}` already exists.")
+    module_name, class_name = _parse_component_name(dg_context, name)
 
-    scaffold_component(dg_context=dg_context, class_name=name, module_name=module_name, model=model)
+    component_key = PluginObjectKey(name=class_name, namespace=module_name)
+    if registry.has(component_key):
+        exit_with_error(f"Component type `{component_key.to_typename()}` already exists.")
+
+    path = dg_context.get_path_for_local_module(module_name, require_exists=False).with_suffix(
+        ".py"
+    )
+    if path.exists():
+        exit_with_error(f"A module at `{path}` already exists. Please choose a different name.")
+
+    scaffold_component(
+        dg_context=dg_context, class_name=class_name, module_name=module_name, model=model
+    )
+
+
+def _parse_component_name(dg_context: DgContext, name: str) -> tuple[str, str]:
+    """Parse the name into a module name and class name."""
+    if "." in name:
+        module_name, class_name = name.rsplit(".", 1)
+        if not module_name.startswith(dg_context.root_module_name):
+            exit_with_error(
+                f"Component `{name}` must be nested under the root module `{dg_context.root_module_name}`."
+            )
+        elif dg_context.has_registry_module_entry_point and not module_name.startswith(
+            dg_context.default_registry_root_module_name
+        ):
+            exit_with_error(
+                f"Component `{name}` must be nested under the declared entry point module `{dg_context.default_registry_root_module_name}`."
+            )
+    else:
+        final_module = snakecase(name)
+        module_name, class_name = (
+            f"{dg_context.default_registry_root_module_name}.{final_module}",
+            name,
+        )
+    return module_name, class_name

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
@@ -203,7 +203,7 @@ def test_list_registry_modules_json_success():
 def test_list_registry_modules_includes_modules_with_no_objects():
     with (
         ProxyRunner.test() as runner,
-        isolated_example_project_foo_bar(runner, in_workspace=False),
+        isolated_example_component_library_foo_bar(runner),
     ):
         result = runner.invoke("list", "registry-modules")
         assert_runner_result(result)

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/component.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/component.py
@@ -26,7 +26,7 @@ class RemotePluginRegistry:
     def from_dg_context(
         dg_context: "DgContext", extra_modules: Optional[Sequence[str]] = None
     ) -> "RemotePluginRegistry":
-        """Fetches the set of available plugin objects. The default set includes everything
+        """Fetches the set of available registry objects. The default set includes everything
         discovered under the "dagster_dg_cli.registry_modules" entry point group in the target environment. If
         `extra_modules` is provided, these will also be searched for component types.
         """
@@ -45,8 +45,15 @@ class RemotePluginRegistry:
                 _load_module_registry_objects(dg_context, extra_modules)
             )
 
+        # Only load project plugin modules if there is no entry point
+        if dg_context.is_project and not dg_context.has_registry_module_entry_point:
+            if dg_context.project_registry_modules:
+                plugin_manifest = plugin_manifest.merge(
+                    _load_module_registry_objects(dg_context, dg_context.project_registry_modules)
+                )
+
         if (
-            dg_context.is_plugin
+            dg_context.has_registry_module_entry_point
             and not dg_context.config.cli.use_component_modules
             and dg_context.default_registry_root_module_name not in plugin_manifest.modules
         ):

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/config.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/config.py
@@ -315,6 +315,7 @@ class DgProjectConfig:
     python_environment: DgProjectPythonEnvironment = field(
         default_factory=lambda: DgProjectPythonEnvironment(active=True)
     )
+    registry_modules: list[str] = field(default_factory=list)
 
     @classmethod
     def from_raw(cls, raw: "DgRawProjectConfig") -> Self:
@@ -332,6 +333,9 @@ class DgProjectConfig:
                 if "python_environment" in raw
                 else cls.__dataclass_fields__["python_environment"].default_factory()
             ),
+            registry_modules=raw.get(
+                "registry_modules", cls.__dataclass_fields__["registry_modules"].default_factory()
+            ),
         )
 
 
@@ -342,6 +346,7 @@ class DgRawProjectConfig(TypedDict):
     code_location_target_module: NotRequired[str]
     code_location_name: NotRequired[str]
     python_environment: NotRequired[DgRawProjectPythonEnvironment]
+    registry_modules: NotRequired[list[str]]
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/context.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/context.py
@@ -28,6 +28,7 @@ from dagster_dg_core.config import (
     load_dg_root_file_config,
     load_dg_user_file_config,
     load_dg_workspace_file_config,
+    modify_dg_toml_config,
 )
 from dagster_dg_core.error import DgError
 from dagster_dg_core.utils import (
@@ -46,6 +47,7 @@ from dagster_dg_core.utils import (
     msg_with_potential_paths,
     pushd,
     resolve_local_venv,
+    set_toml_node,
     strip_activated_venv_from_env_vars,
     validate_dagster_availability,
 )
@@ -55,10 +57,16 @@ from dagster_dg_core.utils.warnings import emit_warning
 # Project
 _DEFAULT_PROJECT_DEFS_SUBMODULE: Final = "defs"
 _DEFAULT_PROJECT_CODE_LOCATION_TARGET_MODULE: Final = "definitions"
+_DEFAULT_PROJECT_PLUGIN_MODULE: Final = "components"
+_DEFAULT_PROJECT_PLUGIN_MODULE_REGISTRY_FILE: Final = "plugin_modules.json"
 _EXCLUDED_COMPONENT_DIRECTORIES: Final = {"__pycache__"}
 DG_PLUGIN_ENTRY_POINT_GROUP: Final = "dagster_dg_cli.registry_modules"
 # Remove in future, in place for backcompat
-OLD_DG_PLUGIN_ENTRY_POINT_GROUPS = ["dagster_dg.library", "dagster_dg.plugin", "dagster_dg_cli.plugin"]
+OLD_DG_PLUGIN_ENTRY_POINT_GROUPS = [
+    "dagster_dg.library",
+    "dagster_dg.plugin",
+    "dagster_dg_cli.plugin",
+]
 
 
 def _should_capture_components_cli_stderr() -> bool:
@@ -183,7 +191,7 @@ class DgContext:
         # available; (b) in a component library context.
         validate_dagster_availability()
 
-        if not context.is_plugin:
+        if not context.has_registry_module_entry_point and not context.is_project:
             exit_with_error(NOT_COMPONENT_LIBRARY_ERROR_MESSAGE)
         return context
 
@@ -291,7 +299,7 @@ class DgContext:
         """Paths that should be watched for changes to the component registry."""
         return [
             self.root_path / "uv.lock",
-            *([self.default_registry_module_path] if self.is_plugin else []),
+            *([self.default_registry_module_path] if self.has_registry_module_entry_point else []),
         ]
 
     # Allowing open-ended str data_type for now so we can do module names
@@ -299,7 +307,7 @@ class DgContext:
         path_parts = [str(part) for part in self.root_path.parts if part != self.root_path.anchor]
         paths_to_hash = [
             self.root_path / "uv.lock",
-            *([self.default_registry_module_path] if self.is_plugin else []),
+            *([self.default_registry_module_path] if self.has_registry_module_entry_point else []),
         ]
         env_hash = hash_paths(paths_to_hash)
         return ("_".join(path_parts), env_hash, data_type)
@@ -354,7 +362,7 @@ class DgContext:
     def root_module_name(self) -> str:
         if self.config.project:
             return self.config.project.root_module
-        elif self.is_plugin:
+        elif self.has_registry_module_entry_point:
             return self.default_registry_root_module_name.split(".")[0]
         else:
             raise DgError("Cannot determine root package name")
@@ -542,24 +550,61 @@ class DgContext:
     # it uses for all component type scaffolding operations.
 
     @property
-    def is_plugin(self) -> bool:
+    def has_registry_module_entry_point(self) -> bool:
         return bool(self._dagster_components_entry_points)
 
     @cached_property
     def default_registry_root_module_name(self) -> str:
-        if not self._dagster_components_entry_points:
+        if self._dagster_components_entry_points:
+            return next(iter(self._dagster_components_entry_points.values()))
+        elif self.is_project:
+            return f"{self.root_module_name}.{_DEFAULT_PROJECT_PLUGIN_MODULE}"
+        else:
             raise DgError(
                 "`default_component_library_module_name` is only available in a component library context"
             )
-        return next(iter(self._dagster_components_entry_points.values()))
 
     @cached_property
     def default_registry_module_path(self) -> Path:
-        if not self.is_plugin:
+        if not self.has_registry_module_entry_point and not self.is_project:
             raise DgError(
                 "`default_plugin_module_path` is only available in a component library context"
             )
-        return self.get_path_for_local_module(self.default_registry_root_module_name)
+        return self.get_path_for_local_module(
+            self.default_registry_root_module_name, require_exists=False
+        )
+
+    @property
+    def project_registry_modules(self) -> list[str]:
+        """Return a mapping of plugin object references for the current project."""
+        if not self.config.project:
+            raise DgError(
+                "`project_registry_modules` is only available in a Dagster project context"
+            )
+        return self.config.project.registry_modules
+
+    def add_project_registry_module(self, module_name: str) -> None:
+        """Add a module name to the project plugin module registry."""
+        import tomlkit
+        import tomlkit.items
+
+        if not self.is_project:
+            raise DgError(
+                "`add_project_registry_module` is only available in a Dagster project context"
+            )
+        with modify_dg_toml_config(self.config_file_path) as toml:
+            if has_toml_node(toml, ("project", "registry_modules")):
+                registry_modules = get_toml_node(
+                    toml, ("project", "registry_modules"), tomlkit.items.Array
+                )
+                registry_modules.add_line(module_name)
+            else:
+                set_toml_node(toml, ("project", "registry_modules"), tomlkit.array())
+                registry_modules = get_toml_node(
+                    toml, ("project", "registry_modules"), tomlkit.items.Array
+                )
+                registry_modules.add_line(module_name)
+                registry_modules.add_line(indent="")
 
     @cached_property
     def _dagster_components_entry_points(self) -> Mapping[str, str]:
@@ -707,8 +752,8 @@ class DgContext:
     def setup_cfg_path(self) -> Path:
         return self.root_path / "setup.cfg"
 
-    def get_path_for_local_module(self, module_name: str) -> Path:
-        if not self.is_project and not self.is_plugin:
+    def get_path_for_local_module(self, module_name: str, require_exists: bool = True) -> Path:
+        if not self.is_project and not self.has_registry_module_entry_point:
             raise DgError(
                 "`get_path_for_local_module` is only available in a project or component library context"
             )
@@ -718,14 +763,17 @@ class DgContext:
         # Attempt to resolve the path for a local module by looking in both `src` and the root
         # level. Unfortunately there is no setting reliably present in pyproject.toml or setup.py
         # that can be relied on to know in advance the package root (src or root level).
-        for path in [
-            self.root_path / "src" / Path(*module_name.split(".")),
-            self.root_path / Path(*module_name.split(".")),
-        ]:
-            if path.exists():
-                return path
-            elif path.with_suffix(".py").exists():
-                return path.with_suffix(".py")
+
+        base_path = self.root_path / "src" if (self.root_path / "src").exists() else self.root_path
+        path = base_path / Path(*module_name.split("."))
+        if path.with_suffix(".py").exists():
+            return path.with_suffix(".py")
+
+        # Note that when `require_exists` is False, the returned path assumes a directory
+        # instead of a py file.
+        elif path.exists() or not require_exists:
+            return path
+
         exit_with_error(f"Cannot find module `{module_name}` in the current project.")
 
 

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_context.py
@@ -42,6 +42,7 @@ from dagster_dg_core_tests.utils import (
     dg_warns,
     install_editable_dagster_packages_to_venv,
     isolated_components_venv,
+    isolated_example_component_library_foo_bar,
     isolated_example_project_foo_bar,
     isolated_example_workspace,
     modify_dg_toml_config_as_dict,
@@ -211,7 +212,7 @@ def test_warning_suppression():
 def test_setup_cfg_entry_point():
     with (
         ProxyRunner.test() as runner,
-        isolated_example_project_foo_bar(runner, in_workspace=False),
+        isolated_example_component_library_foo_bar(runner),
     ):
         # Delete the entry point section from pyproject.toml
         with modify_toml_as_dict(Path("pyproject.toml")) as toml:
@@ -225,15 +226,17 @@ def test_setup_cfg_entry_point():
                     foo_bar = foo_bar.lib
                 """)
             )
-        context = DgContext.for_project_environment(Path.cwd(), {})
-        assert context.is_plugin
+        context = DgContext.for_component_library_environment(Path.cwd(), {})
+        assert context.has_registry_module_entry_point
 
 
 @pytest.mark.parametrize("deprecated_group", OLD_DG_PLUGIN_ENTRY_POINT_GROUPS)
 def test_deprecated_entry_point_group_warning(deprecated_group: str):
     with (
         ProxyRunner.test() as runner,
-        isolated_example_project_foo_bar(runner),
+        isolated_example_project_foo_bar(
+            runner, include_entry_point=True, in_workspace=False, python_environment="uv_managed"
+        ),
     ):
         with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
             plugin_entry_points = get_toml_node(
@@ -269,7 +272,11 @@ def test_missing_dg_registry_module_in_manifest_warning():
     with (
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(
-            runner, in_workspace=False, python_environment="active", uv_sync=False
+            runner,
+            in_workspace=False,
+            python_environment="active",
+            uv_sync=False,
+            include_entry_point=True,
         ),
     ):
         subprocess.check_output(["uv", "venv"])


### PR DESCRIPTION
## Summary & Motivation

Several changes:

- Scaffolded projects no longer include:
    - a "components" submodule
    - an "entry point"
- Projects now optionally have an associated list of "registry modules" listed in `pyproject.toml` under `tool.dg.project.registry_modules`. This setting does not exist in newly scaffolded projects-- it's created on-demand the first time you scaffold a component.
    - This simple list of modules replaces the Python entry point system for registering plugin modules in a project context.
- `dg scaffold component` can now accept a fully-qualified identifier:
    - `dg scaffold component Foo`
        - expands to `dg scaffold component <root>.components.foo.Foo`
    - `dg scaffold component <root>.foo.Foo`
        - will create `<root>/foo.py` and put `Foo` in it. Error if `<root>/foo.py` exists.
    - `dg scaffold component <root>.bar.foo.Foo`
        - will create `<root>/bar` and `<root>/bar/__init__.py` if they don't exist. It's ok if they do.
        - will create `<root>/bar/foo.py` and put `Foo` in it
    - `dg scaffold component somemod.foo.Foo`
        -  ERROR: any qualified name that doesn't start with `<root>` will fail

The trickiest part of this was the backcompat. Basically any project that _does_ define a `dagster_dg_cli.plugin` entry point will continue functioning as before, and will not use the `project.registry_modules` list.

The one caveat with this that's a little unfortunate is that now, if you do:

```
dg scaffold component Foo
```

You need to reference the component as `<root>.components.foo.Foo` instead of `<root>.components.Foo`.


## How I Tested These Changes

New unit tests + modified existing suite.

## Changelog

- Scaffolded projects no longer contain a "components" directory or a Python `dagster_dg_cli.plugin`entry point.
- Scaffolded components can now be placed anywhere within a project module hierarchy.
