### PR TITLE
[dg] fix docs snippets env var

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/9-dg-component-check.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/9-dg-component-check.txt
@@ -1,10 +1,10 @@
 dg check yaml
 
 /.../ingestion/src/ingestion/defs/ingest_files/defs.yaml:1 - requirements.env Component uses environment variables that are not specified in the component file: SNOWFLAKE_ACCOUNT, SNOWFLAKE_DATABASE, SNOWFLAKE_PASSWORD, SNOWFLAKE_USER
-     |
+     | 
    1 | type: dagster_sling.SlingReplicationCollectionComponent
      | ^ Component uses environment variables that are not specified in the component file: SNOWFLAKE_ACCOUNT, SNOWFLAKE_DATABASE, SNOWFLAKE_PASSWORD, SNOWFLAKE_USER
-   2 |
+   2 | 
    3 | attributes:
    4 |   sling:
    5 |     connections:

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/component.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/component.py
@@ -220,9 +220,10 @@ def get_used_env_vars(data_structure: Union[Mapping[str, Any], Sequence[Any], An
     if isinstance(data_structure, Mapping):
         return set.union(set(), *(get_used_env_vars(value) for value in data_structure.values()))
     elif isinstance(data_structure, str):
-        return set(env_var_regex.findall(data_structure)).union(
+        raw_result = set(env_var_regex.findall(data_structure)).union(
             set(env_var_regex_dot_notation.findall(data_structure))
         )
+        return {var.strip() for var in raw_result}
     elif isinstance(data_structure, Sequence):
         return set.union(set(), *(get_used_env_vars(item) for item in data_structure))
     else:


### PR DESCRIPTION
## Summary & Motivation

The env var discovery regex is matching strings with trailing whitespace, leading to a snippets test failure.

## How I Tested These Changes

Existing test suite.