### PR TITLE
Use post_processing on Sling Component

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/9-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/9-defs.yaml
@@ -4,6 +4,6 @@ attributes:
   replications:
     - path: replication.yaml
 post_processing:
-  processors:
+  assets:
     - attributes:
         automation_condition: "{{ custom_cron('@daily') }}"

--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/9-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/9-defs.yaml
@@ -3,6 +3,7 @@ type: my_project.components.custom_sling_replication_component.CustomSlingReplic
 attributes:
   replications:
     - path: replication.yaml
-  asset_post_processors:
+post_processing:
+  processors:
     - attributes:
         automation_condition: "{{ custom_cron('@daily') }}"

--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/9-component.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/9-component.yaml
@@ -3,6 +3,7 @@ type: my_project.defs.my_sling_sync.component.CustomSlingReplicationComponent
 attributes:
   replications:
     - path: replication.yaml
-  asset_post_processors:
+post_processing:
+  processors:
     - attributes:
         automation_condition: "{{ custom_cron('@daily') }}"

--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/9-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/9-defs.yaml
@@ -3,6 +3,7 @@ type: my_project.defs.my_sling_sync.component.CustomSlingReplicationComponent
 attributes:
   replications:
     - path: replication.yaml
-  asset_post_processors:
+post_processing:
+  processors:
     - attributes:
         automation_condition: "{{ custom_cron('@daily') }}"

--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/9-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/9-defs.yaml
@@ -4,6 +4,6 @@ attributes:
   replications:
     - path: replication.yaml
 post_processing:
-  processors:
+  assets:
     - attributes:
         automation_condition: "{{ custom_cron('@daily') }}"

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_customizing_existing_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_customizing_existing_component.py
@@ -296,7 +296,8 @@ def test_components_docs_adding_attributes_to_assets(
                         instance: /tmp/jaffle_platform.duckdb
                   replications:
                     - path: replication.yaml
-                  asset_post_processors:
+                post_processing:
+                  processors:
                     - attributes:
                         automation_condition: "{{{{ custom_cron('@daily') }}}}"
                 """),

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_customizing_existing_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_customizing_existing_component.py
@@ -297,7 +297,7 @@ def test_components_docs_adding_attributes_to_assets(
                   replications:
                     - path: replication.yaml
                 post_processing:
-                  processors:
+                  assets:
                     - attributes:
                         automation_condition: "{{{{ custom_cron('@daily') }}}}"
                 """),

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -112,7 +112,7 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
         ),
     ] = field(default_factory=SlingResource)
     replications: Sequence[SlingReplicationSpecModel] = field(default_factory=list)
-    # TODO: deprecate and then delete
+    # TODO: deprecate and then delete -- schrockn 2025-06-10
     asset_post_processors: Optional[Sequence[AssetPostProcessor]] = None
 
     def build_asset(

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -17,7 +17,7 @@ from dagster._core.definitions.result import MaterializeResult
 from dagster.components.component.component import Component
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.resolved.context import ResolutionContext
-from dagster.components.resolved.core_models import AssetAttributesModel, AssetPostProcessor, OpSpec
+from dagster.components.resolved.core_models import AssetAttributesModel, OpSpec
 from dagster.components.scaffold.scaffold import scaffold_with
 from dagster.components.utils import TranslatorResolvingInfo
 from typing_extensions import TypeAlias
@@ -112,7 +112,6 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
         ),
     ] = field(default_factory=SlingResource)
     replications: Sequence[SlingReplicationSpecModel] = field(default_factory=list)
-    asset_post_processors: Optional[Sequence[AssetPostProcessor]] = None
 
     def build_asset(
         self, context: ComponentLoadContext, replication_spec_model: SlingReplicationSpecModel
@@ -159,9 +158,6 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
         yield from iterator
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        defs = Definitions(
+        return Definitions(
             assets=[self.build_asset(context, replication) for replication in self.replications],
         )
-        for post_processor in self.asset_post_processors or []:
-            defs = post_processor(defs)
-        return defs

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -17,7 +17,7 @@ from dagster._core.definitions.result import MaterializeResult
 from dagster.components.component.component import Component
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.resolved.context import ResolutionContext
-from dagster.components.resolved.core_models import AssetAttributesModel, OpSpec
+from dagster.components.resolved.core_models import AssetAttributesModel, AssetPostProcessor, OpSpec
 from dagster.components.scaffold.scaffold import scaffold_with
 from dagster.components.utils import TranslatorResolvingInfo
 from typing_extensions import TypeAlias
@@ -112,6 +112,8 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
         ),
     ] = field(default_factory=SlingResource)
     replications: Sequence[SlingReplicationSpecModel] = field(default_factory=list)
+    # TODO: deprecate and then delete
+    asset_post_processors: Optional[Sequence[AssetPostProcessor]] = None
 
     def build_asset(
         self, context: ComponentLoadContext, replication_spec_model: SlingReplicationSpecModel
@@ -158,6 +160,9 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
         yield from iterator
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        return Definitions(
+        defs = Definitions(
             assets=[self.build_asset(context, replication) for replication in self.replications],
         )
+        for post_processor in self.asset_post_processors or []:
+            defs = post_processor(defs)
+        return defs


### PR DESCRIPTION
## Summary & Motivation

Use the generic `post_processing` field instead in tests and examples. Commented to follow up and kill in https://linear.app/dagster-labs/issue/BUILD-1307/deprecate-and-delete-asset-post-processors-on-airlift-and-sling

## How I Tested These Changes

BK


## Changelog

* Removes `asset_post_processors` on `SlingReplicationCollectionComponent` and uses generic `post_processing` key at top-level instead.