### PR TITLE
[components] add error to sling, airlift components using old post processing field

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
@@ -1,3 +1,4 @@
+import textwrap
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from typing import Annotated, Any, Literal, Optional, Union
@@ -206,15 +207,29 @@ class AirflowInstanceComponent(Component, Resolvable):
         )
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        defs = build_job_based_airflow_defs(
+        if self.asset_post_processors:
+            raise Exception(
+                "The asset_post_processors field is deprecated, use the top-level post_processing field instead:\n"
+                + textwrap.dedent(
+                    """
+                    type: dagster_airlift.core.components.AirflowInstanceComponent
+
+                    attributes: ~
+
+                    post_processing:
+                      assets:
+                        - target: "*"
+                          attributes:
+                            group_name: "my_group"
+                    """
+                )
+            )
+        return build_job_based_airflow_defs(
             airflow_instance=self._get_instance(),
             mapped_defs=apply_mappings(defs_from_subdirs(context), self.mappings or []),
             source_code_retrieval_enabled=self.source_code_retrieval_enabled,
             retrieval_filter=self.filter or AirflowFilter(),
         )
-        for post_processor in self.asset_post_processors or []:
-            defs = post_processor(defs)
-        return defs
 
 
 def defs_from_subdirs(context: ComponentLoadContext) -> Definitions:

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -1,3 +1,4 @@
+import textwrap
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
@@ -160,9 +161,24 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
         yield from iterator
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        defs = Definitions(
+        if self.asset_post_processors:
+            raise Exception(
+                "The asset_post_processors field is deprecated, use the top-level post_processing field instead:\n"
+                + textwrap.dedent(
+                    """
+                    type: dagster_sling.SlingReplicationCollectionComponent
+
+                    attributes: ~
+
+                    post_processing:
+                      assets:
+                        - target: "*"
+                          attributes:
+                            group_name: "my_group"
+                    """
+                )
+            )
+
+        return Definitions(
             assets=[self.build_asset(context, replication) for replication in self.replications],
         )
-        for post_processor in self.asset_post_processors or []:
-            defs = post_processor(defs)
-        return defs


### PR DESCRIPTION
## Summary

Loudly errors if a user sets `asset_post_processors` on a Sling or Airlift component. The error points the user to the new pattern.

## Test Plan

New unit test.

## Changelog

[components] The `asset_post_processors` field on `SlingReplicationCollectionComponent` and `AirflowInstanceComponent` is no longer supported, and has been replaced with the top-level `post_processors` field:

```yaml
type: dagster_sling.SlingReplicationCollectionComponent

attributes: ~

post_processing:
  assets:
    - target: "*"
      attributes:
        group_name: "my_group"
```