### PR TITLE
Add missing dynamic partitions store argument to GrapheneAssetNode calls

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -730,7 +730,9 @@ class GrapheneAssetNode(graphene.ObjectType):
         partitions: Optional[Sequence[str]] = None,
     ) -> Sequence[Any]:  # (GrapheneAssetStaleStatus)
         if partitions is None:
-            partitions = self._get_partitions_def().get_partition_keys()
+            partitions = self._get_partitions_def().get_partition_keys(
+                dynamic_partitions_store=graphene_info.context.dynamic_partitions_loader
+            )
         else:
             self._validate_partitions_existence()
         return [
@@ -751,7 +753,9 @@ class GrapheneAssetNode(graphene.ObjectType):
         partitions: Optional[Sequence[str]] = None,
     ) -> Sequence[Sequence[GrapheneAssetStaleCause]]:
         if partitions is None:
-            partitions = self._get_partitions_def().get_partition_keys()
+            partitions = self._get_partitions_def().get_partition_keys(
+                dynamic_partitions_store=graphene_info.context.dynamic_partitions_loader
+            )
         else:
             self._validate_partitions_existence()
         return [self._get_staleCauses(partition) for partition in partitions]
@@ -792,7 +796,9 @@ class GrapheneAssetNode(graphene.ObjectType):
         self, graphene_info: ResolveInfo, partitions: Optional[Sequence[str]] = None
     ) -> Sequence[Optional[str]]:
         if partitions is None:
-            partitions = self._get_partitions_def().get_partition_keys()
+            partitions = self._get_partitions_def().get_partition_keys(
+                dynamic_partitions_store=graphene_info.context.dynamic_partitions_loader
+            )
         else:
             self._validate_partitions_existence()
         data_versions = [


### PR DESCRIPTION
## Summary & Motivation
Without these, the resolvers fail on dynamic partitions

## How I Tested These Changes
New test case

## Changelog
Fixed an issue where the `staleStatusByPartition`, `staleCausesByPartition`, and `dataVersionByPartition` fields on `AssetNode` would fail when called on an asset with dynamic partitions.
