### PR TITLE
Update format of SlingReplicationCollectionComponent `connections` field

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/7-component.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/7-component.py
@@ -13,8 +13,7 @@ class CustomSlingReplicationComponent(SlingReplicationCollectionComponent):
     def execute(
         self,
         context: dg.AssetExecutionContext,
-        sling: SlingResource,
         replication_spec_model: SlingReplicationSpecModel,
     ) -> Iterator:
         context.log.info("*******************CUSTOM*************************")
-        return sling.replicate(context=context, debug=True)
+        return self.sling_resource.replicate(context=context, debug=True)

--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/9-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/9-defs.yaml
@@ -1,6 +1,10 @@
 type: my_project.components.custom_sling_replication_component.CustomSlingReplicationComponent
 
 attributes:
+  connections:
+    DUCKDB:
+      type: duckdb
+      instance: /tmp/jaffle_platform.duckdb
   replications:
     - path: replication.yaml
 post_processing:

--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/9-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/9-defs.yaml
@@ -1,6 +1,10 @@
 type: my_project.defs.my_sling_sync.component.CustomSlingReplicationComponent
 
 attributes:
+  connections:
+    DUCKDB:
+      type: duckdb
+      instance: /tmp/jaffle_platform.duckdb
   replications:
     - path: replication.yaml
 post_processing:

--- a/examples/docs_snippets/docs_snippets/guides/components/integrations/dlt-component/4-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/integrations/dlt-component/4-tree.txt
@@ -5,10 +5,10 @@ my_project/defs
 └── github_snowflake_ingest
     ├── defs.yaml
     ├── github
+    │   ├── README.md
     │   ├── __init__.py
     │   ├── helpers.py
     │   ├── queries.py
-    │   ├── README.md
     │   └── settings.py
     └── loads.py
 

--- a/examples/docs_snippets/docs_snippets/guides/components/integrations/sling-component/11-customized-component.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/integrations/sling-component/11-customized-component.yaml
@@ -1,11 +1,10 @@
 type: dagster_sling.SlingReplicationCollectionComponent
 
 attributes:
-  sling:
-    connections:
-      - name: DUCKDB
-        type: duckdb
-        instance: /tmp/my_project.duckdb
+  connections:
+    DUCKDB:
+      type: duckdb
+      instance: /tmp/my_project.duckdb
   replications:
     - path: ./replication.yaml
       translation:

--- a/examples/docs_snippets/docs_snippets/guides/components/integrations/sling-component/9-customized-component.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/integrations/sling-component/9-customized-component.yaml
@@ -1,10 +1,9 @@
 type: dagster_sling.SlingReplicationCollectionComponent
 
 attributes:
-  sling:
-    connections:
-      - name: DUCKDB
-        type: duckdb
-        instance: /tmp/my_project.duckdb
+  connections:
+    DUCKDB:
+      type: duckdb
+      instance: /tmp/my_project.duckdb
   replications:
     - path: ./replication.yaml

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/10-component-with-env-deps.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/10-component-with-env-deps.yaml
@@ -1,16 +1,15 @@
 type: dagster_sling.SlingReplicationCollectionComponent
 
 attributes:
-  sling:
-    connections:
-      - name: SNOWFLAKE
-        type: snowflake
-        account: "{{ env.SNOWFLAKE_ACCOUNT }}"
-        user: "{{ env.SNOWFLAKE_USER }}"
-        password: "{{ env.SNOWFLAKE_PASSWORD }}"
-        database: "{{ env.SNOWFLAKE_DATABASE }}"
-    replications:
-      - path: replication.yaml
+  connections:
+    SNOWFLAKE:
+      type: snowflake
+      account: "{{ env.SNOWFLAKE_ACCOUNT }}"
+      user: "{{ env.SNOWFLAKE_USER }}"
+      password: "{{ env.SNOWFLAKE_PASSWORD }}"
+      database: "{{ env.SNOWFLAKE_DATABASE }}"
+  replications:
+    - path: replication.yaml
 
 requirements:
   env:

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/8-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/8-defs.yaml
@@ -1,13 +1,12 @@
 type: dagster_sling.SlingReplicationCollectionComponent
 
 attributes:
-  sling:
-    connections:
-      - name: SNOWFLAKE
-        type: snowflake
-        account: "{{ env.SNOWFLAKE_ACCOUNT }}"
-        user: "{{ env.SNOWFLAKE_USER }}"
-        password: "{{ env.SNOWFLAKE_PASSWORD }}"
-        database: "{{ env.SNOWFLAKE_DATABASE }}"
-    replications:
-      - path: replication.yaml
+  connections:
+    SNOWFLAKE:
+      type: snowflake
+      account: "{{ env.SNOWFLAKE_ACCOUNT }}"
+      user: "{{ env.SNOWFLAKE_USER }}"
+      password: "{{ env.SNOWFLAKE_PASSWORD }}"
+      database: "{{ env.SNOWFLAKE_DATABASE }}"
+  replications:
+    - path: replication.yaml

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/9-dg-component-check.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/9-dg-component-check.txt
@@ -6,14 +6,13 @@ dg check yaml
      | ^ Component uses environment variables that are not specified in the component file: SNOWFLAKE_ACCOUNT, SNOWFLAKE_DATABASE, SNOWFLAKE_PASSWORD, SNOWFLAKE_USER
    2 | 
    3 | attributes:
