### PR TITLE
DOC-1192 update version dropdown for 1.10.19

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -207,7 +207,7 @@ const config: Config = {
           lastVersion: 'current',
           versions: {
             current: {
-              label: 'Latest (1.10.18)',
+              label: 'Latest (1.10.19)',
               path: '/',
             },
           },


### PR DESCRIPTION
## Summary & Motivation

Updates docs version dropdown for 1.10.19 release. Will cherry-pick to 1.10.19 release branch.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
