### PR TITLE
Allow undefined value for tag in `getSupplementaryDataKey`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/util.ts
@@ -45,7 +45,7 @@ export function getSupplementaryDataKey({
   value,
 }: {
   field: string;
-  value: string | {key: string; value: string};
+  value: string | {key: string; value?: string | undefined};
 }): string {
   return JSON.stringify({field, value});
 }


### PR DESCRIPTION
## Summary & Motivation

Supplementary data is data we fetch asynchronously for asset selection resolution. In the case of tags we should allow the values to be optional / undefined for column_tags. 

companion to https://github.com/dagster-io/internal/pull/16295

## How I Tested These Changes

see tests in https://github.com/dagster-io/internal/pull/16295
