### PR TITLE
[ui] Fix View link on code location status toast

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
@@ -1,4 +1,4 @@
-import {Box, ButtonLink, Colors} from '@dagster-io/ui-components';
+import {Box, ButtonLink} from '@dagster-io/ui-components';
 import qs from 'qs';
 import {useCallback, useContext, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {useHistory} from 'react-router-dom';
@@ -309,11 +309,7 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
 };
 
 const ViewCodeLocationsButton = ({onClick}: {onClick: () => void}) => {
-  return (
-    <ViewButton onClick={onClick} color={Colors.accentWhite()}>
-      View
-    </ViewButton>
-  );
+  return <ViewButton onClick={onClick}>View</ViewButton>;
 };
 
 const ViewButton = styled(ButtonLink)`


### PR DESCRIPTION
## Summary & Motivation

The "View" link on code location status toasts is hardcoded to `accentWhite`. I think this is an oversight on my part from when we changed to the new toast styles, since previously they were always dark solid colors.

## How I Tested These Changes

Force toasts to appear, verify that links use correct color.

## Changelog

[ui] Fix "View" link color on code location status toasts.
