### PR TITLE
[ui] Insights v2: Fix chart clicks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
@@ -252,7 +252,7 @@ export const AssetCatalogInsightsLineChart = React.memo(
 
       const clickedElements = chart.getElementsAtEventForMode(
         event.nativeEvent,
-        'y',
+        'index',
         {axis: 'x', intersect: false},
         false, // get elements in the clicked position even if animations are not completed
       );


### PR DESCRIPTION
## Summary & Motivation

When clicking on an Insights v2 chart, show the dialog based on the x-axis element index being clicked, not the specific y-axis point. This makes it so that when you click on the chart, you don't need to get the click exactly on the graph line.

## How I Tested These Changes

View insights graphs, click to view asset breakdown. Verify that the dialog appears correctly with my needing to click exactly on the graph line.