### PR TITLE
[components] Export FunctionComponent, PythonScriptComponent, UvRunComponent from top level `dagster.components`, add docstrings

### DIFF
--- a/python_modules/dagster/dagster/components/__init__.py
+++ b/python_modules/dagster/dagster/components/__init__.py
@@ -14,6 +14,15 @@ from dagster.components.core.load_defs import (
     load_defs as load_defs,
 )
 from dagster.components.definitions import definitions as definitions
+from dagster.components.lib.executable_component.function_component import (
+    FunctionComponent as FunctionComponent,
+)
+from dagster.components.lib.executable_component.python_script_component import (
+    PythonScriptComponent as PythonScriptComponent,
+)
+from dagster.components.lib.executable_component.uv_run_component import (
+    UvRunComponent as UvRunComponent,
+)
 from dagster.components.resolved.base import Resolvable as Resolvable
 from dagster.components.resolved.context import ResolutionContext as ResolutionContext
 from dagster.components.resolved.core_models import (

--- a/python_modules/dagster/dagster/components/lib/executable_component/function_component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/function_component.py
@@ -93,6 +93,37 @@ class ExecuteFnMetadata:
 
 
 class FunctionComponent(ExecutableComponent):
+    """Represents a Python function, alongside the set of assets or asset checks that it is responsible for executing.
+
+    The provided function should return either a `MaterializeResult` or an `AssetCheckResult`.
+
+    Examples:
+    ```yaml
+    type: dagster.components.FunctionComponent
+    attributes:
+      execution:
+        fn: .my_module.update_table
+      assets:
+        - key: my_table
+    ```
+
+    ```python
+    from dagster import MaterializeResult
+
+    def update_table(context: AssetExecutionContext) -> MaterializeResult:
+        # ...
+        return MaterializeResult(metadata={"rows_updated": 100})
+
+    @component
+    def my_component():
+        return FunctionComponent(
+            execution=update_table,
+            assets=[AssetSpec(key="my_table")],
+        )
+    ```
+
+    """
+
     ## Begin overloads
     execution: Union[FunctionSpec, ResolvableCallable]
 

--- a/python_modules/dagster/dagster/components/lib/executable_component/python_script_component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/python_script_component.py
@@ -1,13 +1,10 @@
 import shutil
 from collections.abc import Sequence
 from functools import cached_property
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from dagster_shared import check
 
-from dagster._core.execution.context.asset_check_execution_context import AssetCheckExecutionContext
-from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster._core.pipes.context import PipesExecutionResult
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.lib.executable_component.component import ExecutableComponent, OpSpec
 from dagster.components.lib.executable_component.script_utils import (
@@ -16,8 +13,30 @@ from dagster.components.lib.executable_component.script_utils import (
     invoke_runner,
 )
 
+if TYPE_CHECKING:
+    from dagster._core.execution.context.asset_check_execution_context import (
+        AssetCheckExecutionContext,
+    )
+    from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+    from dagster._core.pipes.context import PipesExecutionResult
+
 
 class PythonScriptComponent(ExecutableComponent):
+    """Represents a Python script, alongside the set of assets and asset checks that it is responsible for executing.
+
+    Accepts a path to a Python script which will be executed in a dagster-pipes subprocess using your installed `python` executable.
+
+    Examples:
+    ```yaml
+    type: dagster.components.PythonScriptComponent
+    attributes:
+      execution:
+        path: update_table.py
+      assets:
+        - key: my_table
+    ```
+    """
+
     execution: ScriptSpec
 
     @property
@@ -30,9 +49,9 @@ class PythonScriptComponent(ExecutableComponent):
 
     def invoke_execute_fn(
         self,
-        context: Union[AssetExecutionContext, AssetCheckExecutionContext],
+        context: Union["AssetExecutionContext", "AssetCheckExecutionContext"],
         component_load_context: ComponentLoadContext,
-    ) -> Sequence[PipesExecutionResult]:
+    ) -> Sequence["PipesExecutionResult"]:
         assert not self.resource_keys, "Pipes subprocess scripts cannot have resources"
         return invoke_runner(
             context=context,

--- a/python_modules/dagster/dagster/components/lib/executable_component/script_utils.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/script_utils.py
@@ -2,13 +2,16 @@ import os
 import shlex
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
-from dagster._core.execution.context.asset_check_execution_context import AssetCheckExecutionContext
-from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster._core.pipes.context import PipesExecutionResult
-from dagster._core.pipes.subprocess import PipesSubprocessClient
 from dagster.components.lib.executable_component.component import OpSpec
+
+if TYPE_CHECKING:
+    from dagster._core.execution.context.asset_check_execution_context import (
+        AssetCheckExecutionContext,
+    )
+    from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+    from dagster._core.pipes.context import PipesExecutionResult
 
 
 class ScriptSpec(OpSpec):
@@ -30,10 +33,10 @@ class ScriptSpec(OpSpec):
 
 
 def invoke_runner(
-    *,
-    context: Union[AssetExecutionContext, AssetCheckExecutionContext],
-    command: list[str],
-) -> Sequence[PipesExecutionResult]:
+    *, context: Union["AssetExecutionContext", "AssetCheckExecutionContext"], command: list[str]
+) -> Sequence["PipesExecutionResult"]:
+    from dagster._core.pipes.subprocess import PipesSubprocessClient
+
     return (
         PipesSubprocessClient()
         .run(context=context.op_execution_context, command=command)

--- a/python_modules/dagster/dagster/components/lib/executable_component/uv_run_component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/uv_run_component.py
@@ -1,13 +1,10 @@
 import shutil
 from collections.abc import Sequence
 from functools import cached_property
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from dagster_shared import check
 
-from dagster._core.execution.context.asset_check_execution_context import AssetCheckExecutionContext
-from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster._core.pipes.context import PipesExecutionResult
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.lib.executable_component.component import ExecutableComponent, OpSpec
 from dagster.components.lib.executable_component.script_utils import (
@@ -16,8 +13,30 @@ from dagster.components.lib.executable_component.script_utils import (
     invoke_runner,
 )
 
+if TYPE_CHECKING:
+    from dagster._core.execution.context.asset_check_execution_context import (
+        AssetCheckExecutionContext,
+    )
+    from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+    from dagster._core.pipes.context import PipesExecutionResult
+
 
 class UvRunComponent(ExecutableComponent):
+    """Represents a Python script, alongside the set of assets or asset checks that it is responsible for executing.
+
+    Accepts a path to a Python script which will be executed in a dagster-pipes subprocess using the `uv run` command.
+
+    Example:
+    ```yaml
+    type: dagster.components.UvRunComponent
+    attributes:
+      execution:
+        path: update_table.py
+      assets:
+        - key: my_table
+    ```
+    """
+
     execution: ScriptSpec
 
     @property
@@ -30,9 +49,9 @@ class UvRunComponent(ExecutableComponent):
 
     def invoke_execute_fn(
         self,
-        context: Union[AssetExecutionContext, AssetCheckExecutionContext],
+        context: Union["AssetExecutionContext", "AssetCheckExecutionContext"],
         component_load_context: ComponentLoadContext,
-    ) -> Sequence[PipesExecutionResult]:
+    ) -> Sequence["PipesExecutionResult"]:
         assert not self.resource_keys, "Pipes subprocess scripts cannot have resources"
         command = get_cmd(
             script_runner_exe=[check.not_none(shutil.which("uv"), "uv not found"), "run"],

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
@@ -16,7 +16,7 @@ def test_pipes_subprocess_script_hello_world() -> None:
 
         with sandbox.load(
             component_body={
-                "type": "dagster.components.lib.executable_component.python_script_component.PythonScriptComponent",
+                "type": "dagster.components.PythonScriptComponent",
                 "attributes": {
                     "execution": {
                         "name": "op_name",
@@ -53,7 +53,7 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
 
         with sandbox.load(
             component_body={
-                "type": "dagster.components.lib.executable_component.python_script_component.PythonScriptComponent",
+                "type": "dagster.components.PythonScriptComponent",
                 "attributes": {
                     "execution": {
                         "path": "op_name.py",
@@ -81,7 +81,7 @@ def test_pipes_subprocess_script_with_name_override() -> None:
     with scaffold_defs_sandbox(component_cls=PythonScriptComponent) as sandbox:
         with sandbox.load(
             component_body={
-                "type": "dagster.components.lib.executable_component.python_script_component.PythonScriptComponent",
+                "type": "dagster.components.PythonScriptComponent",
                 "attributes": {
                     "execution": {
                         "name": "op_name_override",
@@ -116,7 +116,7 @@ def test_pipes_subprocess_script_with_checks_only() -> None:
 
         with sandbox.load(
             component_body={
-                "type": "dagster.components.lib.executable_component.python_script_component.PythonScriptComponent",
+                "type": "dagster.components.PythonScriptComponent",
                 "attributes": {
                     "execution": {
                         "path": "only_checks.py",
@@ -169,7 +169,7 @@ def test_pipes_subprocess_with_args() -> None:
         copy_code_to_file(template_vars_content, template_vars_path)
         with sandbox.load(
             component_body={
-                "type": "dagster.components.lib.executable_component.python_script_component.PythonScriptComponent",
+                "type": "dagster.components.PythonScriptComponent",
                 "attributes": {
                     "execution": {
                         "path": "op_name.py",
@@ -210,7 +210,7 @@ def test_pipes_subprocess_with_inline_str() -> None:
         copy_code_to_file(op_name_contents, execute_path)
         with sandbox.load(
             component_body={
-                "type": "dagster.components.lib.executable_component.python_script_component.PythonScriptComponent",
+                "type": "dagster.components.PythonScriptComponent",
                 "attributes": {
                     "execution": {
                         "path": "op_name.py",

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
@@ -32,7 +32,7 @@ def test_pipes_subprocess_script_hello_world() -> None:
 
         with sandbox.load(
             component_body={
-                "type": "dagster.components.lib.executable_component.uv_run_component.UvRunComponent",
+                "type": "dagster.components.UvRunComponent",
                 "attributes": {
                     "execution": {
                         "name": "op_name",

--- a/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
+++ b/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
@@ -22,7 +22,7 @@ def test_nested_component() -> None:
 
         with sandbox.load(
             component_body={
-                "type": "dagster.components.lib.executable_component.function_component.FunctionComponent",
+                "type": "dagster.components.FunctionComponent",
                 "attributes": {
                     "execution": {
                         "name": "nested_component",


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/BUILD-1316/expose-function-python-script-and-uv-run-script-top-level-and-document  

## How I Tested These Changes

## Changelog

[components] Added `FunctionComponent`, `PythonScriptComponent`, and `UvRunComponent` to make it easier to define arbitrary computations that execute assets or asset checks when invoked.
