### PR TITLE
[dagster-tableau] Make spec loader a cached method of BaseTableauWorkspace

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -5,6 +5,7 @@ import uuid
 from abc import abstractmethod
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
+from functools import lru_cache
 from typing import Any, Optional, Union
 
 import jwt
@@ -581,6 +582,38 @@ class BaseTableauWorkspace(ConfigurableResource):
             workbooks + sheets + dashboards + data_sources,
         )
 
+    # Cache spec retrieval for a specific translator class and workbook_selector_fn
+    @lru_cache(maxsize=1)
+    def load_asset_specs(
+        self,
+        dagster_tableau_translator: Optional[DagsterTableauTranslator] = None,
+        workbook_selector_fn: Optional[WorkbookSelectorFn] = None,
+    ) -> Sequence[AssetSpec]:
+        """Returns a list of AssetSpecs representing the Tableau content in the workspace.
+
+        Args:
+            dagster_tableau_translator (Optional[DagsterTableauTranslator]):
+                The translator to use to convert Tableau content into :py:class:`dagster.AssetSpec`.
+                Defaults to :py:class:`DagsterTableauTranslator`.
+            workbook_selector_fn (Optional[WorkbookSelectorFn]):
+                A function that allows for filtering which Tableau workbook assets are created for,
+                including data sources, sheets and dashboards.
+
+        Returns:
+            List[AssetSpec]: The set of assets representing the Tableau content in the workspace.
+        """
+        with self.process_config_and_initialize_cm() as initialized_workspace:
+            return check.is_list(
+                TableauWorkspaceDefsLoader(
+                    workspace=initialized_workspace,
+                    translator=dagster_tableau_translator or DagsterTableauTranslator(),
+                    workbook_selector_fn=workbook_selector_fn,
+                )
+                .build_defs()
+                .assets,
+                AssetSpec,
+            )
+
     def refresh_and_poll(
         self, context: AssetExecutionContext
     ) -> Iterator[Union[Output, ObserveResult]]:
