### PR TITLE
[ui] Use a component for home dark launch

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/home/HomeDarkLaunch.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/home/HomeDarkLaunch.oss.tsx
@@ -1,0 +1,2 @@
+// OSS stub for component to perform dark launch queries for Dagster+ home.
+export const HomeDarkLaunch = () => <></>;

--- a/js_modules/dagster-ui/packages/ui-core/src/home/useHomeDarkLaunch.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/home/useHomeDarkLaunch.oss.tsx
@@ -1,2 +1,0 @@
-// OSS stub for hook to perform dark launch queries for Dagster+ home.
-export const useHomeDarkLaunch = () => {};

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -1,7 +1,7 @@
 import {Box, Button, ButtonGroup, ErrorBoundary, TextInput} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {useDeferredValue, useMemo} from 'react';
-import {useHomeDarkLaunch} from 'shared/home/useHomeDarkLaunch.oss';
+import {HomeDarkLaunch} from 'shared/home/HomeDarkLaunch.oss';
 
 import {GroupTimelineRunsBySelect} from './GroupTimelineRunsBySelect';
 import {groupRunsByAutomation} from './groupRunsByAutomation';
@@ -104,10 +104,6 @@ export const OverviewTimelineRoot = ({Header}: Props) => {
 
   const runsForTimelineRet = useRunsForTimeline({rangeMs});
 
-  // Dagster+ Home dark launch queries.
-  // todo dish: Remove this when features are live on Home.
-  useHomeDarkLaunch();
-
   // Use deferred value to allow paginating quickly with the UI feeling more responsive.
   const {jobs, loading, refreshState} = useDeferredValue(runsForTimelineRet);
 
@@ -183,6 +179,8 @@ export const OverviewTimelineRoot = ({Header}: Props) => {
       <ErrorBoundary region="timeline">
         <RunTimeline loading={loading} rangeMs={rangeMs} rows={visibleRows} />
       </ErrorBoundary>
+      {/* Dagster+ Home dark launch queries. todo dish: Remove this when features are live on Home. */}
+      <HomeDarkLaunch />
     </>
   );
 };


### PR DESCRIPTION
## Summary & Motivation

Use a component instead of a hook for the home dark launch. This allows for better gating on the Cloud side.

## How I Tested These Changes

TS, lint, jest. Load app, verify that the component renders as expected in Cloud.