### PR TITLE
Fix bucketing in insights details dialog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogActivityChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogActivityChart.tsx
@@ -172,8 +172,8 @@ const ActivityChartRow = React.memo(
                       }
                       onClick={() => {
                         onClick({
-                          before: date / 1000 + (index + 1) * 60 * 60,
-                          after: date / 1000 + index * 60 * 60,
+                          before: date / 1000 + index * 60 * 60,
+                          after: date / 1000 + (index - 1) * 60 * 60,
                           metric,
                           unit,
                         });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
@@ -270,8 +270,8 @@ export const AssetCatalogInsightsLineChart = React.memo(
             }
           }
 
-          const after = metrics.timestamps[index]!;
-          const before = after + timeSliceSeconds;
+          const before = metrics.timestamps[index]!;
+          const after = before - timeSliceSeconds;
 
           // Only open the dialog if data exists for the clicked index
           // in the current period


### PR DESCRIPTION
There's an off-by-one error in the insights details dialog. The previously logic checked for events between the selected hour `X` and `X+1`, when it was supposed to check for events between `X-1` and `X`.

## How I Tested These Changes
Locally viewed

## Changelog
NOCHANGELOG
