### PR TITLE
Use target instead of job in Defining Schedules

### DIFF
--- a/docs/docs/guides/automate/schedules/defining-schedules.md
+++ b/docs/docs/guides/automate/schedules/defining-schedules.md
@@ -15,7 +15,7 @@ The following examples demonstrate how to define some basic schedules.
 <Tabs>
   <TabItem value="Using ScheduleDefinition">
 
-This example demonstrates how to define a schedule using <PyObject section="schedules-sensors" module="dagster" object="ScheduleDefinition" /> that will run a job every day at midnight. While this example uses op jobs, the same approach will work with [asset jobs](/guides/build/jobs/asset-jobs).
+This example demonstrates how to define a schedule using <PyObject section="schedules-sensors" module="dagster" object="ScheduleDefinition" /> that will run all assets every day at midnight.
 
 <CodeExample
   path="docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py"
@@ -42,7 +42,7 @@ The `cron_schedule` argument accepts standard [cron expressions](https://en.wiki
 This example demonstrates how to define a schedule using <PyObject section="schedules-sensors" module="dagster" object="schedule" decorator />, which provides more flexibility than <PyObject section="schedules-sensors" module="dagster" object="ScheduleDefinition" />. For example, you can [configure job behavior based on its scheduled run time](/guides/automate/schedules/configuring-job-behavior) or [emit log messages](#emitting-log-messages-from-schedule-evaluation).
 
 ```python
-@schedule(job=my_job, cron_schedule="0 0 * * *")
+@schedule(target="*", cron_schedule="0 0 * * *")
 def basic_schedule(): ...
   # things the schedule does, like returning a RunRequest or SkipReason
 ```

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
@@ -1,13 +1,8 @@
 import dagster as dg
 
-
 # start_basic_schedule
-@dg.job
-def my_job(): ...
-
-
 basic_schedule = dg.ScheduleDefinition(
-    name="basic_schedule", job=my_job, cron_schedule="0 0 * * *"
+    name="basic_schedule", cron_schedule="0 0 * * *", target="*"
 )
 # end_basic_schedule
 
@@ -57,14 +52,18 @@ def configurable_job_schedule(context: dg.ScheduleEvaluationContext):
 
 # start_timezone
 my_timezone_schedule = dg.ScheduleDefinition(
-    job=my_job, cron_schedule="0 9 * * *", execution_timezone="America/Los_Angeles"
+    name="my_timezone_schedule",
+    target="*",
+    cron_schedule="0 9 * * *",
+    execution_timezone="America/Los_Angeles",
 )
 
 # end_timezone
 
 # start_running_in_code
 my_running_schedule = dg.ScheduleDefinition(
-    job=my_job,
+    name="my_running_schedule",
+    target="*",
     cron_schedule="0 9 * * *",
     default_status=dg.DefaultScheduleStatus.RUNNING,
 )
@@ -73,7 +72,7 @@ my_running_schedule = dg.ScheduleDefinition(
 
 
 # start_schedule_logging
-@dg.schedule(job=my_job, cron_schedule="* * * * *")
+@dg.schedule(target="*", cron_schedule="* * * * *")
 def logs_then_skips(context):
     context.log.info("Logging from a dg.schedule!")
     return dg.SkipReason("Nothing to do")


### PR DESCRIPTION
## Summary & Motivation

Doing a long overdue sweep around automation and using `target` instead of `job`. Doing so in the "Defining Schedules" page.

## How I Tested These Changes

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/a0a29ddf-c114-43f0-b0c5-8ebfa969f9b2.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/17a16aa5-b6a7-42e1-9e7e-b9b0675fa15c.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/d24f6b08-3cda-441c-b5d2-9937724e2a91.png)

