### PR TITLE
Hide inline-componont scaffold command

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold.py
@@ -328,7 +328,7 @@ def scaffold_defs_group(context: click.Context, help_: bool, **global_options: o
 @scaffold_defs_group.command(
     name="inline-component",
     cls=ScaffoldDefsSubCommand,
-    hidden=True,
+    hidden=True,  # hiding for initial launch of 1.11 as it is undocumented. Will push out incrementally in later release -- schrockn 2025-06-20
 )
 @click.argument("path", type=str)
 @click.option(


### PR DESCRIPTION
## Summary & Motivation

Inline components are potentially a useful feature but it is not critical, it is undocumented, and it causes confusing helpstring output as a result. Hiding it using click but keeping it alive in tests.

## How I Tested These Changes

BK

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/a3d9c7b3-b478-4fba-af7c-4d1915fb1387.png)

## Changelog

* Hiding `inline-component` subcommand of `dg scaffold defs`.