### PR TITLE
[7/n] Move x-component access to use ComponentTree, cache defs load

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -857,6 +857,11 @@ class Definitions(IHaveNew):
         asset_graph = self.resolve_asset_graph()
         return [asset_node.to_asset_spec() for asset_node in asset_graph.asset_nodes]
 
+    @public
+    def resolve_all_asset_keys(self) -> Sequence[AssetKey]:
+        """Returns an AssetKey object for every asset contained inside the resolved Definitions object."""
+        return [spec.key for spec in self.resolve_all_asset_specs()]
+
     @preview
     def with_reconstruction_metadata(self, reconstruction_metadata: Mapping[str, str]) -> Self:
         """Add reconstruction metadata to the Definitions object. This is typically used to cache data

--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -267,9 +267,12 @@ class Component(ABC):
     @classmethod
     def load(cls, attributes: Optional[BaseModel], context: "ComponentLoadContext") -> Self:
         if issubclass(cls, Resolvable):
+            context_with_injected_scope = context.with_rendering_scope(
+                {"component_tree": context.component_tree}
+            )
             return (
                 cls.resolve_from_model(
-                    context.resolution_context.at_path("attributes"),
+                    context_with_injected_scope.resolution_context.at_path("attributes"),
                     attributes,
                 )
                 if attributes

--- a/python_modules/dagster/dagster/components/core/context.py
+++ b/python_modules/dagster/dagster/components/core/context.py
@@ -133,18 +133,6 @@ class ComponentDeclLoadContext:
             else type_str
         )
 
-    def load_defs(self, module: ModuleType) -> Definitions:
-        """Builds the set of Dagster definitions for a component module.
-
-        This is useful for resolving dependencies on other components.
-        """
-        # FIXME: This should go through the component loader system
-        # to allow for this value to be cached and more selectively
-        # loaded. This is just a temporary hack to keep tests passing.
-        from dagster.components.core.load_defs import load_defs
-
-        return load_defs(module, self.project_root)
-
     def load_defs_relative_python_module(self, path: Path) -> ModuleType:
         """Load a python module relative to the defs's context path. This is useful for loading code
         the resides within the defs directory.

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
@@ -1,14 +1,15 @@
+from pathlib import Path
+
 import dagster as dg
 from dagster.components.core.context import ComponentLoadContext
-from dagster_shared import check
 
 
 @dg.definitions
 def defs(context: ComponentLoadContext) -> dg.Definitions:
-    from component_component_deps.defs import my_python_defs  # type:ignore
-
     @dg.asset(
-        deps=check.is_list(context.load_defs(my_python_defs).assets, of_type=dg.AssetsDefinition)
+        deps=context.component_tree.build_defs_at_path(
+            Path("my_python_defs")
+        ).resolve_all_asset_specs()
     )
     def downstream_of_all_my_python_defs(): ...
 

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_custom_component/defs/depends_on_my_python_defs/custom_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_custom_component/defs/depends_on_my_python_defs/custom_component.py
@@ -1,22 +1,15 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
 
 import dagster as dg
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
 
 MY_PYTHON_DEFS_COMPONENT_PATH = Path(__file__).parent.parent / "my_python_defs"
 
 
 class MyCustomComponent(dg.Component):
     def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
-        from component_component_deps_custom_component.defs import my_python_defs  # type:ignore
-
-        assets_from_my_python_defs = cast(
-            "Sequence[dg.AssetsDefinition]",
-            context.load_defs(my_python_defs).assets,
-        )
+        assets_from_my_python_defs = context.component_tree.build_defs_at_path(
+            MY_PYTHON_DEFS_COMPONENT_PATH
+        ).resolve_all_asset_keys()
 
         @dg.asset(deps=assets_from_my_python_defs)
         def downstream_of_all_my_python_defs():

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_yaml/defs/depends_on_my_python_defs/custom_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_yaml/defs/depends_on_my_python_defs/custom_component.py
@@ -1,0 +1,17 @@
+from collections.abc import Sequence
+
+import dagster as dg
+from dagster import AssetKey as AssetKey
+from dagster_shared.record import record
+
+
+@record
+class MyCustomComponent(dg.Component, dg.Resolvable):
+    deps: Sequence[dg.ResolvedAssetKey]
+
+    def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
+        @dg.asset(deps=self.deps)
+        def downstream_of_all_my_python_defs():
+            pass
+
+        return dg.Definitions(assets=[downstream_of_all_my_python_defs])

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_yaml/defs/depends_on_my_python_defs/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_yaml/defs/depends_on_my_python_defs/defs.yaml
@@ -1,0 +1,4 @@
+type: .custom_component.MyCustomComponent
+
+attributes:
+  deps: "{{ component_tree.build_defs_at_path('my_python_defs').resolve_all_asset_keys() }}"

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_yaml/defs/my_python_defs/definitions.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_yaml/defs/my_python_defs/definitions.py
@@ -1,0 +1,11 @@
+import dagster as dg
+
+
+@dg.asset
+def my_cool_asset():
+    pass
+
+
+@dg.asset
+def my_other_cool_asset():
+    pass

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_yaml/defs/my_python_defs/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_yaml/defs/my_python_defs/defs.yaml
@@ -1,0 +1,3 @@
+type: dagster.components.DefsFolderComponent
+
+attributes: {}

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_cross_component_deps.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_cross_component_deps.py
@@ -43,3 +43,24 @@ def test_dependency_between_components_with_custom_component():
     ) == set(defs.resolve_asset_graph().get_all_asset_keys()) - {
         dg.AssetKey("downstream_of_all_my_python_defs")
     }
