### PR TITLE
add a flag for requiring streamline when computing asset health

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_check_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_check_health.py
@@ -194,6 +194,9 @@ async def get_asset_check_status_and_metadata(
     asset_check_health_state = await AssetCheckHealthState.gen(context, asset_key)
     # captures streamline disabled or consumer state doesn't exist
     if asset_check_health_state is None:
+        if context.instance.streamline_read_asset_health_required():
+            return AssetHealthStatus.UNKNOWN, None
+
         # Note - this will only compute check health if there is a definition for the asset and checks in the
         # asset graph. If check results are reported for assets or checks that are not in the asset graph, those
         # results will not be picked up. If we add storage methods to get all check results for an asset by

--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_freshness_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_freshness_health.py
@@ -82,6 +82,9 @@ async def get_freshness_status_and_metadata(
     if (
         asset_freshness_health_state is None
     ):  # if streamline reads are off or no streamline state exists for the asset compute it from the DB
+        if context.instance.streamline_read_asset_health_required():
+            return AssetHealthStatus.UNKNOWN, None
+
         if (
             not context.asset_graph.has(asset_key)
             or context.asset_graph.get(asset_key).internal_freshness_policy is None

--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
@@ -263,6 +263,9 @@ async def get_materialization_status_and_metadata(
     )
     # captures streamline disabled or consumer state doesn't exist
     if asset_materialization_health_state is None:
+        if context.instance.streamline_read_asset_health_required():
+            return AssetHealthStatus.UNKNOWN, None
+
         if not context.asset_graph.has(asset_key):
             # if the asset is not in the asset graph, it could be because materializations are reported by
             # an external system, determine the status as best we can based on the asset record

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3659,6 +3659,9 @@ class DagsterInstance(DynamicPartitionsStore):
     def streamline_read_asset_health_supported(self) -> bool:
         return False
 
+    def streamline_read_asset_health_required(self) -> bool:
+        return False
+
     def get_asset_check_health_state_for_assets(
         self, asset_keys: Sequence[AssetKey]
     ) -> Optional[Mapping[AssetKey, Optional["AssetCheckHealthState"]]]:


### PR DESCRIPTION
## Summary & Motivation
This fallback path is slow even if it short circuits relatively quickly, since it checks whether asset keys are in the graph and that is slow.

Open to discussion about what the correct fallback value is here.

## Test Plan
Updated test cases in adjacent PR