### PR TITLE
make error severity dbt tests blocking asset checks

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -658,12 +658,17 @@ def default_asset_check_fn(
         for parent_id in parent_unique_ids
     }
     additional_deps.discard(asset_key)
+
+    severity = test_resource_props.get("config", {}).get("severity", "error")
+    blocking = severity.lower() == "error"
+
     return AssetCheckSpec(
         name=test_resource_props["name"],
         asset=asset_key,
         description=test_resource_props.get("meta", {}).get("description"),
         additional_deps=additional_deps,
         metadata={DAGSTER_DBT_UNIQUE_ID_METADATA_KEY: test_unique_id},
+        blocking=blocking,
     )
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -95,8 +95,26 @@ def test_customized_checks(test_asset_checks_manifest: dict[str, Any]) -> None:
         assert spec.description == "blah"
 
 
-def test_asset_checks_enabled_by_default(test_asset_checks_manifest: dict[str, Any]) -> None:
-    @dbt_assets(manifest=test_asset_checks_manifest)
+@pytest.mark.parametrize(
+    "block_on_error_severity",
+    [True, False],
+)
+def test_asset_checks_enabled_by_default(
+    test_asset_checks_manifest: dict[str, Any], block_on_error_severity: bool
+) -> None:
+    class CustomDagsterDbtTranslatorWithNonBlockingChecks(DagsterDbtTranslator):
+        def get_asset_check_spec(self, asset_spec, manifest, unique_id, project):
+            default_check_spec = super().get_asset_check_spec(
+                asset_spec, manifest, unique_id, project
+            )
+            return default_check_spec._replace(blocking=False) if default_check_spec else None
+
+    @dbt_assets(
+        manifest=test_asset_checks_manifest,
+        dagster_dbt_translator=CustomDagsterDbtTranslatorWithNonBlockingChecks()
+        if not block_on_error_severity
+        else None,  # block_on_error_severity is the default
+    )
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
         yield from dbt.cli(["build"], context=context).stream()
 
