### PR TITLE
Add autoload module defs property to dagster-cloud-cli

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationRowSet.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationRowSet.tsx
@@ -82,7 +82,11 @@ export const ModuleOrPackageOrFile = ({
   metadata: WorkspaceDisplayMetadataFragment[];
 }) => {
   const imageKV = metadata.find(
-    ({key}) => key === 'module_name' || key === 'package_name' || key === 'python_file',
+    ({key}) =>
+      key === 'module_name' ||
+      key === 'package_name' ||
+      key === 'python_file' ||
+      key === 'autoload_defs_module_name',
   );
   if (imageKV) {
     return (

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/workspace/__init__.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/workspace/__init__.py
@@ -24,25 +24,6 @@ DEFAULT_LOCATIONS_YAML_FILENAME = "locations.yaml"
 app = Typer(help="Manage your Dagster Cloud workspace.")
 
 
-def _get_location_input(location: str, kwargs: dict[str, Any]) -> gql.CliInputCodeLocation:
-    python_file = kwargs.get("python_file")
-
-    return gql.CliInputCodeLocation(
-        name=location,
-        python_file=str(python_file) if python_file else None,
-        package_name=kwargs.get("package_name"),
-        image=kwargs.get("image"),
-        module_name=kwargs.get("module_name"),
-        working_directory=kwargs.get("working_directory"),
-        executable_path=kwargs.get("executable_path"),
-        attribute=kwargs.get("attribute"),
-        commit_hash=(
-            kwargs["git"].get("commit_hash") if "git" in kwargs else kwargs.get("commit_hash")
-        ),
-        url=kwargs["git"].get("url") if "git" in kwargs else kwargs.get("git_url"),
-    )
-
-
 def _add_or_update_location(
     client: DagsterCloudGraphQLClient,
     location_document: dict[str, Any],
@@ -333,7 +314,8 @@ def format_workspace_config(workspace_config) -> dict[str, Any]:
             new_location = {
                 k: v
                 for k, v in location.items()
-                if k not in ("python_file", "package_name", "module_name")
+                if k
+                not in ("python_file", "package_name", "module_name", "autoload_defs_module_name")
             }
             new_location["code_source"] = {}
             if "python_file" in location:
@@ -342,9 +324,9 @@ def format_workspace_config(workspace_config) -> dict[str, Any]:
                 new_location["code_source"]["package_name"] = location["package_name"]
             if "module_name" in location:
                 new_location["code_source"]["module_name"] = location["module_name"]
-            if "autodefs_module_name" in location:
-                new_location["code_source"]["autodefs_module_name"] = location[
-                    "autodefs_module_name"
+            if "autoload_defs_module_name" in location:
+                new_location["code_source"]["autoload_defs_module_name"] = location[
+                    "autoload_defs_module_name"
                 ]
 
             new_location["location_name"] = name

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/config/models.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/config/models.py
@@ -10,6 +10,7 @@ class CodeSource(BaseModel, extra="forbid"):
     package_name: Optional[str] = None
     module_name: Optional[str] = None
     python_file: Optional[str] = None
+    autoload_defs_module_name: Optional[str] = None
 
     @model_validator(mode="before")
     def exactly_one_source_defined(
@@ -21,7 +22,9 @@ class CodeSource(BaseModel, extra="forbid"):
                 "only one of the following fields should be defined: " + ", ".join(defined)
             )
         elif not defined:
-            raise ValueError("one of package_name, module_name and python_file must be specified")
+            raise ValueError(
+                "one of package_name, module_name, python_file, or autoload_defs_module_name must be specified"
+            )
         return values
 
 

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/workspace.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/workspace.py
@@ -82,6 +82,7 @@ class CodeLocationDeployData(
             ("cloud_context_env", dict[str, Any]),
             ("pex_metadata", Optional[PexMetadata]),
             ("agent_queue", Optional[AgentQueue]),
+            ("autoload_defs_module_name", Optional[str]),
         ],
     )
 ):
@@ -99,10 +100,18 @@ class CodeLocationDeployData(
         cloud_context_env=None,
         pex_metadata=None,
         agent_queue=None,
+        autoload_defs_module_name=None,
     ):
         check.invariant(
-            len([val for val in [python_file, package_name, module_name] if val]) == 1,
-            "Must supply exactly one of a file name, a package name, or a module name",
+            len(
+                [
+                    val
+                    for val in [python_file, package_name, module_name, autoload_defs_module_name]
+                    if val
+                ]
+            )
+            == 1,
+            "Must supply exactly one of python_file, package_name, module_name, or autoload_defs_module_name.",
         )
 
         return super().__new__(
@@ -119,6 +128,7 @@ class CodeLocationDeployData(
             check.opt_dict_param(cloud_context_env, "cloud_context_env", key_type=str),
             check.opt_inst_param(pex_metadata, "pex_metadata", PexMetadata),
             check.opt_str_param(agent_queue, "agent_queue"),
+            check.opt_str_param(autoload_defs_module_name, "autoload_defs_module_name"),
         )
 
     def with_cloud_context_env(self, cloud_context_env: dict[str, Any]) -> "CodeLocationDeployData":


### PR DESCRIPTION
## Summary & Motivation
Add the argument to the client and data model classes used by the dagster-cloud and dg clis.

## How I Tested These Changes
New test case, deploy a local autodefs module

## Changelog
Fixed an issue where dg projects using autoload_defs=true could not be deployed to Dagster+.
