### PR TITLE
[3/n] finish consolidating on ComponentTree in load_defs

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1945,7 +1945,9 @@ class ComponentTreeSnap:
     def from_tree(tree: ComponentTree) -> "ComponentTreeSnap":
         leaves = []
 
-        for comp_path, comp_inst in tree.load_root_component().iterate_path_component_pairs():
+        for comp_path, comp_inst in check.inst(
+            tree.load_root_component(), DefsFolderComponent
+        ).iterate_path_component_pairs():
             if not isinstance(
                 comp_inst,
                 (
@@ -1958,7 +1960,7 @@ class ComponentTreeSnap:
                 cls = comp_inst.__class__
                 leaves.append(
                     ComponentInstanceSnap(
-                        key=comp_path.get_relative_key(tree.load_root_component().path),
+                        key=comp_path.get_relative_key(tree.defs_module_path),
                         full_type_name=f"{cls.__module__}.{cls.__qualname__}",
                     )
                 )

--- a/python_modules/dagster/dagster/components/core/load_defs.py
+++ b/python_modules/dagster/dagster/components/core/load_defs.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Optional
 
+from dagster_shared import check
 from dagster_shared.serdes.objects.package_entry import json_for_all_components
 from dagster_shared.utils.config import (
     get_canonical_defs_module_name,

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
@@ -29,10 +29,12 @@ def assert_tree_node_structure_matches(
 ):
     nodes_by_path = {
         ComponentPath(
-            file_path=node_path.file_path.relative_to(tree.find_root_decl().path),
+            file_path=node_path.file_path.relative_to(tree.defs_module_path),
             instance_key=node_path.instance_key,
         ): node
-        for node_path, node in tree.find_root_decl().iterate_path_component_decl_pairs()
+        for node_path, node in check.inst(
+            tree.find_root_decl(), DefsFolderDecl
+        ).iterate_path_component_decl_pairs()
     }
     unrepresented_paths = set(nodes_by_path.keys())
 

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
@@ -86,7 +86,7 @@ def test_defs_folder_decl(component_tree: MockComponentTree):
         component_node_fn=lambda context: my_other_component,
     )
 
-    defs_path = Path(__file__).parent / "defs"
+    defs_path = Path(__file__).parent
     decl = DefsFolderDecl(
         context=component_tree.load_context,
         path=defs_path,


### PR DESCRIPTION
## Summary

Continues the consolidation of manually constructed `ComponentLoadContext`s into `ComponentTree` by handling the `load_defs` case. Currently, this relies on some thorny branching behavior where we try to use `ComponentTree` and fallback to a non-Tree load if the root is not a `DefsFolderComponent`.

This requires some lift so that `ComponentTree` can still be used for e.g. singular components or a single composite YAML file.
