### PR TITLE
[dagster-sling] Update SlingReplicationComponent configuration + docs

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/9-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/global/9-defs.yaml
@@ -1,6 +1,10 @@
 type: my_project.components.custom_sling_replication_component.CustomSlingReplicationComponent
 
 attributes:
+  connections:
+    DUCKDB:
+      type: duckdb
+      instance: /tmp/jaffle_platform.duckdb
   replications:
     - path: replication.yaml
 post_processing:

--- a/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/9-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/customizing-existing-component/local/9-defs.yaml
@@ -1,6 +1,10 @@
 type: my_project.defs.my_sling_sync.component.CustomSlingReplicationComponent
 
 attributes:
+  connections:
+    DUCKDB:
+      type: duckdb
+      instance: /tmp/jaffle_platform.duckdb
   replications:
     - path: replication.yaml
 post_processing:

--- a/examples/docs_snippets/docs_snippets/guides/components/integrations/dlt-component/4-tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/integrations/dlt-component/4-tree.txt
@@ -5,10 +5,10 @@ my_project/defs
 └── github_snowflake_ingest
     ├── defs.yaml
     ├── github
+    │   ├── README.md
     │   ├── __init__.py
     │   ├── helpers.py
     │   ├── queries.py
-    │   ├── README.md
     │   └── settings.py
     └── loads.py
 

--- a/examples/docs_snippets/docs_snippets/guides/components/integrations/sling-component/11-customized-component.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/integrations/sling-component/11-customized-component.yaml
@@ -1,11 +1,10 @@
 type: dagster_sling.SlingReplicationCollectionComponent
 
 attributes:
-  sling:
-    connections:
-      - name: DUCKDB
-        type: duckdb
-        instance: /tmp/my_project.duckdb
+  connections:
+    DUCKDB:
+      type: duckdb
+      instance: /tmp/my_project.duckdb
   replications:
     - path: ./replication.yaml
       translation:

--- a/examples/docs_snippets/docs_snippets/guides/components/integrations/sling-component/9-customized-component.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/components/integrations/sling-component/9-customized-component.yaml
@@ -1,10 +1,9 @@
 type: dagster_sling.SlingReplicationCollectionComponent
 
 attributes:
-  sling:
-    connections:
-      - name: DUCKDB
-        type: duckdb
-        instance: /tmp/my_project.duckdb
+  connections:
+    DUCKDB:
+      type: duckdb
+      instance: /tmp/my_project.duckdb
   replications:
     - path: ./replication.yaml

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/10-component-with-env-deps.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/10-component-with-env-deps.yaml
@@ -1,16 +1,15 @@
 type: dagster_sling.SlingReplicationCollectionComponent
 
 attributes:
-  sling:
-    connections:
-      - name: SNOWFLAKE
-        type: snowflake
-        account: "{{ env.SNOWFLAKE_ACCOUNT }}"
-        user: "{{ env.SNOWFLAKE_USER }}"
-        password: "{{ env.SNOWFLAKE_PASSWORD }}"
-        database: "{{ env.SNOWFLAKE_DATABASE }}"
-    replications:
-      - path: replication.yaml
+  connections:
+    SNOWFLAKE:
+      type: snowflake
+      account: "{{ env.SNOWFLAKE_ACCOUNT }}"
+      user: "{{ env.SNOWFLAKE_USER }}"
+      password: "{{ env.SNOWFLAKE_PASSWORD }}"
+      database: "{{ env.SNOWFLAKE_DATABASE }}"
+  replications:
+    - path: replication.yaml
 
 requirements:
   env:

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/8-defs.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/8-defs.yaml
@@ -1,13 +1,12 @@
 type: dagster_sling.SlingReplicationCollectionComponent
 
 attributes:
-  sling:
-    connections:
-      - name: SNOWFLAKE
-        type: snowflake
-        account: "{{ env.SNOWFLAKE_ACCOUNT }}"
-        user: "{{ env.SNOWFLAKE_USER }}"
-        password: "{{ env.SNOWFLAKE_PASSWORD }}"
-        database: "{{ env.SNOWFLAKE_DATABASE }}"
-    replications:
-      - path: replication.yaml
+  connections:
+    SNOWFLAKE:
+      type: snowflake
+      account: "{{ env.SNOWFLAKE_ACCOUNT }}"
+      user: "{{ env.SNOWFLAKE_USER }}"
+      password: "{{ env.SNOWFLAKE_PASSWORD }}"
+      database: "{{ env.SNOWFLAKE_DATABASE }}"
+  replications:
+    - path: replication.yaml

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/9-dg-component-check.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/9-dg-component-check.txt
@@ -6,14 +6,13 @@ dg check yaml
      | ^ Component uses environment variables that are not specified in the component file: SNOWFLAKE_ACCOUNT, SNOWFLAKE_DATABASE, SNOWFLAKE_PASSWORD, SNOWFLAKE_USER
    2 | 
    3 | attributes:
