### PR TITLE
[4/n] Cleanup+consolidation pass on Decl layer

### DIFF
--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -21,6 +21,7 @@ from dagster.components.scaffold.scaffold import scaffold_with
 
 if TYPE_CHECKING:
     from dagster.components.core.context import ComponentLoadContext
+    from dagster.components.core.decl import ComponentDecl
 
 
 @public
@@ -226,6 +227,12 @@ class Component(ABC):
         - :py:func:`dagster.scaffold_with`: Decorator for custom scaffolding
 
     """
+
+    @classmethod
+    def get_decl_type(cls) -> type["ComponentDecl"]:
+        from dagster.components.core.decl import YamlDecl
+
+        return YamlDecl
 
     @classmethod
     def __dg_package_entry__(cls) -> None: ...

--- a/python_modules/dagster/dagster/components/core/decl.py
+++ b/python_modules/dagster/dagster/components/core/decl.py
@@ -6,6 +6,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import Generic, Optional, TypeVar, Union
 
+from dagster_shared.record import record
 from dagster_shared.serdes.objects import EnvRegistryKey
 from dagster_shared.seven import load_module_object
 from dagster_shared.yaml_utils import parse_yamls_with_source_position
@@ -38,119 +39,126 @@ from dagster.components.resolved.core_models import AssetPostProcessor
 T = TypeVar("T", bound=Component)
 
 
+@record
 class ComponentDecl(abc.ABC, Generic[T]):
     """Class representing a not-yet-loaded component in the defs hierarchy. In effect, a closure
     with all information needed to load the component. A tree of component decls is initially
     built before any components are loaded.
     """
 
+    path: ComponentPath
+
     @abc.abstractmethod
     def _load_component(self) -> T:
         """Loads the component represented by this decl."""
+        ...
+
+    def iterate_component_decls(self) -> Iterator["ComponentDecl"]:
+        for _, component in self.iterate_path_component_decl_pairs():
+            yield component
+
+    def iterate_path_component_decl_pairs(
+        self,
+    ) -> Iterator[tuple[ComponentPath, "ComponentDecl"]]:
+        yield self.path, self
 
 
+@record
 class ComponentLoaderDecl(ComponentDecl[Component]):
     """Declaration of a component that is loaded by a user-defined Python function."""
 
-    def __init__(
-        self,
-        context: ComponentLoadContext,
-        component_node_fn: Callable[[ComponentLoadContext], Component],
-    ):
-        self.context = context
-        self.component_node = component_node_fn
+    context: ComponentLoadContext
+    component_node_fn: Callable[[ComponentLoadContext], Component]
 
     def _load_component(self) -> Component:
-        return self.component_node(self.context)
+        return self.component_node_fn(self.context)
 
 
+@record
 class CompositePythonDecl(ComponentDecl[CompositeComponent]):
     """Declaration of a Python CompositeComponent, corresponding to a Python file with one or more
     ComponentLoaderDecls.
     """
 
-    def __init__(self, context: ComponentLoadContext, decls: Mapping[str, ComponentLoaderDecl]):
-        self.context = context
-        self.decls = decls
+    context: ComponentLoadContext
+    decls: Mapping[str, ComponentLoaderDecl]
 
     def _load_component(self) -> "CompositeComponent":
         return CompositeComponent(
             components={attr: decl._load_component() for attr, decl in self.decls.items()}  # noqa: SLF001
         )
 
-
-class YamlDecl(ComponentDecl):
-    """Declaration of a single component loaded from a YAML file."""
-
-    @staticmethod
-    def from_source_tree(
-        context: ComponentLoadContext,
-        source_tree: ValueAndSourcePositionTree,
-    ) -> "YamlDecl":
-        component_file_model = _parse_and_populate_model_with_annotated_errors(
-            cls=ComponentFileModel, obj_parse_root=source_tree, obj_key_path_prefix=[]
-        )
-        return YamlDecl(
-            context=context, source_tree=source_tree, component_file_model=component_file_model
-        )
-
-    def __init__(
+    def iterate_path_component_decl_pairs(
         self,
-        context: ComponentLoadContext,
-        source_tree: ValueAndSourcePositionTree,
-        component_file_model: ComponentFileModel,
-    ):
-        self.context = context
-        self.source_tree = source_tree
-        self.component_file_model = component_file_model
+    ) -> Iterator[tuple[ComponentPath, ComponentDecl]]:
+        yield self.path, self
+        for decl in self.decls.values():
+            yield from decl.iterate_path_component_decl_pairs()
 
-    def _get_attributes_model(self, model_cls: Optional[type[BaseModel]]) -> Optional[BaseModel]:
-        if model_cls is None or not self.source_tree or not self.component_file_model.attributes:
-            return None
 
-        attributes_position_tree = self.source_tree.source_position_tree.children.get(
-            "attributes", None
+def _get_component_class(
+    context: ComponentLoadContext, component_file_model: ComponentFileModel
+) -> type[Component]:
+    # TODO: lookup in cache so we don't have to import the class directly
+    type_str = context.normalize_component_type_str(component_file_model.type)
+    key = EnvRegistryKey.from_typename(type_str)
+    obj = load_module_object(key.namespace, key.name)
+    if not isinstance(obj, type) or not issubclass(obj, Component):
+        raise DagsterInvalidDefinitionError(
+            f"Component type {type_str} is of type {type(obj)}, but must be a subclass of dagster.Component"
         )
-        with (
-            enrich_validation_errors_with_source_position(attributes_position_tree, ["attributes"])
-            if attributes_position_tree
-            else nullcontext()
-        ):
-            return TypeAdapter(model_cls).validate_python(self.component_file_model.attributes)
+
+    return obj
+
+
+def _process_attributes_with_enriched_validation_err(
+    source_tree: Optional[ValueAndSourcePositionTree],
+    component_file_model: Optional[ComponentFileModel],
+    model_cls: Optional[type[BaseModel]],
+) -> Optional[BaseModel]:
+    if (
+        model_cls is None
+        or not source_tree
+        or not component_file_model
+        or not component_file_model.attributes
+    ):
         return None
+
+    attributes_position_tree = source_tree.source_position_tree.children.get("attributes", None)
+    with (
+        enrich_validation_errors_with_source_position(attributes_position_tree, ["attributes"])
+        if attributes_position_tree
+        else nullcontext()
+    ):
+        return TypeAdapter(model_cls).validate_python(component_file_model.attributes)
+    return None
+
+
+@record
+class YamlBackedComponentDecl(ComponentDecl[T]):
+    context: ComponentLoadContext
+    source_tree: Optional[ValueAndSourcePositionTree]
+    component_file_model: Optional[ComponentFileModel]
 
     @cached_property
     def context_with_component_injected_scope(self) -> ComponentLoadContext:
+        if not self.component_file_model:
+            return self.context
         return context_with_injected_scope(
-            self.context, self.component_cls, self.component_file_model.template_vars_module
+            self.context,
+            self.component_cls,
+            self.component_file_model.template_vars_module,
         )
 
     @cached_property
     def component_cls(self) -> type[Component]:
         """The class of the component that is being loaded."""
-        type_str = self.context.normalize_component_type_str(self.component_file_model.type)
-        key = EnvRegistryKey.from_typename(type_str)
-        obj = load_module_object(key.namespace, key.name)
-        if not isinstance(obj, type) or not issubclass(obj, Component):
-            raise DagsterInvalidDefinitionError(
-                f"Component type {type_str} is of type {type(obj)}, but must be a subclass of dagster.Component"
-            )
-        return obj
-
-    def _load_component(self) -> "Component":
-        context = self.context_with_component_injected_scope
-
-        context = context.with_source_position_tree(
-            self.source_tree.source_position_tree,
-        )
-
-        model_cls = self.component_cls.get_model_cls()
-
-        attributes = self._get_attributes_model(model_cls)
-
-        return self.component_cls.load(attributes, context)
+        return _get_component_class(self.context, check.not_none(self.component_file_model))
 
     def get_asset_post_processor_lists(self) -> list[AssetPostProcessor]:
+        if not self.source_tree or not self.component_file_model:
+            return []
+
         post_processing_position_tree = self.source_tree.source_position_tree.children.get(
             "post_processing", None
         )
@@ -167,20 +175,50 @@ class YamlDecl(ComponentDecl):
             )
 
 
+@record
+class YamlDecl(YamlBackedComponentDecl):
+    """Declaration of a single component loaded from a YAML file."""
+
+    @staticmethod
+    def from_source_tree(
+        context: ComponentLoadContext,
+        source_tree: ValueAndSourcePositionTree,
+        path: ComponentPath,
+    ) -> "YamlDecl":
+        component_file_model = _parse_and_populate_model_with_annotated_errors(
+            cls=ComponentFileModel, obj_parse_root=source_tree, obj_key_path_prefix=[]
+        )
+        return YamlDecl(
+            context=context,
+            source_tree=source_tree,
+            component_file_model=component_file_model,
+            path=path,
+        )
+
+    def _load_component(self) -> "Component":
+        context = self.context_with_component_injected_scope
+        context = context.with_source_position_tree(
+            check.not_none(self.source_tree).source_position_tree,
+        )
+
+        model_cls = self.component_cls.get_model_cls()
+
+        attributes = _process_attributes_with_enriched_validation_err(
+            self.source_tree, self.component_file_model, model_cls
+        )
+
+        return self.component_cls.load(attributes, context)
+
+
+@record
 class YamlFileDecl(ComponentDecl[CompositeYamlComponent]):
     """Declaration of a CompositeYamlComponent, corresponding to a YAML file with one or more
     YamlDecls.
     """
 
-    def __init__(
-        self,
-        context: ComponentLoadContext,
-        decls: Sequence[YamlDecl],
-        source_positions: Sequence[SourcePosition],
-    ):
-        self.context = context
-        self.decls = decls
-        self.source_positions = source_positions
+    context: ComponentLoadContext
+    decls: Sequence[YamlBackedComponentDecl]
+    source_positions: Sequence[SourcePosition]
 
     def _load_component(self) -> "CompositeYamlComponent":
         return CompositeYamlComponent(
@@ -191,25 +229,29 @@ class YamlFileDecl(ComponentDecl[CompositeYamlComponent]):
             ],
         )
 
+    def iterate_path_component_decl_pairs(
+        self,
+    ) -> Iterator[tuple[ComponentPath, ComponentDecl]]:
+        yield self.path, self
+        for decl in self.decls:
+            yield from decl.iterate_path_component_decl_pairs()
 
+
+@record
 class DagsterDefsDecl(ComponentDecl[DagsterDefsComponent]):
-    def __init__(self, context: ComponentLoadContext, path: Path):
-        self.path = path
+    context: ComponentLoadContext
 
     def _load_component(self) -> DagsterDefsComponent:
-        return DagsterDefsComponent(path=self.path)
+        return DagsterDefsComponent(path=self.path.file_path)
 
 
-class DefsFolderDecl(ComponentDecl[DefsFolderComponent]):
-    def __init__(
-        self, context: ComponentLoadContext, path: Path, children: Mapping[Path, ComponentDecl]
-    ):
-        self.path = path
-        self.children = children
+@record
+class DefsFolderDecl(YamlBackedComponentDecl[DefsFolderComponent]):
+    children: Mapping[Path, ComponentDecl]
 
     @classmethod
     def get(cls, context: ComponentLoadContext) -> "DefsFolderDecl":
-        component = get_component_decl(context)
+        component = build_component_decl_from_context(context)
         return check.inst(
             component,
             DefsFolderDecl,
@@ -217,34 +259,23 @@ class DefsFolderDecl(ComponentDecl[DefsFolderComponent]):
         )
 
     def _load_component(self) -> "DefsFolderComponent":
+        _process_attributes_with_enriched_validation_err(
+            self.source_tree, self.component_file_model, DefsFolderComponent.get_model_cls()
+        )
         return DefsFolderComponent(
-            path=self.path,
+            path=self.path.file_path,
             children={subpath: decl._load_component() for subpath, decl in self.children.items()},  # noqa: SLF001
         )
-
-    def iterate_component_decls(self) -> Iterator[ComponentDecl]:
-        for _, component in self.iterate_path_component_decl_pairs():
-            yield component
 
     def iterate_path_component_decl_pairs(
         self,
     ) -> Iterator[tuple[ComponentPath, ComponentDecl]]:
-        for path, component_node in self.children.items():
-            yield ComponentPath(file_path=path), component_node
-
-            if isinstance(component_node, DefsFolderDecl):
-                yield from component_node.iterate_path_component_decl_pairs()
-
-            if isinstance(component_node, YamlFileDecl):
-                for idx, inner_comp in enumerate(component_node.decls):
-                    yield ComponentPath(file_path=path, instance_key=idx), inner_comp
-
-            if isinstance(component_node, CompositePythonDecl):
-                for attr, inner_comp in component_node.decls.items():
-                    yield ComponentPath(file_path=path, instance_key=attr), inner_comp
+        yield self.path, self
+        for component_node in self.children.values():
+            yield from component_node.iterate_path_component_decl_pairs()
 
 
-def get_component_decl(context: ComponentLoadContext) -> Optional[ComponentDecl]:
+def build_component_decl_from_context(context: ComponentLoadContext) -> Optional[ComponentDecl]:
     """Attempts to determine the type of component that should be loaded for the given context.  Iterates through potential component
     type matches, prioritizing more specific types: YAML, Python, plain Dagster defs, and component
     folder.
