### PR TITLE
[dagster-fivetran] Move snapshot_path to FivetranWorkspace

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -23,7 +23,7 @@ from dagster import (
     get_dagster_logger,
     resource,
 )
-from dagster._annotations import beta_param, deprecated, public
+from dagster._annotations import deprecated, public
 from dagster._config.pythonic_config import ConfigurableResource
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
@@ -936,6 +936,13 @@ class FivetranWorkspace(ConfigurableResource):
     account_id: str = Field(description="The Fivetran account ID.")
     api_key: str = Field(description="The Fivetran API key to use for this resource.")
     api_secret: str = Field(description="The Fivetran API secret to use for this resource.")
+    snapshot_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Path to a snapshot file to load Fivetran data from,"
+            "rather than fetching it from the Fivetran API."
+        ),
+    )
     request_max_retries: int = Field(
         default=3,
         description=(
@@ -1053,13 +1060,11 @@ class FivetranWorkspace(ConfigurableResource):
             workspace=self, translator=DagsterFivetranTranslator()
         ).get_or_fetch_state()
 
-    @beta_param(param="snapshot_path")
     @cached_method
     def load_asset_specs(
         self,
         dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
         connector_selector_fn: Optional[ConnectorSelectorFn] = None,
-        snapshot_path: Optional[Union[str, Path]] = None,
     ) -> Sequence[AssetSpec]:
         """Returns a list of AssetSpecs representing the Fivetran content in the workspace.
 
@@ -1069,8 +1074,6 @@ class FivetranWorkspace(ConfigurableResource):
                 Defaults to :py:class:`DagsterFivetranTranslator`.
             connector_selector_fn (Optional[ConnectorSelectorFn]):
                 A function that allows for filtering which Fivetran connector assets are created for.
-            snapshot_path (Optional[Union[str, Path]]): Path to a snapshot file to load Fivetran data from,
-                rather than fetching it from the Fivetran API.
 
         Returns:
             List[AssetSpec]: The set of assets representing the Fivetran content in the workspace.
@@ -1095,8 +1098,8 @@ class FivetranWorkspace(ConfigurableResource):
         dagster_fivetran_translator = dagster_fivetran_translator or DagsterFivetranTranslator()
 
         snapshot = None
-        if snapshot_path and not os.getenv(FIVETRAN_SNAPSHOT_ENV_VAR_NAME):
-            snapshot = deserialize_value(Path(snapshot_path).read_text(), RepositoryLoadData)
+        if self.snapshot_path and not os.getenv(FIVETRAN_SNAPSHOT_ENV_VAR_NAME):
+            snapshot = deserialize_value(Path(self.snapshot_path).read_text(), RepositoryLoadData)
 
         with self.process_config_and_initialize_cm() as initialized_workspace:
             return [
@@ -1239,12 +1242,10 @@ class FivetranWorkspace(ConfigurableResource):
             context.log.warning(f"Assets were not materialized: {unmaterialized_asset_keys}")
 
 
-@beta_param(param="snapshot_path")
 def load_fivetran_asset_specs(
     workspace: FivetranWorkspace,
     dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
     connector_selector_fn: Optional[ConnectorSelectorFn] = None,
-    snapshot_path: Optional[Union[str, Path]] = None,
 ) -> Sequence[AssetSpec]:
     """Returns a list of AssetSpecs representing the Fivetran content in the workspace.
 
@@ -1255,8 +1256,6 @@ def load_fivetran_asset_specs(
             Defaults to :py:class:`DagsterFivetranTranslator`.
         connector_selector_fn (Optional[ConnectorSelectorFn]):
                 A function that allows for filtering which Fivetran connector assets are created for.
-        snapshot_path (Optional[Union[str, Path]]): Path to a snapshot file to load Fivetran data from,
-            rather than fetching it from the Fivetran API.
 
     Returns:
         List[AssetSpec]: The set of assets representing the Fivetran content in the workspace.
@@ -1282,7 +1281,6 @@ def load_fivetran_asset_specs(
     return workspace.load_asset_specs(
         dagster_fivetran_translator=dagster_fivetran_translator,
         connector_selector_fn=connector_selector_fn,
-        snapshot_path=snapshot_path,
     )
 
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/pending_repo_snapshot.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/pending_repo_snapshot.py
@@ -5,11 +5,15 @@ from dagster_fivetran import FivetranWorkspace, load_fivetran_asset_specs
 
 from dagster_fivetran_tests.conftest import TEST_ACCOUNT_ID, TEST_API_KEY, TEST_API_SECRET
 
+snapshot_path = os.getenv("FIVETRAN_SNAPSHOT_PATH")
+
 workspace = FivetranWorkspace(
-    account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
+    account_id=TEST_ACCOUNT_ID,
+    api_key=TEST_API_KEY,
+    api_secret=TEST_API_SECRET,
+    snapshot_path=snapshot_path,
 )
 
-snapshot_path = os.getenv("FIVETRAN_SNAPSHOT_PATH")
-fivetran_specs = load_fivetran_asset_specs(workspace=workspace, snapshot_path=snapshot_path)
+fivetran_specs = load_fivetran_asset_specs(workspace=workspace)
 
 defs = Definitions(assets=fivetran_specs)


### PR DESCRIPTION
## Summary & Motivation

`snapshot_path` is now passed to FivetranWorkspace instead. This allows to load the snapshot behind the scenes whenever users are using `load_asset_specs`. Subsequent PR to also support the snapshot when using `get_or_fetch_workspace_data`

## How I Tested These Changes

Updated tests with BK

