### PR TITLE
[dg] Make `dg scaffold defs` work for arbitrary valid refs

### DIFF
--- a/python_modules/dagster/dagster/components/component_scaffolding.py
+++ b/python_modules/dagster/dagster/components/component_scaffolding.py
@@ -7,9 +7,9 @@ import click
 import yaml
 from dagster_shared import check
 from dagster_shared.serdes.objects import EnvRegistryKey
+from dagster_shared.seven import load_module_object
 from pydantic import BaseModel, TypeAdapter
 
-from dagster.components.core.package_entry import load_package_object
 from dagster.components.scaffold.scaffold import (
     NoParams,
     ScaffolderUnavailableReason,
@@ -75,7 +75,7 @@ def scaffold_object(
     from dagster.components.component.component import Component
 
     key = EnvRegistryKey.from_typename(typename)
-    obj = load_package_object(key)
+    obj = load_module_object(key.namespace, key.name)
 
     scaffolder = get_scaffolder(obj)
 

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -8,6 +8,7 @@ from typing import Any, Optional, TypeVar, Union
 
 from dagster_shared.record import record
 from dagster_shared.serdes.objects import EnvRegistryKey
+from dagster_shared.seven import load_module_object
 from dagster_shared.yaml_utils import parse_yamls_with_source_position
 from dagster_shared.yaml_utils.source_position import SourcePosition, ValueAndSourcePositionTree
 from pydantic import BaseModel, ConfigDict, TypeAdapter
@@ -33,7 +34,6 @@ from dagster.components.component.component import Component
 from dagster.components.component.component_loader import is_component_loader
 from dagster.components.component.template_vars import find_inline_template_vars_in_module
 from dagster.components.core.context import ComponentLoadContext
-from dagster.components.core.package_entry import load_package_object
 from dagster.components.definitions import LazyDefinitions
 from dagster.components.resolved.base import Resolvable
 from dagster.components.resolved.context import ResolutionContext
@@ -522,7 +522,7 @@ def load_yaml_component_from_path(context: ComponentLoadContext, component_def_p
 
 def get_package_obj_for_type(type_str: str) -> type[Component]:
     key = EnvRegistryKey.from_typename(type_str)
-    obj = load_package_object(key)
+    obj = load_module_object(key.namespace, key.name)
     if not isinstance(obj, type) or not issubclass(obj, Component):
         raise DagsterInvalidDefinitionError(
             f"Component type {type_str} is of type {type(obj)}, but must be a subclass of dagster.Component"

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
@@ -20,7 +20,7 @@ from dagster_dg_core.utils import (
     DgClickCommand,
     DgClickGroup,
     exit_with_error,
-    generate_missing_plugin_object_error_message,
+    generate_missing_registry_object_error_message,
 )
 from dagster_dg_core.utils.editor import (
     install_or_update_yaml_schema_extension,
@@ -159,7 +159,7 @@ def inspect_component_type_command(
     registry = EnvRegistry.from_dg_context(dg_context)
     component_key = EnvRegistryKey.from_typename(component_type)
     if not registry.has(component_key):
-        exit_with_error(generate_missing_plugin_object_error_message(component_type))
+        exit_with_error(generate_missing_registry_object_error_message(component_type))
     elif sum([description, scaffold_params_schema, component_schema]) > 1:
         exit_with_error(
             "Only one of --description, --scaffold-params-schema, and --component-schema can be specified."

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_integrity.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_integrity.py
@@ -2,7 +2,10 @@ import shutil
 import subprocess
 
 from dagster_dg_cli.cli import cli
-from dagster_dg_core.utils import DgClickCommand, DgClickGroup
+from dagster_dg_core.utils import DgClickCommand, DgClickGroup, ensure_dagster_dg_tests_import
+
+ensure_dagster_dg_tests_import()
+
 from dagster_dg_core_tests.utils import ProxyRunner, isolated_dg_venv
 
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_utils_inspect_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_utils_inspect_command.py
@@ -203,4 +203,4 @@ def test_utils_inspect_component_type_undefined_component_type_fails() -> None:
             "fake.Fake",
         )
         assert_runner_result(result, exit_0=False)
-        assert "No plugin object `fake.Fake` is registered" in result.output
+        assert "No registry object `fake.Fake` is registered" in result.output

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/__init__.py
@@ -289,11 +289,11 @@ def format_multiline_str(message: str) -> str:
     return "\n\n".join(paragraphs)
 
 
-def generate_missing_plugin_object_error_message(plugin_object_key: str) -> str:
+def generate_missing_registry_object_error_message(registry_object_key: str) -> str:
     return f"""
-        No plugin object `{plugin_object_key}` is registered. Use `dg list components`
-        to see the registered plugin objects in your environment. You may need to install a package
-        that provides `{plugin_object_key}` into your environment.
+        No registry object `{registry_object_key}` is registered. Use `dg list components`
+        to see the registered objects in your environment. You may need to install a package
+        that provides `{registry_object_key}` into your environment.
     """
 
 

--- a/python_modules/libraries/dagster-shared/dagster_shared/error.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/error.py
@@ -20,6 +20,10 @@ class DagsterError(Exception):
         return False
 
 
+class DagsterUnresolvableSymbolError(DagsterError):
+    """Exception raised when a Python symbol reference can't be resolved."""
+
+
 # TODO: Eventually we need to move the rest of the code in dagster._utils.error into dagster_shared,
 # but that is a significant refactor. Currently we're just moving SerializableErrorInfo so that we
 # can use it with the dg packages`.

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/package_entry.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/package_entry.py
@@ -32,6 +32,15 @@ class EnvRegistryKey:
         return f"{self.namespace}.{self.name}"
 
     @staticmethod
+    def is_valid_typename(typename: str) -> bool:
+        """Check if the typename is valid."""
+        try:
+            EnvRegistryKey.from_typename(typename)
+            return True
+        except ValueError:
+            return False
+
+    @staticmethod
     def from_typename(typename: str) -> "EnvRegistryKey":
         parts = typename.split(".")
         for part in parts:
@@ -77,7 +86,7 @@ class ScaffoldTargetTypeData(EnvRegistryObjectFeatureData):
 
 
 ###############
-# PLUGIN MANIFEST
+# ENV REGISTRY MANIFEST
 ###############
 
 

--- a/python_modules/libraries/dagster-shared/dagster_shared/seven/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/seven/__init__.py
@@ -226,6 +226,18 @@ def is_valid_module_pattern(pattern: str) -> bool:
 
 
 def load_module_object(module_name: str, attr: str) -> object:
+    """Loads a top-level attribute from a module.
+
+    Args:
+        module_name: The name of the module to load the attribute from.
+        attr: The name of the attribute to load.
+
+    Returns:
+        The attribute value.
+
+    Raises:
+        DagsterUnresolvableSymbolError: If the module or attribute is not found.
+    """
     from dagster_shared.error import DagsterUnresolvableSymbolError
 
     try:

--- a/python_modules/libraries/dagster-shared/dagster_shared/seven/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/seven/__init__.py
@@ -223,3 +223,19 @@ def is_valid_module_pattern(pattern: str) -> bool:
             return False
 
     return True
+
+
+def load_module_object(module_name: str, attr: str) -> object:
+    from dagster_shared.error import DagsterUnresolvableSymbolError
+
+    try:
+        module = importlib.import_module(module_name)
+        if not hasattr(module, attr):
+            raise DagsterUnresolvableSymbolError(
+                f"Module `{module_name}` has no attribute `{attr}`."
+            )
+        return getattr(module, attr)
+    except ModuleNotFoundError as e:
+        raise DagsterUnresolvableSymbolError(f"Module `{module_name}` not found.") from e
+    except ImportError as e:
+        raise DagsterUnresolvableSymbolError(f"Error loading module `{module_name}`.") from e


### PR DESCRIPTION
## Summary & Motivation

Currently `dg scaffold defs <ref>` only works for registered objects (or their aliases, or substring matches). This is part of the legacy of having a registry sourced from out-of-process.

This PR introduces on the fly dynamic subcommand resolution. If the user passes:

```
dg scaffold defs some.component.SomeComponent
```

It will work as long as it is a valid python reference to a scaffoldable object in the environment (though we still rely on the registry when listing available subcommands).

This will allow removal of the `EnvRegistryObjectSnap` layer upstack.

## How I Tested These Changes

New unit test