### PR TITLE
feat: enable explicit source control platform

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -303,6 +303,7 @@ from dagster._core.definitions.metadata import (
     TimestampMetadataValue as TimestampMetadataValue,
     UrlCodeReference as UrlCodeReference,
     UrlMetadataValue as UrlMetadataValue,
+    base_git_url as base_git_url,
     link_code_references_to_git as link_code_references_to_git,
     with_source_code_references as with_source_code_references,
 )

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -303,7 +303,6 @@ from dagster._core.definitions.metadata import (
     TimestampMetadataValue as TimestampMetadataValue,
     UrlCodeReference as UrlCodeReference,
     UrlMetadataValue as UrlMetadataValue,
-    base_git_url as base_git_url,
     link_code_references_to_git as link_code_references_to_git,
     with_source_code_references as with_source_code_references,
 )

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from dagster_shared.dagster_model import DagsterModel
-from typing_extensions import TypeAlias
+from typing_extensions import Literal, TypeAlias
 
 import dagster._check as check
 from dagster._annotations import beta, public
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     )
 
 DEFAULT_SOURCE_FILE_KEY = "asset_definition"
+Platform = Literal["github", "gitlab"]
 
 
 @beta
@@ -332,12 +333,28 @@ def _convert_local_path_to_git_path_single_definition(
     )
 
 
-def _build_github_url(url: str, branch: str) -> str:
-    return f"{url}/tree/{branch}"
+def base_git_url(url: str, branch: str, platform: Platform | None) -> str:
+    if platform is None:
+        if "gitlab" in url:
+            platform = "gitlab"
+        elif "github" in url:
+            platform = "github"
 
-
-def _build_gitlab_url(url: str, branch: str) -> str:
-    return f"{url}/-/tree/{branch}"
+    match platform:
+        case "gitlab":
+            return f"{url}/-/tree/{branch}"
+        case "github":
+            return f"{url}/tree/{branch}"
+        case None:
+            raise ValueError(
+                "Invalid `git_url`."
+                " Unable to infer the source control platform from the `git_url`. Please supply a `platform`."
+            )
+        case _:
+            raise ValueError(
+                "Invalid `platform`."
+                " Only gitlab and github are supported for linking to source control at this time."
+            )
 
 
 @beta
