### PR TITLE
[docs] fix missing source links for decorated functions

### DIFF
--- a/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
@@ -190,13 +190,7 @@ class MdxTranslator(SphinxTranslator):
             "__func__",  # Method objects
             "fget",  # Property objects
             "__call__",  # Callable objects (last resort)
-            # Framework-specific patterns (generic names to avoid coupling):
-            "logger_fn",  # Dagster LoggerDefinition
-            "op_fn",  # Dagster OpDefinition
-            "resource_fn",  # Dagster ResourceDefinition
-            "sensor_fn",  # Dagster SensorDefinition
-            "schedule_fn",  # Dagster ScheduleDefinition
-            "hook_fn",  # Dagster HookDefinition
+            # Generic function storage patterns:
             "decorated",  # Generic decorated function access
             "inner",  # Generic inner function access
             "wrapped",  # Alternative to __wrapped__
@@ -204,6 +198,17 @@ class MdxTranslator(SphinxTranslator):
             "_fn",  # Private function storage (short form)
             "callback",  # Callback-style wrappers
             "handler",  # Handler-style wrappers
+            "target",  # Target function in wrappers
+            "original",  # Original function reference
+            "impl",  # Implementation function
+            "implementation",  # Full implementation name
+            # Common framework patterns (type_fn suffix pattern):
+            "fn",  # Simple fn suffix
+            "logger_fn",  # Any logger-type function
+            "main_fn",  # Main function reference
+            "exec_fn",  # Execution function
+            "run_fn",  # Run function
+            "call_fn",  # Call function
         ]
 
         current_obj = obj

--- a/docs/sphinx/_ext/sphinx-mdx-builder/tests/dummy_module.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/tests/dummy_module.py
@@ -7,6 +7,14 @@ from enum import Enum
 from typing import Any, Optional
 
 
+def decorator_with_args(**kwargs):
+    """A decorator that takes arguments to simulate @logger decorator."""
+    def decorator(func):
+        func._decorator_metadata = kwargs
+        return func
+    return decorator
+
+
 class Color(Enum):
     """Color enumeration for testing enum documentation."""
 
@@ -145,3 +153,22 @@ EXAMPLE_CARS = [
     Car("Honda", "Civic", 2019, 4, Color.RED),
     Car("Ford", "Mustang", 2021, 2, Color.RED),
 ]
+
+
+@decorator_with_args(
+    config={"log_level": "INFO", "name": "test_logger"},
+    description="A test decorated logger function."
+)
+def test_decorated_logger(init_context=None):
+    """This is a test function with a decorator to replicate the colored_console_logger issue.
+    
+    This function simulates the dagster._loggers.colored_console_logger pattern
+    where source links might be missing for decorated functions.
+    
+    Args:
+        init_context: The initialization context (optional)
+        
+    Returns:
+        str: A test logger message
+    """
+    return f"Test logger initialized with context: {init_context}"

--- a/docs/sphinx/_ext/sphinx-mdx-builder/tests/dummy_module.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/tests/dummy_module.py
@@ -9,9 +9,11 @@ from typing import Any, Optional
 
 def decorator_with_args(**kwargs):
     """A decorator that takes arguments to simulate @logger decorator."""
+
     def decorator(func):
-        func._decorator_metadata = kwargs
+        func.decorator_metadata = kwargs
         return func
+
     return decorator
 
 
