### PR TITLE
Asset config for configurable behavior

### DIFF
--- a/docs/docs/guides/automate/schedules/configuring-job-behavior.md
+++ b/docs/docs/guides/automate/schedules/configuring-job-behavior.md
@@ -1,14 +1,10 @@
 ---
-description: Use run config to vary the behavior of a Dagster job based on its scheduled run time.
+description: Use run config to vary run behavior based on its scheduled launch time.
 sidebar_position: 200
-title: Configuring job behavior based on scheduled run time
+title: Configuring behavior based on scheduled run time
 ---
 
-import ScaffoldAsset from '@site/docs/partials/\_ScaffoldAsset.md';
-
-<ScaffoldAsset />
-
-This example demonstrates how to use run config to vary the behavior of a job based on its scheduled run time.
+This example demonstrates how to use run config to vary the behavior of a run based on its scheduled launch time.
 
 <CodeExample
   path="docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py"
@@ -19,8 +15,7 @@ This example demonstrates how to use run config to vary the behavior of a job ba
 
 ## APIs in this example
 
-- <PyObject section="ops" module="dagster" object="op" decorator />
-- <PyObject section="jobs" module="dagster" object="job" decorator />
-- <PyObject section="execution" module="dagster" object="OpExecutionContext" />
+- <PyObject section="assets" module="dagster" object="asset" decorator />
+- <PyObject section="execution" module="dagster" object="AssetExecutionContext" />
 - <PyObject section="schedules-sensors" object="ScheduleEvaluationContext" />
 - <PyObject section="schedules-sensors" module="dagster" object="RunRequest" />


### PR DESCRIPTION
## Summary & Motivation

Changes "Configuring behavior based on scheduled run time" docs to target assets.

* Uses Pythonic config for Config
* `@asset` instead of `@op`
* `target` parameter instead of `job` on `schedule`.


## How I Tested These Changes

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/1483366b-9d48-458c-a01f-739b6f3d8cae.png)

Manual testing of code snippet localy

## Changelog

> Insert changelog entry or delete this section.
