### PR TITLE
[docs] improve CONTRIBUTING.md - clarify setup instructions for Windows and Linux users

### DIFF
--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -8,13 +8,20 @@ We love to see our community members get involved! If you are planning to contri
 
 ## Environment setup
 
-1. [Install uv](https://docs.astral.sh/uv/getting-started/installation/). On macOS, you can use `curl` to download the script and execute it with `sh`:
+1. Clone the Dagster repository to the destination of your choice:
+
+   ```bash
+   git clone git@github.com:dagster-io/dagster.git
+   cd dagster
+   ```
+
+2. [Install uv](https://docs.astral.sh/uv/getting-started/installation/). On macOS, Linux, or WSL, you can use `curl` to download the script and execute it with `sh`:
 
    ```bash
    curl -LsSf https://astral.sh/uv/install.sh | sh
    ```
 
-2. Create and activate a virtual environment using uv with a Python version that Dagster supports:
+3. Create and activate a virtual environment using uv with a Python version that Dagster supports:
 
    ```bash
    uv venv --python 3.12
@@ -23,31 +30,35 @@ We love to see our community members get involved! If you are planning to contri
 
    Dagster supports Python 3.9 through 3.12.
 
-3. Ensure that you have node installed by running `node -v`, and that you have [yarn](https://yarnpkg.com/lang/en/) installed. If you are on macOS, you can install yarn with Homebrew:
+4. Ensure that you have a supported version of [node](https://nodejs.org/en/download) by running `node -v`, and that you have [yarn](https://yarnpkg.com/lang/en/) installed. Once you have node installed, you can use `npm` to install yarn.
 
    ```bash
-   brew install yarn
+   npm install --global yarn
    ```
 
-4. Clone the Dagster repository to the destination of your choice:
+   Dagster supports Node 20.X and above.
 
-   ```bash
-   git clone git@github.com:dagster-io/dagster.git
-   ```
-
-5. Run `make dev_install` at the root of the repository. This sets up a full Dagster developer environment with all modules and runs tests that do not require heavy external dependencies such as docker. This will take a few minutes. Note that certain sections of the makefile (`sanity_check`, which is part of `rebuild_ui`) require POSIX-compliant shells and will fail on CMD and powershell—if developing on windows, using something like WSL or git-bash is recommended.
+5. Run `make dev_install` at the root of the repository. This sets up a full Dagster developer environment with all modules and runs tests that do not require heavy external dependencies such as docker. Note that certain sections of the makefile (`sanity_check`, which is part of `rebuild_ui`) require POSIX-compliant shells and will fail on CMD and powershell—if developing on windows, using something like WSL or git-bash is recommended.
 
    ```bash
    make dev_install
    ```
 
-   **Note for Macs with an Apple silicon chip**: Some users have reported installation problems due to missing wheels for arm64 Macs when installing the `grpcio` package. To install the `dagster` development environment using our pre-built wheel of the `grpcio` package for M1, M2, and M3 machines, run `make dev_install_m1_grpcio_wheel` instead of `make dev_install`.
+   This will take a few minutes.
+
+<details>
+  <summary>Note for Macs with an Apple silicon chip</summary>
+
+    Some users have reported installation problems due to missing wheels for arm64 Macs when installing the `grpcio` package. To install the `dagster` development environment using our pre-built wheel of the `grpcio` package for M1, M2, and M3 machines, run `make dev_install_m1_grpcio_wheel` instead of `make dev_install`.
+ </details>
 
 6. Run some tests manually to make sure things are working:
 
    ```bash
    python -m pytest python_modules/dagster/dagster_tests
    ```
+
+   Depending on the speed of your computer, running the entire test suite can take an hour or more. `pytest` supports only running a subset of tests, for example `python -m pytest python_modules/dagster/dagster_tests/core_tests` will only run tests in the `core_tests` folder. See [this page](https://docs.pytest.org/en/stable/how-to/usage.html#specifying-which-tests-to-run) for more information on this feature.
 
 ## Developing Dagster
 

--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -78,18 +78,21 @@ Some notes on developing in Dagster:
 For development, run an instance of the webserver providing GraphQL service on a different port than the webapp, with any pipeline. For example:
 
 ```bash
-cd dagster/examples/docs_snippets/docs_snippets/intro_tutorial/basics/connecting_ops/
+cd examples/docs_snippets/docs_snippets/intro_tutorial/basics/connecting_ops/
 dagster-webserver -p 3333 -f complex_job.py
 ```
 
 Keep this running. Then, in another terminal, run the local development (autoreloading, etc.) version of the webapp:
 
+:::tip
+Don't forget to activate the virtual environment (`source .venv/scripts/activate`) when you open another terminal!
+:::
 ```bash
-cd dagster/js_modules/dagster-ui
+cd js_modules/dagster-ui
 make dev_webapp
 ```
 
-During development, you might find these commands useful. Run them from `dagster/js_modules/dagster-ui`:
+During development, you might find these commands useful. Run them from `js_modules/dagster-ui`:
 
 - `yarn ts`: Typescript typechecking
 - `yarn lint`: Linting with autofix

--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -8,6 +8,8 @@ We love to see our community members get involved! If you are planning to contri
 
 ## Environment setup
 
+You can develop for dagster using macOS, Linux, or Windows. If using Windows, you will need to install [WSL](https://learn.microsoft.com/windows/wsl/install) to follow the steps in this guide.
+
 1. Clone the Dagster repository to the destination of your choice:
 
    ```bash
@@ -15,7 +17,7 @@ We love to see our community members get involved! If you are planning to contri
    cd dagster
    ```
 
-2. [Install uv](https://docs.astral.sh/uv/getting-started/installation/). On macOS, Linux, or WSL, you can use `curl` to download the script and execute it with `sh`:
+2. [Install uv](https://docs.astral.sh/uv/getting-started/installation/). You can use `curl` to download the script and execute it with `sh`:
 
    ```bash
    curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -66,7 +66,7 @@ You can develop for Dagster using macOS, Linux, or Windows. If using Windows, yo
 
 7. (optional)
 
-   You can further verify your environment is setup by running Dagster's test suite, however this can take an hour or more to complete.
+   You can further verify your environment is set up by running Dagster's test suite, however this can take an hour or more to complete.
    ```bash
    python -m pytest python_modules/dagster/dagster_tests
    ```

--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -8,7 +8,7 @@ We love to see our community members get involved! If you are planning to contri
 
 ## Environment setup
 
-You can develop for Dagster using macOS, Linux, or Windows. If using Windows, you will need to install [WSL](https://learn.microsoft.com/windows/wsl/install) to follow the steps in this guide.
+You can develop for Dagster using macOS, Linux, or Windows. If using Windows, you will need to install and use [WSL](https://learn.microsoft.com/windows/wsl/install) to follow the steps in this guide.
 
 1. Clone the Dagster repository to the destination of your choice:
 
@@ -32,13 +32,11 @@ You can develop for Dagster using macOS, Linux, or Windows. If using Windows, yo
 
    Dagster supports Python 3.9 through 3.12.
 
-4. Ensure that you have a supported version of [node](https://nodejs.org/en/download) by running `node -v`, and that you have [yarn](https://yarnpkg.com/lang/en/) installed. Once you have node installed, you can use `npm` to install yarn.
+4. Ensure that you have a supported version of [node](https://nodejs.org/en/download) (20.X and above) by running `node -v`, and that you have [yarn](https://yarnpkg.com/lang/en/) installed. Once you have node installed, you can use `npm` to install yarn.
 
    ```bash
    npm install --global yarn
    ```
-
-   Dagster supports Node 20.X and above.
 
 5. Run `make dev_install` at the root of the repository. This sets up a full Dagster developer environment with all modules and runs tests that do not require heavy external dependencies such as docker. Note that certain sections of the makefile (`sanity_check`, which is part of `rebuild_ui`) require POSIX-compliant shells and will fail on CMD and powershell—if developing on windows, using something like WSL or git-bash is recommended.
 
@@ -85,7 +83,7 @@ dagster-webserver -p 3333 -f complex_job.py
 Keep this running. Then, in another terminal, run the local development (autoreloading, etc.) version of the webapp:
 
 :::tip
-Don't forget to activate the virtual environment (`source .venv/scripts/activate`) when you open another terminal!
+Don't forget to activate the virtual environment (`source .venv/bin/activate`) when you open another terminal!
 :::
 ```bash
 cd js_modules/dagster-ui

--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -8,7 +8,7 @@ We love to see our community members get involved! If you are planning to contri
 
 ## Environment setup
 
-You can develop for dagster using macOS, Linux, or Windows. If using Windows, you will need to install [WSL](https://learn.microsoft.com/windows/wsl/install) to follow the steps in this guide.
+You can develop for Dagster using macOS, Linux, or Windows. If using Windows, you will need to install [WSL](https://learn.microsoft.com/windows/wsl/install) to follow the steps in this guide.
 
 1. Clone the Dagster repository to the destination of your choice:
 

--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -38,7 +38,7 @@ You can develop for Dagster using macOS, Linux, or Windows. If using Windows, yo
    npm install --global yarn
    ```
 
-5. Run `make dev_install` at the root of the repository. This sets up a full Dagster developer environment with all modules and runs tests that do not require heavy external dependencies such as docker. Note that certain sections of the makefile (`sanity_check`, which is part of `rebuild_ui`) require POSIX-compliant shells and will fail on CMD and powershell—if developing on windows, using something like WSL or git-bash is recommended.
+5. Run `make dev_install` at the root of the repository. This sets up a full Dagster developer environment with all modules and runs tests that do not require heavy external dependencies such as docker.
 
    ```bash
    make dev_install
@@ -52,13 +52,25 @@ You can develop for Dagster using macOS, Linux, or Windows. If using Windows, yo
     Some users have reported installation problems due to missing wheels for arm64 Macs when installing the `grpcio` package. To install the `dagster` development environment using our pre-built wheel of the `grpcio` package for M1, M2, and M3 machines, run `make dev_install_m1_grpcio_wheel` instead of `make dev_install`.
  </details>
 
-6. Run some tests manually to make sure things are working:
+6. Verify `dagster` and `dagster-webserver` are installed and editable
+  
+    ```bash
+   $ dagster --version
+    dagster, version 1!0+dev
 
+   $ dagster-webserver --version
+   dagster-webserver, version 1!0+dev
+   ```
+
+   As long as you see `version 1!0+dev` in the output, you are all set up and ready to start making code changes to Dagster! 🎉  
+
+7. (optional)
+
+   You can further verify your environment is setup by running Dagster's test suite, however this can take an hour or more to complete.
    ```bash
    python -m pytest python_modules/dagster/dagster_tests
    ```
-
-   Depending on the speed of your computer, running the entire test suite can take an hour or more. `pytest` supports only running a subset of tests, for example `python -m pytest python_modules/dagster/dagster_tests/core_tests` will only run tests in the `core_tests` folder. See [this page](https://docs.pytest.org/en/stable/how-to/usage.html#specifying-which-tests-to-run) for more information on this feature.
+   To run only some of the tests, see [this page](https://docs.pytest.org/en/stable/how-to/usage.html#specifying-which-tests-to-run) of the `pytest` documentation.
 
 ## Developing Dagster
 


### PR DESCRIPTION
## Summary & Motivation
I work for [CodeDay](https://codeday.org) and we run a mentoring program helping students make their first Open Source contributions to projects like Dagster.

A common point of confusion for our students when getting started is they think you can only develop for Dagster on macOS.
This PR is primarily intended to improve that language, however I've also included other small changes to help make this page more accessible to new contributors. I've included my rationale for these changes as comments on the diff.

## How I Tested These Changes
I set the Dagster development environment up on my Linux machine, and confirmed these instructions work. I'm traveling this week and unable to access a Windows machine, but a colleague of mine has agreed to confirm the instructions work as provided using WSL, too - expect an update on that in the next couple days.

For the docs changes
```bash
cd docs
yarn build-api-docs
yarn build
```