### PR TITLE
[dagster-tableau] Implement refresh_and_poll with AssetExecutionContext

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -11,6 +11,7 @@ import jwt
 import requests
 import tableauserverclient as TSC
 from dagster import (
+    AssetExecutionContext,
     AssetSpec,
     ConfigurableResource,
     Definitions,
@@ -33,6 +34,7 @@ from dagster_tableau.translator import (
     DagsterTableauTranslator,
     TableauContentData,
     TableauContentType,
+    TableauDataSourceMetadataSet,
     TableauMetadataSet,
     TableauTagSet,
     TableauTranslatorData,
@@ -633,6 +635,64 @@ class BaseTableauWorkspace(ConfigurableResource):
             ],
             resources={resource_key: self},
         )
+
+    def refresh_and_poll(
+        self, context: AssetExecutionContext
+    ) -> Iterator[Union[Output, ObserveResult]]:
+        """Executes a refresh and poll process to materialize Tableau assets,
+        including data sources with extracts, views and workbooks.
+        This method can only be used in the context of an asset execution.
+        """
+        assets_def = context.assets_def
+        specs = assets_def.specs
+        refreshable_data_source_ids = [
+            check.not_none(TableauDataSourceMetadataSet.extract(spec.metadata).id)
+            for spec in specs
+            if TableauDataSourceMetadataSet.extract(spec.metadata).has_extracts
+        ]
+
+        with self.get_client() as client:
+            refreshed_data_source_ids = set()
+            for refreshable_data_source_id in refreshable_data_source_ids:
+                refreshed_data_source_ids.add(
+                    client.refresh_and_poll_data_source(refreshable_data_source_id)
+                )
+
+            # If a sheet depends on a refreshed data source, then its workbook is considered refreshed
+            refreshed_workbook_ids = set()
+            specs_by_asset_key = {spec.key: spec for spec in specs}
+            for spec in specs:
+                if TableauTagSet.extract(spec.tags).asset_type == "sheet":
+                    for dep in spec.deps:
+                        # Only materializable data sources are included in materializable asset specs,
+                        # so we must verify for None values - data sources that are external specs are not available here.
+                        dep_spec = specs_by_asset_key.get(dep.asset_key, None)
+                        if (
+                            dep_spec
+                            and TableauMetadataSet.extract(dep_spec.metadata).id
+                            in refreshed_data_source_ids
+                        ):
+                            refreshed_workbook_ids.add(
+                                TableauViewMetadataSet.extract(spec.metadata).workbook_id
+                            )
+                            break
+
+            for spec in specs:
+                asset_type = check.inst(TableauTagSet.extract(spec.tags).asset_type, str)
+                asset_id = check.inst(TableauMetadataSet.extract(spec.metadata).id, str)
+
+                if asset_type == "data_source":
+                    yield from create_data_source_asset_event(
+                        data_source=client.get_data_source(asset_id),
+                        spec=spec,
+                        refreshed_data_source_ids=refreshed_data_source_ids,
+                    )
+                else:
+                    yield from create_view_asset_event(
+                        view=client.get_view(asset_id),
+                        spec=spec,
+                        refreshed_workbook_ids=refreshed_workbook_ids,
+                    )
 
 
 @beta


### PR DESCRIPTION
## Summary & Motivation

This PR implements a materialization function to be used with a multi asset, or the tableau_assets decorator to be implemented in the subsequent PR. 

It is now possible to select a subset of Tableau assets to refresh.

## How I Tested These Changes

Additional test with BK.