### PR TITLE
Workaround for logspew from importing dbt cli in dbt component scaffolder

### DIFF
--- a/python_modules/dagster/dagster/_cli/definitions.py
+++ b/python_modules/dagster/dagster/_cli/definitions.py
@@ -111,8 +111,6 @@ def definitions_validate_command_impl(
             allow_in_process=allow_in_process,
             log_level=log_level,
         ) as workspace:
-            if logger.parent:
-                logger.parent.handlers.clear()
             invalid_locations = [
                 entry
                 for entry in workspace.get_code_location_entries().values()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/scaffolder.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/scaffolder.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from typing import Optional
@@ -6,8 +7,14 @@ import dagster._check as check
 from dagster.components.component.component_scaffolder import Scaffolder
 from dagster.components.component_scaffolding import scaffold_component
 from dagster.components.scaffold.scaffold import ScaffoldRequest
-from dbt.cli.main import dbtRunner
 from pydantic import BaseModel, Field
+
+# dbt.cli.main adds a handler to the root logger, restore original handlers to prevent logspew
+existing_root_logger_handlers = [*logging.getLogger().handlers]
+
+from dbt.cli.main import dbtRunner
+
+logging.getLogger().handlers = existing_root_logger_handlers
 
 
 class DbtScaffoldParams(BaseModel):


### PR DESCRIPTION
Summary:
Workaround for https://github.com/snowplow/snowplow-python-tracker/issues/373 that cause just importing dbt-core to cause unsightly log spew to appear in dg and dagster commands afterwards.

We could separately do this more systemically in e.g. https://app.graphite.dev/github/pr/dagster-io/dagster/30466/Remove-any-extra-logging-handlers-that-may-have-been-added-at-user-code-import-time - but this is a more targeted fix at the specific place I've seen this happen.

Also remove the handler removal in the definitions validate codepath which I think was a workaround for this same issue?

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
