### PR TITLE
In the scheduling tutorials, use target instead of passing in explicit asset jobs

### DIFF
--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
@@ -6,7 +6,9 @@ import dagster as dg
 def my_job(): ...
 
 
-basic_schedule = dg.ScheduleDefinition(job=my_job, cron_schedule="0 0 * * *")
+basic_schedule = dg.ScheduleDefinition(
+    name="basic_schedule", job=my_job, cron_schedule="0 0 * * *"
+)
 # end_basic_schedule
 
 
@@ -18,11 +20,11 @@ def my_asset():
 # start_basic_asset_schedule
 import dagster as dg
 
-asset_job = dg.define_asset_job(
-    "asset_job", dg.AssetSelection.groups("some_asset_group")
+basic_schedule = dg.ScheduleDefinition(
+    name="basic_asset_schedule",
+    cron_schedule="0 0 * * *",
+    target=dg.AssetSelection.groups("some_asset_group"),
 )
-
-basic_schedule = dg.ScheduleDefinition(job=asset_job, cron_schedule="0 0 * * *")
 
 # end_basic_asset_schedule
 

--- a/examples/docs_snippets/docs_snippets/docs_beta/guides/automation/simple-schedule-example.py
+++ b/examples/docs_snippets/docs_snippets/docs_beta/guides/automation/simple-schedule-example.py
@@ -9,19 +9,12 @@ def customer_data(): ...
 def sales_report(): ...
 
 
-daily_refresh_job = define_asset_job(
-    "daily_refresh", selection=["customer_data", "sales_report"]
-)
-
 # highlight-start
 daily_schedule = ScheduleDefinition(
-    job=daily_refresh_job,
+    name="daily_refresh",
     cron_schedule="0 0 * * *",  # Runs at midnight daily
+    target=[customer_data, sales_report],
 )
 # highlight-end
 
-defs = Definitions(
-    assets=[customer_data, sales_report],
-    jobs=[daily_refresh_job],
-    schedules=[daily_schedule],
-)
+defs = Definitions(schedules=[daily_schedule])

--- a/examples/docs_snippets/docs_snippets/guides/automation/simple-schedule-example.py
+++ b/examples/docs_snippets/docs_snippets/guides/automation/simple-schedule-example.py
@@ -9,13 +9,13 @@ def customer_data(): ...
 def sales_report(): ...
 
 
-daily_refresh_job = dg.define_asset_job(
-    "daily_refresh", selection=["customer_data", "sales_report"]
-)
-
 # highlight-start
 daily_schedule = dg.ScheduleDefinition(
-    job=daily_refresh_job,
+    name="daily_refresh",
     cron_schedule="0 0 * * *",  # Runs at midnight daily
+    target=[customer_data, sales_report],
 )
 # highlight-end
+
+
+defs = dg.Definitions(schedules=[daily_schedule])


### PR DESCRIPTION
## Summary & Motivation

We support a `target` argument to schedules which can make examples much less verbose.

## How I Tested These Changes

Read.

Example

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/a5855628-af64-4aec-a22b-8f9f4c4e0d95.png)

