### PR TITLE
[core] Implement lazy resolution of job configs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -131,7 +131,7 @@ class JobDefinition(IHasInternalInit):
 
         self._graph_def = graph_def
         self._current_level_node_defs = self._graph_def.node_defs
-        # Recursively explore all nodes in the this job
+        # Recursively explore all nodes in this job
         self._all_node_defs = _build_all_node_defs(self._current_level_node_defs)
         self._asset_layer = check.opt_inst_param(
             asset_layer, "asset_layer", AssetLayer
@@ -154,7 +154,7 @@ class JobDefinition(IHasInternalInit):
         )
         config = convert_config_input(config)
 
-        partitions_def = check.opt_inst_param(
+        self._original_partitions_def_argument = check.opt_inst_param(
             partitions_def, "partitions_def", PartitionsDefinition
         )
         # tags and description can exist on graph as well, but since
@@ -183,7 +183,7 @@ class JobDefinition(IHasInternalInit):
         for key in resource_defs.keys():
             if not key.isidentifier():
                 check.failed(f"Resource key '{key}' must be a valid Python identifier.")
-        was_provided_resources = (
+        self._was_provided_resources = (
             bool(resource_defs)
             if _was_explicitly_provided_resources is None
             else _was_explicitly_provided_resources
@@ -192,54 +192,15 @@ class JobDefinition(IHasInternalInit):
             DEFAULT_IO_MANAGER_KEY: default_job_io_manager,
             **resource_defs,
         }
-        self._required_resource_keys = self._get_required_resource_keys(was_provided_resources)
+        self._required_resource_keys = self._get_required_resource_keys(
+            self._was_provided_resources
+        )
 
         self._config_mapping = None
         self._partitioned_config = None
         self._run_config = None
         self._run_config_schema = None
         self._original_config_argument = config
-
-        if partitions_def:
-            self._partitioned_config = PartitionedConfig.from_flexible_config(
-                config, partitions_def
-            )
-        else:
-            if isinstance(config, ConfigMapping):
-                self._config_mapping = config
-            elif isinstance(config, PartitionedConfig):
-                self._partitioned_config = config
-                if asset_layer:
-                    for asset_key in asset_layer.asset_keys_by_node_output_handle.values():
-                        asset_partitions_def = asset_layer.get(asset_key).partitions_def
-                        check.invariant(
-                            asset_partitions_def is None
-                            or asset_partitions_def == config.partitions_def,
-                            "Can't supply a PartitionedConfig for 'config' with a different PartitionsDefinition"
-                            f" than supplied for a target asset 'partitions_def'. Asset: {asset_key.to_user_string()}",
-                        )
-
-            elif isinstance(config, dict):
-                self._run_config = config
-                # Using config mapping here is a trick to make it so that the preset will be used even
-                # when no config is supplied for the job.
-                self._config_mapping = _config_mapping_with_default_value(
-                    get_run_config_schema_for_job(
-                        graph_def,
-                        self.resource_defs,
-                        self.executor_def,
-                        self.loggers,
-                        asset_layer,
-                        was_explicitly_provided_resources=was_provided_resources,
-                    ),
-                    config,
-                    self.name,
-                )
-            elif config is not None:
-                check.failed(
-                    "config param must be a ConfigMapping, a PartitionedConfig, or a dictionary,"
-                    f" but is an object of type {type(config)}"
-                )
 
         self._subset_selection_data = _subset_selection_data
         self.input_values = input_values
@@ -403,12 +364,14 @@ class JobDefinition(IHasInternalInit):
         return self._resource_defs
 
     @public
-    @property
+    @cached_property
     def partitioned_config(self) -> Optional[PartitionedConfig]:
         """The partitioned config for the job, if it has one.
 
         A partitioned config defines a way to map partition keys to run config for the job.
         """
+        if self.has_unresolved_configs:
+            self._resolve_configs()
         return self._partitioned_config
 
     @public
@@ -418,6 +381,8 @@ class JobDefinition(IHasInternalInit):
 
         A config mapping defines a way to map a top-level config schema to run config for the job.
         """
+        if self.has_unresolved_configs:
+            self._resolve_configs()
         return self._config_mapping
 
     @public
@@ -448,6 +413,8 @@ class JobDefinition(IHasInternalInit):
 
     @property
     def run_config(self) -> Optional[Mapping[str, Any]]:
+        if self.has_unresolved_configs:
+            self._resolve_configs()
         return self._run_config
 
     @property
@@ -492,6 +459,57 @@ class JobDefinition(IHasInternalInit):
     @property
     def op_retry_policy(self) -> Optional[RetryPolicy]:
         return self._op_retry_policy
+
+    @property
+    def has_unresolved_configs(self) -> bool:
+        return (
+            self._partitioned_config is None
+            and self._run_config is None
+            and self._config_mapping is None
+        )
+
+    @cached_method
+    def _resolve_configs(self) -> None:
+        config = self._original_config_argument
+        partition_def = self._original_partitions_def_argument
+        if partition_def:
+            self._partitioned_config = PartitionedConfig.from_flexible_config(config, partition_def)
+        else:
+            if isinstance(config, ConfigMapping):
+                self._config_mapping = config
+            elif isinstance(config, PartitionedConfig):
+                self._partitioned_config = config
+                if self.asset_layer:
+                    for asset_key in self._asset_layer.asset_keys_by_node_output_handle.values():
+                        asset_partitions_def = self._asset_layer.get(asset_key).partitions_def
+                        check.invariant(
+                            asset_partitions_def is None
+                            or asset_partitions_def == config.partitions_def,
+                            "Can't supply a PartitionedConfig for 'config' with a different PartitionsDefinition"
+                            f" than supplied for a target asset 'partitions_def'. Asset: {asset_key.to_user_string()}",
+                        )
+
+            elif isinstance(config, dict):
+                self._run_config = config
+                # Using config mapping here is a trick to make it so that the preset will be used even
+                # when no config is supplied for the job.
+                self._config_mapping = _config_mapping_with_default_value(
+                    get_run_config_schema_for_job(
+                        self._graph_def,
+                        self.resource_defs,
+                        self.executor_def,
+                        self.loggers,
+                        self._asset_layer,
+                        was_explicitly_provided_resources=self._was_provided_resources,
+                    ),
+                    config,
+                    self.name,
+                )
+            elif config is not None:
+                check.failed(
+                    "config param must be a ConfigMapping, a PartitionedConfig, or a dictionary,"
+                    f" but is an object of type {type(config)}"
+                )
 
     def node_def_named(self, name: str) -> NodeDefinition:
         check.str_param(name, "name")
@@ -1091,7 +1109,7 @@ class JobDefinition(IHasInternalInit):
             _subset_selection_data=self._subset_selection_data,
             asset_layer=self.asset_layer,
             input_values=self.input_values,
-            partitions_def=self.partitions_def,
+            partitions_def=self._original_partitions_def_argument,
             _was_explicitly_provided_resources=None,
         )
         resolved_kwargs = {**base_kwargs, **kwargs}  # base kwargs overwritten for conflicts

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -364,7 +364,7 @@ class JobDefinition(IHasInternalInit):
         return self._resource_defs
 
     @public
-    @cached_property
+    @property
     def partitioned_config(self) -> Optional[PartitionedConfig]:
         """The partitioned config for the job, if it has one.
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -732,7 +732,7 @@ def test_mismatched_job_partitioned_config_with_asset_partitions():
     ):
         define_asset_job("job", config=myconfig).resolve(
             asset_graph=AssetGraph.from_assets([asset1])
-        )
+        ).execute_in_process()
 
 
 def test_partition_range_single_run() -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -496,7 +496,7 @@ def test_to_job_incomplete_default_config():
             DagsterInvalidConfigError,
             match=error_msg,
         ):
