### PR TITLE
[dagster-dbt] Allow check specs to be customized via DagsterDbtTranslator

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -781,12 +781,11 @@ def build_dbt_specs(
             if not child_unique_id.startswith("test"):
                 continue
 
-            check_spec = default_asset_check_fn(
-                manifest,
-                translator,
-                spec.key,
-                child_unique_id,
-                project,
+            check_spec = translator.get_asset_check_spec(
+                manifest=manifest,
+                asset_key=spec.key,
+                test_unique_id=child_unique_id,
+                project=project,
             )
             if check_spec:
                 check_specs[check_spec.get_python_identifier()] = check_spec
@@ -807,13 +806,14 @@ def build_dbt_specs(
                 for child_unique_id in manifest["child_map"][upstream_id]:
                     if not child_unique_id.startswith("test"):
                         continue
-                    check_spec = default_asset_check_fn(
+
+                    check_spec = translator.get_asset_check_spec(
                         manifest=manifest,
-                        dagster_dbt_translator=translator,
                         asset_key=key_by_unique_id[upstream_id],
                         test_unique_id=child_unique_id,
                         project=project,
                     )
+
                     if check_spec:
                         check_specs[check_spec.get_python_identifier()] = check_spec
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 from dagster import (
+    AssetCheckSpec,
     AssetDep,
     AssetKey,
     AssetSpec,
@@ -29,6 +30,7 @@ from dagster_dbt.asset_utils import (
     DAGSTER_DBT_MANIFEST_METADATA_KEY,
     DAGSTER_DBT_TRANSLATOR_METADATA_KEY,
     DAGSTER_DBT_UNIQUE_ID_METADATA_KEY,
+    default_asset_check_fn,
     default_asset_key_fn,
     default_auto_materialize_policy_fn,
     default_code_version_fn,
@@ -184,6 +186,22 @@ class DagsterDbtTranslator:
         self._resolved_specs[memo_id] = spec
 
         return self._resolved_specs[memo_id]
+
+    def get_asset_check_spec(
+        self,
+        manifest: Mapping[str, Any],
+        asset_key: AssetKey,
+        test_unique_id: str,
+        project: Optional["DbtProject"],
+    ) -> Optional[AssetCheckSpec]:
+        """Returns an AssetCheckSpec representing a specific dbt test as an asset check."""
+        return default_asset_check_fn(
+            manifest=manifest,
+            dagster_dbt_translator=self,
+            asset_key=asset_key,
+            test_unique_id=test_unique_id,
+            project=project,
+        )
 
     @public
     def get_asset_key(self, dbt_resource_props: Mapping[str, Any]) -> AssetKey:


### PR DESCRIPTION
## Summary & Motivation

I noticed that dbt asset checks don't provide any sort of default description, and instead rely on the `meta` being set on every test. I personally don't fancy writing 4,000 descriptions 😆 

This PR makes it easier to override the `AssetCheckSpec` generated for dbt tests by exposing the translation via `DagsterDbtTranslator`, so as a developer, I can choose to render a test's YAML definition into the description.

## How I Tested These Changes

The test suites already cover this change, and the change is non-functional by dault.

## Changelog

> [dagster-dbt] Allow check specs to be customized via DagsterDbtTranslator
