### PR TITLE
[ui] Asset checks: Show blocking

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -40,7 +40,7 @@
   "RunningBackfillsNoticeQuery": "edaaca1d6474672ae342eb3887f2aed16fbb502b704a603986d21f14bc10ee53",
   "AssetCheckAutomationListQuery": "559745a4f28472ae6f81faa603be4b4cedacad38132ce20f72e1799833430273",
   "AssetCheckDetailsQuery": "dafb023319ef2c8aa8075c43686b318d3206f5781b8b87cf21130db3172a9f71",
-  "AssetChecksQuery": "655a37486ebc6427fe969b59420b9590440a901b3b0c7adc4c8a9873c593a7fe",
+  "AssetChecksQuery": "df2f0eba0bb9816ab3ffabe630b837f47a61ae541a1b543bd7abf365b0754094",
   "AssetDaemonTicksQuery": "399ac77e660d40eba32c2ab06db2a2936a71e660d93ec108364eec1fdfc16788",
   "JobTileQuery": "6fd1bb8a16c8bd5fff0fb75f6608d5402a426d5c2763fefcb61d60e94ff0a3e8",
   "AssetColumnLineage": "bcb70460f77b88bbbfaec90982f3e99f522d9a4e270e63832684cfde169fabc7",

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckOverview.tsx
@@ -5,9 +5,11 @@ import {
   Colors,
   ExternalAnchorButton,
   FontFamily,
+  Icon,
   NonIdealState,
   Subtitle1,
   Subtitle2,
+  Tooltip,
 } from '@dagster-io/ui-components';
 import {useMemo} from 'react';
 import {Link} from 'react-router-dom';
@@ -51,6 +53,8 @@ export const AssetCheckOverview = ({
     [executions],
   );
 
+  const {blocking} = selectedCheck;
+
   return (
     <Box
       flex={{grow: 1, direction: 'column', gap: 12}}
@@ -61,6 +65,28 @@ export const AssetCheckOverview = ({
         header={<Subtitle1>About</Subtitle1>}
         arrowSide="right"
       >
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}} padding={{top: 12}}>
+          <Icon
+            name={blocking ? 'shield_check' : 'shield'}
+            color={blocking ? Colors.accentYellow() : Colors.accentPrimary()}
+          />
+          <Caption>
+            This is a <strong>{blocking ? 'blocking' : 'non-blocking'}</strong> asset check.
+          </Caption>
+          <Tooltip
+            placement="top"
+            display="block"
+            content={
+              <div style={{width: 300}}>
+                {blocking
+                  ? 'A blocking check prevents downstream asset materializations if the check fails.'
+                  : 'A non-blocking check allows downstream asset materializations to proceed regardless of the check result.'}
+              </div>
+            }
+          >
+            <Icon name="info" color={Colors.accentGray()} size={12} />
+          </Tooltip>
+        </Box>
         <Box padding={{top: 12}} flex={{gap: 12, direction: 'column'}}>
           {selectedCheck.description ? (
             <Description description={selectedCheck.description} maxHeight={260} />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
@@ -154,6 +154,7 @@ export const ASSET_CHECK_TABLE_FRAGMENT = gql`
     name
     description
     canExecuteIndividually
+    blocking
     automationCondition {
       label
       expandedLabel

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecksQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecksQuery.types.ts
@@ -31,6 +31,7 @@ export type AssetChecksQuery = {
                 canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
                 jobNames: Array<string>;
                 description: string | null;
+                blocking: boolean;
                 assetKey: {__typename: 'AssetKey'; path: Array<string>};
                 automationCondition: {
                   __typename: 'AutomationCondition';
@@ -256,4 +257,4 @@ export type AssetChecksQuery = {
     | {__typename: 'AssetNotFoundError'};
 };
 
-export const AssetChecksQueryVersion = '655a37486ebc6427fe969b59420b9590440a901b3b0c7adc4c8a9873c593a7fe';
+export const AssetChecksQueryVersion = 'df2f0eba0bb9816ab3ffabe630b837f47a61ae541a1b543bd7abf365b0754094';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/VirtualizedAssetCheckTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/VirtualizedAssetCheckTable.types.ts
@@ -7,6 +7,7 @@ export type AssetCheckTableFragment = {
   name: string;
   description: string | null;
   canExecuteIndividually: Types.AssetCheckCanExecuteIndividually;
+  blocking: boolean;
   jobNames: Array<string>;
   automationCondition: {
     __typename: 'AutomationCondition';


### PR DESCRIPTION
## Summary & Motivation

Show whether an asset check is `blocking`.

Non-blocking:

<img width="271" alt="Screenshot 2025-06-24 at 11 52 01" src="https://github.com/user-attachments/assets/450522f0-f113-4897-aa1a-945320b921c0" />

Blocking:

<img width="252" alt="Screenshot 2025-06-24 at 11 51 47" src="https://github.com/user-attachments/assets/3c571980-e86a-4515-948d-1077b0a26bbb" />


## How I Tested These Changes

View an asset check, force one `blocking` value or the other. Verify rendering.

## Changelog

[ui] Show whether an asset check is `blocking`.
