### PR TITLE
Remove `internal_asset_freshness_enabled` flag

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -863,9 +863,6 @@ class GrapheneAssetNode(graphene.ObjectType):
     def resolve_internalFreshnessPolicy(
         self, graphene_info: ResolveInfo
     ) -> Optional[GrapheneInternalFreshnessPolicy]:
-        if not graphene_info.context.instance.internal_asset_freshness_enabled():
-            return None
-
         if self._asset_node_snap.internal_freshness_policy:
             return GrapheneInternalFreshnessPolicy.from_policy(
                 self._asset_node_snap.internal_freshness_policy

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_internal_freshness.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_internal_freshness.py
@@ -56,11 +56,13 @@ def get_repo() -> RepositoryDefinition:
 # There is a separate implementation for plus graphql tests.
 def test_internal_freshness_policy():
     with instance_for_test() as instance:
-        assert not instance.internal_asset_freshness_enabled()
         with define_out_of_process_context(__file__, "get_repo", instance) as graphql_context:
             result = execute_dagster_graphql(
                 graphql_context,
                 GET_INTERNAL_FRESHNESS_POLICY,
                 variables={"assetKey": asset_with_internal_freshness_policy.key.to_graphql_input()},
             )
-            assert result.data["assetNodes"][0]["internalFreshnessPolicy"] is None
+            assert result.data["assetNodes"][0]["internalFreshnessPolicy"] == {
+                "failWindowSeconds": 600,
+                "warnWindowSeconds": None,
+            }

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3641,9 +3641,6 @@ class DagsterInstance(DynamicPartitionsStore):
     def can_read_asset_failure_events(self) -> bool:
         return False
 
-    def internal_asset_freshness_enabled(self) -> bool:
-        return os.getenv("DAGSTER_ASSET_FRESHNESS_ENABLED", "").lower() == "true"
-
     def streamline_read_asset_health_supported(self) -> bool:
         return False
 


### PR DESCRIPTION
## Summary & Motivation
Removes instance method `internal_asset_freshness_enabled`, was being used as a feature flag in the `internalFreshnessPolicy` resolver.

Removing this flag will allow all OSS users to view freshness policies on assets.

Also removed from the cloud instance in https://github.com/dagster-io/internal/pull/16361

## How I Tested These Changes
bk, manual testing w/ `dagster dev` to ensure the policies can be seen in OSS without enabling any flags or setting env vars.

## Changelog

> Insert changelog entry or delete this section.
