### PR TITLE
[ui] Revert change to button alignment, add story showing a select with minWidth

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/StyledButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/StyledButton.tsx
@@ -109,6 +109,6 @@ export const StyledButtonText = styled.span`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  text-align: center;
+  text-align: left;
   flex: 1;
 `;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Button.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Button.stories.tsx
@@ -30,7 +30,9 @@ export const Default = () => {
         flex={{direction: 'column', alignItems: 'stretch'}}
         style={{width: 320}}
       >
-        <Button>Full-width Flex Child</Button>
+        <Button>
+          <div style={{width: '100%', textAlign: 'center'}}>Full-width Flex Child</div>
+        </Button>
       </Box>
     </Group>
   );

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Select.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Select.stories.tsx
@@ -40,3 +40,31 @@ export const Default = () => {
     </Select>
   );
 };
+
+export const WithMinWidth = () => {
+  const [active, setActive] = useState<Product | null>(null);
+
+  const items = useMemo(() => {
+    const items = new Array(10).fill(null).map(() => ({productName: faker.commerce.productName()}));
+    return Array.from(new Set(items));
+  }, []);
+
+  return (
+    <Select<Product>
+      items={items}
+      itemPredicate={(query, item) => item.productName.toLowerCase().includes(query)}
+      itemRenderer={(item, props) => (
+        <MenuItem key={item.productName} text={item.productName} onClick={props.handleClick} />
+      )}
+      onItemSelect={(item) => setActive(item)}
+    >
+      <Button
+        intent="primary"
+        style={{minWidth: '200px', display: 'flex', justifyContent: 'space-between'}}
+        rightIcon={<Icon name="arrow_drop_down" />}
+      >
+        {active ? active.productName : 'Choose a product'}
+      </Button>
+    </Select>
+  );
+};


### PR DESCRIPTION
Additionally added a story that illustrates a select with a minwidth that is implemented the same way the ones in User Settings are - would have helped me see my last change broke something!

<img width="780" alt="image" src="https://github.com/user-attachments/assets/ec94dacb-0eb7-445b-81bb-fd0a8ebc4a33" />
