### PR TITLE
[RFC] `@computation` decorator and `Computation` class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/computation.py
+++ b/python_modules/dagster/dagster/_core/definitions/computation.py
@@ -1,0 +1,113 @@
+from collections.abc import Mapping, Sequence, Set
+from typing import TYPE_CHECKING, Optional, Union
+
+from dagster_shared import check
+from dagster_shared.record import copy, record
+
+from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.asset_key import AssetKey, EntityKey
+from dagster._core.definitions.asset_spec import AssetExecutionType, AssetSpec
+from dagster._core.definitions.node_definition import NodeDefinition
+from dagster._core.definitions.op_definition import OpDefinition
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.assets import AssetsDefinition
+
+
+@record
+class Effect:
+    spec: Union[AssetSpec, AssetCheckSpec]
+    execution_type: Optional[AssetExecutionType]
+
+    @staticmethod
+    def materialize(spec: AssetSpec) -> "Effect":
+        return Effect(spec=spec, execution_type=AssetExecutionType.MATERIALIZATION)
+
+    @staticmethod
+    def observe(spec: AssetSpec) -> "Effect":
+        return Effect(spec=spec, execution_type=AssetExecutionType.OBSERVATION)
+
+    @staticmethod
+    def check(spec: AssetCheckSpec) -> "Effect":
+        return Effect(spec=spec, execution_type=None)
+
+
+@record
+class Computation:
+    node_def: NodeDefinition
+    input_mappings: Mapping[str, AssetKey]
+    output_mappings: Mapping[str, Effect]
+
+    # subsetting
+    inactive_outputs: Set[str]
+
+    @property
+    def is_subset(self) -> bool:
+        return len(self.inactive_outputs) > 0
+
+    @property
+    def asset_specs(self) -> Sequence[AssetSpec]:
+        return [
+            effect.spec
+            for output_name, effect in self.output_mappings.items()
+            if isinstance(effect.spec, AssetSpec) and output_name not in self.inactive_outputs
+        ]
+
+    @property
+    def asset_check_specs(self) -> Sequence[AssetCheckSpec]:
+        return [
+            effect.spec
+            for output_name, effect in self.output_mappings.items()
+            if isinstance(effect.spec, AssetCheckSpec) and output_name in self.inactive_outputs
+        ]
+
+    def subset_for(self, keys: Set[EntityKey]) -> "Computation":
+        # TODO: handle graph definitions
+        check.inst(self.node_def, OpDefinition)
+        return copy(
+            self,
+            selected_outputs={
+                output_name
+                for output_name, effect in self.output_mappings.items()
+                if effect.spec.key in keys
+            },
+        )
+
+    def to_assets_def(self) -> "AssetsDefinition":
+        from dagster._core.definitions.assets import AssetsDefinition
+
+        execution_types = {effect.execution_type for effect in self.output_mappings.values()}
+        execution_types.discard(None)
+        check.invariant(
+            len(execution_types) <= 1,
+            f"All output effects must have the same execution type, found: {execution_types}",
+        )
+        execution_type = next(iter(execution_types))
+
+        return AssetsDefinition(
+            node_def=self.node_def,
+            execution_type=execution_type,
+            specs=self.asset_specs,
+            keys_by_input_name={input_name: key for input_name, key in self.input_mappings.items()},
+            keys_by_output_name={
+                output_name: effect.spec.key
+                for output_name, effect in self.output_mappings.items()
+                if isinstance(effect.spec, AssetSpec)
+            },
+            check_specs_by_output_name={
+                output_name: effect.spec
+                for output_name, effect in self.output_mappings.items()
+                if isinstance(effect.spec, AssetCheckSpec)
+            },
+            selected_asset_keys={
+                effect.spec.key
+                for output_name, effect in self.output_mappings.items()
+                if isinstance(effect.spec, AssetSpec) and output_name not in self.inactive_outputs
+            },
+            selected_asset_check_keys={
+                effect.spec.key
+                for output_name, effect in self.output_mappings.items()
+                if isinstance(effect.spec, AssetCheckSpec)
+                and output_name not in self.inactive_outputs
+            },
+        )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/computation_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/computation_decorator.py
@@ -1,0 +1,92 @@
+from collections.abc import Generator, Mapping, Sequence
+from typing import Callable, Optional, Union
+
+from typing_extensions import TypeAlias
+
+import dagster._check as check
+from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.asset_spec import AssetExecutionType, AssetSpec
+from dagster._core.definitions.computation import Computation, Effect
+from dagster._core.definitions.decorators.decorator_assets_definition_builder import (
+    DecoratorAssetsDefinitionBuilder,
+    DecoratorAssetsDefinitionBuilderArgs,
+    create_check_specs_by_output_name,
+)
+from dagster._core.definitions.result import AssetCheckResult, AssetResult
+
+ComputationResult: TypeAlias = Generator[Union[AssetResult, AssetCheckResult], None, None]
+
+
+@check.checked
+def computation(
+    *,
+    specs: Sequence[Union[AssetSpec, AssetCheckSpec]],
+    asset_execution_type: AssetExecutionType = AssetExecutionType.MATERIALIZATION,
+    # compute node
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    tags: Optional[Mapping[str, str]] = None,
+    pool: Optional[str] = None,
+) -> Callable[[Callable[..., ComputationResult]], Computation]:
+    asset_specs = [spec for spec in specs if isinstance(spec, AssetSpec)]
+    asset_check_specs = [spec for spec in specs if isinstance(spec, AssetCheckSpec)]
+    args = DecoratorAssetsDefinitionBuilderArgs(
+        decorator_name="@computation",
+        name=name,
+        op_description=description,
+        op_tags=tags,
+        pool=pool,
+        specs=asset_specs,
+        check_specs_by_output_name=create_check_specs_by_output_name(asset_check_specs),
+        can_subset=any(spec.skippable for spec in asset_specs),
+        execution_type=asset_execution_type,
+        allow_arbitrary_check_specs=True,
+        # unset params
+        asset_out_map={},
+        asset_deps={},
+        asset_in_map={},
+        upstream_asset_deps=None,
+        group_name=None,
+        partitions_def=None,
+        retry_policy=None,
+        code_version=None,
+        config_schema=None,
+        compute_kind=None,
+        required_resource_keys=set(),
+        op_def_resource_defs={},
+        assets_def_resource_defs={},
+        backfill_policy=None,
+        hooks=None,
+    )
+
+    def inner(fn: Callable[..., ComputationResult]) -> Computation:
+        builder = DecoratorAssetsDefinitionBuilder.for_multi_asset(fn=fn, args=args)
+
+        # TODO: move this logic into the builder
+        node_def = builder.create_op_definition()
+
+        output_names_by_key = {
+            **{v: k for k, v in builder.asset_keys_by_output_name.items()},
+            **{v.key: k for k, v in builder.check_specs_by_output_name.items()},
+        }
+
+        output_mappings = {}
+        for spec in specs:
+            output_name = output_names_by_key[spec.key]
+            if isinstance(spec, AssetSpec):
+                output_mappings[output_name] = (
+                    Effect.observe(spec)
+                    if asset_execution_type == AssetExecutionType.OBSERVATION
+                    else Effect.materialize(spec)
+                )
+            else:
+                output_mappings[output_name] = Effect.check(spec)
+
+        return Computation(
+            node_def=node_def,
+            input_mappings=builder.asset_keys_by_input_name,
+            output_mappings=output_mappings,
+            inactive_outputs=set(),
+        )
+
+    return inner

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -302,7 +302,8 @@ class DecoratorAssetsDefinitionBuilder:
 
         if args.specs:
             check.invariant(
-                args.decorator_name == "@multi_asset", "Only hit this code path in multi_asset."
+                args.decorator_name in ("@multi_asset", "@computation"),
+                "Only hit this code path in multi_asset.",
             )
             if args.upstream_asset_deps:
                 raise DagsterInvalidDefinitionError(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_computation.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_computation.py
@@ -1,0 +1,96 @@
+from collections.abc import Generator
+
+import dagster as dg
+from dagster._core.definitions.asset_spec import AssetExecutionType
+from dagster._core.definitions.computation import Computation, Effect
+from dagster._core.definitions.decorators.computation_decorator import (
+    ComputationResult,
+    computation,
+)
+
+
+def test_simple_class_construction():
+    @dg.op
+    def the_op(upstream: int):
+        return upstream + 1
+
+    computation = Computation(
+        node_def=the_op,
+        input_mappings={
+            "upstream": dg.AssetKey("upstream"),
+        },
+        output_mappings={
+            "result": Effect.materialize(
+                dg.AssetSpec(key=dg.AssetKey("the_asset"), group_name="the_group")
+            ),
+        },
+        inactive_outputs=set(),
+    )
+
+    assets_def = dg.AssetsDefinition(
+        node_def=the_op,
+        specs=[dg.AssetSpec(key=dg.AssetKey("the_asset"), group_name="the_group")],
+        keys_by_output_name={
+            "result": dg.AssetKey("the_asset"),
+        },
+        keys_by_input_name={
+            "upstream": dg.AssetKey("upstream"),
+        },
+    )
+
+    assert computation.to_assets_def().keys_by_output_name == assets_def.keys_by_output_name
+    assert computation.to_assets_def().keys_by_input_name == assets_def.keys_by_input_name
+
+    assert computation.to_assets_def().to_computation() == assets_def.to_computation()
+
+
+def test_single_decorator():
+    @computation(
+        specs=[
+            dg.AssetSpec(key=dg.AssetKey("the_asset"), deps=["upstream"]),
+        ]
+    )
+    def the_thing(upstream: int) -> Generator[dg.MaterializeResult, None, None]:
+        yield dg.MaterializeResult(
+            metadata={"foo": "bar"},
+        )
+
+    assert the_thing
+
+
+def test_multi_decorator_observe_with_checks():
+    @dg.asset
+    def upstream_explicit() -> int:
+        return 1
+
+    @computation(
+        specs=[
+            dg.AssetSpec(key=dg.AssetKey("a"), deps=["upstream_explicit"]),
+            dg.AssetSpec(key=dg.AssetKey("b"), deps=["upstream_implicit"]),
+            dg.AssetSpec(key=dg.AssetKey("c"), deps=["a", "b"]),
+            dg.AssetCheckSpec(name="check_a", asset="a"),
+            dg.AssetCheckSpec(name="check_upstream", asset="upstream_implicit"),
+        ],
+        asset_execution_type=AssetExecutionType.OBSERVATION,
+    )
+    def the_thing(upstream_explicit: int) -> ComputationResult:
+        yield dg.ObserveResult(
+            asset_key=dg.AssetKey("a"),
+            metadata={"foo": "bar"},
+            check_results=[dg.AssetCheckResult(asset_key=dg.AssetKey("a"), passed=True)],
+        )
+        yield dg.ObserveResult(asset_key=dg.AssetKey("b"), metadata={"some_val": 2})
+        yield dg.ObserveResult(asset_key=dg.AssetKey("c"), metadata={"some_val": 3})
+        yield dg.AssetCheckResult(asset_key=dg.AssetKey("upstream_implicit"), passed=False)
+
+    defs = dg.Definitions(
+        assets=[upstream_explicit, the_thing.to_assets_def()],
+    )
+
+    job = defs.get_implicit_global_asset_job_def()
+    result = job.execute_in_process()
+
+    assert result.success
+    assert len(result.get_asset_materialization_events()) == 1  # upstream_explicit
+    assert len(result.get_asset_check_evaluations()) == 2  # check_a, check_upstream
+    assert len(result.get_asset_observation_events()) == 3  # a, b, c


### PR DESCRIPTION
## Summary & Motivation

This is a quick demonstration of a unified decorator that combines together capabilities of `@asset`, `@multi_asset`, `@multi_asset_check`, `@multi_observable_source_asset`, etc.

This follows along the thread of @schrockn's doc here: https://www.notion.so/dagster/A-new-core-API-StepComponent-and-step-1be18b92e46280f58cefcea49bb0d45a#1be18b92e46280d48f5cde2fd0bd1b1a, with a couple of key differences:

1. Most obviously, this is called `Computation`, and not `Step`. I haven't actually thought enough about this to have a strong opinion there, I just avoided the step terminology because it conflicts with the existing "ExecutionStep" concept.
2. For simplicity, I didn't implement `ExecutionRecord` as proposed in the PR, and so all `@computation`s are generators to work with existing framework APIs (basically there's no way to emit a MaterializeResult for multiple assets at once). In reality, I would want the allowable type signatures to be either `-> ExecutionRecord` or `-> Generator[ExecutionRecord, None, None]`
3. I created a `Computation` class that is designed to eventually replace the `AssetsDefinition` class
4. There is no component-related part of this PR, as this is already somewhat spec'd out with the `ExecutableComponent`. This PR is more of an effort to push that design philosophy further down into the system.

