### PR TITLE
Don't allow users to apply a null freshness policy to assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -20,6 +20,7 @@ from dagster._annotations import (
     only_allow_hidden_params_in_kwargs,
     public,
 )
+from dagster._check import checked
 from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.declarative_automation.automation_condition import (
@@ -457,6 +458,7 @@ def map_asset_specs(
     ]
 
 
+@checked
 def attach_internal_freshness_policy(
     spec: AssetSpec, policy: InternalFreshnessPolicy, overwrite_existing=True
 ) -> AssetSpec:

--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -50,7 +50,7 @@ class InternalFreshnessPolicy(ABC):
         cls, metadata: Mapping[str, Any]
     ) -> Optional["InternalFreshnessPolicy"]:
         serialized_policy = metadata.get(INTERNAL_FRESHNESS_POLICY_METADATA_KEY)
-        if serialized_policy is None:
+        if serialized_policy is None or serialized_policy == "null":
             return None
         return deserialize_value(serialized_policy.value, cls)  # pyright: ignore
 

--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -50,6 +50,10 @@ class InternalFreshnessPolicy(ABC):
         cls, metadata: Mapping[str, Any]
     ) -> Optional["InternalFreshnessPolicy"]:
         serialized_policy = metadata.get(INTERNAL_FRESHNESS_POLICY_METADATA_KEY)
+
+        # We had a few asset spec metadatas with internal freshness policies set to literal "null" string,
+        # need special handling for those cases.
+        # https://github.com/dagster-io/dagster/pull/30615
         if serialized_policy is None or serialized_policy == "null":
             return None
         return deserialize_value(serialized_policy.value, cls)  # pyright: ignore

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 import pytest
 from dagster import AssetKey, AssetsDefinition, AssetSpec, Definitions
-from dagster._check import CheckError
+from dagster._check import CheckError, ParameterCheckError
 from dagster._core.definitions.asset_spec import attach_internal_freshness_policy
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.freshness import (
@@ -17,6 +17,26 @@ from dagster_shared.serdes.utils import SerializableTimeDelta
 from dagster_tests.core_tests.host_representation_tests.test_external_data import (
     _get_asset_node_snaps_from_definitions,
 )
+
+
+class TestAttachInternalFreshnessPolicy:
+    def test_attach_internal_freshness_policy_explicit_none_fails(self) -> None:
+        """Check that we cannot apply a null policy to assets."""
+
+        @asset
+        def asset_no_freshness():
+            pass
+
+        defs = Definitions(assets=[asset_no_freshness])
+
+        with pytest.raises(ParameterCheckError):
+            defs.map_asset_specs(
+                func=lambda spec: attach_internal_freshness_policy(
+                    spec,
+                    None,
+                    overwrite_existing=False,
+                )
+            )
 
 
 class TestTimeWindowFreshnessPolicy:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
@@ -19,6 +19,14 @@ from dagster_tests.core_tests.host_representation_tests.test_external_data impor
 )
 
 
+class TestInternalFreshnessPolicy:
+    def test_internal_freshness_policy_from_asset_spec_metadata_handles_null(self) -> None:
+        """Special case handling for asset metadata that was set to "null" string literal."""
+        metadata = {"internal_freshness_policy": "null"}
+        policy = InternalFreshnessPolicy.from_asset_spec_metadata(metadata)
+        assert policy is None
+
+
 class TestAttachInternalFreshnessPolicy:
     def test_attach_internal_freshness_policy_explicit_none_fails(self) -> None:
         """Check that we cannot apply a null policy to assets."""

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
@@ -41,7 +41,7 @@ class TestAttachInternalFreshnessPolicy:
             defs.map_asset_specs(
                 func=lambda spec: attach_internal_freshness_policy(
                     spec,
-                    None,
+                    None,  # pyright: ignore[reportArgumentType]
                     overwrite_existing=False,
                 )
             )


### PR DESCRIPTION
## Summary & Motivation
To resolve 500s in prod for design partners: https://dagsterlabs.slack.com/archives/C03F99LCHM4/p1749511791789919

Previously user code could pass `None` as the policy to `attach_internal_freshness_policy`, which would serialize to a string literal `"null"`, resulting in 500s when the `AssetNode` attempts to deserialize it to an `InternalFreshnessPolicy`.

Solution is to add explicit runtime type checking to  `attach_internal_freshness_policy`.

Also adds special case handling for asset spec metadata that already has "null" literal for the freshness policy.

## How I Tested These Changes
unit tests that:
- explicitly try to apply a `None` freshness policy
- cover special handling for metadata with "null" literal freshness policy

## Changelog

> Insert changelog entry or delete this section.
