### PR TITLE
Make custom dbt translators still work if you subclass and don't call the constructor

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -87,7 +87,6 @@ class DagsterDbtTranslator:
             settings (Optional[DagsterDbtTranslatorSettings]): Settings for the translator.
         """
         self._settings = settings or DagsterDbtTranslatorSettings()
-        self._resolved_specs: dict[tuple, AssetSpec] = {}
 
     @property
     def settings(self) -> DagsterDbtTranslatorSettings:
@@ -106,6 +105,11 @@ class DagsterDbtTranslator:
         # memoize resolution for a given manifest & unique_id
         # since we recursively call get_asset_spec for dependencies
         memo_id = (id(manifest), unique_id)
+
+        # Don't initialize this in the constructor in case a subclass does not call __init__
+        if not hasattr(self, "_resolved_specs"):
+            self._resolved_specs = {}
+
         if memo_id in self._resolved_specs:
             return self._resolved_specs[memo_id]
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -604,6 +604,20 @@ def test_with_description_replacements(test_jaffle_shop_manifest: dict[str, Any]
         assert expected_specs_by_key[asset_key].description == expected_description
 
 
+def test_with_subclassed_init(test_jaffle_shop_manifest: dict[str, Any]) -> None:
+    class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+        def __init__(self):
+            pass
+
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomDagsterDbtTranslator()
+    )
+    def my_dbt_assets(): ...
+
+    expected_specs = build_dbt_asset_specs(manifest=test_jaffle_shop_manifest)
+    assert my_dbt_assets.keys == {spec.key for spec in expected_specs}
+
+
 def test_with_metadata_replacements(test_jaffle_shop_manifest: dict[str, Any]) -> None:
     expected_metadata = {"customized": "metadata"}
 


### PR DESCRIPTION
## Summary
https://github.com/dagster-io/dagster/pull/29123/files added a new property on the translator and not all child classes will neccesarily call the parent constructor.

## Test Plan
Existing dbt translator tests
    
## Changelog
Fixed an issue where creating a DagsterDbtTranslator that didn't call the parent class's constructor in it's __init__ method raised an Exception during execution.
