### PR TITLE
Mark config_fields as cached_property

### DIFF
--- a/python_modules/dagster/dagster/components/lib/executable_component/component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/component.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterable
+from functools import cached_property
 from typing import Any, Optional, TypeVar, Union
 
 from dagster_shared import check
@@ -70,7 +71,7 @@ class ExecutableComponent(Component, Resolvable, Model, ABC):
     def resource_keys(self) -> set[str]:
         return set()
 
-    @property
+    @cached_property
     def config_fields(self) -> Optional[dict[str, Field]]:
         return None
 


### PR DESCRIPTION
Fixes pyright error from https://github.com/dagster-io/dagster/pull/30578

Given that this PR also introduced the method, I think it's fine to just mark it as a cached_property on the parent. And if we need this to vary depending on implementation, we can fix that later.