### PR TITLE
[freshness] [breaking] Rename FreshnessPolicy to LegacyFreshnessPolicy

### DIFF
--- a/examples/components_yaml_checks_dsl/existing_code/engine.py
+++ b/examples/components_yaml_checks_dsl/existing_code/engine.py
@@ -10,7 +10,7 @@ from dagster import (
     AssetKey,
     DagsterEventType,
     EventRecordsFilter,
-    FreshnessPolicy,
+    LegacyFreshnessPolicy,
     MetadataValue,
     asset_check,
     build_column_schema_change_checks,
@@ -70,7 +70,7 @@ def handle_freshness_check(check: dict):
         asset_key = AssetKey(asset.split("."))
 
         if "maximum_lag_minutes" in check:
-            policy = FreshnessPolicy(maximum_lag_minutes=check["maximum_lag_minutes"])
+            policy = LegacyFreshnessPolicy(maximum_lag_minutes=check["maximum_lag_minutes"])
             safe_name = f"{'_'.join(asset_key.path)}_freshness_check"
 
             @asset_check(asset=asset_key, name=safe_name)
@@ -81,7 +81,7 @@ def handle_freshness_check(check: dict):
             checks.append(freshness_check)
 
         if "maximum_lag_minutes_by_partition" in check:
-            policy = FreshnessPolicy(  # noqa
+            policy = LegacyFreshnessPolicy(  # noqa
                 maximum_lag_minutes=check["maximum_lag_minutes_by_partition"],
                 cron_schedule="* * * * *",
             )  # cron required for partition

--- a/python_modules/dagster-graphql/dagster_graphql/schema/freshness_policy.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/freshness_policy.py
@@ -1,6 +1,6 @@
 import dagster._check as check
 import graphene
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._time import get_current_datetime
 
 
@@ -24,9 +24,9 @@ class GrapheneFreshnessPolicy(graphene.ObjectType):
     class Meta:
         name = "FreshnessPolicy"
 
-    def __init__(self, freshness_policy: FreshnessPolicy):
+    def __init__(self, freshness_policy: LegacyFreshnessPolicy):
         self._freshness_policy = check.inst_param(
-            freshness_policy, "freshness_policy", FreshnessPolicy
+            freshness_policy, "freshness_policy", LegacyFreshnessPolicy
         )
 
         super().__init__(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -100,7 +100,7 @@ from dagster._core.definitions.events import Failure
 from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.definitions.external_asset import external_asset_from_spec
 from dagster._core.definitions.freshness import InternalFreshnessPolicy
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
@@ -1832,7 +1832,7 @@ def fresh_diamond_right(fresh_diamond_top):
 
 
 @asset(
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=30),
+    freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=30),
     auto_materialize_policy=AutoMaterializePolicy.lazy(),
 )
 def fresh_diamond_bottom(fresh_diamond_left, fresh_diamond_right):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_freshness.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_freshness.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 from dagster import (
     Definitions,
-    FreshnessPolicy,
+    LegacyFreshnessPolicy,
     ObserveResult,
     RepositoryDefinition,
     observable_source_asset,
@@ -29,7 +29,7 @@ GET_FRESHNESS_INFO = """
 """
 
 
-@observable_source_asset(freshness_policy=FreshnessPolicy(maximum_lag_minutes=30))
+@observable_source_asset(freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=30))
 def source_asset_with_freshness(context):
     return ObserveResult(metadata={DATA_TIME_METADATA_KEY: float(context.run.tags["data_time"])})
 

--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/lazy_repo_2.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/lazy_repo_2.py
@@ -6,7 +6,7 @@ from dagster import (
     asset,
     repository,
 )
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 
 ### Non partitioned ###
 
@@ -25,7 +25,7 @@ def lazy_downstream_3(lazy_downstream_1):
 
 @asset(
     auto_materialize_policy=AutoMaterializePolicy.lazy(),
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=1440),
+    freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=1440),
 )
 def lazy_downstream_4(lazy_downstream_2, lazy_downstream_3):
     return lazy_downstream_2 + lazy_downstream_3
@@ -52,7 +52,7 @@ def lazy_downstream_3_partitioned(lazy_downstream_1_partitioned):
 @asset(
     partitions_def=daily_partitions_def,
     auto_materialize_policy=AutoMaterializePolicy.lazy(),
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=1440),
+    freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=1440),
 )
 def lazy_downstream_4_partitioned(lazy_downstream_2_partitioned, lazy_downstream_3_partitioned):
     return lazy_downstream_2_partitioned + lazy_downstream_3_partitioned

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -252,7 +252,9 @@ from dagster._core.definitions.executor_definition import (
     multiple_process_executor_requirements as multiple_process_executor_requirements,
     multiprocess_executor as multiprocess_executor,
 )
-from dagster._core.definitions.freshness_policy import FreshnessPolicy as FreshnessPolicy
+from dagster._core.definitions.freshness_policy import (
+    LegacyFreshnessPolicy as LegacyFreshnessPolicy,
+)
 from dagster._core.definitions.graph_definition import GraphDefinition as GraphDefinition
 from dagster._core.definitions.hook_definition import HookDefinition as HookDefinition
 from dagster._core.definitions.input import (

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -22,7 +22,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
 )
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
@@ -113,7 +113,7 @@ class AssetNode(BaseAssetNode):
         return self._spec.partition_mappings
 
     @property
-    def freshness_policy(self) -> Optional[FreshnessPolicy]:
+    def freshness_policy(self) -> Optional[LegacyFreshnessPolicy]:
         return self._spec.freshness_policy
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -15,7 +15,7 @@ from dagster._core.definitions.events import (
     CoercibleToAssetKey,
     CoercibleToAssetKeyPrefix,
 )
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.input import NoValueSentinel
 from dagster._core.definitions.output import Out
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -157,7 +157,7 @@ class AssetOut:
                     AutomationCondition,
                 ),
                 freshness_policy=check.opt_inst_param(
-                    freshness_policy, "freshness_policy", FreshnessPolicy
+                    freshness_policy, "freshness_policy", LegacyFreshnessPolicy
                 ),
                 owners=check.opt_sequence_param(owners, "owners", of_type=str),
                 tags=normalize_tags(tags or {}, strict=True),
@@ -190,7 +190,7 @@ class AssetOut:
         return self._spec.code_version
 
     @property
