### PR TITLE
[components] Refactor SQL component to `dagster.TemplatedSqlComponent`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,9 @@ pythonenv*/
 # DuckDB
 *.duckdb
 
+# Cursorrules
+.cursor
+
 # PyRight config
 pyrightconfig*
 

--- a/examples/docs_snippets/docs_snippets/guides/components/index/17-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/17-dg-list-components.txt
@@ -14,6 +14,8 @@ dg list components
 │ dagster.PythonScriptComponent                     │ Represents a Python script, alongside the set of assets and      │
 │                                                   │ asset checks that it is responsible for executing.               │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
+│ dagster.TemplatedSqlComponent                     │ A component which executes templated SQL from a string or file.  │
+├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
 │ dagster.UvRunComponent                            │ Represents a Python script, alongside the set of assets or asset │
 │                                                   │ checks that it is responsible for executing.                     │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤

--- a/examples/docs_snippets/docs_snippets/guides/components/index/26-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/26-dg-list-components.txt
@@ -14,6 +14,8 @@ dg list components
 │ dagster.PythonScriptComponent                     │ Represents a Python script, alongside the set of assets and      │
 │                                                   │ asset checks that it is responsible for executing.               │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
+│ dagster.TemplatedSqlComponent                     │ A component which executes templated SQL from a string or file.  │
+├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
 │ dagster.UvRunComponent                            │ Represents a Python script, alongside the set of assets or asset │
 │                                                   │ checks that it is responsible for executing.                     │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤

--- a/examples/docs_snippets/docs_snippets/guides/components/index/4-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/4-dg-list-components.txt
@@ -14,6 +14,8 @@ dg list components
 │ dagster.PythonScriptComponent │ Represents a Python script, alongside the set of assets and asset checks that it is  │
 │                               │ responsible for executing.                                                           │
 ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────┤
+│ dagster.TemplatedSqlComponent │ A component which executes templated SQL from a string or file.                      │
+├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────┤
 │ dagster.UvRunComponent        │ Represents a Python script, alongside the set of assets or asset checks that it is   │
 │                               │ responsible for executing.                                                           │
 └───────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────┘

--- a/examples/docs_snippets/docs_snippets/guides/components/index/6-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/6-dg-list-components.txt
@@ -14,6 +14,8 @@ dg list components
 │ dagster.PythonScriptComponent                     │ Represents a Python script, alongside the set of assets and      │
 │                                                   │ asset checks that it is responsible for executing.               │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
+│ dagster.TemplatedSqlComponent                     │ A component which executes templated SQL from a string or file.  │
+├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
 │ dagster.UvRunComponent                            │ Represents a Python script, alongside the set of assets or asset │
 │                                                   │ checks that it is responsible for executing.                     │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/generated/3-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/generated/3-dg-list-components.txt
@@ -14,6 +14,8 @@ dg list components
 │ dagster.PythonScriptComponent                    │ Represents a Python script, alongside the set of assets and asset │
 │                                                  │ checks that it is responsible for executing.                      │
 ├──────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
+│ dagster.TemplatedSqlComponent                    │ A component which executes templated SQL from a string or file.   │
+├──────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
 │ dagster.UvRunComponent                           │ Represents a Python script, alongside the set of assets or asset  │
 │                                                  │ checks that it is responsible for executing.                      │
 ├──────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────┤

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/11-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/11-list-components.txt
@@ -14,6 +14,8 @@ dg list components
 │ dagster.PythonScriptComponent      │ Represents a Python script, alongside the set of assets and asset checks that   │
 │                                    │ it is responsible for executing.                                                │
 ├────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
+│ dagster.TemplatedSqlComponent      │ A component which executes templated SQL from a string or file.                 │
+├────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
 │ dagster.UvRunComponent             │ Represents a Python script, alongside the set of assets or asset checks that it │
 │                                    │ is responsible for executing.                                                   │
 ├────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/4-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/4-dg-list-components.txt
@@ -14,6 +14,8 @@ dg list components
 │ dagster.PythonScriptComponent                     │ Represents a Python script, alongside the set of assets and      │
 │                                                   │ asset checks that it is responsible for executing.               │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
+│ dagster.TemplatedSqlComponent                     │ A component which executes templated SQL from a string or file.  │
+├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
 │ dagster.UvRunComponent                            │ Represents a Python script, alongside the set of assets or asset │
 │                                                   │ checks that it is responsible for executing.                     │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/CLAUDE.md
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/CLAUDE.md
@@ -1,0 +1,11 @@
+# Testing Snippet Tests
+
+All snippet tests should be tested by navigating to:
+```
+cd $DAGSTER_GIT_REPO_DIR/examples/docs_snippets
+```
+
+Then running via tox:
+```
+tox -e docs_snapshot_update -- <path to test>
+```

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/CLAUDE.md
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/CLAUDE.md
@@ -1,11 +1,13 @@
 # Testing Snippet Tests
 
 All snippet tests should be tested by navigating to:
