### PR TITLE
better error when a sensor or schedule runs on a code server in an error state

### DIFF
--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -557,6 +557,11 @@ class DagsterApiServer(DagsterApiServicer):
         self,
         remote_repo_origin: RemoteRepositoryOrigin,
     ) -> RepositoryDefinition:
+        if not self._loaded_repositories:
+            raise Exception(
+                f"Could not load definitions since the code server is in an error state: {check.not_none(self._serializable_load_error)}"
+            )
+
         loaded_repos = check.not_none(self._loaded_repositories)
         if remote_repo_origin.repository_name not in loaded_repos.definitions_by_name:
             raise Exception(
@@ -568,6 +573,11 @@ class DagsterApiServer(DagsterApiServicer):
         self,
         remote_repo_origin: RemoteRepositoryOrigin,
     ) -> ReconstructableRepository:
+        if not self._loaded_repositories:
+            raise Exception(
+                f"Could not load definitions since the code server is in an error state: {check.not_none(self._serializable_load_error)}"
+            )
+
         loaded_repos = check.not_none(self._loaded_repositories)
         if remote_repo_origin.repository_name not in loaded_repos.definitions_by_name:
             raise Exception(


### PR DESCRIPTION
## Summary & Motivation
This should not be common, but can happen in certain edge cases (a pod restarting). Include the error stack trace when it does.

## How I Tested These Changes
New test case
