### PR TITLE
[dg] Make scaffold defs scaffolder params more clear

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_custom_help_format.py
@@ -198,10 +198,11 @@ def test_dynamic_subcommand_help_message():
                 │ *    instance_name      TEXT  [required]                                                                             │
                 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-                │ --json-params          TEXT           JSON string of component parameters.                                           │
                 │ --format               [yaml|python]  Format of the component configuration (yaml or python)                         │
-                │ --asset-key            TEXT           asset_key                                                                      │
-                │ --filename             TEXT           filename                                                                       │
+                │ --json-params          TEXT           JSON string of scaffolder parameters. Mutually exclusive with passing          │
+                │                                       individual parameters as options.                                              │
+                │ --asset-key            TEXT           (scaffolder param) asset_key                                                   │
+                │ --filename             TEXT           (scaffolder param) filename                                                    │
                 │ --help         -h                     Show this message and exit.                                                    │
                 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                 ╭─ Global options ─────────────────────────────────────────────────────────────────────────────────────────────────────╮

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
@@ -103,6 +103,27 @@ def test_scaffold_defs_component_no_params_success(in_workspace: bool) -> None:
         )
 
 
+def test_scaffold_defs_component_json_params_only_for_scaffold_params() -> None:
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
+        # SimplePipesScriptComponent has scaffold params, so --json-params should be defined
+        result = runner.invoke(
+            "scaffold", "defs", "dagster_test.components.SimplePipesScriptComponent", "--help"
+        )
+        assert_runner_result(result)
+        assert "--json-params" in result.output
+
+        # AllMetadataEmptyComponent does not have scaffold params, so --json-params should not be
+        # defined
+        result = runner.invoke(
+            "scaffold", "defs", "dagster_test.components.AllMetadataEmptyComponent", "--help"
+        )
+        assert_runner_result(result)
+        assert "--json-params" not in result.output
+
+
 @pytest.mark.parametrize(
     "selection",
     ["", "y", "n", "a"],

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/__init__.py
@@ -425,13 +425,13 @@ def json_schema_property_to_click_option(
     # Handle object type fields as JSON strings
     if field_type == "object":
         option_type = str  # JSON string input
-        help_text = f"{key} (JSON string)"
+        help_text = f"[scaffolder parameter] {key} (JSON string)"
         callback = parse_json_option
 
     # Handle other basic types
     else:
         option_type = _JSON_SCHEMA_TYPE_TO_CLICK_TYPE[field_type]
-        help_text = key
+        help_text = f"(scaffolder param) {key}"
         callback = None
 
     return click.Option(


### PR DESCRIPTION
## Summary & Motivation

Some adjustment to `scaffold defs` parameters for clarity:

- Improve help text of `--json-params` to make clear it is about SCAFFOLDER params, not component params.
- Currently `--json-params` is added to all subcommands. This is confusing when there are no actual scaffolder params. Only add `--json-params` if scaffolder params exist.
- Explicitly mark options that are scaffolder parameters in the help text by preceding with `(scaffolder param)`

Before:

<img width="825" alt="image" src="https://github.com/user-attachments/assets/09710fef-5f38-4f35-9d2a-14c0afa39dbe" />

After:

<img width="825" alt="image" src="https://github.com/user-attachments/assets/25f2e76e-6221-4fe3-afc1-5945c0384e40" />

## How I Tested These Changes

Existing test suite.