### PR TITLE
Move DagsterError to dagster_shared.error

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -4,11 +4,7 @@ from typing import TYPE_CHECKING, Union, cast
 import dagster._check as check
 from dagster._core.definitions.selector import PartitionsByAssetSelector, RepositorySelector
 from dagster._core.definitions.utils import check_valid_title
-from dagster._core.errors import (
-    DagsterError,
-    DagsterInvariantViolationError,
-    DagsterUserCodeProcessError,
-)
+from dagster._core.errors import DagsterInvariantViolationError, DagsterUserCodeProcessError
 from dagster._core.events import AssetKey
 from dagster._core.execution.asset_backfill import create_asset_backfill_data_from_asset_partitions
 from dagster._core.execution.backfill import (
@@ -24,6 +20,7 @@ from dagster._core.utils import make_new_backfill_id
 from dagster._core.workspace.permissions import Permissions
 from dagster._time import datetime_from_timestamp, get_current_timestamp
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
+from dagster_shared.error import DagsterError
 
 from dagster_graphql.implementation.utils import (
     AssetBackfillPreviewParams,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -10,7 +10,7 @@ from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPo
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
-from dagster._core.errors import DagsterError, DagsterInvariantViolationError
+from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.asset_backfill import (
     AssetBackfillStatus,
     PartitionedAssetBackfillStatus,
@@ -29,6 +29,7 @@ from dagster._core.storage.tags import (
 )
 from dagster._core.workspace.permissions import Permissions
 from dagster_shared import seven
+from dagster_shared.error import DagsterError
 
 from dagster_graphql.implementation.fetch_partition_sets import (
     partition_status_counts_from_run_partition_data,

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -72,6 +72,7 @@ sys.meta_path.insert(
 # ##### DYNAMIC IMPORTS
 # ########################
 
+from dagster_shared.error import DagsterError as DagsterError
 from dagster_shared.libraries import DagsterLibraryRegistry
 from dagster_shared.serdes import (
     deserialize_value as deserialize_value,
@@ -453,7 +454,6 @@ from dagster._core.definitions.utils import (
 )
 from dagster._core.errors import (
     DagsterConfigMappingFunctionError as DagsterConfigMappingFunctionError,
-    DagsterError as DagsterError,
     DagsterEventLogInvalidForRun as DagsterEventLogInvalidForRun,
     DagsterExecutionInterruptedError as DagsterExecutionInterruptedError,
     DagsterExecutionStepExecutionError as DagsterExecutionStepExecutionError,

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -15,6 +15,7 @@ from typing import (  # noqa: UP035
 )
 
 from dagster_shared.dagster_model.pydantic_compat_layer import model_fields
+from dagster_shared.error import DagsterError
 from pydantic import BaseModel
 from typing_extensions import TypeAlias, TypeGuard, get_args, get_origin
 
@@ -50,11 +51,7 @@ from dagster._core.definitions.resource_definition import (
     has_at_least_one_parameter,
 )
 from dagster._core.definitions.resource_requirement import ResourceRequirement
-from dagster._core.errors import (
-    DagsterError,
-    DagsterInvalidConfigError,
-    DagsterInvalidDefinitionError,
-)
+from dagster._core.errors import DagsterInvalidConfigError, DagsterInvalidDefinitionError
 from dagster._core.execution.context.init import InitResourceContext, build_init_resource_context
 from dagster._core.storage.io_manager import IOManagerDefinition
 from dagster._record import record

--- a/python_modules/dagster/dagster/_core/definitions/input.py
+++ b/python_modules/dagster/dagster/_core/definitions/input.py
@@ -3,6 +3,8 @@ from collections.abc import Mapping
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, TypeVar, Union
 
+from dagster_shared.error import DagsterError
+
 import dagster._check as check
 from dagster._annotations import PublicAttr, deprecated_param, superseded
 from dagster._core.definitions.events import AssetKey
@@ -14,7 +16,7 @@ from dagster._core.definitions.metadata import (
     normalize_metadata,
 )
 from dagster._core.definitions.utils import NoValueSentinel, check_valid_name
-from dagster._core.errors import DagsterError, DagsterInvalidDefinitionError
+from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import (  # BuiltinScalarDagsterType,
     DagsterType,
     resolve_dagster_type,

--- a/python_modules/dagster/dagster/_core/definitions/output.py
+++ b/python_modules/dagster/dagster/_core/definitions/output.py
@@ -1,6 +1,8 @@
 import inspect
 from typing import Any, NamedTuple, Optional, TypeVar, Union
 
+from dagster_shared.error import DagsterError
+
 import dagster._check as check
 from dagster._annotations import PublicAttr, deprecated_param
 from dagster._core.definitions.inference import InferredOutputProps
@@ -11,7 +13,7 @@ from dagster._core.definitions.metadata import (
     normalize_metadata,
 )
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY, DEFAULT_OUTPUT, check_valid_name
-from dagster._core.errors import DagsterError, DagsterInvalidDefinitionError
+from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import (
     DagsterType,
     is_dynamic_output_annotation,

--- a/python_modules/dagster/dagster/_core/errors.py
+++ b/python_modules/dagster/dagster/_core/errors.py
@@ -20,6 +20,8 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
+from dagster_shared.error import DagsterError
+
 import dagster._check as check
 from dagster._utils.interrupts import raise_interrupts_as
 
@@ -34,18 +36,6 @@ class DagsterExecutionInterruptedError(BaseException):
     as to not be accidentally caught by code that catches Exception
     and thus prevent the interpreter from exiting.
     """
-
-
-class DagsterError(Exception):
-    """Base class for all errors thrown by the Dagster framework.
-
-    Users should not subclass this base class for their own exceptions.
-    """
-
-    @property
-    def is_user_code_error(self):
-        """Returns true if this error is attributable to user code."""
-        return False
 
 
 class DagsterInvalidDefinitionError(DagsterError):

--- a/python_modules/dagster/dagster/_core/execution/context_creation_job.py
+++ b/python_modules/dagster/dagster/_core/execution/context_creation_job.py
@@ -17,6 +17,8 @@ from typing import (  # noqa: UP035
     cast,
 )
 
+from dagster_shared.error import DagsterError
+
 import dagster._check as check
 from dagster._core.definitions import ExecutorDefinition, JobDefinition
 from dagster._core.definitions.executor_definition import check_cross_process_constraints
@@ -25,7 +27,6 @@ from dagster._core.definitions.repository_definition.repository_definition impor
     RepositoryDefinition,
 )
 from dagster._core.definitions.resource_definition import ScopedResourcesBuilder
-from dagster._core.errors import DagsterError, DagsterUserCodeExecutionError
 from dagster._core.events import DagsterEvent, RunFailureReason
 from dagster._core.execution.context.logger import InitLoggerContext
 from dagster._core.execution.context.system import (
@@ -51,6 +52,7 @@ from dagster._utils import EventGenerationManager
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 if TYPE_CHECKING:
+    from dagster._core.errors import DagsterUserCodeExecutionError
     from dagster._core.execution.plan.outputs import StepOutputHandle
     from dagster._core.executor.base import Executor
 

--- a/python_modules/dagster/dagster/_core/execution/execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/execution_result.py
@@ -2,11 +2,13 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import AbstractSet, Callable, Optional, cast  # noqa: UP035
 
+from dagster_shared.error import DagsterError
+
 import dagster._check as check
 from dagster._core.definitions import AssetCheckEvaluation, JobDefinition, NodeHandle
 from dagster._core.definitions.events import AssetMaterialization, AssetObservation
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
-from dagster._core.errors import DagsterError, DagsterInvariantViolationError
+from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.events import (
     AssetObservationData,
     DagsterEvent,

--- a/python_modules/dagster/dagster/_core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/_core/execution/host_mode.py
@@ -3,6 +3,8 @@ import sys
 from collections.abc import Iterator, Mapping, Sequence
 from typing import Optional, Union
 
+from dagster_shared.error import DagsterError
+
 import dagster._check as check
 from dagster._config import Field, process_config
 from dagster._core.definitions.executor_definition import (
@@ -12,11 +14,7 @@ from dagster._core.definitions.executor_definition import (
 )
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.definitions.run_config import selector_for_named_defs
-from dagster._core.errors import (
-    DagsterError,
-    DagsterInvalidConfigError,
-    DagsterInvariantViolationError,
-)
+from dagster._core.errors import DagsterInvalidConfigError, DagsterInvariantViolationError
 from dagster._core.events import DagsterEvent, RunFailureReason
 from dagster._core.execution.api import ExecuteRunWithPlanIterable, job_execution_iterator
 from dagster._core.execution.context.logger import InitLoggerContext

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
@@ -3,10 +3,11 @@ from collections.abc import Iterator, Sequence
 from contextlib import ExitStack
 from typing import Optional, cast
 
+from dagster_shared.error import DagsterError
+
 import dagster._check as check
 from dagster._core.definitions import Failure, HookExecutionResult, RetryRequested
 from dagster._core.errors import (
-    DagsterError,
     DagsterExecutionInterruptedError,
     DagsterMaxRetriesExceededError,
     DagsterUserCodeExecutionError,

--- a/python_modules/dagster/dagster/_core/execution/plan/utils.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/utils.py
@@ -3,10 +3,11 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable
 
+from dagster_shared.error import DagsterError
+
 import dagster._check as check
 from dagster._core.definitions.events import Failure, RetryRequested
 from dagster._core.errors import (
-    DagsterError,
     DagsterExecutionInterruptedError,
     DagsterUserCodeExecutionError,
     raise_execution_interrupts,

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -5,6 +5,8 @@ from functools import cached_property
 from threading import RLock
 from typing import TYPE_CHECKING, AbstractSet, Callable, Optional, Union  # noqa: UP035
 
+from dagster_shared.error import DagsterError
+
 import dagster._check as check
 from dagster import AssetSelection
 from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot
@@ -32,7 +34,6 @@ from dagster._core.definitions.sensor_definition import (
     SensorType,
 )
 from dagster._core.definitions.utils import get_default_automation_condition_sensor_selection
-from dagster._core.errors import DagsterError
 from dagster._core.execution.plan.handle import ResolvedFromDynamicStepHandle, StepHandle
 from dagster._core.instance import DagsterInstance
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin

--- a/python_modules/dagster/dagster/_core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_core/scheduler/scheduler.py
@@ -3,12 +3,12 @@ import os
 from collections.abc import Mapping, Sequence
 from typing import Any, NamedTuple, Optional
 
+from dagster_shared.error import DagsterError
 from typing_extensions import Self
 
 import dagster._check as check
 from dagster._config import Field, IntSource
 from dagster._core.definitions.run_request import InstigatorType
-from dagster._core.errors import DagsterError
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import RemoteSchedule
 from dagster._core.scheduler.instigation import (

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -7,13 +7,11 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Optional, cast
 
+from dagster_shared.error import DagsterError
+
 import dagster._check as check
 from dagster._core.definitions.instigation_logger import InstigationLogger
-from dagster._core.errors import (
-    DagsterCodeLocationLoadError,
-    DagsterError,
-    DagsterUserCodeUnreachableError,
-)
+from dagster._core.errors import DagsterCodeLocationLoadError, DagsterUserCodeUnreachableError
 from dagster._core.execution.asset_backfill import execute_asset_backfill_iteration
 from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
 from dagster._core.execution.job_backfill import execute_job_backfill_iteration

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -11,6 +11,7 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Callable, NamedTuple, Optional, Union, cast
 
 import dagster_shared.seven as seven
+from dagster_shared.error import DagsterError
 from typing_extensions import Self
 
 import dagster._check as check
@@ -29,7 +30,6 @@ from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.definitions.sensor_definition import DefaultSensorStatus, SensorType
 from dagster._core.errors import (
     DagsterCodeLocationLoadError,
-    DagsterError,
     DagsterInvalidInvocationError,
     DagsterUserCodeUnreachableError,
 )

--- a/python_modules/dagster/dagster/components/core/package_entry.py
+++ b/python_modules/dagster/dagster/components/core/package_entry.py
@@ -5,9 +5,9 @@ import sys
 from collections.abc import Iterable, Sequence
 from types import ModuleType
 
+from dagster_shared.error import DagsterError
 from dagster_shared.serdes.objects import EnvRegistryKey
 
-from dagster._core.errors import DagsterError
 from dagster.components.utils import format_error_message
 
 PACKAGE_ENTRY_ATTR = "__dg_package_entry__"

--- a/python_modules/dagster/dagster/components/lib/executable_component/function_component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/function_component.py
@@ -112,7 +112,7 @@ class FunctionComponent(ExecutableComponent):
         return self.execute_fn_metadata.resource_keys
 
     @cached_property
-    def config_fields(self) -> Optional[dict[str, Field]]:
+    def config_fields(self) -> Optional[dict[str, Field]]:  # type: ignore  # (pyright complains it is @cached_property but not @property)
         return self.execute_fn_metadata.config_fields
 
     @property

--- a/python_modules/dagster/dagster/components/utils.py
+++ b/python_modules/dagster/dagster/components/utils.py
@@ -10,11 +10,11 @@ from types import ModuleType
 from typing import Any, TypeVar, Union
 
 import click
+from dagster_shared.error import DagsterError
 from pydantic import BaseModel
 
 from dagster import _check as check
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.errors import DagsterError
 from dagster.components.resolved.context import ResolutionContext
 from dagster.components.resolved.core_models import (
     AssetAttributesModel,

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -20,8 +20,8 @@ from dagster._core.definitions.decorators.sensor_decorator import sensor
 from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
 from dagster._core.definitions.sensor_definition import RunRequest
-from dagster._core.errors import DagsterError
 from dagster._core.storage.tags import EXTERNAL_JOB_SOURCE_TAG_KEY
+from dagster_shared.error import DagsterError
 
 
 @op

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_async.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_async.py
@@ -4,9 +4,9 @@ from contextlib import asynccontextmanager
 import pytest
 from dagster import ConfigurableResource, Output, asset, materialize
 from dagster._core.definitions.decorators import op
-from dagster._core.errors import DagsterError
 from dagster._core.execution.context.invocation import build_asset_context, build_op_context
 from dagster._utils.test import wrap_op_in_graph_and_execute
+from dagster_shared.error import DagsterError
 from pydantic import PrivateAttr
 
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/airflow_instance.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/airflow_instance.py
@@ -7,8 +7,8 @@ from typing import Any, Optional
 import requests
 from dagster._annotations import beta, public
 from dagster._core.definitions.utils import check_valid_name
-from dagster._core.errors import DagsterError
 from dagster._time import get_current_datetime
+from dagster_shared.error import DagsterError
 
 from dagster_airlift.core.filter import AirflowFilter
 from dagster_airlift.core.runtime_representations import DagRun, TaskInstance

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/integration_tests/test_airflow_instance.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/integration_tests/test_airflow_instance.py
@@ -1,9 +1,9 @@
 import datetime
 
 import pytest
-from dagster._core.errors import DagsterError
 from dagster_airlift.core import AirflowBasicAuthBackend, AirflowInstance
 from dagster_airlift.core.filter import AirflowFilter
+from dagster_shared.error import DagsterError
 
 from dagster_airlift_tests.integration_tests.conftest import assert_link_exists
 

--- a/python_modules/libraries/dagster-shared/dagster_shared/error.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/error.py
@@ -8,6 +8,18 @@ from typing_extensions import Self
 from dagster_shared.serdes.serdes import whitelist_for_serdes
 
 
+class DagsterError(Exception):
+    """Base class for all errors thrown by the Dagster framework.
+
+    Users should not subclass this base class for their own exceptions.
+    """
+
+    @property
+    def is_user_code_error(self):
+        """Returns true if this error is attributable to user code."""
+        return False
+
+
 # TODO: Eventually we need to move the rest of the code in dagster._utils.error into dagster_shared,
 # but that is a significant refactor. Currently we're just moving SerializableErrorInfo so that we
 # can use it with the dg packages`.

--- a/python_modules/libraries/dagstermill/dagstermill/errors.py
+++ b/python_modules/libraries/dagstermill/dagstermill/errors.py
@@ -1,4 +1,4 @@
-from dagster._core.errors import DagsterError
+from dagster_shared.error import DagsterError
 
 
 class DagstermillError(DagsterError):


### PR DESCRIPTION
## Summary & Motivation

This will allow utilities in dagster-shared, or code in any of our packages, to throw `DagsterError`.

## How I Tested These Changes

Existing test suite.