### PR TITLE
[2/n] hoist ComponentTree into ComponentLoadContext

### DIFF
--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -322,12 +322,12 @@ class Component(ABC):
         Returns:
             A Component instance.
         """
-        from dagster.components.core.context import ComponentLoadContext
+        from dagster.components.core.tree import ComponentTree
 
         model_cls = cls.get_model_cls()
         assert model_cls
         model = TypeAdapter(model_cls).validate_python(attributes)
-        return cls.load(model, context if context else ComponentLoadContext.for_test())
+        return cls.load(model, context if context else ComponentTree.for_test().load_context)
 
     @classmethod
     def from_yaml_path(
@@ -342,9 +342,9 @@ class Component(ABC):
         Returns:
             A Component instance.
         """
-        from dagster.components.core.context import ComponentLoadContext
         from dagster.components.core.defs_module import load_yaml_component_from_path
+        from dagster.components.core.tree import ComponentTree
 
         return load_yaml_component_from_path(
-            context=context or ComponentLoadContext.for_test(), component_def_path=yaml_path
+            context=context or ComponentTree.for_test().load_context, component_def_path=yaml_path
         )

--- a/python_modules/dagster/dagster/components/core/context.py
+++ b/python_modules/dagster/dagster/components/core/context.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from dagster_shared import check
 from dagster_shared.yaml_utils.source_position import SourcePositionTree
@@ -13,7 +13,10 @@ from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils import pushd
 from dagster.components.resolved.context import ResolutionContext
-from dagster.components.utils import get_path_from_module
+
+if TYPE_CHECKING:
+    from dagster.components.core.tree import ComponentTree
+
 
 RESOLUTION_CONTEXT_STASH_KEY = "component_load_context"
 
@@ -100,7 +103,7 @@ class ComponentLoadContext:
     Note:
         This context is automatically provided by Dagster's autoloading system and
         should not be instantiated manually in most cases. For testing purposes,
-        use ``ComponentLoadContext.for_test()`` to create a test instance.
+        use ``ComponentTree.for_test().load_context`` to create a test instance.
 
     See Also:
         - :py:func:`dagster.definitions`: Decorator that receives this context
@@ -113,6 +116,7 @@ class ComponentLoadContext:
     defs_module_path: PublicAttr[Path]
     defs_module_name: PublicAttr[str]
     resolution_context: PublicAttr[ResolutionContext]
+    component_tree: "ComponentTree"
     terminate_autoloading_on_keyword_files: bool
 
     def __post_init__(self):
