### PR TITLE
Fix pytest skips for repositories that are not tests

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/cli_test_error_workspace.yaml
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/cli_test_error_workspace.yaml
@@ -1,7 +1,7 @@
 load_from:
   - python_file:
       relative_path: test_cli_repo.py
-      attribute: test
+      attribute: the_test_repo
       location_name: test_cli_location
   - python_module:
       module_name: does_not_exist_module

--- a/python_modules/dagster-graphql/dagster_graphql_tests/cli_test_workspace.yaml
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/cli_test_workspace.yaml
@@ -1,5 +1,5 @@
 load_from:
   - python_file:
       relative_path: test_cli_repo.py
-      attribute: test
+      attribute: the_test_repo
       location_name: test_cli_location

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_misc.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_misc.py
@@ -1,7 +1,6 @@
 import csv
 from collections import OrderedDict
 
-import pytest
 from dagster import (
     DependencyDefinition,
     In,
@@ -150,9 +149,8 @@ def define_circular_dependency_job():
     )
 
 
-@pytest.mark.skip(reason="this is a repository, not a test")
 @repository  # pyright: ignore[reportArgumentType]
-def test_repository():
+def the_test_repository():
     return {"jobs": {"circular_dependency_job": define_circular_dependency_job}}
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/test_cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/test_cli.py
@@ -123,7 +123,7 @@ def test_basic_variables():
     }
     """
     variables = (
-        '{"pipelineName": "math", "repositoryName": "test", "repositoryLocationName":'
+        '{"pipelineName": "math", "repositoryName": "the_test_repo", "repositoryLocationName":'
         ' "test_cli_location"}'
     )
     workspace_path = file_relative_path(__file__, "./cli_test_workspace.yaml")
@@ -169,7 +169,7 @@ def test_start_execution_text():
             "executionParams": {
                 "selector": {
                     "repositoryLocationName": "test_cli_location",
-                    "repositoryName": "test",
+                    "repositoryName": "the_test_repo",
                     "pipelineName": "math",
                 },
                 "runConfigData": {"ops": {"add_one": {"inputs": {"num": {"value": 123}}}}},
@@ -202,7 +202,7 @@ def test_start_execution_file():
                 "selector": {
                     "pipelineName": "math",
                     "repositoryLocationName": "test_cli_location",
-                    "repositoryName": "test",
+                    "repositoryName": "the_test_repo",
                 },
                 "runConfigData": {"ops": {"add_one": {"inputs": {"num": {"value": 123}}}}},
             }
@@ -235,7 +235,7 @@ def test_start_execution_save_output():
             "executionParams": {
                 "selector": {
                     "repositoryLocationName": "test_cli_location",
-                    "repositoryName": "test",
+                    "repositoryName": "the_test_repo",
                     "pipelineName": "math",
                 },
                 "runConfigData": {"ops": {"add_one": {"inputs": {"num": {"value": 123}}}}},
@@ -281,7 +281,7 @@ def test_start_execution_predefined():
             "executionParams": {
                 "selector": {
                     "repositoryLocationName": "test_cli_location",
-                    "repositoryName": "test",
+                    "repositoryName": "the_test_repo",
                     "pipelineName": "math",
                 },
                 "runConfigData": {"ops": {"add_one": {"inputs": {"num": {"value": 123}}}}},
@@ -308,7 +308,7 @@ def test_logs_in_start_execution_predefined():
             "executionParams": {
                 "selector": {
                     "repositoryLocationName": "test_cli_location",
-                    "repositoryName": "test",
+                    "repositoryName": "the_test_repo",
                     "pipelineName": "math",
                 },
                 "runConfigData": {"ops": {"add_one": {"inputs": {"num": {"value": 123}}}}},

--- a/python_modules/dagster-graphql/dagster_graphql_tests/test_cli_repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/test_cli_repo.py
@@ -1,4 +1,3 @@
-import pytest
 from dagster import ScheduleDefinition, job, op, repository
 
 
@@ -44,7 +43,6 @@ def define_schedules():
     return [math_hourly_schedule]
 
 
-@pytest.mark.skip(reason="this is a repository, not a test")
 @repository
-def test():
+def the_test_repo():
     return [math, subset_test] + define_schedules()


### PR DESCRIPTION
## Summary & Motivation
Instead of skipping the fake test, rename the repository

## How I Tested These Changes
BK
