### PR TITLE
add the support of cross-region worker tasks for ecs run launcher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ filterwarnings = [
 timeout = 240
 addopts = "-ra --force-flaky --max-runs=2 --no-success-flaky-report"
 
+# quick fix to suppress warning in tests https://github.com/pytest-dev/pytest-asyncio/issues/924#issuecomment-2321921915
+asyncio_default_fixture_loop_scope = "function"
+
 # ########################
 # ##### RUFF
 # ########################

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
@@ -5,6 +5,7 @@ from dagster import (
     Array,
     BoolSource,
     Field,
+    Map,
     Noneable,
     Permissive,
     Shape,
@@ -168,6 +169,36 @@ ECS_CONTAINER_CONTEXT_SCHEMA = {
         StringSource,
         is_required=False,
         description="Name of the container in the task definition to use to run Dagster code.",
+    ),
+    "regional": Field(
+        Map(
+            key_type=str,
+            inner_type=Shape(
+                {
+                    "cluster": Field(
+                        StringSource, is_required=True, description="ARN of the ECS cluster."
+                    ),
+                    "subnets": Field(
+                        Array(StringSource),
+                        is_required=True,
+                        description="List of subnet IDs (at least one required).",
+                    ),
+                    "security_groups": Field(
+                        Array(StringSource),
+                        is_required=True,
+                        description="List of security group IDs (at least one required).",
+                    ),
+                    "assign_public_ip": Field(
+                        StringSource,
+                        is_required=False,
+                        default_value="DISABLED",
+                        description="Whether to request the assignment of public IP.",
+                    ),
+                }
+            ),
+        ),
+        is_required=False,
+        description="Per-region cluster configuration. Each key must be an AWS region name.",
     ),
     "server_resources": Field(
         Permissive(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/conftest.py
@@ -11,8 +11,23 @@ def region():
 
 
 @pytest.fixture
+def xregion():
+    return "eu-central-1"
+
+
+@pytest.fixture
+def xregion_cluster_arn():
+    return "xregion-cluster-arn"
+
+
+@pytest.fixture
 def ecs(region):
     return ThreadsafeStubbedEcs(region_name=region)
+
+
+@pytest.fixture
+def ecs_xregion(xregion):
+    return ThreadsafeStubbedEcs(region_name=xregion)
 
 
 @pytest.fixture

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -217,6 +217,29 @@ def instance_dont_use_current_task(
 
 
 @pytest.fixture
+def instance_regional(
+    instance_cm: Callable[..., ContextManager[DagsterInstance]],
+    subnet,
+    security_group,
+    xregion,
+    xregion_cluster_arn,
+) -> Iterator[DagsterInstance]:
+    with instance_cm(
+        config={
+            "regional": {
+                xregion: {
+                    "cluster": xregion_cluster_arn,
+                    "subnets": [subnet.id],
+                    "security_groups": [security_group.id],
+                    "assign_public_ip": "DISABLED",
+                }
+            }
+        }
+    ) as dagster_instance:
+        yield dagster_instance
+
+
+@pytest.fixture
 def instance_fargate_spot(
     instance_cm: Callable[..., ContextManager[DagsterInstance]],
 ) -> Iterator[DagsterInstance]:

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_termination.py
@@ -1,7 +1,40 @@
 from dagster import DagsterRunStatus
+from dagster._core.definitions.job_definition import JobDefinition
+from dagster._core.remote_representation.external import RemoteJob
+from dagster._core.test_utils import in_process_test_workspace
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+
+from dagster_aws_tests.ecs_tests.launcher_tests import repo
 
 
 def test_termination(instance, workspace, run):
+    instance.launch_run(run.run_id, workspace)
+
+    assert instance.run_launcher.terminate(run.run_id)
+
+    assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.CANCELING
+
+    assert not instance.run_launcher.terminate(run.run_id)
+
+
+def test_termination_xregion(
+    instance_regional, workspace, job: JobDefinition, remote_job: RemoteJob, image: str, xregion
+):
+    instance = instance_regional
+    run = instance.create_run_for_job(
+        job,
+        remote_job_origin=remote_job.get_remote_origin(),
+        job_code_origin=remote_job.get_python_origin(),
+        tags={"region": xregion},
+    )
+    workspace = in_process_test_workspace(
+        instance,
+        loadable_target_origin=LoadableTargetOrigin(
+            python_file=repo.__file__,
+            attribute=repo.repository.name,
+        ),
+        container_image=image,
+    )
     instance.launch_run(run.run_id, workspace)
 
     assert instance.run_launcher.terminate(run.run_id)


### PR DESCRIPTION
add the support of cross-region worker tasks for ecs run launcher with cluster configuration via dagster.yaml

## Summary & Motivation

This feature is needed for following use case: a dagster deployment in a single region while it is needed to do compute in several other regions (because of proximity to data storage).

In this PR, a separate field `regional` holds details needed to launch a new task in the different region. 
Please note that this PR has temporary `xregion_hardcode` tag which is triggers injection of the regional configuration for testing in our prod-like setup, and needed because patched config cannot be loaded in the similar way as run launcher config can be (via module and class in dagster.yaml).

Also, in separate version of PR, I am trying to pass all needed config via `ecs/*` tags, so no new/separate field like `regional` would be needed. 

Maintainers' opinion would be invaluable to understand if or which the direction is right 🙏 

Example of the config below:
```
ECS_CONTAINER_CONTEXT_SCHEMA['regional'] = 
Field(
        Map(
            key_type=str,
            inner_type=Shape(
                {
                    "cluster": Field(
                        StringSource, is_required=True, description="ARN of the ECS cluster."
                    ),
                    "subnets": Field(
                        Array(StringSource),
                        is_required=True,
                        description="List of subnet IDs (at least one required).",
                    ),
                    "security_groups": Field(
                        Array(StringSource),
                        is_required=True,
                        description="List of security group IDs (at least one required).",
                    ),
                    "assign_public_ip": Field(
                        StringSource,
                        is_required=False,
                        default_value="DISABLED",
                        description="Whether to request the assignment of public IP.",
                    ),
                }
            )
        ),
```

## How I Tested These Changes

There are tests for launching and terminating cross-region tasks. Also I did manual testing. Tasks are successfully launched in the requested region, with logging, health worker status and termination.