-    def freshness_policy(self) -> Optional[FreshnessPolicy]:
+    def freshness_policy(self) -> Optional[LegacyFreshnessPolicy]:
         return self._spec.freshness_policy
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -31,7 +31,7 @@ from dagster._core.definitions.freshness import (
     INTERNAL_FRESHNESS_POLICY_METADATA_KEY,
     InternalFreshnessPolicy,
 )
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.utils import (
@@ -161,7 +161,7 @@ class AssetSpec(IHasInternalInit, IHaveNew, LegacyNamedTupleMixin):
     group_name: PublicAttr[Optional[str]]
     skippable: PublicAttr[bool]
     code_version: PublicAttr[Optional[str]]
-    freshness_policy: PublicAttr[Optional[FreshnessPolicy]]
+    freshness_policy: PublicAttr[Optional[LegacyFreshnessPolicy]]
     automation_condition: PublicAttr[Optional[AutomationCondition]]
     owners: PublicAttr[Sequence[str]]
     tags: PublicAttr[Mapping[str, str]]
@@ -228,7 +228,7 @@ class AssetSpec(IHasInternalInit, IHaveNew, LegacyNamedTupleMixin):
             freshness_policy=check.opt_inst_param(
                 kwargs.get("freshness_policy"),
                 "freshness_policy",
-                FreshnessPolicy,
+                LegacyFreshnessPolicy,
             ),
             automation_condition=check.opt_inst_param(
                 resolve_automation_condition(
@@ -330,7 +330,7 @@ class AssetSpec(IHasInternalInit, IHaveNew, LegacyNamedTupleMixin):
         tags: Optional[Mapping[str, str]] = ...,
         kinds: Optional[set[str]] = ...,
         partitions_def: Optional[PartitionsDefinition] = ...,
-        freshness_policy: Optional[FreshnessPolicy] = ...,
+        freshness_policy: Optional[LegacyFreshnessPolicy] = ...,
     ) -> "AssetSpec":
         """Returns a new AssetSpec with the specified attributes replaced."""
         current_tags_without_kinds = {

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -37,7 +37,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 )
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.events import CoercibleToAssetKey, CoercibleToAssetKeyPrefix
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
@@ -133,7 +133,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         group_names_by_key: Optional[Mapping[AssetKey, str]] = None,
         metadata_by_key: Optional[Mapping[AssetKey, ArbitraryMetadataMapping]] = None,
         tags_by_key: Optional[Mapping[AssetKey, Mapping[str, str]]] = None,
-        freshness_policies_by_key: Optional[Mapping[AssetKey, FreshnessPolicy]] = None,
+        freshness_policies_by_key: Optional[Mapping[AssetKey, LegacyFreshnessPolicy]] = None,
         backfill_policy: Optional[BackfillPolicy] = None,
         # descriptions by key is more accurately understood as _overriding_ the descriptions
         # by key that are in the OutputDefinitions associated with the asset key.
@@ -440,7 +440,9 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
         metadata_by_output_name: Optional[Mapping[str, Optional[ArbitraryMetadataMapping]]] = None,
         tags_by_output_name: Optional[Mapping[str, Optional[Mapping[str, str]]]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        freshness_policies_by_output_name: Optional[
+            Mapping[str, Optional[LegacyFreshnessPolicy]]
+        ] = None,
         automation_conditions_by_output_name: Optional[
             Mapping[str, Optional[AutomationCondition]]
         ] = None,
@@ -557,7 +559,9 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
         metadata_by_output_name: Optional[Mapping[str, Optional[ArbitraryMetadataMapping]]] = None,
         tags_by_output_name: Optional[Mapping[str, Optional[Mapping[str, str]]]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        freshness_policies_by_output_name: Optional[
+            Mapping[str, Optional[LegacyFreshnessPolicy]]
+        ] = None,
         automation_conditions_by_output_name: Optional[
             Mapping[str, Optional[AutomationCondition]]
         ] = None,
@@ -660,7 +664,9 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         descriptions_by_output_name: Optional[Mapping[str, str]] = None,
         metadata_by_output_name: Optional[Mapping[str, Optional[ArbitraryMetadataMapping]]] = None,
         tags_by_output_name: Optional[Mapping[str, Optional[Mapping[str, str]]]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, Optional[FreshnessPolicy]]] = None,
+        freshness_policies_by_output_name: Optional[
+            Mapping[str, Optional[LegacyFreshnessPolicy]]
+        ] = None,
         code_versions_by_output_name: Optional[Mapping[str, Optional[str]]] = None,
         automation_conditions_by_output_name: Optional[
             Mapping[str, Optional[AutomationCondition]]
@@ -1007,7 +1013,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         }
 
     @property
-    def freshness_policies_by_key(self) -> Mapping[AssetKey, FreshnessPolicy]:
+    def freshness_policies_by_key(self) -> Mapping[AssetKey, LegacyFreshnessPolicy]:
         return {
             key: spec.freshness_policy
             for key, spec in self._specs_by_key.items()
@@ -1261,7 +1267,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         group_names_by_key: Mapping[AssetKey, str] = {},
         tags_by_key: Mapping[AssetKey, Mapping[str, str]] = {},
         freshness_policy: Optional[
-            Union[FreshnessPolicy, Mapping[AssetKey, FreshnessPolicy]]
+            Union[LegacyFreshnessPolicy, Mapping[AssetKey, LegacyFreshnessPolicy]]
         ] = None,
         automation_condition: Optional[
             Union[AutomationCondition, Mapping[AssetKey, AutomationCondition]]
@@ -1808,7 +1814,7 @@ def _asset_specs_from_attr_key_params(
     group_names_by_key: Optional[Mapping[AssetKey, str]],
     metadata_by_key: Optional[Mapping[AssetKey, ArbitraryMetadataMapping]],
     tags_by_key: Optional[Mapping[AssetKey, Mapping[str, str]]],
-    freshness_policies_by_key: Optional[Mapping[AssetKey, FreshnessPolicy]],
+    freshness_policies_by_key: Optional[Mapping[AssetKey, LegacyFreshnessPolicy]],
     automation_conditions_by_key: Optional[Mapping[AssetKey, AutomationCondition]],
     code_versions_by_key: Optional[Mapping[AssetKey, str]],
     descriptions_by_key: Optional[Mapping[AssetKey, str]],
@@ -1839,7 +1845,7 @@ def _asset_specs_from_attr_key_params(
         freshness_policies_by_key,
         "freshness_policies_by_key",
         key_type=AssetKey,
-        value_type=FreshnessPolicy,
+        value_type=LegacyFreshnessPolicy,
     )
 
     validated_automation_conditions_by_key = check.opt_mapping_param(

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -21,7 +21,7 @@ from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_key import AssetKey, EntityKey, T_EntityKey
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
@@ -152,7 +152,7 @@ class BaseAssetNode(BaseEntityNode[AssetKey]):
 
     @property
     @abstractmethod
-    def freshness_policy(self) -> Optional[FreshnessPolicy]: ...
+    def freshness_policy(self) -> Optional[LegacyFreshnessPolicy]: ...
 
     @property
     @abstractmethod
@@ -656,7 +656,7 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
     @cached_method
     def get_downstream_freshness_policies(
         self, *, asset_key: AssetKey
-    ) -> AbstractSet[FreshnessPolicy]:
+    ) -> AbstractSet[LegacyFreshnessPolicy]:
         asset = self.get(asset_key)
         downstream_policies = set().union(
             *(

--- a/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKeyPrefix
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.resource_requirement import ResourceAddable
@@ -33,7 +33,7 @@ class AssetsDefinitionCacheableData(
             ("key_prefix", Optional[CoercibleToAssetKeyPrefix]),
             ("can_subset", bool),
             ("extra_metadata", Optional[Mapping[Any, Any]]),
-            ("freshness_policies_by_output_name", Optional[Mapping[str, FreshnessPolicy]]),
+            ("freshness_policies_by_output_name", Optional[Mapping[str, LegacyFreshnessPolicy]]),
             (
                 "auto_materialize_policies_by_output_name",
                 Optional[Mapping[str, AutoMaterializePolicy]],
@@ -56,7 +56,7 @@ class AssetsDefinitionCacheableData(
         key_prefix: Optional[Sequence[str]] = None,
         can_subset: bool = False,
         extra_metadata: Optional[Mapping[Any, Any]] = None,
-        freshness_policies_by_output_name: Optional[Mapping[str, FreshnessPolicy]] = None,
+        freshness_policies_by_output_name: Optional[Mapping[str, LegacyFreshnessPolicy]] = None,
         auto_materialize_policies_by_output_name: Optional[
             Mapping[str, AutoMaterializePolicy]
         ] = None,
@@ -98,7 +98,7 @@ class AssetsDefinitionCacheableData(
                 freshness_policies_by_output_name,
                 "freshness_policies_by_output_name",
                 key_type=str,
-                value_type=FreshnessPolicy,
+                value_type=LegacyFreshnessPolicy,
             ),
             auto_materialize_policies_by_output_name=check.opt_nullable_mapping_param(
                 auto_materialize_policies_by_output_name,
@@ -156,7 +156,7 @@ class CacheableAssetsDefinition(ResourceAddable, ABC):
         asset_key_replacements: Optional[Mapping[AssetKey, AssetKey]] = None,
         group_names_by_key: Optional[Mapping[AssetKey, str]] = None,
         freshness_policy: Optional[
-            Union[FreshnessPolicy, Mapping[AssetKey, FreshnessPolicy]]
+            Union[LegacyFreshnessPolicy, Mapping[AssetKey, LegacyFreshnessPolicy]]
         ] = None,
     ) -> "CacheableAssetsDefinition":
         return PrefixOrGroupWrappedCacheableAssetsDefinition(
@@ -179,7 +179,7 @@ class CacheableAssetsDefinition(ResourceAddable, ABC):
     def with_attributes_for_all(
         self,
         group_name: Optional[str],
-        freshness_policy: Optional[FreshnessPolicy],
+        freshness_policy: Optional[LegacyFreshnessPolicy],
         auto_materialize_policy: Optional[AutoMaterializePolicy],
         backfill_policy: Optional[BackfillPolicy],
     ) -> "CacheableAssetsDefinition":
@@ -250,7 +250,7 @@ class PrefixOrGroupWrappedCacheableAssetsDefinition(WrappedCacheableAssetsDefini
         group_name_for_all_assets: Optional[str] = None,
         prefix_for_all_assets: Optional[list[str]] = None,
         freshness_policy: Optional[
-            Union[FreshnessPolicy, Mapping[AssetKey, FreshnessPolicy]]
+            Union[LegacyFreshnessPolicy, Mapping[AssetKey, LegacyFreshnessPolicy]]
         ] = None,
         auto_materialize_policy: Optional[
             Union[AutoMaterializePolicy, Mapping[AssetKey, AutoMaterializePolicy]]

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -35,7 +35,7 @@ from dagster._core.definitions.events import (
     CoercibleToAssetKeyPrefix,
 )
 from dagster._core.definitions.freshness import INTERNAL_FRESHNESS_POLICY_METADATA_KEY
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.input import GraphIn
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping, RawMetadataMapping
@@ -412,7 +412,7 @@ class AssetDecoratorArgs(NamedTuple):
     op_tags: Optional[Mapping[str, Any]]
     group_name: Optional[str]
     output_required: bool
-    freshness_policy: Optional[FreshnessPolicy]
+    freshness_policy: Optional[LegacyFreshnessPolicy]
     automation_condition: Optional[AutomationCondition]
     backfill_policy: Optional[BackfillPolicy]
     retry_policy: Optional[RetryPolicy]
@@ -774,7 +774,7 @@ def graph_asset(
     tags: Optional[Mapping[str, str]] = ...,
     owners: Optional[Sequence[str]] = None,
     kinds: Optional[AbstractSet[str]] = None,
-    freshness_policy: Optional[FreshnessPolicy] = ...,
+    freshness_policy: Optional[LegacyFreshnessPolicy] = ...,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = ...,
     automation_condition: Optional[AutomationCondition] = ...,
     backfill_policy: Optional[BackfillPolicy] = ...,
@@ -955,7 +955,7 @@ def graph_asset_no_defaults(
     metadata: Optional[RawMetadataMapping],
     tags: Optional[Mapping[str, str]],
     owners: Optional[Sequence[str]],
-    freshness_policy: Optional[FreshnessPolicy],
+    freshness_policy: Optional[LegacyFreshnessPolicy],
     automation_condition: Optional[AutomationCondition],
     backfill_policy: Optional[BackfillPolicy],
     resource_defs: Optional[Mapping[str, ResourceDefinition]],

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.decorators.decorator_assets_definition_builder im
     create_check_specs_by_output_name,
 )
 from dagster._core.definitions.events import CoercibleToAssetKey, CoercibleToAssetKeyPrefix
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.resource_annotation import get_resource_args
@@ -47,7 +47,7 @@ def observable_source_asset(
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
     auto_observe_interval_minutes: Optional[float] = None,
-    freshness_policy: Optional[FreshnessPolicy] = None,
+    freshness_policy: Optional[LegacyFreshnessPolicy] = None,
     automation_condition: Optional[AutomationCondition] = None,
     op_tags: Optional[Mapping[str, Any]] = None,
     tags: Optional[Mapping[str, str]] = None,
@@ -163,7 +163,7 @@ class _ObservableSourceAsset:
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         auto_observe_interval_minutes: Optional[float] = None,
-        freshness_policy: Optional[FreshnessPolicy] = None,
+        freshness_policy: Optional[LegacyFreshnessPolicy] = None,
         automation_condition: Optional[AutomationCondition] = None,
         op_tags: Optional[Mapping[str, Any]] = None,
         tags: Optional[Mapping[str, str]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -16,7 +16,7 @@ from dagster._core.definitions.declarative_automation.legacy.valid_asset_subset 
     ValidAssetSubset,
 )
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._utils.schedules import cron_string_iterator
 
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 def get_execution_period_for_policy(
-    freshness_policy: FreshnessPolicy,
+    freshness_policy: LegacyFreshnessPolicy,
     effective_data_time: Optional[datetime.datetime],
     current_time: datetime.datetime,
 ) -> TimeWindow:
@@ -67,8 +67,8 @@ def get_execution_period_for_policy(
 
 
 def get_execution_period_and_evaluation_data_for_policies(
-    local_policy: Optional[FreshnessPolicy],
-    policies: AbstractSet[FreshnessPolicy],
+    local_policy: Optional[LegacyFreshnessPolicy],
+    policies: AbstractSet[LegacyFreshnessPolicy],
     effective_data_time: Optional[datetime.datetime],
     current_time: datetime.datetime,
 ) -> tuple[Optional[TimeWindow], Optional["TextRuleEvaluationData"]]:

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -26,8 +26,8 @@ class FreshnessMinutes(NamedTuple):
     additional_warn_text="For monitoring freshness, use freshness checks instead. If using lazy "
     "auto-materialize, use AutomationCondition.cron() and AutomationCondition.any_downstream_conditions().",
 )
-@whitelist_for_serdes
-class FreshnessPolicy(
+@whitelist_for_serdes(storage_name="FreshnessPolicy")
+class LegacyFreshnessPolicy(
     NamedTuple(
         "_FreshnessPolicy",
         [

--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/load_assets_from_modules.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
 )
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.module_loaders.object_list import ModuleScopedDagsterDefs
 from dagster._core.definitions.module_loaders.utils import find_modules_in_package
 from dagster._core.definitions.source_asset import SourceAsset
@@ -57,7 +57,7 @@ def load_assets_from_modules(
     group_name: Optional[str] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     *,
-    freshness_policy: Optional[FreshnessPolicy] = None,
+    freshness_policy: Optional[LegacyFreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     automation_condition: Optional[AutomationCondition] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
@@ -109,7 +109,7 @@ def load_assets_from_modules(
             ),
             group_name=check.opt_str_param(group_name, "group_name"),
             freshness_policy=check.opt_inst_param(
-                freshness_policy, "freshness_policy", FreshnessPolicy
+                freshness_policy, "freshness_policy", LegacyFreshnessPolicy
             ),
             automation_condition=resolve_automation_condition(
                 automation_condition, auto_materialize_policy
@@ -126,7 +126,7 @@ def load_assets_from_current_module(
     group_name: Optional[str] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     *,
-    freshness_policy: Optional[FreshnessPolicy] = None,
+    freshness_policy: Optional[LegacyFreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     automation_condition: Optional[AutomationCondition] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
@@ -179,7 +179,7 @@ def load_assets_from_package_module(
     group_name: Optional[str] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     *,
-    freshness_policy: Optional[FreshnessPolicy] = None,
+    freshness_policy: Optional[LegacyFreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     automation_condition: Optional[AutomationCondition] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
@@ -229,7 +229,7 @@ def load_assets_from_package_name(
     group_name: Optional[str] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     *,
-    freshness_policy: Optional[FreshnessPolicy] = None,
+    freshness_policy: Optional[LegacyFreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     source_key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,

--- a/python_modules/dagster/dagster/_core/definitions/module_loaders/object_list.py
+++ b/python_modules/dagster/dagster/_core/definitions/module_loaders/object_list.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
 )
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.module_loaders.utils import (
     find_objects_in_module_of_types,
@@ -349,7 +349,7 @@ class DagsterObjectsList:
         key_prefix: Optional[CoercibleToAssetKeyPrefix],
         source_key_prefix: Optional[CoercibleToAssetKeyPrefix],
         group_name: Optional[str],
-        freshness_policy: Optional[FreshnessPolicy],
+        freshness_policy: Optional[LegacyFreshnessPolicy],
         automation_condition: Optional[AutomationCondition],
         backfill_policy: Optional[BackfillPolicy],
     ) -> "DagsterObjectsList":

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -36,7 +36,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
 )
 from dagster._core.definitions.freshness import InternalFreshnessPolicy
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
@@ -107,7 +107,7 @@ class RemoteAssetNode(BaseAssetNode, ABC):
         return partitions_snap.get_partitions_definition() if partitions_snap else None
 
     @property
-    def freshness_policy(self) -> Optional[FreshnessPolicy]:
+    def freshness_policy(self) -> Optional[LegacyFreshnessPolicy]:
         # It is currently not possible to access the freshness policy for an observation definition
         # if a materialization definition also exists. This needs to be fixed.
         return self.resolve_to_singular_repo_scoped_node().asset_node_snap.freshness_policy

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -16,7 +16,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
 )
 from dagster._core.definitions.events import AssetKey, AssetObservation, CoercibleToAssetKey, Output
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.metadata import (
     ArbitraryMetadataMapping,
     MetadataMapping,
@@ -207,7 +207,7 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
     op_tags: Optional[Mapping[str, Any]]
     _node_def: Optional[OpDefinition]  # computed lazily
     auto_observe_interval_minutes: Optional[float]
-    freshness_policy: Optional[FreshnessPolicy]
+    freshness_policy: Optional[LegacyFreshnessPolicy]
     automation_condition: Optional[AutomationCondition]
     tags: Mapping[str, str]
 
@@ -225,7 +225,7 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
         op_tags: Optional[Mapping[str, Any]] = None,
         *,
         auto_observe_interval_minutes: Optional[float] = None,
-        freshness_policy: Optional[FreshnessPolicy] = None,
+        freshness_policy: Optional[LegacyFreshnessPolicy] = None,
         automation_condition: Optional[AutomationCondition] = None,
         tags: Optional[Mapping[str, str]] = None,
         # This is currently private because it is necessary for source asset observation functions,
@@ -278,7 +278,7 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
             auto_observe_interval_minutes, "auto_observe_interval_minutes"
         )
         self.freshness_policy = check.opt_inst_param(
-            freshness_policy, "freshness_policy", FreshnessPolicy
+            freshness_policy, "freshness_policy", LegacyFreshnessPolicy
         )
         self.automation_condition = check.opt_inst_param(
             automation_condition, "automation_condition", AutomationCondition
@@ -298,7 +298,7 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
         observe_fn: Optional[SourceAssetObserveFunction],
         op_tags: Optional[Mapping[str, Any]],
         auto_observe_interval_minutes: Optional[float],
-        freshness_policy: Optional[FreshnessPolicy],
+        freshness_policy: Optional[LegacyFreshnessPolicy],
         automation_condition: Optional[AutomationCondition],
         tags: Optional[Mapping[str, str]],
         _required_resource_keys: Optional[AbstractSet[str]],

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -65,7 +65,7 @@ from dagster._core.definitions.dependency import (
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness import InternalFreshnessPolicy
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.metadata import (
     MetadataFieldSerializer,
     MetadataMapping,
@@ -1417,7 +1417,7 @@ class AssetNodeSnap(IHaveNew):
     metadata: Mapping[str, MetadataValue]
     tags: Optional[Mapping[str, str]]
     group_name: str
-    freshness_policy: Optional[FreshnessPolicy]
+    freshness_policy: Optional[LegacyFreshnessPolicy]
     is_source: bool
     is_observable: bool
     # If a set of assets can't be materialized independently from each other, they will all
@@ -1451,7 +1451,7 @@ class AssetNodeSnap(IHaveNew):
         metadata: Optional[Mapping[str, MetadataValue]] = None,
         tags: Optional[Mapping[str, str]] = None,
         group_name: Optional[str] = None,
-        freshness_policy: Optional[FreshnessPolicy] = None,
+        freshness_policy: Optional[LegacyFreshnessPolicy] = None,
         is_source: Optional[bool] = None,
         is_observable: bool = False,
         execution_set_identifier: Optional[str] = None,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -14,7 +14,6 @@ from dagster import (
     DagsterEventType,
     DailyPartitionsDefinition,
     Definitions,
-    FreshnessPolicy,
     GraphOut,
     HookContext,
     IdentityPartitionMapping,
@@ -22,6 +21,7 @@ from dagster import (
     IOManager,
     IOManagerDefinition,
     LastPartitionMapping,
+    LegacyFreshnessPolicy,
     Out,
     Output,
     ResourceDefinition,
@@ -180,7 +180,7 @@ def test_retain_group():
 
 
 def test_retain_freshness_policy():
-    fp = FreshnessPolicy(maximum_lag_minutes=24.5)
+    fp = LegacyFreshnessPolicy(maximum_lag_minutes=24.5)
 
     @asset(freshness_policy=fp)
     def bar():
@@ -194,8 +194,8 @@ def test_retain_freshness_policy():
 
 
 def test_graph_backed_retain_freshness_policy_and_auto_materialize_policy():
-    fpa = FreshnessPolicy(maximum_lag_minutes=24.5)
-    fpb = FreshnessPolicy(
+    fpa = LegacyFreshnessPolicy(maximum_lag_minutes=24.5)
+    fpb = LegacyFreshnessPolicy(
         maximum_lag_minutes=30.5, cron_schedule="0 0 * * *", cron_schedule_timezone="US/Eastern"
     )
     ampa = AutoMaterializePolicy.eager()
@@ -944,7 +944,7 @@ def test_from_graph_w_key_prefix():
     def silly_graph():
         return bar(foo())
 
-    freshness_policy = FreshnessPolicy(maximum_lag_minutes=60)
+    freshness_policy = LegacyFreshnessPolicy(maximum_lag_minutes=60)
     description = "This is a description!"
     metadata = {"test_metadata": "This is some metadata"}
 
@@ -995,7 +995,7 @@ def test_from_op_w_key_prefix():
     def foo():
         return 1
 
-    freshness_policy = FreshnessPolicy(maximum_lag_minutes=60)
+    freshness_policy = LegacyFreshnessPolicy(maximum_lag_minutes=60)
     description = "This is a description!"
     metadata = {"test_metadata": "This is some metadata"}
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -9,10 +9,10 @@ from dagster import (
     DagsterInvalidDefinitionError,
     DailyPartitionsDefinition,
     DimensionPartitionMapping,
-    FreshnessPolicy,
     GraphIn,
     IdentityPartitionMapping,
     In,
+    LegacyFreshnessPolicy,
     MultiPartitionMapping,
     MultiPartitionsDefinition,
     Nothing,
@@ -967,7 +967,7 @@ def test_graph_asset_with_args(automation_condition_arg):
     @graph_asset(
         group_name="group1",
         metadata={"my_metadata": "some_metadata"},
-        freshness_policy=FreshnessPolicy(maximum_lag_minutes=5),
+        freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=5),
         resource_defs={"foo": foo_resource},
         tags={"foo": "bar"},
         owners=["team:team1", "claire@dagsterlabs.com"],
@@ -979,7 +979,7 @@ def test_graph_asset_with_args(automation_condition_arg):
 
     assert my_asset.group_names_by_key[AssetKey("my_asset")] == "group1"
     assert my_asset.metadata_by_key[AssetKey("my_asset")] == {"my_metadata": "some_metadata"}
-    assert my_asset.freshness_policies_by_key[AssetKey("my_asset")] == FreshnessPolicy(
+    assert my_asset.freshness_policies_by_key[AssetKey("my_asset")] == LegacyFreshnessPolicy(
         maximum_lag_minutes=5
     )
     assert my_asset.tags_by_key[AssetKey("my_asset")] == {"foo": "bar"}
@@ -1179,7 +1179,7 @@ def test_graph_multi_asset_decorator(automation_condition_arg):
     @graph_multi_asset(
         outs={
             "first_asset": AssetOut(code_version="abc", **automation_condition_arg),
-            "second_asset": AssetOut(freshness_policy=FreshnessPolicy(maximum_lag_minutes=5)),
+            "second_asset": AssetOut(freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=5)),
         },
         group_name="grp",
         resource_defs={"foo": foo_resource},
@@ -1198,7 +1198,7 @@ def test_graph_multi_asset_decorator(automation_condition_arg):
     assert two_assets.group_names_by_key[AssetKey("second_asset")] == "grp"
 
     assert two_assets.freshness_policies_by_key.get(AssetKey("first_asset")) is None
-    assert two_assets.freshness_policies_by_key[AssetKey("second_asset")] == FreshnessPolicy(
+    assert two_assets.freshness_policies_by_key[AssetKey("second_asset")] == LegacyFreshnessPolicy(
         maximum_lag_minutes=5
     )
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -13,7 +13,7 @@ from dagster import (
     DailyPartitionsDefinition,
     Definitions,
     DynamicPartitionsDefinition,
-    FreshnessPolicy,
+    LegacyFreshnessPolicy,
     MultiPartitionsDefinition,
     PipesSubprocessClient,
     SourceAsset,
@@ -315,7 +315,7 @@ def test_get_stats_from_remote_repo_observable_source_assets():
 
 
 def test_get_stats_from_remote_repo_freshness_policies():
-    @asset(freshness_policy=FreshnessPolicy(maximum_lag_minutes=30))
+    @asset(freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=30))
     def asset1(): ...
 
     @asset

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/active_run_scenarios.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/active_run_scenarios.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from dagster import DailyPartitionsDefinition, PartitionKeyRange
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.time_window_partitions import HourlyPartitionsDefinition
 from dagster._core.events import DagsterEvent, StepMaterializationData
 from dagster._core.events.log import EventLogEntry
@@ -33,7 +33,7 @@ freshness_with_observable_source_assets = [
     observable_source_asset_def("observable_source"),
     asset_def("asset0"),
     asset_def("asset1", ["observable_source", "asset0"]),
-    asset_def("asset2", ["asset1"], freshness_policy=FreshnessPolicy(maximum_lag_minutes=30)),
+    asset_def("asset2", ["asset1"], freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=30)),
 ]
 
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.auto_materialize_rule_impls import (
     DiscardOnMaxMaterializationsExceededRule,
 )
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._time import create_datetime
 
 from dagster_tests.declarative_automation_tests.legacy_tests.scenarios.asset_graphs import (
@@ -52,7 +52,7 @@ lazy_assets_nothing_dep = [
         "asset3",
         ["asset2"],
         auto_materialize_policy=AutoMaterializePolicy.lazy(),
-        freshness_policy=FreshnessPolicy(maximum_lag_minutes=60),
+        freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=60),
     ),
 ]
 single_lazy_asset = [asset_def("asset1", auto_materialize_policy=AutoMaterializePolicy.lazy())]
@@ -60,12 +60,14 @@ single_lazy_asset_with_freshness_policy = [
     asset_def(
         "asset1",
         auto_materialize_policy=AutoMaterializePolicy.lazy(),
-        freshness_policy=FreshnessPolicy(maximum_lag_minutes=60),
+        freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=60),
     )
 ]
 overlapping_freshness_inf = diamond + [
-    asset_def("asset5", ["asset3"], freshness_policy=FreshnessPolicy(maximum_lag_minutes=30)),
-    asset_def("asset6", ["asset4"], freshness_policy=FreshnessPolicy(maximum_lag_minutes=99999999)),
+    asset_def("asset5", ["asset3"], freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=30)),
+    asset_def(
+        "asset6", ["asset4"], freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=99999999)
+    ),
 ]
 vee = [
     asset_def("A"),
@@ -117,7 +119,7 @@ non_auto_to_lazy = [
         "auto",
         ["non_auto"],
         auto_materialize_policy=AutoMaterializePolicy.lazy(),
-        freshness_policy=FreshnessPolicy(maximum_lag_minutes=60),
+        freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=60),
     ),
 ]
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/freshness_policy_scenarios.py
@@ -3,7 +3,7 @@ import datetime
 from dagster import AssetSelection, DailyPartitionsDefinition
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import TextRuleEvaluationData
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 
 from dagster_tests.declarative_automation_tests.scenario_utils.base_scenario import (
     AssetEvaluationSpec,
@@ -14,8 +14,8 @@ from dagster_tests.declarative_automation_tests.scenario_utils.base_scenario imp
     run_request,
 )
 
-freshness_30m = FreshnessPolicy(maximum_lag_minutes=30)
-freshness_60m = FreshnessPolicy(maximum_lag_minutes=60)
+freshness_30m = LegacyFreshnessPolicy(maximum_lag_minutes=30)
+freshness_60m = LegacyFreshnessPolicy(maximum_lag_minutes=60)
 
 non_subsettable_multi_asset_on_top = [
     multi_asset_def(["asset1", "asset2", "asset3"], can_subset=False),

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/multi_code_location_scenarios.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/multi_code_location_scenarios.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 
-from dagster import AssetsDefinition, FreshnessPolicy
+from dagster import AssetsDefinition, LegacyFreshnessPolicy
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 
 from dagster_tests.declarative_automation_tests.legacy_tests.scenarios.basic_scenarios import (
@@ -13,8 +13,8 @@ from dagster_tests.declarative_automation_tests.scenario_utils.base_scenario imp
     run_request,
 )
 
-freshness_30m = FreshnessPolicy(maximum_lag_minutes=30)
-freshness_inf = FreshnessPolicy(maximum_lag_minutes=99999)
+freshness_30m = LegacyFreshnessPolicy(maximum_lag_minutes=30)
+freshness_inf = LegacyFreshnessPolicy(maximum_lag_minutes=99999)
 
 diamond_freshness = diamond[:-1] + [
     asset_def("asset4", ["asset2", "asset3"], freshness_policy=freshness_30m)

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -50,7 +50,7 @@ from dagster._core.definitions.automation_tick_evaluation_context import (
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.data_version import DataVersionsByPartition
 from dagster._core.definitions.events import CoercibleToAssetKey
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.partition import PartitionsSubset, ScheduleType
 from dagster._core.definitions.time_window_partitions import get_time_partitions_def
@@ -605,7 +605,7 @@ def asset_def(
     key: str,
     deps: Optional[Union[list[str], Mapping[str, Optional[PartitionMapping]]]] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
-    freshness_policy: Optional[FreshnessPolicy] = None,
+    freshness_policy: Optional[LegacyFreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
     code_version: Optional[str] = None,
     config_schema: Optional[Mapping[str, Field]] = None,
@@ -648,7 +648,7 @@ def multi_asset_def(
     keys: list[str],
     deps: Optional[Union[list[str], Mapping[str, set[str]]]] = None,
     can_subset: bool = False,
-    freshness_policies: Optional[Mapping[str, FreshnessPolicy]] = None,
+    freshness_policies: Optional[Mapping[str, LegacyFreshnessPolicy]] = None,
 ) -> AssetsDefinition:
     if deps is None:
         non_argument_deps = None

--- a/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/test_load_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/module_loader_tests/test_load_assets_from_modules.py
@@ -7,7 +7,7 @@ from dagster import (
     AssetKey,
     AssetsDefinition,
     DagsterInvalidDefinitionError,
-    FreshnessPolicy,
+    LegacyFreshnessPolicy,
     SourceAsset,
     asset,
     load_assets_from_current_module,
@@ -245,14 +245,14 @@ def test_load_assets_with_freshness_policy():
 
     assets = load_assets_from_modules(
         [asset_package, module_with_assets],
-        freshness_policy=FreshnessPolicy(maximum_lag_minutes=50),
+        freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=50),
     )
-    check_freshness_policy(assets, FreshnessPolicy(maximum_lag_minutes=50))
+    check_freshness_policy(assets, LegacyFreshnessPolicy(maximum_lag_minutes=50))
 
     assets = load_assets_from_package_module(
-        asset_package, freshness_policy=FreshnessPolicy(maximum_lag_minutes=50)
+        asset_package, freshness_policy=LegacyFreshnessPolicy(maximum_lag_minutes=50)
     )
-    check_freshness_policy(assets, FreshnessPolicy(maximum_lag_minutes=50))
+    check_freshness_policy(assets, LegacyFreshnessPolicy(maximum_lag_minutes=50))
 
 
 def test_load_assets_with_auto_materialize_policy():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
@@ -23,7 +23,7 @@ from dagster._core.definitions.external_asset import (
     create_external_asset_from_source_asset,
     external_assets_from_specs,
 )
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition
 
 
@@ -265,7 +265,7 @@ def test_how_partitioned_source_assets_are_backwards_compatible() -> None:
 
 
 def test_observable_source_asset_decorator() -> None:
-    freshness_policy = FreshnessPolicy(maximum_lag_minutes=30)
+    freshness_policy = LegacyFreshnessPolicy(maximum_lag_minutes=30)
 
     @observable_source_asset(freshness_policy=freshness_policy)
     def an_observable_source_asset() -> DataVersion:

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -13,7 +13,7 @@ from dagster import (
     AssetKey,
     AssetOut,
     AutoMaterializePolicy,
-    FreshnessPolicy,
+    LegacyFreshnessPolicy,
     Nothing,
     Output,
     ResourceDefinition,
@@ -72,7 +72,7 @@ def _build_airbyte_asset_defn_metadata(
     group_name: Optional[str] = None,
     io_manager_key: Optional[str] = None,
     schema_by_table_name: Optional[Mapping[str, TableSchema]] = None,
-    freshness_policy: Optional[FreshnessPolicy] = None,
+    freshness_policy: Optional[LegacyFreshnessPolicy] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
 ) -> AssetsDefinitionCacheableData:
     asset_key_prefix = (
@@ -260,7 +260,7 @@ def build_airbyte_assets(
     deps: Optional[Iterable[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]]] = None,
     upstream_assets: Optional[set[AssetKey]] = None,
     schema_by_table_name: Optional[Mapping[str, TableSchema]] = None,
-    freshness_policy: Optional[FreshnessPolicy] = None,
+    freshness_policy: Optional[LegacyFreshnessPolicy] = None,
     stream_to_asset_map: Optional[Mapping[str, str]] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
 ) -> Sequence[AssetsDefinition]:
@@ -592,7 +592,7 @@ class AirbyteCoreCacheableAssetsDefinition(CacheableAssetsDefinition):
         connection_filter: Optional[Callable[[AirbyteConnectionMetadata], bool]],
         connection_to_asset_key_fn: Optional[Callable[[AirbyteConnectionMetadata, str], AssetKey]],
         connection_to_freshness_policy_fn: Optional[
-            Callable[[AirbyteConnectionMetadata], Optional[FreshnessPolicy]]
+            Callable[[AirbyteConnectionMetadata], Optional[LegacyFreshnessPolicy]]
         ],
         connection_to_auto_materialize_policy_fn: Optional[
             Callable[[AirbyteConnectionMetadata], Optional[AutoMaterializePolicy]]
@@ -708,7 +708,7 @@ class AirbyteInstanceCacheableAssetsDefinition(AirbyteCoreCacheableAssetsDefinit
         connection_filter: Optional[Callable[[AirbyteConnectionMetadata], bool]],
         connection_to_asset_key_fn: Optional[Callable[[AirbyteConnectionMetadata, str], AssetKey]],
         connection_to_freshness_policy_fn: Optional[
-            Callable[[AirbyteConnectionMetadata], Optional[FreshnessPolicy]]
+            Callable[[AirbyteConnectionMetadata], Optional[LegacyFreshnessPolicy]]
         ],
         connection_to_auto_materialize_policy_fn: Optional[
             Callable[[AirbyteConnectionMetadata], Optional[AutoMaterializePolicy]]
@@ -822,7 +822,7 @@ class AirbyteYAMLCacheableAssetsDefinition(AirbyteCoreCacheableAssetsDefinition)
         connection_directories: Optional[Sequence[str]],
         connection_to_asset_key_fn: Optional[Callable[[AirbyteConnectionMetadata, str], AssetKey]],
         connection_to_freshness_policy_fn: Optional[
-            Callable[[AirbyteConnectionMetadata], Optional[FreshnessPolicy]]
+            Callable[[AirbyteConnectionMetadata], Optional[LegacyFreshnessPolicy]]
         ],
         connection_to_auto_materialize_policy_fn: Optional[
             Callable[[AirbyteConnectionMetadata], Optional[AutoMaterializePolicy]]
@@ -914,7 +914,7 @@ def load_assets_from_airbyte_instance(
         Callable[[AirbyteConnectionMetadata, str], AssetKey]
     ] = None,
     connection_to_freshness_policy_fn: Optional[
-        Callable[[AirbyteConnectionMetadata], Optional[FreshnessPolicy]]
+        Callable[[AirbyteConnectionMetadata], Optional[LegacyFreshnessPolicy]]
     ] = None,
     connection_to_auto_materialize_policy_fn: Optional[
         Callable[[AirbyteConnectionMetadata], Optional[AutoMaterializePolicy]]

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/managed/reconciliation.py
@@ -6,7 +6,7 @@ from dagster import AssetKey
 from dagster._annotations import beta, deprecated, public
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 from dagster._core.definitions.events import CoercibleToAssetKeyPrefix
-from dagster._core.definitions.freshness_policy import FreshnessPolicy
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.execution.context.init import build_init_resource_context
 from dagster._utils.merger import deep_merge_dicts
@@ -698,7 +698,7 @@ class AirbyteManagedElementCacheableAssetsDefinition(AirbyteInstanceCacheableAss
         connection_to_io_manager_key_fn: Optional[Callable[[str], Optional[str]]],
         connection_to_asset_key_fn: Optional[Callable[[AirbyteConnectionMetadata, str], AssetKey]],
         connection_to_freshness_policy_fn: Optional[
-            Callable[[AirbyteConnectionMetadata], Optional[FreshnessPolicy]]
+            Callable[[AirbyteConnectionMetadata], Optional[LegacyFreshnessPolicy]]
         ],
     ):
         defined_conn_names = {conn.name for conn in connections}
@@ -744,7 +744,7 @@ def load_assets_from_connections(
         Callable[[AirbyteConnectionMetadata, str], AssetKey]
     ] = None,
     connection_to_freshness_policy_fn: Optional[
-        Callable[[AirbyteConnectionMetadata], Optional[FreshnessPolicy]]
+        Callable[[AirbyteConnectionMetadata], Optional[LegacyFreshnessPolicy]]
     ] = None,
 ) -> CacheableAssetsDefinition:
     """Loads Airbyte connection assets from a configured AirbyteResource instance, checking against a list of AirbyteConnection objects.

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -3,7 +3,7 @@ import responses
 from dagster import (
     AssetKey,
     AutoMaterializePolicy,
-    FreshnessPolicy,
+    LegacyFreshnessPolicy,
     TableColumn,
     TableSchema,
     asset,
@@ -108,7 +108,7 @@ def test_assets(schema_prefix, auto_materialize_policy, monkeypatch):
 @responses.activate
 @pytest.mark.parametrize("schema_prefix", ["", "the_prefix_"])
 @pytest.mark.parametrize("source_asset", [None, "my_source_asset_key"])
-@pytest.mark.parametrize("freshness_policy", [None, FreshnessPolicy(maximum_lag_minutes=60)])
+@pytest.mark.parametrize("freshness_policy", [None, LegacyFreshnessPolicy(maximum_lag_minutes=60)])
 @pytest.mark.parametrize("auto_materialize_policy", [None, AutoMaterializePolicy.lazy()])
 def test_assets_with_normalization(
     schema_prefix, source_asset, freshness_policy, auto_materialize_policy

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -6,9 +6,9 @@ import responses
 from dagster import (
     AssetKey,
     EnvVar,
-    FreshnessPolicy,
     InputContext,
     IOManager,
+    LegacyFreshnessPolicy,
     OutputContext,
     asset,
     io_manager,
@@ -34,7 +34,7 @@ from dagster_airbyte_tests.utils import (
     get_project_job_json,
 )
 
-TEST_FRESHNESS_POLICY = FreshnessPolicy(maximum_lag_minutes=60)
+TEST_FRESHNESS_POLICY = LegacyFreshnessPolicy(maximum_lag_minutes=60)
 
 
 @pytest.fixture(name="airbyte_instance", params=[True, False], scope="module")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -18,7 +18,7 @@ from dagster import (
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
     DefaultScheduleStatus,
-    FreshnessPolicy,
+    LegacyFreshnessPolicy,
     OpExecutionContext,
     RunConfig,
     ScheduleDefinition,
@@ -587,12 +587,14 @@ def default_owners_from_dbt_resource_props(
     return [owner]
 
 
-def default_freshness_policy_fn(dbt_resource_props: Mapping[str, Any]) -> Optional[FreshnessPolicy]:
+def default_freshness_policy_fn(
+    dbt_resource_props: Mapping[str, Any],
+) -> Optional[LegacyFreshnessPolicy]:
     dagster_metadata = dbt_resource_props.get("meta", {}).get("dagster", {})
     freshness_policy_config = dagster_metadata.get("freshness_policy", {})
 
     freshness_policy = (
-        FreshnessPolicy(
+        LegacyFreshnessPolicy(
             maximum_lag_minutes=float(freshness_policy_config["maximum_lag_minutes"]),
             cron_schedule=freshness_policy_config.get("cron_schedule"),
             cron_schedule_timezone=freshness_policy_config.get("cron_schedule_timezone"),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -11,7 +11,7 @@ from dagster import (
     AssetKey,
     AssetsDefinition,
     AutoMaterializePolicy,
-    FreshnessPolicy,
+    LegacyFreshnessPolicy,
     MetadataValue,
     PartitionsDefinition,
     ResourceDefinition,
@@ -52,7 +52,9 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
         job_id: int,
         node_info_to_asset_key: Callable[[Mapping[str, Any]], AssetKey],
         node_info_to_group_fn: Callable[[Mapping[str, Any]], Optional[str]],
-        node_info_to_freshness_policy_fn: Callable[[Mapping[str, Any]], Optional[FreshnessPolicy]],
+        node_info_to_freshness_policy_fn: Callable[
+            [Mapping[str, Any]], Optional[LegacyFreshnessPolicy]
+        ],
         node_info_to_auto_materialize_policy_fn: Callable[
             [Mapping[str, Any]], Optional[AutoMaterializePolicy]
         ],
@@ -545,7 +547,7 @@ def load_assets_from_dbt_cloud_job(
         [Mapping[str, Any]], Optional[str]
     ] = default_group_from_dbt_resource_props,
     node_info_to_freshness_policy_fn: Callable[
-        [Mapping[str, Any]], Optional[FreshnessPolicy]
+        [Mapping[str, Any]], Optional[LegacyFreshnessPolicy]
     ] = default_freshness_policy_fn,
     node_info_to_auto_materialize_policy_fn: Callable[
         [Mapping[str, Any]], Optional[AutoMaterializePolicy]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -12,7 +12,7 @@ from dagster import (
     AutoMaterializePolicy,
     AutomationCondition,
     DagsterInvalidDefinitionError,
-    FreshnessPolicy,
+    LegacyFreshnessPolicy,
     PartitionMapping,
 )
 from dagster._annotations import beta, public
@@ -495,7 +495,7 @@ class DagsterDbtTranslator:
     @beta(emit_runtime_warning=False)
     def get_freshness_policy(
         self, dbt_resource_props: Mapping[str, Any]
-    ) -> Optional[FreshnessPolicy]:
+    ) -> Optional[LegacyFreshnessPolicy]:
         """A function that takes a dictionary representing properties of a dbt resource, and
         returns the Dagster :py:class:`dagster.FreshnessPolicy` for that resource.
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -9,7 +9,7 @@ from dagster import (
     AssetSelection,
     AutoMaterializePolicy,
     DailyPartitionsDefinition,
-    FreshnessPolicy,
+    LegacyFreshnessPolicy,
     MetadataValue,
     asset,
     define_asset_job,
@@ -458,7 +458,7 @@ def test_custom_freshness_policy(dbt_cloud, dbt_cloud_service):
     dbt_cloud_cacheable_assets = load_assets_from_dbt_cloud_job(
         dbt_cloud=dbt_cloud,
         job_id=DBT_CLOUD_JOB_ID,
-        node_info_to_freshness_policy_fn=lambda node_info: FreshnessPolicy(
+        node_info_to_freshness_policy_fn=lambda node_info: LegacyFreshnessPolicy(
             maximum_lag_minutes=len(node_info["name"])
         ),
     )
@@ -468,7 +468,7 @@ def test_custom_freshness_policy(dbt_cloud, dbt_cloud_service):
     )
 
     assert dbt_cloud_assets[0].freshness_policies_by_key == {
-        key: FreshnessPolicy(maximum_lag_minutes=len(key.path[-1]))
+        key: LegacyFreshnessPolicy(maximum_lag_minutes=len(key.path[-1]))
         for key in dbt_cloud_assets[0].keys
     }
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -16,9 +16,9 @@ from dagster import (
     Definitions,
     DependencyDefinition,
     DimensionPartitionMapping,
-    FreshnessPolicy,
     Jitter,
     LastPartitionMapping,
+    LegacyFreshnessPolicy,
     MultiPartitionMapping,
     NodeInvocation,
     OpDefinition,
@@ -339,7 +339,7 @@ def test_backfill_policy(
     expected_backfill_policy: BackfillPolicy,
 ) -> None:
     class CustomDagsterDbtTranslator(DagsterDbtTranslator):
-        def get_freshness_policy(self, _: Mapping[str, Any]) -> Optional[FreshnessPolicy]:  # pyright: ignore[reportIncompatibleMethodOverride]
+        def get_freshness_policy(self, _: Mapping[str, Any]) -> Optional[LegacyFreshnessPolicy]:  # pyright: ignore[reportIncompatibleMethodOverride]
             # Disable freshness policies when using static partitions
             return None
 
@@ -749,10 +749,10 @@ def test_all_assets_have_a_distinct_code_version(test_jaffle_shop_manifest: dict
 
 
 def test_with_freshness_policy_replacements(test_jaffle_shop_manifest: dict[str, Any]) -> None:
-    expected_freshness_policy = FreshnessPolicy(maximum_lag_minutes=60)
+    expected_freshness_policy = LegacyFreshnessPolicy(maximum_lag_minutes=60)
 
     class CustomDagsterDbtTranslator(DagsterDbtTranslator):
-        def get_freshness_policy(self, _: Mapping[str, Any]) -> Optional[FreshnessPolicy]:  # pyright: ignore[reportIncompatibleMethodOverride]
+        def get_freshness_policy(self, _: Mapping[str, Any]) -> Optional[LegacyFreshnessPolicy]:  # pyright: ignore[reportIncompatibleMethodOverride]
             return expected_freshness_policy
 
     expected_specs_by_key = {
@@ -885,7 +885,9 @@ def test_dbt_meta_auto_materialize_policy(test_meta_config_manifest: dict[str, A
 
 
 def test_dbt_meta_freshness_policy(test_meta_config_manifest: dict[str, Any]) -> None:
-    expected_freshness_policy = FreshnessPolicy(maximum_lag_minutes=60.0, cron_schedule="* * * * *")
+    expected_freshness_policy = LegacyFreshnessPolicy(
+        maximum_lag_minutes=60.0, cron_schedule="* * * * *"
+    )
     expected_specs_by_key = {
         spec.key: spec for spec in build_dbt_asset_specs(manifest=test_meta_config_manifest)
     }

--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
-from dagster import AssetKey, AssetSpec, AutoMaterializePolicy, FreshnessPolicy, MetadataValue
+from dagster import AssetKey, AssetSpec, AutoMaterializePolicy, LegacyFreshnessPolicy, MetadataValue
 from dagster._annotations import public, superseded
 from dagster._utils.names import clean_name_lower_with_dots
 from dagster._utils.warnings import supersession_warning
@@ -471,7 +471,7 @@ class DagsterSlingTranslator:
     @public
     def get_freshness_policy(
         self, stream_definition: Mapping[str, Any]
-    ) -> Optional[FreshnessPolicy]:
+    ) -> Optional[LegacyFreshnessPolicy]:
         """Retrieves the freshness policy for a given stream definition.
 
         This method checks the provided stream definition for a specific configuration
@@ -491,7 +491,7 @@ class DagsterSlingTranslator:
 
     def _default_freshness_policy_fn(
         self, stream_definition: Mapping[str, Any]
-    ) -> Optional[FreshnessPolicy]:
+    ) -> Optional[LegacyFreshnessPolicy]:
         """Retrieves the freshness policy for a given stream definition.
 
         This method checks the provided stream definition for a specific configuration
@@ -511,7 +511,7 @@ class DagsterSlingTranslator:
         meta = config.get("meta", {})
         freshness_policy_config = meta.get("dagster", {}).get("freshness_policy")
         if freshness_policy_config:
-            return FreshnessPolicy(
+            return LegacyFreshnessPolicy(
                 maximum_lag_minutes=float(freshness_policy_config["maximum_lag_minutes"]),
                 cron_schedule=freshness_policy_config.get("cron_schedule"),
                 cron_schedule_timezone=freshness_policy_config.get("cron_schedule_timezone"),

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
@@ -11,8 +11,8 @@ from dagster import (
     AssetKey,
     AssetSpec,
     Config,
-    FreshnessPolicy,
     JsonMetadataValue,
+    LegacyFreshnessPolicy,
     file_relative_path,
 )
 from dagster._core.definitions.materialize import materialize
@@ -210,7 +210,7 @@ def test_base_with_meta_config_translator():
     }
 
     assert my_sling_assets.freshness_policies_by_key == {
-        AssetKey(["target", "departments"]): FreshnessPolicy(
+        AssetKey(["target", "departments"]): LegacyFreshnessPolicy(
             maximum_lag_minutes=0.0, cron_schedule="5 4 * * *", cron_schedule_timezone="UTC"
         )
     }

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_dagster_sling_translator.py
@@ -1,5 +1,5 @@
 import pytest
-from dagster import AssetKey, AutoMaterializePolicy, FreshnessPolicy, JsonMetadataValue
+from dagster import AssetKey, AutoMaterializePolicy, JsonMetadataValue, LegacyFreshnessPolicy
 from dagster_sling.dagster_sling_translator import DagsterSlingTranslator
 
 
@@ -127,7 +127,7 @@ def test_group_name_from_get_asset_spec(stream, expected):
                 "name": "foo",
                 "config": {"meta": {"dagster": {"freshness_policy": {"maximum_lag_minutes": 5}}}},
             },
-            FreshnessPolicy(maximum_lag_minutes=5),
+            LegacyFreshnessPolicy(maximum_lag_minutes=5),
         ),
     ],
 )


### PR DESCRIPTION
## Summary & Motivation
Part 1 of moving over to the new `FreshnessPolicy` (currently named `InternalFreshnessPolicy`). We'd like to reuse the `FreshnessPolicy` name, so renaming the existing class to `LegacyFreshnessPolicy`.

Since this is a breaking change for users, it needs to go out in the `1.11` major release. Will need to hold merge to `main` until after the `1.11` release branch is cut and then cherry pick onto the release branch.


## How I Tested These Changes
oss tests, backcompat snapshot test added in the cloud repo: https://github.com/dagster-io/internal/pull/16306

## Changelog

[breaking] rename `FreshnessPolicy` to `LegacyFreshnessPolicy`