### PR TITLE
[dg] Add `<root>.components.*` as default registry_modules in new projects

### DIFF
--- a/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
+++ b/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
@@ -17,5 +17,8 @@ directory_type = "project"
 [tool.dg.project]
 root_module = "{{ project_name }}"
 autoload_defs = true
+registry_modules = [
+    "{{ project_name }}.components.*",
+]
 
 {{ uv_sources }}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
@@ -1,3 +1,4 @@
+import importlib
 import inspect
 import json
 import re
@@ -156,6 +157,7 @@ def test_list_components_project_wildcard_pattern():
         result = runner.invoke(
             "scaffold", "component", "foo_bar.components.my_component.MyComponent"
         )
+        importlib.invalidate_caches()  # Needed to make sure new submodule is discoverable
         assert_runner_result(result)
 
         # Remove the generated registry module entry, confirm that our scaffolded component is not
@@ -185,6 +187,7 @@ def test_list_components_project_wildcard_pattern_no_duplicates():
         result = runner.invoke(
             "scaffold", "component", "foo_bar.components.my_component.MyComponent"
         )
+        importlib.invalidate_caches()  # Needed to make sure new submodule is discoverable
         assert_runner_result(result)
 
         # Add a wildcard that will match a component already in the list


### PR DESCRIPTION
## Summary & Motivation

Changes the default scaffolded project to include `<root>.components.*` under `project.registry_modules`. This means that when components are scaffolded with either of the below patterns, the pyproject.toml will not be modified because the default pattern will already match the scaffolded module.

- `dg scaffold components Foo`
- `dg scaffold components <root>.components.foo.Foo`

## How I Tested These Changes

New unit tests.

## Changelog

`project.registry_modules` can now accept wildcards (e.g. `foo_bar.components.*`). This will register any module matching the pattern with `dg`.
