### PR TITLE
[components] Remove @preview from DefsFolderComponent

### DIFF
--- a/docs/sphinx/sections/api/apidocs/dagster/components.rst
+++ b/docs/sphinx/sections/api/apidocs/dagster/components.rst
@@ -62,3 +62,8 @@ common Dagster types.
 
     Allows resolving to an AssetCheckSpec via a YAML-friendly schema.
 
+
+Built-in Components
+-------------------
+
+.. autoclass:: DefsFolderComponent

--- a/examples/docs_snippets/docs_snippets/guides/components/index/17-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/17-dg-list-components.txt
@@ -5,8 +5,8 @@ dg list components
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ dagster.DefinitionsComponent                      │ An arbitrary set of Dagster definitions.                         │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
-│ dagster.DefsFolderComponent                       │ A folder which may contain multiple submodules, each             │
-│                                                   │ which define components.                                         │
+│ dagster.DefsFolderComponent                       │ A component that represents a directory containing multiple      │
+│                                                   │ Dagster definition modules.                                      │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
 │ dagster.FunctionComponent                         │ Represents a Python function, alongside the set of assets or     │
 │                                                   │ asset checks that it is responsible for executing.               │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/26-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/26-dg-list-components.txt
@@ -5,8 +5,8 @@ dg list components
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ dagster.DefinitionsComponent                      │ An arbitrary set of Dagster definitions.                         │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
-│ dagster.DefsFolderComponent                       │ A folder which may contain multiple submodules, each             │
-│                                                   │ which define components.                                         │
+│ dagster.DefsFolderComponent                       │ A component that represents a directory containing multiple      │
+│                                                   │ Dagster definition modules.                                      │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
 │ dagster.FunctionComponent                         │ Represents a Python function, alongside the set of assets or     │
 │                                                   │ asset checks that it is responsible for executing.               │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/4-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/4-dg-list-components.txt
@@ -5,8 +5,8 @@ dg list components
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ dagster.DefinitionsComponent  │ An arbitrary set of Dagster definitions.                                             │
 ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────┤
-│ dagster.DefsFolderComponent   │ A folder which may contain multiple submodules, each                                 │
-│                               │ which define components.                                                             │
+│ dagster.DefsFolderComponent   │ A component that represents a directory containing multiple Dagster definition       │
+│                               │ modules.                                                                             │
 ├───────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────┤
 │ dagster.FunctionComponent     │ Represents a Python function, alongside the set of assets or asset checks that it is │
 │                               │ responsible for executing.                                                           │

--- a/examples/docs_snippets/docs_snippets/guides/components/index/6-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/6-dg-list-components.txt
@@ -5,8 +5,8 @@ dg list components
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ dagster.DefinitionsComponent                      │ An arbitrary set of Dagster definitions.                         │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
-│ dagster.DefsFolderComponent                       │ A folder which may contain multiple submodules, each             │
-│                                                   │ which define components.                                         │
+│ dagster.DefsFolderComponent                       │ A component that represents a directory containing multiple      │
+│                                                   │ Dagster definition modules.                                      │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
 │ dagster.FunctionComponent                         │ Represents a Python function, alongside the set of assets or     │
 │                                                   │ asset checks that it is responsible for executing.               │

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/3-dg-list-components.txt
@@ -5,8 +5,8 @@ dg list components
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ dagster.DefinitionsComponent                     │ An arbitrary set of Dagster definitions.                          │
 ├──────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
-│ dagster.DefsFolderComponent                      │ A folder which may contain multiple submodules, each              │
-│                                                  │ which define components.                                          │
+│ dagster.DefsFolderComponent                      │ A component that represents a directory containing multiple       │
+│                                                  │ Dagster definition modules.                                       │
 ├──────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
 │ dagster.FunctionComponent                        │ Represents a Python function, alongside the set of assets or      │
 │                                                  │ asset checks that it is responsible for executing.                │