-   4 |   sling:
-   5 |     connections:
-   6 |       - name: SNOWFLAKE
-   7 |         type: snowflake
-   8 |         account: "{{ env.SNOWFLAKE_ACCOUNT }}"
-   9 |         user: "{{ env.SNOWFLAKE_USER }}"
-  10 |         password: "{{ env.SNOWFLAKE_PASSWORD }}"
-  11 |         database: "{{ env.SNOWFLAKE_DATABASE }}"
-  12 |     replications:
-  13 |       - path: replication.yaml
+   4 |   connections:
+   5 |     SNOWFLAKE:
+   6 |       type: snowflake
+   7 |       account: "{{ env.SNOWFLAKE_ACCOUNT }}"
+   8 |       user: "{{ env.SNOWFLAKE_USER }}"
+   9 |       password: "{{ env.SNOWFLAKE_PASSWORD }}"
+  10 |       database: "{{ env.SNOWFLAKE_DATABASE }}"
+  11 |   replications:
+  12 |     - path: replication.yaml
      |

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_sling_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_sling_component.py
@@ -134,11 +134,10 @@ def test_components_docs_sling_workspace(
                 type: dagster_sling.SlingReplicationCollectionComponent
 
                 attributes:
-                  sling:
-                    connections:
-                      - name: DUCKDB
-                        type: duckdb
-                        instance: /tmp/my_project.duckdb
+                  connections:
+                    DUCKDB:
+                      type: duckdb
+                      instance: /tmp/my_project.duckdb
                   replications:
                     - path: ./replication.yaml
                     """
@@ -159,11 +158,10 @@ def test_components_docs_sling_workspace(
                 type: dagster_sling.SlingReplicationCollectionComponent
 
                 attributes:
-                  sling:
-                    connections:
-                      - name: DUCKDB
-                        type: duckdb
-                        instance: /tmp/my_project.duckdb
+                  connections:
+                    DUCKDB:
+                      type: duckdb
+                      instance: /tmp/my_project.duckdb
                   replications:
                     - path: ./replication.yaml
                       translation:

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_customizing_existing_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_customizing_existing_component.py
@@ -207,11 +207,10 @@ def test_components_docs_adding_attributes_to_assets(
                 {type_str}
 
                 attributes:
-                  sling:
-                    connections:
-                      - name: DUCKDB
-                        type: duckdb
-                        instance: /tmp/jaffle_platform.duckdb
+                  connections:
+                    DUCKDB:
+                      type: duckdb
+                      instance: /tmp/jaffle_platform.duckdb
                   replications:
                     - path: replication.yaml
                 """),
@@ -238,11 +237,10 @@ def test_components_docs_adding_attributes_to_assets(
                     def execute(
                         self,
                         context: dg.AssetExecutionContext,
-                        sling: SlingResource,
                         replication_spec_model: SlingReplicationSpecModel,
                     ) -> Iterator:
                         context.log.info("*******************CUSTOM*************************")
-                        return sling.replicate(context=context, debug=True)
+                        return self.sling_resource.replicate(context=context, debug=True)
 
                 """
             ),
@@ -289,11 +287,10 @@ def test_components_docs_adding_attributes_to_assets(
                 {type_str}
 
                 attributes:
-                  sling:
-                    connections:
-                      - name: DUCKDB
-                        type: duckdb
-                        instance: /tmp/jaffle_platform.duckdb
+                  connections:
+                    DUCKDB:
+                      type: duckdb
+                      instance: /tmp/jaffle_platform.duckdb
                   replications:
                     - path: replication.yaml
                 post_processing:

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_using_env.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_using_env.py
@@ -320,16 +320,15 @@ def test_component_docs_using_env(
                     type: dagster_sling.SlingReplicationCollectionComponent
 
                     attributes:
-                      sling:
-                        connections:
-                          - name: SNOWFLAKE
-                            type: snowflake
-                            account: "{{ env.SNOWFLAKE_ACCOUNT }}"
-                            user: "{{ env.SNOWFLAKE_USER }}"
-                            password: "{{ env.SNOWFLAKE_PASSWORD }}"
-                            database: "{{ env.SNOWFLAKE_DATABASE }}"
-                        replications:
-                          - path: replication.yaml
+                      connections:
+                        SNOWFLAKE:
+                          type: snowflake
+                          account: "{{ env.SNOWFLAKE_ACCOUNT }}"
+                          user: "{{ env.SNOWFLAKE_USER }}"
+                          password: "{{ env.SNOWFLAKE_PASSWORD }}"
+                          database: "{{ env.SNOWFLAKE_DATABASE }}"
+                      replications:
+                        - path: replication.yaml
                     """),
             )
 
