### PR TITLE
Fix ETL tutorial project setup instructions

### DIFF
--- a/docs/docs/etl-pipeline-tutorial/create-and-materialize-assets.md
+++ b/docs/docs/etl-pipeline-tutorial/create-and-materialize-assets.md
@@ -3,7 +3,7 @@ title: Create and materialize assets
 description: Load project data and create and materialize assets
 last_update:
   author: Alex Noonan
-sidebar_position: 10
+sidebar_position: 15
 ---
 
 In the first step of the tutorial, you created your Dagster project with the raw data files. In this step, you will:

--- a/docs/docs/etl-pipeline-tutorial/index.md
+++ b/docs/docs/etl-pipeline-tutorial/index.md
@@ -75,7 +75,14 @@ Run the following command to create the project directories and files for this t
 dagster project from-example --example getting_started_etl_tutorial
 ```
 
-Your project should have this structure:
+This command will create a *getting_started_etl_tutorial* directory with the example files. Move the contents to your current directory (*dagster-etl-tutorial*):
+
+```bash
+mv getting_started_etl_tutorial/* .
+rmdir getting_started_etl_tutorial
+```
+
+Your project should now have this structure:
 {/* vale off */}
 
 ```


### PR DESCRIPTION
## Summary & Motivation

1. Fix incorrect project setup instructions in the ETL pipeline tutorial. The `dagster project from-example --example getting_started_etl_tutorial` command creates a nested `getting_started_etl_tutorial` directory, but the documentation didn't explain how to properly move the files to the project root directory. This caused confusion for users following the tutorial.
2. Fix navigation order issue in the ETL pipeline tutorial. The ["Create and materialize assets"](https://docs.dagster.io/etl-pipeline-tutorial/create-and-materialize-assets#:~:text=an%20ETL%20Pipeline-,Next,Build%20an%20ETL%20Pipeline,-1.%20Create%20a) page had the same sidebar_position (10) as the tutorial index page, causing incorrect prev/next navigation that would loop back to the ETL pipeline tutorial instead of proceeding to the next step in the tutorial sequence.

## How I Tested These Changes

- Confirmed the file movement commands work as expected
- Verified that all ETL tutorial pages now have unique and sequential sidebar_position values

## Changelog

- **Fixed**: ETL tutorial project setup instructions now include proper file movement steps
- **Fixed**: ETL tutorial navigation order by changing sidebar_position from 10 to 15 for the "Create and materialize assets" page