--- a/examples/docs_snippets/docs_snippets/guides/dg/adding-components-to-existing-project/6-definitions.py
+++ b/examples/docs_snippets/docs_snippets/guides/dg/adding-components-to-existing-project/6-definitions.py
@@ -23,21 +23,22 @@ defs = dg.Definitions.merge(
         schedules=[sync_tables_daily_schedule, regenerate_analytics_hourly_schedule],
     ),
     dg.build_defs_for_component(
-        component=SlingReplicationCollectionComponent(
-            connections=[
-                SlingConnectionResource(
-                    name="DUCKDB",
-                    type="duckdb",
-                    instance="/tmp/jaffle_platform.duckdb",
-                )
-            ],
-            replications=[
-                SlingReplicationSpecModel(
-                    path=(
-                        Path(__file__).parent / "elt" / "sling" / "replication.yaml"
-                    ).as_posix(),
-                )
-            ],
+        component=dagster_sling.SlingReplicationCollectionComponent.from_attributes_dict(
+            attributes={
+                "connections": {
+                    "DUCKDB": {
+                        "type": "duckdb",
+                        "instance": "/tmp/jaffle_platform.duckdb",
+                    }
+                },
+                "replications": [
+                    {
+                        "path": (
+                            Path(__file__).parent / "elt" / "sling" / "replication.yaml"
+                        ).as_posix(),
+                    }
+                ],
+            }
         )
     ),
 )

--- a/examples/docs_snippets/docs_snippets/guides/dg/adding-components-to-existing-project/6-definitions.py
+++ b/examples/docs_snippets/docs_snippets/guides/dg/adding-components-to-existing-project/6-definitions.py
@@ -23,22 +23,21 @@ defs = dg.Definitions.merge(
         schedules=[sync_tables_daily_schedule, regenerate_analytics_hourly_schedule],
     ),
     dg.build_defs_for_component(
-        component=dagster_sling.SlingReplicationCollectionComponent.from_attributes_dict(
-            attributes={
-                "connections": {
-                    "DUCKDB": {
-                        "type": "duckdb",
-                        "instance": "/tmp/jaffle_platform.duckdb",
-                    }
-                },
-                "replications": [
-                    {
-                        "path": (
-                            Path(__file__).parent / "elt" / "sling" / "replication.yaml"
-                        ).as_posix(),
-                    }
-                ],
-            }
+        component=SlingReplicationCollectionComponent(
+            connections=[
+                SlingConnectionResource(
+                    name="DUCKDB",
+                    type="duckdb",
+                    instance="/tmp/jaffle_platform.duckdb",
+                )
+            ],
+            replications=[
+                SlingReplicationSpecModel(
+                    path=(
+                        Path(__file__).parent / "elt" / "sling" / "replication.yaml"
+                    ).as_posix(),
+                )
+            ],
         )
     ),
 )

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/11-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/11-list-components.txt
@@ -5,8 +5,8 @@ dg list components
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ dagster.DefinitionsComponent       │ An arbitrary set of Dagster definitions.                                        │
 ├────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
-│ dagster.DefsFolderComponent        │ A folder which may contain multiple submodules, each                            │
-│                                    │ which define components.                                                        │
+│ dagster.DefsFolderComponent        │ A component that represents a directory containing multiple Dagster definition  │
+│                                    │ modules.                                                                        │
 ├────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
 │ dagster.FunctionComponent          │ Represents a Python function, alongside the set of assets or asset checks that  │
 │                                    │ it is responsible for executing.                                                │
@@ -16,9 +16,6 @@ dg list components
 ├────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
 │ dagster.UvRunComponent             │ Represents a Python script, alongside the set of assets or asset checks that it │
 │                                    │ is responsible for executing.                                                   │
-├────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
-│ dagster.DefsFolderComponent        │ A component that represents a directory containing multiple Dagster definition  │
-│                                    │ modules.                                                                        │
 ├────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
 │ my_existing_project.components.Foo │ COMPONENT SUMMARY HERE.                                                         │
 └────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────┘

--- a/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/11-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/migrating-project/11-list-components.txt
@@ -17,5 +17,8 @@ dg list components
 │ dagster.UvRunComponent             │ Represents a Python script, alongside the set of assets or asset checks that it │
 │                                    │ is responsible for executing.                                                   │
 ├────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
