### PR TITLE
docs: add AGENTS guide

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENT instructions for `docs`
+
+This directory contains the Dagster documentation site which is built with
+[Docusaurus](https://docusaurus.io/).
+
+## Setup
+- Run `yarn install` after cloning to install dependencies.
+
+## Local development
+- Launch a local dev server with `yarn start`. This will open the site at
+  `http://localhost:3050`.
+
+## Building docs
+- To check for broken links and other build errors, first generate API docs with
+  `yarn build-api-docs` then build the site with `yarn build`.
+- Building API docs requires a Python environment. Run `make dev_install` as
+  outlined in the Dagster contributing guide to set it up. Avoid this step unless necessary because it can be slow.
+
+## Linting and formatting
+- Run `yarn format` to apply Prettier formatting to docs files.
+
+## Generated content
+- Kinds tags in `docs/partials/_KindsTags.md` can be regenerated with
+  `yarn build-kinds-tags` (typically handled during production builds).
+
+Refer to `README.md` in this directory for full details.


### PR DESCRIPTION
This adds some basic agent instructions for use with ChatGPT Codex. 


## Summary
- add AGENTS instructions for editing docs
- refine build info and remove production deployment section

## Testing
- `yarn format`


------
https://chatgpt.com/codex/tasks/task_b_6840c70a3dc8832ca5453685c2e25806