### PR TITLE
Clearer warning messages in `get_job_def`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -487,6 +487,29 @@ class Definitions(IHaveNew):
         check.str_param(name, "name")
         return self.get_repository_def().get_job(name)
 
+    def dig_for_warnings(self, name: str) -> None:
+        for job in self.jobs or []:
+            if job.name == name:
+                if isinstance(job, JobDefinition):
+                    continue
+                check.failed(
+                    f"Found asset job named {job.name} passed to `jobs` parameter. You must now use Definitions.resolve_job_def correctly resolve retrieve this job definition."
+                )
+
+        for sensor in self.sensors or []:
+            for job in sensor.jobs:
+                if job.name == name:
+                    check.failed(
+                        f"Found job or graph named {job.name} passed to sensor named {sensor.name} that was passed to Definitions in the sensors param. You must call Definitions.resolve_job_def to retrieve this job definition."
+                    )
+
+        for schedule in self.schedules or []:
+            job = schedule.job
+            if job.name == name:
+                check.failed(
+                    f"Found job named {job.name} passed to schedule named {schedule.name} that was passed to Definitions in the schedules param. You must call Definitions.resolve_job_def to retrieve this job definition."
+                )
+
     @public
     def get_sensor_def(self, name: str) -> SensorDefinition:
         """Get a :py:class:`SensorDefinition` by name.

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -470,12 +470,16 @@ class Definitions(IHaveNew):
                     found_direct = True
 
         if not found_direct:
-            warnings.warn(
-                f"JobDefinition with name {name} directly passed to Definitions not found, "
-                "will attempt to resolve to a JobDefinition. "
-                "This will be an error in a future release and will require a call to "
-                "resolve_job_def in dagster 1.11. "
-            )
+            warning = self.dig_for_warning(name)
+            if warning:
+                warnings.warn(warning)
+            else:
+                warnings.warn(
+                    f"JobDefinition with name {name} directly passed to Definitions not found, "
+                    "will attempt to resolve to a JobDefinition. "
+                    "This will be an error in a future release and will require a call to "
+                    "resolve_job_def in dagster 1.11. "
+                )
 
         return self.resolve_job_def(name)
 
@@ -487,28 +491,35 @@ class Definitions(IHaveNew):
         check.str_param(name, "name")
         return self.get_repository_def().get_job(name)
 
-    def dig_for_warnings(self, name: str) -> None:
+    def dig_for_warning(self, name: str) -> Optional[str]:
         for job in self.jobs or []:
             if job.name == name:
                 if isinstance(job, JobDefinition):
-                    continue
-                check.failed(
-                    f"Found asset job named {job.name} passed to `jobs` parameter. You must now use Definitions.resolve_job_def correctly resolve retrieve this job definition."
+                    return None
+                return (
+                    f"Found asset job named {job.name} of type {type(job)} passed to `jobs` parameter. Starting in "
+                    "dagster 1.11, you must now use Definitions.resolve_job_def correctly "
+                    "resolve retrieve this job definition."
                 )
 
         for sensor in self.sensors or []:
             for job in sensor.jobs:
                 if job.name == name:
-                    check.failed(
-                        f"Found job or graph named {job.name} passed to sensor named {sensor.name} that was passed to Definitions in the sensors param. You must call Definitions.resolve_job_def to retrieve this job definition."
+                    return (
+                        f"Found job or graph named {job.name} passed to sensor named {sensor.name} "
+                        "that was passed to Definitions in the sensors param. Starting in dagster 1.11, "
+                        "you must call Definitions.resolve_job_def to retrieve this job definition."
                     )
 
         for schedule in self.schedules or []:
             job = schedule.job
             if job.name == name:
-                check.failed(
-                    f"Found job named {job.name} passed to schedule named {schedule.name} that was passed to Definitions in the schedules param. You must call Definitions.resolve_job_def to retrieve this job definition."
+                return (
+                    f"Found job named {job.name} passed to schedule named {schedule.name} "
+                    "that was passed to Definitions in the schedules param. Starting in dagster 1.11, "
+                    "you must call Definitions.resolve_job_def to retrieve this job definition."
                 )
+        return None
 
     @public
     def get_sensor_def(self, name: str) -> SensorDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -498,8 +498,8 @@ class Definitions(IHaveNew):
                     return None
                 return (
                     f"Found asset job named {job.name} of type {type(job)} passed to `jobs` parameter. Starting in "
-                    "dagster 1.11, you must now use Definitions.resolve_job_def correctly "
-                    "resolve retrieve this job definition."
+                    "dagster 1.11, you must now use Definitions.resolve_job_def to correctly "
+                    "retrieve this job definition."
                 )
 
         for sensor in self.sensors or []:

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_object.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_object.py
@@ -23,12 +23,14 @@ from dagster._core.definitions.source_asset import SourceAsset
 from dagster_shared.check.functions import CheckError
 
 
-def ensure_get_job_def_warns(defs: Definitions, name: str) -> None:
+def ensure_get_job_def_warns(defs: Definitions, name: str) -> str:
     warnings.resetwarnings()
     with warnings.catch_warnings(record=True) as w:
         defs.get_job_def(name)
         assert len(w) == 1
-        assert "require a call to resolve_job_def" in str(w[0].message)
+    message = str(w[0].message)
+    assert message
+    return message
 
 
 def ensure_resolve_job_succeeds(defs: Definitions, name: str) -> None:
@@ -83,7 +85,7 @@ def test_get_direct_asset_job_fails() -> None:
 
     defs = Definitions(jobs=[asset_job])
 
-    ensure_get_job_def_warns(defs, "asset_job")
+    assert "Found asset job named asset_job" in ensure_get_job_def_warns(defs, "asset_job")
     assert defs.has_resolved_repository_def()
 
 
@@ -113,7 +115,7 @@ def test_sensor_target_job_get_fails() -> None:
 
     defs = Definitions(sensors=[my_sensor])
 
-    ensure_get_job_def_warns(defs, "asset_job")
+    assert "Found job or graph named asset_job" in ensure_get_job_def_warns(defs, "asset_job")
     assert defs.has_resolved_repository_def()
 
 
@@ -130,7 +132,7 @@ def test_sensor_get_direct_job_succeeds() -> None:
 
     defs = Definitions(sensors=[my_sensor])
 
-    ensure_get_job_def_warns(defs, direct_job.name)
+    assert "Found job or graph named direct_job" in ensure_get_job_def_warns(defs, direct_job.name)
     assert defs.has_resolved_repository_def()
 
 
@@ -160,7 +162,7 @@ def test_schedule_target_job_get_fails() -> None:
 
     defs = Definitions(schedules=[my_schedule])
 
-    ensure_get_job_def_warns(defs, "asset_job")
+    assert "Found job named asset_job" in ensure_get_job_def_warns(defs, "asset_job")
     assert defs.has_resolved_repository_def()
 
 
@@ -177,7 +179,7 @@ def test_schedule_get_direct_job_succeeds() -> None:
 
     defs = Definitions(schedules=[my_schedule])
 
-    ensure_get_job_def_warns(defs, direct_job.name)
+    assert "Found job named direct_job" in ensure_get_job_def_warns(defs, direct_job.name)
     assert defs.has_resolved_repository_def()
 
 


### PR DESCRIPTION
## Summary & Motivation

This digs through all the jobs in the `Definitions` object to give higher quality warning (and eventually error) messages.

## How I Tested These Changes

BK
