### PR TITLE
[ui] Move global AMP to Automations section

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -1,9 +1,12 @@
-import {Page} from '@dagster-io/ui-components';
+import {Box, Page, PageHeader, Subtitle1} from '@dagster-io/ui-components';
 import {Redirect} from 'react-router-dom';
+import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
 import {GlobalAutomaterializationContent} from './GlobalAutomaterializationContent';
+import {featureEnabled} from '../../app/Flags';
 import {assertUnreachable} from '../../app/Util';
 import {useTrackPageView} from '../../app/analytics';
+import {AutomationTabs} from '../../automation/AutomationTabs';
 import {useDocumentTitle} from '../../hooks/useDocumentTitle';
 import {OverviewPageHeader} from '../../overview/OverviewPageHeader';
 import {useAutoMaterializeSensorFlag} from '../AutoMaterializeSensorFlag';
@@ -27,10 +30,20 @@ export const AutomaterializationRoot = () => {
 
 const GlobalAutomaterializationRoot = () => {
   useTrackPageView();
-  useDocumentTitle('Overview | Auto-materialize');
+  useDocumentTitle('Automations | Auto-materialize');
+  const showTabs = featureEnabled(FeatureFlag.flagUseNewObserveUIs);
   return (
     <Page>
-      <OverviewPageHeader tab="amp" />
+      {showTabs ? (
+        <>
+          <PageHeader title={<Subtitle1>Automation</Subtitle1>} />
+          <Box padding={{horizontal: 24}} border="bottom">
+            <AutomationTabs tab="global-amp" />
+          </Box>
+        </>
+      ) : (
+        <OverviewPageHeader tab="amp" />
+      )}
       <GlobalAutomaterializationContent />
     </Page>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationTabs.tsx
@@ -1,0 +1,46 @@
+import {Box, Colors, Spinner, Tabs} from '@dagster-io/ui-components';
+
+import {useAutoMaterializeSensorFlag} from '../assets/AutoMaterializeSensorFlag';
+import {useAutomaterializeDaemonStatus} from '../assets/useAutomaterializeDaemonStatus';
+import {TabLink} from '../ui/TabLink';
+
+interface Props {
+  tab: 'schedules-and-sensors' | 'global-amp';
+}
+
+export const AutomationTabs = (props: Props) => {
+  const {tab} = props;
+
+  const automaterialize = useAutomaterializeDaemonStatus();
+  const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
+
+  return (
+    <Tabs selectedTabId={tab}>
+      <TabLink id="schedules-and-sensors" title="Schedules and sensors" to="/automation" />
+      {automaterializeSensorsFlagState === 'has-global-amp' ? (
+        <TabLink
+          id="global-amp"
+          title={
+            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+              <div>Auto-materialize</div>
+              {automaterialize.loading ? (
+                <Spinner purpose="body-text" />
+              ) : (
+                <div
+                  style={{
+                    width: '10px',
+                    height: '10px',
+                    borderRadius: '50%',
+                    backgroundColor:
+                      automaterialize.paused === false ? Colors.accentBlue() : Colors.accentGray(),
+                  }}
+                />
+              )}
+            </Box>
+          }
+          to="/overview/automation"
+        />
+      ) : null}
+    </Tabs>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/MergedAutomationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/MergedAutomationRoot.tsx
@@ -13,8 +13,10 @@ import {
 import {useCallback, useContext, useMemo} from 'react';
 
 import {AutomationBulkActionMenu} from './AutomationBulkActionMenu';
+import {AutomationTabs} from './AutomationTabs';
 import {AutomationsTable} from './AutomationsTable';
 import {useTrackPageView} from '../app/analytics';
+import {useAutoMaterializeSensorFlag} from '../assets/AutoMaterializeSensorFlag';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {useSelectionReducer} from '../hooks/useSelectionReducer';
@@ -68,6 +70,8 @@ export const MergedAutomationRoot = () => {
     loading: workspaceLoading,
     data: cachedData,
   } = useContext(WorkspaceContext);
+
+  const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
 
   const [searchValue, setSearchValue] = useQueryPersistedState<string>({
     queryKey: 'search',
@@ -349,6 +353,11 @@ export const MergedAutomationRoot = () => {
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
       <PageHeader title={<Subtitle1>Automation</Subtitle1>} />
+      {automaterializeSensorsFlagState === 'has-global-amp' ? (
+        <Box padding={{horizontal: 24}} border="bottom">
+          <AutomationTabs tab="schedules-and-sensors" />
+        </Box>
+      ) : null}
       <Box
         padding={{horizontal: 24, vertical: 12}}
         flex={{

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
@@ -1,7 +1,9 @@
 import {Box, Colors, Spinner, Tabs} from '@dagster-io/ui-components';
 import {useContext} from 'react';
+import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
 import {QueryResult} from '../apollo-client';
+import {featureEnabled} from '../app/Flags';
 import {QueryRefreshCountdown, RefreshState} from '../app/QueryRefresh';
 import {AssetFeatureContext} from '../assets/AssetFeatureContext';
 import {useAutoMaterializeSensorFlag} from '../assets/AutoMaterializeSensorFlag';
@@ -20,6 +22,7 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
   const automaterialize = useAutomaterializeDaemonStatus();
   const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
   const {enableAssetHealthOverviewPreview} = useContext(AssetFeatureContext);
+  const hideAMPTab = featureEnabled(FeatureFlag.flagUseNewObserveUIs);
 
   return (
     <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
@@ -28,7 +31,7 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
         {enableAssetHealthOverviewPreview && (
           <TabLink id="asset-health" title="Asset health" to="/overview/asset-health" />
         )}
-        {automaterializeSensorsFlagState === 'has-global-amp' ? (
+        {automaterializeSensorsFlagState === 'has-global-amp' && !hideAMPTab ? (
           <TabLink
             id="amp"
             title={


### PR DESCRIPTION
## Summary & Motivation

Global AMP does not have many remaining users, so let's move it off the main "Overview" page to the Automations section of the app.

Users who have `global-amp` will see tabs here, with schedules/sensors on one page, and global AMP on the other. Users who are using sensor AMP will not see tabs.

## How I Tested These Changes

Navigate to Automations. Verify that by default (no global AMP), the tabs do not appear.

Force `global-amp`, verify rendering and behavior of tabs.

## Changelog

[ui] Moved legacy Auto-materialize (global AMP) tab from Overview to Automations.