-   4 |   sling:
-   5 |     connections:
-   6 |       - name: SNOWFLAKE
-   7 |         type: snowflake
-   8 |         account: "{{ env.SNOWFLAKE_ACCOUNT }}"
-   9 |         user: "{{ env.SNOWFLAKE_USER }}"
-  10 |         password: "{{ env.SNOWFLAKE_PASSWORD }}"
-  11 |         database: "{{ env.SNOWFLAKE_DATABASE }}"
-  12 |     replications:
-  13 |       - path: replication.yaml
+   4 |   connections:
+   5 |     SNOWFLAKE:
+   6 |       type: snowflake
+   7 |       account: "{{ env.SNOWFLAKE_ACCOUNT }}"
+   8 |       user: "{{ env.SNOWFLAKE_USER }}"
+   9 |       password: "{{ env.SNOWFLAKE_PASSWORD }}"
+  10 |       database: "{{ env.SNOWFLAKE_DATABASE }}"
+  11 |   replications:
+  12 |     - path: replication.yaml
      |

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_sling_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_sling_component.py
@@ -134,11 +134,10 @@ def test_components_docs_sling_workspace(
                 type: dagster_sling.SlingReplicationCollectionComponent
 
                 attributes:
-                  sling:
-                    connections:
-                      - name: DUCKDB
-                        type: duckdb
-                        instance: /tmp/my_project.duckdb
+                  connections:
+                    DUCKDB:
+                      type: duckdb
+                      instance: /tmp/my_project.duckdb
                   replications:
                     - path: ./replication.yaml
                     """
@@ -159,11 +158,10 @@ def test_components_docs_sling_workspace(
                 type: dagster_sling.SlingReplicationCollectionComponent
 
                 attributes:
-                  sling:
-                    connections:
-                      - name: DUCKDB
-                        type: duckdb
-                        instance: /tmp/my_project.duckdb
+                  connections:
+                    DUCKDB:
+                      type: duckdb
+                      instance: /tmp/my_project.duckdb
                   replications:
                     - path: ./replication.yaml
                       translation:

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_customizing_existing_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_customizing_existing_component.py
@@ -207,11 +207,10 @@ def test_components_docs_adding_attributes_to_assets(
                 {type_str}
 
                 attributes:
-                  sling:
-                    connections:
-                      - name: DUCKDB
-                        type: duckdb
-                        instance: /tmp/jaffle_platform.duckdb
+                  connections:
+                    DUCKDB:
+                      type: duckdb
+                      instance: /tmp/jaffle_platform.duckdb
                   replications:
                     - path: replication.yaml
                 """),
