### PR TITLE
[5/n] Broker all component loads through `ComponentTree`

### DIFF
--- a/python_modules/dagster/dagster/components/core/context.py
+++ b/python_modules/dagster/dagster/components/core/context.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
 
 from dagster_shared import check
 from dagster_shared.yaml_utils.source_position import SourcePositionTree
@@ -15,6 +15,8 @@ from dagster._utils import pushd
 from dagster.components.resolved.context import ResolutionContext
 
 if TYPE_CHECKING:
+    from dagster.components.component.component import Component
+    from dagster.components.core.defs_module import ComponentPath
     from dagster.components.core.tree import ComponentTree
 
 
@@ -216,3 +218,14 @@ class ComponentLoadContext:
         It is as if one typed "import a_project.defs.my_component.my_python_file" in the python interpreter.
         """
         return importlib.import_module(self.defs_relative_module_name(path))
+
+    def load_component_at_path(self, defs_path: Union[Path, "ComponentPath"]) -> "Component":
+        """Loads a component from the given path.
+
+        Args:
+            defs_path: Path to the component to load. If relative, resolves relative to the defs root.
+
+        Returns:
+            Component: The component loaded from the given path.
+        """
+        return self.component_tree.load_component_at_path(defs_path)

--- a/python_modules/dagster/dagster/components/core/decl.py
+++ b/python_modules/dagster/dagster/components/core/decl.py
@@ -86,7 +86,7 @@ class CompositePythonDecl(ComponentDecl[CompositeComponent]):
     def _load_component(self) -> "CompositeComponent":
         return CompositeComponent(
             components={
-                attr: self.context.component_tree.load_component_at_path(decl.path)
+                attr: self.context.load_component_at_path(decl.path)
                 for attr, decl in self.decls.items()
             }
         )
@@ -224,9 +224,7 @@ class YamlFileDecl(ComponentDecl[CompositeYamlComponent]):
 
     def _load_component(self) -> "CompositeYamlComponent":
         return CompositeYamlComponent(
-            components=[
-                self.context.component_tree.load_component_at_path(decl.path) for decl in self.decls
-            ],
+            components=[self.context.load_component_at_path(decl.path) for decl in self.decls],
             source_positions=self.source_positions,
             asset_post_processor_lists=[
                 decl.get_asset_post_processor_lists() for decl in self.decls
@@ -269,7 +267,7 @@ class DefsFolderDecl(YamlBackedComponentDecl[DefsFolderComponent]):
         return DefsFolderComponent(
             path=self.path.file_path,
             children={
-                subpath: self.context.component_tree.load_component_at_path(decl.path)
+                subpath: self.context.load_component_at_path(decl.path)
                 for subpath, decl in self.children.items()
             },
         )

--- a/python_modules/dagster/dagster/components/core/decl.py
+++ b/python_modules/dagster/dagster/components/core/decl.py
@@ -85,7 +85,10 @@ class CompositePythonDecl(ComponentDecl[CompositeComponent]):
 
     def _load_component(self) -> "CompositeComponent":
         return CompositeComponent(
-            components={attr: decl._load_component() for attr, decl in self.decls.items()}  # noqa: SLF001
+            components={
+                attr: self.context.component_tree.load_component_at_path(decl.path)
+                for attr, decl in self.decls.items()
+            }
         )
 
     def iterate_path_component_decl_pairs(
@@ -221,7 +224,9 @@ class YamlFileDecl(ComponentDecl[CompositeYamlComponent]):
 
     def _load_component(self) -> "CompositeYamlComponent":
         return CompositeYamlComponent(
-            components=[decl._load_component() for decl in self.decls],  # noqa: SLF001
+            components=[
+                self.context.component_tree.load_component_at_path(decl.path) for decl in self.decls
+            ],
             source_positions=self.source_positions,
             asset_post_processor_lists=[
                 decl.get_asset_post_processor_lists() for decl in self.decls
@@ -263,7 +268,10 @@ class DefsFolderDecl(YamlBackedComponentDecl[DefsFolderComponent]):
         )
         return DefsFolderComponent(
             path=self.path.file_path,
-            children={subpath: decl._load_component() for subpath, decl in self.children.items()},  # noqa: SLF001
+            children={
+                subpath: self.context.component_tree.load_component_at_path(decl.path)
+                for subpath, decl in self.children.items()
+            },
         )
 
     def iterate_path_component_decl_pairs(

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -169,7 +169,7 @@ def get_component(context: ComponentLoadContext) -> Optional[Component]:
 
     component_decl = build_component_decl_from_context(context)
     if component_decl:
-        return context.component_tree.load_component_at_path(component_decl.path)
+        return context.load_component_at_path(component_decl.path)
     return None
 
 
@@ -400,7 +400,7 @@ def load_yaml_component_from_path(context: ComponentLoadContext, component_def_p
     from dagster.components.core.decl import build_component_decl_from_yaml_file
 
     decl = build_component_decl_from_yaml_file(context, component_def_path)
-    return context.component_tree.load_component_at_path(decl.path)
+    return context.load_component_at_path(decl.path)
 
 
 # When we remove component.yaml, we can remove this function for just a defs.yaml check

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -169,7 +169,7 @@ def get_component(context: ComponentLoadContext) -> Optional[Component]:
 
     component_decl = build_component_decl_from_context(context)
     if component_decl:
-        return component_decl._load_component()  # noqa: SLF001
+        return context.component_tree.load_component_at_path(component_decl.path)
     return None
 
 
@@ -399,7 +399,8 @@ def invoke_inline_template_var(context: ComponentLoadContext, tv: Callable) -> A
 def load_yaml_component_from_path(context: ComponentLoadContext, component_def_path: Path):
     from dagster.components.core.decl import build_component_decl_from_yaml_file
 
-    return build_component_decl_from_yaml_file(context, component_def_path)._load_component()  # noqa: SLF001
+    decl = build_component_decl_from_yaml_file(context, component_def_path)
+    return context.component_tree.load_component_at_path(decl.path)
 
 
 # When we remove component.yaml, we can remove this function for just a defs.yaml check

--- a/python_modules/dagster/dagster/components/core/tree.py
+++ b/python_modules/dagster/dagster/components/core/tree.py
@@ -119,7 +119,7 @@ class ComponentTree:
 
     @cached_method
     def load_root_component(self) -> Component:
-        return self.find_root_decl()._load_component()  # noqa: SLF001
+        return self.load_component_at_path(self.defs_module_path)
 
     @cached_method
     def build_defs(self) -> Definitions:

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
@@ -51,11 +51,10 @@ def test_component_loader_decl(component_tree: MockComponentTree):
     my_component = MyComponent()
     decl = ComponentLoaderDecl(
         context=component_tree.load_context,
-        path=ComponentPath(file_path=Path(__file__).parent / "my_component", instance_key=None),
+        path=ComponentPath(file_path=Path(__file__).parent, instance_key=None),
         component_node_fn=lambda context: my_component,
     )
 
-    assert decl._load_component() == my_component  # noqa: SLF001
     component_tree.set_root_decl(decl)
     assert component_tree.load_root_component() == my_component
 
@@ -75,11 +74,10 @@ def test_composite_python_decl(component_tree: MockComponentTree):
         decls={"my_component": loader_decl},
     )
 
-    loaded_component = decl._load_component()  # noqa: SLF001
+    component_tree.set_root_decl(decl)
+    loaded_component = component_tree.load_root_component()
     assert isinstance(loaded_component, CompositeComponent)
     assert loaded_component.components["my_component"] == my_component
-    component_tree.set_root_decl(decl)
-    assert isinstance(component_tree.load_root_component(), CompositeComponent)
 
 
 def test_defs_folder_decl(component_tree: MockComponentTree):
@@ -111,12 +109,11 @@ def test_defs_folder_decl(component_tree: MockComponentTree):
         component_file_model=None,
     )
 
-    loaded_component = decl._load_component()  # noqa: SLF001
+    component_tree.set_root_decl(decl)
+    loaded_component = component_tree.load_root_component()
     assert isinstance(loaded_component, DefsFolderComponent)
     assert loaded_component.children[defs_path / "my_component"] == my_component
-    component_tree.set_root_decl(decl)
 
-    assert isinstance(component_tree.load_root_component(), DefsFolderComponent)
     assert component_tree.find_decl_at_path(defs_path) == decl
     assert component_tree.find_decl_at_path(defs_path / "my_component") == loader_decl
     assert (

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
@@ -63,13 +63,11 @@ def test_composite_python_decl(component_tree: MockComponentTree):
     my_component = MyComponent()
     loader_decl = ComponentLoaderDecl(
         context=component_tree.load_context,
-        path=ComponentPath(
-            file_path=Path(__file__).parent / "components.py", instance_key="my_component"
-        ),
+        path=ComponentPath(file_path=Path(__file__).parent, instance_key="my_component"),
         component_node_fn=lambda context: my_component,
     )
     decl = CompositePythonDecl(
-        path=ComponentPath(file_path=Path(__file__).parent / "components.py", instance_key=None),
+        path=ComponentPath(file_path=Path(__file__).parent, instance_key=None),
         context=component_tree.load_context,
         decls={"my_component": loader_decl},
     )

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -128,7 +128,9 @@ def resolve_connections(
     return [
         SlingConnectionResource(
             name=name,
-            **context.resolve_value(connection.model_dump()),
+            **context.resolve_value(
+                connection if isinstance(connection, dict) else connection.model_dump()
+            ),
         )
         for name, connection in connections.items()
     ]


### PR DESCRIPTION
## Summary

The first major cutover to the `Decl` system.

Brokers all component-component interactions exclusively through the tree. In this case, updates all callsites for `ComponentDecl._load_component` to use the tree.

## Test Plan

Existing tests.