### PR TITLE
[resolved] Support dot access to `env`, explicit error messages when calling env incorrectly

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/context.py
+++ b/python_modules/dagster/dagster/components/resolved/context.py
@@ -28,8 +28,11 @@ class EnvScope:
         if key.startswith("jinja"):
             raise AttributeError(f"{key} not found")
 
+        return os.environ.get(key)
+
+    def __getitem__(self, key: str) -> Optional[str]:
         raise ResolutionException(
-            f"To access environment variables, use the `env` function, e.g. `env('{key}')`"
+            f"To access environment variables, use dot access or the `env` function, e.g. `env.{key}` or `env('{key}')`"
         )
 
 

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_env.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_env.py
@@ -21,20 +21,19 @@ def test_env():
         )
 
 
-def test_env_typo():
+def test_env_dot_access():
     with environ({"MY_ENV_VAR": "my_value"}):
 
         @dataclass
         class MyNewThing(Resolvable):
             name: str
 
-        with pytest.raises(
-            ResolutionException,
-            match=r".*To access environment variables, use the `env` function, e.g. `env\('MY_ENV_VAR'\)`.*",
-        ):
+        assert (
             MyNewThing.resolve_from_yaml("""
     name: "{{ env.MY_ENV_VAR }}"
-    """)
+    """).name
+            == "my_value"
+        )
 
 
 def test_env_indexing():
@@ -46,7 +45,7 @@ def test_env_indexing():
 
         with pytest.raises(
             ResolutionException,
-            match=r".*To access environment variables, use the `env` function, e.g. `env\('MY_ENV_VAR'\)`.*",
+            match=r".*To access environment variables, use dot access or the `env` function, e.g. `env\.MY_ENV_VAR` or `env\('MY_ENV_VAR'\)`.*",
         ):
             MyNewThing.resolve_from_yaml("""
     name: "{{ env['MY_ENV_VAR'] }}"


### PR DESCRIPTION
## Summary

https://linear.app/dagster-labs/issue/BUILD-770/envfoo-quietly-returns-undefined

Now supports env var access with `{{ env.MY_ENV_VAR }}` instead of `{{ env('MY_ENV_VAR') }}`, augments the typical jinja error message pointing the user to the proper call if the user uses e.g. `{{ env['MY_ENV_VAR'] }}`.

## Test Plan

Unit test.
