### PR TITLE
[asset health] gate on different feature flag

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -547,7 +547,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         return self._asset_node_snap.is_executable
 
     def resolve_assetHealth(self, graphene_info: ResolveInfo) -> Optional[GrapheneAssetHealth]:
-        if not graphene_info.context.instance.dagster_observe_supported():
+        if not graphene_info.context.instance.dagster_asset_health_queries_supported():
             return None
         return GrapheneAssetHealth(
             asset_key=self.assetKey,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_health.py
@@ -172,7 +172,7 @@ class GrapheneAssetHealth(graphene.ObjectType):
         return freshness_status_metadata
 
     async def resolve_assetHealth(self, graphene_info: ResolveInfo) -> AssetHealthStatus:
-        if not graphene_info.context.instance.dagster_observe_supported():
+        if not graphene_info.context.instance.dagster_asset_health_queries_supported():
             return AssetHealthStatus.UNKNOWN
         if self.materialization_status_task is None:
             self.materialization_status_task = asyncio.create_task(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -441,7 +441,7 @@ class GrapheneAsset(graphene.ObjectType):
         return None
 
     def resolve_assetHealth(self, graphene_info: ResolveInfo) -> Optional[GrapheneAssetHealth]:
-        if not graphene_info.context.instance.dagster_observe_supported():
+        if not graphene_info.context.instance.dagster_asset_health_queries_supported():
             return None
         return GrapheneAssetHealth(
             asset_key=self.key,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_health.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_health.py
@@ -27,7 +27,7 @@ query GetAssetHealth($assetKey: AssetKeyInput!) {
 class TestAssetHealth(ExecutingGraphQLContextTestMatrix):
     def test_asset_health_status(self, graphql_context: WorkspaceRequestContext):
         instance = graphql_context.instance
-        assert not instance.dagster_observe_supported()
+        assert not instance.dagster_asset_health_queries_supported()
         res = execute_dagster_graphql(
             graphql_context, GET_ASSET_HEALTH, variables={"assetKey": {"path": ["asset_1"]}}
         )

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3610,6 +3610,9 @@ class DagsterInstance(DynamicPartitionsStore):
     def dagster_observe_supported(self) -> bool:
         return False
 
+    def dagster_asset_health_queries_supported(self) -> bool:
+        return False
+
     def can_read_failure_events_for_asset(self, asset_record: "AssetRecord") -> bool:
         return False
 


### PR DESCRIPTION
## Summary & Motivation
Gates returning asset health data on `ENABLE_ASSET_HEALTH_QUERIES` instead of `ENABLE_OBSERVE`.
See discussion in https://github.com/dagster-io/internal/pull/16300 for reasoning