Note that for now, computations must be converted back into `AssetsDefinition` objects, but the eventual goal would be to have `Computation` be the internal substrate of the system and leave `AssetsDefinition` behind as a legacy / backcompat layer that is swiftly converted into the relevent `Computation` object. Obviously that is a much bigger lift that has not been attempted here.

Comparing the two classes, `Computation` has a much simpler parameterization scheme (partly due to not having to support a bunch of backcompat), and generally is significantly simpler to work with, while retaining all of the same information.

It also ends up being more flexible, in that each individual output is associated with an arbitrary "Effect". Currently, those effects are one of:

- check an asset check
- observe an asset
- materialize an asset

this means that you can (in principle), have a single computation that does all three of those things. realistically, it's unlikely that people will really need to do this very often, but it's nice that the framework can support that if desired. We may come up with other types of effects in the future where this sort of mix-and-matching might be more useful.

Also note that this abandons a lot of the magic of the `@asset` decorator provides -- creating an asset spec by hand is a lot more verbose! I'm envisioning this as being a replacement for all of the `multi_*` decorators, but we'd probably want to retain `@asset_check` and `@asset` in docs / tutorials (where `@asset` would be updated to also handle `@observable_source_asset` use cases). 

This decorator would be used primarily by advanced users who have more complicated multi-type use cases. This would also be useful for developers of more advanced integrations / component authors.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