+
+
+CROSS_COMPONENT_DEPENDENCY_PATH_YAML = (
+    Path(__file__).parent.parent / "code_locations" / "component_component_deps_yaml"
+)
+
+
+def test_dependency_between_components_with_yaml():
+    sys.path.append(str(CROSS_COMPONENT_DEPENDENCY_PATH_YAML.parent))
+
+    defs = dg.build_component_defs(CROSS_COMPONENT_DEPENDENCY_PATH_YAML / "defs")
+    assert (
+        dg.AssetKey("downstream_of_all_my_python_defs")
+        in defs.resolve_asset_graph().get_all_asset_keys()
+    )
+    downstream_of_all_my_python_defs = defs.resolve_assets_def("downstream_of_all_my_python_defs")
+    assert set(
+        downstream_of_all_my_python_defs.asset_deps[dg.AssetKey("downstream_of_all_my_python_defs")]
+    ) == set(defs.resolve_asset_graph().get_all_asset_keys()) - {
+        dg.AssetKey("downstream_of_all_my_python_defs")
+    }

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -1,12 +1,10 @@
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from types import ModuleType
-from typing import TYPE_CHECKING, Annotated, Any, Callable, Optional, Union, cast
+from typing import Annotated, Any, Callable, Optional, Union
 
 from dagster import Resolvable
-from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
@@ -20,20 +18,12 @@ from dagster.components.utils import TranslatorResolvingInfo
 from typing_extensions import TypeAlias
 
 from dagster_dbt.asset_decorator import dbt_assets
-from dagster_dbt.asset_utils import (
-    DBT_DEFAULT_EXCLUDE,
-    DBT_DEFAULT_SELECT,
-    get_asset_key_for_model,
-    get_node,
-)
+from dagster_dbt.asset_utils import DBT_DEFAULT_EXCLUDE, DBT_DEFAULT_SELECT, get_node
 from dagster_dbt.components.dbt_project.scaffolder import DbtProjectComponentScaffolder
 from dagster_dbt.core.resource import DbtCliResource
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
 from dagster_dbt.dbt_manifest_asset_selection import DbtManifestAssetSelection
 from dagster_dbt.dbt_project import DbtProject
-
-if TYPE_CHECKING:
-    from dagster._core.definitions.assets.definition.assets_definition import AssetsDefinition
 
 TranslationFn: TypeAlias = Callable[[AssetSpec, Mapping[str, Any]], AssetSpec]
 
@@ -245,37 +235,6 @@ class DbtProjectComponent(Component, Resolvable):
 
     def execute(self, context: AssetExecutionContext, dbt: DbtCliResource) -> Iterator:
         yield from dbt.cli(["build"], context=context).stream()
-
-
-def get_asset_key_for_model_from_module(
-    context: ComponentLoadContext, dbt_component_module: ModuleType, model_name: str
-) -> AssetKey:
-    """Component-based version of dagster_dbt.get_asset_key_for_model. Returns the corresponding Dagster
-    asset key for a dbt model, seed, or snapshot, loaded from the passed component path.
-
-    Args:
-        dbt_component_module (ModuleType): The module that was used to load the dbt project.
-        model_name (str): The name of the dbt model, seed, or snapshot.
-
-    Returns:
-        AssetKey: The corresponding Dagster asset key.
-
-    Examples:
-        .. code-block:: python
-
-            from dagster import asset
-            from dagster.components.components.dbt_project import get_asset_key_for_model_from_module
-            from dagster.components.core.component import ComponentLoadContext
-            from my_project.defs import dbt_component
-
-            ctx = ComponentLoadContext.get()
-
-            @asset(deps={get_asset_key_for_model_from_module(ctx, dbt_component, "customers")})
-            def cleaned_customers():
-                ...
-    """
-    defs = context.load_defs(dbt_component_module)
-    return get_asset_key_for_model(cast("Sequence[AssetsDefinition]", defs.assets), model_name)
 
 
 class ProxyDagsterDbtTranslator(DagsterDbtTranslator):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/dependency_on_dbt_project_location/defs/depends_on_dbt/definitions.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/dependency_on_dbt_project_location/defs/depends_on_dbt/definitions.py
@@ -1,13 +1,17 @@
 import dagster as dg
 from dagster.components.core.context import ComponentLoadContext
-from dagster_dbt.components.dbt_project.component import get_asset_key_for_model_from_module
+from dagster_dbt.asset_utils import get_asset_key_for_model
 
 
 @dg.definitions
 def defs(context: ComponentLoadContext) -> dg.Definitions:
-    from dependency_on_dbt_project_location.defs import jaffle_shop_dbt  # type: ignore
+    dbt_assets = (
+        context.component_tree.build_defs_at_path("jaffle_shop_dbt")
+        .resolve_asset_graph()
+        .assets_defs
+    )
 
-    @dg.asset(deps={get_asset_key_for_model_from_module(context, jaffle_shop_dbt, "customers")})
+    @dg.asset(deps={get_asset_key_for_model(dbt_assets, "customers")})
     def downstream_of_customers():
         pass
 


### PR DESCRIPTION
## Summary

Move x-component loading to use the `component_tree`, now available on the context, instead of brokering access through the context directly. The immediate benefit is that all component loads & defs builds are now cached, and are loaded/built at most once.

```python
deps = context.component_tree.build_defs_at_path("my_python_defs").resolve_all_asset_keys()
```

```yaml
deps: "{{ component_tree.build_defs_at_path('my_python_defs').resolve_all_asset_keys()}}"
```

This is a bit clunky ergonomically, so curious for thoughts on how we might make this more compact.

## Test Plan

Existing tests, new test invoking UDF.

