### PR TITLE
Update freshness docs code samples for `1.11`

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/freshness/cron_policy.py
+++ b/examples/docs_snippets/docs_snippets/guides/freshness/cron_policy.py
@@ -1,11 +1,11 @@
 from datetime import timedelta
 
 from dagster import asset
-from dagster._core.definitions.freshness import InternalFreshnessPolicy
+from dagster.preview.freshness import FreshnessPolicy
 
 
 @asset(
-    internal_freshness_policy=InternalFreshnessPolicy.cron(
+    freshness_policy=FreshnessPolicy.cron(
         deadline_cron="0 10 * * *",
         lower_bound_delta=timedelta(hours=1),
         timezone="America/Los_Angeles",

--- a/examples/docs_snippets/docs_snippets/guides/freshness/default_freshness.py
+++ b/examples/docs_snippets/docs_snippets/guides/freshness/default_freshness.py
@@ -1,8 +1,7 @@
 from datetime import timedelta
 
 from dagster import Definitions, asset
-from dagster._core.definitions.asset_spec import attach_internal_freshness_policy
-from dagster._core.definitions.freshness import InternalFreshnessPolicy
+from dagster.preview.freshness import FreshnessPolicy, apply_freshness_policy
 
 
 @asset
@@ -12,7 +11,7 @@ def default_asset():
 
 
 @asset(
-    internal_freshness_policy=InternalFreshnessPolicy.cron(
+    freshness_policy=FreshnessPolicy.cron(
         deadline_cron="0 10 * * *",
         lower_bound_delta=timedelta(hours=1),
     )
@@ -24,11 +23,11 @@ def override_asset():
 
 defs = Definitions(assets=[default_asset, override_asset])
 
-default_policy = InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))
+default_policy = FreshnessPolicy.time_window(fail_window=timedelta(hours=24))
 
 # This will apply default_policy to default_asset, but retain the cron policy on override_asset
 defs = defs.map_asset_specs(
-    func=lambda spec: attach_internal_freshness_policy(
+    func=lambda spec: apply_freshness_policy(
         spec, default_policy, overwrite_existing=False
     ),
 )

--- a/examples/docs_snippets/docs_snippets/guides/freshness/individual_asset_policy.py
+++ b/examples/docs_snippets/docs_snippets/guides/freshness/individual_asset_policy.py
@@ -1,15 +1,15 @@
 from datetime import timedelta
 
 from dagster import AssetSpec, asset
-from dagster._core.definitions.freshness import InternalFreshnessPolicy
+from dagster.preview.freshness import FreshnessPolicy
 
-policy = InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))
+policy = FreshnessPolicy.time_window(fail_window=timedelta(hours=24))
 
 
-@asset(internal_freshness_policy=policy)
+@asset(freshness_policy=policy)
 def my_asset():
     pass
 
 
 # Or on an asset spec
-spec = AssetSpec("my_asset", internal_freshness_policy=policy)
+spec = AssetSpec("my_asset", freshness_policy=policy)

--- a/examples/docs_snippets/docs_snippets/guides/freshness/map_asset_specs_direct.py
+++ b/examples/docs_snippets/docs_snippets/guides/freshness/map_asset_specs_direct.py
@@ -1,9 +1,8 @@
 from datetime import timedelta
 
 from dagster import asset, map_asset_specs
-from dagster._core.definitions.asset_spec import attach_internal_freshness_policy
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.freshness import InternalFreshnessPolicy
+from dagster.preview.freshness import FreshnessPolicy, apply_freshness_policy
 
 
 @asset
@@ -16,11 +15,11 @@ def asset_2():
     pass
 
 
-policy = InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))
+policy = FreshnessPolicy.time_window(fail_window=timedelta(hours=24))
 
 assets = [asset_1, asset_2]
 assets_with_policies = map_asset_specs(
-    func=lambda spec: attach_internal_freshness_policy(spec, policy), iterable=assets
+    func=lambda spec: apply_freshness_policy(spec, policy), iterable=assets
 )
 
 defs = Definitions(assets=assets_with_policies)

--- a/examples/docs_snippets/docs_snippets/guides/freshness/multiple_assets_policy.py
+++ b/examples/docs_snippets/docs_snippets/guides/freshness/multiple_assets_policy.py
@@ -1,8 +1,7 @@
 from datetime import timedelta
 
 from dagster import Definitions, asset
-from dagster._core.definitions.asset_spec import attach_internal_freshness_policy
-from dagster._core.definitions.freshness import InternalFreshnessPolicy
+from dagster.preview.freshness import FreshnessPolicy, apply_freshness_policy
 
 
 @asset
@@ -20,17 +19,15 @@ def asset_2():
     pass
 
 
-policy = InternalFreshnessPolicy.time_window(fail_window=timedelta(hours=24))
+policy = FreshnessPolicy.time_window(fail_window=timedelta(hours=24))
 
 defs = Definitions(assets=[parent_asset, child_asset, asset_2])
 
 # Apply the policy to multiple assets - in this case, all assets in defs
-defs = defs.map_asset_specs(
-    func=lambda spec: attach_internal_freshness_policy(spec, policy)
-)
+defs = defs.map_asset_specs(func=lambda spec: apply_freshness_policy(spec, policy))
 
 # Use map_resolved_asset_specs to apply the policy to a selection
 defs = defs.map_resolved_asset_specs(
-    func=lambda spec: attach_internal_freshness_policy(spec, policy),
+    func=lambda spec: apply_freshness_policy(spec, policy),
     selection='key:"parent_asset"+',  # will apply policy to parent_asset and its downstream dependencies
 )

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -459,9 +459,9 @@ def map_asset_specs(
 def apply_freshness_policy(
     spec: AssetSpec, policy: InternalFreshnessPolicy, overwrite_existing=True
 ) -> AssetSpec:
-    """Apply a freshness policy to an asset spec, attaching it to the spec's metadata.
+    """Apply a freshness policy to an asset spec.
 
-    You can use this in Definitions.map_asset_specs to attach a freshness policy to an asset spec.
+    You can use this in Definitions.map_asset_specs to attach a freshness policy to a selection of asset specs.
     """
     if overwrite_existing:
         return spec._replace(freshness_policy=policy)


### PR DESCRIPTION
## Summary & Motivation
Update freshness docs code samples to be consistent with our recommended imports and usage for `1.11`.

- `from dagster._core.definitions.freshness import InternalFreshnessPolicy` -> `from dagster.preview.freshness import FreshnessPolicy`
- `from dagster._core.definitions.asset_spec import attach_internal_freshness_policy` -> `from dagster.preview.freshness import apply_freshness_policy`

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
