### PR TITLE
Add get_all_components_defs_within_project and get_component_defs_within_project

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -676,6 +676,12 @@ from dagster.components.scaffold.scaffold import (
     ScaffoldRequest as ScaffoldRequest,
     scaffold_with as scaffold_with,
 )
+from dagster.components.testing import (
+    component_defs as component_defs,
+    defs_from_component_yaml_path as defs_from_component_yaml_path,
+    get_all_components_defs_within_project as get_all_components_defs_within_project,
+    get_component_defs_within_project as get_component_defs_within_project,
+)
 from dagster.version import __version__ as __version__
 
 DagsterLibraryRegistry.register("dagster", __version__)

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -257,9 +257,11 @@ def get_all_components_defs_within_project(
         from dagster_dg_core.config import discover_config_file
         from dagster_dg_core.context import DgContext
     except ImportError:
+
         raise Exception(
-            "dagster_dg_core is not installed. Please install it to use to get default project_name and defs module from pyproject.toml or dg.toml."
+            "dagster_dg_core is not installed. Please install it to use default project_name and defs module from pyproject.toml or dg.toml."
         )
+
 
     project_root = Path(project_root)
     component_path = Path(component_path)

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -401,6 +401,24 @@ def scaffold_defs_sandbox(
 
 
 def copy_code_to_file(fn: Callable, file_path: Path) -> None:
+    """Takes a function and writes the body of the function to a file.
+
+    Args:
+        fn: The function to write to the file.
+        file_path: The path to the file to write the function to.
+
+    Example:
+
+    .. code-block:: python
+
+        def code_to_copy() -> None:
+            import dagster as dg
+
+            def execute_fn(context) -> dg.MaterializeResult:
+                return dg.MaterializeResult()
+
+        copy_code_to_file(code_to_copy, sandbox.defs_folder_path / "execute.py")
+    """
     source_code_text = inspect.getsource(fn)
     source_code_text = "\n".join(source_code_text.split("\n")[1:])
     dedented_source_code_text = textwrap.dedent(source_code_text)

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -257,11 +257,9 @@ def get_all_components_defs_within_project(
         from dagster_dg_core.config import discover_config_file
         from dagster_dg_core.context import DgContext
     except ImportError:
-
         raise Exception(
             "dagster_dg_core is not installed. Please install it to use default project_name and defs module from pyproject.toml or dg.toml."
         )
-
 
     project_root = Path(project_root)
     component_path = Path(component_path)

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -1,8 +1,12 @@
 import importlib
+import inspect
 import secrets
 import shutil
 import string
 import sys
+import textwrap
+from pathlib import Path
+from typing import Callable
 
 import yaml
 from dagster_shared import check
@@ -14,7 +18,6 @@ import tempfile
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Optional, Union
 
 from dagster._core.definitions.definitions_class import Definitions
@@ -186,18 +189,24 @@ class DefsPathSandbox:
     @contextmanager
     def load_all(self) -> Iterator[list[tuple[Component, Definitions]]]:
         with alter_sys_path(to_add=[str(self.project_root / "src")], to_remove=[]):
-            module_path = f"{self.project_name}.defs.{self.component_path}"
+            module_path = get_module_path(
+                defs_module_name=f"{self.project_name}.defs", component_path=self.component_path
+            )
             try:
                 yield get_all_components_defs_from_defs_path(
                     project_root=self.project_root,
-                    component_path=self.component_path,
-                    project_name=self.project_name,
+                    module_path=module_path,
                 )
 
             finally:
                 modules_to_remove = [name for name in sys.modules if name.startswith(module_path)]
                 for name in modules_to_remove:
                     del sys.modules[name]
+
+
+def get_module_path(defs_module_name: str, component_path: Path):
+    component_module_path = str(component_path).replace("/", ".")
+    return f"{defs_module_name}.{component_module_path}"
 
 
 def flatten_components(parent_component: Optional[Component]) -> list[Component]:
@@ -209,14 +218,68 @@ def flatten_components(parent_component: Optional[Component]) -> list[Component]
         return []
 
 
-def get_all_components_defs_from_defs_path(
+def get_component_defs_within_project(
     *,
-    project_name: str,
     project_root: Path,
     component_path: Path,
-    defs_module_name: str = "defs",
+) -> tuple[Component, Definitions]:
+    """Get the component defs for a component within a project. This only works if dagster_dg_core is installed.
+
+    Args:
+        project_root: The root of the project.
+        component_path: The path to the component.
+
+    Returns:
+        A tuple of the component and its definitions.
+    """
+    all_component_defs = get_all_components_defs_within_project(
+        project_root=project_root, component_path=component_path
+    )
+    check.invariant(
+        len(all_component_defs) == 1,
+        "Only one component is supported. To get all components use get_all_components_defs_within_project.",
+    )
+    return all_component_defs[0][0], all_component_defs[0][1]
+
+
+def get_all_components_defs_within_project(
+    *,
+    project_root: Path,
+    component_path: Path,
 ) -> list[tuple[Component, Definitions]]:
-    module_path = f"{project_name}.{defs_module_name}.{component_path}"
+    """Get all the component defs for a component within a project. This only works if dagster_dg_core is installed.
+
+    Args:
+        project_root: The root of the project.
+        component_path: The path to the component.
+
+    Returns:
+        A list of tuples of the component and its definitions.
+    """
+    try:
+        from dagster_dg_core.config import discover_config_file
+        from dagster_dg_core.context import DgContext
+    except ImportError:
+        raise Exception(
+            "dagster_dg_core is not installed. Please install it to use to get default project_name and defs module from pyproject.toml or dg.toml."
+        )
+
+    dg_context = DgContext.from_file_discovery_and_command_line_config(
+        path=check.not_none(discover_config_file(project_root), "No project config file found."),
+        command_line_config={},
+    )
+
+    return get_all_components_defs_from_defs_path(
+        module_path=get_module_path(dg_context.defs_module_name, component_path),
+        project_root=project_root,
+    )
+
+
+def get_all_components_defs_from_defs_path(
+    *,
+    module_path: str,
+    project_root: Path,
+) -> list[tuple[Component, Definitions]]:
     module = importlib.import_module(module_path)
     context = ComponentLoadContext.for_module(
         defs_module=module,
@@ -228,13 +291,11 @@ def get_all_components_defs_from_defs_path(
 
 
 def get_component_defs_from_defs_path(
-    *,
-    project_name: str,
-    project_root: Path,
-    component_path: Path,
+    *, project_name: str, project_root: Path, module_path: str
 ) -> tuple[Component, Definitions]:
     components = get_all_components_defs_from_defs_path(
-        project_name=project_name, project_root=project_root, component_path=component_path
+        project_root=project_root,
+        module_path=module_path,
     )
     check.invariant(
         len(components) == 1,
@@ -337,3 +398,10 @@ def scaffold_defs_sandbox(
             component_path=Path(component_path),
             component_format=scaffold_format,
         )
+
+
+def copy_code_to_file(fn: Callable, file_path: Path) -> None:
+    source_code_text = inspect.getsource(fn)
+    source_code_text = "\n".join(source_code_text.split("\n")[1:])
+    dedented_source_code_text = textwrap.dedent(source_code_text)
+    file_path.write_text(dedented_source_code_text)

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -236,10 +236,6 @@ def get_component_defs_within_project(
     all_component_defs = get_all_components_defs_within_project(
         project_root=project_root, component_path=component_path
     )
-    check.invariant(
-        len(all_component_defs) == 1,
-        "Only one component is supported. To get all components use get_all_components_defs_within_project.",
-    )
     return all_component_defs[instance_key][0], all_component_defs[instance_key][1]
 
 

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -220,8 +220,9 @@ def flatten_components(parent_component: Optional[Component]) -> list[Component]
 
 def get_component_defs_within_project(
     *,
-    project_root: Path,
-    component_path: Path,
+    project_root: Union[str, Path],
+    component_path: Union[str, Path],
+    instance_key: int = 0,
 ) -> tuple[Component, Definitions]:
     """Get the component defs for a component within a project. This only works if dagster_dg_core is installed.
 
@@ -239,13 +240,13 @@ def get_component_defs_within_project(
         len(all_component_defs) == 1,
         "Only one component is supported. To get all components use get_all_components_defs_within_project.",
     )
-    return all_component_defs[0][0], all_component_defs[0][1]
+    return all_component_defs[instance_key][0], all_component_defs[instance_key][1]
 
 
 def get_all_components_defs_within_project(
     *,
-    project_root: Path,
-    component_path: Path,
+    project_root: Union[str, Path],
+    component_path: Union[str, Path],
 ) -> list[tuple[Component, Definitions]]:
     """Get all the component defs for a component within a project. This only works if dagster_dg_core is installed.
 
@@ -264,6 +265,9 @@ def get_all_components_defs_within_project(
             "dagster_dg_core is not installed. Please install it to use to get default project_name and defs module from pyproject.toml or dg.toml."
         )
 
+    project_root = Path(project_root)
+    component_path = Path(component_path)
+
     dg_context = DgContext.from_file_discovery_and_command_line_config(
         path=check.not_none(discover_config_file(project_root), "No project config file found."),
         command_line_config={},
@@ -278,12 +282,12 @@ def get_all_components_defs_within_project(
 def get_all_components_defs_from_defs_path(
     *,
     module_path: str,
-    project_root: Path,
+    project_root: Union[str, Path],
 ) -> list[tuple[Component, Definitions]]:
     module = importlib.import_module(module_path)
     context = ComponentLoadContext.for_module(
         defs_module=module,
-        project_root=project_root,
+        project_root=Path(project_root),
         terminate_autoloading_on_keyword_files=False,
     )
     components = flatten_components(get_component(context))
@@ -291,7 +295,7 @@ def get_all_components_defs_from_defs_path(
 
 
 def get_component_defs_from_defs_path(
-    *, project_name: str, project_root: Path, module_path: str
+    *, module_path: str, project_root: Union[str, Path]
 ) -> tuple[Component, Definitions]:
     components = get_all_components_defs_from_defs_path(
         project_root=project_root,

--- a/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
+++ b/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
@@ -1,4 +1,7 @@
-from dagster.components.lib.executable_component.function_component import FunctionComponent
+from dagster.components.lib.executable_component.function_component import (
+    FunctionComponent,
+    FunctionSpec,
+)
 from dagster.components.testing import copy_code_to_file, scaffold_defs_sandbox
 
 
@@ -34,4 +37,5 @@ def test_nested_component() -> None:
             },
         ) as (component, defs):
             assert isinstance(component, FunctionComponent)
+            assert isinstance(component.execution, FunctionSpec)
             assert component.execution.name == "nested_component"

--- a/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
+++ b/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
@@ -1,0 +1,37 @@
+from dagster.components.lib.executable_component.function_component import FunctionComponent
+from dagster.components.testing import copy_code_to_file, scaffold_defs_sandbox
+
+
+def test_nested_component() -> None:
+    with scaffold_defs_sandbox(
+        component_cls=FunctionComponent,
+        component_path="parent_folder/nested_component",
+        project_name="nested_component_project",
+    ) as sandbox:
+
+        def code_to_copy() -> None:
+            import dagster as dg
+
+            def execute_fn(context) -> dg.MaterializeResult:
+                return dg.MaterializeResult()
+
+        copy_code_to_file(code_to_copy, sandbox.defs_folder_path / "execute.py")
+
+        with sandbox.load(
+            component_body={
+                "type": "dagster.components.lib.executable_component.function_component.FunctionComponent",
+                "attributes": {
+                    "execution": {
+                        "name": "nested_component",
+                        "fn": ".execute.execute_fn",
+                    },
+                    "assets": [
+                        {
+                            "key": "asset1",
+                        }
+                    ],
+                },
+            },
+        ) as (component, defs):
+            assert isinstance(component, FunctionComponent)
+            assert component.execution.name == "nested_component"

--- a/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_get_within_project.py
+++ b/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_get_within_project.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from dagster.components.testing import get_all_components_defs_within_project
+from dagster_test.components.simple_asset import SimpleAssetComponent
+
+
+def test_get_component_defs_in_dagster_test() -> None:
+    project_root = Path(__file__).parent.parent.parent.parent.parent / "dagster-test"
+    component_defs = get_all_components_defs_within_project(
+        project_root=project_root,
+        component_path=Path("composites/yaml"),
+    )
+    # type: dagster_test.components.simple_asset.SimpleAssetComponent
+    # attributes:
+    #   asset_key: first_yaml
+    #   value: one
+
+    # ---
+    # type: dagster_test.components.simple_asset.SimpleAssetComponent
+    # attributes:
+    #   asset_key: second_yaml
+    #   value: two
+    assert len(component_defs) == 2
+    assert isinstance(component_defs[0][0], SimpleAssetComponent)
+    assert isinstance(component_defs[1][0], SimpleAssetComponent)
+    assert component_defs[0][0].asset_key.to_user_string() == "first_yaml"
+    assert component_defs[1][0].asset_key.to_user_string() == "second_yaml"


### PR DESCRIPTION
## Summary & Motivation

This PR enhances the component testing utilities by adding functions to load component definitions within a project context. It introduces:

1. `get_module_path` to construct proper module paths from component paths
2. `get_component_defs_within_project` and `get_all_components_defs_within_project` to load component definitions using project configuration from pyproject.toml or dg.toml
3. `copy_code_to_file` utility to help with test scaffolding

The PR also refactors existing functions to use the new module path construction and adds tests for nested components and retrieving components within a project.

One thing to note is that these conditionally include `dagster_dg_core` to get access to `DgContext`.

## How I Tested These Changes

Added two new test files:
- `test_defs_sandbox.py` to verify nested component loading works correctly
- `test_get_within_project.py` to verify the new project-aware component loading functions