### PR TITLE
DOC-1234 add definitions decorator apidoc and remove preview

### DIFF
--- a/docs/sphinx/sections/api/apidocs/dagster/definitions.rst
+++ b/docs/sphinx/sections/api/apidocs/dagster/definitions.rst
@@ -6,6 +6,8 @@ Definitions
 .. autoclass:: Definitions
     :members: get_job_def, get_sensor_def, get_schedule_def, load_asset_value, get_asset_value_loader
 
+.. autodecorator:: definitions
+
 .. autofunction:: create_repository_using_definitions_args
 
 .. autofunction:: load_definitions_from_current_module

--- a/python_modules/dagster/dagster/components/definitions.py
+++ b/python_modules/dagster/dagster/components/definitions.py
@@ -1,7 +1,7 @@
 import inspect
 from typing import Callable, Generic, Optional, TypeVar, Union, cast
 
-from dagster._annotations import preview, public
+from dagster._annotations import public
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.repository_definition.repository_definition import (
     RepositoryDefinition,
@@ -46,7 +46,6 @@ class LazyDefinitions(Generic[T_Defs]):
 
 
 @public
-@preview(emit_runtime_warning=False)
 def definitions(
     fn: Union[Callable[[], Definitions], Callable[[ComponentLoadContext], Definitions]],
 ) -> Callable[..., Definitions]:
@@ -108,4 +107,4 @@ def definitions(
 # For backwards compatibility with existing test cases
 def lazy_repository(fn: Callable[[], RepositoryDefinition]) -> Callable[[], RepositoryDefinition]:
     lazy_defs = LazyDefinitions[RepositoryDefinition](load_fn=fn, has_context_arg=False)
-    return cast("Callable[[],RepositoryDefinition]", lazy_defs)
+    return cast("Callable[[], RepositoryDefinition]", lazy_defs)


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes
https://06-20-doc-1234-add-definitions-decorator-apidoc-and-remove-prev.archive.dagster-docs.io/api/dagster/definitions#dagster.definitions

## Changelog

> Insert changelog entry or delete this section.