@@ -115,43 +133,53 @@ def test_asset_checks_enabled_by_default(test_asset_checks_manifest: dict[str, A
         "customers_not_null_customers_customer_id": AssetCheckSpec(
             name="not_null_customers_customer_id",
             asset=AssetKey(["customers"]),
+            blocking=block_on_error_severity,
         ),
         "customers_unique_customers_customer_id": AssetCheckSpec(
             name="unique_customers_customer_id",
             asset=AssetKey(["customers"]),
+            blocking=False,  # severity is warn
         ),
         "orders_accepted_values_orders_status__placed__shipped__completed__return_pending__returned": AssetCheckSpec(
             name="accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
             asset=AssetKey(["orders"]),
             description="Status must be one of ['placed', 'shipped', 'completed', 'return_pending', or 'returned']",
+            blocking=block_on_error_severity,
         ),
         "orders_not_null_orders_amount": AssetCheckSpec(
             name="not_null_orders_amount",
             asset=AssetKey(["orders"]),
+            blocking=block_on_error_severity,
         ),
         "orders_not_null_orders_bank_transfer_amount": AssetCheckSpec(
             name="not_null_orders_bank_transfer_amount",
             asset=AssetKey(["orders"]),
+            blocking=block_on_error_severity,
         ),
         "orders_not_null_orders_coupon_amount": AssetCheckSpec(
             name="not_null_orders_coupon_amount",
             asset=AssetKey(["orders"]),
+            blocking=block_on_error_severity,
         ),
         "orders_not_null_orders_credit_card_amount": AssetCheckSpec(
             name="not_null_orders_credit_card_amount",
             asset=AssetKey(["orders"]),
+            blocking=block_on_error_severity,
         ),
         "orders_not_null_orders_customer_id": AssetCheckSpec(
             name="not_null_orders_customer_id",
             asset=AssetKey(["orders"]),
+            blocking=block_on_error_severity,
         ),
         "orders_not_null_orders_gift_card_amount": AssetCheckSpec(
             name="not_null_orders_gift_card_amount",
             asset=AssetKey(["orders"]),
+            blocking=block_on_error_severity,
         ),
         "orders_not_null_orders_order_id": AssetCheckSpec(
             name="not_null_orders_order_id",
             asset=AssetKey(["orders"]),
+            blocking=block_on_error_severity,
         ),
         "orders_relationships_orders_customer_id__customer_id__ref_customers_": AssetCheckSpec(
             name="relationships_orders_customer_id__customer_id__ref_customers_",
@@ -159,6 +187,7 @@ def test_asset_checks_enabled_by_default(test_asset_checks_manifest: dict[str, A
             additional_deps=[
                 AssetKey(["customers"]),
             ],
+            blocking=block_on_error_severity,
         ),
         "orders_relationships_orders_customer_id__id__source_jaffle_shop_raw_customers_": AssetCheckSpec(
             name="relationships_orders_customer_id__id__source_jaffle_shop_raw_customers_",
@@ -166,6 +195,7 @@ def test_asset_checks_enabled_by_default(test_asset_checks_manifest: dict[str, A
             additional_deps=[
                 AssetKey(["jaffle_shop", "raw_customers"]),
             ],
+            blocking=block_on_error_severity,
         ),
         "orders_relationships_with_duplicate_orders_ref_customers___customer_id__customer_id__ref_customers_": AssetCheckSpec(
             name="relationships_with_duplicate_orders_ref_customers___customer_id__customer_id__ref_customers_",
@@ -173,54 +203,67 @@ def test_asset_checks_enabled_by_default(test_asset_checks_manifest: dict[str, A
             additional_deps=[
                 AssetKey(["customers"]),
             ],
+            blocking=block_on_error_severity,
         ),
         "orders_unique_orders_order_id": AssetCheckSpec(
             name="unique_orders_order_id",
             asset=AssetKey(["orders"]),
+            blocking=block_on_error_severity,
         ),
         "stg_customers_not_null_stg_customers_customer_id": AssetCheckSpec(
             name="not_null_stg_customers_customer_id",
             asset=AssetKey(["stg_customers"]),
+            blocking=block_on_error_severity,
         ),
         "stg_customers_unique_stg_customers_customer_id": AssetCheckSpec(
             name="unique_stg_customers_customer_id",
             asset=AssetKey(["stg_customers"]),
+            blocking=block_on_error_severity,
         ),
         "stg_orders_accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned": AssetCheckSpec(
             name="accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
             asset=AssetKey(["stg_orders"]),
+            blocking=block_on_error_severity,
         ),
         "stg_orders_not_null_stg_orders_order_id": AssetCheckSpec(
             name="not_null_stg_orders_order_id",
             asset=AssetKey(["stg_orders"]),
+            blocking=block_on_error_severity,
         ),
         "stg_orders_unique_stg_orders_order_id": AssetCheckSpec(
             name="unique_stg_orders_order_id",
             asset=AssetKey(["stg_orders"]),
+            blocking=block_on_error_severity,
         ),
         "stg_payments_accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card": AssetCheckSpec(
             name="accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
             asset=AssetKey(["stg_payments"]),
+            blocking=block_on_error_severity,
         ),
         "stg_payments_not_null_stg_payments_payment_id": AssetCheckSpec(
             name="not_null_stg_payments_payment_id",
             asset=AssetKey(["stg_payments"]),
+            blocking=block_on_error_severity,
         ),
         "stg_payments_unique_stg_payments_payment_id": AssetCheckSpec(
             name="unique_stg_payments_payment_id",
             asset=AssetKey(["stg_payments"]),
+            blocking=block_on_error_severity,
         ),
         "fail_tests_model_accepted_values_fail_tests_model_first_name__foo__bar__baz": AssetCheckSpec(
             name="accepted_values_fail_tests_model_first_name__foo__bar__baz",
             asset=AssetKey(["fail_tests_model"]),
+            blocking=block_on_error_severity,
         ),
         "fail_tests_model_unique_fail_tests_model_id": AssetCheckSpec(
             name="unique_fail_tests_model_id",
             asset=AssetKey(["fail_tests_model"]),
+            blocking=block_on_error_severity,
         ),
         "customers_singular_test_with_single_dependency": AssetCheckSpec(
             name="singular_test_with_single_dependency",
             asset=AssetKey(["customers"]),
+            blocking=block_on_error_severity,
         ),
         "customers_singular_test_with_meta_and_multiple_dependencies": AssetCheckSpec(
             name="singular_test_with_meta_and_multiple_dependencies",
@@ -228,6 +271,7 @@ def test_asset_checks_enabled_by_default(test_asset_checks_manifest: dict[str, A
             additional_deps=[
                 AssetKey(["orders"]),
             ],
+            blocking=block_on_error_severity,
         ),
     }
 
@@ -601,8 +645,16 @@ def test_asset_checks_results(
     result = materialize(
         [my_dbt_assets],
         resources={"dbt": DbtCliResource(project_dir=os.fspath(test_asset_checks_path))},
+        raise_on_error=False,
     )
-    assert result.success
+    assert not result.success
+    assert len(result.get_asset_materialization_events()) == 10
+    assert len(result.get_asset_check_evaluations()) == 26
+    assert len(result.get_step_failure_events()) == 1
+    assert (
+        "1 blocking asset check failed with ERROR severity:\\nfail_tests_model: accepted_values_fail_tests_model_first_name__foo__bar__baz"
+        in str(result.get_step_failure_events()[0])
+    )
 
 
 def test_asset_checks_evaluations(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -31,6 +31,7 @@ from dagster import (
     asset,
     materialize,
 )
+from dagster._core.definitions.dependency import BlockingAssetChecksDependencyDefinition
 from dagster._core.definitions.tags import build_kind_tag, has_kind
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.execution.context.compute import AssetExecutionContext
@@ -1121,11 +1122,41 @@ def test_dbt_with_python_interleaving(
         },
         # the second invocation of my_dbt_assets depends on the first, and the python step
         NodeInvocation(name="my_dbt_assets"): {
-            "__subset_input__stg_orders": DependencyDefinition(
-                node="my_dbt_assets_2", output="stg_orders"
+            "__subset_input__stg_orders": BlockingAssetChecksDependencyDefinition(
+                asset_check_dependencies=[
+                    DependencyDefinition(
+                        node="my_dbt_assets_2",
+                        output="stg_orders_accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+                    ),
+                    DependencyDefinition(
+                        node="my_dbt_assets_2",
+                        output="stg_orders_not_null_stg_orders_order_id",
+                    ),
+                    DependencyDefinition(
+                        node="my_dbt_assets_2",
+                        output="stg_orders_unique_stg_orders_order_id",
+                    ),
+                ],
+                other_dependency=DependencyDefinition(node="my_dbt_assets_2", output="stg_orders"),
             ),
-            "__subset_input__stg_payments": DependencyDefinition(
-                node="my_dbt_assets_2", output="stg_payments"
+            "__subset_input__stg_payments": BlockingAssetChecksDependencyDefinition(
+                asset_check_dependencies=[
+                    DependencyDefinition(
+                        node="my_dbt_assets_2",
+                        output="stg_payments_accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+                    ),
+                    DependencyDefinition(
+                        node="my_dbt_assets_2",
+                        output="stg_payments_not_null_stg_payments_payment_id",
+                    ),
+                    DependencyDefinition(
+                        node="my_dbt_assets_2",
+                        output="stg_payments_unique_stg_payments_payment_id",
+                    ),
+                ],
+                other_dependency=DependencyDefinition(
+                    node="my_dbt_assets_2", output="stg_payments"
+                ),
             ),
             "dagster_python_augmented_customers": DependencyDefinition(
                 node="dagster__python_augmented_customers", output="result"


### PR DESCRIPTION
## Summary & Motivation
After https://github.com/dagster-io/dagster/pull/30350, dbt tests can be made blocking, which better matches the underlying semantics of dbt tests - as per https://docs.getdbt.com/reference/resource-configs/severity

The only significant behavior change here should be with the new "retry from asset failure" method, which will correctly realize that a test failure should include the connected asset in the retried run. Otherwise there should be no behavior change during execution here.since the dbt cli invocation was already failing on these assets.

We could consider making this change configurable or opt outable in some fashion though.

## How I Tested These Changes
Modified test cases, verified that they would have short-circuited early and incorrectly without the upstream change

## Changelog
[dagster-dbt] dbt tests with error severity are now modeled as blocking asset checks, ensuring that if a run fails due to a dbt test failure, the connected model is included in a retried run if it is retried using the experimental "Enable retries from asset failure" feature.

This change should not result in any behavior changes during execution since the dbt cli already fails the step and any downstream models if dbt tests fail with error severity, but could change the behavior that depends on blocking tests (for example, Automation Conditions that require blocking checks on upstream assets to pass).

To restore the previous behavior after upgrading, you can use a custom DbtTranslator like the following:

```

from dagster_dbt import DagsterDbtTranslator
from dagster_dbt.asset_utils import default_asset_check_fn

class CustomDagsterDbtTranslatorWithNonBlockingChecks(DagsterDbtTranslator):
    def get_asset_check_spec(self, asset_spec, manifest, unique_id, project):
        default_check_spec = super().get_asset_check_spec(
            asset_spec, manifest, unique_id, project
        )
        return default_check_spec._replace(blocking=False) if default_check_spec else None
```