### PR TITLE
Fix run_retries template for Helm 3.13

### DIFF
--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -113,7 +113,7 @@ data:
     {{- $runRetries := .Values.dagsterDaemon.runRetries }}
     run_retries:
       enabled: {{ $runRetries.enabled }}
-      {{- if $runRetries.maxRetries }}
+      {{- if gt $runRetries.maxRetries 0 }}
       max_retries: {{ $runRetries.maxRetries }}
       {{- end }}
       {{- if hasKey $runRetries "retryOnAssetOrOpFailure" }}


### PR DESCRIPTION
## Summary
- fix run_retries max_retries rendering on Helm 3.13

## Testing
- `pytest helm/dagster/schema/schema_tests/test_dagster_daemon.py::test_run_retries_default -q` *(fails: unrecognized arguments due to missing pytest plugins)*

------
https://chatgpt.com/codex/tasks/task_e_685afc4b232883318b9914ab28843273

## Changelog

NOCHANGELOG