### PR TITLE
Don't fail the build if `make wipe` fails

### DIFF
--- a/python_modules/libraries/dagster-dbt/kitchen-sink/Makefile
+++ b/python_modules/libraries/dagster-dbt/kitchen-sink/Makefile
@@ -24,4 +24,4 @@ run_dagster:
 	dagster dev -m dagster_dbt_cloud_kitchen_sink.defs -p 3333
 
 wipe: ## Wipe out all the files created by the Makefile
-	rm -rf $(DAGSTER_HOME)
+	- rm -rf $(DAGSTER_HOME)


### PR DESCRIPTION
kitchen sink is occassionally failing builds - I think because it can't do test fixture teardown.

Which is kind of a bummer because we can't use our typical mute tooling to get around it as easily (other than muting the entire build step).

But I just don't think this cleanup is that important. The dash should tell make to suppress any errors during this command.

https://www.gnu.org/software/make/manual/html_node/Errors.html

https://buildkite.com/dagster/dagster-dagster/builds/125669#01975abf-306b-4c80-a35f-ebd50f261f59/525-1428