### PR TITLE
[dagster-tableau] Implement WorkbookSelectorFn

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -21,7 +21,7 @@ from dagster import (
     _check as check,
     get_dagster_logger,
 )
-from dagster._annotations import beta, superseded
+from dagster._annotations import beta, beta_param, superseded
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
 from dagster._record import record
 from dagster._utils.cached_method import cached_method
@@ -641,6 +641,7 @@ class BaseTableauWorkspace(ConfigurableResource):
 
 
 @beta
+@beta_param(param="workbook_selector_fn")
 def load_tableau_asset_specs(
     workspace: BaseTableauWorkspace,
     dagster_tableau_translator: Optional[DagsterTableauTranslator] = None,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -39,6 +39,7 @@ from dagster_tableau.translator import (
     TableauTranslatorData,
     TableauViewMetadataSet,
     TableauWorkspaceData,
+    WorkbookSelectorFn,
 )
 
 DEFAULT_POLL_INTERVAL_SECONDS = 10
@@ -643,6 +644,7 @@ class BaseTableauWorkspace(ConfigurableResource):
 def load_tableau_asset_specs(
     workspace: BaseTableauWorkspace,
     dagster_tableau_translator: Optional[DagsterTableauTranslator] = None,
+    workbook_selector_fn: Optional[WorkbookSelectorFn] = None,
 ) -> Sequence[AssetSpec]:
     """Returns a list of AssetSpecs representing the Tableau content in the workspace.
 
@@ -651,6 +653,9 @@ def load_tableau_asset_specs(
         dagster_tableau_translator (Optional[DagsterTableauTranslator]):
             The translator to use to convert Tableau content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterTableauTranslator`.
+        workbook_selector_fn (Optional[WorkbookSelectorFn]):
+            A function that allows for filtering which Tableau workbook assets are created for,
+            including data sources, sheets and dashboards.
 
     Returns:
         List[AssetSpec]: The set of assets representing the Tableau content in the workspace.
@@ -660,6 +665,7 @@ def load_tableau_asset_specs(
             TableauWorkspaceDefsLoader(
                 workspace=initialized_workspace,
                 translator=dagster_tableau_translator or DagsterTableauTranslator(),
+                workbook_selector_fn=workbook_selector_fn,
             )
             .build_defs()
             .assets,
@@ -709,6 +715,7 @@ class TableauServerWorkspace(BaseTableauWorkspace):
 class TableauWorkspaceDefsLoader(StateBackedDefinitionsLoader[Mapping[str, Any]]):
     workspace: BaseTableauWorkspace
     translator: DagsterTableauTranslator
+    workbook_selector_fn: Optional[WorkbookSelectorFn] = None
 
     @property
     def defs_key(self) -> str:
@@ -718,15 +725,19 @@ class TableauWorkspaceDefsLoader(StateBackedDefinitionsLoader[Mapping[str, Any]]
         return self.workspace.fetch_tableau_workspace_data()
 
     def defs_from_state(self, state: TableauWorkspaceData) -> Definitions:  # pyright: ignore[reportIncompatibleMethodOverride]
+        selected_state = state.to_workspace_data_selection(
+            workbook_selector_fn=self.workbook_selector_fn
+        )
+
         all_external_data = [
-            *state.data_sources_by_id.values(),
-            *state.sheets_by_id.values(),
-            *state.dashboards_by_id.values(),
+            *selected_state.data_sources_by_id.values(),
+            *selected_state.sheets_by_id.values(),
+            *selected_state.dashboards_by_id.values(),
         ]
 
         all_external_asset_specs = [
             self.translator.get_asset_spec(
-                TableauTranslatorData(content_data=content, workspace_data=state)
+                TableauTranslatorData(content_data=content, workspace_data=selected_state)
             )
             for content in all_external_data
         ]

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -138,7 +138,7 @@ class TableauWorkspaceData:
             },
         )
 
-    # Cache workspace data selection for a specific connector_selector_fn
+    # Cache workspace data selection for a specific workbook_selector_fn
     @cached_method
     def to_workspace_data_selection(
         self, workbook_selector_fn: Optional[WorkbookSelectorFn]

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -12,6 +12,8 @@ from dagster_tableau import TableauCloudWorkspace, TableauServerWorkspace, load_
 from dagster_tableau.asset_utils import parse_tableau_external_and_materializable_asset_specs
 from dagster_tableau.translator import DagsterTableauTranslator, TableauTranslatorData
 
+from dagster_tableau_tests.conftest import TEST_PROJECT_ID, TEST_PROJECT_NAME, TEST_WORKBOOK_ID
+
 
 @responses.activate
 @pytest.mark.parametrize(
@@ -287,3 +289,77 @@ def test_parse_asset_specs(
         )
         assert len(external_asset_specs) == 1
         assert len(materializable_asset_specs) == 4
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    "attribute, value, expected_result",
+    [
+        (None, None, 1),
+        ("id", TEST_WORKBOOK_ID, 1),
+        ("project_name", TEST_PROJECT_NAME, 1),
+        ("project_id", TEST_PROJECT_ID, 1),
+        ("id", "non_matching_workbook_id", 0),
+        ("project_name", "non_matching_project_name", 0),
+        ("project_id", "non_matching_project_id", 0),
+    ],
+    ids=[
+        "no_selector_present_workbook",
+        "workbook_id_selector_present_workbook",
+        "project_name_selector_present_workbook",
+        "project_id_selector_present_workbook",
+        "workbook_id_selector_absent_workbook",
+        "project_name_selector_absent_workbook",
+        "project_id_selector_absent_workbook",
+    ],
+)
+@pytest.mark.parametrize(
+    "clazz,host_key,host_value",
+    [
+        (TableauServerWorkspace, "server_name", "fake_server_name"),
+        (TableauCloudWorkspace, "pod_name", "fake_pod_name"),
+    ],
+)
+@pytest.mark.usefixtures("site_name")
+@pytest.mark.usefixtures("sign_in")
+@pytest.mark.usefixtures("get_workbooks")
+@pytest.mark.usefixtures("get_workbook")
+def test_fivetran_connector_selector(
+    attribute: str,
+    value: str,
+    expected_result: int,
+    clazz: Union[type[TableauCloudWorkspace], type[TableauServerWorkspace]],
+    host_key: str,
+    host_value: str,
+    site_name: str,
+    sign_in: MagicMock,
+    get_workbooks: MagicMock,
+    get_workbook: MagicMock,
+) -> None:
+    connected_app_client_id = uuid.uuid4().hex
+    connected_app_secret_id = uuid.uuid4().hex
+    connected_app_secret_value = uuid.uuid4().hex
+    username = "fake_username"
+
+    resource_args = {
+        "connected_app_client_id": connected_app_client_id,
+        "connected_app_secret_id": connected_app_secret_id,
+        "connected_app_secret_value": connected_app_secret_value,
+        "username": username,
+        "site_name": site_name,
+        host_key: host_value,
+    }
+
+    resource = clazz(**resource_args)  # type: ignore
+    resource.build_client()
+
+    workbook_selector_fn = (
+        (lambda workbook: getattr(workbook, attribute) == value) if attribute else None
+    )
+
+    actual_workspace_data = resource.fetch_tableau_workspace_data()
+    selected_workspace_data = actual_workspace_data.to_workspace_data_selection(
+        workbook_selector_fn=workbook_selector_fn
+    )
+
+    assert len(selected_workspace_data.workbooks_by_id) == expected_result

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -324,7 +324,7 @@ def test_parse_asset_specs(
 @pytest.mark.usefixtures("sign_in")
 @pytest.mark.usefixtures("get_workbooks")
 @pytest.mark.usefixtures("get_workbook")
-def test_fivetran_connector_selector(
+def test_tableau_workbook_selector(
     attribute: str,
     value: str,
     expected_result: int,


### PR DESCRIPTION
## Summary & Motivation

Allow users to select specific Tableau workbooks when creating their assets definition and asset spec. Workbooks can be selected by ID, project name and project ID. All assets related to the workbook are selected if the workbook is selected - data sources, sheets and dashboards.

```python
from dagster_tableau import TableauCloudWorkspace, tableau_assets

import dagster as dg

tableau_workspace = TableauCloudWorkspace(
    connected_app_client_id=dg.EnvVar("TABLEAU_CONNECTED_APP_CLIENT_ID"),
    connected_app_secret_id=dg.EnvVar("TABLEAU_CONNECTED_APP_SECRET_ID"),
    connected_app_secret_value=dg.EnvVar("TABLEAU_CONNECTED_APP_SECRET_VALUE"),
    username=dg.EnvVar("TABLEAU_USERNAME"),
    site_name=dg.EnvVar("TABLEAU_SITE_NAME"),
    pod_name=dg.EnvVar("TABLEAU_POD_NAME"),
)

@tableau_assets(
    workspace=tableau_workspace,
    name="tableau_project_assets",
    workbook_selector_fn=(lambda workbook.project_id in {"my_project_id"})
)
def tableau_project_assets(context: dg.AssetExecutionContext, tableau: TableauCloudWorkspace):
    yield from tableau.refresh_and_poll(context=context)

defs = dg.Definitions(
    assets=[tableau_project_assets],
    resources={"tableau": tableau_workspace},
)
```

## How I Tested These Changes

Additional tests with BK

## Changelog

[dagster-tableau] Tableau workbooks fetched in Dagster can now be filtered and selected using the WorkbookSelectorFn.
