### PR TITLE
[ui] Fix group-by persistence on timeline view

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/overview/useGroupTimelineRunsBy.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/useGroupTimelineRunsBy.tsx
@@ -22,9 +22,9 @@ export const useGroupTimelineRunsBy = (
 ): [GroupRunsBy, (value: GroupRunsBy) => void] => {
   const [storedValue, setStoredValue] = useStateWithStorage(GROUP_BY_KEY, validate);
 
-  const [queryValue, setQueryValue] = useQueryPersistedState<GroupRunsBy>({
+  const [queryValue, setQueryValue] = useQueryPersistedState<GroupRunsBy | null>({
     queryKey: 'groupBy',
-    encode: (value) => ({groupBy: value}),
+    encode: (value) => (value ? {groupBy: value} : {}),
     decode: (pair) => {
       if (typeof pair.groupBy === 'string') {
         const result = validate(pair.groupBy);
@@ -32,7 +32,7 @@ export const useGroupTimelineRunsBy = (
           return result;
         }
       }
-      return defaultValue;
+      return null;
     },
   });
 


### PR DESCRIPTION
## Summary & Motivation

I think this has been broken for a while. Fix persistence of the group-by setting on Timeline.

## How I Tested These Changes

Set the group-by value on timeline, reload the page without the query param. Verify that the value is persisted.

Delete the LS key, repeat.

## Changelog

[ui] FIx persistence of group-by setting on run timeline.
