### PR TITLE
functions to get asset health data take a context instead of graphene resolve info

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -121,7 +121,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
     async def resolve_materializationStatus(self, graphene_info: ResolveInfo) -> str:
         if self.materialization_status_task is None:
             self.materialization_status_task = asyncio.create_task(
-                get_materialization_status_and_metadata(graphene_info, self._asset_key)
+                get_materialization_status_and_metadata(graphene_info.context, self._asset_key)
             )
         materialization_status, _ = await self.materialization_status_task
         return materialization_status
@@ -131,7 +131,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
     ) -> GrapheneAssetHealthMaterializationMeta:
         if self.materialization_status_task is None:
             self.materialization_status_task = asyncio.create_task(
-                get_materialization_status_and_metadata(graphene_info, self._asset_key)
+                get_materialization_status_and_metadata(graphene_info.context, self._asset_key)
             )
         _, materialization_status_metadata = await self.materialization_status_task
         return materialization_status_metadata
@@ -139,7 +139,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
     async def resolve_assetChecksStatus(self, graphene_info: ResolveInfo) -> str:
         if self.asset_check_status_task is None:
             self.asset_check_status_task = asyncio.create_task(
-                get_asset_check_status_and_metadata(graphene_info, self._asset_key)
+                get_asset_check_status_and_metadata(graphene_info.context, self._asset_key)
             )
 
         asset_checks_status, _ = await self.asset_check_status_task
@@ -150,7 +150,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
     ) -> GrapheneAssetHealthCheckMeta:
         if self.asset_check_status_task is None:
             self.asset_check_status_task = asyncio.create_task(
-                get_asset_check_status_and_metadata(graphene_info, self._asset_key)
+                get_asset_check_status_and_metadata(graphene_info.context, self._asset_key)
             )
 
         _, asset_checks_status_metadata = await self.asset_check_status_task
@@ -159,7 +159,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
     async def resolve_freshnessStatus(self, graphene_info: ResolveInfo) -> str:
         if self.freshness_status_task is None:
             self.freshness_status_task = asyncio.create_task(
-                get_freshness_status_and_metadata(graphene_info, self._asset_key)
+                get_freshness_status_and_metadata(graphene_info.context, self._asset_key)
             )
 
         freshness_status, _ = await self.freshness_status_task
@@ -170,7 +170,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
     ) -> GrapheneAssetHealthFreshnessMeta:
         if self.freshness_status_task is None:
             self.freshness_status_task = asyncio.create_task(
-                get_freshness_status_and_metadata(graphene_info, self._asset_key)
+                get_freshness_status_and_metadata(graphene_info.context, self._asset_key)
             )
 
         _, freshness_status_metadata = await self.freshness_status_task
@@ -181,17 +181,17 @@ class GrapheneAssetHealth(graphene.ObjectType):
             return GrapheneAssetHealthStatus.UNKNOWN
         if self.materialization_status_task is None:
             self.materialization_status_task = asyncio.create_task(
-                get_materialization_status_and_metadata(graphene_info, self._asset_key)
+                get_materialization_status_and_metadata(graphene_info.context, self._asset_key)
             )
         materialization_status, _ = await self.materialization_status_task
         if self.asset_check_status_task is None:
             self.asset_check_status_task = asyncio.create_task(
-                get_asset_check_status_and_metadata(graphene_info, self._asset_key)
+                get_asset_check_status_and_metadata(graphene_info.context, self._asset_key)
             )
         asset_checks_status, _ = await self.asset_check_status_task
         if self.freshness_status_task is None:
             self.freshness_status_task = asyncio.create_task(
-                get_freshness_status_and_metadata(graphene_info, self._asset_key)
+                get_freshness_status_and_metadata(graphene_info.context, self._asset_key)
             )
         freshness_status, _ = await self.freshness_status_task
         statuses = [


### PR DESCRIPTION
## Summary & Motivation
We were always accessing the context to do everything anyway, and this makes it easier to re-use these functions in other places like https://github.com/dagster-io/internal/pull/16144

## How I Tested These Changes
existing tests