### PR TITLE
Add Python 3.13 block for dbt17 tests

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -473,6 +473,12 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             for deps_factor in ["dbt17", "dbt18", "dbt19"]
             for command_factor in ["cloud", "core-main", "core-derived-metadata"]
         ],
+        # dbt-core 1.7's protobuf<5 constraint conflicts with the grpc requirement for Python 3.13
+        unsupported_python_versions=(
+            lambda tox_factor: [AvailablePythonVersion.V3_13]
+            if tox_factor.startswith("dbt17")
+            else []
+        ),
     ),
     PackageSpec(
         "python_modules/libraries/dagster-snowflake",


### PR DESCRIPTION
## Summary
- mark Python 3.13 as unsupported for dagster-dbt's dbt17 tox factor
- note dbt-core 1.7's protobuf requirement conflicts with grpc

## Testing
- `ruff check .buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py` *(fails: Required version `==0.11.5` does not match the running version `0.11.13`)*

------
https://chatgpt.com/codex/tasks/task_e_685aff96124c8331bc20a13f6053fe64