### PR TITLE
[componetnts] Support dot notation in env

### DIFF
--- a/docs/docs/guides/labs/components/building-pipelines-with-components/adding-components.md
+++ b/docs/docs/guides/labs/components/building-pipelines-with-components/adding-components.md
@@ -65,14 +65,14 @@ Each `defs.yaml` file supports a rich templating syntax, powered by `jinja2`.
 
 #### Templating environment variables
 
-A common use case for templating is to avoid exposing environment variables (particularly secrets) in your YAML files. The Jinja scope for a `defs.yaml` file contains an `env` function that can be used to insert environment variables into the template:
+A common use case for templating is to avoid exposing environment variables (particularly secrets) in your YAML files. The Jinja scope for a `defs.yaml` file contains an `env` template variable that can be used to insert environment variables into the template:
 
 ```yaml
 type: snowflake_lib.SnowflakeComponent
 
 attributes:
-  account: "{{ env('SNOWFLAKE_ACCOUNT') }}"
-  password: "{{ env('SNOWFLAKE_PASSWORD') }}"
+  account: "{{ env.SNOWFLAKE_ACCOUNT }}"
+  password: "{{ env.SNOWFLAKE_PASSWORD }}"
 ```
 
 #### Multiple component instances in the same file
@@ -84,12 +84,12 @@ To configure multiple instances of a component in the same `defs.yaml` file, add
 type: snowflake_lib.SnowflakeComponent
 
 attributes:
-  account: "{{ env('SNOWFLAKE_INSTANCE_ONE_ACCOUNT') }}"
-  password: "{{ env('SNOWFLAKE_INSTANCE_ONE_PASSWORD') }}"
+  account: "{{ env.SNOWFLAKE_INSTANCE_ONE_ACCOUNT }}"
+  password: "{{ env.SNOWFLAKE_INSTANCE_ONE_PASSWORD }}"
 ---
 type: snowflake_lib.SnowflakeComponent
 
 attributes:
-  account: "{{ env('SNOWFLAKE_INSTANCE_TWO_ACCOUNT') }}"
-  password: "{{ env('SNOWFLAKE_INSTANCE_TWO_PASSWORD') }}"
+  account: "{{ env.SNOWFLAKE_INSTANCE_TWO_ACCOUNT }}"
+  password: "{{ env.SNOWFLAKE_INSTANCE_TWO_PASSWORD }}"
 ```

--- a/python_modules/dagster/dagster/components/resolved/context.py
+++ b/python_modules/dagster/dagster/components/resolved/context.py
@@ -18,7 +18,7 @@ from dagster.components.resolved.errors import ResolutionException
 T = TypeVar("T")
 
 
-class EnvScope:
+class EnvTemplateVar:
     def __call__(self, key: str) -> Optional[str]:
         return os.environ.get(key)
 
@@ -56,7 +56,7 @@ class ResolutionContext:
     @staticmethod
     def default(source_position_tree: Optional[SourcePositionTree] = None) -> "ResolutionContext":
         return ResolutionContext(
-            scope={"env": EnvScope(), "automation_condition": automation_condition_scope()},
+            scope={"env": EnvTemplateVar(), "automation_condition": automation_condition_scope()},
             source_position_tree=source_position_tree,
         )
 

--- a/python_modules/dagster/dagster/components/resolved/context.py
+++ b/python_modules/dagster/dagster/components/resolved/context.py
@@ -18,8 +18,12 @@ from dagster.components.resolved.errors import ResolutionException
 T = TypeVar("T")
 
 
-def env_scope(key: str) -> Optional[str]:
-    return os.environ.get(key)
+class EnvScope:
+    def __call__(self, key: str) -> Optional[str]:
+        return os.environ.get(key)
+
+    def __getattr__(self, key: str) -> Optional[str]:
+        return os.environ.get(key)
 
 
 def automation_condition_scope() -> Mapping[str, Any]:
@@ -52,7 +56,7 @@ class ResolutionContext:
     @staticmethod
     def default(source_position_tree: Optional[SourcePositionTree] = None) -> "ResolutionContext":
         return ResolutionContext(
-            scope={"env": env_scope, "automation_condition": automation_condition_scope()},
+            scope={"env": EnvScope(), "automation_condition": automation_condition_scope()},
             source_position_tree=source_position_tree,
         )
 

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_env.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_env.py
@@ -1,10 +1,10 @@
-from dagster.components.resolved.context import EnvScope
+from dagster.components.resolved.context import EnvTemplateVar
 from dagster_shared.utils import environ
 
 
 def test_env_syntaxs() -> None:
     with environ({"foo": "bar"}):
-        env = EnvScope()
+        env = EnvTemplateVar()
         assert env("foo") == "bar"
         assert env.foo == "bar"
         assert env("missing") is None

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_env.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_env.py
@@ -1,0 +1,11 @@
+from dagster.components.resolved.context import EnvScope
+from dagster_shared.utils import environ
+
+
+def test_env_syntaxs() -> None:
+    with environ({"foo": "bar"}):
+        env = EnvScope()
+        assert env("foo") == "bar"
+        assert env.foo == "bar"
+        assert env("missing") is None
+        assert env.missing is None

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -47,9 +47,9 @@ BASIC_FIVETRAN_COMPONENT_BODY = {
     "type": "dagster_fivetran.FivetranAccountComponent",
     "attributes": {
         "workspace": {
-            "api_key": "{{ env('FIVETRAN_API_KEY') }}",
-            "api_secret": "{{ env('FIVETRAN_API_SECRET') }}",
-            "account_id": "{{ env('FIVETRAN_ACCOUNT_ID') }}",
+            "api_key": "{{ env.FIVETRAN_API_KEY }}",
+            "api_secret": "{{ env.FIVETRAN_API_SECRET }}",
+            "account_id": "{{ env.FIVETRAN_ACCOUNT_ID }}",
         },
     },
 }


### PR DESCRIPTION
## Summary & Motivation

In templating systems like github actions, dot notation can be used to access environment variables (e.g. "{{env.foo}}". This adds that syntax to Resolved.

We still retain function syntax for cases where one would programatically generate env vars in a udf.

Assuming that we like this we would follow up with changes to purina, examples, etc to use this syntax by default.

## How I Tested These Changes

BK
