### PR TITLE
[helm] Made the PostgreSQL Secret Key Changeable

### DIFF
--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -93,7 +93,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" . | quote }}
-                  key: postgresql-password
+                  key: {{ .Values.global.postgresqlSecretKey }}
             # This is a list by default, but for backcompat it can be a map. As
             # a map it's written to the webserver-env configmap.
             {{- if and ($_.Values.dagsterWebserver.env) (kindIs "slice" $_.Values.dagsterWebserver.env) }}

--- a/helm/dagster/templates/secret-postgres.yaml
+++ b/helm/dagster/templates/secret-postgres.yaml
@@ -11,6 +11,6 @@ metadata:
 type: Opaque
 data:
   {{- if not (empty .Values.postgresql) }}
-  postgresql-password: "{{ .Values.postgresql.postgresqlPassword | b64enc }}"
+  {{ .Values.global.postgresqlSecretKey }}: "{{ .Values.postgresql.postgresqlPassword | b64enc }}"
   {{- end }}
 {{ end }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1200,6 +1200,10 @@
                     "title": "Postgresqlsecretname",
                     "type": "string"
                 },
+                "postgresqlSecretKey": {
+                    "title": "Postgresqlsecretkey",
+                    "type": "string"
+                },
                 "dagsterHome": {
                     "title": "Dagsterhome",
                     "type": "string"
@@ -1215,6 +1219,7 @@
             },
             "required": [
                 "postgresqlSecretName",
+                "postgresqlSecretKey",
                 "dagsterHome",
                 "serviceAccountName",
                 "celeryConfigSecretName"

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -6,6 +6,8 @@
 ---
 global:
   postgresqlSecretName: "dagster-postgresql-secret"
+  postgresqlSecretKey: "postgresql-password"
+
   # The DAGSTER_HOME env var is set by default on all nodes from this value
   dagsterHome: "/opt/dagster/dagster_home"
 


### PR DESCRIPTION
## Summary & Motivation

This PR updates the Helm Chart to allow the PostgreSQL key to be editable. This is done, so that externally created secrets can use a different key than `postgresql-password` - this also makes it possible to use secrets that automatically created by other services such as CloudNativePG (uses just `password` for the key).

## How I Tested These Changes



## Changelog

> Insert changelog entry or delete this section.
