### PR TITLE
Improve activation message when activating a project with uv

### DIFF
--- a/python_modules/libraries/create-dagster/create_dagster/cli/scaffold.py
+++ b/python_modules/libraries/create-dagster/create_dagster/cli/scaffold.py
@@ -186,7 +186,7 @@ def scaffold_project_command(
         display_venv_path = get_shortest_path_repr(venv_path)
         click.echo(
             f"""
-            Run `{get_venv_activation_cmd(display_venv_path)}` to activate your project's virtual environment.
+            Run `{get_venv_activation_cmd(display_venv_path, path)}` to activate your project's virtual environment.
             """.strip()
         )
 

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/__init__.py
@@ -93,7 +93,6 @@ def get_venv_activation_cmd(venv_dir: Path, project_path: Path) -> str:
     else:
         relative_venv_path = venv_dir.relative_to(project_path)
         return f"cd {get_shortest_path_repr(project_path)} && source {relative_venv_path / 'bin' / 'activate'}"
-        return f"source {venv_dir / 'bin' / 'activate'}"
 
 
 def get_venv_executable(venv_dir: Path, executable: str = "python") -> Path:

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/__init__.py
@@ -87,10 +87,12 @@ def clear_screen():
         os.system("clear")
 
 
-def get_venv_activation_cmd(venv_dir: Path) -> str:
+def get_venv_activation_cmd(venv_dir: Path, project_path: Path) -> str:
     if is_windows():
         return str(venv_dir / "Scripts" / "activate.bat")
     else:
+        relative_venv_path = venv_dir.relative_to(project_path)
+        return f"cd {get_shortest_path_repr(project_path)} && source {relative_venv_path / 'bin' / 'activate'}"
         return f"source {venv_dir / 'bin' / 'activate'}"
 
 


### PR DESCRIPTION
## Summary & Motivation

Changes the message on project activation using `uv` to have a single copy-pasteable command and ends up with the user in the project folder.

## How I Tested These Changes


![Screenshot 2025-06-05 at 4.18.54 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/63b1645a-d159-4931-8aa7-5b941f8c08d6.png)
