### PR TITLE
fix deserialization of freshness policies

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -54,7 +54,7 @@ class InternalFreshnessPolicy(ABC):
         # We had a few asset spec metadatas with internal freshness policies set to literal "null" string,
         # need special handling for those cases.
         # https://github.com/dagster-io/dagster/pull/30615
-        if serialized_policy is None or serialized_policy == "null":
+        if serialized_policy is None or serialized_policy.value == "null":
             return None
         return deserialize_value(serialized_policy.value, cls)  # pyright: ignore
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_internal_freshness.py
@@ -11,6 +11,7 @@ from dagster._core.definitions.freshness import (
     InternalFreshnessPolicy,
     TimeWindowFreshnessPolicy,
 )
+from dagster._core.definitions.metadata.metadata_value import TextMetadataValue
 from dagster._serdes import deserialize_value, serialize_value
 from dagster_shared.serdes.utils import SerializableTimeDelta
 
@@ -20,9 +21,10 @@ from dagster_tests.core_tests.host_representation_tests.test_external_data impor
 
 
 class TestInternalFreshnessPolicy:
+    # TestInternalFreshnessPolicy::test_internal_freshness_policy_from_asset_spec_metadata_handles_null
     def test_internal_freshness_policy_from_asset_spec_metadata_handles_null(self) -> None:
         """Special case handling for asset metadata that was set to "null" string literal."""
-        metadata = {"internal_freshness_policy": "null"}
+        metadata = {INTERNAL_FRESHNESS_POLICY_METADATA_KEY: TextMetadataValue("null")}
         policy = InternalFreshnessPolicy.from_asset_spec_metadata(metadata)
         assert policy is None
 


### PR DESCRIPTION
## Summary & Motivation
fixes an issue when deserializing freshness policies that had been stored in the DB as `"null"`

```
dagster_shared.serdes.errors.deserializationerror: Deserialized object was not expected type <class 'dagster._core.definitions.freshness.InternalFreshnessPolicy'>, got <class 'NoneType'> 
```

Tested by running a shadow script that failed with this error before this change and succeeded after. Fixed a unit test to accurately replicate the backcompat condition