@@ -126,33 +130,6 @@ class ComponentLoadContext:
     def from_resolution_context(resolution_context: ResolutionContext) -> "ComponentLoadContext":
         return check.inst(
             resolution_context.stash.get(RESOLUTION_CONTEXT_STASH_KEY), ComponentLoadContext
-        )
-
-    @staticmethod
-    def for_module(
-        defs_module: ModuleType,
-        project_root: Path,
-        terminate_autoloading_on_keyword_files: bool = True,
-    ) -> "ComponentLoadContext":
-        path = get_path_from_module(defs_module)
-        return ComponentLoadContext(
-            path=path,
-            project_root=project_root,
-            defs_module_path=path,
-            defs_module_name=defs_module.__name__,
-            resolution_context=ResolutionContext.default(),
-            terminate_autoloading_on_keyword_files=terminate_autoloading_on_keyword_files,
-        )
-
-    @staticmethod
-    def for_test() -> "ComponentLoadContext":
-        return ComponentLoadContext(
-            path=Path.cwd(),
-            project_root=Path.cwd(),
-            defs_module_path=Path.cwd(),
-            defs_module_name="test",
-            resolution_context=ResolutionContext.default(),
-            terminate_autoloading_on_keyword_files=True,
         )
 
     def _with_resolution_context(

--- a/python_modules/dagster/dagster/components/core/load_defs.py
+++ b/python_modules/dagster/dagster/components/core/load_defs.py
@@ -15,8 +15,7 @@ from dagster._annotations import deprecated, public
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils.warnings import suppress_dagster_warnings
 from dagster.components.component.component import Component
-from dagster.components.core.context import ComponentLoadContext
-from dagster.components.core.tree import ComponentTree
+from dagster.components.core.tree import ComponentTree, LegacyAutoloadingComponentTree
 
 PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY = "plugin_component_types_json"
 
@@ -80,7 +79,7 @@ def build_defs_for_component(component: Component) -> Definitions:
     Args:
         component (Component): The component to load defs from.
     """
-    return component.build_defs(ComponentLoadContext.for_test())
+    return component.build_defs(ComponentTree.for_test().load_context)
 
 
 @public
@@ -172,9 +171,15 @@ def load_defs(
     project_root = project_root if project_root else get_project_root(defs_root)
 
     # create a top-level DefsModule component from the root module
-    context = ComponentLoadContext.for_module(
-        defs_root, project_root, terminate_autoloading_on_keyword_files
+    tree = (
+        LegacyAutoloadingComponentTree.from_module(defs_module=defs_root, project_root=project_root)
+        if terminate_autoloading_on_keyword_files
+        else ComponentTree.from_module(
+            defs_module=defs_root,
+            project_root=project_root,
+        )
     )
+    context = tree.load_context
 
     # Despite the argument being named defs_root, load_defs supports loading arbitrary components
     # directly, so use get_component instead of DefsFolderComponent.get
@@ -184,7 +189,7 @@ def load_defs(
 
     # If we did get a folder component back, assume its the root tree
     tree = (
-        ComponentTree(defs_module=defs_root, project_root=project_root)
+        ComponentTree.from_module(defs_module=defs_root, project_root=project_root)
         if isinstance(root_component, DefsFolderComponent)
         else None
     )

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -15,6 +15,7 @@ from dagster_shared.merger import deep_merge_dicts
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.partition import StaticPartitionsDefinition
+from dagster.components.core.tree import ComponentTree
 
 """Testing utilities for components."""
 
@@ -83,7 +84,7 @@ def component_defs(
             ).get_assets_def("an_asset")
             assert an_asset.key == AssetKey("an_asset")
     """
-    context = context or ComponentLoadContext.for_test()
+    context = context or ComponentTree.for_test().load_context
     return component.build_defs(context).with_resources(resources)
 
 
@@ -93,7 +94,7 @@ def defs_from_component_yaml_path(
     context: Optional[ComponentLoadContext] = None,
     resources: Optional[dict[str, Any]] = None,
 ):
-    context = context or ComponentLoadContext.for_test()
+    context = context or ComponentTree.for_test().load_context
     component = load_yaml_component_from_path(context=context, component_def_path=component_yaml)
     return component_defs(component=component, resources=resources, context=context)
 
@@ -300,11 +301,10 @@ def get_all_components_defs_from_defs_path(
     project_root: Union[str, Path],
 ) -> list[tuple[Component, Definitions]]:
     module = importlib.import_module(module_path)
-    context = ComponentLoadContext.for_module(
+    context = ComponentTree(
         defs_module=module,
         project_root=Path(project_root),
-        terminate_autoloading_on_keyword_files=False,
-    )
+    ).load_context
     components = flatten_components(get_component(context))
     return [(component, component.build_defs(context)) for component in components]
 

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_asset_check_only.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_asset_check_only.py
@@ -11,7 +11,7 @@ from dagster._core.definitions.metadata.metadata_value import TextMetadataValue
 from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
-from dagster.components.core.context import ComponentLoadContext
+from dagster.components.core.tree import ComponentTree
 from dagster.components.lib.executable_component.function_component import (
     FunctionComponent,
     FunctionSpec,
@@ -78,7 +78,7 @@ def test_execute_asset_with_check() -> None:
         }
     )
 
-    defs = component.build_defs(ComponentLoadContext.for_test())
+    defs = component.build_defs(ComponentTree.for_test().load_context)
 
     assets_def = defs.get_assets_def("asset")
     assert assets_def
@@ -126,7 +126,7 @@ def test_standalone_asset_check() -> None:
     assert isinstance(component.execution, FunctionSpec)
     assert isinstance(component.execution.fn(None), AssetCheckResult)
 
-    defs = component.build_defs(ComponentLoadContext.for_test())
+    defs = component.build_defs(ComponentTree.for_test().load_context)
     assert defs.asset_checks
     asset_checks_def = next(iter(defs.asset_checks))
     assert isinstance(asset_checks_def, AssetChecksDefinition)