@@ -661,17 +694,10 @@ def load_tableau_asset_specs(
     Returns:
         List[AssetSpec]: The set of assets representing the Tableau content in the workspace.
     """
-    with workspace.process_config_and_initialize_cm() as initialized_workspace:
-        return check.is_list(
-            TableauWorkspaceDefsLoader(
-                workspace=initialized_workspace,
-                translator=dagster_tableau_translator or DagsterTableauTranslator(),
-                workbook_selector_fn=workbook_selector_fn,
-            )
-            .build_defs()
-            .assets,
-            AssetSpec,
-        )
+    return workspace.load_asset_specs(
+        dagster_tableau_translator=dagster_tableau_translator,
+        workbook_selector_fn=workbook_selector_fn,
+    )
 
 
 @beta

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -5,7 +5,6 @@ import uuid
 from abc import abstractmethod
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from functools import lru_cache
 from typing import Any, Optional, Union
 
 import jwt
@@ -583,7 +582,7 @@ class BaseTableauWorkspace(ConfigurableResource):
         )
 
     # Cache spec retrieval for a specific translator class and workbook_selector_fn
-    @lru_cache(maxsize=1)
+    @cached_method
     def load_asset_specs(
         self,
         dagster_tableau_translator: Optional[DagsterTableauTranslator] = None,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
@@ -67,7 +67,7 @@ def cacheable_asset_defs():
         )
     finally:
         # Clearing cache for other tests
-        resource.load_asset_specs.cache_clear()  # pyright: ignore[reportPossiblyUnboundVariable]
+        resource.load_asset_specs.cache_clear()
 
 
 @definitions
@@ -97,7 +97,7 @@ def cacheable_asset_defs_refreshable_workbooks():
         )
     finally:
         # Clearing cache for other tests
-        resource.load_asset_specs.cache_clear()  # pyright: ignore[reportPossiblyUnboundVariable]
+        resource.load_asset_specs.cache_clear()
 
 
 @definitions
@@ -129,7 +129,7 @@ def cacheable_asset_defs_refreshable_data_sources():
         )
     finally:
         # Clearing cache for other tests
-        resource.load_asset_specs.cache_clear()  # pyright: ignore[reportPossiblyUnboundVariable]
+        resource.load_asset_specs.cache_clear()
 
 
 @definitions
@@ -147,7 +147,7 @@ def cacheable_asset_defs_asset_decorator_with_context():
         )
     finally:
         # Clearing cache for other tests
-        resource.load_asset_specs.cache_clear()  # pyright: ignore[reportPossiblyUnboundVariable]
+        resource.load_asset_specs.cache_clear()
 
 
 @definitions
@@ -168,7 +168,7 @@ def cacheable_asset_defs_custom_translator():
         return Definitions(assets=[*tableau_specs], jobs=[define_asset_job("all_asset_job")])
     finally:
         # Clearing cache for other tests
-        resource.load_asset_specs.cache_clear()  # pyright: ignore[reportPossiblyUnboundVariable]
+        resource.load_asset_specs.cache_clear()
 
 
 def test_load_assets_workspace_data_refreshable_workbooks(

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
@@ -30,145 +30,156 @@ from dagster_tableau_tests.conftest import (
     FAKE_USERNAME,
 )
 
-resource = TableauCloudWorkspace(
-    connected_app_client_id=FAKE_CONNECTED_APP_CLIENT_ID,
-    connected_app_secret_id=FAKE_CONNECTED_APP_SECRET_ID,
-    connected_app_secret_value=FAKE_CONNECTED_APP_SECRET_VALUE,
-    username=FAKE_USERNAME,
-    site_name=FAKE_SITE_NAME,
-    pod_name=FAKE_POD_NAME,
-)
-
 
 @definitions
 def cacheable_asset_defs():
-    try:
-        tableau_specs = load_tableau_asset_specs(
-            workspace=resource,
-        )
+    resource = TableauCloudWorkspace(
+        connected_app_client_id=FAKE_CONNECTED_APP_CLIENT_ID,
+        connected_app_secret_id=FAKE_CONNECTED_APP_SECRET_ID,
+        connected_app_secret_value=FAKE_CONNECTED_APP_SECRET_VALUE,
+        username=FAKE_USERNAME,
+        site_name=FAKE_SITE_NAME,
+        pod_name=FAKE_POD_NAME,
+    )
 
-        external_asset_specs, materializable_asset_specs = (
-            parse_tableau_external_and_materializable_asset_specs(tableau_specs)
-        )
+    tableau_specs = load_tableau_asset_specs(
+        workspace=resource,
+    )
 
-        resource_key = "tableau"
+    external_asset_specs, materializable_asset_specs = (
+        parse_tableau_external_and_materializable_asset_specs(tableau_specs)
+    )
 
-        return Definitions(
-            assets=[
-                # We don't pass a list of refreshable IDs - we yield observe results without refreshing Tableau assets.
-                build_tableau_materializable_assets_definition(
-                    resource_key=resource_key,
-                    specs=materializable_asset_specs,
-                ),
-                *external_asset_specs,
-            ],
-            jobs=[define_asset_job("all_asset_job")],
-            resources={resource_key: resource},
-        )
-    finally:
-        # Clearing cache for other tests
-        resource.load_asset_specs.cache_clear()
+    resource_key = "tableau"
+
+    return Definitions(
+        assets=[
+            # We don't pass a list of refreshable IDs - we yield observe results without refreshing Tableau assets.
+            build_tableau_materializable_assets_definition(
+                resource_key=resource_key,
+                specs=materializable_asset_specs,
+            ),
+            *external_asset_specs,
+        ],
+        jobs=[define_asset_job("all_asset_job")],
+        resources={resource_key: resource},
+    )
 
 
 @definitions
 def cacheable_asset_defs_refreshable_workbooks():
-    try:
-        tableau_specs = load_tableau_asset_specs(
-            workspace=resource,
-        )
+    resource = TableauCloudWorkspace(
+        connected_app_client_id=FAKE_CONNECTED_APP_CLIENT_ID,
+        connected_app_secret_id=FAKE_CONNECTED_APP_SECRET_ID,
+        connected_app_secret_value=FAKE_CONNECTED_APP_SECRET_VALUE,
+        username=FAKE_USERNAME,
+        site_name=FAKE_SITE_NAME,
+        pod_name=FAKE_POD_NAME,
+    )
+    tableau_specs = load_tableau_asset_specs(
+        workspace=resource,
+    )
 
-        external_asset_specs, materializable_asset_specs = (
-            parse_tableau_external_and_materializable_asset_specs(tableau_specs)
-        )
+    external_asset_specs, materializable_asset_specs = (
+        parse_tableau_external_and_materializable_asset_specs(tableau_specs)
+    )
 
-        resource_key = "tableau"
+    resource_key = "tableau"
 
-        return Definitions(
-            assets=[
-                build_tableau_materializable_assets_definition(
-                    resource_key=resource_key,
-                    specs=materializable_asset_specs,
-                    refreshable_workbook_ids=["b75fc023-a7ca-4115-857b-4342028640d0"],
-                ),
-                *external_asset_specs,
-            ],
-            jobs=[define_asset_job("all_asset_job")],
-            resources={resource_key: resource},
-        )
-    finally:
-        # Clearing cache for other tests
-        resource.load_asset_specs.cache_clear()
+    return Definitions(
+        assets=[
+            build_tableau_materializable_assets_definition(
+                resource_key=resource_key,
+                specs=materializable_asset_specs,
+                refreshable_workbook_ids=["b75fc023-a7ca-4115-857b-4342028640d0"],
+            ),
+            *external_asset_specs,
+        ],
+        jobs=[define_asset_job("all_asset_job")],
+        resources={resource_key: resource},
+    )
 
 
 @definitions
 def cacheable_asset_defs_refreshable_data_sources():
-    try:
-        tableau_specs = load_tableau_asset_specs(
-            workspace=resource,
-        )
+    resource = TableauCloudWorkspace(
+        connected_app_client_id=FAKE_CONNECTED_APP_CLIENT_ID,
+        connected_app_secret_id=FAKE_CONNECTED_APP_SECRET_ID,
+        connected_app_secret_value=FAKE_CONNECTED_APP_SECRET_VALUE,
+        username=FAKE_USERNAME,
+        site_name=FAKE_SITE_NAME,
+        pod_name=FAKE_POD_NAME,
+    )
 
-        external_asset_specs, materializable_asset_specs = (
-            parse_tableau_external_and_materializable_asset_specs(
-                tableau_specs, include_data_sources_with_extracts=True
-            )
-        )
+    tableau_specs = load_tableau_asset_specs(
+        workspace=resource,
+    )
 
-        resource_key = "tableau"
-
-        return Definitions(
-            assets=[
-                build_tableau_materializable_assets_definition(
-                    resource_key=resource_key,
-                    specs=materializable_asset_specs,
-                    refreshable_data_source_ids=["1f5660c7-3b05-5ff0-90ce-4199226956c6"],
-                ),
-                *external_asset_specs,
-            ],
-            jobs=[define_asset_job("all_asset_job")],
-            resources={resource_key: resource},
+    external_asset_specs, materializable_asset_specs = (
+        parse_tableau_external_and_materializable_asset_specs(
+            tableau_specs, include_data_sources_with_extracts=True
         )
-    finally:
-        # Clearing cache for other tests
-        resource.load_asset_specs.cache_clear()
+    )
+
+    resource_key = "tableau"
+
+    return Definitions(
+        assets=[
+            build_tableau_materializable_assets_definition(
+                resource_key=resource_key,
+                specs=materializable_asset_specs,
+                refreshable_data_source_ids=["1f5660c7-3b05-5ff0-90ce-4199226956c6"],
+            ),
+            *external_asset_specs,
+        ],
+        jobs=[define_asset_job("all_asset_job")],
+        resources={resource_key: resource},
+    )
 
 
 @definitions
 def cacheable_asset_defs_asset_decorator_with_context():
-    try:
+    resource = TableauCloudWorkspace(
+        connected_app_client_id=FAKE_CONNECTED_APP_CLIENT_ID,
+        connected_app_secret_id=FAKE_CONNECTED_APP_SECRET_ID,
+        connected_app_secret_value=FAKE_CONNECTED_APP_SECRET_VALUE,
+        username=FAKE_USERNAME,
+        site_name=FAKE_SITE_NAME,
+        pod_name=FAKE_POD_NAME,
+    )
 
-        @tableau_assets(workspace=resource)
-        def my_tableau_assets(context: AssetExecutionContext, tableau: TableauCloudWorkspace):
-            yield from tableau.refresh_and_poll(context=context)
+    @tableau_assets(workspace=resource)
+    def my_tableau_assets(context: AssetExecutionContext, tableau: TableauCloudWorkspace):
+        yield from tableau.refresh_and_poll(context=context)
 
-        return Definitions(
-            assets=[my_tableau_assets],
-            jobs=[define_asset_job("all_asset_job")],
-            resources={"tableau": resource},
-        )
-    finally:
-        # Clearing cache for other tests
-        resource.load_asset_specs.cache_clear()
+    return Definitions(
+        assets=[my_tableau_assets],
+        jobs=[define_asset_job("all_asset_job")],
+        resources={"tableau": resource},
+    )
 
 
 @definitions
 def cacheable_asset_defs_custom_translator():
-    try:
+    resource = TableauCloudWorkspace(
+        connected_app_client_id=FAKE_CONNECTED_APP_CLIENT_ID,
+        connected_app_secret_id=FAKE_CONNECTED_APP_SECRET_ID,
+        connected_app_secret_value=FAKE_CONNECTED_APP_SECRET_VALUE,
+        username=FAKE_USERNAME,
+        site_name=FAKE_SITE_NAME,
+        pod_name=FAKE_POD_NAME,
+    )
 
-        class MyCoolTranslator(DagsterTableauTranslator):
-            def get_asset_spec(self, data: TableauTranslatorData) -> AssetSpec:
-                default_spec = super().get_asset_spec(data)
-                return default_spec.replace_attributes(
-                    key=default_spec.key.with_prefix("my_prefix")
-                )
+    class MyCoolTranslator(DagsterTableauTranslator):
+        def get_asset_spec(self, data: TableauTranslatorData) -> AssetSpec:
+            default_spec = super().get_asset_spec(data)
+            return default_spec.replace_attributes(key=default_spec.key.with_prefix("my_prefix"))
 
-        tableau_specs = load_tableau_asset_specs(
-            workspace=resource, dagster_tableau_translator=MyCoolTranslator()
-        )
+    tableau_specs = load_tableau_asset_specs(
+        workspace=resource, dagster_tableau_translator=MyCoolTranslator()
+    )
 
-        return Definitions(assets=[*tableau_specs], jobs=[define_asset_job("all_asset_job")])
-    finally:
-        # Clearing cache for other tests
-        resource.load_asset_specs.cache_clear()
+    return Definitions(assets=[*tableau_specs], jobs=[define_asset_job("all_asset_job")])
 
 
 def test_load_assets_workspace_data_refreshable_workbooks(

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
@@ -42,109 +42,133 @@ resource = TableauCloudWorkspace(
 
 @definitions
 def cacheable_asset_defs():
-    tableau_specs = load_tableau_asset_specs(
-        workspace=resource,
-    )
+    try:
+        tableau_specs = load_tableau_asset_specs(
+            workspace=resource,
+        )
 
-    external_asset_specs, materializable_asset_specs = (
-        parse_tableau_external_and_materializable_asset_specs(tableau_specs)
-    )
+        external_asset_specs, materializable_asset_specs = (
+            parse_tableau_external_and_materializable_asset_specs(tableau_specs)
+        )
 
-    resource_key = "tableau"
+        resource_key = "tableau"
 
-    return Definitions(
-        assets=[
-            # We don't pass a list of refreshable IDs - we yield observe results without refreshing Tableau assets.
-            build_tableau_materializable_assets_definition(
-                resource_key=resource_key,
-                specs=materializable_asset_specs,
-            ),
-            *external_asset_specs,
-        ],
-        jobs=[define_asset_job("all_asset_job")],
-        resources={resource_key: resource},
-    )
+        return Definitions(
+            assets=[
+                # We don't pass a list of refreshable IDs - we yield observe results without refreshing Tableau assets.
+                build_tableau_materializable_assets_definition(
+                    resource_key=resource_key,
+                    specs=materializable_asset_specs,
+                ),
+                *external_asset_specs,
+            ],
+            jobs=[define_asset_job("all_asset_job")],
+            resources={resource_key: resource},
+        )
+    finally:
+        # Clearing cache for other tests
+        resource.load_asset_specs.cache_clear()  # pyright: ignore[reportPossiblyUnboundVariable]
 
 
 @definitions
 def cacheable_asset_defs_refreshable_workbooks():
-    tableau_specs = load_tableau_asset_specs(
-        workspace=resource,
-    )
+    try:
+        tableau_specs = load_tableau_asset_specs(
+            workspace=resource,
+        )
 
-    external_asset_specs, materializable_asset_specs = (
-        parse_tableau_external_and_materializable_asset_specs(tableau_specs)
-    )
+        external_asset_specs, materializable_asset_specs = (
+            parse_tableau_external_and_materializable_asset_specs(tableau_specs)
+        )
 
-    resource_key = "tableau"
+        resource_key = "tableau"
 
-    return Definitions(
-        assets=[
-            build_tableau_materializable_assets_definition(
-                resource_key=resource_key,
-                specs=materializable_asset_specs,
-                refreshable_workbook_ids=["b75fc023-a7ca-4115-857b-4342028640d0"],
-            ),
-            *external_asset_specs,
-        ],
-        jobs=[define_asset_job("all_asset_job")],
-        resources={resource_key: resource},
-    )
+        return Definitions(
+            assets=[
+                build_tableau_materializable_assets_definition(
+                    resource_key=resource_key,
+                    specs=materializable_asset_specs,
+                    refreshable_workbook_ids=["b75fc023-a7ca-4115-857b-4342028640d0"],
+                ),
+                *external_asset_specs,
+            ],
+            jobs=[define_asset_job("all_asset_job")],
+            resources={resource_key: resource},
+        )
+    finally:
+        # Clearing cache for other tests
+        resource.load_asset_specs.cache_clear()  # pyright: ignore[reportPossiblyUnboundVariable]
 
 
 @definitions
 def cacheable_asset_defs_refreshable_data_sources():
-    tableau_specs = load_tableau_asset_specs(
-        workspace=resource,
-    )
-
-    external_asset_specs, materializable_asset_specs = (
-        parse_tableau_external_and_materializable_asset_specs(
-            tableau_specs, include_data_sources_with_extracts=True
+    try:
+        tableau_specs = load_tableau_asset_specs(
+            workspace=resource,
         )
-    )
 
-    resource_key = "tableau"
+        external_asset_specs, materializable_asset_specs = (
+            parse_tableau_external_and_materializable_asset_specs(
+                tableau_specs, include_data_sources_with_extracts=True
+            )
+        )
 
-    return Definitions(
-        assets=[
-            build_tableau_materializable_assets_definition(
-                resource_key=resource_key,
-                specs=materializable_asset_specs,
-                refreshable_data_source_ids=["1f5660c7-3b05-5ff0-90ce-4199226956c6"],
-            ),
-            *external_asset_specs,
-        ],
-        jobs=[define_asset_job("all_asset_job")],
-        resources={resource_key: resource},
-    )
+        resource_key = "tableau"
+
+        return Definitions(
+            assets=[
+                build_tableau_materializable_assets_definition(
+                    resource_key=resource_key,
+                    specs=materializable_asset_specs,
+                    refreshable_data_source_ids=["1f5660c7-3b05-5ff0-90ce-4199226956c6"],
+                ),
+                *external_asset_specs,
+            ],
+            jobs=[define_asset_job("all_asset_job")],
+            resources={resource_key: resource},
+        )
+    finally:
+        # Clearing cache for other tests
+        resource.load_asset_specs.cache_clear()  # pyright: ignore[reportPossiblyUnboundVariable]
 
 
 @definitions
 def cacheable_asset_defs_asset_decorator_with_context():
-    @tableau_assets(workspace=resource)
-    def my_tableau_assets(context: AssetExecutionContext, tableau: TableauCloudWorkspace):
-        yield from tableau.refresh_and_poll(context=context)
+    try:
 
-    return Definitions(
-        assets=[my_tableau_assets],
-        jobs=[define_asset_job("all_asset_job")],
-        resources={"tableau": resource},
-    )
+        @tableau_assets(workspace=resource)
+        def my_tableau_assets(context: AssetExecutionContext, tableau: TableauCloudWorkspace):
+            yield from tableau.refresh_and_poll(context=context)
+
+        return Definitions(
+            assets=[my_tableau_assets],
+            jobs=[define_asset_job("all_asset_job")],
+            resources={"tableau": resource},
+        )
+    finally:
+        # Clearing cache for other tests
+        resource.load_asset_specs.cache_clear()  # pyright: ignore[reportPossiblyUnboundVariable]
 
 
 @definitions
 def cacheable_asset_defs_custom_translator():
-    class MyCoolTranslator(DagsterTableauTranslator):
-        def get_asset_spec(self, data: TableauTranslatorData) -> AssetSpec:
-            default_spec = super().get_asset_spec(data)
-            return default_spec.replace_attributes(key=default_spec.key.with_prefix("my_prefix"))
+    try:
 
-    tableau_specs = load_tableau_asset_specs(
-        workspace=resource, dagster_tableau_translator=MyCoolTranslator()
-    )
+        class MyCoolTranslator(DagsterTableauTranslator):
+            def get_asset_spec(self, data: TableauTranslatorData) -> AssetSpec:
+                default_spec = super().get_asset_spec(data)
+                return default_spec.replace_attributes(
+                    key=default_spec.key.with_prefix("my_prefix")
+                )
 
-    return Definitions(assets=[*tableau_specs], jobs=[define_asset_job("all_asset_job")])
+        tableau_specs = load_tableau_asset_specs(
+            workspace=resource, dagster_tableau_translator=MyCoolTranslator()
+        )
+
+        return Definitions(assets=[*tableau_specs], jobs=[define_asset_job("all_asset_job")])
+    finally:
+        # Clearing cache for other tests
+        resource.load_asset_specs.cache_clear()  # pyright: ignore[reportPossiblyUnboundVariable]
 
 
 def test_load_assets_workspace_data_refreshable_workbooks(


### PR DESCRIPTION
## Summary & Motivation

Move state-backed defs logic to load the asset specs in the resource and cache the method.

## How I Tested These Changes

Updated tests with bk

## Changelog

> Insert changelog entry or delete this section.
