### PR TITLE
[freshness] Allow importing `FreshnessPolicy` from `dagster.deprecated`

### DIFF
--- a/python_modules/dagster/dagster/deprecated/__init__.py
+++ b/python_modules/dagster/dagster/deprecated/__init__.py
@@ -1,0 +1,3 @@
+from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy as FreshnessPolicy
+
+__all__ = ["FreshnessPolicy"]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
@@ -210,7 +210,10 @@ def test_freshness_policy_deprecated_import():
     """We should be able to import FreshnessPolicy from `dagster.deprecated` and use it to define a freshness policy on an asset."""
     from dagster.deprecated import FreshnessPolicy
 
-    @dg.asset(freshness_policy=FreshnessPolicy(maximum_lag_minutes=1))
+    policy = FreshnessPolicy(maximum_lag_minutes=1)
+    assert isinstance(policy, LegacyFreshnessPolicy)
+
+    @dg.asset(freshness_policy=policy)
     def foo():
         pass
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
@@ -204,3 +204,14 @@ def test_legacy_freshness_backcompat():
 
     # Then, check that the deserialized snapshots are the same
     assert new_snap == old_snap_deserialized
+
+
+def test_freshness_policy_deprecated_import():
+    """We should be able to import FreshnessPolicy from `dagster.deprecated` and use it to define a freshness policy on an asset."""
+    from dagster.deprecated import FreshnessPolicy
+
+    @dg.asset(freshness_policy=FreshnessPolicy(maximum_lag_minutes=1))
+    def foo():
+        pass
+
+    dg.Definitions(assets=[foo])


### PR DESCRIPTION
## Summary & Motivation
Adds a new top-level module `deprecated` which exports deprecated classes, and exports `LegacyFreshnessPolicy` from it with its old name `FreshnessPolicy`.

This enables users to migrate their existing code with `FreshnessPolicy` to `1.11` by simply changing the import line, without needing to change the name of every reference to `FreshnessPolicy`.

Users will still be able to import `LegacyFreshnessPolicy` from the top-level `dagster` module.

```
# old code
from dagster import FreshnessPolicy

<usages>

# new code
from dagster.deprecated import FreshnessPolicy

<usages>

# also an option
from dagster import LegacyFreshnessPolicy

<usages: change to LegacyFreshnessPolicy>
```

## How I Tested These Changes
a unit test that imports `FreshnessPolicy` from `dagster.deprecated`.

## Changelog

> Allow importing `FreshnessPolicy` from `dagster.deprecated`.