### PR TITLE
[dg] dg list plugin-modules -> dg list registry-modules

### DIFF
--- a/docs/docs/guides/labs/dg/incrementally-adopting-dg/migrating-project.md
+++ b/docs/docs/guides/labs/dg/incrementally-adopting-dg/migrating-project.md
@@ -141,10 +141,10 @@ Entry points can be declared in either `pyproject.toml` or `setup.py`:
 </Tabs>
 
 If we've done everything correctly, we should now be able to run `dg list
-plugin-modules` and see the module `my_existing_project.components`, which we have registered as an entry point, listed in the output.
+registry-modules` and see the module `my_existing_project.components`, which we have registered as an entry point, listed in the output.
 
 <CliInvocationExample
-path="docs_snippets/docs_snippets/guides/dg/migrating-project/9-list-plugin-modules.txt"
+path="docs_snippets/docs_snippets/guides/dg/migrating-project/9-list-registry-modules.txt"
 />
 
 We can now scaffold a new component type in our project and it will be

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/9-list-registry-modules.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/9-list-registry-modules.txt
@@ -1,0 +1,8 @@
+dg list registry-modules
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Module                         ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ dagster                        │
+│ my_existing_project.components │
+└────────────────────────────────┘

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_project/test_migrating_project.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_project/test_migrating_project.py
@@ -230,8 +230,8 @@ def test_migrating_project(
                 )
 
             context.run_command_and_snippet_output(
-                cmd="dg list plugin-modules",
-                snippet_path=f"{context.get_next_snip_number()}-list-plugin-modules.txt",
+                cmd="dg list registry-modules",
+                snippet_path=f"{context.get_next_snip_number()}-list-registry-modules.txt",
             )
 
             context.run_command_and_snippet_output(

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/list.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/list.py
@@ -150,7 +150,7 @@ def list_components_command(
 FEATURE_COLOR_MAP = {"component": "deep_sky_blue3", "scaffold-target": "khaki1"}
 
 
-@list_group.command(name="plugin-modules", aliases=["plugin-module"], cls=DgClickCommand)
+@list_group.command(name="registry-modules", aliases=["registry-module"], cls=DgClickCommand)
 @click.option(
     "--json",
     "output_json",
@@ -161,7 +161,7 @@ FEATURE_COLOR_MAP = {"component": "deep_sky_blue3", "scaffold-target": "khaki1"}
 @dg_path_options
 @dg_global_options
 @cli_telemetry_wrapper
-def list_plugin_modules_command(
+def list_registry_modules_command(
     output_json: bool,
     path: Path,
     **global_options: object,

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold.py
@@ -917,7 +917,9 @@ def scaffold_component_command(
     registry = RemotePluginRegistry.from_dg_context(dg_context)
 
     module_name = snakecase(name)
-    component_key = PluginObjectKey(name=name, namespace=dg_context.default_plugin_module_name)
+    component_key = PluginObjectKey(
+        name=name, namespace=dg_context.default_registry_root_module_name
+    )
     if registry.has(component_key):
         exit_with_error(f"Component type`{component_key.to_typename()}` already exists.")
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/scaffold.py
@@ -17,7 +17,7 @@ ScaffoldFormatOptions: TypeAlias = Literal["yaml", "python"]
 def scaffold_component(
     *, dg_context: DgContext, class_name: str, module_name: str, model: bool
 ) -> None:
-    root_path = Path(dg_context.default_plugin_module_path)
+    root_path = Path(dg_context.default_registry_module_path)
     click.echo(f"Creating a Dagster component type at {root_path}/{module_name}.py.")
 
     scaffold_subtree(
@@ -32,7 +32,7 @@ def scaffold_component(
     with open(root_path / "__init__.py") as f:
         lines = f.readlines()
     lines.append(
-        f"from {dg_context.default_plugin_module_name}.{module_name} import {class_name} as {class_name}\n"
+        f"from {dg_context.default_registry_root_module_name}.{module_name} import {class_name} as {class_name}\n"
     )
     with open(root_path / "__init__.py", "w") as f:
         f.writelines(lines)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_environment_validation.py
@@ -57,7 +57,7 @@ REGISTRY_CONTEXT_COMMANDS = [
     CommandSpec(tuple(), "--rebuild-plugin-cache"),
     CommandSpec(("docs", "serve")),
     CommandSpec(("list", "component")),
-    CommandSpec(("list", "plugin-modules")),
+    CommandSpec(("list", "registry-modules")),
     CommandSpec(("utils", "inspect-component"), DEFAULT_COMPONENT_TYPE),
 ]
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
@@ -177,45 +177,45 @@ _EXPECTED_PLUGIN_JSON = textwrap.dedent("""
 """).strip()
 
 
-def test_list_plugin_modules_success():
+def test_list_registry_modules_success():
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_components_venv(runner),
     ):
         with fixed_panel_width(width=120):
-            result = runner.invoke("list", "plugin-modules")
+            result = runner.invoke("list", "registry-modules")
             assert_runner_result(result)
 
             match_terminal_box_output(result.output.strip(), _EXPECTED_PLUGINS_TABLE)
 
 
-def test_list_plugin_modules_json_success():
+def test_list_registry_modules_json_success():
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_components_venv(runner),
     ):
-        result = runner.invoke("list", "plugin-modules", "--json")
+        result = runner.invoke("list", "registry-modules", "--json")
         assert_runner_result(result)
 
         assert match_json_output(result.output.strip(), _EXPECTED_PLUGIN_JSON)
 
 
-def test_list_plugin_modules_includes_modules_with_no_objects():
+def test_list_registry_modules_includes_modules_with_no_objects():
     with (
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner, in_workspace=False),
     ):
-        result = runner.invoke("list", "plugin-modules")
+        result = runner.invoke("list", "registry-modules")
         assert_runner_result(result)
         assert "foo_bar" in result.output
 
 
-def test_list_plugin_modules_bad_entry_point_fails():
-    _assert_entry_point_error(["list", "plugin-modules"])
+def test_list_registry_modules_bad_entry_point_fails():
+    _assert_entry_point_error(["list", "registry-modules"])
 
 
-@pytest.mark.parametrize("alias", ["plugin-module", "plugin-modules"])
-def test_list_plugin_modules_aliases(alias: str):
+@pytest.mark.parametrize("alias", ["registry-module", "registry-modules"])
+def test_list_registry_modules_aliases(alias: str):
     with ProxyRunner.test() as runner:
         assert_runner_result(runner.invoke("list", alias, "--help"))
 

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/context.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/context.py
@@ -290,7 +290,7 @@ class DgContext:
         """Paths that should be watched for changes to the component registry."""
         return [
             self.root_path / "uv.lock",
-            *([self.default_plugin_module_path] if self.is_plugin else []),
+            *([self.default_registry_module_path] if self.is_plugin else []),
         ]
 
     # Allowing open-ended str data_type for now so we can do module names
@@ -298,7 +298,7 @@ class DgContext:
         path_parts = [str(part) for part in self.root_path.parts if part != self.root_path.anchor]
         paths_to_hash = [
             self.root_path / "uv.lock",
-            *([self.default_plugin_module_path] if self.is_plugin else []),
+            *([self.default_registry_module_path] if self.is_plugin else []),
         ]
         env_hash = hash_paths(paths_to_hash)
         return ("_".join(path_parts), env_hash, data_type)
@@ -354,7 +354,7 @@ class DgContext:
         if self.config.project:
             return self.config.project.root_module
         elif self.is_plugin:
-            return self.default_plugin_module_name.split(".")[0]
+            return self.default_registry_root_module_name.split(".")[0]
         else:
             raise DgError("Cannot determine root package name")
 
@@ -545,7 +545,7 @@ class DgContext:
         return bool(self._dagster_components_entry_points)
 
     @cached_property
-    def default_plugin_module_name(self) -> str:
+    def default_registry_root_module_name(self) -> str:
         if not self._dagster_components_entry_points:
             raise DgError(
                 "`default_component_library_module_name` is only available in a component library context"
@@ -553,12 +553,12 @@ class DgContext:
         return next(iter(self._dagster_components_entry_points.values()))
 
     @cached_property
-    def default_plugin_module_path(self) -> Path:
+    def default_registry_module_path(self) -> Path:
         if not self.is_plugin:
             raise DgError(
                 "`default_plugin_module_path` is only available in a component library context"
             )
-        return self.get_path_for_local_module(self.default_plugin_module_name)
+        return self.get_path_for_local_module(self.default_registry_root_module_name)
 
     @cached_property
     def _dagster_components_entry_points(self) -> Mapping[str, str]:


### PR DESCRIPTION
## Summary & Motivation

Rename `dg list plugin-modules` to `dg list registry-modules`

## How I Tested These Changes

Existing test suite.

## Changelog

`dg list plugin-modules` has been renamed to `dg list registry-modules`