+│ dagster.DefsFolderComponent        │ A component that represents a directory containing multiple Dagster definition  │
+│                                    │ modules.                                                                        │
+├────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
 │ my_existing_project.components.Foo │ COMPONENT SUMMARY HERE.                                                         │
 └────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────┘

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/4-dg-list-components.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/4-dg-list-components.txt
@@ -5,8 +5,8 @@ dg list components
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ dagster.DefinitionsComponent                      │ An arbitrary set of Dagster definitions.                         │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
-│ dagster.DefsFolderComponent                       │ A folder which may contain multiple submodules, each             │
-│                                                   │ which define components.                                         │
+│ dagster.DefsFolderComponent                       │ A component that represents a directory containing multiple      │
+│                                                   │ Dagster definition modules.                                      │
 ├───────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────┤
 │ dagster.FunctionComponent                         │ Represents a Python function, alongside the set of assets or     │
 │                                                   │ asset checks that it is responsible for executing.               │

--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -71,14 +71,14 @@ class Component(ABC):
     """Abstract base class for creating Dagster components.
 
     Components are the primary building blocks for programmatically creating Dagster
-    definitions. They enable building multiple interrelated definitions for use cases, provide
-    schema-based configuration, and built-in scaffolding support to simplify
+    definitions. They enable building multiple interrelated definitions for specific use cases,
+    provide schema-based configuration, and built-in scaffolding support to simplify
     component instantiation in projects. Components are automatically discovered by
     Dagster tooling and can be instantiated from YAML configuration files or Python code that
     conform to the declared schema.
 
     Key Capabilities:
-    - **Definition Factory**: Creates Dagster assets, jobs, schedules, and other definitions.
+    - **Definition Factory**: Creates Dagster assets, jobs, schedules, and other definitions
     - **Schema-Based Configuration**: Optional parameterization via YAML or Python objects
     - **Scaffolding Support**: Custom project structure generation via ``dg scaffold`` commands
     - **Tool Integration**: Automatic discovery by Dagster CLI and UI tools
@@ -88,10 +88,6 @@ class Component(ABC):
     - Every component must implement the ``build_defs()`` method, which serves as a factory for creating Dagster definitions.
     - Components can optionally inherit from ``Resolvable`` to add schema-based configuration capabilities, enabling parameterization through YAML files or structured Python objects.
     - Components can attach a custom scaffolder with the ``@scaffold_with`` decorator.
-
-    Args:
-        This is an abstract base class and should be subclassed rather than instantiated directly.
-        Configuration parameters are defined by subclassing ``Resolvable`` and adding fields.
 
     Examples:
         Simple component with hardcoded definitions:
@@ -222,17 +218,13 @@ class Component(ABC):
                 # Component implementation
                 pass
 
-    Note:
-        Components are abstract and must implement ``build_defs()``. The component system
-        automatically handles instantiation, parameter resolution, and integration with
-        Dagster's loading mechanisms.
-
     See Also:
         - :py:class:`dagster.Definitions`: The object returned by ``build_defs()``
         - :py:class:`dagster.ComponentLoadContext`: Context provided to ``build_defs()``
         - :py:class:`dagster.components.resolved.base.Resolvable`: Base for configurable components
         - :py:class:`dagster.Model`: Recommended base class for component schemas
         - :py:func:`dagster.scaffold_with`: Decorator for custom scaffolding
+
     """
 
     @classmethod


### PR DESCRIPTION
## Summary & Motivation

Remove `@preview` and add documentation for `DefsFolderComponent`

I also cleaned up the Component docblock a little bit:

## How I Tested These Changes

Claude and Read

![Screenshot 2025-06-23 at 7.48.41 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/712b5783-1320-4d1c-8fdb-3f6d10308ebe.png)

![Screenshot 2025-06-23 at 7.50.33 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/f114323b-153f-4e18-8152-20cf30064cfb.png)

## Changelog

* Remove `@preview` from `DefsFolderComponent`