+
 ```
 cd $DAGSTER_GIT_REPO_DIR/examples/docs_snippets
 ```
 
 Then running via tox:
+
 ```
 tox -e docs_snapshot_update -- <path to test>
 ```

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -279,8 +279,7 @@ def test_components_docs_index(
 
             # Test sling sync
 
-            if not update_snippets:
-                _run_command("dg launch --assets '*'")
+            _run_command("dg launch --assets '*'")
             context.run_command_and_snippet_output(
                 cmd='duckdb /tmp/jaffle_platform.duckdb -c "SELECT * FROM raw_customers LIMIT 5;"',
                 snippet_path=f"{next_snip_no()}-duckdb-select.txt",

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -670,6 +670,10 @@ from dagster.components.core.load_defs import (
 )
 from dagster.components.definitions import definitions as definitions
 from dagster.components.lib.shim_components.resources import resources as resources
+from dagster.components.lib.sql_component.sql_component import (
+    SqlComponent as SqlComponent,
+    TemplatedSqlComponent as TemplatedSqlComponent,
+)
 from dagster.components.resolved.base import Resolvable as Resolvable
 from dagster.components.resolved.context import ResolutionContext as ResolutionContext
 from dagster.components.resolved.core_models import (

--- a/python_modules/dagster/dagster/components/__init__.py
+++ b/python_modules/dagster/dagster/components/__init__.py
@@ -25,6 +25,10 @@ from dagster.components.lib.executable_component.python_script_component import 
 from dagster.components.lib.executable_component.uv_run_component import (
     UvRunComponent as UvRunComponent,
 )
+from dagster.components.lib.sql_component.sql_component import (
+    SqlComponent as SqlComponent,
+    TemplatedSqlComponent as TemplatedSqlComponent,
+)
 from dagster.components.resolved.base import Resolvable as Resolvable
 from dagster.components.resolved.context import ResolutionContext as ResolutionContext
 from dagster.components.resolved.core_models import (

--- a/python_modules/dagster/dagster/components/lib/sql_component/sql_client.py
+++ b/python_modules/dagster/dagster/components/lib/sql_component/sql_client.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 
-class ISQLClient(ABC):
+class SQLClient(ABC):
     """An interface for a SQL client that can connect to a database and execute SQL queries."""
 
     @abstractmethod

--- a/python_modules/dagster/dagster/components/lib/sql_component/sql_client.py
+++ b/python_modules/dagster/dagster/components/lib/sql_component/sql_client.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+
+class ISQLClient(ABC):
+    """An interface for a SQL client that can connect to a database and execute SQL queries."""
+
+    @abstractmethod
+    def connect_and_execute(self, sql: str) -> None:
+        """Connect to the SQL database and execute the SQL query."""
+        ...

--- a/python_modules/dagster/dagster/components/lib/sql_component/sql_component.py
+++ b/python_modules/dagster/dagster/components/lib/sql_component/sql_component.py
@@ -78,9 +78,7 @@ ResolvedSqlTemplate = Annotated[
 
 
 class TemplatedSqlComponent(SqlComponent):
-    """Executes templated SQL from a string or file using Jinja2 against the
-    supplied SQL connection.
-    """
+    """A component which executes templated SQL from a string or file."""
 
     sql_template: Annotated[
         ResolvedSqlTemplate,

--- a/python_modules/dagster/dagster/components/lib/sql_component/sql_component.py
+++ b/python_modules/dagster/dagster/components/lib/sql_component/sql_component.py
@@ -13,6 +13,7 @@ from dagster._core.execution.context.asset_check_execution_context import AssetC
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.lib.executable_component.component import ExecutableComponent
+from dagster.components.lib.sql_component.sql_client import SQLClient
 from dagster.components.resolved.base import Resolvable
 from dagster.components.resolved.core_models import OpSpec
 from dagster.components.resolved.model import Resolver
@@ -26,10 +27,13 @@ class SqlComponent(ExecutableComponent, Resolvable, ABC):
     and how to execute it.
     """
 
+    class Config:
+        arbitrary_types_allowed = True
+
     connection: Annotated[
         Annotated[
-            Any,
-            Resolver(lambda ctx, value: value, model_field_type=str),
+            SQLClient,
+            Resolver(lambda ctx, value: value, model_field_type=Any),  # type: ignore
         ],
         Field(description="The resource key to use for the Snowflake resource."),
     ]

--- a/python_modules/dagster/dagster/components/lib/sql_component/sql_component.py
+++ b/python_modules/dagster/dagster/components/lib/sql_component/sql_component.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Annotated, Any, Optional, Union
 
 from dagster_shared import check
-from jinja2 import Template
 from pydantic import BaseModel, Field
 
 from dagster._annotations import preview, public
@@ -92,6 +91,8 @@ class TemplatedSqlComponent(SqlComponent):
     ] = None
 
     def get_sql_content(self, context: AssetExecutionContext) -> str:
+        from jinja2 import Template
+
         template_str = self.sql_template
         if isinstance(template_str, SqlFile):
             template_str = Path(template_str.path).read_text()

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/components/workspace_component/component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/components/workspace_component/component.py
@@ -108,7 +108,7 @@ class AirbyteCloudWorkspaceComponent(dg.Component, dg.Model, dg.Resolvable):
         AirbyteCloudWorkspace,
         dg.Resolver(
             lambda context, model: AirbyteCloudWorkspace(
-                **resolve_fields(model, AirbyteCloudWorkspace, context)  # type: ignore
+                **resolve_fields(model, AirbyteCloudWorkspace, context)
             )
         ),
     ]

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/components/workspace_component/component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/components/workspace_component/component.py
@@ -108,7 +108,7 @@ class FivetranAccountComponent(dg.Component, dg.Model, dg.Resolvable):
         FivetranWorkspace,
         dg.Resolver(
             lambda context, model: FivetranWorkspace(
-                **resolve_fields(model, FivetranWorkspace, context)  # type: ignore
+                **resolve_fields(model, FivetranWorkspace, context)
             )
         ),
     ]

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/__init__.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/__init__.py
@@ -1,6 +1,10 @@
 from dagster_shared.libraries import DagsterLibraryRegistry
 
-from dagster_snowflake.components import SnowflakeSqlComponent as SnowflakeSqlComponent
+from dagster_snowflake.components import (
+    BaseSnowflakeSqlComponent as BaseSnowflakeSqlComponent,
+    SnowflakeConnectionComponent as SnowflakeConnectionComponent,
+    SnowflakeTemplatedSqlComponent as SnowflakeTemplatedSqlComponent,
+)
 from dagster_snowflake.ops import snowflake_op_for_query as snowflake_op_for_query
 from dagster_snowflake.resources import (
     SnowflakeConnection as SnowflakeConnection,

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/__init__.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/__init__.py
@@ -1,9 +1,7 @@
 from dagster_shared.libraries import DagsterLibraryRegistry
 
 from dagster_snowflake.components import (
-    BaseSnowflakeSqlComponent as BaseSnowflakeSqlComponent,
     SnowflakeConnectionComponent as SnowflakeConnectionComponent,
-    SnowflakeTemplatedSqlComponent as SnowflakeTemplatedSqlComponent,
 )
 from dagster_snowflake.ops import snowflake_op_for_query as snowflake_op_for_query
 from dagster_snowflake.resources import (

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/__init__.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/__init__.py
@@ -1,3 +1,11 @@
-from dagster_snowflake.components.sql_component.component import SnowflakeSqlComponent
+from dagster_snowflake.components.sql_component.component import (
+    BaseSnowflakeSqlComponent,
+    SnowflakeConnectionComponent,
+    SnowflakeTemplatedSqlComponent,
+)
 
-__all__ = ["SnowflakeSqlComponent"]
+__all__ = [
+    "BaseSnowflakeSqlComponent",
+    "SnowflakeConnectionComponent",
+    "SnowflakeTemplatedSqlComponent",
+]

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/__init__.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/__init__.py
@@ -1,11 +1,5 @@
-from dagster_snowflake.components.sql_component.component import (
-    BaseSnowflakeSqlComponent,
-    SnowflakeConnectionComponent,
-    SnowflakeTemplatedSqlComponent,
-)
+from dagster_snowflake.components.sql_component.component import SnowflakeConnectionComponent
 
 __all__ = [
-    "BaseSnowflakeSqlComponent",
     "SnowflakeConnectionComponent",
-    "SnowflakeTemplatedSqlComponent",
 ]

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/sql_component/component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/sql_component/component.py
@@ -1,24 +1,87 @@
-from typing import Annotated
+from abc import ABC
+from typing import Annotated, Optional
 
+import dagster as dg
+from dagster._annotations import preview, public
+from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster.components.base.sql_component import TemplatedSqlComponent
-from pydantic import Field
+from dagster.components.base.sql_component import SqlComponent, TemplatedSqlComponentMixin
+from dagster.components.core.context import ComponentLoadContext
+from dagster.components.resolved.base import resolve_fields
+from dagster.components.resolved.context import ResolutionContext
+from dagster.components.resolved.model import Model, Resolver
+from pydantic import BaseModel, Field, create_model
 
 from dagster_snowflake.resources import SnowflakeResource
 
+# Dynamically create SnowflakeResourceModel from SnowflakeResource without validators
+field_definitions = {}
+for field_name, field in SnowflakeResource.model_fields.items():
+    field_definitions[field_name] = (field.annotation, field)
+SnowflakeResourceModel = create_model(
+    "SnowflakeResourceModel",
+    __base__=Model,
+    **field_definitions,
+)
 
-class SnowflakeSqlComponent(TemplatedSqlComponent[SnowflakeResource]):
-    """A component that executes SQL from a file in Snowflake."""
+
+def resolve_snowflake_resource(context: ResolutionContext, value) -> SnowflakeResource:
+    return SnowflakeResource(**resolve_fields(value, SnowflakeResource, context))
+
+
+@public
+@preview
+class BaseSnowflakeSqlComponent(SqlComponent, ABC):
+    """A component which implements executing a SQL query using a Snowflake resource.
+    This is an abstract base class which does not provide instructions on where to source
+    the SQL content from.
+    """
+
+    connection: Annotated[
+        Annotated[
+            SnowflakeResource,
+            Resolver(
+                resolve_snowflake_resource,
+                model_field_type=SnowflakeResourceModel,
+            ),
+        ],
+        Field(description="The resource key to use for the Snowflake resource."),
+    ]
+
+    def execute(self, context: AssetExecutionContext) -> None:
+        """Execute the SQL content using the Snowflake resource."""
+        with self.connection.get_connection() as conn:
+            conn.cursor().execute(self.get_sql_content(context))
+
+
+@public
+@preview
+class SnowflakeTemplatedSqlComponent(
+    TemplatedSqlComponentMixin,
+    BaseSnowflakeSqlComponent,
+):
+    """A component that executes templated SQL from a string or file in Snowflake."""
+
+
+@public
+@preview
+class SnowflakeConnectionComponent(dg.Component, dg.Resolvable, SnowflakeResource):
+    """A component that represents a Snowflake connection."""
 
     resource_key: Annotated[
-        str, Field(description="The resource key to use for the Snowflake resource.")
-    ] = "snowflake"
+        Optional[str],
+        Field(
+            description="A resource key to expose this connection to use in other Dagster assets."
+        ),
+    ] = None
 
-    def execute(self, context: AssetExecutionContext, resource: SnowflakeResource) -> None:
-        """Execute the SQL content using the Snowflake resource."""
-        with resource.get_connection() as conn:
-            conn.cursor().execute(self.sql_content)
+    @classmethod
+    def load(
+        cls, attributes: Optional[BaseModel], context: "ComponentLoadContext"
+    ) -> "SnowflakeConnectionComponent":
+        return super().load(attributes, context)
 
-    @property
-    def resource_keys(self) -> set[str]:
-        return {self.resource_key}
+    def build_defs(self, context: ComponentLoadContext) -> Definitions:
+        return (
+            Definitions(resources={self.resource_key: self}) if self.resource_key else Definitions()
+        )

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/sql_component/component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/sql_component/component.py
@@ -18,7 +18,12 @@ class SnowflakeConnectionComponentBase(dg.Component, dg.Resolvable, dg.Model, SQ
 
     @cached_property
     def _snowflake_resource(self) -> SnowflakeResource:
-        return SnowflakeResource(**self.__dict__)
+        return SnowflakeResource(
+            **{
+                (field.alias or field_name): getattr(self, field_name)
+                for field_name, field in self.__class__.model_fields.items()
+            }
+        )
 
     def connect_and_execute(self, sql: str) -> None:
         """Connect to the SQL database and execute the SQL query."""
@@ -33,7 +38,7 @@ def _copy_fields_to_model(
 ) -> None:
     """Given two models, creates a copy of the second model with the fields of the first model."""
     field_definitions: dict[str, tuple[type, Any]] = {
-        (field.alias or field_name): (cast("type", field.annotation), field.default)
+        field_name: (cast("type", field.annotation), field)
         for field_name, field in copy_from.model_fields.items()
     }
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/sql_component/component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/sql_component/component.py
@@ -4,7 +4,6 @@ import dagster as dg
 from dagster._annotations import preview, public
 from dagster._core.definitions.definitions_class import Definitions
 from dagster.components.core.context import ComponentLoadContext
-from dagster.components.lib.sql_component.sql_client import ISQLClient
 from pydantic import BaseModel, Field
 
 from dagster_snowflake.resources import SnowflakeResource
@@ -12,7 +11,7 @@ from dagster_snowflake.resources import SnowflakeResource
 
 @public
 @preview
-class SnowflakeConnectionComponent(dg.Component, dg.Resolvable, SnowflakeResource, ISQLClient):
+class SnowflakeConnectionComponent(dg.Component, dg.Resolvable, SnowflakeResource):
     """A component that represents a Snowflake connection."""
 
     resource_key: Annotated[
@@ -32,7 +31,3 @@ class SnowflakeConnectionComponent(dg.Component, dg.Resolvable, SnowflakeResourc
         return (
             Definitions(resources={self.resource_key: self}) if self.resource_key else Definitions()
         )
-
-    def connect_and_execute(self, sql: str) -> None:
-        with self.get_connection() as conn:
-            conn.cursor().execute(sql)

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/sql_component/component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/sql_component/component.py
@@ -1,71 +1,18 @@
-from abc import ABC
 from typing import Annotated, Optional
 
 import dagster as dg
 from dagster._annotations import preview, public
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-from dagster.components.base.sql_component import SqlComponent, TemplatedSqlComponentMixin
 from dagster.components.core.context import ComponentLoadContext
-from dagster.components.resolved.base import resolve_fields
-from dagster.components.resolved.context import ResolutionContext
-from dagster.components.resolved.model import Model, Resolver
-from pydantic import BaseModel, Field, create_model
+from dagster.components.lib.sql_component.sql_client import ISQLClient
+from pydantic import BaseModel, Field
 
 from dagster_snowflake.resources import SnowflakeResource
 
-# Dynamically create SnowflakeResourceModel from SnowflakeResource without validators
-field_definitions = {}
-for field_name, field in SnowflakeResource.model_fields.items():
-    field_definitions[field_name] = (field.annotation, field)
-SnowflakeResourceModel = create_model(
-    "SnowflakeResourceModel",
-    __base__=Model,
-    **field_definitions,
-)
-
-
-def resolve_snowflake_resource(context: ResolutionContext, value) -> SnowflakeResource:
-    return SnowflakeResource(**resolve_fields(value, SnowflakeResource, context))
-
 
 @public
 @preview
-class BaseSnowflakeSqlComponent(SqlComponent, ABC):
-    """A component which implements executing a SQL query using a Snowflake resource.
-    This is an abstract base class which does not provide instructions on where to source
-    the SQL content from.
-    """
-
-    connection: Annotated[
-        Annotated[
-            SnowflakeResource,
-            Resolver(
-                resolve_snowflake_resource,
-                model_field_type=SnowflakeResourceModel,
-            ),
-        ],
-        Field(description="The resource key to use for the Snowflake resource."),
-    ]
-
-    def execute(self, context: AssetExecutionContext) -> None:
-        """Execute the SQL content using the Snowflake resource."""
-        with self.connection.get_connection() as conn:
-            conn.cursor().execute(self.get_sql_content(context))
-
-
-@public
-@preview
-class SnowflakeTemplatedSqlComponent(
-    TemplatedSqlComponentMixin,
-    BaseSnowflakeSqlComponent,
-):
-    """A component that executes templated SQL from a string or file in Snowflake."""
-
-
-@public
-@preview
-class SnowflakeConnectionComponent(dg.Component, dg.Resolvable, SnowflakeResource):
+class SnowflakeConnectionComponent(dg.Component, dg.Resolvable, SnowflakeResource, ISQLClient):
     """A component that represents a Snowflake connection."""
 
     resource_key: Annotated[
@@ -85,3 +32,7 @@ class SnowflakeConnectionComponent(dg.Component, dg.Resolvable, SnowflakeResourc
         return (
             Definitions(resources={self.resource_key: self}) if self.resource_key else Definitions()
         )
+
+    def connect_and_execute(self, sql: str) -> None:
+        with self.get_connection() as conn:
+            conn.cursor().execute(sql)

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -19,6 +19,7 @@ from dagster._annotations import public
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.storage.event_log.sql_event_log import SqlDbConnection
 from dagster._utils.cached_method import cached_method
+from dagster.components.lib.sql_component.sql_client import SQLClient
 from pydantic import Field, model_validator, validator
 
 from dagster_snowflake.constants import (
@@ -40,7 +41,7 @@ except ImportError:
     raise
 
 
-class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext):
+class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext, SQLClient):
     """A resource for connecting to the Snowflake data warehouse.
 
     If connector configuration is not set, SnowflakeResource.get_connection() will return a
@@ -576,6 +577,10 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             log=get_dagster_logger(),
             snowflake_connection_resource=self,
         )
+
+    def connect_and_execute(self, sql: str) -> None:
+        with self.get_connection() as conn:
+            conn.cursor().execute(sql)
 
 
 class SnowflakeConnection:

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
@@ -1,16 +1,22 @@
+import importlib
 import os
 import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
+from pathlib import Path
 from unittest import mock
 
 import pytest
+import yaml
 from dagster import AssetKey, Definitions
 from dagster._core.definitions.materialize import materialize
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._utils import alter_sys_path
+from dagster.components.core.tree import ComponentTree
 from dagster.components.testing import scaffold_defs_sandbox
-from dagster_snowflake.components import SnowflakeSqlComponent
+from dagster_snowflake.components import SnowflakeTemplatedSqlComponent
+from dagster_snowflake.components.sql_component.component import BaseSnowflakeSqlComponent
 from dagster_snowflake.constants import SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER
-from dagster_snowflake.resources import SnowflakeResource
 
 from dagster_snowflake_tests.utils import create_mock_connector
 
@@ -18,50 +24,42 @@ from dagster_snowflake_tests.utils import create_mock_connector
 @contextmanager
 def setup_snowflake_component(
     component_body: dict,
-) -> Iterator[tuple[SnowflakeSqlComponent, Definitions]]:
+) -> Iterator[tuple[SnowflakeTemplatedSqlComponent, Definitions]]:
     """Sets up a components project with a snowflake component based on provided params."""
     with scaffold_defs_sandbox(
-        component_cls=SnowflakeSqlComponent,
+        component_cls=SnowflakeTemplatedSqlComponent,
     ) as defs_sandbox:
         with defs_sandbox.load(component_body=component_body) as (component, defs):
-            assert isinstance(component, SnowflakeSqlComponent)
+            assert isinstance(component, SnowflakeTemplatedSqlComponent)
             yield component, defs
 
 
 BASIC_SNOWFLAKE_COMPONENT_BODY = {
-    "type": "dagster_snowflake.SnowflakeSqlComponent",
+    "type": "dagster_snowflake.SnowflakeTemplatedSqlComponent",
     "attributes": {
         "sql_template": "SELECT * FROM MY_TABLE;",
         "assets": [{"key": "TESTDB/TESTSCHEMA/TEST_TABLE"}],
+        "connection": {
+            "account": "test_account",
+            "user": "test_user",
+            "password": "test_password",
+            "database": "TESTDB",
+            "schema": "TESTSCHEMA",
+        },
     },
 }
 
 
 @mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)
 def test_snowflake_sql_component(snowflake_connect):
-    """Test that the SnowflakeSqlComponent correctly builds and executes SQL."""
+    """Test that the SnowflakeTemplatedSqlComponent correctly builds and executes SQL."""
     with setup_snowflake_component(
         component_body=BASIC_SNOWFLAKE_COMPONENT_BODY,
     ) as (component, defs):
-        defs_with_resource = Definitions.merge_unbound_defs(
-            defs,
-            Definitions(
-                resources={
-                    "snowflake": SnowflakeResource(
-                        account="test_account",
-                        user="test_user",
-                        password="test_password",
-                        database="TESTDB",
-                        schema="TESTSCHEMA",
-                    )
-                },
-            ),
-        )
         asset_key = AssetKey(["TESTDB", "TESTSCHEMA", "TEST_TABLE"])
-        asset_def = defs_with_resource.get_assets_def(asset_key)
+        asset_def = defs.get_assets_def(asset_key)
         result = materialize(
             [asset_def],
-            resources=defs_with_resource.resources,
         )
         assert result.success
         snowflake_connect.assert_called_once_with(
@@ -74,7 +72,7 @@ def test_snowflake_sql_component(snowflake_connect):
         )
         mock_cursor = snowflake_connect.return_value.cursor.return_value
         mock_cursor.execute.assert_called_once_with("SELECT * FROM MY_TABLE;")
-        assert defs_with_resource.resolve_asset_graph().get_all_asset_keys() == {
+        assert defs.resolve_asset_graph().get_all_asset_keys() == {
             AssetKey(["TESTDB", "TESTSCHEMA", "TEST_TABLE"])
         }
 
@@ -88,7 +86,7 @@ def test_snowflake_sql_component(snowflake_connect):
 )
 @mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)
 def test_snowflake_sql_component_with_templates(snowflake_connect, sql_template):
-    """Test that the SnowflakeSqlComponent correctly handles SQL templates from strings and files."""
+    """Test that the SnowflakeTemplatedSqlComponent correctly handles SQL templates from strings and files."""
     # If sql_template is None, create a temporary file with the template
     if sql_template is None:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".sql", delete=False) as f:
@@ -100,7 +98,7 @@ def test_snowflake_sql_component_with_templates(snowflake_connect, sql_template)
 
     try:
         component_body = {
-            "type": "dagster_snowflake.SnowflakeSqlComponent",
+            "type": "dagster_snowflake.SnowflakeTemplatedSqlComponent",
             "attributes": {
                 "sql_template": sql_template,
                 "assets": [{"key": "TESTDB/TESTSCHEMA/TEST_TABLE"}],
@@ -108,32 +106,94 @@ def test_snowflake_sql_component_with_templates(snowflake_connect, sql_template)
                     "date": "2024-03-20",
                     "limit": 100,
                 },
+                "connection": {
+                    "account": "test_account",
+                    "user": "test_user",
+                    "password": "test_password",
+                    "database": "TESTDB",
+                    "schema": "TESTSCHEMA",
+                },
             },
         }
         with setup_snowflake_component(
             component_body=component_body,
         ) as (component, defs):
