### PR TITLE
Use post_processing on airlift component

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
@@ -222,7 +222,6 @@ def defs_from_subdirs(context: ComponentLoadContext) -> Definitions:
     return DefsFolderComponent(
         path=context.path,
         children=find_components_from_context(context),
-        asset_post_processors=None,
     ).build_defs(context)
 
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
@@ -13,11 +13,7 @@ from dagster.components.component_scaffolding import scaffold_component
 from dagster.components.core.defs_module import DefsFolderComponent, find_components_from_context
 from dagster.components.resolved.base import resolve_fields
 from dagster.components.resolved.context import ResolutionContext
-from dagster.components.resolved.core_models import (
-    AssetPostProcessor,
-    ResolvedAssetKey,
-    ResolvedAssetSpec,
-)
+from dagster.components.resolved.core_models import ResolvedAssetKey, ResolvedAssetSpec
 from dagster.components.resolved.model import Resolver
 from dagster.components.scaffold.scaffold import Scaffolder, ScaffoldRequest, scaffold_with
 from pydantic import BaseModel
@@ -196,7 +192,6 @@ class AirflowInstanceComponent(Component, Resolvable):
     filter: Optional[ResolvedAirflowFilter] = None
     mappings: Optional[Sequence[AirflowDagMapping]] = None
     source_code_retrieval_enabled: Optional[bool] = None
-    asset_post_processors: Optional[Sequence[AssetPostProcessor]] = None
 
     def _get_instance(self) -> dg_airlift_core.AirflowInstance:
         return dg_airlift_core.AirflowInstance(
@@ -205,15 +200,12 @@ class AirflowInstanceComponent(Component, Resolvable):
         )
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        defs = build_job_based_airflow_defs(
+        return build_job_based_airflow_defs(
             airflow_instance=self._get_instance(),
             mapped_defs=apply_mappings(defs_from_subdirs(context), self.mappings or []),
             source_code_retrieval_enabled=self.source_code_retrieval_enabled,
             retrieval_filter=self.filter or AirflowFilter(),
         )
-        for post_processor in self.asset_post_processors or []:
-            defs = post_processor(defs)
-        return defs
 
 
 def defs_from_subdirs(context: ComponentLoadContext) -> Definitions:

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
@@ -68,8 +68,8 @@ def component_for_test(temp_cwd: Path):
 
 def test_load_dags_basic(component_for_test: type[AirflowInstanceComponent]) -> None:
     defs = build_component_defs_for_test(
-        component_for_test,
-        {
+        component_type=component_for_test,
+        attrs={
             "auth": {
                 "type": "basic_auth",
                 "webserver_url": "http://localhost:8080",
@@ -79,7 +79,7 @@ def test_load_dags_basic(component_for_test: type[AirflowInstanceComponent]) -> 
             "name": "test_instance",
         },
         post_processing={
-            "processors": [
+            "assets": [
                 {
                     "target": "*",
                     "attributes": {
@@ -190,8 +190,8 @@ def test_mapped_assets(component_for_test: type[AirflowInstanceComponent], temp_
 
     # Next, add an airlift component which references the asset
     defs = build_component_defs_for_test(
-        component_for_test,
-        {
+        component_type=component_for_test,
+        attrs={
             "auth": {
                 "type": "basic_auth",
                 "webserver_url": "http://localhost:8080",
@@ -213,14 +213,10 @@ def test_mapped_assets(component_for_test: type[AirflowInstanceComponent], temp_
             ],
         },
         post_processing={
-            "processors": [
+            "assets": [
                 {
                     "target": "*",
-                    "attributes": {
-                        "metadata": {
-                            "foo": "bar",
-                        },
-                    },
+                    "attributes": {"metadata": {"foo": "bar"}},
                 }
             ]
         },

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
@@ -77,7 +77,9 @@ def test_load_dags_basic(component_for_test: type[AirflowInstanceComponent]) -> 
                 "password": "admin",
             },
             "name": "test_instance",
-            "asset_post_processors": [
+        },
+        post_processing={
+            "processors": [
                 {
                     "target": "*",
                     "attributes": {
@@ -86,7 +88,7 @@ def test_load_dags_basic(component_for_test: type[AirflowInstanceComponent]) -> 
                         },
                     },
                 }
-            ],
+            ]
         },
     )
 
@@ -209,7 +211,9 @@ def test_mapped_assets(component_for_test: type[AirflowInstanceComponent], temp_
                     "assets": [{"by_key": "my_asset_2"}, {"spec": {"key": "my_ext_asset_2"}}],
                 }
             ],
-            "asset_post_processors": [
+        },
+        post_processing={
+            "processors": [
                 {
                     "target": "*",
                     "attributes": {
@@ -218,7 +222,7 @@ def test_mapped_assets(component_for_test: type[AirflowInstanceComponent], temp_
                         },
                     },
                 }
-            ],
+            ]
         },
     )
 


### PR DESCRIPTION
## Summary & Motivation

We're moving to top-level `post_processing` field instead component-specific `asset_post_processors`

https://linear.app/dagster-labs/issue/BUILD-1307/deprecate-and-delete-asset-post-processors-on-airlift-and-sling tracking follow up to deprecate and eliminate the asset_post_processors field.

## How I Tested These Changes

BK