@@ -356,16 +355,15 @@ def test_component_docs_using_env(
                     type: dagster_sling.SlingReplicationCollectionComponent
 
                     attributes:
-                      sling:
-                        connections:
-                          - name: SNOWFLAKE
-                            type: snowflake
-                            account: "{{ env.SNOWFLAKE_ACCOUNT }}"
-                            user: "{{ env.SNOWFLAKE_USER }}"
-                            password: "{{ env.SNOWFLAKE_PASSWORD }}"
-                            database: "{{ env.SNOWFLAKE_DATABASE }}"
-                        replications:
-                          - path: replication.yaml
+                      connections:
+                        SNOWFLAKE:
+                          type: snowflake
+                          account: "{{ env.SNOWFLAKE_ACCOUNT }}"
+                          user: "{{ env.SNOWFLAKE_USER }}"
+                          password: "{{ env.SNOWFLAKE_PASSWORD }}"
+                          database: "{{ env.SNOWFLAKE_DATABASE }}"
+                      replications:
+                        - path: replication.yaml
 
                     requirements:
                       env:

--- a/python_modules/libraries/dagster-sling/dagster_sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/asset_decorator.py
@@ -118,7 +118,7 @@ def sling_assets(
 def get_sling_asset_specs(
     replication_config: SlingReplicationParam,
     dagster_sling_translator: Optional[DagsterSlingTranslator] = None,
-    partitions_def: Optional[PartitionsDefinition] = None,
+    partitions_def: Optional[PartitionsDefinition] = ...,
 ) -> list[AssetSpec]:
     replication_config = validate_replication(replication_config)
 
@@ -140,7 +140,7 @@ def get_sling_asset_specs(
             return asset_spec.replace_attributes(code_version=code_version)
         return asset_spec
 
-    return [
+    specs = [
         update_code_version_if_unset_by_translator(
             dagster_sling_translator.get_asset_spec(stream).merge_attributes(
                 metadata={
@@ -148,9 +148,12 @@ def get_sling_asset_specs(
                     METADATA_KEY_REPLICATION_CONFIG: replication_config,
                 }
             )
-        ).replace_attributes(
-            partitions_def=partitions_def,
-            skippable=True,
         )
         for stream in streams
+    ]
+    return [
+        spec.replace_attributes(
+            partitions_def=partitions_def or spec.partitions_def, skippable=True
+        )
+        for spec in specs
     ]

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/code_locations/sling_location/defs/ingest/defs.yaml
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/code_locations/sling_location/defs/ingest/defs.yaml
@@ -6,7 +6,7 @@ attributes:
       translation:
         key: "foo/{{ stream_definition.config.meta.dagster.asset_key }}"
   connections:
-    - name: DUCKDB
+    DUCKDB:
       type: duckdb
       instance: <PLACEHOLDER>
       password: "{{ env.SOME_PASSWORD }}"

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -83,7 +83,7 @@ def temp_sling_component_instance(
                     data["attributes"]["replications"] = replication_specs
 
                 # update the defs yaml to add a duckdb instance
-                data["attributes"]["connections"][0]["instance"] = f"{temp_dir}/duckdb"
+                data["attributes"]["connections"]["DUCKDB"]["instance"] = f"{temp_dir}/duckdb"
 
             context = ComponentLoadContext.for_test().for_path(component_path)
             component = get_underlying_component(context)
@@ -178,7 +178,7 @@ def test_sling_subclass() -> None:
     defs = build_component_defs_for_test(
         DebugSlingReplicationComponent,
         {
-            "connections": [],
+            "connections": {},
             "replications": [{"path": str(REPLICATION_PATH)}],
         },
     )
@@ -198,7 +198,7 @@ class TestSlingTranslation(TestTranslation):
         defs = build_component_defs_for_test(
             SlingReplicationCollectionComponent,
             {
-                "sling": {},
+                "connections": {},
                 "replications": [{"path": str(REPLICATION_PATH), "translation": attributes}],
             },
         )
@@ -247,7 +247,7 @@ def test_asset_post_processors_deprecation_error() -> None:
                     data["attributes"]["asset_post_processors"] = [
                         {"target": "*", "attributes": {"group_name": "test_group"}}
                     ]
-                    data["attributes"]["sling"]["connections"][0]["instance"] = f"{temp_dir}/duckdb"
+                    data["attributes"]["connections"]["DUCKDB"]["instance"] = f"{temp_dir}/duckdb"
 
                 context = ComponentLoadContext.for_test().for_path(component_path)
                 component = get_underlying_component(context)
@@ -281,7 +281,7 @@ def test_udf_map_spec(map_fn: Callable[[AssetSpec], Any]) -> None:
     defs = build_component_defs_for_test(
         DebugSlingReplicationComponent,
         {
-            "connections": [],
+            "connections": {},
             "replications": [
                 {"path": str(REPLICATION_PATH), "translation": "{{ map_spec(spec) }}"}
             ],


### PR DESCRIPTION
## Summary & Motivation

See comment on below pr: https://github.com/dagster-io/dagster/pull/30561#pullrequestreview-2946678785

Resolved is great!

## How I Tested These Changes

existing tests

## Changelog

- The `SlingReplicationCollectionComponent`'s `connections` yaml schema now shares the same format as Sling's `env.yaml`.
