### PR TITLE
[docs] render nested command info for dg commands

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -155,3 +155,5 @@ napoleon_numpy_docstring = False
 
 # Prevent docs generation for Sphinx-specific files
 exclude_patterns = ["_build", "_ext"]
+
+suppress_warnings = ["autosectionlabel.*"]

--- a/docs/sphinx/sections/api/apidocs/dg/dg-cli.rst
+++ b/docs/sphinx/sections/api/apidocs/dg/dg-cli.rst
@@ -5,23 +5,23 @@ dg CLI
 
 .. click:: dagster_dg_cli.cli.check:check_group
     :prog: dg check
-    :nested:
+    :nested: full
 
 .. click:: dagster_dg_cli.cli.dev:dev_command
     :prog: dg dev
-    :nested:
+    :nested: full
 
 .. click:: dagster_dg_cli.cli.launch:launch_command
     :prog: dg launch
-    :nested:
+    :nested: full
 
 .. click:: dagster_dg_cli.cli.list:list_group
     :prog: dg list
-    :nested:
+    :nested: full
 
 .. click:: dagster_dg_cli.cli.plus:plus_group
     :prog: dg plus
-    :nested:
+    :nested: full
 
 .. click:: dagster_dg_cli.cli.scaffold:scaffold_group
     :prog: dg scaffold


### PR DESCRIPTION
## Summary

Enable rendering nested command info in the Sphinx docs for `dg` CLI. Enable for all commands except scaffold - this compiles correctly but produces invalid `.md` files for some reason, investigating.

