### PR TITLE
[refactor][tests] Unify asset customization testing into util

### DIFF
--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -8,7 +8,6 @@ import textwrap
 from pathlib import Path
 from typing import Callable
 
-import pytest
 import yaml
 from dagster_shared import check
 
@@ -34,6 +33,18 @@ from dagster.components.core.defs_module import (
     load_yaml_component_from_path,
 )
 from dagster.components.scaffold.scaffold import ScaffoldFormatOptions
+
+try:
+    import pytest  # type: ignore
+except ImportError:
+
+    class pytest:
+        @staticmethod
+        def fixture(*args, **kwargs) -> Callable:
+            def wrapper(fn):
+                return fn
+
+            return wrapper
 
 
 def component_defs(

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -475,9 +475,9 @@ class TestTranslation:
                 None,
             ),
             (
-                {"deps": ["customers"]},
+                {"deps": ["nonexistent"]},
                 lambda asset_spec: len(asset_spec.deps) == 1
-                and asset_spec.deps[0].asset_key == AssetKey("customers"),
+                and asset_spec.deps[0].asset_key == AssetKey("nonexistent"),
                 None,
             ),
             (

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -434,25 +434,21 @@ class TestTranslation:
             (
                 {"group_name": "group"},
                 lambda asset_spec: asset_spec.group_name == "group",
-                False,
                 None,
             ),
             (
                 {"owners": ["team:analytics"]},
                 lambda asset_spec: asset_spec.owners == ["team:analytics"],
-                False,
                 None,
             ),
             (
                 {"tags": {"foo": "bar"}},
                 lambda asset_spec: asset_spec.tags.get("foo") == "bar",
-                False,
                 None,
             ),
             (
                 {"kinds": ["snowflake", "dbt"]},
                 lambda asset_spec: "snowflake" in asset_spec.kinds and "dbt" in asset_spec.kinds,
-                False,
                 None,
             ),
             (
@@ -460,45 +456,38 @@ class TestTranslation:
                 lambda asset_spec: "snowflake" in asset_spec.kinds
                 and "dbt" in asset_spec.kinds
                 and asset_spec.tags.get("foo") == "bar",
-                False,
                 None,
             ),
-            ({"code_version": "1"}, lambda asset_spec: asset_spec.code_version == "1", False, None),
+            ({"code_version": "1"}, lambda asset_spec: asset_spec.code_version == "1", None),
             (
                 {"description": "some description"},
                 lambda asset_spec: asset_spec.description == "some description",
-                False,
                 None,
             ),
             (
                 {"metadata": {"foo": "bar"}},
                 lambda asset_spec: asset_spec.metadata.get("foo") == "bar",
-                False,
                 None,
             ),
             (
                 {"deps": ["customers"]},
                 lambda asset_spec: len(asset_spec.deps) == 1
                 and asset_spec.deps[0].asset_key == AssetKey("customers"),
-                False,
                 None,
             ),
             (
                 {"automation_condition": "{{ automation_condition.eager() }}"},
                 lambda asset_spec: asset_spec.automation_condition is not None,
-                False,
                 None,
             ),
             (
                 {"key": "{{ spec.key.to_user_string() + '_suffix' }}"},
                 lambda asset_spec: asset_spec.key.path[-1].endswith("_suffix"),
-                False,
                 lambda key: AssetKey(path=key.path[:-1] + [f"{key.path[-1]}_suffix"]),
             ),
             (
                 {"key_prefix": "cool_prefix"},
                 lambda asset_spec: asset_spec.key.has_prefix(["cool_prefix"]),
-                False,
                 lambda key: AssetKey(path=["cool_prefix"] + key.path),
             ),
         ],
@@ -527,10 +516,6 @@ class TestTranslation:
     @pytest.fixture
     def assertion(self, translation_params):
         return translation_params[1]
-
-    @pytest.fixture
-    def should_error(self, translation_params):
-        return translation_params[2]
 
     @pytest.fixture
     def key_modifier(self, translation_params):

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -524,4 +524,4 @@ class TestTranslation:
 
     @pytest.fixture
     def key_modifier(self, translation_params):
-        return translation_params[3]
+        return translation_params[2]

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -34,6 +34,8 @@ from dagster.components.core.defs_module import (
 )
 from dagster.components.scaffold.scaffold import ScaffoldFormatOptions
 
+# Unfortunate hack - we only use this util in pytest tests, we just drop in a no-op
+# implementation if pytest is not installed.
 try:
     import pytest  # type: ignore
 except ImportError:

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -429,6 +429,11 @@ def copy_code_to_file(fn: Callable, file_path: Path) -> None:
 
 
 class TestTranslation:
