### PR TITLE
[dg] Emit warning when autoload_defs is on and definitions.py found (BUILD-1242)

### DIFF
--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/config.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/config.py
@@ -632,6 +632,15 @@ class _DgConfigValidator:
                         "Module patterns must consist of '.'-separated segments that are either "
                         "valid Python identifiers or wildcards ('*')."
                     )
+        if "code_location_target_module" in section and section.get("autoload_defs"):
+            autoload_defs_key = self._get_full_key("project.autoload_defs")
+            code_location_target_module_key = self._get_full_key(
+                "project.code_location_target_module"
+            )
+            raise DgValidationError(
+                f"Cannot specify `{code_location_target_module_key}` when `{autoload_defs_key}` is True. These options are mutually exclusive."
+                " Please set `autoload_defs` to False or remove the `code_location_target_module`."
+            )
 
     def _validate_file_config_workspace_section(self, section: object) -> None:
         if not isinstance(section, dict):


### PR DESCRIPTION
## Summary & Motivation

- Per title, emit a warning if `project.autoload_defs` is set but we also find a `<root>/definitions.py` module (which won't be loaded with autoloaded defs).
- Also have config validation error if it detects that `code_location_load_target_module` and `autoload_defs` are both set.

## How I Tested These Changes

New unit tests.