@@ -157,17 +159,17 @@ EXAMPLE_CARS = [
 
 @decorator_with_args(
     config={"log_level": "INFO", "name": "test_logger"},
-    description="A test decorated logger function."
+    description="A test decorated logger function.",
 )
 def test_decorated_logger(init_context=None):
     """This is a test function with a decorator to replicate the colored_console_logger issue.
-    
+
     This function simulates the dagster._loggers.colored_console_logger pattern
     where source links might be missing for decorated functions.
-    
+
     Args:
         init_context: The initialization context (optional)
-        
+
     Returns:
         str: A test logger message
     """

--- a/docs/sphinx/_ext/sphinx-mdx-builder/tests/test_docs/dummy_module.rst
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/tests/test_docs/dummy_module.rst
@@ -41,6 +41,14 @@ Functions
 
 .. autofunction:: dummy_module.get_car_summary
 
+.. autofunction:: dummy_module.test_dagster_style_logger
+
+.. autofunction:: dummy_module.test_func_wrapper
+
+.. autofunction:: dummy_module.test_function_wrapper
+
+.. autofunction:: dummy_module.test_callback_wrapper
+
 Constants
 ---------
 

--- a/docs/sphinx/_ext/sphinx-mdx-builder/tests/test_mdx_builder.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/tests/test_mdx_builder.py
@@ -226,7 +226,7 @@ class TestMdxBuilder:
 
         # Test functions with different wrapper patterns
         wrapper_functions = [
-            ("test_dagster_style_logger", 202, 208),  # LoggerDefinition with logger_fn
+            ("test_dagster_style_logger", 202, 208),  # Custom wrapper with logger_fn
             ("test_func_wrapper", 224, 230),  # GenericWrapper with func
             ("test_function_wrapper", 234, 240),  # GenericWrapper with function
             ("test_callback_wrapper", 243, 249),  # GenericWrapper with callback

--- a/docs/sphinx/_ext/sphinx-mdx-builder/tests/test_mdx_builder.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/tests/test_mdx_builder.py
@@ -237,7 +237,7 @@ class TestMdxBuilder:
 
         # Find all source links in the content
         source_link_pattern = (
-            r'<a[^>]*href="([^"]*tests/dummy_module\.py#L\d+)"[^>]*>\[source\]</a>'
+            r"<a[^>]*href='([^']*tests/dummy_module\.py#L\d+)'[^>]*>\[source\]</a>"
         )
         source_links = re.findall(source_link_pattern, content)
 

--- a/docs/sphinx/_ext/sphinx-mdx-builder/tests/test_mdx_builder.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/tests/test_mdx_builder.py
@@ -230,32 +230,34 @@ class TestMdxBuilder:
         # Check that source links are present for decorated functions
         # This test is designed to catch the missing source link issue
         assert "[source]" in content, "Should have source links for decorated functions"
-        
+
         # Look for the specific source link for the decorated function
         # The source link should point to the line where the function is defined
         import re
-        
+
         # Find all source links in the content
-        source_link_pattern = r'<a[^>]*href="([^"]*tests/dummy_module\.py#L\d+)"[^>]*>\[source\]</a>'
+        source_link_pattern = (
+            r'<a[^>]*href="([^"]*tests/dummy_module\.py#L\d+)"[^>]*>\[source\]</a>'
+        )
         source_links = re.findall(source_link_pattern, content)
-        
+
         # Check that we have source links (this will fail if decorated functions are missing them)
         assert len(source_links) > 0, "Should have at least one source link for functions"
-        
+
         # Specifically check if there's a source link that includes the line number
         # where test_decorated_logger is defined (around line 162)
         decorated_function_source_found = False
         for link in source_links:
             if "dummy_module.py#L" in link:
                 # Extract line number from the link
-                line_match = re.search(r'#L(\d+)', link)
+                line_match = re.search(r"#L(\d+)", link)
                 if line_match:
                     line_num = int(line_match.group(1))
                     # The decorated function starts around line 158-162
                     if 158 <= line_num <= 165:
                         decorated_function_source_found = True
                         break
-        
+
         assert decorated_function_source_found, (
             "Should have source link for decorated function test_decorated_logger. "
             f"Found source links: {source_links}"

--- a/docs/sphinx/_ext/sphinx-mdx-builder/tests/test_mdx_builder.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/tests/test_mdx_builder.py
@@ -219,6 +219,48 @@ class TestMdxBuilder:
             "Source links should have proper security attributes"
         )
 
+    def test_decorated_function_source_links(self, built_docs):
+        """Test that decorated functions have source links generated properly."""
+        dummy_module_file = built_docs / "dummy_module.mdx"
+        content = dummy_module_file.read_text()
+
+        # Check that the decorated function is documented
+        assert "test_decorated_logger" in content, "Should document decorated function"
+
+        # Check that source links are present for decorated functions
+        # This test is designed to catch the missing source link issue
+        assert "[source]" in content, "Should have source links for decorated functions"
+        
+        # Look for the specific source link for the decorated function
+        # The source link should point to the line where the function is defined
+        import re
+        
+        # Find all source links in the content
+        source_link_pattern = r'<a[^>]*href="([^"]*tests/dummy_module\.py#L\d+)"[^>]*>\[source\]</a>'
+        source_links = re.findall(source_link_pattern, content)
+        
+        # Check that we have source links (this will fail if decorated functions are missing them)
+        assert len(source_links) > 0, "Should have at least one source link for functions"
+        
+        # Specifically check if there's a source link that includes the line number
+        # where test_decorated_logger is defined (around line 162)
+        decorated_function_source_found = False
+        for link in source_links:
+            if "dummy_module.py#L" in link:
+                # Extract line number from the link
+                line_match = re.search(r'#L(\d+)', link)
+                if line_match:
+                    line_num = int(line_match.group(1))
+                    # The decorated function starts around line 158-162
+                    if 158 <= line_num <= 165:
+                        decorated_function_source_found = True
+                        break
+        
+        assert decorated_function_source_found, (
+            "Should have source link for decorated function test_decorated_logger. "
+            f"Found source links: {source_links}"
+        )
+
 
 def test_direct_builder_import():
     """Test that the builder can be imported directly."""


### PR DESCRIPTION
## Summary & Motivation

- Fixes missing source links for decorated functions (eg. `dagster._loggers.colored_console_logger`)

## How I Tested These Changes

Confirmed links are present here:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8uYb05u2cFYvF82VTjME/853a5e61-a5ce-4eb4-9feb-6282fb207b9b.png)

## Changelog

NOCHANGELOG
