### PR TITLE
Fix default timeout for ExternalRepository call when using dagster dev

### DIFF
--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -12,7 +12,7 @@ from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeL
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.__generated__ import dagster_api_pb2
 from dagster._grpc.__generated__.dagster_api_pb2_grpc import DagsterApiServicer
-from dagster._grpc.client import DEFAULT_GRPC_TIMEOUT
+from dagster._grpc.client import DEFAULT_GRPC_TIMEOUT, DEFAULT_REPOSITORY_GRPC_TIMEOUT
 from dagster._grpc.constants import GrpcServerCommand
 from dagster._grpc.types import (
     CancelExecutionRequest,
@@ -260,7 +260,9 @@ class DagsterProxyApiServicer(DagsterApiServicer):
         return self._query("GetCurrentImage", request, context)
 
     def StreamingExternalRepository(self, request, context):
-        return self._streaming_query("StreamingExternalRepository", request, context)
+        return self._streaming_query(
+            "StreamingExternalRepository", request, context, timeout=DEFAULT_REPOSITORY_GRPC_TIMEOUT
+        )
 
     def Heartbeat(self, request, context):
         self.__last_heartbeat_time = time.time()


### PR DESCRIPTION
## Summary & Motivation
The default here should be 180 seconds, but is only set on the real code server, not the proxy server. So repos that take a long time to run this call are more likely to time out when using the proxy server.

## How I Tested These Changes
add a time.sleep(75) to ExternalRepository on the server. Before it would time out, now it does not.

## Changelog
Fixed an issue where `dagster dev` was sometimes failing to load code locations with a "Deadline Exceeded" error unless the "--use-legacy-code-server-behavior" flag was set.
