### PR TITLE
[da] Propagate `.allow()` and `.ignore()` through SinceAutomationCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -47,6 +47,9 @@ if TYPE_CHECKING:
     from dagster._core.definitions.declarative_automation.operators.dep_operators import (
         DepsAutomationCondition,
     )
+    from dagster._core.definitions.declarative_automation.operators.since_operator import (
+        SinceCondition,
+    )
 
 
 class AutomationCondition(ABC, Generic[T_EntityKey]):
@@ -261,7 +264,7 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
 
     def since(
         self, reset_condition: "AutomationCondition[T_EntityKey]"
-    ) -> "BuiltinAutomationCondition[T_EntityKey]":
+    ) -> "SinceCondition[T_EntityKey]":
         """Returns an AutomationCondition that is true if this condition has ever been
         true since the last time the reset condition became true.
         """

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/utils.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
         DepsAutomationCondition,
         NotAutomationCondition,
         OrAutomationCondition,
+        SinceCondition,
     )
 
 
@@ -25,6 +26,7 @@ def has_allow_ignore(
         "DepsAutomationCondition",
         "NotAutomationCondition",
         "OrAutomationCondition",
+        "SinceCondition",
     ]
 ]:
     from dagster._core.definitions.declarative_automation.operators import (
@@ -33,6 +35,7 @@ def has_allow_ignore(
         DepsAutomationCondition,
         NotAutomationCondition,
         OrAutomationCondition,
+        SinceCondition,
     )
 
     return isinstance(
@@ -43,5 +46,6 @@ def has_allow_ignore(
             DepsAutomationCondition,
             NotAutomationCondition,
             OrAutomationCondition,
+            SinceCondition,
         ),
     )

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_since_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_since_condition.py
@@ -237,3 +237,13 @@ def test_since_condition() -> None:
         reset_evaluation_id=8,
         reset_timestamp=timestamp,
     )
+
+
+def test_allow_ignore() -> None:
+    selection = dg.AssetSelection.groups("a")
+    a = dg.AutomationCondition.any_deps_updated()
+    b = dg.AutomationCondition.any_deps_in_progress()
+    initial = a.since(b)
+
+    assert initial.allow(selection) == a.allow(selection).since(b.allow(selection))
+    assert initial.ignore(selection) == a.ignore(selection).since(b.ignore(selection))


### PR DESCRIPTION
## Summary & Motivation

Fixes an issue where iuf you used `.allow()` or `.ignore()` on an (e.g.) eager automation condition, this would not actually apply to parts of the selection.

## How I Tested These Changes

## Changelog

Fixed an issue that would cause `.allow()` and `.ignore()` applications to not progpagate through `.since()` automation conditions. 
