### PR TITLE
Fix sensor timeout

### DIFF
--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -12,7 +12,11 @@ from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeL
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.__generated__ import dagster_api_pb2
 from dagster._grpc.__generated__.dagster_api_pb2_grpc import DagsterApiServicer
-from dagster._grpc.client import DEFAULT_GRPC_TIMEOUT, DEFAULT_REPOSITORY_GRPC_TIMEOUT
+from dagster._grpc.client import (
+    DEFAULT_GRPC_TIMEOUT,
+    DEFAULT_REPOSITORY_GRPC_TIMEOUT,
+    DEFAULT_SENSOR_GRPC_TIMEOUT,
+)
 from dagster._grpc.constants import GrpcServerCommand
 from dagster._grpc.types import (
     CancelExecutionRequest,
@@ -323,7 +327,7 @@ class DagsterProxyApiServicer(DagsterApiServicer):
             "SyncExternalSensorExecution",
             request,
             context,
-            sensor_execution_args.timeout or DEFAULT_GRPC_TIMEOUT,
+            sensor_execution_args.timeout or DEFAULT_SENSOR_GRPC_TIMEOUT,
         )
 
     def ShutdownServer(self, request, context):

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -679,6 +679,12 @@ class SensorExecutionArgs(
             last_completion_time=normalized_last_tick_completion_time,
         )
 
+    def with_default_timeout(self, timeout: int) -> "SensorExecutionArgs":
+        """If the timeout is not explicitly set, provides a default timeout which is used for the sensor execution."""
+        if self.timeout is None:
+            return self._replace(timeout=timeout)
+        return self
+
 
 @whitelist_for_serdes
 class ExternalJobArgs(


### PR DESCRIPTION
## Summary & Motivation
When making the call to execute a sensor from the grpc client, we need to thread the timeout through the args so that it's respected by the proxy server. Currently that's not happening, and it's manifesting as a timeout in the request that the proxy server makes of 60 seconds, even if the timeout is higher at the client.

## How I Tested These Changes
- Initially got this to trigger by having a 70 second sleeping sensor, setting the timeout to be 80 seconds on the call to sensor execution, then observing that the sensor execution still times out at 60 seconds. After the fix, the sensor call completes in 70 seconds.

## Changelog
- Fixed a bug with `DAGSTER_GRPC_SENSOR_TIMEOUT_SECONDS` not being propogated through from daemon to code severs, resulting in the sensor still timing out at 60 seconds if the `dagster code-server start` entrypoint was used (also settable via `codeServerArgs` on the helm chart).
