### PR TITLE
Allow `MaterializeResult` to take a `value` argument

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -74,7 +74,7 @@ from dagster._utils.warnings import deprecation_warning, normalize_renamed_param
 
 ArbitraryMetadataMapping: TypeAlias = Mapping[str, Any]
 
-RawMetadataValue = Union[
+RawMetadataValue: TypeAlias = Union[
     MetadataValue,
     TableSchema,
     AssetKey,

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -77,6 +77,7 @@ ArbitraryMetadataMapping: TypeAlias = Mapping[str, Any]
 RawMetadataValue: TypeAlias = Union[
     MetadataValue,
     TableSchema,
+    TableColumnLineage,
     AssetKey,
     os.PathLike,
     dict[Any, Any],

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -38,7 +38,7 @@ from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionKey,
     get_tags_from_multi_partition_key,
 )
-from dagster._core.definitions.result import AssetResult
+from dagster._core.definitions.result import AssetResult, MaterializeResult
 from dagster._core.definitions.source_asset import SYSTEM_METADATA_KEY_SOURCE_ASSET_OBSERVATION
 from dagster._core.errors import (
     DagsterAssetCheckFailedError,
@@ -70,8 +70,19 @@ from dagster._utils.warnings import beta_warning, disable_dagster_warnings
 class AssetResultOutput(Output):
     """This is a marker subclass that represents an Output that was produced from an AssetResult."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, value_unset: bool, **kwargs):
         super().__init__(*args, **kwargs)
+        self.value_unset = value_unset
+
+    def with_metadata(self, metadata):
+        return self.__class__(
+            value=self.value,
+            output_name=self.output_name,
+            metadata=metadata,
+            data_version=self.data_version,
+            tags=self.tags,
+            value_unset=self.value_unset,
+        )
 
 
 def _process_asset_results_to_events(
@@ -103,8 +114,14 @@ def _process_user_event(
             yield from _process_user_event(step_context, check_result)
 
         with disable_dagster_warnings():
+            if isinstance(user_event, MaterializeResult):
+                value = user_event.value
+                value_unset = user_event.value_unset
+            else:
+                value, value_unset = None, True
             yield AssetResultOutput(
-                value=None,
+                value=value,
+                value_unset=value_unset,
                 output_name=output_name,
                 metadata=user_event.metadata,
                 data_version=user_event.data_version,
@@ -766,8 +783,20 @@ def _store_output(
     if (
         step_output.properties.asset_check_key
         or (step_context.output_observes_source_asset(step_output_handle.output_name))
-        or isinstance(output, AssetResultOutput)
         or output_context.dagster_type.is_nothing
+        or (
+            # FIXME: currently, when an output type is unset, this quickly gets coerced to the Any type,
+            # making it impossible to distinguish between a user declaring that they expect an output
+            # of any type, and a user not declaring any expectation at all.
+            #
+            # For now, we assume that if the output type is Any AND the user has not explicitly set a
+            # value for their materialize result, that they do not expect the IO manager to be invoked.
+            # In contrast, if the user does explicitly set the output value to any value (including None),
+            # the IO manager *will* be invoked.
+            output_context.dagster_type.is_any
+            and isinstance(output, AssetResultOutput)
+            and output.value_unset
+        )
     ):
         yield from _log_materialization_or_observation_events_for_asset(
             step_context=step_context,

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -41,6 +41,8 @@ from dagster._core.definitions.resource_requirement import (
     ResourceRequirement,
     TypeResourceRequirement,
 )
+from dagster._core.definitions.result import MaterializeResult
+from dagster._core.definitions.utils import NoValueSentinel
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
@@ -489,10 +491,10 @@ class _Nothing(DagsterType):
     def type_check_method(
         self, _context: "TypeCheckContext", value: object
     ) -> TypeCheck:
-        if value is not None:
+        if value is not None and value != NoValueSentinel:
             return TypeCheck(
                 success=False,
-                description=f"Value must be None, got a {type(value)}",
+                description=f"Value must be None or unset, got a {type(value)}",
             )
 
         return TypeCheck(success=True)
@@ -906,7 +908,9 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
     )
 
     # First, check to see if we're using Dagster's generic output type to do the type catching.
-    if is_generic_output_annotation(dagster_type):
+    if is_generic_output_annotation(
+        dagster_type
+    ) or is_generic_materialize_result_annotation(dagster_type):
         type_args = get_args(dagster_type)
         # If no inner type was provided, forward Any type.
         dagster_type = type_args[0] if len(type_args) == 1 else Any
@@ -915,10 +919,7 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
         type_args = get_args(dynamic_out_annotation)
         dagster_type = type_args[0] if len(type_args) == 1 else Any
     elif dagster_type == MaterializeResult:
-        # convert MaterializeResult type annotation to Nothing until returning
-        # scalar values via MaterializeResult is supported
-        # https://github.com/dagster-io/dagster/issues/16887
-        dagster_type = Nothing
+        dagster_type = Any
     elif dagster_type == ObserveResult:
         # ObserveResult does not include a value
         dagster_type = Nothing
@@ -1000,6 +1001,13 @@ def is_dynamic_output_annotation(dagster_type: object) -> bool:
 
 def is_generic_output_annotation(dagster_type: object) -> bool:
     return dagster_type == Output or get_origin(dagster_type) == Output
+
+
+def is_generic_materialize_result_annotation(dagster_type: object) -> bool:
+    return (
+        dagster_type == MaterializeResult
+        or get_origin(dagster_type) == MaterializeResult
+    )
 
 
 def resolve_python_type_to_dagster_type(python_type: t.Type) -> DagsterType:

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -274,6 +274,10 @@ class DagsterType:
         return self.kind == DagsterTypeKind.NOTHING
 
     @property
+    def is_any(self) -> bool:
+        return self.kind == DagsterTypeKind.ANY
+
+    @property
     def supports_fan_in(self) -> bool:
         return False
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2258,8 +2258,8 @@ def test_replace_asset_keys_for_asset_with_owners():
 def test_asset_spec_with_code_versions():
     @multi_asset(specs=[AssetSpec(key="a", code_version="1"), AssetSpec(key="b", code_version="2")])
     def multi_asset_with_versions():
-        yield MaterializeResult("a")  # pyright: ignore[reportCallIssue]
-        yield MaterializeResult("b")  # pyright: ignore[reportCallIssue]
+        yield MaterializeResult("a")
+        yield MaterializeResult("b")
 
     code_versions_by_key = {spec.key: spec.code_version for spec in multi_asset_with_versions.specs}
     assert code_versions_by_key == {AssetKey(["a"]): "1", AssetKey(["b"]): "2"}
@@ -2270,8 +2270,8 @@ def test_asset_spec_with_metadata():
         specs=[AssetSpec(key="a", metadata={"foo": "1"}), AssetSpec(key="b", metadata={"bar": "2"})]
     )
     def multi_asset_with_metadata():
-        yield MaterializeResult("a")  # pyright: ignore[reportCallIssue]
-        yield MaterializeResult("b")  # pyright: ignore[reportCallIssue]
+        yield MaterializeResult("a")
+        yield MaterializeResult("b")
 
     metadata_by_key = {spec.key: spec.metadata for spec in multi_asset_with_metadata.specs}
     assert metadata_by_key == {AssetKey(["a"]): {"foo": "1"}, AssetKey(["b"]): {"bar": "2"}}


### PR DESCRIPTION
## Summary & Motivation

This is based off of: https://github.com/dagster-io/dagster/pull/30144

An upstack PR will handle the input side of the world, this just tackles `MaterializeResult`.

We do end up needing to differentiate between the case of "explicitly passing the value `None` into the constructor" and "not passing any value at all":

```python

# io manager not invoked at all, retaining current-day behavior
@asset
def my_asset() -> MaterializeResult:
    return MaterializeResult()


# io manager invoked, passing the value of None
@asset
def my_asset() -> MaterializeResult:
    return MaterializeResult(value=None)
```

One small nice thing to note is that users who opt-in to using the more specific type hint get nice linter support, which is something I was a bit worried about (i thought it might be easy to forget to pass the value):

```python
@asset
def a() -> MaterializeResult[int]:
    return MaterializeResult()
```

![Screenshot 2025-06-17 at 4.55.21 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cTPQ7oSxo9qxXgkzpnaK/3a0383ac-4976-4322-8a1e-25110da5266d.png)

## How I Tested These Changes

## Changelog

`MaterializeResult` now optionally supports a `value` parameter. If set, the asset's IOManager will be invoked. You may also optionally annotate your return types with `-> MaterializeResult[T]` to indicate the specific value type you expect.
