### PR TITLE
[Resolved] Add weekly, arbitrary time-window partition def

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/core_models.py
+++ b/python_modules/dagster/dagster/components/resolved/core_models.py
@@ -18,6 +18,8 @@ from dagster._core.definitions.partition import PartitionsDefinition, StaticPart
 from dagster._core.definitions.time_window_partitions import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    TimeWindowPartitionsDefinition,
+    WeeklyPartitionsDefinition,
 )
 from dagster.components.resolved.base import Resolvable, resolve_fields
 from dagster.components.resolved.context import ResolutionContext
@@ -51,6 +53,25 @@ class DailyPartitionsDefinitionModel(Resolvable, Model):
     hour_offset: int = 0
 
 
+class WeeklyPartitionsDefinitionModel(Resolvable, Model):
+    type: Literal["weekly"] = "weekly"
+    start_date: str
+    end_date: Optional[str] = None
+    timezone: Optional[str] = None
+    minute_offset: int = 0
+    hour_offset: int = 0
+    day_offset: int = 0
+
+
+class TimeWindowPartitionsDefinitionModel(Resolvable, Model):
+    type: Literal["time_window"] = "time_window"
+    start_date: str
+    end_date: Optional[str] = None
+    timezone: Optional[str] = None
+    fmt: str
+    cron_schedule: str
+
+
 class StaticPartitionsDefinitionModel(Resolvable, Model):
     type: Literal["static"] = "static"
     partition_keys: Sequence[str]
@@ -73,6 +94,24 @@ def resolve_partitions_def(context: ResolutionContext, model) -> Optional[Partit
             end_date=model.end_date,
             timezone=model.timezone,
             minute_offset=model.minute_offset,
+            hour_offset=model.hour_offset,
+        )
+    elif model.type == "weekly":
+        return WeeklyPartitionsDefinition(
+            start_date=model.start_date,
+            end_date=model.end_date,
+            timezone=model.timezone,
+            minute_offset=model.minute_offset,
+            hour_offset=model.hour_offset,
+            day_offset=model.day_offset,
+        )
+    elif model.type == "time_window":
+        return TimeWindowPartitionsDefinition(
+            start=model.start_date,
+            end=model.end_date,
+            timezone=model.timezone,
+            fmt=model.fmt,
+            cron_schedule=model.cron_schedule,
         )
     elif model.type == "static":
         return StaticPartitionsDefinition(partition_keys=model.partition_keys)
@@ -212,6 +251,8 @@ class SharedAssetKwargs(Resolvable):
             model_field_type=Union[
                 HourlyPartitionsDefinitionModel,
                 DailyPartitionsDefinitionModel,
+                WeeklyPartitionsDefinitionModel,
+                TimeWindowPartitionsDefinitionModel,
                 StaticPartitionsDefinitionModel,
             ],
         ),

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolvable_transformer.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolvable_transformer.py
@@ -14,6 +14,8 @@ from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    TimeWindowPartitionsDefinition,
+    WeeklyPartitionsDefinition,
 )
 from dagster.components.resolved.context import ResolutionContext
 from dagster.components.resolved.core_models import (
@@ -125,6 +127,44 @@ def test_asset_spec_hourly_partitions_def():
     assert spec.partitions_def.end == datetime.datetime(
         year=2021, month=1, day=1, hour=2, tzinfo=datetime.timezone.utc
     )
+
+
+def test_asset_spec_weekly_partitions_def():
+    model = AssetSpecKwargs.model()(
+        key="asset_key",
+        partitions_def={
+            "type": "weekly",
+            "start_date": "2021-01-01",
+            "timezone": "UTC",
+        },
+    )
+
+    spec = resolve_asset_spec(model=model, context=ResolutionContext.default())
+    assert isinstance(spec.partitions_def, WeeklyPartitionsDefinition)
+    assert spec.partitions_def.start == datetime.datetime(
+        year=2021, month=1, day=1, tzinfo=datetime.timezone.utc
+    )
+
+
+def test_asset_spec_time_window_partitions_def():
+    model = AssetSpecKwargs.model()(
+        key="asset_key",
+        partitions_def={
+            "type": "time_window",
+            "start_date": "2021-01-01",
+            "timezone": "UTC",
+            "fmt": "%Y-%m-%d",
+            "cron_schedule": "0 11/2 * * *",
+        },
+    )
+
+    spec = resolve_asset_spec(model=model, context=ResolutionContext.default())
+    assert isinstance(spec.partitions_def, TimeWindowPartitionsDefinition)
+    assert spec.partitions_def.start == datetime.datetime(
+        year=2021, month=1, day=1, tzinfo=datetime.timezone.utc
+    )
+    assert spec.partitions_def.timezone == "UTC"
+    assert spec.partitions_def.cron_schedule == "0 11/2 * * *"
 
 
 def test_asset_spec_static_partitions_def():

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/__init__.py
@@ -291,7 +291,7 @@ def format_multiline_str(message: str) -> str:
 
 def generate_missing_plugin_object_error_message(plugin_object_key: str) -> str:
     return f"""
-        No plugin object `{plugin_object_key}` is registered. Use `dg list plugins`
+        No plugin object `{plugin_object_key}` is registered. Use `dg list components`
         to see the registered plugin objects in your environment. You may need to install a package
         that provides `{plugin_object_key}` into your environment.
     """


### PR DESCRIPTION
## Summary

Allows for arbitrary time-window partitions and built-in weekly partitions.


## Test Plan

Unit tests.

## Changelog

> [components] Weekly and arbitrary time-window partitions can now be provided to the  `partitions_def` asset customization in YAML.