### PR TITLE
[ui] Tile changes for Home

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryTile.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryTile.tsx
@@ -1,13 +1,15 @@
-import {Box, Colors, MiddleTruncate} from '@dagster-io/ui-components';
+import {Box, Colors, Icon, MiddleTruncate} from '@dagster-io/ui-components';
 import clsx from 'clsx';
 import React, {useEffect, useMemo} from 'react';
 import {Link} from 'react-router-dom';
 
 import styles from './AssetSelectionSummaryTile.module.css';
 import {useAssetSelectionFiltering} from '../../asset-selection/useAssetSelectionFiltering';
+import {RepoAddress} from '../../workspace/types';
+import {workspacePathFromAddress} from '../../workspace/workspacePath';
 import {AssetTableFragment} from '../types/AssetTableFragment.types';
 import {useAllAssets} from '../useAllAssets';
-import {ViewType, getThreadId, useAssetHealthStatuses} from './util';
+import {getThreadId, useAssetHealthStatuses} from './util';
 
 export const TILE_WIDTH = 272;
 export const TILE_HEIGHT = 104;
@@ -18,14 +20,16 @@ export const TILE_GAP = 12;
 // since the array of nodes they receive aren't the same when you visit the page again since they're the result of `.filter` calls.
 const memoryCache = new Map<string, {assets: any[]}>();
 
+type Selection = {
+  selection: {
+    querySelection: string | null;
+  };
+  name: string;
+  link: string;
+};
+
 export const AssetSelectionSummaryTileFromSelection = React.memo(
-  ({
-    icon,
-    selection,
-  }: {
-    icon: React.ReactNode;
-    selection: Extract<ViewType, {__typename: 'CatalogView'}>;
-  }) => {
+  ({icon, selection}: {icon: React.ReactNode; selection: Selection}) => {
     const assetSelection = selection.selection.querySelection ?? '';
     const {assets: allAssets, loading: allAssetsLoading} = useAllAssets();
 
@@ -102,3 +106,29 @@ export const AssetSelectionSummaryTile = React.memo(
     );
   },
 );
+
+export const JobTile = ({name, repoAddress}: {name: string; repoAddress: RepoAddress}) => {
+  const link = workspacePathFromAddress(repoAddress, `/jobs/${name}`);
+  return (
+    <Link to={link} className={styles.tileLink}>
+      <Box
+        border="all"
+        style={{
+          minWidth: TILE_WIDTH,
+          minHeight: TILE_HEIGHT,
+        }}
+        className={styles.tile}
+      >
+        <div className={styles.header}>
+          <div>
+            <Icon name="job" size={20} />
+          </div>
+          <div className={styles.title} style={{color: Colors.textLight()}}>
+            <MiddleTruncate text={name} />
+          </div>
+        </div>
+        {/* todo dish: Display latest run status */}
+      </Box>
+    </Link>
+  );
+};


### PR DESCRIPTION
## Summary & Motivation

Make a couple changes to the tile components used in catalog and Dagster+ home.

- Strip down the type required for `AssetSelectionSummaryTileFromSelection` to the minimum, so that I don't need a specific fragment type
- Add a `JobTile` for use in Home. Adding it here since I could see it being useful elsewhere in OSS.

## How I Tested These Changes

TS, lint, jest. Verify that tiles render correctly in Home.