### PR TITLE
[components] Avoid adding trailing whitespace to env vars that use dot notation in components

### DIFF
--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/component.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/component.py
@@ -209,7 +209,7 @@ def get_specified_env_var_deps(component_data: Mapping[str, Any]) -> set[str]:
 
 
 env_var_regex = re.compile(r"\{\{\s*env\(\s*['\"]([^'\"]+)['\"]\)\s*\}\}")
-env_var_regex_dot_notation = re.compile(r"\{\{\s*env\.([^'\"]+)\s*\}\}")
+env_var_regex_dot_notation = re.compile(r"\{\{\s*env\.([^'\"\s]+)\s*\}\}")
 
 
 def get_used_env_vars(data_structure: Union[Mapping[str, Any], Sequence[Any], Any]) -> set[str]:


### PR DESCRIPTION
## Summary & Motivation

`dg check yaml` was incorrectly matching environment variables in `defs.yaml`.

## How I Tested These Changes

```python
import re

# Before
env_var_regex_dot_notation = re.compile(r"\{\{\s*env\.([^'\"]+)\s*\}\}")
print(env_var_regex_dot_notation.findall("{{ env.FOO }}"))
# ['FOO ']   NOTICE THE TRAILING SPACE :D

# After
env_var_regex_dot_notation = re.compile(r"\{\{\s*env\.([^'\"\s]+)\s*\}\}")
print(env_var_regex_dot_notation.findall("{{ env.FOO }}"))
# ['FOO']
```

## Changelog

- Avoid adding trailing whitespace in env vars that use dot notation in components