-            my_graph.to_job(name="my_job", config=invalid_config)
+            my_graph.to_job(name="my_job", config=invalid_config).execute_in_process()
 
 
 class TestEnum(enum.Enum):
@@ -849,7 +849,7 @@ def test_top_level_graph_outer_config_failure():
         my_graph.to_job().execute_in_process(run_config={"ops": {"config": {"bad_type": "foo"}}})
 
     with pytest.raises(DagsterInvalidConfigError, match="Invalid scalar at path root:config"):
-        my_graph.to_job(config={"ops": {"config": {"bad_type": "foo"}}})
+        my_graph.to_job(config={"ops": {"config": {"bad_type": "foo"}}}).execute_in_process()
 
 
 def test_graph_dict_config():


### PR DESCRIPTION
## Summary & Motivation

This PR fixes [AD-930 - GraphDefinition.to_job() with config blows up if op has custom IO manager](https://linear.app/dagster-labs/issue/AD-930/graphdefinitionto-job-with-config-blows-up-if-op-has-custom-io-manager).

Before the changes made in this PR, this code was raising a `DagsterInvalidDefinitionError` stating that the dummy IO manager was missing:

```python
from dagster import Definitions, Out, graph, op
from dagster._core.storage.fs_io_manager import FilesystemIOManager


@op(out=Out(io_manager_key="dummy"))
def alpha(x: int):
    return x


@graph
def my_graph(x):
    alpha(x)


my_job = my_graph.to_job(config={"inputs": {"x": 1}})


defs = Definitions(jobs=[my_job], resources={"dummy": FilesystemIOManager(base_dir=".")})
```

The problem: 

When passing a config dictionary to the job, the process that resolves the configs at job initialization creates a ConfigMapping for the job. Because the resource definition for the IO manager is passed at the definition-level and not at the job-level, the resources defs for the job are incomplete when the configs are resolved.

The solution:

We move the process that resolves the configs from __init__ to the config properties, so that we resolve configs only the first time they are used.

## How I Tested These Changes

Updated and new tests with BK.

## Changelog

TODO
