### PR TITLE
Fix broken fivetran docs snippets test

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_utils.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_utils.py
@@ -10,11 +10,7 @@ from dagster_fivetran.asset_defs import (
 from dagster_fivetran.components.workspace_component.component import (
     FivetranAccountComponent,
 )
-from dagster_fivetran.resources import (
-    FivetranConnector,
-    FivetranWorkspace,
-    load_fivetran_asset_specs,
-)
+from dagster_fivetran.resources import FivetranConnector, FivetranWorkspace
 from dagster_fivetran.translator import (
     FivetranDestination,
     FivetranSchema,
@@ -27,19 +23,6 @@ from dagster._utils.cached_method import cached_method
 
 
 class MockFivetranWorkspace(FivetranWorkspace):
-    @cached_method
-    def load_asset_specs(
-        self,
-        dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
-        connector_selector_fn: Optional[ConnectorSelectorFn] = None,
-    ) -> Sequence[AssetSpec]:
-        return load_fivetran_asset_specs(
-            workspace=self,
-            dagster_fivetran_translator=dagster_fivetran_translator
-            or DagsterFivetranTranslator(),
-            connector_selector_fn=connector_selector_fn,
-        )
-
     @cached_method
     def fetch_fivetran_workspace_data(
         self,


### PR DESCRIPTION
## Summary & Motivation

This was muted (hence builds not breaking), but there was a maximum recursion depth exceeded thing going on because the method being invoked just invoked `workspace.build_asset_specs()`.

Getting rid of this override causes the test to pass

## How I Tested These Changes

## Changelog

NOCHANGELOG