+    """Pytest test class for testing translation of asset attributes. You can subclass
+    this class and implement a test_translation function using the various fixtures in
+    order to comprehensively test asset translation options for your component.
+    """
+
     @pytest.fixture(
         params=[
             (

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
@@ -15,7 +15,7 @@ from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
 from dagster._utils.env import environ
 from dagster.components import ComponentLoadContext
-from dagster.components.testing import scaffold_defs_sandbox
+from dagster.components.testing import TestTranslation, scaffold_defs_sandbox
 from dagster_airbyte.components.workspace_component.component import AirbyteCloudWorkspaceComponent
 from dagster_airbyte.resources import AirbyteCloudWorkspace
 from dagster_airbyte.translator import AirbyteConnection
@@ -164,108 +164,38 @@ def test_custom_filter_fn_python(
     assert len(defs.resolve_asset_graph().get_all_asset_keys()) == num_assets
 
 
-@pytest.mark.parametrize(
-    "attributes, assertion, should_error",
-    [
-        ({"group_name": "group"}, lambda asset_spec: asset_spec.group_name == "group", False),
-        (
-            {"owners": ["team:analytics"]},
-            lambda asset_spec: asset_spec.owners == ["team:analytics"],
-            False,
-        ),
-        ({"tags": {"foo": "bar"}}, lambda asset_spec: asset_spec.tags.get("foo") == "bar", False),
-        (
-            {"kinds": ["snowflake", "airbyte"]},
-            lambda asset_spec: "snowflake" in asset_spec.kinds and "airbyte" in asset_spec.kinds,
-            False,
-        ),
-        (
-            {"tags": {"foo": "bar"}, "kinds": ["snowflake", "airbyte"]},
-            lambda asset_spec: "snowflake" in asset_spec.kinds
-            and "airbyte" in asset_spec.kinds
-            and asset_spec.tags.get("foo") == "bar",
-            False,
-        ),
-        ({"code_version": "1"}, lambda asset_spec: asset_spec.code_version == "1", False),
-        (
-            {"description": "some description"},
-            lambda asset_spec: asset_spec.description == "some description",
-            False,
-        ),
-        (
-            {"metadata": {"foo": "bar"}},
-            lambda asset_spec: asset_spec.metadata.get("foo") == "bar",
-            False,
-        ),
-        (
-            {"deps": ["customers"]},
-            lambda asset_spec: len(asset_spec.deps) == 1
-            and asset_spec.deps[0].asset_key == AssetKey("customers"),
-            False,
-        ),
-        (
-            {"automation_condition": "{{ automation_condition.eager() }}"},
-            lambda asset_spec: asset_spec.automation_condition is not None,
-            False,
-        ),
-        (
-            {"key": "{{ spec.key.to_user_string() + '_suffix' }}"},
-            lambda asset_spec: asset_spec.key == AssetKey(["test_prefix_test_stream_suffix"]),
-            False,
-        ),
-        (
-            {"key_prefix": "cool_prefix"},
-            lambda asset_spec: asset_spec.key.has_prefix(["cool_prefix"]),
-            False,
-        ),
-    ],
-    ids=[
-        "group_name",
-        "owners",
-        "tags",
-        "kinds",
-        "tags-and-kinds",
-        "code-version",
-        "description",
-        "metadata",
-        "deps",
-        "automation_condition",
-        "key",
-        "key_prefix",
-    ],
-)
-def test_translation(
-    fetch_workspace_data_api_mocks,
-    attributes: Mapping[str, Any],
-    assertion: Optional[Callable[[AssetSpec], bool]],
-    should_error: bool,
-) -> None:
-    wrapper = pytest.raises(Exception) if should_error else nullcontext()
-    with wrapper:
-        body = copy.deepcopy(BASIC_AIRBYTE_COMPONENT_BODY)
-        body["attributes"]["translation"] = attributes
-        with (
-            environ(
-                {
-                    "AIRBYTE_CLIENT_ID": TEST_CLIENT_ID,
-                    "AIRBYTE_CLIENT_SECRET": TEST_CLIENT_SECRET,
-                    "AIRBYTE_WORKSPACE_ID": TEST_WORKSPACE_ID,
-                }
-            ),
-            setup_airbyte_component(
-                component_body=body,
-            ) as (
-                component,
-                defs,
-            ),
-        ):
-            if "key" in attributes:
-                key = AssetKey(["test_prefix_test_stream_suffix"])
-            elif "key_prefix" in attributes:
-                key = AssetKey(["cool_prefix", "test_prefix_test_stream"])
-            else:
+class TestAirbyteTranslation(TestTranslation):
+    def test_translation(
+        self,
+        fetch_workspace_data_api_mocks,
+        attributes: Mapping[str, Any],
+        assertion: Optional[Callable[[AssetSpec], bool]],
+        should_error: bool,
+        key_modifier: Optional[Callable[[AssetKey], AssetKey]],
+    ) -> None:
+        wrapper = pytest.raises(Exception) if should_error else nullcontext()
+        with wrapper:
+            body = copy.deepcopy(BASIC_AIRBYTE_COMPONENT_BODY)
+            body["attributes"]["translation"] = attributes
+            with (
+                environ(
+                    {
+                        "AIRBYTE_CLIENT_ID": TEST_CLIENT_ID,
+                        "AIRBYTE_CLIENT_SECRET": TEST_CLIENT_SECRET,
+                        "AIRBYTE_WORKSPACE_ID": TEST_WORKSPACE_ID,
+                    }
+                ),
+                setup_airbyte_component(
+                    component_body=body,
+                ) as (
+                    component,
+                    defs,
+                ),
+            ):
                 key = AssetKey(["test_prefix_test_stream"])
+                if key_modifier:
+                    key = key_modifier(key)
 
-            assets_def = defs.get_assets_def(key)
-            if assertion:
-                assert assertion(assets_def.get_asset_spec(key))
+                assets_def = defs.get_assets_def(key)
+                if assertion:
+                    assert assertion(assets_def.get_asset_spec(key))

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
@@ -169,7 +169,7 @@ class TestAirbyteTranslation(TestTranslation):
         self,
         fetch_workspace_data_api_mocks,
         attributes: Mapping[str, Any],
-        assertion: Optional[Callable[[AssetSpec], bool]],
+        assertion: Callable[[AssetSpec], bool],
         key_modifier: Optional[Callable[[AssetKey], AssetKey]],
     ) -> None:
         body = copy.deepcopy(BASIC_AIRBYTE_COMPONENT_BODY)
@@ -194,5 +194,4 @@ class TestAirbyteTranslation(TestTranslation):
                 key = key_modifier(key)
 
             assets_def = defs.get_assets_def(key)
-            if assertion:
-                assert assertion(assets_def.get_asset_spec(key))
+            assert assertion(assets_def.get_asset_spec(key))

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -173,7 +173,7 @@ class TestDbtTranslation(TestTranslation):
         self,
         dbt_path: Path,
         attributes: Mapping[str, Any],
-        assertion: Optional[Callable[[AssetSpec], bool]],
+        assertion: Callable[[AssetSpec], bool],
         key_modifier: Optional[Callable[[AssetKey], AssetKey]],
     ) -> None:
         defs = build_component_defs_for_test(
@@ -189,8 +189,7 @@ class TestDbtTranslation(TestTranslation):
             key = key_modifier(key)
 
         assets_def = defs.resolve_assets_def(key)
-        if assertion:
-            assert assertion(assets_def.get_asset_spec(key))
+        assert assertion(assets_def.get_asset_spec(key))
 
 
 def test_subselection(dbt_path: Path) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -2,7 +2,6 @@ import shutil
 import sys
 import tempfile
 from collections.abc import Iterator, Mapping
-from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -21,6 +20,7 @@ from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.load_defs import build_component_defs
 from dagster.components.resolved.core_models import AssetAttributesModel
 from dagster.components.resolved.errors import ResolutionException
+from dagster.components.testing import TestTranslation
 from dagster_dbt import DbtProject, DbtProjectComponent
 from dagster_dbt.cli.app import project_app_typer_click_object
 from dagster_dbt.components.dbt_project.component import get_projects_from_dbt_component
@@ -151,7 +151,11 @@ def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
     class DebugDbtProjectComponent(DbtProjectComponent):
         @classmethod
         def get_additional_scope(cls) -> Mapping[str, Any]:
-            return {"get_tags_for_node": lambda node: {"model_id": node["name"].replace("_", "-")}}
+            return {
+                "get_tags_for_node": lambda node: {
+                    "model_id": str(node.get("name", "")).replace("_", "-")
+                }
+            }
 
     defs = build_component_defs_for_test(
         DebugDbtProjectComponent,
@@ -164,81 +168,14 @@ def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
     assert assets_def.get_asset_spec(AssetKey("stg_customers")).tags["model_id"] == "stg-customers"
 
 
-@pytest.mark.parametrize(
-    "attributes, assertion, should_error",
-    [
-        ({"group_name": "group"}, lambda asset_spec: asset_spec.group_name == "group", False),
-        (
-            {"owners": ["team:analytics"]},
-            lambda asset_spec: asset_spec.owners == ["team:analytics"],
-            False,
-        ),
-        ({"tags": {"foo": "bar"}}, lambda asset_spec: asset_spec.tags.get("foo") == "bar", False),
-        (
-            {"kinds": ["snowflake", "dbt"]},
-            lambda asset_spec: "snowflake" in asset_spec.kinds and "dbt" in asset_spec.kinds,
-            False,
-        ),
-        (
-            {"tags": {"foo": "bar"}, "kinds": ["snowflake", "dbt"]},
-            lambda asset_spec: "snowflake" in asset_spec.kinds
-            and "dbt" in asset_spec.kinds
-            and asset_spec.tags.get("foo") == "bar",
-            False,
-        ),
-        ({"code_version": "1"}, lambda asset_spec: asset_spec.code_version == "1", False),
-        (
-            {"description": "some description"},
-            lambda asset_spec: asset_spec.description == "some description",
-            False,
-        ),
-        (
-            {"metadata": {"foo": "bar"}},
-            lambda asset_spec: asset_spec.metadata.get("foo") == "bar"
-            and "dagster-dbt/materialization_type"
-            in asset_spec.metadata,  # Ensure dagster-dbt populated metadata is not overwritten
-            False,
-        ),
-        ({"deps": ["customers"]}, None, True),
-        (
-            {"automation_condition": "{{ automation_condition.eager() }}"},
-            lambda asset_spec: asset_spec.automation_condition is not None,
-            False,
-        ),
-        (
-            {"key": "{{ node.name }}_suffix"},
-            lambda asset_spec: asset_spec.key == AssetKey("stg_customers_suffix"),
-            False,
-        ),
-        (
-            {"key_prefix": "cool_prefix"},
-            lambda asset_spec: asset_spec.key.has_prefix(["cool_prefix"]),
-            False,
-        ),
-    ],
-    ids=[
-        "group_name",
-        "owners",
-        "tags",
-        "kinds",
-        "tags-and-kinds",
-        "code-version",
-        "description",
-        "metadata",
-        "deps",
-        "automation_condition",
-        "key",
-        "key_prefix",
-    ],
-)
-def test_asset_attributes(
-    dbt_path: Path,
-    attributes: Mapping[str, Any],
-    assertion: Optional[Callable[[AssetSpec], bool]],
-    should_error: bool,
-) -> None:
-    wrapper = pytest.raises(Exception) if should_error else nullcontext()
-    with wrapper:
+class TestDbtTranslation(TestTranslation):
+    def test_translation(
+        self,
+        dbt_path: Path,
+        attributes: Mapping[str, Any],
+        assertion: Optional[Callable[[AssetSpec], bool]],
+        key_modifier: Optional[Callable[[AssetKey], AssetKey]],
+    ) -> None:
         defs = build_component_defs_for_test(
             DbtProjectComponent,
             {
@@ -246,33 +183,14 @@ def test_asset_attributes(
                 "translation": attributes,
             },
         )
-        if "key" in attributes:
-            key = AssetKey("stg_customers_suffix")
-        elif "key_prefix" in attributes:
-            key = AssetKey(["cool_prefix", "stg_customers"])
-        else:
-            key = AssetKey("stg_customers")
-            assert defs.resolve_asset_graph().get_all_asset_keys() == JAFFLE_SHOP_KEYS
+        key = AssetKey("stg_customers")
+
+        if key_modifier:
+            key = key_modifier(key)
 
         assets_def = defs.resolve_assets_def(key)
         if assertion:
             assert assertion(assets_def.get_asset_spec(key))
-
-
-IGNORED_KEYS = {"skippable"}
-
-
-def test_asset_attributes_is_comprehensive():
-    all_asset_attribute_keys = []
-    for test_arg in test_asset_attributes.pytestmark[0].args[1]:  # pyright: ignore[reportFunctionMemberAccess]
-        all_asset_attribute_keys.extend(test_arg[0].keys())
-    from dagster.components.resolved.core_models import AssetAttributesModel
-
-    assert set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS == set(
-        all_asset_attribute_keys
-    ), (
-        f"The test_asset_attributes test does not cover all fields, missing: {set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS - set(all_asset_attribute_keys)}"
-    )
 
 
 def test_subselection(dbt_path: Path) -> None:

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -1,6 +1,5 @@
 # ruff: noqa: F841 TID252
 
-import copy
 import inspect
 import subprocess
 import textwrap
@@ -19,6 +18,7 @@ from dagster._utils.env import environ
 from dagster.components.testing import TestTranslation, scaffold_defs_sandbox
 from dagster_dlt import DagsterDltResource, DltLoadCollectionComponent
 from dagster_dlt.components.dlt_load_collection.component import DltLoadSpecModel
+from dagster_tests.components_tests.utils import build_component_defs_for_test
 
 if TYPE_CHECKING:
     from dagster._core.definitions.assets import AssetsDefinition
@@ -207,30 +207,29 @@ def test_component_load_multiple_pipelines() -> None:
 class TestDltTranslation(TestTranslation):
     def test_translation(
         self,
+        dlt_pipeline: Pipeline,
         attributes: Mapping[str, Any],
-        assertion: Optional[Callable[[AssetSpec], bool]],
+        assertion: Callable[[AssetSpec], bool],
         key_modifier: Optional[Callable[[AssetKey], AssetKey]],
     ) -> None:
-        body = copy.deepcopy(BASIC_GITHUB_COMPONENT_BODY)
-        body["attributes"]["loads"][0]["translation"] = attributes
-        with (
-            environ({"SOURCES__ACCESS_TOKEN": "fake"}),
-            setup_dlt_component(
-                load_py_contents=github_load,
-                component_body=body,
-                setup_dlt_sources=lambda: dlt_init("github", "snowflake"),
-            ) as (
-                component,
-                defs,
-            ),
-        ):
-            key = AssetKey(["duckdb_issues", "issues"])
-            if key_modifier:
-                key = key_modifier(key)
+        defs = build_component_defs_for_test(
+            DltLoadCollectionComponent,
+            {
+                "loads": [
+                    {
+                        "source": dlt_source(),
+                        "pipeline": dlt_pipeline,
+                        "translation": attributes,
+                    }
+                ],
+            },
+        )
+        key = AssetKey("input_duckdb")
+        if key_modifier:
+            key = key_modifier(key)
 
-            assets_def = defs.resolve_assets_def(key)
-            if assertion:
-                assert assertion(assets_def.get_asset_spec(key))
+        assets_def = defs.resolve_assets_def(key)
+        assert assertion(assets_def.get_asset_spec(key))
 
 
 def test_python_interface(dlt_pipeline: Pipeline):

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -16,7 +16,7 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils import pushd
 from dagster._utils.env import environ
-from dagster.components.testing import scaffold_defs_sandbox
+from dagster.components.testing import TestTranslation, scaffold_defs_sandbox
 from dagster_dlt import DagsterDltResource, DltLoadCollectionComponent
 from dagster_dlt.components.dlt_load_collection.component import DltLoadSpecModel
 
@@ -204,106 +204,36 @@ def test_component_load_multiple_pipelines() -> None:
         }
 
 
-@pytest.mark.parametrize(
-    "attributes, assertion, should_error",
-    [
-        ({"group_name": "group"}, lambda asset_spec: asset_spec.group_name == "group", False),
-        (
-            {"owners": ["team:analytics"]},
-            lambda asset_spec: asset_spec.owners == ["team:analytics"],
-            False,
-        ),
-        ({"tags": {"foo": "bar"}}, lambda asset_spec: asset_spec.tags.get("foo") == "bar", False),
-        (
-            {"kinds": ["snowflake", "dbt"]},
-            lambda asset_spec: "snowflake" in asset_spec.kinds and "dbt" in asset_spec.kinds,
-            False,
-        ),
-        (
-            {"tags": {"foo": "bar"}, "kinds": ["snowflake", "dbt"]},
-            lambda asset_spec: "snowflake" in asset_spec.kinds
-            and "dbt" in asset_spec.kinds
-            and asset_spec.tags.get("foo") == "bar",
-            False,
-        ),
-        ({"code_version": "1"}, lambda asset_spec: asset_spec.code_version == "1", False),
-        (
-            {"description": "some description"},
-            lambda asset_spec: asset_spec.description == "some description",
-            False,
-        ),
-        (
-            {"metadata": {"foo": "bar"}},
-            lambda asset_spec: asset_spec.metadata.get("foo") == "bar",
-            False,
-        ),
-        (
-            {"deps": ["customers"]},
-            lambda asset_spec: len(asset_spec.deps) == 1
-            and asset_spec.deps[0].asset_key == AssetKey("customers"),
-            False,
-        ),
-        (
-            {"automation_condition": "{{ automation_condition.eager() }}"},
-            lambda asset_spec: asset_spec.automation_condition is not None,
-            False,
-        ),
-        (
-            {"key": "{{ spec.key.to_user_string() + '_suffix' }}"},
-            lambda asset_spec: asset_spec.key == AssetKey(["duckdb_issues", "issues_suffix"]),
-            False,
-        ),
-        (
-            {"key_prefix": "cool_prefix"},
-            lambda asset_spec: asset_spec.key.has_prefix(["cool_prefix"]),
-            False,
-        ),
-    ],
-    ids=[
-        "group_name",
-        "owners",
-        "tags",
-        "kinds",
-        "tags-and-kinds",
-        "code-version",
-        "description",
-        "metadata",
-        "deps",
-        "automation_condition",
-        "key",
-        "key_prefix",
-    ],
-)
-def test_translation(
-    attributes: Mapping[str, Any],
-    assertion: Optional[Callable[[AssetSpec], bool]],
-    should_error: bool,
-) -> None:
-    wrapper = pytest.raises(Exception) if should_error else nullcontext()
-    with wrapper:
-        body = copy.deepcopy(BASIC_GITHUB_COMPONENT_BODY)
-        body["attributes"]["loads"][0]["translation"] = attributes
-        with (
-            environ({"SOURCES__ACCESS_TOKEN": "fake"}),
-            setup_dlt_component(
-                load_py_contents=github_load,
-                component_body=body,
-                setup_dlt_sources=lambda: dlt_init("github", "snowflake"),
-            ) as (
-                component,
-                defs,
-            ),
-        ):
-            if "key" in attributes:
-                key = AssetKey(["duckdb_issues", "issues_suffix"])
-            elif "key_prefix" in attributes:
-                key = AssetKey(["cool_prefix", "duckdb_issues", "issues"])
-            else:
+class TestDltTranslation(TestTranslation):
+    def test_translation(
+        self,
+        attributes: Mapping[str, Any],
+        assertion: Optional[Callable[[AssetSpec], bool]],
+        should_error: bool,
+        key_modifier: Optional[Callable[[AssetKey], AssetKey]],
+    ) -> None:
+        wrapper = pytest.raises(Exception) if should_error else nullcontext()
+        with wrapper:
+            body = copy.deepcopy(BASIC_GITHUB_COMPONENT_BODY)
+            body["attributes"]["loads"][0]["translation"] = attributes
+            with (
+                environ({"SOURCES__ACCESS_TOKEN": "fake"}),
+                setup_dlt_component(
+                    load_py_contents=github_load,
+                    component_body=body,
+                    setup_dlt_sources=lambda: dlt_init("github", "snowflake"),
+                ) as (
+                    component,
+                    defs,
+                ),
+            ):
                 key = AssetKey(["duckdb_issues", "issues"])
+                if key_modifier:
+                    key = key_modifier(key)
 
-            assets_def = defs.resolve_assets_def(key)
-            if assertion:
-                assert assertion(assets_def.get_asset_spec(key))
+                assets_def = defs.resolve_assets_def(key)
+                if assertion:
+                    assert assertion(assets_def.get_asset_spec(key))
 
 
 def test_python_interface(dlt_pipeline: Pipeline):

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -2,7 +2,7 @@
 
 import copy
 from collections.abc import Iterator, Mapping
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from typing import Any, Callable, Optional
 
 import pytest
@@ -172,35 +172,32 @@ class TestFivetranTranslation(TestTranslation):
         fetch_workspace_data_multiple_connectors_mocks,
         attributes: Mapping[str, Any],
         assertion: Optional[Callable[[AssetSpec], bool]],
-        should_error: bool,
         key_modifier: Optional[Callable[[AssetKey], AssetKey]],
     ) -> None:
-        wrapper = pytest.raises(Exception) if should_error else nullcontext()
-        with wrapper:
-            body = copy.deepcopy(BASIC_FIVETRAN_COMPONENT_BODY)
-            body["attributes"]["translation"] = attributes
-            with (
-                environ(
-                    {
-                        "FIVETRAN_API_KEY": TEST_API_KEY,
-                        "FIVETRAN_API_SECRET": TEST_API_SECRET,
-                        "FIVETRAN_ACCOUNT_ID": TEST_ACCOUNT_ID,
-                    }
-                ),
-                setup_fivetran_component(
-                    component_body=body,
-                ) as (
-                    component,
-                    defs,
-                ),
-            ):
-                key = AssetKey(["schema_name_in_destination_1", "table_name_in_destination_1"])
-                if key_modifier:
-                    key = key_modifier(key)
+        body = copy.deepcopy(BASIC_FIVETRAN_COMPONENT_BODY)
+        body["attributes"]["translation"] = attributes
+        with (
+            environ(
+                {
+                    "FIVETRAN_API_KEY": TEST_API_KEY,
+                    "FIVETRAN_API_SECRET": TEST_API_SECRET,
+                    "FIVETRAN_ACCOUNT_ID": TEST_ACCOUNT_ID,
+                }
+            ),
+            setup_fivetran_component(
+                component_body=body,
+            ) as (
+                component,
+                defs,
+            ),
+        ):
+            key = AssetKey(["schema_name_in_destination_1", "table_name_in_destination_1"])
+            if key_modifier:
+                key = key_modifier(key)
 
-                assets_def = defs.resolve_assets_def(key)
-                if assertion:
-                    assert assertion(assets_def.get_asset_spec(key))
+            assets_def = defs.resolve_assets_def(key)
+            if assertion:
+                assert assertion(assets_def.get_asset_spec(key))
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -171,7 +171,7 @@ class TestFivetranTranslation(TestTranslation):
         self,
         fetch_workspace_data_multiple_connectors_mocks,
         attributes: Mapping[str, Any],
-        assertion: Optional[Callable[[AssetSpec], bool]],
+        assertion: Callable[[AssetSpec], bool],
         key_modifier: Optional[Callable[[AssetKey], AssetKey]],
     ) -> None:
         body = copy.deepcopy(BASIC_FIVETRAN_COMPONENT_BODY)
@@ -196,8 +196,7 @@ class TestFivetranTranslation(TestTranslation):
                 key = key_modifier(key)
 
             assets_def = defs.resolve_assets_def(key)
-            if assertion:
-                assert assertion(assets_def.get_asset_spec(key))
+            assert assertion(assets_def.get_asset_spec(key))
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -1,7 +1,7 @@
 import shutil
 import tempfile
 from collections.abc import Iterator, Mapping
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
@@ -23,7 +23,6 @@ from dagster._core.instance_for_test import instance_for_test
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
 from dagster._utils.env import environ
-from dagster.components.resolved.context import ResolutionException
 from dagster.components.resolved.core_models import AssetAttributesModel
 from dagster.components.testing import (
     TestTranslation,
@@ -197,16 +196,11 @@ class TestSlingTranslation(TestTranslation):
         self,
         attributes: Mapping[str, Any],
         assertion: Optional[Callable[[AssetSpec], bool]],
-        should_error: bool,
         key_modifier: Optional[Callable[[AssetKey], AssetKey]],
     ) -> None:
-        wrapper = pytest.raises(ResolutionException) if should_error else nullcontext()
-        with (
-            wrapper,
-            temp_sling_component_instance(
-                [{"path": "./replication.yaml", "translation": attributes}]
-            ) as (component, defs),
-        ):
+        with temp_sling_component_instance(
+            [{"path": "./replication.yaml", "translation": attributes}]
+        ) as (component, defs):
             key = AssetKey("input_duckdb")
             if key_modifier:
                 key = key_modifier(key)

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -25,7 +25,11 @@ from dagster._utils import alter_sys_path
 from dagster._utils.env import environ
 from dagster.components.resolved.context import ResolutionException
 from dagster.components.resolved.core_models import AssetAttributesModel
-from dagster.components.testing import get_underlying_component, scaffold_defs_sandbox
+from dagster.components.testing import (
+    TestTranslation,
+    get_underlying_component,
+    scaffold_defs_sandbox,
+)
 from dagster_shared import check
 from dagster_sling import SlingReplicationCollectionComponent, SlingResource
 
@@ -188,106 +192,28 @@ def test_sling_subclass() -> None:
     }
 
 
-@pytest.mark.parametrize(
-    "attributes, assertion, should_error",
-    [
-        ({"group_name": "group"}, lambda asset_spec: asset_spec.group_name == "group", False),
-        (
-            {"owners": ["team:analytics"]},
-            lambda asset_spec: asset_spec.owners == ["team:analytics"],
-            False,
-        ),
-        ({"tags": {"foo": "bar"}}, lambda asset_spec: asset_spec.tags.get("foo") == "bar", False),
-        ({"kinds": ["snowflake"]}, lambda asset_spec: "snowflake" in asset_spec.kinds, False),
-        (
-            {"tags": {"foo": "bar"}, "kinds": ["snowflake"]},
-            lambda asset_spec: "snowflake" in asset_spec.kinds
-            and asset_spec.tags.get("foo") == "bar",
-            False,
-        ),
-        ({"code_version": "1"}, lambda asset_spec: asset_spec.code_version == "1", False),
-        (
-            {"description": "some description"},
-            lambda asset_spec: asset_spec.description == "some description",
-            False,
-        ),
-        (
-            {"metadata": {"foo": "bar"}},
-            lambda asset_spec: asset_spec.metadata.get("foo") == "bar",
-            False,
-        ),
-        (
-            {"deps": ["customers"]},
-            lambda asset_spec: {dep.asset_key for dep in asset_spec.deps}
-            == {AssetKey("customers")},
-            False,
-        ),
-        (
-            {"automation_condition": "{{ automation_condition.eager() }}"},
-            lambda asset_spec: asset_spec.automation_condition is not None,
-            False,
-        ),
-        (
-            {"key": "overridden_key"},
-            lambda asset_spec: asset_spec.key == AssetKey("overridden_key"),
-            False,
-        ),
-        (
-            {"key_prefix": "overridden_prefix"},
-            lambda asset_spec: asset_spec.key.has_prefix(["overridden_prefix"]),
-            False,
-        ),
-    ],
-    ids=[
-        "group_name",
-        "owners",
-        "tags",
-        "kinds",
-        "tags-and-kinds",
-        "code-version",
-        "description",
-        "metadata",
-        "deps",
-        "automation_condition",
-        "key",
-        "key_prefix",
-    ],
-)
-def test_translation(
-    attributes: Mapping[str, Any],
-    assertion: Optional[Callable[[AssetSpec], bool]],
-    should_error: bool,
-) -> None:
-    wrapper = pytest.raises(ResolutionException) if should_error else nullcontext()
-    with (
-        wrapper,
-        temp_sling_component_instance(
-            [{"path": "./replication.yaml", "translation": attributes}]
-        ) as (component, defs),
-    ):
-        key = AssetKey(attributes.get("key", "input_duckdb"))
-        if attributes.get("key_prefix"):
-            key = key.with_prefix(attributes["key_prefix"])
+class TestSlingTranslation(TestTranslation):
+    def test_translation(
+        self,
+        attributes: Mapping[str, Any],
+        assertion: Optional[Callable[[AssetSpec], bool]],
+        should_error: bool,
+        key_modifier: Optional[Callable[[AssetKey], AssetKey]],
+    ) -> None:
+        wrapper = pytest.raises(ResolutionException) if should_error else nullcontext()
+        with (
+            wrapper,
+            temp_sling_component_instance(
+                [{"path": "./replication.yaml", "translation": attributes}]
+            ) as (component, defs),
+        ):
+            key = AssetKey("input_duckdb")
+            if key_modifier:
+                key = key_modifier(key)
 
-        assets_def: AssetsDefinition = defs.resolve_assets_def(key)
-    if assertion:
-        assert assertion(assets_def.get_asset_spec(key))
-
-
-IGNORED_KEYS = {"skippable"}
-
-
-def test_translation_is_comprehensive():
-    all_asset_attribute_keys = []
-    for test_arg in test_translation.pytestmark[0].args[1]:  # pyright: ignore[reportFunctionMemberAccess]
-        all_asset_attribute_keys.extend(test_arg[0].keys())
-    from dagster.components.resolved.core_models import AssetAttributesModel
-
-    assert set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS == set(
-        all_asset_attribute_keys
-    ), (
-        f"The test_translation test does not cover all fields, missing: {set(AssetAttributesModel.model_fields.keys()) - IGNORED_KEYS - set(all_asset_attribute_keys)}"
-    )
+            assets_def: AssetsDefinition = defs.resolve_assets_def(key)
+            if assertion:
+                assert assertion(assets_def.get_asset_spec(key))
 
 
 def test_scaffold_sling():

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -195,19 +195,22 @@ class TestSlingTranslation(TestTranslation):
     def test_translation(
         self,
         attributes: Mapping[str, Any],
-        assertion: Optional[Callable[[AssetSpec], bool]],
+        assertion: Callable[[AssetSpec], bool],
         key_modifier: Optional[Callable[[AssetKey], AssetKey]],
     ) -> None:
-        with temp_sling_component_instance(
-            [{"path": "./replication.yaml", "translation": attributes}]
-        ) as (component, defs):
-            key = AssetKey("input_duckdb")
-            if key_modifier:
-                key = key_modifier(key)
+        defs = build_component_defs_for_test(
+            SlingReplicationCollectionComponent,
+            {
+                "sling": {},
+                "replications": [{"path": str(REPLICATION_PATH), "translation": attributes}],
+            },
+        )
+        key = AssetKey("input_duckdb")
+        if key_modifier:
+            key = key_modifier(key)
 
-            assets_def: AssetsDefinition = defs.resolve_assets_def(key)
-            if assertion:
-                assert assertion(assets_def.get_asset_spec(key))
+        assets_def = defs.resolve_assets_def(key)
+        assert assertion(assets_def.get_asset_spec(key))
 
 
 def test_scaffold_sling():


### PR DESCRIPTION
## Summary

We replicate a huge list of test parameters between each of our component tests to validate that customizing assets works as expected.
This PR moves this param list to a shared pytest class which component authors can then subclass.
