### PR TITLE
[dagster-sling] Fix bug when using `EnvVar` with SlingConnectionResource

### DIFF
--- a/python_modules/libraries/dagster-sling/dagster_sling/resources.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/resources.py
@@ -635,6 +635,8 @@ def _process_env_vars(config: dict[str, Any]) -> dict[str, Any]:
     for key, value in config.items():
         if isinstance(value, dict) and len(value) == 1 and next(iter(value.keys())) == "env":
             out[key] = EnvVar(next(iter(value.values()))).get_value()
+        elif isinstance(value, EnvVar):
+            out[key] = value.get_value()
         else:
             out[key] = value
     return out


### PR DESCRIPTION
## Summary & Motivation

See changelog

## How I Tested These Changes

We had the explicitly wrong behavior under test

## Changelog

[dagster-sling] Fixed an issue with the `SlingResource` that could cause values specified with `EnvVar`s to provide the env var name instead of the env var value to the sling replication configuration.
