### PR TITLE
[ui] Remove Overview tabs for observe-gated users

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageHeader.tsx
@@ -1,7 +1,9 @@
 import {Box, PageHeader} from '@dagster-io/ui-components';
 import React from 'react';
+import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
 import {OverviewTabs} from './OverviewTabs';
+import {featureEnabled} from '../app/Flags';
 
 export const OverviewPageHeader = ({
   tab,
@@ -10,6 +12,11 @@ export const OverviewPageHeader = ({
   ...rest
 }: React.ComponentProps<typeof OverviewTabs> &
   Omit<React.ComponentProps<typeof PageHeader>, 'title'>) => {
+  const observeUIEnabled = featureEnabled(FeatureFlag.flagUseNewObserveUIs);
+  if (observeUIEnabled) {
+    return null;
+  }
+
   return (
     <PageHeader
       tabs={


### PR DESCRIPTION
## Summary & Motivation

For users in the new Observe UI flag, we're no longer going to show Asset Health or Resources on the Overview page -- it's just going to be the Timeline.

## How I Tested These Changes

Verify that the tabs appear by default on Overview. Force the flag on, verify that the tabs disappear.

## Changelog

[ui] For users with the new Observe UIs, do not show Asset Health and Resources on Timeline page.