@@ -163,7 +163,7 @@ def test_standalone_asset_check_with_resources() -> None:
         }
     )
 
-    defs = component.build_defs(ComponentLoadContext.for_test())
+    defs = component.build_defs(ComponentTree.for_test().load_context)
 
     asset_checks_def = next(iter(defs.asset_checks or []))
     assert isinstance(asset_checks_def, AssetChecksDefinition)
@@ -203,7 +203,7 @@ def test_trivial_properties() -> None:
     )
 
     assert component_only_assets.build_underlying_assets_def(
-        ComponentLoadContext.for_test()
+        ComponentTree.for_test().load_context
     ).op.tags == {"op_tag": "op_tag_value"}
 
     component_only_asset_checks = FunctionComponent.from_attributes_dict(
@@ -225,14 +225,16 @@ def test_trivial_properties() -> None:
     )
 
     for component in [component_only_assets, component_only_asset_checks]:
-        assert component.build_underlying_assets_def(ComponentLoadContext.for_test()).op.tags == {
-            "op_tag": "op_tag_value"
-        }
+        assert component.build_underlying_assets_def(
+            ComponentTree.for_test().load_context
+        ).op.tags == {"op_tag": "op_tag_value"}
         assert (
-            component.build_underlying_assets_def(ComponentLoadContext.for_test()).op.description
+            component.build_underlying_assets_def(
+                ComponentTree.for_test().load_context
+            ).op.description
             == "op_description"
         )
         assert (
-            component.build_underlying_assets_def(ComponentLoadContext.for_test()).op.pool
+            component.build_underlying_assets_def(ComponentTree.for_test().load_context).op.pool
             == "op_pool"
         )

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/component_loader.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/component_loader.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 import pytest
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils import pushd
-from dagster.components.core.tree import ComponentTree
+from dagster.components.core.tree import ComponentTree, LegacyAutoloadingComponentTree
 
 from dagster_tests.components_tests.utils import create_project_from_components
 
