### PR TITLE
no longer pass a GrapheneAssetNode into GrapheneAsset

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -608,21 +608,18 @@ type Asset {
   key: AssetKey!
   assetMaterializations(
     partitions: [String!]
-    partitionInLast: Int
     beforeTimestampMillis: String
     afterTimestampMillis: String
     limit: Int
   ): [MaterializationEvent!]!
   assetObservations(
     partitions: [String!]
-    partitionInLast: Int
     beforeTimestampMillis: String
     afterTimestampMillis: String
     limit: Int
   ): [ObservationEvent!]!
   assetEventHistory(
     partitions: [String!]
-    partitionInLast: Int
     beforeTimestampMillis: String
     afterTimestampMillis: String
     limit: Int!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -116,7 +116,6 @@ export type AssetAssetEventHistoryArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
   eventTypeSelectors: Array<AssetEventHistoryEventTypeSelector>;
   limit: Scalars['Int']['input'];
-  partitionInLast?: InputMaybe<Scalars['Int']['input']>;
   partitions?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
@@ -124,7 +123,6 @@ export type AssetAssetMaterializationsArgs = {
   afterTimestampMillis?: InputMaybe<Scalars['String']['input']>;
   beforeTimestampMillis?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
-  partitionInLast?: InputMaybe<Scalars['Int']['input']>;
   partitions?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
@@ -132,7 +130,6 @@ export type AssetAssetObservationsArgs = {
   afterTimestampMillis?: InputMaybe<Scalars['String']['input']>;
   beforeTimestampMillis?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
-  partitionInLast?: InputMaybe<Scalars['Int']['input']>;
   partitions?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -13,6 +13,7 @@ from dagster import (
 )
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
+from dagster._core.definitions.remote_asset_graph import RemoteAssetNode
 from dagster._core.definitions.time_window_partitions import (
     PartitionRangeStatus,
     TimeWindowPartitionsDefinition,
@@ -121,7 +122,7 @@ def get_assets(
 
     asset_nodes_by_asset_key = {
         asset_key: asset_node
-        for asset_key, asset_node in get_asset_nodes_by_asset_key(graphene_info).items()
+        for asset_key, asset_node in _get_asset_nodes_by_asset_key(graphene_info).items()
         if (not prefix or asset_key.path[: len(prefix)] == prefix)
         and (not normalized_cursor_str or asset_key.to_string() > normalized_cursor_str)
         and (not asset_keys or asset_key in asset_keys)
@@ -134,13 +135,7 @@ def get_assets(
         merged_asset_keys = merged_asset_keys[:limit]
 
     return GrapheneAssetConnection(
-        nodes=[
-            GrapheneAsset(
-                key=asset_key,
-                definition=asset_nodes_by_asset_key.get(asset_key),
-            )
-            for asset_key in merged_asset_keys
-        ],
+        nodes=[GrapheneAsset(key=asset_key) for asset_key in merged_asset_keys],
         cursor=merged_asset_keys[-1].to_string() if merged_asset_keys else None,
     )
 
@@ -191,16 +186,14 @@ def get_asset_node_definition_collisions(
     return results
 
 
-def get_asset_nodes_by_asset_key(
+def _get_asset_nodes_by_asset_key(
     graphene_info: "ResolveInfo",
-) -> Mapping[AssetKey, "GrapheneAssetNode"]:
+) -> Mapping[AssetKey, RemoteAssetNode]:
     """If multiple repositories have asset nodes for the same asset key, chooses the asset node that
     has an op.
     """
-    from dagster_graphql.schema.asset_graph import GrapheneAssetNode
-
     return {
-        remote_node.key: GrapheneAssetNode(remote_node)
+        remote_node.key: remote_node
         for remote_node in graphene_info.context.asset_graph.asset_nodes
     }
 
@@ -223,7 +216,6 @@ def get_asset_node(
 def get_asset(
     graphene_info: "ResolveInfo", asset_key: AssetKey
 ) -> Union["GrapheneAsset", "GrapheneAssetNotFoundError"]:
-    from dagster_graphql.schema.asset_graph import GrapheneAssetNode
     from dagster_graphql.schema.errors import GrapheneAssetNotFoundError
     from dagster_graphql.schema.pipelines.pipeline import GrapheneAsset
 
@@ -234,14 +226,7 @@ def get_asset(
     if not has_remote_node and not instance.has_asset_key(asset_key):
         return GrapheneAssetNotFoundError(asset_key=asset_key)
 
-    if has_remote_node:
-        def_node = GrapheneAssetNode(
-            graphene_info.context.asset_graph.get(asset_key),
-        )
-    else:
-        def_node = None
-
-    return GrapheneAsset(key=asset_key, definition=def_node)
+    return GrapheneAsset(key=asset_key)
 
 
 def get_asset_materialization_event_records(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -117,20 +117,20 @@ def get_assets(
         materialized_keys = instance.get_asset_keys(
             prefix=prefix, limit=limit, cursor=normalized_cursor_str
         )
+        asset_nodes_by_asset_key = {
+            asset_key: asset_node
+            for asset_key, asset_node in _get_asset_nodes_by_asset_key(graphene_info).items()
+            if (not prefix or asset_key.path[: len(prefix)] == prefix)
+            and (not normalized_cursor_str or asset_key.to_string() > normalized_cursor_str)
+            and (not asset_keys or asset_key in asset_keys)
+        }
+
+        merged_asset_keys = sorted(
+            set(materialized_keys).union(asset_nodes_by_asset_key.keys()), key=str
+        )
     else:
-        materialized_keys = asset_keys
+        merged_asset_keys = asset_keys
 
-    asset_nodes_by_asset_key = {
-        asset_key: asset_node
-        for asset_key, asset_node in _get_asset_nodes_by_asset_key(graphene_info).items()
-        if (not prefix or asset_key.path[: len(prefix)] == prefix)
-        and (not normalized_cursor_str or asset_key.to_string() > normalized_cursor_str)
-        and (not asset_keys or asset_key in asset_keys)
-    }
-
-    merged_asset_keys = sorted(
-        set(materialized_keys).union(asset_nodes_by_asset_key.keys()), key=str
-    )
     if limit:
         merged_asset_keys = merged_asset_keys[:limit]
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -38,7 +38,7 @@ from dagster_graphql.implementation.events import (
     iterate_metadata_entries,
 )
 from dagster_graphql.implementation.fetch_asset_checks import get_asset_checks_for_run_id
-from dagster_graphql.implementation.fetch_assets import get_assets_for_run, get_unique_asset_id
+from dagster_graphql.implementation.fetch_assets import get_assets_for_run
 from dagster_graphql.implementation.fetch_pipelines import get_job_reference_or_raise
 from dagster_graphql.implementation.fetch_runs import get_runs, get_stats, get_step_stats
 from dagster_graphql.implementation.fetch_schedules import get_schedules_for_job
@@ -252,7 +252,6 @@ class GrapheneAsset(graphene.ObjectType):
     assetMaterializations = graphene.Field(
         non_null_list(GrapheneMaterializationEvent),
         partitions=graphene.List(graphene.NonNull(graphene.String)),
-        partitionInLast=graphene.Int(),
         beforeTimestampMillis=graphene.String(),
         afterTimestampMillis=graphene.String(),
         limit=graphene.Int(),
@@ -260,7 +259,6 @@ class GrapheneAsset(graphene.ObjectType):
     assetObservations = graphene.Field(
         non_null_list(GrapheneObservationEvent),
         partitions=graphene.List(graphene.NonNull(graphene.String)),
-        partitionInLast=graphene.Int(),
         beforeTimestampMillis=graphene.String(),
         afterTimestampMillis=graphene.String(),
         limit=graphene.Int(),
@@ -268,7 +266,6 @@ class GrapheneAsset(graphene.ObjectType):
     assetEventHistory = graphene.Field(
         graphene.NonNull(GrapheneAssetResultEventHistoryConnection),
         partitions=graphene.List(graphene.NonNull(graphene.String)),
-        partitionInLast=graphene.Int(),
         beforeTimestampMillis=graphene.String(),
         afterTimestampMillis=graphene.String(),
         limit=graphene.NonNull(graphene.Int),
@@ -285,22 +282,28 @@ class GrapheneAsset(graphene.ObjectType):
     class Meta:
         name = "Asset"
 
-    def __init__(self, key, definition: Optional["GrapheneAssetNode"] = None):
-        super().__init__(key=key, definition=definition)
-        self._definition = definition
+    def __init__(self, key):
+        super().__init__(
+            key=GrapheneAssetKey(path=key.path),
+        )
 
     def resolve_id(self, _) -> str:
-        # If the asset is not a SDA asset (has no definition), the id is the asset key
-        # Else, return a unique identifier containing the repository location and name
-        if self._definition:
-            return self._definition.id
-        return get_unique_asset_id(self.key)
+        return self.key.to_string()
+
+    def resolve_definition(self, graphene_info: ResolveInfo) -> Optional["GrapheneAssetNode"]:
+        from dagster_graphql.schema.asset_graph import GrapheneAssetNode
+
+        remote_asset_node = (
+            graphene_info.context.asset_graph.get(self.key)
+            if graphene_info.context.asset_graph.has(self.key)
+            else None
+        )
+        return GrapheneAssetNode(remote_asset_node) if remote_asset_node else None
 
     async def resolve_assetMaterializations(
         self,
         graphene_info: ResolveInfo,
         partitions: Optional[Sequence[str]] = None,
-        partitionInLast: Optional[int] = None,
         beforeTimestampMillis: Optional[str] = None,
         afterTimestampMillis: Optional[str] = None,
         limit: Optional[int] = None,
@@ -310,13 +313,7 @@ class GrapheneAsset(graphene.ObjectType):
         before_timestamp = parse_timestamp(beforeTimestampMillis)
         after_timestamp = parse_timestamp(afterTimestampMillis)
 
-        if (
-            limit == 1
-            and not partitions
-            and not partitionInLast
-            and not before_timestamp
-            and not after_timestamp
-        ):
+        if limit == 1 and not partitions and not before_timestamp and not after_timestamp:
             record = await AssetRecord.gen(graphene_info.context, self.key)
             latest_materialization_event = (
                 record.asset_entry.last_materialization if record else None
@@ -326,9 +323,6 @@ class GrapheneAsset(graphene.ObjectType):
                 return []
 
             return [GrapheneMaterializationEvent(event=latest_materialization_event)]
-
-        if partitionInLast and self._definition:
-            partitions = self._definition.get_partition_keys()[-int(partitionInLast) :]
 
         events = get_asset_materializations(
             graphene_info,
@@ -346,7 +340,6 @@ class GrapheneAsset(graphene.ObjectType):
         eventTypeSelectors: Sequence[GrapheneAssetEventHistoryEventTypeSelector],
         limit: Optional[int],
         partitions: Optional[Sequence[str]] = None,
-        partitionInLast: Optional[int] = None,
         beforeTimestampMillis: Optional[str] = None,
         afterTimestampMillis: Optional[str] = None,
         cursor: Optional[str] = None,
@@ -359,9 +352,6 @@ class GrapheneAsset(graphene.ObjectType):
 
         before_timestamp = parse_timestamp(beforeTimestampMillis)
         after_timestamp = parse_timestamp(afterTimestampMillis)
-        if partitionInLast and self._definition:
-            partitions = self._definition.get_partition_keys()[-int(partitionInLast) :]
-
         failure_events = []
         success_events = []
         observation_events = []
@@ -428,7 +418,6 @@ class GrapheneAsset(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
         partitions: Optional[Sequence[str]] = None,
-        partitionInLast: Optional[int] = None,
         beforeTimestampMillis: Optional[str] = None,
         afterTimestampMillis: Optional[str] = None,
         limit: Optional[int] = None,
@@ -437,8 +426,6 @@ class GrapheneAsset(graphene.ObjectType):
 
         before_timestamp = parse_timestamp(beforeTimestampMillis)
         after_timestamp = parse_timestamp(afterTimestampMillis)
-        if partitionInLast and self._definition:
-            partitions = self._definition.get_partition_keys()[-int(partitionInLast) :]
 
         return [
             GrapheneObservationEvent(event=event)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_assets.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_assets.ambr
@@ -14,7 +14,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["asset_1"]',
+          'id': '["asset_1"]',
           'key': dict({
             'path': list([
               'asset_1',
@@ -22,7 +22,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["asset_2"]',
+          'id': '["asset_2"]',
           'key': dict({
             'path': list([
               'asset_2',
@@ -30,7 +30,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["asset_3"]',
+          'id': '["asset_3"]',
           'key': dict({
             'path': list([
               'asset_3',
@@ -38,7 +38,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["asset_one"]',
+          'id': '["asset_one"]',
           'key': dict({
             'path': list([
               'asset_one',
@@ -46,7 +46,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["asset_two"]',
+          'id': '["asset_two"]',
           'key': dict({
             'path': list([
               'asset_two',
@@ -54,7 +54,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["asset_with_automation_condition"]',
+          'id': '["asset_with_automation_condition"]',
           'key': dict({
             'path': list([
               'asset_with_automation_condition',
@@ -62,7 +62,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["asset_with_custom_automation_condition"]',
+          'id': '["asset_with_custom_automation_condition"]',
           'key': dict({
             'path': list([
               'asset_with_custom_automation_condition',
@@ -70,7 +70,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["asset_yields_observation"]',
+          'id': '["asset_yields_observation"]',
           'key': dict({
             'path': list([
               'asset_yields_observation',
@@ -86,7 +86,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["bar"]',
+          'id': '["bar"]',
           'key': dict({
             'path': list([
               'bar',
@@ -94,7 +94,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["baz"]',
+          'id': '["baz"]',
           'key': dict({
             'path': list([
               'baz',
@@ -110,7 +110,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["check_in_op_asset"]',
+          'id': '["check_in_op_asset"]',
           'key': dict({
             'path': list([
               'check_in_op_asset',
@@ -118,7 +118,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["concurrency_asset"]',
+          'id': '["concurrency_asset"]',
           'key': dict({
             'path': list([
               'concurrency_asset',
@@ -126,7 +126,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["concurrency_graph_asset"]',
+          'id': '["concurrency_graph_asset"]',
           'key': dict({
             'path': list([
               'concurrency_graph_asset',
@@ -134,7 +134,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["concurrency_multi_asset_1"]',
+          'id': '["concurrency_multi_asset_1"]',
           'key': dict({
             'path': list([
               'concurrency_multi_asset_1',
@@ -142,7 +142,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["concurrency_multi_asset_2"]',
+          'id': '["concurrency_multi_asset_2"]',
           'key': dict({
             'path': list([
               'concurrency_multi_asset_2',
@@ -150,7 +150,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["diamond_source"]',
+          'id': '["diamond_source"]',
           'key': dict({
             'path': list([
               'diamond_source',
@@ -158,7 +158,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["downstream_asset"]',
+          'id': '["downstream_asset"]',
           'key': dict({
             'path': list([
               'downstream_asset',
@@ -166,7 +166,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["downstream_dynamic_partitioned_asset"]',
+          'id': '["downstream_dynamic_partitioned_asset"]',
           'key': dict({
             'path': list([
               'downstream_dynamic_partitioned_asset',
@@ -174,7 +174,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["downstream_static_partitioned_asset"]',
+          'id': '["downstream_static_partitioned_asset"]',
           'key': dict({
             'path': list([
               'downstream_static_partitioned_asset',
@@ -182,7 +182,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["downstream_time_partitioned_asset"]',
+          'id': '["downstream_time_partitioned_asset"]',
           'key': dict({
             'path': list([
               'downstream_time_partitioned_asset',
@@ -190,7 +190,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["downstream_weekly_partitioned_asset"]',
+          'id': '["downstream_weekly_partitioned_asset"]',
           'key': dict({
             'path': list([
               'downstream_weekly_partitioned_asset',
@@ -198,7 +198,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["dummy_source_asset"]',
+          'id': '["dummy_source_asset"]',
           'key': dict({
             'path': list([
               'dummy_source_asset',
@@ -206,7 +206,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["dynamic_in_multipartitions_fail"]',
+          'id': '["dynamic_in_multipartitions_fail"]',
           'key': dict({
             'path': list([
               'dynamic_in_multipartitions_fail',
@@ -214,7 +214,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["dynamic_in_multipartitions_success"]',
+          'id': '["dynamic_in_multipartitions_success"]',
           'key': dict({
             'path': list([
               'dynamic_in_multipartitions_success',
@@ -222,7 +222,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["executable_asset"]',
+          'id': '["executable_asset"]',
           'key': dict({
             'path': list([
               'executable_asset',
@@ -230,7 +230,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["fail_partition_materialization"]',
+          'id': '["fail_partition_materialization"]',
           'key': dict({
             'path': list([
               'fail_partition_materialization',
@@ -238,7 +238,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["first_asset"]',
+          'id': '["first_asset"]',
           'key': dict({
             'path': list([
               'first_asset',
@@ -246,7 +246,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["first_kinds_key"]',
+          'id': '["first_kinds_key"]',
           'key': dict({
             'path': list([
               'first_kinds_key',
@@ -254,7 +254,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["foo"]',
+          'id': '["foo"]',
           'key': dict({
             'path': list([
               'foo',
@@ -262,7 +262,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["foo_bar"]',
+          'id': '["foo_bar"]',
           'key': dict({
             'path': list([
               'foo_bar',
@@ -270,7 +270,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["fourth_kinds_key"]',
+          'id': '["fourth_kinds_key"]',
           'key': dict({
             'path': list([
               'fourth_kinds_key',
@@ -278,7 +278,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["fresh_diamond_bottom"]',
+          'id': '["fresh_diamond_bottom"]',
           'key': dict({
             'path': list([
               'fresh_diamond_bottom',
@@ -286,7 +286,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["fresh_diamond_left"]',
+          'id': '["fresh_diamond_left"]',
           'key': dict({
             'path': list([
               'fresh_diamond_left',
@@ -294,7 +294,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["fresh_diamond_right"]',
+          'id': '["fresh_diamond_right"]',
           'key': dict({
             'path': list([
               'fresh_diamond_right',
@@ -302,7 +302,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["fresh_diamond_top"]',
+          'id': '["fresh_diamond_top"]',
           'key': dict({
             'path': list([
               'fresh_diamond_top',
@@ -310,7 +310,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["grouped_asset_1"]',
+          'id': '["grouped_asset_1"]',
           'key': dict({
             'path': list([
               'grouped_asset_1',
@@ -318,7 +318,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["grouped_asset_2"]',
+          'id': '["grouped_asset_2"]',
           'key': dict({
             'path': list([
               'grouped_asset_2',
@@ -326,7 +326,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["grouped_asset_4"]',
+          'id': '["grouped_asset_4"]',
           'key': dict({
             'path': list([
               'grouped_asset_4',
@@ -334,7 +334,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["grouping_prefix", "asset_with_prefix_1"]',
+          'id': '["grouping_prefix", "asset_with_prefix_1"]',
           'key': dict({
             'path': list([
               'grouping_prefix',
@@ -343,7 +343,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["grouping_prefix", "asset_with_prefix_2"]',
+          'id': '["grouping_prefix", "asset_with_prefix_2"]',
           'key': dict({
             'path': list([
               'grouping_prefix',
@@ -352,7 +352,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["grouping_prefix", "asset_with_prefix_3"]',
+          'id': '["grouping_prefix", "asset_with_prefix_3"]',
           'key': dict({
             'path': list([
               'grouping_prefix',
@@ -361,7 +361,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["grouping_prefix", "asset_with_prefix_4"]',
+          'id': '["grouping_prefix", "asset_with_prefix_4"]',
           'key': dict({
             'path': list([
               'grouping_prefix',
@@ -370,7 +370,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["grouping_prefix", "asset_with_prefix_5"]',
+          'id': '["grouping_prefix", "asset_with_prefix_5"]',
           'key': dict({
             'path': list([
               'grouping_prefix',
@@ -379,7 +379,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["hanging_asset"]',
+          'id': '["hanging_asset"]',
           'key': dict({
             'path': list([
               'hanging_asset',
@@ -387,7 +387,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["hanging_graph"]',
+          'id': '["hanging_graph"]',
           'key': dict({
             'path': list([
               'hanging_graph',
@@ -395,7 +395,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["hanging_partition_asset"]',
+          'id': '["hanging_partition_asset"]',
           'key': dict({
             'path': list([
               'hanging_partition_asset',
@@ -403,7 +403,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["int_asset"]',
+          'id': '["int_asset"]',
           'key': dict({
             'path': list([
               'int_asset',
@@ -411,7 +411,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["integers_asset"]',
+          'id': '["integers_asset"]',
           'key': dict({
             'path': list([
               'integers_asset',
@@ -419,7 +419,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["middle_static_partitioned_asset_1"]',
+          'id': '["middle_static_partitioned_asset_1"]',
           'key': dict({
             'path': list([
               'middle_static_partitioned_asset_1',
@@ -427,7 +427,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["middle_static_partitioned_asset_2"]',
+          'id': '["middle_static_partitioned_asset_2"]',
           'key': dict({
             'path': list([
               'middle_static_partitioned_asset_2',
@@ -435,7 +435,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["multi_run_backfill_policy_asset"]',
+          'id': '["multi_run_backfill_policy_asset"]',
           'key': dict({
             'path': list([
               'multi_run_backfill_policy_asset',
@@ -443,7 +443,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["multipartitions_1"]',
+          'id': '["multipartitions_1"]',
           'key': dict({
             'path': list([
               'multipartitions_1',
@@ -451,7 +451,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["multipartitions_2"]',
+          'id': '["multipartitions_2"]',
           'key': dict({
             'path': list([
               'multipartitions_2',
@@ -459,7 +459,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["multipartitions_fail"]',
+          'id': '["multipartitions_fail"]',
           'key': dict({
             'path': list([
               'multipartitions_fail',
@@ -467,7 +467,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["never_runs_asset"]',
+          'id': '["never_runs_asset"]',
           'key': dict({
             'path': list([
               'never_runs_asset',
@@ -475,7 +475,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["no_multipartitions_1"]',
+          'id': '["no_multipartitions_1"]',
           'key': dict({
             'path': list([
               'no_multipartitions_1',
@@ -483,7 +483,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["not_included_asset"]',
+          'id': '["not_included_asset"]',
           'key': dict({
             'path': list([
               'not_included_asset',
@@ -491,7 +491,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["observable_asset_same_version"]',
+          'id': '["observable_asset_same_version"]',
           'key': dict({
             'path': list([
               'observable_asset_same_version',
@@ -499,7 +499,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["one"]',
+          'id': '["one"]',
           'key': dict({
             'path': list([
               'one',
@@ -507,7 +507,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["output_then_hang_asset"]',
+          'id': '["output_then_hang_asset"]',
           'key': dict({
             'path': list([
               'output_then_hang_asset',
@@ -515,7 +515,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["second_kinds_key"]',
+          'id': '["second_kinds_key"]',
           'key': dict({
             'path': list([
               'second_kinds_key',
@@ -523,7 +523,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["single_run_backfill_policy_asset"]',
+          'id': '["single_run_backfill_policy_asset"]',
           'key': dict({
             'path': list([
               'single_run_backfill_policy_asset',
@@ -531,7 +531,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["str_asset"]',
+          'id': '["str_asset"]',
           'key': dict({
             'path': list([
               'str_asset',
@@ -539,7 +539,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["third_kinds_key"]',
+          'id': '["third_kinds_key"]',
           'key': dict({
             'path': list([
               'third_kinds_key',
@@ -547,7 +547,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["two"]',
+          'id': '["two"]',
           'key': dict({
             'path': list([
               'two',
@@ -555,7 +555,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["typed_asset"]',
+          'id': '["typed_asset"]',
           'key': dict({
             'path': list([
               'typed_asset',
@@ -563,7 +563,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["unconnected"]',
+          'id': '["unconnected"]',
           'key': dict({
             'path': list([
               'unconnected',
@@ -571,7 +571,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["unexecutable_asset"]',
+          'id': '["unexecutable_asset"]',
           'key': dict({
             'path': list([
               'unexecutable_asset',
@@ -579,7 +579,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["ungrouped_asset_3"]',
+          'id': '["ungrouped_asset_3"]',
           'key': dict({
             'path': list([
               'ungrouped_asset_3',
@@ -587,7 +587,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["ungrouped_asset_5"]',
+          'id': '["ungrouped_asset_5"]',
           'key': dict({
             'path': list([
               'ungrouped_asset_5',
@@ -595,7 +595,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["unpartitioned_upstream_of_partitioned"]',
+          'id': '["unpartitioned_upstream_of_partitioned"]',
           'key': dict({
             'path': list([
               'unpartitioned_upstream_of_partitioned',
@@ -603,7 +603,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["untyped_asset"]',
+          'id': '["untyped_asset"]',
           'key': dict({
             'path': list([
               'untyped_asset',
@@ -611,7 +611,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["upstream_daily_partitioned_asset"]',
+          'id': '["upstream_daily_partitioned_asset"]',
           'key': dict({
             'path': list([
               'upstream_daily_partitioned_asset',
@@ -619,7 +619,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["upstream_dynamic_partitioned_asset"]',
+          'id': '["upstream_dynamic_partitioned_asset"]',
           'key': dict({
             'path': list([
               'upstream_dynamic_partitioned_asset',
@@ -627,7 +627,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["upstream_static_partitioned_asset"]',
+          'id': '["upstream_static_partitioned_asset"]',
           'key': dict({
             'path': list([
               'upstream_static_partitioned_asset',
@@ -635,7 +635,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["upstream_time_partitioned_asset"]',
+          'id': '["upstream_time_partitioned_asset"]',
           'key': dict({
             'path': list([
               'upstream_time_partitioned_asset',
@@ -643,7 +643,7 @@
           }),
         }),
         dict({
-          'id': 'test_location.test_repo.["yield_partition_materialization"]',
+          'id': '["yield_partition_materialization"]',
           'key': dict({
             'path': list([
               'yield_partition_materialization',


### PR DESCRIPTION
## Summary & Motivation
This id was being used in two places:
- to determine the id (but the asset key already uniquely determines a given GrapheneAsset, unlike GrapheneAssetNode),
- to help with a couple of fields that are not under test and are not currently working

So let's just remove it. I think this would allow us to remove GrapheneAssetRecord as well if we want now that definitions are totally optional on GrapheneAsset.

## How I Tested These Changes
BK
