### PR TITLE
Replace JSON.stringify with `useStableReferenceByHash` backed by murmur hash

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useStableReferenceByHash.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useStableReferenceByHash.test.tsx
@@ -1,0 +1,15 @@
+import {renderHook} from '@testing-library/react-hooks';
+
+import {useStableReferenceByHash} from '../useStableReferenceByHash';
+
+describe('useStableReferenceByHash', () => {
+  it('should return the same value for the same input', () => {
+    const aValue = {a: 1};
+    const aValue2 = {a: 1};
+    const {result: aResult} = renderHook(() => useStableReferenceByHash(aValue, true));
+    const {result: aResult2} = renderHook(() => useStableReferenceByHash(aValue2, true));
+
+    expect(aResult.current).toBe(aValue);
+    expect(aResult2.current).toBe(aValue);
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useStableReferenceByHash.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useStableReferenceByHash.tsx
@@ -7,8 +7,20 @@ import {hashObject} from '../util/hashObject';
  * It is useful to avoid unsubscribing/re-subscribing to the same keys in case the reference changes but the keys are the same.
  * It is also useful to avoid re-rendering the component when the value changes but the hash is the same.
  */
-export const useStableReferenceByHash = <T,>(value: T, hashFn = hashObject) => {
+
+const referenceCache = new Map<string, any>();
+
+export const useStableReferenceByHash = <T,>(value: T, storeInMap = false, hashFn = hashObject) => {
   const hash = useMemo(() => hashFn(value), [value, hashFn]);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useMemo(() => value, [hash]);
+  return useMemo(() => {
+    const cached = referenceCache.get(hash);
+    if (cached) {
+      return cached;
+    }
+    if (storeInMap) {
+      referenceCache.set(hash, value);
+    }
+    return value;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hash]);
 };


### PR DESCRIPTION
## Summary & Motivation
Continuing the quest to reduce memory usage in asset graph/asset selection stuff in order to have it scale to larger workspaces.

This time removing a JSON.stringify and replacing it with our lower memory usage hashing approach to keep references stable and avoid a JSON.stringify/JSON.parse cycle.

## How I Tested These Changes

jest + local testing