### PR TITLE
[dg] Allow any python reference to work for yaml check

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_check_yaml_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_check_yaml_command.py
@@ -1,3 +1,5 @@
+import importlib
+import json
 import shutil
 import subprocess
 import time
@@ -134,6 +136,32 @@ def test_check_yaml_succeeds_non_default_defs_module() -> None:
 
         result = runner.invoke("check", "yaml")
         assert_runner_result(result, exit_0=True)
+
+
+def test_check_yaml_succeeds_unregistered_component() -> None:
+    """Ensure that a valid python symbol reference to a component type still works even if it is not registered."""
+    with ProxyRunner.test() as runner, create_project_from_components(runner):
+        result = runner.invoke("scaffold", "component", "Baz")
+        assert_runner_result(result, exit_0=True)
+        importlib.invalidate_caches()  # Ensure component discovery not blocked by python import cache
+
+        # Create component instance
+        result = runner.invoke("scaffold", "defs", "foo_bar.components.baz.Baz", "qux")
+        assert_runner_result(result, exit_0=True)
+
+        # Remove registry module entry that would make the newly scaffolded component discoverable
+        with modify_toml_as_dict(Path("pyproject.toml")) as toml_dict:
+            create_toml_node(toml_dict, ("tool", "dg", "project", "registry_modules"), [])
+
+        # Make sure the new component is not registered
+        result = runner.invoke("list", "components", "--json")
+        assert_runner_result(result)
+        component_keys = [c["key"] for c in json.loads(result.stdout)]
+        assert "foo_bar.components.baz.Baz" not in component_keys
+
+        # Check YAML should pass anyway, since we support unregistered components
+        result = runner.invoke("check", "yaml")
+        assert_runner_result(result)
 
 
 def test_check_yaml_with_watch() -> None:

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/check.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/check.py
@@ -152,10 +152,10 @@ def check_yaml(
             key = PluginObjectKey.from_typename(qualified_key)
             component_contents_by_key[key] = component_doc_tree
 
-            # We need to fetch components from any modules local to the project because these are
-            # not cached with the components from the general environment.
-            if key.namespace.startswith(dg_context.defs_module_name):
-                modules_to_fetch.add(key.namespace)
+            # Add every module referenced to be explicitly fetched. If we don't do this, only
+            # modules that are explicitly declared as registry modules will work.
+            # `from_dg_context()` on the registry ensures that modules aren't double-fetched.
+            modules_to_fetch.add(key.namespace)
 
     # Fetch the local component types, if we need any local components
     component_registry = RemotePluginRegistry.from_dg_context(


### PR DESCRIPTION
## Summary & Motivation

Allow any valid python symbol component reference to work as a `type` in a `defs.yaml` file when running `dg check yaml`. Prior to this PR only types matching a registered component type or inline components in the defs folder are supported.

## How I Tested These Changes

New unit test.

## Changelog

Fix a bug with `dg check yaml` where valid component type names were rejected if they were not registered (i.e. visible from `dg check components`).