-            defs_with_resource = Definitions.merge_unbound_defs(
-                defs,
-                Definitions(
-                    resources={
-                        "snowflake": SnowflakeResource(
-                            account="test_account",
-                            user="test_user",
-                            password="test_password",
-                            database="TESTDB",
-                            schema="TESTSCHEMA",
-                        )
-                    },
-                ),
+            mock_cursor = snowflake_connect.return_value.cursor.return_value
+            mock_cursor.execute.assert_called_once_with(
+                "SELECT * FROM TESTDB.TESTSCHEMA.TEST_TABLE WHERE date = '2024-03-20' LIMIT 100"
             )
-            asset_key = AssetKey(["TESTDB", "TESTSCHEMA", "TEST_TABLE"])
-            asset_def = defs_with_resource.get_assets_def(asset_key)
+            assert defs.resolve_asset_graph().get_all_asset_keys() == {
+                AssetKey(["TESTDB", "TESTSCHEMA", "TEST_TABLE"])
+            }
+    finally:
+        # Clean up the temporary file if it was created
+        if isinstance(sql_template, dict) and "path" in sql_template:
+            os.unlink(sql_template["path"])
+
+
+@mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)
+def test_snowflake_sql_component_with_execution(snowflake_connect):
+    """Test that the SnowflakeTemplatedSqlComponent correctly handles execution parameter with op description."""
+    component_body = {
+        "type": "dagster_snowflake.SnowflakeTemplatedSqlComponent",
+        "attributes": {
+            "sql_template": "SELECT * FROM MY_TABLE;",
+            "assets": [{"key": "TESTDB/TESTSCHEMA/TEST_TABLE"}],
+            "execution": {"description": "This is a test op description"},
+            "connection": {
+                "account": "test_account",
+                "user": "test_user",
+                "password": "test_password",
+                "database": "TESTDB",
+                "schema": "TESTSCHEMA",
+            },
+        },
+    }
+    with setup_snowflake_component(
+        component_body=component_body,
+    ) as (component, defs):
+        asset_key = AssetKey(["TESTDB", "TESTSCHEMA", "TEST_TABLE"])
+        asset_def = defs.get_assets_def(asset_key)
+
+        # Verify the op description is set correctly
+        assert asset_def.op.description == "This is a test op description"
+
+
+class RefreshExternalTableComponent(BaseSnowflakeSqlComponent):
+    """A custom component which refreshes an external table in Snowflake."""
+
+    table_name: str
+
+    def get_sql_content(self, context: AssetExecutionContext) -> str:
+        return f"ALTER TABLE {self.table_name} REFRESH;"
+
+
+@mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)
+def test_custom_snowflake_sql_component(snowflake_connect):
+    """Test that a custom SnowflakeSqlComponent subclass correctly builds and executes SQL."""
+    component_body = {
+        "type": "dagster_snowflake_tests.test_sql_component.RefreshExternalTableComponent",
+        "attributes": {
+            "table_name": "TESTDB.TESTSCHEMA.EXTERNAL_TABLE",
+            "assets": [{"key": "TESTDB/TESTSCHEMA/EXTERNAL_TABLE"}],
+            "connection": {
+                "account": "test_account",
+                "user": "test_user",
+                "password": "test_password",
+                "database": "TESTDB",
+                "schema": "TESTSCHEMA",
+            },
+        },
+    }
+    with scaffold_defs_sandbox(
+        component_cls=RefreshExternalTableComponent,
+    ) as defs_sandbox:
+        with defs_sandbox.load(component_body=component_body) as (component, defs):
+            asset_key = AssetKey(["TESTDB", "TESTSCHEMA", "EXTERNAL_TABLE"])
+            asset_def = defs.get_assets_def(asset_key)
             result = materialize(
                 [asset_def],
-                resources=defs_with_resource.resources,
             )