@@ -36,7 +36,7 @@ def construct_component_tree_for_test(
     with create_project_from_components(
         str(src_path), local_component_defn_to_inject=local_component_defn_to_inject
     ) as (_, project_name):
-        yield ComponentTree(
+        yield LegacyAutoloadingComponentTree.from_module(
             defs_module=importlib.import_module(f"{project_name}.defs"),
             project_root=src_path.parent.parent,
         )

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
@@ -6,7 +6,6 @@ import pytest
 from dagster import AssetKey, load_defs, load_from_defs_folder
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._utils.env import environ
-from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.decl import ComponentDecl, DagsterDefsDecl, DefsFolderDecl
 from dagster.components.core.defs_module import (
     ComponentPath,
@@ -267,7 +266,9 @@ def test_ignored_empty_dir():
     src_path = Path(path_str)
     with create_project_from_components(path_str) as (project_root, project_name):
         module = importlib.import_module(f"{project_name}.defs.{src_path.stem}")
-        context = ComponentLoadContext.for_module(module, project_root)
+        context = ComponentTree.from_module(
+            defs_module=module, project_root=project_root
+        ).load_context
         defs_root = check.inst(get_underlying_component(context), DefsFolderComponent)
         for comp in defs_root.iterate_components():
             if isinstance(comp, DefsFolderComponent):

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_custom_scope.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_custom_scope.py
@@ -2,8 +2,8 @@ import importlib
 from pathlib import Path
 
 from dagster import AssetSpec, AutomationCondition
-from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.load_defs import load_defs
+from dagster.components.core.tree import ComponentTree
 
 
 def test_custom_scope() -> None:
@@ -37,5 +37,5 @@ asset_attributes:
     foo: ''
 """)
 
-    defs = c.build_defs(ComponentLoadContext.for_test())
+    defs = c.build_defs(ComponentTree.for_test().load_context)
     assert defs.assets

--- a/python_modules/dagster/dagster_tests/components_tests/template_vars_tests/test_fn_decorators.py
+++ b/python_modules/dagster/dagster_tests/components_tests/template_vars_tests/test_fn_decorators.py
@@ -2,6 +2,7 @@ from typing import Callable
 
 from dagster.components.component.template_vars import is_template_var, template_var
 from dagster.components.core.context import ComponentLoadContext
+from dagster.components.core.tree import ComponentTree
 
 
 def test_template_udf_decorator():
@@ -10,7 +11,7 @@ def test_template_udf_decorator():
         return lambda x: f"udf_{x}"
 
     assert is_template_var(my_udf)
-    assert my_udf(ComponentLoadContext.for_test())("test") == "udf_test"
+    assert my_udf(ComponentTree.for_test().load_context)("test") == "udf_test"
 
 
 def test_template_udf_decorator_with_parens():
@@ -19,7 +20,7 @@ def test_template_udf_decorator_with_parens():
         return lambda x: f"udf_{x}"
 
     assert is_template_var(my_udf)
-    assert my_udf(ComponentLoadContext.for_test())("test") == "udf_test"
+    assert my_udf(ComponentTree.for_test().load_context)("test") == "udf_test"
 
 
 def test_template_udf_decorator_preserves_function_metadata():
@@ -50,7 +51,7 @@ def test_template_var_decorator():
         return "var_value"
 
     assert is_template_var(my_var)
-    assert my_var(ComponentLoadContext.for_test()) == "var_value"
+    assert my_var(ComponentTree.for_test().load_context) == "var_value"
 
 
 def test_template_var_decorator_with_parens():
@@ -59,7 +60,7 @@ def test_template_var_decorator_with_parens():
         return "var_value"
 
     assert is_template_var(my_var)
-    assert my_var(ComponentLoadContext.for_test()) == "var_value"
+    assert my_var(ComponentTree.for_test().load_context) == "var_value"
 
 
 def test_template_var_decorator_preserves_function_metadata():

--- a/python_modules/dagster/dagster_tests/components_tests/test_code_references.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_code_references.py
@@ -1,7 +1,6 @@
 import tempfile
 from pathlib import Path
 
-from dagster import build_defs_for_component
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 from dagster._core.definitions.decorators.asset_decorator import asset
@@ -10,6 +9,7 @@ from dagster._core.test_utils import new_cwd
 from dagster.components.component.component import Component
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.defs_module import CompositeYamlComponent
+from dagster.components.core.tree import ComponentTree
 from dagster_shared.yaml_utils.source_position import LineCol, SourcePosition
 
 
@@ -46,7 +46,7 @@ def test_composite_yaml_component_code_references():
             asset_post_processor_lists=[[]],
         )
 
-        defs = build_defs_for_component(component=component)
+        defs = component.build_defs(ComponentTree.for_test().load_context)
         assets = list(defs.assets or [])
         assert len(assets) == 2
         spec = next(a for a in assets if isinstance(a, AssetSpec))

--- a/python_modules/dagster/dagster_tests/components_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_definitions.py
@@ -5,7 +5,7 @@ import pytest
 from dagster import AssetSpec, ComponentLoadContext, Definitions
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.remote_representation.external_data import RepositorySnap
-from dagster.components.core.tree import ComponentTree
+from dagster.components.core.tree import ComponentTree, LegacyAutoloadingComponentTree
 from dagster.components.definitions import definitions
 from dagster_shared import check
 
@@ -36,7 +36,7 @@ def test_definitions_decorator_with_context():
         assert isinstance(context, ComponentLoadContext)
         return Definitions(assets=[AssetSpec(key="asset1")])
 
-    context = ComponentLoadContext.for_test()
+    context = ComponentTree.for_test().load_context
     result = my_defs_with_context(context)
     assert isinstance(result, Definitions)
     assets = list(result.assets or [])
@@ -86,7 +86,7 @@ def test_definitions_decorator_with_context_using_context():
             ]
         )
 
-    context = ComponentLoadContext.for_test()
+    context = ComponentTree.for_test().load_context
     result = my_defs_with_context(context)
     assert isinstance(result, Definitions)
     assets = list(result.assets or [])
@@ -98,7 +98,7 @@ def test_definitions_decorator_with_context_using_context():
 def test_component_tree():
     dagster_test_path = Path(__file__).joinpath("../../../../dagster-test").resolve()
     assert dagster_test_path.exists()
-    defs = ComponentTree.load(dagster_test_path).build_defs()
+    defs = LegacyAutoloadingComponentTree.load(dagster_test_path).build_defs()
 
     repo_snap = RepositorySnap.from_def(defs.get_repository_def())
     assert repo_snap.component_tree

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_invariant_errors.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_invariant_errors.py
@@ -1,8 +1,9 @@
-from dagster import Component, ComponentLoadContext
+from dagster import Component
+from dagster.components.core.tree import ComponentTree
 
 
 def test_component_does_not_implement_resolved_anything():
     class AComponent(Component):
         def build_defs(self, context): ...  # pyright: ignore[reportIncompatibleMethodOverride]
 
-    assert AComponent.load(attributes=None, context=ComponentLoadContext.for_test())
+    assert AComponent.load(attributes=None, context=ComponentTree.for_test().load_context)

--- a/python_modules/dagster/dagster_tests/components_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/components_tests/utils.py
@@ -20,6 +20,7 @@ from dagster.components.core.defs_module import (
     asset_post_processor_list_from_post_processing_dict,
     context_with_injected_scope,
 )
+from dagster.components.core.tree import ComponentTree
 from dagster.components.resolved.core_models import post_process_defs
 from dagster.components.utils import ensure_loadable_path
 from dagster_shared import check
@@ -35,7 +36,7 @@ def load_context_and_component_for_test(
     attrs: Union[str, dict[str, Any]],
     template_vars_module: Optional[str] = None,
 ) -> tuple[ComponentLoadContext, T_Component]:
-    context = ComponentLoadContext.for_test()
+    context = ComponentTree.for_test().load_context
     model_cls = check.not_none(
         component_type.get_model_cls(), "Component must have schema for direct test"
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -834,8 +834,11 @@ def test_merge():
     def logger2(_):
         raise Exception("not executed")
 
-    origin = ComponentTree(
-        defs_module=Mock(),
+    mock_module = Mock()
+    mock_module.__file__ = Path()
+    mock_module.__name__ = "mock_module"
+    origin = ComponentTree.from_module(
+        defs_module=mock_module,
         project_root=Path(),
     )
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
@@ -14,7 +14,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
 from dagster._utils.env import environ
-from dagster.components import ComponentLoadContext
+from dagster.components.core.tree import ComponentTree
 from dagster.components.testing import TestTranslation, scaffold_defs_sandbox
 from dagster_airbyte.components.workspace_component.component import AirbyteCloudWorkspaceComponent
 from dagster_airbyte.resources import AirbyteCloudWorkspace
@@ -160,7 +160,7 @@ def test_custom_filter_fn_python(
         ),
         connection_selector=filter_fn,
         translation=None,
-    ).build_defs(ComponentLoadContext.for_test())
+    ).build_defs(ComponentTree.for_test().load_context)
     assert len(defs.resolve_asset_graph().get_all_asset_keys()) == num_assets
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -16,8 +16,8 @@ from dagster._core.definitions.metadata.source_code import (
 )
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils.env import environ
-from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.load_defs import build_component_defs
+from dagster.components.core.tree import ComponentTree
 from dagster.components.resolved.core_models import AssetAttributesModel, OpSpec
 from dagster.components.resolved.errors import ResolutionException
 from dagster.components.testing import TestOpCustomization, TestTranslation
@@ -317,7 +317,7 @@ def test_state_path(
 
 
 def test_python_interface(dbt_path: Path):
-    context = ComponentLoadContext.for_test()
+    context = ComponentTree.for_test().load_context
     assert DbtProjectComponent(
         project=DbtProject(dbt_path),
     ).build_defs(context)

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -10,12 +10,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import pytest
-from dagster import AssetKey, ComponentLoadContext
+from dagster import AssetKey
 from dagster._core.definitions import materialize
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils import pushd
 from dagster._utils.env import environ
+from dagster.components.core.tree import ComponentTree
 from dagster.components.testing import TestTranslationBatched, scaffold_defs_sandbox
 from dagster_dlt import DagsterDltResource, DltLoadCollectionComponent
 from dagster_dlt.components.dlt_load_collection.component import DltLoadSpecModel
@@ -234,7 +235,7 @@ class TestDltTranslation(TestTranslationBatched):
 
 
 def test_python_interface(dlt_pipeline: Pipeline):
-    context = ComponentLoadContext.for_test()
+    context = ComponentTree.for_test().load_context
     defs = DltLoadCollectionComponent(
         loads=[
             DltLoadSpecModel(
@@ -300,7 +301,7 @@ def test_execute_component(dlt_pipeline: Pipeline):
                 pipeline=dlt_pipeline,
             )
         ]
-    ).build_defs(ComponentLoadContext.for_test())
+    ).build_defs(ComponentTree.for_test().load_context)
 
     asset_def = cast("AssetsDefinition", next(iter(defs.assets or [])))
     result = materialize(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -8,10 +8,11 @@ from typing import Any, Callable, Optional
 import pytest
 import responses
 import yaml
-from dagster import AssetKey, ComponentLoadContext
+from dagster import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils.env import environ
+from dagster.components.core.tree import ComponentTree
 from dagster.components.testing import TestTranslation, scaffold_defs_sandbox
 from dagster_fivetran.components.workspace_component.component import FivetranAccountComponent
 from dagster_fivetran.resources import FivetranWorkspace
@@ -162,7 +163,7 @@ def test_custom_filter_fn_python(
         ),
         connector_selector=filter_fn,
         translation=None,
-    ).build_defs(ComponentLoadContext.for_test())
+    ).build_defs(ComponentTree.for_test().load_context)
     assert len(defs.resolve_asset_graph().get_all_asset_keys()) == num_assets
 
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_pipes.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.utils import make_new_run_id
-from dagster.components.core.context import ComponentLoadContext
+from dagster.components.core.tree import ComponentTree
 from dagster_k8s.component import PipesK8sComponent
 from dagster_k8s.pipes import (
     _DEV_NULL_MESSAGE_WRITER,
@@ -481,7 +481,7 @@ assets:
   - key: foo
 image: my_foo_image:latest
 """)
-    defs = c.build_defs(ComponentLoadContext.for_test())
+    defs = c.build_defs(ComponentTree.for_test().load_context)
     assert defs
     assert len(defs.resolve_all_asset_specs()) == 1
 
@@ -503,6 +503,6 @@ base_pod_spec:
           memory: "128Mi"
           cpu: "500m"
 """)
-    defs = c.build_defs(ComponentLoadContext.for_test())
+    defs = c.build_defs(ComponentTree.for_test().load_context)
     assert defs
     assert len(defs.resolve_all_asset_specs()) == 2

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import pytest
 import yaml
-from dagster import AssetKey, ComponentLoadContext
+from dagster import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.definitions_class import Definitions
@@ -24,6 +24,7 @@ from dagster._core.instance_for_test import instance_for_test
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
 from dagster._utils.env import environ
+from dagster.components.core.tree import ComponentTree
 from dagster.components.resolved.core_models import AssetAttributesModel, OpSpec
 from dagster.components.testing import (
     TestOpCustomization,
@@ -94,7 +95,7 @@ def temp_sling_component_instance(
                 else:
                     data["attributes"]["connections"]["DUCKDB"]["instance"] = f"{temp_dir}/duckdb"
 
-            context = ComponentLoadContext.for_test().for_path(component_path)
+            context = ComponentTree.for_test().load_context.for_path(component_path)
             component = get_underlying_component(context)
             assert isinstance(component, SlingReplicationCollectionComponent)
             yield component, component.build_defs(context)
@@ -281,7 +282,7 @@ def test_asset_post_processors_deprecation_error() -> None:
                     ]
                     data["attributes"]["connections"]["DUCKDB"]["instance"] = f"{temp_dir}/duckdb"
 
-                context = ComponentLoadContext.for_test().for_path(component_path)
+                context = ComponentTree.for_test().load_context.for_path(component_path)
                 component = get_underlying_component(context)
                 assert isinstance(component, SlingReplicationCollectionComponent)
 


### PR DESCRIPTION
## Summary

This PR begins the process of recentering component loading on the `ComponentTree` object, which is now "in charge" of the component loading process, including caching components and their definitions. We'll need a back-reference to the tree available in the context so that components can e.g. load other components.

This means any path which constructs a `ComponentLoadContext` will instead construct a `ComponentTree`, which it now uses to vend the context.

This PR is a pretty dumb drop-in replacement for most callsites, but most could subsequently be cleaned up.

## Test Plan

Existing tests.