### PR TITLE
[dg] Improve scaffold defs validation error output (BUILD-1224)

### DIFF
--- a/python_modules/dagster/dagster/components/component_scaffolding.py
+++ b/python_modules/dagster/dagster/components/component_scaffolding.py
@@ -74,10 +74,6 @@ def scaffold_object(
 ) -> None:
     from dagster.components.component.component import Component
 
-    click.echo(f"Creating a component at {path}.")
-    if not path.exists():
-        path.mkdir(parents=True)
-
     key = EnvRegistryKey.from_typename(typename)
     obj = load_package_object(key)
 
@@ -94,6 +90,10 @@ def scaffold_object(
     )
 
     params_model = parse_params_model(obj=obj, json_params=json_params)
+
+    click.echo(f"Creating a component at {path}.")
+    if not path.exists():
+        path.mkdir(parents=True)
 
     scaffolder.scaffold(
         ScaffoldRequest(

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
@@ -85,6 +85,44 @@ def test_scaffold_defs_classname_conflict_no_alias() -> None:
             assert f"type: {full_type}" in defs_yaml_path.read_text()
 
 
+def test_scaffold_defs_validation_failure() -> None:
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        isolated_example_project_foo_bar(runner),
+    ):
+        result = runner.invoke(
+            "scaffold", "defs", "dagster_test.components.SimplePipesScriptComponent", "qux"
+        )
+        assert_runner_result(result, exit_0=False)
+        assert (
+            result.output.strip()
+            == textwrap.dedent("""
+            Error validating scaffold parameters for `dagster_test.components.SimplePipesScriptComponent`:
+
+            [
+                {
+                    "type": "missing",
+                    "loc": [
+                        "asset_key"
+                    ],
+                    "msg": "Field required",
+                    "input": {},
+                    "url": "https://errors.pydantic.dev/2.11/v/missing"
+                },
+                {
+                    "type": "missing",
+                    "loc": [
+                        "filename"
+                    ],
+                    "msg": "Field required",
+                    "input": {},
+                    "url": "https://errors.pydantic.dev/2.11/v/missing"
+                }
+            ]
+        """).strip()
+        )
+
+
 @pytest.mark.parametrize("in_workspace", [True, False])
 def test_scaffold_defs_component_no_params_success(in_workspace: bool) -> None:
     with (


### PR DESCRIPTION
## Summary & Motivation

Catch validation errors in scaffolding params and print nice output.

Before:

<img width="825" alt="image" src="https://github.com/user-attachments/assets/dfa6d3e0-f843-4a42-8c18-b888a16f4ade" />

After:

<img width="825" alt="image" src="https://github.com/user-attachments/assets/e54e6e7c-4ffc-42db-862c-a5f85aba13dc" />


## How I Tested These Changes

New unit test

## Changelog

A clean and informative error message is now printed when an invalid set of parameters is passed to `dg scaffold defs ...`.
