### PR TITLE
[ui] Fix rendering of team tags in asset node tooltips

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/BaseTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/BaseTag.tsx
@@ -39,7 +39,12 @@ export const BaseTag = (props: Props) => {
     tooltipText,
   } = props;
   return (
-    <StyledTag $fillColor={fillColor} $interactive={interactive} $textColor={textColor}>
+    <StyledTag
+      className="StyledTag"
+      $fillColor={fillColor}
+      $interactive={interactive}
+      $textColor={textColor}
+    >
       {icon || null}
       {label !== undefined && label !== null ? (
         <span

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode2025.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode2025.tsx
@@ -1,10 +1,10 @@
 import {Box, ButtonLink, Colors, Icon, Tag, Tooltip} from '@dagster-io/ui-components';
+import clsx from 'clsx';
 import isEqual from 'lodash/isEqual';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 import {UserDisplay} from 'shared/runs/UserDisplay.oss';
-import styled from 'styled-components';
 
 import {
   AssetDescription,
@@ -18,12 +18,14 @@ import {AssetNodeFreshnessRow, AssetNodeFreshnessRowOld} from './AssetNodeFreshn
 import {AssetNodeHealthRow} from './AssetNodeHealthRow';
 import {assetNodeLatestEventContent, buildAssetNodeStatusContent} from './AssetNodeStatusContent';
 import {LiveDataForNode, LiveDataForNodeWithStaleData} from './Utils';
+import styles from './css/AssetNode2025.module.css';
 import {ASSET_NODE_TAGS_HEIGHT} from './layout';
 import {featureEnabled} from '../app/Flags';
 import {useAssetAutomationData} from '../asset-data/AssetAutomationDataProvider';
 import {useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
 import {AssetAutomationFragment} from '../asset-data/types/AssetAutomationDataProvider.types';
 import {EvaluationUserLabel} from '../assets/AutoMaterializePolicyPage/EvaluationConditionalLabel';
+import {EvaluationDetailDialog} from '../assets/AutoMaterializePolicyPage/EvaluationDetailDialog';
 import {ChangedReasonsTag} from '../assets/ChangedReasons';
 import {StaleReasonsTag} from '../assets/Stale';
 import {AssetChecksStatusSummary} from '../assets/asset-checks/AssetChecksStatusSummary';
@@ -31,7 +33,6 @@ import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetKind} from '../graph/KindTags';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
 import {AssetNodeFragment} from './types/AssetNode.types';
-import {EvaluationDetailDialog} from '../assets/AutoMaterializePolicyPage/EvaluationDetailDialog';
 
 interface Props2025 {
   definition: AssetNodeFragment;
@@ -305,12 +306,14 @@ const AssetNodeStatusRow = ({
 const SingleOwnerOrTooltip = ({owners}: {owners: AssetNodeFragment['owners']}) => {
   if (owners.length === 1) {
     const owner = owners[0]!;
-    return owner.__typename === 'UserAssetOwner' ? (
-      <UserDisplayWrapNoPadding>
-        <UserDisplay email={owner.email} size="very-small" />
-      </UserDisplayWrapNoPadding>
-    ) : (
-      <Tag icon="people">{owner.team}</Tag>
+    return (
+      <div className={styles.UserDisplayWrapNoPadding}>
+        {owner.__typename === 'UserAssetOwner' ? (
+          <UserDisplay email={owner.email} size="very-small" />
+        ) : (
+          <Tag icon="people">{owner.team}</Tag>
+        )}
+      </div>
     );
   }
 
@@ -318,18 +321,19 @@ const SingleOwnerOrTooltip = ({owners}: {owners: AssetNodeFragment['owners']}) =
     <Tooltip
       placement="top"
       content={
-        <Box flex={{wrap: 'wrap', gap: 12}} style={{maxWidth: 300}}>
-          {owners.map((o, idx) =>
-            o.__typename === 'UserAssetOwner' ? (
-              <UserDisplayWrapNoPadding key={idx}>
+        <Box flex={{wrap: 'wrap', gap: 12}} style={{maxWidth: 300, lineHeight: 0}}>
+          {owners.map((o, idx) => (
+            <div
+              key={idx}
+              className={clsx(styles.UserDisplayWrapNoPadding, styles.UserDisplayInTooltip)}
+            >
+              {o.__typename === 'UserAssetOwner' ? (
                 <UserDisplay email={o.email} size="very-small" />
-              </UserDisplayWrapNoPadding>
-            ) : (
-              <Tag key={idx} icon="people">
-                {o.team}
-              </Tag>
-            ),
-          )}
+              ) : (
+                <Tag icon="people">{o.team}</Tag>
+              )}
+            </div>
+          ))}
         </Box>
       }
     >
@@ -378,10 +382,3 @@ export const AutomationConditionEvaluationLink = ({
     </Link>
   );
 };
-
-const UserDisplayWrapNoPadding = styled.div`
-  & > div > div {
-    background: none;
-    padding: 0;
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -14,6 +14,7 @@ import {
   buildAssetNode,
   buildMaterializationEvent,
   buildRun,
+  buildTeamAssetOwner,
   buildUserAssetOwner,
 } from '../../graphql/types';
 import {LiveDataForNodeWithStaleData} from '../Utils';
@@ -71,8 +72,8 @@ export const AssetNodeFragmentBasic: AssetNodeFragment = buildAssetNode({
     buildUserAssetOwner({
       email: 'test@company.com',
     }),
-    buildUserAssetOwner({
-      email: 'test2@company.com',
+    buildTeamAssetOwner({
+      team: 'Team Foo',
     }),
   ],
 });
@@ -830,6 +831,34 @@ export const AssetNodeScenariosBase = [
     definition: {
       ...AssetNodeFragmentBasic,
       assetKey: buildAssetKey({path: ['very_long_asset_which_was_totally_reasonable_at_the_time']}),
+    },
+    expectedText: [],
+  },
+  {
+    title: 'Single owner - long team name',
+    liveData: LiveDataForNodeMaterialized,
+    definition: {
+      ...AssetNodeFragmentBasic,
+      assetKey: buildAssetKey({path: ['very_long_asset_which_was_totally_reasonable_at_the_time']}),
+      owners: [
+        buildTeamAssetOwner({
+          team: 'Team Foobar Fizz Buzz Definitely Requires Truncation',
+        }),
+      ],
+    },
+    expectedText: [],
+  },
+  {
+    title: 'Single owner - long user name',
+    liveData: LiveDataForNodeMaterialized,
+    definition: {
+      ...AssetNodeFragmentBasic,
+      assetKey: buildAssetKey({path: ['very_long_asset_which_was_totally_reasonable_at_the_time']}),
+      owners: [
+        buildUserAssetOwner({
+          email: 'madeline.manning.mathison@boringcompany.com',
+        }),
+      ],
     },
     expectedText: [],
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
@@ -1,6 +1,6 @@
 import {MockedProvider} from '@apollo/client/testing';
 import {Box, Checkbox} from '@dagster-io/ui-components';
-import React, {useState} from 'react';
+import {useState} from 'react';
 
 import {AssetBaseData} from '../../asset-data/AssetBaseDataProvider';
 import {AssetLiveDataProvider} from '../../asset-data/AssetLiveDataProvider';
@@ -9,7 +9,7 @@ import {KNOWN_TAGS} from '../../graph/OpTags';
 import {buildAssetKey, buildAssetNode, buildStaleCause} from '../../graphql/types';
 import {AssetNode, AssetNodeMinimal} from '../AssetNode';
 import {AssetNode2025} from '../AssetNode2025';
-import {AssetNodeFacet, AssetNodeFacetDefaults} from '../AssetNodeFacets';
+import {AllAssetNodeFacets, AssetNodeFacet} from '../AssetNodeFacets';
 import {AssetNodeFacetsPicker} from '../AssetNodeFacetsPicker';
 import {AssetNodeLink} from '../ForeignNode';
 import {tokenForAssetKey} from '../Utils';
@@ -24,7 +24,7 @@ export default {
 
 export const LiveStates = () => {
   const [newDesign, setNewDesign] = useState<boolean>(true);
-  const [facets, setFacets] = useState<Set<AssetNodeFacet>>(new Set(AssetNodeFacetDefaults));
+  const [facets, setFacets] = useState<Set<AssetNodeFacet>>(new Set(AllAssetNodeFacets));
 
   const caseWithLiveData = (scenario: (typeof Mocks.AssetNodeScenariosBase)[0]) => {
     const definitionCopy = {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/css/AssetNode2025.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/css/AssetNode2025.module.css
@@ -1,0 +1,10 @@
+.UserDisplayWrapNoPadding {
+  min-width: 0;
+}
+.UserDisplayWrapNoPadding :global(.StyledTag) {
+  background: none;
+  padding: 0;
+}
+.UserDisplayInTooltip * {
+  color: var(--color-tooltip-text);
+}


### PR DESCRIPTION
## Summary & Motivation

This PR fixes a rendering issue with the "owners" row in the new faceted asset nodes. When more than one owner is present, they appear in a tooltip, and they were not rendered in the the tooltip text color.

I opted to override the tag CSS because the user tags are essentially an "opaque" component since they are overridden in cloud. 

This PR also moves the AssetNode from styled-components to a CSS module.  We talked a bit about these scenarios in the FE sync - in order to override the rendering of a StyledTag, I applied a global classname to the component. I think that we'll be doing this for a bunch of components in order to move off styled-components and this is the first one. 

<img width="365" alt="image" src="https://github.com/user-attachments/assets/ac3584da-a75a-4ead-9436-14e4b6f97edb" />
