### PR TITLE
add component origin metadata to definitions

### DIFF
--- a/python_modules/dagster-test/dagster_test/dg_defs/python/component.py
+++ b/python_modules/dagster-test/dagster_test/dg_defs/python/component.py
@@ -1,0 +1,14 @@
+import dagster as dg
+from dagster.components.lib.executable_component.function_component import FunctionComponent
+
+
+def solo():
+    return None
+
+
+@dg.component_instance
+def only(_):
+    return FunctionComponent(
+        execution=solo,
+        assets=[dg.AssetSpec(key="solo_py")],
+    )

--- a/python_modules/dagster-test/dagster_test/dg_defs/yaml/defs.yaml
+++ b/python_modules/dagster-test/dagster_test/dg_defs/yaml/defs.yaml
@@ -1,0 +1,5 @@
+---
+type: dagster_test.components.simple_asset.SimpleAssetComponent
+attributes:
+  asset_key: solo_yaml
+  value: solo

--- a/python_modules/dagster/dagster/components/list/list.py
+++ b/python_modules/dagster/dagster/components/list/list.py
@@ -28,7 +28,7 @@ from dagster._cli.workspace.cli_target import get_repository_python_origin_from_
 from dagster._config.pythonic_config.resource import get_resource_type_name
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets.job.asset_job import is_reserved_asset_job_name
-from dagster._core.definitions.metadata import CodeReferencesMetadataValue
+from dagster._core.definitions.metadata import ArbitraryMetadataMapping, CodeReferencesMetadataValue
 from dagster._core.definitions.metadata.source_code import LocalFileCodeReference
 from dagster._core.definitions.repository_definition.repository_definition import (
     RepositoryDefinition,
@@ -161,20 +161,6 @@ def list_definitions(
             key=lambda key: key.to_user_string(),
         ):
             node = asset_graph.get(key)
-            source = None
-            code_ref_metadata = check.opt_inst(
-                node.metadata.get("dagster/code_references"), CodeReferencesMetadataValue
-            )
-            if code_ref_metadata and code_ref_metadata.code_references:
-                source = next(
-                    (
-                        str(Path(ref.source).relative_to(dg_context.root_path))
-                        for ref in code_ref_metadata.code_references
-                        if isinstance(ref, LocalFileCodeReference)
-                    ),
-                    None,
-                )
-
             assets.append(
                 DgAssetMetadata(
                     key=key.to_user_string(),
@@ -188,19 +174,12 @@ def list_definitions(
                     else None,
                     tags=sorted(f'"{k}"="{v}"' for k, v in node.tags.items() if _tag_filter(k)),
                     is_executable=node.is_executable,
-                    source=source,
+                    source=_get_source(node.metadata, dg_context),
                 )
             )
         checks = []
         for key in selected_checks if selected_checks is not None else asset_graph.asset_check_keys:
             node = asset_graph.get(key)
-            source = None
-            code_ref_metadata = check.opt_inst(
-                node.metadata.get("dagster/code_references"), CodeReferencesMetadataValue
-            )
-            if code_ref_metadata and code_ref_metadata.code_references:
-                source = code_ref_metadata.code_references[0].source
-
             checks.append(
                 DgAssetCheckMetadata(
                     key=key.to_user_string(),
@@ -208,24 +187,18 @@ def list_definitions(
                     name=key.name,
                     additional_deps=sorted([k.to_user_string() for k in node.parent_entity_keys]),
                     description=node.description,
-                    source=source,
+                    source=_get_source(node.metadata, dg_context),
                 )
             )
 
         jobs = []
         for job in repo_def.get_all_jobs():
             if not is_reserved_asset_job_name(job.name):
-                source = None
-                code_ref_metadata = check.opt_inst(
-                    job.metadata.get("dagster/code_references"), CodeReferencesMetadataValue
-                )
-                if code_ref_metadata and code_ref_metadata.code_references:
-                    source = code_ref_metadata.code_references[0].source
                 jobs.append(
                     DgJobMetadata(
                         name=job.name,
                         description=job.description,
-                        source=source,
+                        source=_get_source(job.metadata, dg_context),
                     )
                 )
 
@@ -236,32 +209,20 @@ def list_definitions(
                 if isinstance(schedule.cron_schedule, str)
                 else ", ".join(schedule.cron_schedule)
             )
-            source = None
-            code_ref_metadata = check.opt_inst(
-                schedule.metadata.get("dagster/code_references"), CodeReferencesMetadataValue
-            )
-            if code_ref_metadata and code_ref_metadata.code_references:
-                source = code_ref_metadata.code_references[0].source
             schedules.append(
                 DgScheduleMetadata(
                     name=schedule.name,
                     cron_schedule=schedule_str,
-                    source=source,
+                    source=_get_source(schedule.metadata, dg_context),
                 )
             )
 
         sensors = []
         for sensor in repo_def.sensor_defs:
-            source = None
-            code_ref_metadata = check.opt_inst(
-                sensor.metadata.get("dagster/code_references"), CodeReferencesMetadataValue
-            )
-            if code_ref_metadata and code_ref_metadata.code_references:
-                source = code_ref_metadata.code_references[0].source
             sensors.append(
                 DgSensorMetadata(
                     name=sensor.name,
-                    source=source,
+                    source=_get_source(sensor.metadata, dg_context),
                 )
             )
 
@@ -308,3 +269,23 @@ def _load_component_types(
         for key, obj in _load_plugin_objects(entry_points, extra_modules).items()
         if isinstance(obj, type) and issubclass(obj, Component)
     }
+
+
+def _get_source(
+    metadata: ArbitraryMetadataMapping,
+    dg_context: DgContext,
+) -> Optional[str]:
+    code_ref_metadata = check.opt_inst(
+        metadata.get("dagster/code_references"), CodeReferencesMetadataValue
+    )
+    if code_ref_metadata and code_ref_metadata.code_references:
+        return next(
+            (
+                str(Path(ref.source).relative_to(dg_context.root_path))
+                for ref in code_ref_metadata.code_references
+                if isinstance(ref, LocalFileCodeReference)
+            ),
+            None,
+        )
+
+    return None

--- a/python_modules/dagster/dagster_tests/components_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_definitions.py
@@ -96,11 +96,43 @@ def test_component_tree():
     assert dagster_test_path.exists()
     defs = LegacyAutoloadingComponentTree.load(dagster_test_path).build_defs()
 
-    repo_snap = RepositorySnap.from_def(defs.get_repository_def())
+    repo_def = defs.get_repository_def()
+    asset = repo_def.asset_graph.get(dg.AssetKey("first_yaml"))
+    assert asset is not None
+    assert asset.metadata["dagster/component_origin"]
+    assert (
+        asset.metadata["dagster/component_origin"].instance.__class__.__name__
+        == "SimpleAssetComponent"
+    )
+
+    asset = repo_def.asset_graph.get(dg.AssetKey("solo_yaml"))
+    assert asset is not None
+    assert asset.metadata["dagster/component_origin"]
+    assert (
+        asset.metadata["dagster/component_origin"].instance.__class__.__name__
+        == "SimpleAssetComponent"
+    )
+
+    asset = repo_def.asset_graph.get(dg.AssetKey("first_py"))
+    assert asset is not None
+    assert asset.metadata["dagster/component_origin"]
+    assert asset.metadata["dagster/component_origin"].instance.__class__.__name__ == "PyComponent"
+
+    asset = repo_def.asset_graph.get(dg.AssetKey("solo_py"))
+    assert asset is not None
+    assert asset.metadata["dagster/component_origin"]
+    assert (
+        asset.metadata["dagster/component_origin"].instance.__class__.__name__
+        == "FunctionComponent"
+    )
+
+    repo_snap = RepositorySnap.from_def(repo_def)
     assert repo_snap.component_tree
 
     inst_map = {snap.key: snap.full_type_name for snap in repo_snap.component_tree.leaf_instances}
     assert inst_map == {
+        "python/component.py[only]": "dagster.components.lib.executable_component.function_component.FunctionComponent",
+        "yaml[0]": "dagster_test.components.simple_asset.SimpleAssetComponent",
         "composites/python/component.py[first]": "dagster_test.dg_defs.composites.python.component.PyComponent",
         "composites/python/component.py[second]": "dagster_test.dg_defs.composites.python.component.PyComponent",
         "composites/yaml[0]": "dagster_test.components.simple_asset.SimpleAssetComponent",

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/__snapshots__/test_list_commands.ambr
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/__snapshots__/test_list_commands.ambr
@@ -113,7 +113,7 @@
           {
               "name": "my_job",
               "description": null,
-              "source": null
+              "source": "src/foo_bar/defs/mydefs/defs.yaml:1"
           }
       ],
       "resources": [
@@ -126,13 +126,13 @@
           {
               "name": "my_schedule",
               "cron_schedule": "@daily",
-              "source": null
+              "source": "src/foo_bar/defs/mydefs/defs.yaml:1"
           }
       ],
       "sensors": [
           {
               "name": "my_sensor",
-              "source": null
+              "source": "src/foo_bar/defs/mydefs/defs.yaml:1"
           }
       ]
   }


### PR DESCRIPTION
Adds a `dagster/component_origin` metadata entry for all defs coming from yaml or python component instances. 

## How I Tested These Changes

updated test 