### PR TITLE
Smallest interval in cron

### DIFF
--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 
 import dagster._check as check
 from dagster._core.definitions.partition import ScheduleType
-from dagster._time import get_timezone
+from dagster._time import get_current_datetime, get_timezone
 from dagster._vendored.croniter import croniter as _croniter
 from dagster._vendored.dateutil.relativedelta import relativedelta
 from dagster._vendored.dateutil.tz import datetime_ambiguous, datetime_exists
@@ -882,7 +882,7 @@ def get_smallest_cron_interval(
     execution_timezone = execution_timezone or "UTC"
 
     # Always start at current time in the specified timezone
-    start_time = datetime.datetime.now(tz=get_timezone(execution_timezone))
+    start_time = get_current_datetime(tz=execution_timezone)
 
     # Start sampling from a year ago to capture seasonal variations (DST, leap years)
     sampling_start = start_time - datetime.timedelta(days=365)

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -862,9 +862,8 @@ def get_smallest_cron_interval(
 ) -> datetime.timedelta:
     """Find the smallest interval between cron ticks for a given cron schedule.
 
-    This method first attempts to recognize common schedule patterns (hourly, daily,
-    weekly, monthly) and calculate their minimum intervals directly. For irregular
-    patterns, it falls back to a sampling approach.
+    Uses a naive, sampling-based approach to find the minimum interval by generating
+    consecutive cron ticks and measuring the gaps between them.
 
     Args:
         cron_string: A cron string
@@ -876,208 +875,19 @@ def get_smallest_cron_interval(
     Raises:
         CheckError: If the cron string is invalid or not recognized by Dagster
     """
-    from dagster._core.definitions.partition import ScheduleType
-
     check.invariant(
         is_valid_cron_string(cron_string), desc=f"{cron_string} must be a valid cron string"
     )
 
-    # Use existing schedule type detection logic from cron_string_iterator
     execution_timezone = execution_timezone or "UTC"
 
-    # Croniter < 1.4 returns 2 items, >= 1.4 returns 3 items
-    cron_parts, nth_weekday_of_month, *_ = CroniterShim.expand(cron_string)
-
-    is_numeric = [len(part) == 1 and isinstance(part[0], int) for part in cron_parts]
-    is_wildcard = [len(part) == 1 and part[0] == "*" for part in cron_parts]
-
-    all_numeric_minutes = len(cron_parts[0]) > 0 and all(
-        cron_part != "*" for cron_part in cron_parts[0]
-    )
-
-    known_schedule_type: Optional[ScheduleType] = None
-
-    # Detect known schedule types using same logic as cron_string_iterator
-    if not nth_weekday_of_month:
-        if (
-            all(is_numeric[0:3])
-            and all(is_wildcard[3:])
-            and cron_parts[2][0] <= MAX_DAY_OF_MONTH_WITH_GUARANTEED_MONTHLY_INTERVAL
-        ):  # monthly
-            known_schedule_type = ScheduleType.MONTHLY
-        elif all(is_numeric[0:2]) and is_numeric[4] and all(is_wildcard[2:4]):  # weekly
-            known_schedule_type = ScheduleType.WEEKLY
-        elif all(is_numeric[0:2]) and all(is_wildcard[2:]):  # daily
-            known_schedule_type = ScheduleType.DAILY
-        elif all_numeric_minutes and all(is_wildcard[1:]):  # hourly
-            known_schedule_type = ScheduleType.HOURLY
-
-    # Calculate interval directly for known schedule types
-    if known_schedule_type == ScheduleType.HOURLY:
-        return _calculate_hourly_interval(cron_parts[0])
-    elif known_schedule_type == ScheduleType.DAILY:
-        # For DST timezones, fall back to sampling to correctly capture 23-hour intervals
-        dst_timezones = {
-            "America/New_York",
-            "America/Chicago",
-            "America/Denver",
-            "America/Los_Angeles",
-            "America/Toronto",
-            "America/Vancouver",
-            "US/Eastern",
-            "US/Central",
-            "US/Mountain",
-            "US/Pacific",
-            "Europe/London",
-            "Europe/Berlin",
-            "Europe/Paris",
-            "Europe/Rome",
-            "Europe/Madrid",
-            "Europe/Amsterdam",
-            "Europe/Brussels",
-            "Europe/Vienna",
-            "Europe/Prague",
-            "Europe/Warsaw",
-            "Europe/Stockholm",
-            "Europe/Oslo",
-            "Europe/Copenhagen",
-            "Europe/Helsinki",
-            "Europe/Athens",
-            "Europe/Budapest",
-            "Australia/Sydney",
-            "Australia/Melbourne",
-            "Australia/Brisbane",
-            "Australia/Perth",
-            "Australia/Adelaide",
-            "Australia/Darwin",
-            "Australia/Hobart",
-        }
-
-        if execution_timezone in dst_timezones:
-            # Use sampling for DST timezones to correctly detect 23-hour intervals
-            return _sample_cron_interval(cron_string, execution_timezone)
-        else:
-            return _calculate_daily_interval(execution_timezone)
-    elif known_schedule_type == ScheduleType.WEEKLY:
-        return datetime.timedelta(days=7)
-    elif known_schedule_type == ScheduleType.MONTHLY:
-        return _calculate_monthly_interval()
-
-    # Fall back to sampling for irregular patterns
-    return _sample_cron_interval(cron_string, execution_timezone)
-
-
-def _calculate_hourly_interval(minute_parts: Sequence[Union[int, str]]) -> datetime.timedelta:
-    """Calculate minimum interval for hourly schedules."""
-    if len(minute_parts) == 1:
-        # Single minute value - interval is always 1 hour
-        return datetime.timedelta(hours=1)
-
-    # Multiple minute values - find minimum gap
-    minutes = [int(m) for m in minute_parts if isinstance(m, int)]
-    minutes.sort()
-
-    min_gap = 60  # Maximum possible gap (full hour)
-    for i in range(len(minutes)):
-        # Calculate gap to next minute (wrapping around at 60)
-        next_minute = minutes[(i + 1) % len(minutes)]
-        if i == len(minutes) - 1:
-            # Wrap around case: last minute to first minute next hour
-            gap = (60 - minutes[i]) + next_minute
-        else:
-            gap = next_minute - minutes[i]
-        min_gap = min(min_gap, gap)
-
-    return datetime.timedelta(minutes=min_gap)
-
-
-def _calculate_daily_interval(execution_timezone: str) -> datetime.timedelta:
-    """Calculate minimum interval for daily schedules.
-
-    Normally 24 hours, but 23 hours during DST spring forward.
-    """
-    # Check if timezone has DST transitions
-    if execution_timezone in {"UTC", "GMT"}:
-        return datetime.timedelta(days=1)
-
-    # For DST timezones, the minimum interval occurs during spring forward (23 hours)
-    # Check known DST timezones
-    dst_timezones = {
-        "America/New_York",
-        "America/Chicago",
-        "America/Denver",
-        "America/Los_Angeles",
-        "America/Toronto",
-        "America/Vancouver",
-        "US/Eastern",
-        "US/Central",
-        "US/Mountain",
-        "US/Pacific",
-        "Europe/London",
-        "Europe/Berlin",
-        "Europe/Paris",
-        "Europe/Rome",
-        "Europe/Madrid",
-        "Europe/Amsterdam",
-        "Europe/Brussels",
-        "Europe/Vienna",
-        "Europe/Prague",
-        "Europe/Warsaw",
-        "Europe/Stockholm",
-        "Europe/Oslo",
-        "Europe/Copenhagen",
-        "Europe/Helsinki",
-        "Europe/Athens",
-        "Europe/Budapest",
-        "Australia/Sydney",
-        "Australia/Melbourne",
-        "Australia/Brisbane",
-        "Australia/Perth",
-        "Australia/Adelaide",
-        "Australia/Darwin",
-        "Australia/Hobart",
-    }
-
-    if execution_timezone in dst_timezones:
-        return datetime.timedelta(hours=23)
-
-    # More robust DST detection - check if timezone has different offsets throughout the year
-    try:
-        tz = get_timezone(execution_timezone)
-
-        # Create two dates: one in winter, one in summer
-        winter_date = datetime.datetime(2023, 1, 15, 12, 0, 0, tzinfo=tz)
-        summer_date = datetime.datetime(2023, 7, 15, 12, 0, 0, tzinfo=tz)
-
-        # If the UTC offsets are different, the timezone has DST
-        if winter_date.utcoffset() != summer_date.utcoffset():
-            return datetime.timedelta(hours=23)
-    except Exception:
-        # If we can't determine DST status, fall back to sampling
-        # This ensures we don't return wrong results for unknown timezones
-        pass
-
-    # Default to 24 hours if no DST detected
-    return datetime.timedelta(days=1)
-
-
-def _calculate_monthly_interval() -> datetime.timedelta:
-    """Calculate minimum interval for monthly schedules.
-
-    The shortest month is February with 28 days in non-leap years.
-    """
-    return datetime.timedelta(days=28)
-
-
-def _sample_cron_interval(cron_string: str, execution_timezone: str) -> datetime.timedelta:
-    """Fall back to sampling approach for irregular cron patterns."""
     # Always start at current time in the specified timezone
     start_time = datetime.datetime.now(tz=get_timezone(execution_timezone))
 
     # Start sampling from a year ago to capture seasonal variations (DST, leap years)
     sampling_start = start_time - datetime.timedelta(days=365)
 
-    # Generate consecutive cron ticks with default sample size
+    # Generate consecutive cron ticks
     cron_iter = schedule_execution_time_iterator(
         start_timestamp=sampling_start.timestamp(),
         cron_schedule=cron_string,
@@ -1089,7 +899,7 @@ def _sample_cron_interval(cron_string: str, execution_timezone: str) -> datetime
     prev_tick = next(cron_iter)
     min_interval = None
 
-    # Sample 1000 ticks by default to cover various edge cases
+    # Sample 1000 ticks to cover various edge cases
     for _ in range(999):
         try:
             current_tick = next(cron_iter)

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
@@ -6,9 +6,11 @@ from dagster._time import create_datetime, get_timezone
 from dagster._utils.schedules import (
     _croniter_string_iterator,
     cron_string_iterator,
+    get_smallest_cron_interval,
     is_valid_cron_string,
     reverse_cron_string_iterator,
 )
+from dagster_shared.check import CheckError
 
 
 def test_cron_iterator_always_advances():
@@ -676,3 +678,148 @@ def test_invalid_cron_strings():
 
     assert is_valid_cron_string("0 0 31 1 *")
     assert not is_valid_cron_string("0 0 32 1 *")
+
+
+def test_get_smallest_cron_interval_basic():
+    """Test basic cron intervals return expected minimums."""
+    # Minute intervals
+    assert get_smallest_cron_interval("*/5 * * * *") == datetime.timedelta(minutes=5)
+    assert get_smallest_cron_interval("*/15 * * * *") == datetime.timedelta(minutes=15)
+    assert get_smallest_cron_interval("*/30 * * * *") == datetime.timedelta(minutes=30)
+
+    # Hourly intervals
+    assert get_smallest_cron_interval("0 * * * *") == datetime.timedelta(hours=1)
+    assert get_smallest_cron_interval("0 */6 * * *") == datetime.timedelta(hours=6)
+    assert get_smallest_cron_interval("0 */12 * * *") == datetime.timedelta(hours=12)
+
+    # Daily intervals
+    assert get_smallest_cron_interval("0 0 * * *") == datetime.timedelta(days=1)
+    assert get_smallest_cron_interval("30 14 * * *") == datetime.timedelta(days=1)
+
+    # Weekly intervals
+    assert get_smallest_cron_interval("0 0 * * 0") == datetime.timedelta(days=7)
+    assert get_smallest_cron_interval("0 9 * * 1") == datetime.timedelta(days=7)
+
+
+def test_get_smallest_cron_interval_irregular():
+    """Test irregular cron schedules return correct minimum intervals."""
+    # Multiple times per hour
+    interval = get_smallest_cron_interval("15,45 * * * *")
+    assert interval == datetime.timedelta(minutes=30)
+
+    # Multiple times per day
+    interval = get_smallest_cron_interval("0 9,17 * * *")
+    assert interval == datetime.timedelta(hours=8)
+
+    # Weekdays only
+    interval = get_smallest_cron_interval("0 9 * * 1-5")
+    assert interval == datetime.timedelta(days=1)  # Daily on weekdays
+
+    # Multiple days per week
+    interval = get_smallest_cron_interval("0 9 * * 1,3,5")
+    assert interval == datetime.timedelta(days=2)  # Mon->Wed->Fri pattern
+
+
+def test_get_smallest_cron_interval_monthly():
+    """Test monthly cron schedules."""
+    # Monthly on 1st
+    interval = get_smallest_cron_interval("0 0 1 * *")
+    # Shortest month interval is 28 days (February)
+    assert interval == datetime.timedelta(days=28)
+
+    # Monthly on 15th
+    interval = get_smallest_cron_interval("0 12 15 * *")
+    assert interval == datetime.timedelta(days=28)
+
+
+def test_get_smallest_cron_interval_leap_year():
+    """Test leap year edge case with Feb 29th."""
+    # Feb 29th only runs on leap years
+    interval = get_smallest_cron_interval("0 0 29 2 *")
+    # Should be 1 year for non-leap years, but our sampling should catch 4-year intervals
+    # during leap year sequences
+    assert interval.days >= 365  # At least 1 year
+
+    # The exact value depends on when we sample, but should be reasonable
+    assert interval.days <= 4 * 365 + 1  # At most 4 years + leap day
+
+
+def test_get_smallest_cron_interval_dst_transitions():
+    """Test DST transition edge cases."""
+    # Daily at 2am in a DST timezone - should catch the 23-hour interval during spring forward
+    interval = get_smallest_cron_interval("0 2 * * *", "America/New_York")
+    assert interval == datetime.timedelta(hours=23)
+
+    # Hourly schedule should not be affected by DST for minimum interval
+    interval = get_smallest_cron_interval("0 * * * *", "America/New_York")
+    assert interval == datetime.timedelta(hours=1)
+
+    # Different timezone with DST
+    interval = get_smallest_cron_interval("0 2 * * *", "Europe/Berlin")
+    assert interval == datetime.timedelta(hours=23)
+
+
+def test_get_smallest_cron_interval_timezones():
+    """Test various timezones work correctly."""
+    # UTC should work
+    interval = get_smallest_cron_interval("*/10 * * * *", "UTC")
+    assert interval == datetime.timedelta(minutes=10)
+
+    # Other timezones should work
+    interval = get_smallest_cron_interval("*/10 * * * *", "Asia/Tokyo")
+    assert interval == datetime.timedelta(minutes=10)
+
+    # Default timezone (UTC) should work
+    interval = get_smallest_cron_interval("*/10 * * * *")
+    assert interval == datetime.timedelta(minutes=10)
+
+
+def test_get_smallest_cron_interval_complex_patterns():
+    """Test complex cron patterns."""
+    # Every 5 minutes during business hours on weekdays
+    interval = get_smallest_cron_interval("*/5 9-17 * * 1-5")
+    assert interval == datetime.timedelta(minutes=5)
+
+    # Multiple specific times
+    interval = get_smallest_cron_interval("0,30 8,12,16 * * 1-5")
+    assert interval == datetime.timedelta(minutes=30)
+
+    # Specific day patterns
+    interval = get_smallest_cron_interval("0 9 1,15 * *")  # 1st and 15th of month
+    # Minimum should be 14 days (15th to 1st of next month can be 14-17 days)
+    assert interval.days >= 14
+    assert interval.days <= 17
+
+
+def test_get_smallest_cron_interval_edge_cases():
+    """Test edge cases and error conditions."""
+    # Invalid cron string should raise error
+    with pytest.raises(CheckError):
+        get_smallest_cron_interval("invalid cron")
+
+    with pytest.raises(CheckError):
+        get_smallest_cron_interval("0 0 32 * *")  # Invalid day
+
+    # Valid but unusual patterns
+    interval = get_smallest_cron_interval("0 0 * * *")  # Daily
+    assert interval == datetime.timedelta(days=1)
+
+    # Very frequent pattern
+    interval = get_smallest_cron_interval("* * * * *")  # Every minute
+    assert interval == datetime.timedelta(minutes=1)
+
+
+def test_get_smallest_cron_interval_consistency():
+    """Test that the method returns consistent results."""
+    # Run the same cron string multiple times to ensure consistency
+    cron_string = "*/15 * * * *"
+    timezone = "America/Los_Angeles"
+
+    results = []
+    for _ in range(3):
+        interval = get_smallest_cron_interval(cron_string, timezone)
+        results.append(interval)
+
+    # All results should be the same
+    assert all(result == results[0] for result in results)
+    assert results[0] == datetime.timedelta(minutes=15)


### PR DESCRIPTION
## Summary & Motivation
Helper method to get the smallest interval from a given cron string.

Needed to validate a field on cron freshness policy, but likely useful elsewhere so I added it to the schedule utils.

## How I Tested These Changes
unit tests

## Changelog

> Insert changelog entry or delete this section.
