### PR TITLE
[ui] Show the latest run on job tiles

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -43,6 +43,7 @@
   "AssetCheckDetailsQuery": "dafb023319ef2c8aa8075c43686b318d3206f5781b8b87cf21130db3172a9f71",
   "AssetChecksQuery": "655a37486ebc6427fe969b59420b9590440a901b3b0c7adc4c8a9873c593a7fe",
   "AssetDaemonTicksQuery": "399ac77e660d40eba32c2ab06db2a2936a71e660d93ec108364eec1fdfc16788",
+  "JobTileQuery": "6fd1bb8a16c8bd5fff0fb75f6608d5402a426d5c2763fefcb61d60e94ff0a3e8",
   "AssetColumnLineage": "bcb70460f77b88bbbfaec90982f3e99f522d9a4e270e63832684cfde169fabc7",
   "AssetRecordsQuery": "1778f6a11acc440983fcf6b6156518b3113c7fa29127130bb30a3e0140807575",
   "GetAutoMaterializePausedQuery": "50f74183f54031274136ab855701d01f26642a6d958d7452ae13aa6c40ca349d",

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryTile.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryTile.tsx
@@ -1,15 +1,20 @@
-import {Box, Colors, Icon, MiddleTruncate} from '@dagster-io/ui-components';
+import {BodySmall, Box, Colors, Icon, MiddleTruncate} from '@dagster-io/ui-components';
 import clsx from 'clsx';
 import React, {useEffect, useMemo} from 'react';
 import {Link} from 'react-router-dom';
 
 import styles from './AssetSelectionSummaryTile.module.css';
+import {JOB_TILE_QUERY} from './JobTileQuery';
 import {useAssetSelectionFiltering} from '../../asset-selection/useAssetSelectionFiltering';
 import {RepoAddress} from '../../workspace/types';
 import {workspacePathFromAddress} from '../../workspace/workspacePath';
 import {AssetTableFragment} from '../types/AssetTableFragment.types';
 import {useAllAssets} from '../useAllAssets';
 import {getThreadId, useAssetHealthStatuses} from './util';
+import {useQuery} from '../../apollo-client';
+import {JobTileQuery, JobTileQueryVariables} from './types/JobTileQuery.types';
+import {RunStatusIndicator} from '../../runs/RunStatusDots';
+import {TimeFromNow} from '../../ui/TimeFromNow';
 
 export const TILE_WIDTH = 272;
 export const TILE_HEIGHT = 104;
@@ -107,7 +112,30 @@ export const AssetSelectionSummaryTile = React.memo(
   },
 );
 
+const THIRTY_SECONDS = 30000;
+
+// todo dish: Move this out of asset-related code, make tile component generic.
 export const JobTile = ({name, repoAddress}: {name: string; repoAddress: RepoAddress}) => {
+  const {data} = useQuery<JobTileQuery, JobTileQueryVariables>(JOB_TILE_QUERY, {
+    variables: {
+      pipelineSelector: {
+        repositoryName: repoAddress.name,
+        repositoryLocationName: repoAddress.location,
+        pipelineName: name,
+      },
+    },
+    pollInterval: THIRTY_SECONDS,
+  });
+
+  const latestRun = useMemo(() => {
+    const job = data?.pipelineOrError;
+    if (!job || job.__typename !== 'Pipeline') {
+      return null;
+    }
+    const {runs} = job;
+    return runs[0] ?? null;
+  }, [data]);
+
   const link = workspacePathFromAddress(repoAddress, `/jobs/${name}`);
   return (
     <Link to={link} className={styles.tileLink}>
@@ -127,7 +155,14 @@ export const JobTile = ({name, repoAddress}: {name: string; repoAddress: RepoAdd
             <MiddleTruncate text={name} />
           </div>
         </div>
-        {/* todo dish: Display latest run status */}
+        {latestRun?.startTime ? (
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+            <RunStatusIndicator status={latestRun.runStatus} />
+            <BodySmall color={Colors.textLight()}>
+              launched <TimeFromNow unixTimestamp={latestRun.startTime} />
+            </BodySmall>
+          </Box>
+        ) : null}
       </Box>
     </Link>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/JobTileQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/JobTileQuery.tsx
@@ -1,0 +1,17 @@
+import {gql} from '../../apollo-client';
+
+export const JOB_TILE_QUERY = gql`
+  query JobTileQuery($pipelineSelector: PipelineSelector!) {
+    pipelineOrError(params: $pipelineSelector) {
+      ... on Pipeline {
+        id
+        runs(limit: 1) {
+          id
+          runId
+          runStatus
+          startTime
+        }
+      }
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/types/JobTileQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/types/JobTileQuery.types.ts
@@ -1,0 +1,28 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type JobTileQueryVariables = Types.Exact<{
+  pipelineSelector: Types.PipelineSelector;
+}>;
+
+export type JobTileQuery = {
+  __typename: 'Query';
+  pipelineOrError:
+    | {__typename: 'InvalidSubsetError'}
+    | {
+        __typename: 'Pipeline';
+        id: string;
+        runs: Array<{
+          __typename: 'Run';
+          id: string;
+          runId: string;
+          runStatus: Types.RunStatus;
+          startTime: number | null;
+        }>;
+      }
+    | {__typename: 'PipelineNotFoundError'}
+    | {__typename: 'PythonError'};
+};
+
+export const JobTileQueryVersion = '6fd1bb8a16c8bd5fff0fb75f6608d5402a426d5c2763fefcb61d60e94ff0a3e8';


### PR DESCRIPTION
## Summary & Motivation

Show the latest run on job tiles for Dagster+ home.

<img width="346" alt="Screenshot 2025-06-09 at 10 40 22" src="https://github.com/user-attachments/assets/17610915-8b22-4106-bb71-6a6ba5620ae3" />

## How I Tested These Changes

View Home, verify that job tiles have latest run information, and that polling leads to updates.