@@ -348,6 +365,7 @@ def link_code_references_to_git(
     git_url: str,
     git_branch: str,
     file_path_mapping: FilePathMapping,
+    platform: Platform | None = None,
 ) -> Sequence[Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition", "AssetSpec"]]:
     """Wrapper function which converts local file path code references to source control URLs
     based on the provided source control URL and branch.
@@ -360,6 +378,8 @@ def link_code_references_to_git(
         git_url (str): The base URL for the source control system. For example,
             "https://github.com/dagster-io/dagster".
         git_branch (str): The branch in the source control system, such as "master".
+        platform (str): The hosting platform for the source control system, "github" or "gitlab". If None, it will
+            be inferred based on `git_url`.
         file_path_mapping (FilePathMapping):
             Specifies the mapping between local file paths and their corresponding paths in a source control repository.
             Simple usage is to provide a `AnchorBasedFilePathMapping` instance, which specifies an anchor file in the
@@ -375,6 +395,7 @@ def link_code_references_to_git(
                         with_source_code_references([my_dbt_assets]),
                         git_url="https://github.com/dagster-io/dagster",
                         git_branch="master",
+                        platform="github",
                         file_path_mapping=AnchorBasedFilePathMapping(
                             local_file_anchor=Path(__file__),
                             file_anchor_path_in_repository="python_modules/my_module/my-module/__init__.py",
@@ -382,19 +403,10 @@ def link_code_references_to_git(
                     )
                 )
     """
-    if "gitlab" in git_url:
-        git_url = _build_gitlab_url(git_url, git_branch)
-    elif "github.com" in git_url:
-        git_url = _build_github_url(git_url, git_branch)
-    else:
-        raise ValueError(
-            "Invalid `git_url`."
-            " Only GitHub and GitLab are supported for linking to source control at this time."
-        )
-
+    base_git_url_ = base_git_url(git_url, git_branch, platform)
     return [
         _convert_local_path_to_git_path_single_definition(
-            base_git_url=git_url,
+            base_git_url=base_git_url_,
             file_path_mapping=file_path_mapping,
             assets_def=assets_def,
         )

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -349,7 +349,7 @@ def base_git_url(url: str, branch: str, platform: Optional[Platform]) -> str:
         return f"{url}/-/tree/{branch}"
     if platform == "github":
         return f"{url}/tree/{branch}"
-    
+
     raise ValueError(
         "Invalid `platform`."
         " Only gitlab and github are supported for linking to source control at this time."

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -333,28 +333,27 @@ def _convert_local_path_to_git_path_single_definition(
     )
 
 
-def base_git_url(url: str, branch: str, platform: Platform | None) -> str:
+def base_git_url(url: str, branch: str, platform: Optional[Platform]) -> str:
     if platform is None:
         if "gitlab" in url:
             platform = "gitlab"
         elif "github" in url:
             platform = "github"
-
-    match platform:
-        case "gitlab":
-            return f"{url}/-/tree/{branch}"
-        case "github":
-            return f"{url}/tree/{branch}"
-        case None:
+        else:
             raise ValueError(
                 "Invalid `git_url`."
                 " Unable to infer the source control platform from the `git_url`. Please supply a `platform`."
             )
-        case _:
-            raise ValueError(
-                "Invalid `platform`."
-                " Only gitlab and github are supported for linking to source control at this time."
-            )
+
+    if platform == "gitlab":
+        return f"{url}/-/tree/{branch}"
+    if platform == "github":
+        return f"{url}/tree/{branch}"
+    
+    raise ValueError(
+        "Invalid `platform`."
+        " Only gitlab and github are supported for linking to source control at this time."
+    )
 
 
 @beta
@@ -365,7 +364,7 @@ def link_code_references_to_git(
     git_url: str,
     git_branch: str,
     file_path_mapping: FilePathMapping,
-    platform: Platform | None = None,
+    platform: Optional[Platform] = None,
 ) -> Sequence[Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition", "AssetSpec"]]:
     """Wrapper function which converts local file path code references to source control URLs
     based on the provided source control URL and branch.

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
@@ -225,8 +225,13 @@ def test_asset_code_origins_source_control_custom_mapping() -> None:
         ("http://x.com", "my_b", "gitlab", "http://x.com/-/tree/my_b"),
     ],
 )
+<<<<<<< HEAD
 def test_base_git_url(url: str, branch: str, platform: str, expected: str) -> None:
     base_url = dg.base_git_url(url, branch, platform)
+=======
+def test_base_git_url(url: str, branch: str, platform: Platform, expected: str) -> None:
+    base_url = base_git_url(url, branch, platform)
+>>>>>>> 16e994335e (fix: support python <3.11)
 
     assert base_url == expected
 
@@ -237,5 +242,10 @@ def test_base_git_url_invalid_git_url() -> None:
 
 
 def test_base_git_url_invalid_platform() -> None:
+    platform: Platform = "bogus_platform"  # type: ignore
     with pytest.raises(ValueError, match="Invalid `platform`"):
+<<<<<<< HEAD
         dg.base_git_url("http://x.com", "my_b", "bogus_platform")
+=======
+        base_git_url("http://x.com", "my_b", platform)
+>>>>>>> 16e994335e (fix: support python <3.11)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
@@ -4,6 +4,7 @@ from typing import cast
 
 import dagster as dg
 import pytest
+from dagster._core.definitions.metadata.source_code import Platform, base_git_url
 
 # path of the `dagster` package on the filesystem
 DAGSTER_PACKAGE_PATH = os.path.normpath(dg.file_relative_path(__file__, "../../"))
@@ -225,27 +226,18 @@ def test_asset_code_origins_source_control_custom_mapping() -> None:
         ("http://x.com", "my_b", "gitlab", "http://x.com/-/tree/my_b"),
     ],
 )
-<<<<<<< HEAD
-def test_base_git_url(url: str, branch: str, platform: str, expected: str) -> None:
-    base_url = dg.base_git_url(url, branch, platform)
-=======
 def test_base_git_url(url: str, branch: str, platform: Platform, expected: str) -> None:
     base_url = base_git_url(url, branch, platform)
->>>>>>> 16e994335e (fix: support python <3.11)
 
     assert base_url == expected
 
 
 def test_base_git_url_invalid_git_url() -> None:
     with pytest.raises(ValueError, match="Unable to infer the source control platform"):
-        dg.base_git_url("http://x.com", "my_b", None)
+        base_git_url("http://x.com", "my_b", None)
 
 
 def test_base_git_url_invalid_platform() -> None:
     platform: Platform = "bogus_platform"  # type: ignore
     with pytest.raises(ValueError, match="Invalid `platform`"):
-<<<<<<< HEAD
-        dg.base_git_url("http://x.com", "my_b", "bogus_platform")
-=======
         base_git_url("http://x.com", "my_b", platform)
->>>>>>> 16e994335e (fix: support python <3.11)


### PR DESCRIPTION
## Summary & Motivation

Users should be able to use git code references even if their base URL does not include the strings "github" or "gitlab". This change allows users to optionally specify their git platform using a new `platform` parameter in `link_code_references_to_git`.

This is a more robust solution to https://github.com/dagster-io/dagster/issues/23135.

## How I Tested These Changes

New unit tests.

## Changelog

Allow explicit git `platform` selection in `link_code_references_to_git`