### PR TITLE
[dagster-fivetran] Support snapshot in FivetranWorkspace.get_or_fetch_workspace_data

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -4,7 +4,7 @@ import os
 import time
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
-from functools import partial, cached_property
+from functools import cached_property, partial
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
 from urllib.parse import urljoin
@@ -1063,7 +1063,9 @@ class FivetranWorkspace(ConfigurableResource):
             FivetranWorkspaceData: A snapshot of the Fivetran workspace's content.
         """
         return FivetranWorkspaceDefsLoader(
-            workspace=self, translator=DagsterFivetranTranslator(), snapshot=self.snapshot,
+            workspace=self,
+            translator=DagsterFivetranTranslator(),
+            snapshot=self.snapshot,
         ).get_or_fetch_state()
 
     @cached_method

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/pending_repo_snapshot.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/pending_repo_snapshot.py
@@ -1,7 +1,7 @@
 import os
 
 from dagster._core.definitions.definitions_class import Definitions
-from dagster_fivetran import FivetranWorkspace, load_fivetran_asset_specs
+from dagster_fivetran import FivetranWorkspace
 
 from dagster_fivetran_tests.conftest import TEST_ACCOUNT_ID, TEST_API_KEY, TEST_API_SECRET
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/pending_repo_snapshot_with_assets.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/pending_repo_snapshot_with_assets.py
@@ -15,5 +15,6 @@ workspace = FivetranWorkspace(
 )
 
 workspace.get_or_fetch_workspace_data()
+fivetran_specs = load_fivetran_asset_specs(workspace=workspace)
 
-defs = Definitions(resources={"fivetran": workspace})
+defs = Definitions(assets=fivetran_specs)

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_specs.py
@@ -396,6 +396,7 @@ def test_translator_invariant_group_name_with_asset_decorator(
             )
             def my_fivetran_assets(): ...
 
+
 @pytest.mark.parametrize(
     "pending_repo, expected_assets",
     [
@@ -408,7 +409,9 @@ def test_translator_invariant_group_name_with_asset_decorator(
     ],
 )
 def test_load_fivetran_specs_with_snapshot(
-    pending_repo: str, expected_assets: int, fetch_workspace_data_api_mocks: responses.RequestsMock,
+    pending_repo: str,
+    expected_assets: int,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
     with instance_for_test() as _instance, TemporaryDirectory() as temp_dir:
         from dagster_fivetran.cli import fivetran_snapshot_command


### PR DESCRIPTION
## Summary & Motivation

This PR adds support to load the snapshot when using `FivetranWorkspace.get_or_fetch_workspace_data`, so that we can load the workspace data from the snapshot whenever we are using the state-backed defs.

## How I Tested These Changes

New tests with BK