-
             assert result.success
             snowflake_connect.assert_called_once_with(
                 account="test_account",
@@ -145,47 +205,69 @@ def test_snowflake_sql_component_with_templates(snowflake_connect, sql_template)
             )
             mock_cursor = snowflake_connect.return_value.cursor.return_value
             mock_cursor.execute.assert_called_once_with(
-                "SELECT * FROM TESTDB.TESTSCHEMA.TEST_TABLE WHERE date = '2024-03-20' LIMIT 100"
+                "ALTER TABLE TESTDB.TESTSCHEMA.EXTERNAL_TABLE REFRESH;"
             )
-            assert defs_with_resource.resolve_asset_graph().get_all_asset_keys() == {
-                AssetKey(["TESTDB", "TESTSCHEMA", "TEST_TABLE"])
+            assert defs.resolve_asset_graph().get_all_asset_keys() == {
+                AssetKey(["TESTDB", "TESTSCHEMA", "EXTERNAL_TABLE"])
             }
-    finally:
-        # Clean up the temporary file if it was created
-        if isinstance(sql_template, dict) and "path" in sql_template:
-            os.unlink(sql_template["path"])
 
 
 @mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)
-def test_snowflake_sql_component_with_execution(snowflake_connect):
-    """Test that the SnowflakeSqlComponent correctly handles execution parameter with op description."""
-    component_body = {
-        "type": "dagster_snowflake.SnowflakeSqlComponent",
-        "attributes": {
-            "sql_template": "SELECT * FROM MY_TABLE;",
-            "assets": [{"key": "TESTDB/TESTSCHEMA/TEST_TABLE"}],
-            "execution": {"description": "This is a test op description"},
-        },
-    }
-    with setup_snowflake_component(
-        component_body=component_body,
-    ) as (component, defs):
-        defs_with_resource = Definitions.merge_unbound_defs(
-            defs,
-            Definitions(
-                resources={
-                    "snowflake": SnowflakeResource(
-                        account="test_account",
-                        user="test_user",
-                        password="test_password",
-                        database="TESTDB",
-                        schema="TESTSCHEMA",
-                    )
-                },
-            ),
-        )
-        asset_key = AssetKey(["TESTDB", "TESTSCHEMA", "TEST_TABLE"])
-        asset_def = defs_with_resource.get_assets_def(asset_key)
+def test_snowflake_sql_component_with_external_connection(snowflake_connect):
+    """Test referring to a connection defined in a separate component."""
+    with tempfile.TemporaryDirectory() as project_root_str:
+        project_root = Path(project_root_str)
+        defs_folder_path = project_root / "src" / "my_project" / "defs"
+        defs_folder_path.mkdir(parents=True, exist_ok=True)
 
