### PR TITLE
Source StaleStatusLoader from the workspace context instead of passing it into GrapheneAssetNode

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -7,7 +7,6 @@ from dagster import (
     DagsterInstance,
     _check as check,
 )
-from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.remote_representation import RemoteRepository
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorType
 
@@ -136,7 +135,3 @@ class RepositoryScopedBatchLoader:
             )
         )
         return self._get(RepositoryDataType.SCHEDULE_TICKS, origin_id, limit)
-
-
-# CachingStaleStatusResolver from core can be used directly as a GQL batch loader.
-StaleStatusLoader = CachingStaleStatusResolver

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -58,7 +58,6 @@ from dagster_graphql.implementation.fetch_assets import (
 from dagster_graphql.implementation.fetch_partition_subsets import (
     regenerate_and_check_partition_subsets,
 )
-from dagster_graphql.implementation.loader import StaleStatusLoader
 from dagster_graphql.schema import external
 from dagster_graphql.schema.asset_checks import (
     AssetChecksOrErrorUnion,
@@ -348,9 +347,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def __init__(
         self,
-        *,
         remote_node: RemoteAssetNode,
-        stale_status_loader: Optional[StaleStatusLoader] = None,
     ):
         from dagster_graphql.implementation.fetch_assets import get_unique_asset_id
 
@@ -360,12 +357,6 @@ class GrapheneAssetNode(graphene.ObjectType):
         self._asset_node_snap = repo_scoped_node.asset_node_snap
         self._repository_handle = repo_scoped_node.repository_handle
         self._repository_selector = self._repository_handle.to_selector()
-
-        self._stale_status_loader = check.opt_inst_param(
-            stale_status_loader,
-            "stale_status_loader",
-            StaleStatusLoader,
-        )
 
         self._remote_job = None  # lazily loaded
         self._node_definition_snap = None  # lazily loaded
@@ -400,14 +391,6 @@ class GrapheneAssetNode(graphene.ObjectType):
     @property
     def asset_node_snap(self) -> AssetNodeSnap:
         return self._asset_node_snap
-
-    @property
-    def stale_status_loader(self) -> StaleStatusLoader:
-        loader = check.not_none(
-            self._stale_status_loader,
-            "stale_status_loader must exist in order to access data versioning information",
-        )
-        return loader
 
     def _get_asset_graph_differ(self, graphene_info: ResolveInfo) -> Optional[AssetGraphDiffer]:
         if self._asset_graph_differ is not None:
@@ -722,7 +705,9 @@ class GrapheneAssetNode(graphene.ObjectType):
     ) -> Any:  # (GrapheneAssetStaleStatus)
         if partition:
             self._validate_partitions_existence()
-        return self.stale_status_loader.get_status(self._asset_node_snap.asset_key, partition)
+        return graphene_info.context.stale_status_loader.get_status(
+            self._asset_node_snap.asset_key, partition
+        )
 
     def resolve_staleStatusByPartition(
         self,
@@ -736,7 +721,9 @@ class GrapheneAssetNode(graphene.ObjectType):
         else:
             self._validate_partitions_existence()
         return [
-            self.stale_status_loader.get_status(self._asset_node_snap.asset_key, partition)
+            graphene_info.context.stale_status_loader.get_status(
+                self._asset_node_snap.asset_key, partition
+            )
             for partition in partitions
         ]
 
@@ -745,7 +732,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     ) -> Sequence[GrapheneAssetStaleCause]:
         if partition:
             self._validate_partitions_existence()
-        return self._get_staleCauses(partition)
+        return self._get_staleCauses(graphene_info, partition)
 
     def resolve_staleCausesByPartition(
         self,
@@ -758,12 +745,12 @@ class GrapheneAssetNode(graphene.ObjectType):
             )
         else:
             self._validate_partitions_existence()
-        return [self._get_staleCauses(partition) for partition in partitions]
+        return [self._get_staleCauses(graphene_info, partition) for partition in partitions]
 
     def _get_staleCauses(
-        self, partition: Optional[str] = None
+        self, graphene_info: ResolveInfo, partition: Optional[str] = None
     ) -> Sequence[GrapheneAssetStaleCause]:
-        causes = self.stale_status_loader.get_stale_root_causes(
+        causes = graphene_info.context.stale_status_loader.get_stale_root_causes(
             self._asset_node_snap.asset_key, partition
         )
         return [
@@ -787,7 +774,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     ) -> Optional[str]:
         if partition:
             self._validate_partitions_existence()
-        version = self.stale_status_loader.get_current_data_version(
+        version = graphene_info.context.stale_status_loader.get_current_data_version(
             self._asset_node_snap.asset_key, partition
         )
         return None if version == NULL_DATA_VERSION else version.value
@@ -802,7 +789,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         else:
             self._validate_partitions_existence()
         data_versions = [
-            self.stale_status_loader.get_current_data_version(
+            graphene_info.context.stale_status_loader.get_current_data_version(
                 self._asset_node_snap.asset_key, partition
             )
             for partition in partitions

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -21,7 +21,7 @@ from dagster._core.workspace.workspace import CodeLocationEntry, CodeLocationLoa
 from dagster.components.core.load_defs import PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY
 
 from dagster_graphql.implementation.fetch_solids import get_solid, get_solids
-from dagster_graphql.implementation.loader import RepositoryScopedBatchLoader, StaleStatusLoader
+from dagster_graphql.implementation.loader import RepositoryScopedBatchLoader
 from dagster_graphql.implementation.utils import capture_error
 from dagster_graphql.schema.asset_graph import GrapheneAssetGroup, GrapheneAssetNode
 from dagster_graphql.schema.env_vars import (
@@ -385,16 +385,9 @@ class GrapheneRepository(graphene.ObjectType):
     def resolve_assetNodes(self, graphene_info: ResolveInfo):
         remote_nodes = self.get_repository(graphene_info).asset_graph.asset_nodes
 
-        stale_status_loader = StaleStatusLoader(
-            instance=graphene_info.context.instance,
-            asset_graph=lambda: self.get_repository(graphene_info).asset_graph,
-            loading_context=graphene_info.context,
-        )
-
         return [
             GrapheneAssetNode(
                 remote_node=remote_node,
-                stale_status_loader=stale_status_loader,
             )
             for remote_node in remote_nodes
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -89,7 +89,6 @@ from dagster_graphql.implementation.fetch_schedules import (
 from dagster_graphql.implementation.fetch_sensors import get_sensor_or_error, get_sensors_or_error
 from dagster_graphql.implementation.fetch_solids import get_graph_or_error
 from dagster_graphql.implementation.fetch_ticks import get_instigation_ticks
-from dagster_graphql.implementation.loader import StaleStatusLoader
 from dagster_graphql.implementation.run_config_schema import resolve_run_config_schema_or_error
 from dagster_graphql.implementation.utils import (
     UserFacingGraphQLError,
@@ -1099,16 +1098,9 @@ class GrapheneQuery(graphene.ObjectType):
             else:
                 return graphene_info.context.asset_graph
 
-        stale_status_loader = StaleStatusLoader(
-            instance=graphene_info.context.instance,
-            asset_graph=load_asset_graph,
-            loading_context=graphene_info.context,
-        )
-
         nodes = [
             GrapheneAssetNode(
                 remote_node=remote_node,
-                stale_status_loader=stale_status_loader,
             )
             for remote_node in results
         ]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
@@ -96,6 +96,7 @@ def test_stale_status():
             assert materialize_assets(context)
             wait_for_runs_to_finish(context.instance)
 
+        with define_out_of_process_context(__file__, "get_repo_v1", instance) as context:
             result = _fetch_data_versions(context, repo)
             foo = _get_asset_node(result, "foo")
             assert foo["dataVersion"] is not None
@@ -105,6 +106,7 @@ def test_stale_status():
             assert materialize_assets(context, asset_selection=[AssetKey(["foo"])])
             wait_for_runs_to_finish(context.instance)
 
+        with define_out_of_process_context(__file__, "get_repo_v1", instance) as context:
             result = _fetch_data_versions(context, repo)
             bar = _get_asset_node(result, "bar")
             assert bar["dataVersion"] is not None
@@ -172,6 +174,7 @@ def test_stale_status_partitioned():
             )
             wait_for_runs_to_finish(context.instance)
 
+        with define_out_of_process_context(__file__, "get_repo_partitioned", instance) as context:
             for key in ["foo", "bar", "dynamic_asset"]:
                 result = _fetch_partition_data_versions(context, AssetKey([key]), "alpha")
                 node = _get_asset_node(result)
@@ -190,6 +193,7 @@ def test_stale_status_partitioned():
             )
             wait_for_runs_to_finish(context.instance)
 
+        with define_out_of_process_context(__file__, "get_repo_partitioned", instance) as context:
             result = _fetch_partition_data_versions(context, AssetKey(["foo"]), "alpha")
             foo = _get_asset_node(result, "foo")
             assert foo["dataVersion"] == "from_config_foo_alpha"

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -15,6 +15,7 @@ import dagster._check as check
 from dagster._config.snap import ConfigTypeSnap
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.data_time import CachingDataTimeResolver
+from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
 from dagster._core.definitions.remote_asset_graph import RemoteRepositoryAssetNode
 from dagster._core.definitions.selector import (
@@ -132,6 +133,14 @@ class BaseWorkspaceRequestContext(LoadingContext):
     @cached_property
     def dynamic_partitions_loader(self) -> CachingDynamicPartitionsLoader:
         return CachingDynamicPartitionsLoader(self.instance)
+
+    @cached_property
+    def stale_status_loader(self) -> CachingStaleStatusResolver:
+        return CachingStaleStatusResolver(
+            self.instance,
+            asset_graph=lambda: self.asset_graph,
+            loading_context=self,
+        )
 
     @cached_property
     def data_time_resolver(self) -> CachingDataTimeResolver:


### PR DESCRIPTION
## Summary & Motivation
Similar to https://github.com/dagster-io/dagster/pull/29717/files but for this other field. Makes it easier to construct a new GrapheneAssetNode without having to pass in a bunch of stuff.

## How I Tested These Changes
BK
