### PR TITLE
Raise a bespoke `ImportError` when importing `FreshnessPolicy` from top-level Dagster

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -741,7 +741,7 @@ _DEPRECATED_RENAMED: Final[Mapping[str, tuple[Callable, str]]] = {
 _DEPRECATED_WITH_ERROR: Final[Mapping[str, str]] = {
     ##### EXAMPLE
     # "Foo": "Use Bar instead.",
-    "FreshnessPolicy": "FreshnessPolicy has been renamed to LegacyFreshnessPolicy. Import it as FreshnessPolicy from `dagster.deprecated` or as LegacyFreshnessPolicy from top-level Dagster.",
+    "FreshnessPolicy": "FreshnessPolicy was renamed to LegacyFreshnessPolicy in 1.11.0. For more information, please refer to the section 'Migrating to 1.11.0' in the migration guide (MIGRATION.md)."
 }
 
 

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -738,6 +738,12 @@ _DEPRECATED_RENAMED: Final[Mapping[str, tuple[Callable, str]]] = {
     # "Foo": (Bar, "1.1.0"),
 }
 
+_DEPRECATED_WITH_ERROR: Final[Mapping[str, str]] = {
+    ##### EXAMPLE
+    # "Foo": "Use Bar instead.",
+    "FreshnessPolicy": "FreshnessPolicy has been renamed to LegacyFreshnessPolicy. Import it as FreshnessPolicy from `dagster.deprecated` or as LegacyFreshnessPolicy from top-level Dagster.",
+}
+
 
 def __getattr__(name: str) -> TypingAny:
     if name in _DEPRECATED:
@@ -756,6 +762,8 @@ def __getattr__(name: str) -> TypingAny:
             stacklevel=stacklevel,
         )
         return value
+    elif name in _DEPRECATED_WITH_ERROR:
+        raise ImportError(_DEPRECATED_WITH_ERROR[name])
     else:
         raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
@@ -229,6 +229,15 @@ def test_freshness_policy_deprecated_import():
     dg.Definitions(assets=[foo])
 
 
+def test_freshness_policy_old_import_raises():
+    """We should not be able to import FreshnessPolicy from top level dagster module."""
+    with pytest.raises(
+        ImportError,
+        match="FreshnessPolicy has been renamed to LegacyFreshnessPolicy. Import it as FreshnessPolicy from `dagster.deprecated` or as LegacyFreshnessPolicy from top-level Dagster.",
+    ):
+        from dagster import FreshnessPolicy  # noqa: F401
+
+
 def test_freshness_policy_metadata_backcompat():
     """We should be able to deserialize freshness policy from an asset spec that stores the policy in its metadata."""
     from dagster._core.definitions.freshness import TimeWindowFreshnessPolicy

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
@@ -233,7 +233,7 @@ def test_freshness_policy_old_import_raises():
     """We should not be able to import FreshnessPolicy from top level dagster module."""
     with pytest.raises(
         ImportError,
-        match="FreshnessPolicy has been renamed to LegacyFreshnessPolicy. Import it as FreshnessPolicy from `dagster.deprecated` or as LegacyFreshnessPolicy from top-level Dagster.",
+        match=r"FreshnessPolicy was renamed to LegacyFreshnessPolicy in 1.11.0. For more information, please refer to the section 'Migrating to 1.11.0' in the migration guide \(MIGRATION.md\)",
     ):
         from dagster import FreshnessPolicy  # noqa: F401
 


### PR DESCRIPTION
## Summary & Motivation
User code should fail to compile with an `ImportError` when it tries to import `FreshnessPolicy` from top-level Dagster module.

```
from dagster import FreshnessPolicy
```
raises:
```
ImportError: FreshnessPolicy has been renamed to LegacyFreshnessPolicy. Import it as FreshnessPolicy from `dagster.deprecated` or as LegacyFreshnessPolicy from top-level Dagster.
```
Without this PR, user code will still fail with an `ImportError` - it just won't have the nice error message.

We'll remove this `ImportError` once the new freshness policy model (currently named `InternalFreshnessPolicy`) is moved out of preview and assumes the name `FreshnessPolicy`.

## How I Tested These Changes
a unit test added in this PR

## Changelog

> Insert changelog entry or delete this section.
- Adds a custom error message when importing `FreshnessPolicy` from the `dagster` module