@@ -289,11 +288,10 @@ def test_components_docs_adding_attributes_to_assets(
                 {type_str}
 
                 attributes:
-                  sling:
-                    connections:
-                      - name: DUCKDB
-                        type: duckdb
-                        instance: /tmp/jaffle_platform.duckdb
+                  connections:
+                    DUCKDB:
+                      type: duckdb
+                      instance: /tmp/jaffle_platform.duckdb
                   replications:
                     - path: replication.yaml
                 post_processing:

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_using_env.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_using_env.py
@@ -320,16 +320,15 @@ def test_component_docs_using_env(
                     type: dagster_sling.SlingReplicationCollectionComponent
 
                     attributes:
-                      sling:
-                        connections:
-                          - name: SNOWFLAKE
-                            type: snowflake
-                            account: "{{ env.SNOWFLAKE_ACCOUNT }}"
-                            user: "{{ env.SNOWFLAKE_USER }}"
-                            password: "{{ env.SNOWFLAKE_PASSWORD }}"
-                            database: "{{ env.SNOWFLAKE_DATABASE }}"
-                        replications:
-                          - path: replication.yaml
+                      connections:
+                        SNOWFLAKE:
+                          type: snowflake
+                          account: "{{ env.SNOWFLAKE_ACCOUNT }}"
+                          user: "{{ env.SNOWFLAKE_USER }}"
+                          password: "{{ env.SNOWFLAKE_PASSWORD }}"
+                          database: "{{ env.SNOWFLAKE_DATABASE }}"
+                      replications:
+                        - path: replication.yaml
                     """),
             )
 
@@ -356,16 +355,15 @@ def test_component_docs_using_env(
                     type: dagster_sling.SlingReplicationCollectionComponent
 
                     attributes:
-                      sling:
-                        connections:
-                          - name: SNOWFLAKE
-                            type: snowflake
-                            account: "{{ env.SNOWFLAKE_ACCOUNT }}"
-                            user: "{{ env.SNOWFLAKE_USER }}"
-                            password: "{{ env.SNOWFLAKE_PASSWORD }}"
-                            database: "{{ env.SNOWFLAKE_DATABASE }}"
-                        replications:
-                          - path: replication.yaml
+                      connections:
+                        SNOWFLAKE:
+                          type: snowflake
+                          account: "{{ env.SNOWFLAKE_ACCOUNT }}"
+                          user: "{{ env.SNOWFLAKE_USER }}"
+                          password: "{{ env.SNOWFLAKE_PASSWORD }}"
+                          database: "{{ env.SNOWFLAKE_DATABASE }}"
+                      replications:
+                        - path: replication.yaml
 
                     requirements:
                       env:

--- a/python_modules/libraries/dagster-sling/dagster_sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/asset_decorator.py
@@ -104,6 +104,22 @@ def sling_assets(
             def my_assets(context, sling: SlingResource):
                 yield from sling.replicate(context=context)
     """
+    return multi_asset(
+        name=name,
+        partitions_def=partitions_def,
+        can_subset=True,
+        op_tags=op_tags,
+        backfill_policy=backfill_policy,
+        specs=get_sling_asset_specs(replication_config, dagster_sling_translator, partitions_def),
+        pool=pool,
+    )
+
+
+def get_sling_asset_specs(
+    replication_config: SlingReplicationParam,
+    dagster_sling_translator: Optional[DagsterSlingTranslator] = None,
+    partitions_def: Optional[PartitionsDefinition] = None,
+) -> list[AssetSpec]:
     replication_config = validate_replication(replication_config)
 
     raw_streams = get_streams_from_replication(replication_config)
@@ -124,22 +140,20 @@ def sling_assets(
             return asset_spec.replace_attributes(code_version=code_version)
         return asset_spec
 
-    return multi_asset(
-        name=name,
-        partitions_def=partitions_def,
-        can_subset=True,
-        op_tags=op_tags,
-        backfill_policy=backfill_policy,
-        specs=[
-            update_code_version_if_unset_by_translator(
-                dagster_sling_translator.get_asset_spec(stream).merge_attributes(
-                    metadata={
-                        METADATA_KEY_TRANSLATOR: dagster_sling_translator,
-                        METADATA_KEY_REPLICATION_CONFIG: replication_config,
-                    }
-                )
+    base_specs = [
+        update_code_version_if_unset_by_translator(
+            dagster_sling_translator.get_asset_spec(stream).merge_attributes(
+                metadata={
+                    METADATA_KEY_TRANSLATOR: dagster_sling_translator,
+                    METADATA_KEY_REPLICATION_CONFIG: replication_config,
+                }
             )
-            for stream in streams
-        ],
-        pool=pool,
-    )
+        )
+        for stream in streams
+    ]
+    return [
+        spec.replace_attributes(
+            partitions_def=partitions_def or spec.partitions_def, skippable=True
+        )
+        for spec in base_specs
+    ]

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -21,6 +21,8 @@ from dagster.components.resolved.context import ResolutionContext
 from dagster.components.resolved.core_models import AssetAttributesModel, AssetPostProcessor, OpSpec
 from dagster.components.scaffold.scaffold import scaffold_with
 from dagster.components.utils import TranslatorResolvingInfo
+from dagster_shared.utils.warnings import deprecation_warning
+from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypeAlias
 
 from dagster_sling.asset_decorator import sling_assets
@@ -28,7 +30,7 @@ from dagster_sling.components.sling_replication_collection.scaffolder import (
     SlingReplicationComponentScaffolder,
 )
 from dagster_sling.dagster_sling_translator import DagsterSlingTranslator
-from dagster_sling.resources import AssetExecutionContext, SlingResource
+from dagster_sling.resources import AssetExecutionContext, SlingConnectionResource, SlingResource
 
 SlingMetadataAddons: TypeAlias = Literal["column_metadata", "row_count"]
 
@@ -87,8 +89,57 @@ class SlingReplicationSpecModel(Resolvable):
 def resolve_resource(
     context: ResolutionContext,
     sling,
-) -> SlingResource:
-    return SlingResource(**context.resolve_value(sling.model_dump())) if sling else SlingResource()
+) -> Optional[SlingResource]:
+    if sling:
+        deprecation_warning(
+            "The `sling` field is deprecated, use `connections` instead. This field will be removed in a future release.",
+            "1.11.1",
+        )
+    return SlingResource(**context.resolve_value(sling.model_dump())) if sling else None
+
+
+def replicate(
+    context: AssetExecutionContext,
+    connections: list[SlingConnectionResource],
+) -> Iterator[Union[AssetMaterialization, MaterializeResult]]:
+    sling = SlingResource(connections=connections)
+    yield from sling.replicate(context=context)
+
+
+class SlingConnectionResourcePropertiesModel(Resolvable, BaseModel):
+    """Properties of a Sling connection resource."""
+
+    # each connection type supports a variety of different properties
+    model_config = ConfigDict(extra="allow")
+
+    type: str = Field(
+        description="Type of the source connection, must match the Sling connection types. Use 'file' for local storage."
+    )
+    connection_string: Optional[str] = Field(
+        description="The optional connection string for the source database, if not using keyword arguments.",
+        default=None,
+    )
+
+
+def resolve_connections(
+    context: ResolutionContext,
+    connections: Mapping[str, SlingConnectionResourcePropertiesModel],
+) -> list[SlingConnectionResource]:
+    return [
+        SlingConnectionResource(
+            name=name,
+            **context.resolve_value(connection.model_dump()),
+        )
+        for name, connection in connections.items()
+    ]
+
+
+ResolvedSlingConnections: TypeAlias = Annotated[
+    list[SlingConnectionResource],
+    Resolver(
+        resolve_connections, model_field_type=Mapping[str, SlingConnectionResourcePropertiesModel]
+    ),
+]
 
 
 @scaffold_with(SlingReplicationComponentScaffolder)
@@ -105,16 +156,18 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
     file. See Sling's [documentation](https://docs.slingdata.io/concepts/replication#overview) on `replication.yaml`.
     """
 
-    resource: Annotated[
-        SlingResource,
-        Resolver(
-            resolve_resource,
-            model_field_name="sling",
-        ),
-    ] = field(default_factory=SlingResource)
+    connections: ResolvedSlingConnections = field(default_factory=list)
     replications: Sequence[SlingReplicationSpecModel] = field(default_factory=list)
     # TODO: deprecate and then delete -- schrockn 2025-06-10
     asset_post_processors: Optional[Sequence[AssetPostProcessor]] = None
+    resource: Annotated[
+        Optional[SlingResource],
+        Resolver(resolve_resource, model_field_name="sling"),
+    ] = None
+
+    @cached_property
+    def sling_resource(self) -> SlingResource:
+        return self.resource or SlingResource(connections=self.connections)
 
     def build_asset(
         self, context: ComponentLoadContext, replication_spec_model: SlingReplicationSpecModel
@@ -142,7 +195,9 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
         )
         def _asset(context: AssetExecutionContext):
             yield from self.execute(
-                context=context, sling=self.resource, replication_spec_model=replication_spec_model
+                context=context,
+                sling=self.sling_resource,
+                replication_spec_model=replication_spec_model,
             )
 
         return _asset

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/code_locations/sling_location_legacy/defs/ingest/defs.yaml
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/code_locations/sling_location_legacy/defs/ingest/defs.yaml
@@ -5,8 +5,9 @@ attributes:
     - path: ./replication.yaml
       translation:
         key: "foo/{{ stream_definition.config.meta.dagster.asset_key }}"
-  connections:
-    DUCKDB:
-      type: duckdb
-      instance: <PLACEHOLDER>
-      password: "{{ env.SOME_PASSWORD }}"
+  sling:
+    connections:
+      - name: DUCKDB
+        type: duckdb
+        instance: <PLACEHOLDER>
+        password: "{{ env.SOME_PASSWORD }}"

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/code_locations/sling_location_legacy/defs/ingest/replication.yaml
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/code_locations/sling_location_legacy/defs/ingest/replication.yaml
@@ -1,0 +1,14 @@
+source: LOCAL
+target: DUCKDB
+
+defaults:
+  mode: full-refresh
+  object: "{stream_table}"
+
+streams:
+  <PLACEHOLDER>:
+    object: "main.tbl"
+    meta:
+      dagster:
+        asset_key: input_duckdb
+        deps: [input_csv]

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/code_locations/sling_location_legacy/input.csv
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/code_locations/sling_location_legacy/input.csv
@@ -1,0 +1,4 @@
+SPECIES_CODE,SPECIES_NAME,UPDATED_AT
+abcdef,scrubjay,1
+defghi,bluejay,2
+jklnop,blackbird,2


### PR DESCRIPTION
## Summary & Motivation

Grabs changes from the following PRs:

- https://github.com/dagster-io/dagster/pull/30561
- https://github.com/dagster-io/dagster/pull/30802

and adds backwards compat (so existing sling usage will continue to function as usual, but will emit a deprecation warning)

In a future release, we can make the sling: config hard-error 

## How I Tested These Changes

## Changelog

[dagster-sling] The `SlingReplicationCollectionComponent` is now configured by passing `connections` directly. This means that the `sling` yaml field and the `resource` python argument are both deprecated, and will be removed in a future release. The `connections` field in yaml now shares a format with Sling's `env.yaml`.
