### PR TITLE
[ui] Add Home dark launch stub

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/home/useHomeDarkLaunch.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/home/useHomeDarkLaunch.oss.tsx
@@ -1,0 +1,2 @@
+// OSS stub for hook to perform dark launch queries for Dagster+ home.
+export const useHomeDarkLaunch = () => {};

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -1,6 +1,7 @@
 import {Box, Button, ButtonGroup, ErrorBoundary, TextInput} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {useDeferredValue, useMemo} from 'react';
+import {useHomeDarkLaunch} from 'shared/home/useHomeDarkLaunch.oss';
 
 import {GroupTimelineRunsBySelect} from './GroupTimelineRunsBySelect';
 import {groupRunsByAutomation} from './groupRunsByAutomation';
@@ -102,6 +103,10 @@ export const OverviewTimelineRoot = ({Header}: Props) => {
   const [groupRunsBy, setGroupRunsBy] = useGroupTimelineRunsBy();
 
   const runsForTimelineRet = useRunsForTimeline({rangeMs});
+
+  // Dagster+ Home dark launch queries.
+  // todo dish: Remove this when features are live on Home.
+  useHomeDarkLaunch();
 
   // Use deferred value to allow paginating quickly with the UI feeling more responsive.
   const {jobs, loading, refreshState} = useDeferredValue(runsForTimelineRet);


### PR DESCRIPTION
## Summary & Motivation

Add a shared component stub for the Home dark launch hook.

## How I Tested These Changes

Proxy, navigate to timeline view. Verify that the dark launch queries are performed as intended.