### PR TITLE
Traverse the parent names of typescript tests to create the full name

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/quarantine-test-utils/custom-jest-environment.ts
+++ b/js_modules/dagster-ui/packages/ui-components/src/quarantine-test-utils/custom-jest-environment.ts
@@ -32,8 +32,15 @@ class CustomJSDOM extends JSDOMEnvironment {
 
 module.exports = CustomJSDOM;
 
-export function getFullTestName(event: {test: {name: string; parent?: {name: string}}}): string {
-  const testName = event.test.name;
-  const testFile = event.test.parent?.name;
-  return `${testFile} ${testName}`;
+export function getFullTestName(event: {
+  test: {name: string; parent?: {name: string; parent?: any}};
+}): string {
+  let fullTestName = event.test.name;
+  let parent = event.test.parent;
+
+  while (parent && parent.name !== 'ROOT_DESCRIBE_BLOCK') {
+    fullTestName = `${parent.name} ${fullTestName}`;
+    parent = parent.parent;
+  }
+  return fullTestName;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/quarantine-test-utils/custom-jest-environment.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/quarantine-test-utils/custom-jest-environment.ts
@@ -32,8 +32,15 @@ class CustomJSDOM extends JSDOMEnvironment {
 
 module.exports = CustomJSDOM;
 
-export function getFullTestName(event: {test: {name: string; parent?: {name: string}}}): string {
-  const testName = event.test.name;
-  const testFile = event.test.parent?.name;
-  return `${testFile} ${testName}`;
+export function getFullTestName(event: {
+  test: {name: string; parent?: {name: string; parent?: any}};
+}): string {
+  let fullTestName = event.test.name;
+  let parent = event.test.parent;
+
+  while (parent && parent.name !== 'ROOT_DESCRIBE_BLOCK') {
+    fullTestName = `${parent.name} ${fullTestName}`;
+    parent = parent.parent;
+  }
+  return fullTestName;
 }


### PR DESCRIPTION
Muting for a specific test was not working: https://dagsterlabs.slack.com/archives/C03EQ628RS7/p1750086261362069

The name that Buildkite had for the test was **AssetTable Materialize button is enabled when rows are selected** but we were generating **Materialize button is enabled when rows are selected**

This PR corrects the issue by traversing the parents and appending their names until we reach the top-level.