@@ -252,34 +283,42 @@ def get_component_decl(context: ComponentLoadContext) -> Optional[ComponentDecl]
     # in priority order
     # yaml component
     if find_defs_or_component_yaml(context.path):
-        return load_yaml_component_decl(context)
+        return build_component_decl_from_yaml_file_backcompat(context)
     # pythonic component
     elif (
         context.terminate_autoloading_on_keyword_files and (context.path / "component.py").exists()
     ):
-        return get_component_decl_from_python_file(context)
+        return build_component_decl_from_python_file(context)
     # defs
     elif (
         context.terminate_autoloading_on_keyword_files
         and (context.path / "definitions.py").exists()
     ):
-        return DagsterDefsDecl(context=context, path=context.path / "definitions.py")
+        return DagsterDefsDecl(
+            context=context,
+            path=ComponentPath(file_path=context.path / "definitions.py", instance_key=None),
+        )
     elif context.path.suffix == ".py":
-        return DagsterDefsDecl(context=context, path=context.path)
+        return DagsterDefsDecl(
+            context=context,
+            path=ComponentPath(file_path=context.path, instance_key=None),
+        )
     # folder
     elif context.path.is_dir():
-        children = find_component_decls_from_context(context)
+        children = build_component_decls_from_directory_items(context)
         if children:
             return DefsFolderDecl(
                 context=context,
-                path=context.path,
+                path=ComponentPath(file_path=context.path, instance_key=None),
                 children=children,
+                source_tree=None,
+                component_file_model=None,
             )
 
     return None
 
 
