### PR TITLE
[ui] UI Component updates to support billing designs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Alert.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Alert.tsx
@@ -6,18 +6,19 @@ import {Colors} from './Color';
 import {Group} from './Group';
 import {Icon, IconName} from './Icon';
 
-export type AlertIntent = 'info' | 'warning' | 'error' | 'success';
+export type AlertIntent = 'info' | 'warning' | 'error' | 'success' | 'none';
 
 interface Props {
   intent?: AlertIntent;
   title: React.ReactNode;
   description?: React.ReactNode;
   icon?: React.ReactNode;
+  rightButton?: React.ReactNode;
   onClose?: () => void;
 }
 
 export const Alert = (props: Props) => {
-  const {intent = 'info', title, description, onClose} = props;
+  const {intent = 'info', title, description, rightButton, onClose} = props;
 
   const {backgroundColor, borderColor, icon, iconColor, textColor} = React.useMemo(() => {
     switch (intent) {
@@ -44,6 +45,15 @@ export const Alert = (props: Props) => {
           icon: 'done',
           iconColor: Colors.accentGreen(),
           textColor: Colors.textGreen(),
+        };
+
+      case 'none':
+        return {
+          backgroundColor: Colors.backgroundGray(),
+          borderColor: Colors.accentGray(),
+          icon: 'info',
+          iconColor: Colors.accentGray(),
+          textColor: Colors.textLight(),
         };
       case 'info':
       default:
@@ -76,6 +86,8 @@ export const Alert = (props: Props) => {
           <ButtonWrapper onClick={onClose}>
             <Icon name="close" color={textColor} />
           </ButtonWrapper>
+        ) : rightButton ? (
+          <div style={{alignSelf: 'center'}}>{rightButton}</div>
         ) : null}
       </Box>
     </AlertContainer>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/BaseButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/BaseButton.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {Colors} from './Color';
 import {StyledButton, StyledButtonText} from './StyledButton';
 
-interface CommonButtonProps {
+export interface CommonButtonProps {
   icon?: React.ReactNode;
   label?: React.ReactNode;
   loading?: boolean;
@@ -16,7 +16,7 @@ interface CommonButtonProps {
   textColor?: string;
 }
 
-interface BaseButtonProps extends CommonButtonProps, React.ComponentPropsWithRef<'button'> {}
+export interface BaseButtonProps extends CommonButtonProps, React.ComponentPropsWithRef<'button'> {}
 
 export const BaseButton = React.forwardRef(
   (props: BaseButtonProps, ref: React.ForwardedRef<HTMLButtonElement>) => {

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Button.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Button.tsx
@@ -1,9 +1,9 @@
 // eslint-disable-next-line no-restricted-imports
-import {AnchorButton as BlueprintAnchorButton, Button as BlueprintButton} from '@blueprintjs/core';
+import {Button as BlueprintButton} from '@blueprintjs/core';
 import * as React from 'react';
 import styled from 'styled-components';
 
-import {BaseButton} from './BaseButton';
+import {BaseButton, BaseButtonProps, CommonButtonProps} from './BaseButton';
 import {Colors} from './Color';
 import {Spinner} from './Spinner';
 import {StyledButton, StyledButtonText} from './StyledButton';
@@ -185,11 +185,13 @@ export const buildColorSet = (config: {intent?: BlueprintIntent; outlined: Bluep
   };
 };
 
+type ButtonProps = BaseButtonProps & {
+  intent?: BlueprintIntent;
+  outlined?: BlueprintOutlined;
+};
+
 export const Button = React.forwardRef(
-  (
-    props: React.ComponentProps<typeof BlueprintButton>,
-    ref: React.ForwardedRef<HTMLButtonElement>,
-  ) => {
+  (props: ButtonProps, ref: React.ForwardedRef<HTMLButtonElement>) => {
     const {children, icon, intent, loading, outlined, rightIcon, ...rest} = props;
 
     let iconOrSpinner = icon;
@@ -248,11 +250,14 @@ export const JoinedButtons = styled.div`
   }
 `;
 
+export type ExternalAnchorButtonProps = CommonButtonProps &
+  React.ComponentPropsWithRef<'a'> & {
+    intent?: BlueprintIntent;
+    outlined?: BlueprintOutlined;
+  };
+
 export const ExternalAnchorButton = React.forwardRef(
-  (
-    props: Omit<React.ComponentProps<typeof BlueprintAnchorButton>, 'loading'>,
-    ref: React.ForwardedRef<HTMLAnchorElement>,
-  ) => {
+  (props: ExternalAnchorButtonProps, ref: React.ForwardedRef<HTMLAnchorElement>) => {
     const {children, icon, intent, outlined, rightIcon, ...rest} = props;
 
     const {fillColor, fillColorHover, textColor, iconColor, strokeColor, strokeColorHover} =

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Dialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Dialog.tsx
@@ -6,8 +6,8 @@ import styled, {createGlobalStyle} from 'styled-components';
 import {Box} from './Box';
 import {Colors} from './Color';
 import {ErrorBoundary} from './ErrorBoundary';
-import {Group} from './Group';
 import {Icon, IconName} from './Icon';
+import {UnstyledButton} from './UnstyledButton';
 
 interface Props
   extends Omit<
@@ -20,37 +20,52 @@ interface Props
 }
 
 export const Dialog = (props: Props) => {
-  const {icon, title, children, ...rest} = props;
+  const {icon, title, children, isCloseButtonShown, onClose, ...rest} = props;
   return (
     <BlueprintDialog
       {...rest}
       portalClassName={`dagster-portal${props.portalClassName ? ` ${props.portalClassName}` : ''}`}
       backdropClassName="dagster-backdrop"
       className={`dagster-dialog${props.className ? ` ${props.className}` : ''}`}
+      onClose={onClose}
     >
-      {title ? <DialogHeader icon={icon} label={title} /> : null}
+      {title ? (
+        <DialogHeader
+          icon={icon}
+          label={title}
+          isCloseButtonShown={isCloseButtonShown}
+          onClose={onClose}
+        />
+      ) : null}
       <ErrorBoundary region="dialog">{children}</ErrorBoundary>
     </BlueprintDialog>
   );
 };
 
 interface HeaderProps {
-  icon?: IconName;
   label: React.ReactNode;
+  icon?: IconName;
+  isCloseButtonShown?: boolean;
+  onClose?: Props['onClose'];
 }
 
 export const DialogHeader = (props: HeaderProps) => {
-  const {icon, label} = props;
+  const {icon, label, isCloseButtonShown, onClose} = props;
   return (
     <Box
       background={Colors.backgroundDefault()}
       padding={{vertical: 16, horizontal: 20}}
       border="bottom"
     >
-      <Group direction="row" spacing={8} alignItems="center">
+      <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
         {icon ? <Icon name={icon} color={Colors.accentPrimary()} /> : null}
         <DialogHeaderText>{label}</DialogHeaderText>
-      </Group>
+        {isCloseButtonShown ? (
+          <UnstyledButton onClick={onClose}>
+            <Icon name="close" />
+          </UnstyledButton>
+        ) : null}
+      </Box>
     </Box>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-components/src/components/StyledButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/StyledButton.tsx
@@ -109,6 +109,6 @@ export const StyledButtonText = styled.span`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  text-align: left;
+  text-align: center;
   flex: 1;
 `;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Alert.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Alert.stories.tsx
@@ -3,6 +3,7 @@ import {useState} from 'react';
 
 import {Alert, AlertIntent} from '../Alert';
 import {Box} from '../Box';
+import {Button} from '../Button';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -10,7 +11,7 @@ export default {
   component: Alert,
 } as Meta;
 
-const intents: AlertIntent[] = ['info', 'warning', 'error', 'success'];
+const intents: AlertIntent[] = ['info', 'warning', 'error', 'success', 'none'];
 
 export const Intents = () => {
   const [isClosed, updateClosed] = useState<boolean[]>(intents.map(() => false));
@@ -42,6 +43,17 @@ export const Intents = () => {
             title="You can dismiss me."
             description="This alert can be dismissed."
             onClose={() => setClosed(i, true)}
+          />
+        ) : null,
+      )}
+      {intents.map((intent, i) =>
+        !isClosed[i] ? (
+          <Alert
+            key={`${intent}-custom-right-button`}
+            intent={intent}
+            title="You can take a CTA action on me."
+            description="This alert has a button."
+            rightButton={<Button onClick={() => setClosed(i, true)}>Go to Billing</Button>}
           />
         ) : null,
       )}

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Button.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Button.stories.tsx
@@ -2,6 +2,7 @@ import {Meta} from '@storybook/react';
 
 import {Box} from '../Box';
 import {Button, JoinedButtons} from '../Button';
+import {Colors} from '../Color';
 import {Group} from '../Group';
 import {Icon} from '../Icon';
 import {Menu, MenuItem} from '../Menu';
@@ -23,6 +24,14 @@ export const Default = () => {
         Button
       </Button>
       <Button icon={<Icon name="cached" />} />
+      <Box
+        background={Colors.backgroundLight()}
+        padding={16}
+        flex={{direction: 'column', alignItems: 'stretch'}}
+        style={{width: 320}}
+      >
+        <Button>Full-width Flex Child</Button>
+      </Box>
     </Group>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataEntriesTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataEntriesTable.tsx
@@ -258,15 +258,13 @@ export const AssetEventMetadataEntriesTable = ({
           </StyledTableWithHeader>
           {displayedCount < filteredRows.length ? (
             <Box padding={{vertical: 8}}>
-              <Button small onClick={() => setDisplayedCount(Number.MAX_SAFE_INTEGER)}>
+              <Button onClick={() => setDisplayedCount(Number.MAX_SAFE_INTEGER)}>
                 Show {filteredRows.length - displayedCount} more
               </Button>
             </Box>
           ) : displayedCount > displayedByDefault ? (
             <Box padding={{vertical: 8}}>
-              <Button small onClick={() => setDisplayedCount(displayedByDefault)}>
-                Show less
-              </Button>
+              <Button onClick={() => setDisplayedCount(displayedByDefault)}>Show less</Button>
             </Box>
           ) : undefined}
         </AssetEventMetadataScrollContainer>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/LineageSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/LineageSection.tsx
@@ -85,13 +85,11 @@ const AssetLinksWithStatus = ({
       ))}
       <Box>
         {displayed.length < assets.length ? (
-          <Button small onClick={() => setDisplayedCount(Number.MAX_SAFE_INTEGER)}>
+          <Button onClick={() => setDisplayedCount(Number.MAX_SAFE_INTEGER)}>
             Show {assets.length - displayed.length} more
           </Button>
         ) : displayed.length > displayedByDefault ? (
-          <Button small onClick={() => setDisplayedCount(displayedByDefault)}>
-            Show less
-          </Button>
+          <Button onClick={() => setDisplayedCount(displayedByDefault)}>Show less</Button>
         ) : undefined}
       </Box>
     </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadConfigExpansionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadConfigExpansionButton.tsx
@@ -48,5 +48,5 @@ export const LaunchpadConfigExpansionButton = ({
     />
   );
 
-  return <Button active={open} title="Toggle second pane" icon={icon} onClick={onClick} />;
+  return <Button title="Toggle second pane" icon={icon} onClick={onClick} />;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizard.tsx
@@ -58,7 +58,6 @@ export const DimensionRangeWizard = ({
         </Box>
         {isTimeseries && (
           <Button
-            small={true}
             onClick={() => setSelected(partitionKeys.slice(-1))}
             data-testid={testId('latest-partition-button')}
           >
@@ -66,7 +65,6 @@ export const DimensionRangeWizard = ({
           </Button>
         )}
         <Button
-          small={true}
           onClick={() => setSelected(partitionKeys)}
           data-testid={testId('all-partition-button')}
         >

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
@@ -288,7 +288,7 @@ export const OpJobPartitionsViewContent = React.memo(
         >
           <Subheading>Status</Subheading>
           <Box flex={{gap: 8}}>
-            <Button onClick={() => setShowSteps(!showSteps)} active={showBackfillSetup}>
+            <Button onClick={() => setShowSteps(!showSteps)}>
               {showSteps ? 'Hide per-step status' : 'Show per-step status'}
             </Button>
             <Button
@@ -300,12 +300,11 @@ export const OpJobPartitionsViewContent = React.memo(
             </Button>
             {canLaunchPartitionBackfill ? (
               <Button
+                icon={<Icon name="add_circle" />}
                 onClick={() => {
                   void partitionsQueryResult.refetch();
                   setShowBackfillSetup(!showBackfillSetup);
                 }}
-                icon={<Icon name="add_circle" />}
-                active={showBackfillSetup}
               >
                 Launch backfill…
               </Button>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/StepLogsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/StepLogsDialog.tsx
@@ -43,11 +43,7 @@ export function useStepLogs({runId, stepKeys}: {runId?: string; stepKeys?: strin
     ),
     button:
       runId && stepKeys ? (
-        <Button
-          small
-          icon={<Icon name="wysiwyg" />}
-          onClick={() => setShowingLogs({runId, stepKeys})}
-        >
+        <Button icon={<Icon name="wysiwyg" />} onClick={() => setShowingLogs({runId, stepKeys})}>
           View logs
         </Button>
       ) : undefined,


### PR DESCRIPTION
This PR makes a few small changes to the core UI components:

- Our button lists a `fill` prop which we use in billing, but it doesn't do anything. This PR removes the `fill` prop and aligns the button label with `text-align: center` so that it renders properly when it's made wider-than-it's-label via a flexbox.

- Adds an `<Alert intent=“none” />` that renders in gray for a subtle notice (used for “After your trial ends, you will be billed on Jun 16” style messages).

- Adds an `<Alert rightButton={<Button…/>} />`. The alerts currently support displaying an X, but we need to support an actual CTA button placed inside an alert notice.

- Dialog has a `isCloseButtonShown` prop that is used in several places but does not actually do anything since we implement our own header. This is fixed.

## Testing:

The changes above are all exercised in a new billing page and I also updated stories to demonstrate the new features.

This PR needs to merge with the new billing page because it removes `<Button fill />`