### PR TITLE
[docs/components] Put remaining parts of component customization docs under test

### DIFF
--- a/docs/docs/guides/labs/components/creating-new-components/component-customization.md
+++ b/docs/docs/guides/labs/components/creating-new-components/component-customization.md
@@ -64,12 +64,8 @@ You can define custom values that will be made available to the templating engin
 
 When a user scaffolds this component definition, they will be able to use this custom scope in their `defs.yaml` file:
 
-```yaml
-component_type: my_component
-
-attributes:
-  script_path: script.sh
-  asset_specs:
-    - key: a
-      partitions_def: '{{ daily_partitions }}'
-```
+<CodeExample
+  path="docs_snippets/docs_snippets/guides/components/shell-script-component/7-custom-scope-defs.yaml"
+  language="yaml"
+  title="my_component_library/components/my_shell_command/defs.yaml"
+/>

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/7-custom-scope-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/7-custom-scope-defs.yaml
@@ -1,0 +1,8 @@
+
+type: my_project.components.shell_command.ShellCommand
+
+attributes:
+  script_path: script.sh
+  asset_specs:
+    - key: my_asset
+      partitions_def: '{{ daily_partitions }}'

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-custom-scope.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-custom-scope.py
@@ -19,11 +19,13 @@ class ShellCommand(dg.Component, dg.Resolvable):
         }
 
     def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
+        resolved_script_path = Path(context.path, self.script_path).absolute()
+
         @dg.multi_asset(name=Path(self.script_path).stem, specs=self.asset_specs)
         def _asset(context: dg.AssetExecutionContext):
-            self.execute(context)
+            self.execute(resolved_script_path, context)
 
         return dg.Definitions(assets=[_asset])
 
-    def execute(self, context: dg.AssetExecutionContext):
-        return subprocess.run(["sh", self.script_path], check=True)
+    def execute(self, resolved_script_path: Path, context: dg.AssetExecutionContext):
+        return subprocess.run(["sh", str(resolved_script_path)], check=True)

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs_creating_a_component.py
@@ -1,3 +1,4 @@
+import textwrap
 from contextlib import ExitStack
 from pathlib import Path
 
@@ -148,3 +149,44 @@ def test_creating_a_component(
             f"{context.get_next_snip_number()}-scaffolded-component-script.sh",
         )
         _run_command("dg launch --assets '*'")
+
+        # Test "Providing resolution logic for non-standard types" section
+        # in docs/docs/guides/labs/components/creating-new-components/component-customization.md
+        context.create_file(
+            Path("src") / "my_project" / "components" / "shell_command.py",
+            contents=(
+                COMPONENTS_SNIPPETS_DIR / "custom-schema-resolution.py"
+            ).read_text(),
+        )
+
+        # We check that instantiating MyComponent with an API key will resolve to MyApiClient
+        _run_command(
+            "python -c 'from my_project.components.shell_command import MyComponent, MyApiClient;"
+            'assert isinstance(MyComponent.resolve_from_dict({"api_key": "foo"}).api_client, MyApiClient)\''
+        )
+
+        # Test "Customizing rendering of YAML values" section
+        # in docs/docs/guides/labs/components/creating-new-components/component-customization.md
+        context.create_file(
+            Path("src") / "my_project" / "components" / "shell_command.py",
+            contents=(COMPONENTS_SNIPPETS_DIR / "with-custom-scope.py").read_text(),
+        )
+
+        yaml_contents = textwrap.dedent("""
+            type: my_project.components.shell_command.ShellCommand
+
+            attributes:
+              script_path: script.sh
+              asset_specs:
+                - key: my_asset
+                  partitions_def: '{{ daily_partitions }}'
+        """)
+
+        context.create_file(
+            Path("src") / "my_project" / "defs" / "my_shell_command" / "defs.yaml",
+            yaml_contents,
+            snippet_path=f"{context.get_next_snip_number()}-custom-scope-defs.yaml",
+        )
+        _run_command("dg check yaml")
+        _run_command("dg check defs")
+        _run_command("dg launch --assets '*' --partition '2024-01-01'")


### PR DESCRIPTION
## Summary

The last two sections of the [Advanced component customization](https://docs.dagster.io/guides/labs/components/creating-new-components/component-customization) docs isn't under test and has become outdated. Adds sections to the integration test to check both these sections.


New version of page: https://dagster-docs-qwvp4144l-elementl.vercel.app/guides/labs/components/creating-new-components/component-customization