-        # Verify the op description is set correctly
-        assert asset_def.op.description == "This is a test op description"
+        execution_body = {
+            "type": "dagster_snowflake.SnowflakeTemplatedSqlComponent",
+            "attributes": {
+                "sql_template": "SELECT * FROM MY_TABLE;",
+                "assets": [{"key": "TESTDB/TESTSCHEMA/TEST_TABLE"}],
+                "connection": "{{ load_component_at_path('sql_connection_component') }}",
+            },
+        }
+        sql_execution_component_path = defs_folder_path / "sql_execution_component"
+        sql_execution_component_path.mkdir(parents=True, exist_ok=True)
+        (sql_execution_component_path / "defs.yaml").write_text(yaml.dump(execution_body))
+
+        connection_body = {
+            "type": "dagster_snowflake.SnowflakeConnectionComponent",
+            "attributes": {
+                "account": "test_account",
+                "user": "test_user",
+                "password": "test_password",
+                "database": "TESTDB",
+                "schema": "TESTSCHEMA",
+            },
+        }
+        sql_connection_component_path = defs_folder_path / "sql_connection_component"
+        sql_connection_component_path.mkdir(parents=True, exist_ok=True)
+        (sql_connection_component_path / "defs.yaml").write_text(yaml.dump(connection_body))
+
+        with alter_sys_path(to_add=[str(project_root / "src")], to_remove=[]):
+            defs = ComponentTree(
+                defs_module=importlib.import_module("my_project.defs"),
+                project_root=Path(project_root),
+            ).build_defs()
+
+            asset_key = AssetKey(["TESTDB", "TESTSCHEMA", "TEST_TABLE"])
+            asset_def = defs.get_assets_def(asset_key)
+            result = materialize(
+                [asset_def],
+            )
+            assert result.success
+            snowflake_connect.assert_called_once_with(
+                account="test_account",
+                user="test_user",
+                password="test_password",
+                database="TESTDB",
+                schema="TESTSCHEMA",
+                application=SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER,
+            )
+            mock_cursor = snowflake_connect.return_value.cursor.return_value
+            mock_cursor.execute.assert_called_once_with("SELECT * FROM MY_TABLE;")
+            assert defs.resolve_asset_graph().get_all_asset_keys() == {
+                AssetKey(["TESTDB", "TESTSCHEMA", "TEST_TABLE"])
+            }

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
@@ -73,22 +73,6 @@ def setup_snowflake_component(
             yield component, defs
 
 
-BASIC_SNOWFLAKE_COMPONENT_BODY = {
-    "type": "dagster.TemplatedSqlComponent",
-    "attributes": {
-        "sql_template": "SELECT * FROM MY_TABLE;",
-        "assets": [{"key": "TESTDB/TESTSCHEMA/TEST_TABLE"}],
-        "connection": {
-            "account": "test_account",
-            "user": "test_user",
-            "password": "test_password",
-            "database": "TESTDB",
-            "schema": "TESTSCHEMA",
-        },
-    },
-}
-
-
 @mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)
 def test_snowflake_sql_component2(snowflake_connect):
     """Test that the TemplatedSqlComponent correctly builds and executes SQL."""


### PR DESCRIPTION
## Summary

Refactors the SQL component to be a single, `dagster`-module exported `SqlComponent` and `TemplatedSqlComponent` which can be used to execute SQL on the given connection.

This connection is specified via UDFs:


```yaml
type: dagster.TemplatedSqlComponent

attributes:
  connection: "{{ load_component_at_path('connection') }}"

  sql_template: SELECT 1;
  assets:
    - key: my_snowflake_asset
```

```yaml
type: dagster_snowflake.SnowflakeConnectionComponent

attributes:
  account: "{{ env.SNOWFLAKE_ACCOUNT }}"
  user: "{{ env.SNOWFLAKE_USER }}"
  password: "{{ env.SNOWFLAKE_PASSWORD }}"

```


