### PR TITLE
[docs][tweak] remove trailing references to component.yaml in docs

### DIFF
--- a/docs/docs/guides/labs/components/creating-new-component-types/subclassing-components.md
+++ b/docs/docs/guides/labs/components/creating-new-component-types/subclassing-components.md
@@ -38,7 +38,7 @@ Next, update the `type` field in the `defs.yaml` file to reference this new comp
 <CodeExample
   path="docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/5-defs.yaml"
   language="yaml"
-  title="my_project/defs/my_sling_sync/component.yaml"
+  title="my_project/defs/my_sling_sync/defs.yaml"
 />
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/4-tree.txt" />

--- a/docs/docs/guides/labs/components/integrations/airbyte-cloud-component-tutorial.md
+++ b/docs/docs/guides/labs/components/integrations/airbyte-cloud-component-tutorial.md
@@ -26,13 +26,13 @@ Now that you have a Dagster project, you can scaffold an Airbyte Cloud component
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/integrations/airbyte-cloud-component/3-scaffold-airbyte-component.txt" />
 
-The scaffold call will generate a `component.yaml` file:
+The scaffold call will generate a `defs.yaml` file:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/integrations/airbyte-cloud-component/4-tree.txt" />
 
-In its scaffolded form, the `component.yaml` file contains the configuration for your Airbyte Cloud workspace:
+In its scaffolded form, the `defs.yaml` file contains the configuration for your Airbyte Cloud workspace:
 
-<CodeExample path="docs_snippets/docs_snippets/guides/components/integrations/airbyte-cloud-component/5-component.yaml" title="my_project/defs/airbyte_ingest/component.yaml" language="yaml" />
+<CodeExample path="docs_snippets/docs_snippets/guides/components/integrations/airbyte-cloud-component/5-component.yaml" title="my_project/defs/airbyte_ingest/defs.yaml" language="yaml" />
 
 You can check the configuration of your component:
 
@@ -44,7 +44,7 @@ You can check the configuration of your component:
 
 You can select specific Airbyte Cloud connections to include in your component using the `connection_selector` key. This allows you to filter which connections are represented as assets:
 
-<CodeExample path="docs_snippets/docs_snippets/guides/components/integrations/airbyte-cloud-component/7-customized-component.yaml" title="my_project/defs/airbyte_ingest/component.yaml" language="yaml" />
+<CodeExample path="docs_snippets/docs_snippets/guides/components/integrations/airbyte-cloud-component/7-customized-component.yaml" title="my_project/defs/airbyte_ingest/defs.yaml" language="yaml" />
 
 <WideContent maxSize={1100}>
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/integrations/airbyte-cloud-component/8-list-defs.txt" />
@@ -52,9 +52,9 @@ You can select specific Airbyte Cloud connections to include in your component u
 
 ## Customizing Airbyte Cloud assets
 
-Properties of the assets emitted by each connection can be customized in the `component.yaml` file using the `translation` key:
+Properties of the assets emitted by each connection can be customized in the `defs.yaml` file using the `translation` key:
 
-<CodeExample path="docs_snippets/docs_snippets/guides/components/integrations/airbyte-cloud-component/9-customized-component.yaml" title="my_project/defs/airbyte_ingest/component.yaml" language="yaml" />
+<CodeExample path="docs_snippets/docs_snippets/guides/components/integrations/airbyte-cloud-component/9-customized-component.yaml" title="my_project/defs/airbyte_ingest/defs.yaml" language="yaml" />
 
 <WideContent maxSize={1100}>
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/integrations/airbyte-cloud-component/10-list-defs.txt" />

--- a/docs/docs/guides/labs/components/integrations/fivetran-component-tutorial.md
+++ b/docs/docs/guides/labs/components/integrations/fivetran-component-tutorial.md
@@ -26,13 +26,13 @@ Now that you have a Dagster project, you can scaffold a Fivetran component. You'
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/integrations/fivetran-component/3-scaffold-fivetran-component.txt" />
 
-The scaffold call will generate a `component.yaml` file:
+The scaffold call will generate a `defs.yaml` file:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/integrations/fivetran-component/4-tree.txt" />
 
-In its scaffolded form, the `component.yaml` file contains the configuration for your Fivetran workspace:
+In its scaffolded form, the `defs.yaml` file contains the configuration for your Fivetran workspace:
 
-<CodeExample path="docs_snippets/docs_snippets/guides/components/integrations/fivetran-component/5-component.yaml" title="my_project/defs/fivetran_ingest/component.yaml" language="yaml" />
+<CodeExample path="docs_snippets/docs_snippets/guides/components/integrations/fivetran-component/5-component.yaml" title="my_project/defs/fivetran_ingest/defs.yaml" language="yaml" />
 
 You can check the configuration of your component:
 
@@ -44,7 +44,7 @@ You can check the configuration of your component:
 
 You can select specific Fivetran connectors to include in your component using the `connector_selector` key. This allows you to filter which connectors are represented as assets:
 
-<CodeExample path="docs_snippets/docs_snippets/guides/components/integrations/fivetran-component/7-customized-component.yaml" title="my_project/defs/fivetran_ingest/component.yaml" language="yaml" />
+<CodeExample path="docs_snippets/docs_snippets/guides/components/integrations/fivetran-component/7-customized-component.yaml" title="my_project/defs/fivetran_ingest/defs.yaml" language="yaml" />
 
 <WideContent maxSize={1100}>
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/integrations/fivetran-component/8-list-defs.txt" />
@@ -52,9 +52,9 @@ You can select specific Fivetran connectors to include in your component using t
 
 ## Customizing Fivetran assets
 
-Properties of the assets emitted by each connector can be customized in the `component.yaml` file using the `translation` key:
+Properties of the assets emitted by each connector can be customized in the `defs.yaml` file using the `translation` key:
 
-<CodeExample path="docs_snippets/docs_snippets/guides/components/integrations/fivetran-component/9-customized-component.yaml" title="my_project/defs/fivetran_ingest/component.yaml" language="yaml" />
+<CodeExample path="docs_snippets/docs_snippets/guides/components/integrations/fivetran-component/9-customized-component.yaml" title="my_project/defs/fivetran_ingest/defs.yaml" language="yaml" />
 
 <WideContent maxSize={1100}>
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/integrations/fivetran-component/10-list-defs.txt" />

--- a/docs/docs/guides/labs/components/using-environment-variables-in-components.md
+++ b/docs/docs/guides/labs/components/using-environment-variables-in-components.md
@@ -40,7 +40,7 @@ Next, we will configure a Sling connection that will sync a local CSV file to a 
   title="src/ingestion/defs/ingest_files/replication.yaml"
 />
 
-We will use the `env` function to template credentials into Sling configuration in our `component.yaml` file. Running `dg check yaml` will highlight that we
+We will use the `env` function to template credentials into Sling configuration in our `defs.yaml` file. Running `dg check yaml` will highlight that we
 need to explicitly encode these environment dependencies at the bottom of the file:
 
 <CodeExample


### PR DESCRIPTION
## Summary

Removing a few refs in file titles & outside of snippets to `component.yaml`
