### PR TITLE
Remove any extra logging handlers that may have been added at user code import time

### DIFF
--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -111,8 +111,6 @@ def definitions_validate_command_impl(
             allow_in_process=allow_in_process,
             log_level=log_level,
         ) as workspace:
-            if logger.parent:
-                logger.parent.handlers.clear()
             invalid_locations = [
                 entry
                 for entry in workspace.get_code_location_entries().values()

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -112,6 +112,7 @@ from dagster._utils.container import (
 )
 from dagster._utils.env import use_verbose, using_dagster_dev
 from dagster._utils.error import serializable_error_info_from_exc_info, unwrap_user_code_error
+from dagster._utils.log import remove_root_logger_stream_handlers
 from dagster._utils.path import is_likely_venv_executable
 from dagster._utils.typed_dict import init_optional_typeddict
 
@@ -303,6 +304,10 @@ class LoadedRepositories:
                         repository_name=repo_def.name,
                     )
                 )
+
+            # remove any extra logger handlers that may have been added to the
+            # root logger during the import
+            remove_root_logger_stream_handlers()
 
     @property
     def loadable_repository_symbols(self) -> Sequence[LoadableRepositorySymbol]:

--- a/python_modules/dagster/dagster/_utils/log.py
+++ b/python_modules/dagster/dagster/_utils/log.py
@@ -331,6 +331,16 @@ def configure_loggers(
     warnings.showwarning = custom_warning_handler
 
 
+def remove_root_logger_stream_handlers():
+    # workaround for issues like https://github.com/snowplow/snowplow-python-tracker/issues/373
+    # where importing code adds a handler to the root logger, producing unwanted logspew from
+    # dagster loggers
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if isinstance(handler, logging.StreamHandler):
+            root_logger.removeHandler(handler)
+
+
 def create_console_logger(name: str, level: Union[str, int]) -> logging.Logger:
     klass = logging.getLoggerClass()
     logger = klass(name, level=level)


### PR DESCRIPTION
Summary:
Workaround for issues like https://github.com/snowplow/snowplow-python-tracker/issues/373 that cause just importing dbt-core to cause unsightly log spew to appear in dg and dagster commands afterwards.

The hesitation here would be if somebody has a legitimate use case for hijacking the root logger? e.g. if they want to emit everything that is logged to a file or something like that? Open to discussion. We could also gate this in some way with an env var or something.

Run dg check defs in a project that imports dbt, no more unsightly logspew

Fixed an issue where importing code that adjusts the handler on the Python root logger would cause extra dagster log commands to be written to the console.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