-def find_component_decls_from_context(
+def build_component_decls_from_directory_items(
     context: ComponentLoadContext,
 ) -> Mapping[Path, ComponentDecl]:
     found = {}
@@ -287,13 +326,13 @@ def find_component_decls_from_context(
         relative_subpath = subpath.relative_to(context.path)
         if any(relative_subpath.match(pattern) for pattern in EXPLICITLY_IGNORED_GLOB_PATTERNS):
             continue
-        component_node = get_component_decl(context.for_path(subpath))
+        component_node = build_component_decl_from_context(context.for_path(subpath))
         if component_node:
             found[subpath] = component_node
     return found
 
 
-def get_component_decl_from_python_file(
+def build_component_decl_from_python_file(
     context: ComponentLoadContext,
 ) -> Union[ComponentLoaderDecl, CompositePythonDecl]:
     # backcompat for component.yaml
@@ -304,37 +343,85 @@ def get_component_decl_from_python_file(
         raise DagsterInvalidDefinitionError("No component nodes found in module")
     elif len(component_loaders) == 1:
         _, component_loader = component_loaders[0]
-        return ComponentLoaderDecl(context=context, component_node_fn=component_loader)
+        return ComponentLoaderDecl(
+            context=context,
+            component_node_fn=component_loader,
+            path=ComponentPath(file_path=context.path, instance_key=None),
+        )
     else:
         return CompositePythonDecl(
+            path=ComponentPath(file_path=context.path, instance_key=None),
             context=context,
             decls={
-                attr: ComponentLoaderDecl(context=context, component_node_fn=component_loader)
+                attr: ComponentLoaderDecl(
+                    context=context,
+                    component_node_fn=component_loader,
+                    path=ComponentPath(file_path=context.path, instance_key=attr),
+                )
                 for attr, component_loader in component_loaders
             },
         )
 
 
-def load_yaml_component_decl(context: ComponentLoadContext) -> ComponentDecl:
+def build_component_decl_from_yaml_file_backcompat(context: ComponentLoadContext) -> ComponentDecl:
     component_def_path = check.not_none(find_defs_or_component_yaml(context.path))
-    return get_component_decl_from_yaml_file(context=context, component_def_path=component_def_path)
+    return build_component_decl_from_yaml_file(
+        context=context, component_def_path=component_def_path
+    )
 
 
-def get_component_decl_from_yaml_file(
+def build_component_decl_from_yaml_file(
     context: ComponentLoadContext, component_def_path: Path
 ) -> ComponentDecl:
     source_trees = parse_yamls_with_source_position(
         component_def_path.read_text(), str(component_def_path)
     )
     component_nodes = []
-    for source_tree in source_trees:
-        component_nodes.append(YamlDecl.from_source_tree(context=context, source_tree=source_tree))
+    for i, source_tree in enumerate(source_trees):
+        component_nodes.append(
+            build_component_decl_from_yaml_document(
+                context=context,
+                source_tree=source_tree,
+                path=ComponentPath(file_path=context.path, instance_key=i),
+            )
+        )
 
     check.invariant(len(component_nodes) > 0, "No components found in YAML file")
     return YamlFileDecl(
+        path=ComponentPath(file_path=context.path, instance_key=None),
         context=context,
         decls=component_nodes,
         source_positions=[
             source_tree.source_position_tree.position for source_tree in source_trees
         ],
     )
+
+
+def build_component_decl_from_yaml_document(
+    context: ComponentLoadContext,
+    source_tree: ValueAndSourcePositionTree,
+    path: ComponentPath,
+) -> ComponentDecl:
+    component_file_model = _parse_and_populate_model_with_annotated_errors(
+        cls=ComponentFileModel, obj_parse_root=source_tree, obj_key_path_prefix=[]
+    )
+    component_cls = _get_component_class(context, component_file_model)
+    component_decl_type = component_cls.get_decl_type()
+    check.invariant(component_decl_type in (YamlDecl, DefsFolderDecl))
+
+    if component_decl_type == DefsFolderDecl:
+        children = build_component_decls_from_directory_items(context)
+        return DefsFolderDecl(
+            context=context,
+            path=path,
+            children=children,
+            source_tree=source_tree,
+            component_file_model=component_file_model,
+        )
+    else:
+        return YamlDecl(
+            context=context,
+            source_tree=source_tree,
+            component_file_model=component_file_model,
+            path=path,
+        )

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/defs.yaml
@@ -1,3 +1,3 @@
-type: dagster.components.DefsFolderComponent
+type: dagster.DefsFolderComponent
 
 attributes: {}

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/my_python_defs/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/my_python_defs/defs.yaml
@@ -1,3 +1,3 @@
-type: dagster.components.DefsFolderComponent
+type: dagster.DefsFolderComponent
 
 attributes: {}

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/defs.yaml
@@ -1,4 +1,4 @@
-type: dagster.components.DefsFolderComponent
+type: dagster.DefsFolderComponent
 
 post_processing:
   assets:

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/defs_object/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/defs_object/defs.yaml
@@ -1,4 +1,4 @@
-type: dagster.components.DefsFolderComponent
+type: dagster.DefsFolderComponent
 
 post_processing:
   assets:

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/loose_defs/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/loose_defs/defs.yaml
@@ -1,4 +1,4 @@
-type: dagster.components.DefsFolderComponent
+type: dagster.DefsFolderComponent
 
 post_processing:
   assets:

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/definitions_at_levels_with_config/loose_defs/inner/innerer/another_level/defs.yaml
@@ -1,4 +1,4 @@
-type: dagster.components.DefsFolderComponent
+type: dagster.DefsFolderComponent
 
 post_processing:
   assets:

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/validation_error_file/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/validation_error_file/defs.yaml
@@ -1,4 +1,4 @@
-type: dagster.components.DefsFolderComponent
+type: dagster.DefsFolderComponent
 
 attributes:
   definitions_path: {}

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
@@ -12,7 +12,11 @@ from dagster.components.core.decl import (
     CompositePythonDecl,
     DefsFolderDecl,
 )
-from dagster.components.core.defs_module import CompositeComponent, DefsFolderComponent
+from dagster.components.core.defs_module import (
+    ComponentPath,
+    CompositeComponent,
+    DefsFolderComponent,
+)
 from dagster.components.core.tree import ComponentTree
 from dagster_shared.record import record
 
@@ -47,6 +51,7 @@ def test_component_loader_decl(component_tree: MockComponentTree):
     my_component = MyComponent()
     decl = ComponentLoaderDecl(
         context=component_tree.load_context,
+        path=ComponentPath(file_path=Path(__file__).parent / "my_component", instance_key=None),
         component_node_fn=lambda context: my_component,
     )
 
@@ -59,9 +64,13 @@ def test_composite_python_decl(component_tree: MockComponentTree):
     my_component = MyComponent()
     loader_decl = ComponentLoaderDecl(
         context=component_tree.load_context,
+        path=ComponentPath(
+            file_path=Path(__file__).parent / "components.py", instance_key="my_component"
+        ),
         component_node_fn=lambda context: my_component,
     )
     decl = CompositePythonDecl(
+        path=ComponentPath(file_path=Path(__file__).parent / "components.py", instance_key=None),
         context=component_tree.load_context,
         decls={"my_component": loader_decl},
     )
@@ -77,23 +86,29 @@ def test_defs_folder_decl(component_tree: MockComponentTree):
     my_component = MyComponent()
     loader_decl = ComponentLoaderDecl(
         context=component_tree.load_context,
+        path=ComponentPath(file_path=Path(__file__).parent / "my_component", instance_key=None),
         component_node_fn=lambda context: my_component,
     )
 
     my_other_component = MyComponent()
     my_other_loader_decl = ComponentLoaderDecl(
         context=component_tree.load_context,
+        path=ComponentPath(
+            file_path=Path(__file__).parent / "my_other_component", instance_key=None
+        ),
         component_node_fn=lambda context: my_other_component,
     )
 
     defs_path = Path(__file__).parent
     decl = DefsFolderDecl(
         context=component_tree.load_context,
-        path=defs_path,
+        path=ComponentPath(file_path=defs_path, instance_key=None),
         children={
             defs_path / "my_component": loader_decl,
             defs_path / "my_other_component": my_other_loader_decl,
         },
+        source_tree=None,
+        component_file_model=None,
     )
 
     loaded_component = decl._load_component()  # noqa: SLF001

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/dependency_on_dbt_project_location/defs/depends_on_dbt/defs.yaml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/dependency_on_dbt_project_location/defs/depends_on_dbt/defs.yaml
@@ -1,3 +1,3 @@
-type: dagster.components.DefsFolderComponent
+type: dagster.DefsFolderComponent
 
 attributes: {}


### PR DESCRIPTION
## Summary

A rework/edge case pass on previous PRs.

- Makes all `ComponentDecl` objects iterable, so any `ComponentDecl` object can now act as the tree root
- `ComponentPath` replaces `Path` as input for various `ComponentTree` fns to allow loading components at specific indices.
- Properly parses out `DefsFolderDecl` from YAML files, allowing the decl tree to successfully continue past user-specified `DefsFolderDecl`s. This is a bit gnarly as written.

This feels like a natural place to start merging the stack, with the PRs beyond this point more intrusively adjusting the existing loading/defs building logic.

Here's a link to view the changes in aggregate up to this point: https://github.com/dagster-io/dagster/compare/master...benpankow/switch-tree-to-use-componentpath

## Test Plan

Update test cases, explicit test of `DefsFolderDecl`-in-yaml
