### PR TITLE
[docs,dg] update installation guide to use `create-dagster` and `dagster-dg-cli`

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -68,9 +68,24 @@ create-dagster project my-project
 
 </Tabs>
 
-### Verifying your new project
+## Alternative: Manual installation in a virtual environment
 
-After creating your project, navigate to the project directory, activate the Python virtual environment, and verify the installation:
+If you prefer to set up Dagster manually or are installing it into an existing project, you can install Dagster directly into your Python environment.
+
+### Installing Dagster
+
+<Tabs>
+<TabItem value="uv" label="uv">
+  <CliInvocationExample contents="uv add dagster dagster-webserver dagster-dg-cli" />
+</TabItem>
+<TabItem value="pip" label="pip">
+  <CliInvocationExample contents="pip install dagster dagster-webserver dagster-dg-cli" />
+</TabItem>
+</Tabs>
+
+## Verifying your new project
+
+To verify that Dagster is installed correctly, run the following command:
 
 <Tabs groupId="os">
   <TabItem value="mac" label="Mac">
@@ -90,26 +105,7 @@ After creating your project, navigate to the project directory, activate the Pyt
   </TabItem>
 </Tabs>
 
-## Alternative: Manual installation in a virtual environment
-
-If you prefer to set up Dagster manually or are installing it into an existing project, you can install Dagster directly into your Python environment.
-
-### Installing Dagster
-
-<Tabs>
-<TabItem value="uv" label="uv">
-  <CliInvocationExample contents="uv add dagster dagster-webserver dagster-dg-cli" />
-</TabItem>
-<TabItem value="pip" label="pip">
-  <CliInvocationExample contents="pip install dagster dagster-webserver dagster-dg-cli" />
-</TabItem>
-</Tabs>
-
-### Verifying installation
-
-To verify that Dagster is installed correctly, run the following command:
-
-<CliInvocationExample contents="dg --version" />
+You should be presented with the version number of `dg` in your environment.
 
 ## Troubleshooting
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -28,9 +28,7 @@ First, install the Python package manager [`uv`](https://docs.astral.sh/uv/) if 
 
 Then run the `create-dagster` command using `uvx`:
 
-```bash
-uvx create-dagster project my-project
-```
+<CliInvocationExample contents="uvx create-dagster project my-project" />
 
 </TabItem>
 
@@ -72,33 +70,25 @@ create-dagster project my-project
 
 After creating your project, navigate to the project directory, activate the Python virtual environment, and verify the installation:
 
-```bash
-cd my-project
-source .venv/bin/activate
-dg --version
-```
+
+<CliInvocationExample contents="cd my-project" />
+
+<CliInvocationExample contents="source .venv/bin/activate" />
+
+<CliInvocationExample contents="dg --version" />
 
 ## Alternative: Manual installation in a virtual environment
 
-If you prefer to set up Dagster manually or are installing it into an existing project, you can install Dagster in a virtual environment.
+If you prefer to set up Dagster manually or are installing it into an existing project, you can install Dagster directly into your Python environment.
 
 ### Installing Dagster
 
 <Tabs>
 <TabItem value="uv" label="uv">
-
-```bash
-uv add dagster dagster-webserver dagster-dg-cli
-```
-
+  <CliInvocationExample contents="uv add dagster dagster-webserver dagster-dg-cli" />
 </TabItem>
-
 <TabItem value="pip" label="pip">
-
-```bash
-pip install dagster dagster-webserver dagster-dg-cli
-```
-
+  <CliInvocationExample contents="pip install dagster dagster-webserver dagster-dg-cli" />
 </TabItem>
 </Tabs>
 
@@ -106,16 +96,7 @@ pip install dagster dagster-webserver dagster-dg-cli
 
 To verify that Dagster is installed correctly, run the following command:
 
-```bash
-dagster --version
-```
-
-The version numbers of Dagster should be printed in the terminal:
-
-```bash
-> dagster --version
-dagster, version 1.8.4
-```
+<CliInvocationExample contents="dg --version" />
 
 ## Troubleshooting
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ To follow the steps in this guide, you'll need:
 
 ## Recommended: Creating a new project with create-dagster
 
-The recommended way to get started with Dagster is to create a project using the `create-dagster` command line utility. This will scaffold a Dagster project with our recommended structure, and required dependencies.
+The recommended way to get started with Dagster is to create a project using the `create-dagster` command line utility. This will scaffold a Dagster project with our recommended structure and required dependencies.
 
 ### Using `create-dagster`
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -40,7 +40,7 @@ Now, you can run the `create-dagster` command using `uvx`:
 
 <CliInvocationExample contents="brew install dagster-io/tap/create-dagster" />
 
-Then run the `create-dagster` command:
+After installation, run the `create-dagster` command:
 
 <CliInvocationExample contents="create-dagster project my-project" />
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -1,51 +1,108 @@
 ---
 title: Installing Dagster
-description: Learn how to install Dagster in a virtual environment.
+description: Learn how to install Dagster and create projects with the new dg CLI.
 sidebar_position: 20
 sidebar_label: Installation
 ---
 
+import InstallUv from '@site/docs/partials/\_InstallUv.md';
+
 To follow the steps in this guide, you'll need:
 
 - To install Python 3.9 or higher. **Python 3.12 is recommended**.
-- To install `pip`, a Python package installer
 
-## Setting up a virtual environment
+## Recommended: Creating a new project with create-dagster
 
-After installing Python, it's recommended that you set up a virtual environment. This will isolate your Dagster project from the rest of your system and make it easier to manage dependencies.
+The recommended way to get started with Dagster is to create a project using the `create-dagster` command line utility. This will scaffold a Dagster project with our recommended structure, and required dependencies.
 
-There are many ways to do this, but this guide will use `venv` as it doesn't require additional dependencies.
+### Using `create-dagster`
+
+The `create-dagster` utility can be installed using [Homebrew](https://brew.sh/), `curl` or invoked without installation using `uvx`.
 
 <Tabs>
-  <TabItem value="macos" label="MacOS">
-    ```bash
-    python -m venv venv
-    source venv/bin/activate
-    ```
-  </TabItem>
-  <TabItem value="windows" label="Windows">
-    ```bash
-    python -m venv venv
-    venv\Scripts\activate
-    ```
-  </TabItem>
-</Tabs>
+<TabItem value="uvx" label="uvx (Recommended)">
 
-:::tip
-**Looking for something more powerful than `venv`?** Try `pyenv` or `pyenv-virtualenv`, which can help you manage multiple versions of Python on a single machine. Learn more in the [pyenv GitHub repository](https://github.com/pyenv/pyenv).
-:::
+First, install the Python package manager [`uv`](https://docs.astral.sh/uv/) if you don't have it:
 
-## Installing Dagster
+<InstallUv />
 
-To install Dagster in your virtual environment, open your terminal and run the following command:
+Then run the `create-dagster` command using `uvx`:
 
 ```bash
-pip install dagster dagster-webserver
+uvx create-dagster project my-project
 ```
 
-This command will install the core Dagster library and the webserver, which is used to serve the Dagster UI.
+</TabItem>
 
-## Verifying installation
+<TabItem value="brew" label="Homebrew">
+
+`create-dagster` is available in a Homebrew tap:
+
+```bash
+brew install dagster-io/tap/create-dagster
+```
+
+Then run the `create-dagster` command:
+
+```bash
+create-dagster project my-project
+```
+
+</TabItem>
+
+<TabItem value="curl" label="curl">
+
+Use `curl` to download a standalone installation script and execute it with `sh`:
+
+```bash
+curl -LsSf https://dg.dagster.io/create-dagster/install.sh | sh
+```
+
+Then run the `create-dagster` command:
+
+```bash
+create-dagster project my-project
+```
+
+</TabItem>
+
+</Tabs>
+
+### Verifying your new project
+
+After creating your project, navigate to the project directory, activate the Python virtual environment, and verify the installation:
+
+```bash
+cd my-project
+source .venv/bin/activate
+dg --version
+```
+
+## Alternative: Manual installation in a virtual environment
+
+If you prefer to set up Dagster manually or are installing it into an existing project, you can install Dagster in a virtual environment.
+
+### Installing Dagster
+
+<Tabs>
+<TabItem value="uv" label="uv">
+
+```bash
+uv add dagster dagster-webserver dagster-dg-cli
+```
+
+</TabItem>
+
+<TabItem value="pip" label="pip">
+
+```bash
+pip install dagster dagster-webserver dagster-dg-cli
+```
+
+</TabItem>
+</Tabs>
+
+### Verifying installation
 
 To verify that Dagster is installed correctly, run the following command:
 
@@ -70,4 +127,5 @@ If you encounter any issues during the installation process:
 ## Next steps
 
 - Get up and running with your first Dagster project in the [Quickstart](/getting-started/quickstart)
+- Learn more about the [`dg` CLI and modern Dagster development](/guides/labs/dg)
 - Learn to [create data assets in Dagster](/guides/build/assets/defining-assets)

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installing Dagster
-description: Learn how to install Dagster and create projects with the new dg CLI.
+description: Learn how to install Dagster and create projects with the dg CLI.
 sidebar_position: 20
 sidebar_label: Installation
 ---

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -28,7 +28,7 @@ This will also install the `uvx` command, which allows you to execute commands w
 
 <InstallUv />
 
-Now, you can run the `create-dagster` command using `uvx` like so:
+Now, you can run the `create-dagster` command using `uvx`:
 
 <CliInvocationExample contents="uvx create-dagster project my-project" />
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -83,7 +83,7 @@ If you prefer to set up Dagster manually or are installing it into an existing p
 </TabItem>
 </Tabs>
 
-## Verifying your new project
+## Verifying your project
 
 To verify that Dagster is installed correctly, run the following command:
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -22,11 +22,13 @@ The `create-dagster` utility can be installed using [Homebrew](https://brew.sh/)
 <Tabs>
 <TabItem value="uvx" label="uvx (Recommended)">
 
-First, install the Python package manager [`uv`](https://docs.astral.sh/uv/) if you don't have it:
+First, install the Python package manager [`uv`](https://docs.astral.sh/uv/) if you don't have it.
+
+This will also install the `uvx` command, which allows you to execute commands without having to install packages directly.
 
 <InstallUv />
 
-Then run the `create-dagster` command using `uvx`:
+Now, you can run the `create-dagster` command using `uvx` like so:
 
 <CliInvocationExample contents="uvx create-dagster project my-project" />
 
@@ -70,12 +72,23 @@ create-dagster project my-project
 
 After creating your project, navigate to the project directory, activate the Python virtual environment, and verify the installation:
 
-
-<CliInvocationExample contents="cd my-project" />
-
-<CliInvocationExample contents="source .venv/bin/activate" />
-
-<CliInvocationExample contents="dg --version" />
+<Tabs groupId="os">
+  <TabItem value="mac" label="Mac">
+    <CliInvocationExample contents="cd my-project" />
+    <CliInvocationExample contents="source .venv/bin/activate" />
+    <CliInvocationExample contents="dg --version" />
+  </TabItem>
+  <TabItem value="windows" label="Windows">
+    <CliInvocationExample contents="cd my-project" />
+    <CliInvocationExample contents=".venv\Scripts\activate" />
+    <CliInvocationExample contents="dg --version" />
+  </TabItem>
+  <TabItem value="linux" label="Linux">
+    <CliInvocationExample contents="cd my-project" />
+    <CliInvocationExample contents="source .venv/bin/activate" />
+    <CliInvocationExample contents="dg --version" />
+  </TabItem>
+</Tabs>
 
 ## Alternative: Manual installation in a virtual environment
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -38,15 +38,11 @@ Now, you can run the `create-dagster` command using `uvx` like so:
 
 `create-dagster` is available in a Homebrew tap:
 
-```bash
-brew install dagster-io/tap/create-dagster
-```
+<CliInvocationExample contents="brew install dagster-io/tap/create-dagster" />
 
 Then run the `create-dagster` command:
 
-```bash
-create-dagster project my-project
-```
+<CliInvocationExample contents="create-dagster project my-project" />
 
 </TabItem>
 
@@ -54,15 +50,11 @@ create-dagster project my-project
 
 Use `curl` to download a standalone installation script and execute it with `sh`:
 
-```bash
-curl -LsSf https://dg.dagster.io/create-dagster/install.sh | sh
-```
+<CliInvocationExample contents="curl -LsSf https://dg.dagster.io/create-dagster/install.sh | sh" />
 
 Then run the `create-dagster` command:
 
-```bash
-create-dagster project my-project
-```
+<CliInvocationExample contents="create-dagster project my-project" />
 
 </TabItem>
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ The recommended way to get started with Dagster is to create a project using the
 
 ### Using `create-dagster`
 
-The `create-dagster` utility can be installed using [Homebrew](https://brew.sh/), `curl` or invoked without installation using `uvx`.
+The `create-dagster` utility can be installed with [Homebrew](https://brew.sh/) or `curl`, or invoked without installation using `uvx`.
 
 <Tabs>
 <TabItem value="uvx" label="uvx (Recommended)">

--- a/docs/docs/partials/_InstallUv.md
+++ b/docs/docs/partials/_InstallUv.md
@@ -9,5 +9,5 @@
     <CliInvocationExample contents="curl -LsSf https://astral.sh/uv/install.sh | sh" />
   </TabItem>
 </Tabs>
-For more detailed `uv` installation instructions, see the [`uv`
-docs](https://docs.astral.sh/uv/getting-started/installation/).
+
+For more detailed `uv` installation instructions, see the [`uv` docs](https://docs.astral.sh/uv/getting-started/installation/).


### PR DESCRIPTION
## Summary & Motivation

Closes DOC-1081.

Updates installation instruction to use `create-dagster` and `dagster-dg-cli`.

## How I Tested These Changes

## Changelog

NOCHANGELOG