### PR TITLE
SubprocessComponent --> PythonScriptComponent

### DIFF
--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
@@ -1,6 +1,6 @@
 from dagster._core.definitions.materialize import materialize
 from dagster._core.definitions.metadata.metadata_value import TextMetadataValue
-from dagster.components.lib.executable_component.subprocess_component import ScriptSpec
+from dagster.components.lib.executable_component.script_utils import ScriptSpec
 from dagster.components.lib.executable_component.uv_run_component import UvRunComponent
 from dagster.components.testing import scaffold_defs_sandbox
 


### PR DESCRIPTION
## Summary & Motivation

This renames `SubprocessComponent` to `PythonScriptComponent` and moves shared utils to `script_utils.py` for `UvRunComponent` to share as well.

## How I Tested These Changes

BK
