### PR TITLE
[ui] Fix top assets x axis font

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Button,
   Colors,
+  FontFamily,
   Icon,
   MiddleTruncate,
   Mono,
@@ -119,6 +120,10 @@ export const AssetCatalogTopAssetsChart = React.memo(
           x: {
             beginAtZero: true,
             max: maxValue,
+            ticks: {
+              color: rgbColors[Colors.textLight()],
+              font: {size: 12, family: FontFamily.monospace},
+            },
             grid: {color: rgbColors[Colors.keylineDefault()], borderDash: [4, 4]},
           },
           y: {grid: {display: false}, ticks: {display: false}, beginAtZero: true},


### PR DESCRIPTION
## Summary & Motivation

I noticed that the x-axis font on the top assets charts is the default Chart.js gray. Change it to use our palette, and monospace.

## How I Tested These Changes

View top assets charts, verify x-axis font style.