### PR TITLE
[freshness] Resolver for freshnessStatusInfo

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -706,6 +706,7 @@ type AssetNode {
   description: String
   freshnessInfo: AssetFreshnessInfo
   freshnessPolicy: FreshnessPolicy
+  freshnessStatusInfo: FreshnessStatusInfo
   internalFreshnessPolicy: InternalFreshnessPolicy
   autoMaterializePolicy: AutoMaterializePolicy
   automationCondition: AutomationCondition
@@ -925,6 +926,11 @@ type FreshnessPolicy {
   cronSchedule: String
   cronScheduleTimezone: String
   lastEvaluationTimestamp: String
+}
+
+type FreshnessStatusInfo {
+  freshnessStatus: AssetHealthStatus!
+  freshnessStatusMetadata: AssetHealthFreshnessMeta
 }
 
 union InternalFreshnessPolicy = TimeWindowFreshnessPolicy | CronFreshnessPolicy

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -539,6 +539,7 @@ export type AssetNode = {
   description: Maybe<Scalars['String']['output']>;
   freshnessInfo: Maybe<AssetFreshnessInfo>;
   freshnessPolicy: Maybe<FreshnessPolicy>;
+  freshnessStatusInfo: Maybe<FreshnessStatusInfo>;
   graphName: Maybe<Scalars['String']['output']>;
   groupName: Scalars['String']['output'];
   hasAssetChecks: Scalars['Boolean']['output'];
@@ -1875,6 +1876,12 @@ export type FreshnessPolicy = {
   cronScheduleTimezone: Maybe<Scalars['String']['output']>;
   lastEvaluationTimestamp: Maybe<Scalars['String']['output']>;
   maximumLagMinutes: Scalars['Float']['output'];
+};
+
+export type FreshnessStatusInfo = {
+  __typename: 'FreshnessStatusInfo';
+  freshnessStatus: AssetHealthStatus;
+  freshnessStatusMetadata: Maybe<AssetHealthFreshnessMeta>;
 };
 
 export type Graph = SolidContainer & {
@@ -7157,6 +7164,12 @@ export const buildAssetNode = (
         : relationshipsToOmit.has('FreshnessPolicy')
           ? ({} as FreshnessPolicy)
           : buildFreshnessPolicy({}, relationshipsToOmit),
+    freshnessStatusInfo:
+      overrides && overrides.hasOwnProperty('freshnessStatusInfo')
+        ? overrides.freshnessStatusInfo!
+        : relationshipsToOmit.has('FreshnessStatusInfo')
+          ? ({} as FreshnessStatusInfo)
+          : buildFreshnessStatusInfo({}, relationshipsToOmit),
     graphName: overrides && overrides.hasOwnProperty('graphName') ? overrides.graphName! : 'et',
     groupName:
       overrides && overrides.hasOwnProperty('groupName') ? overrides.groupName! : 'asperiores',
@@ -9249,6 +9262,27 @@ export const buildFreshnessPolicy = (
       overrides && overrides.hasOwnProperty('maximumLagMinutes')
         ? overrides.maximumLagMinutes!
         : 6.15,
+  };
+};
+
+export const buildFreshnessStatusInfo = (
+  overrides?: Partial<FreshnessStatusInfo>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'FreshnessStatusInfo'} & FreshnessStatusInfo => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('FreshnessStatusInfo');
+  return {
+    __typename: 'FreshnessStatusInfo',
+    freshnessStatus:
+      overrides && overrides.hasOwnProperty('freshnessStatus')
+        ? overrides.freshnessStatus!
+        : AssetHealthStatus.DEGRADED,
+    freshnessStatusMetadata:
+      overrides && overrides.hasOwnProperty('freshnessStatusMetadata')
+        ? overrides.freshnessStatusMetadata!
+        : relationshipsToOmit.has('AssetHealthFreshnessMeta')
+          ? ({} as AssetHealthFreshnessMeta)
+          : buildAssetHealthFreshnessMeta({}, relationshipsToOmit),
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -7,6 +7,9 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.asset_graph_differ import AssetDefinitionChangeType, AssetGraphDiffer
+from dagster._core.definitions.asset_health.asset_freshness_health import (
+    get_freshness_status_and_metadata,
+)
 from dagster._core.definitions.asset_spec import SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET
 from dagster._core.definitions.data_version import (
     NULL_DATA_VERSION,
@@ -85,7 +88,10 @@ from dagster_graphql.schema.dagster_types import (
 )
 from dagster_graphql.schema.entity_key import GrapheneAssetKey
 from dagster_graphql.schema.errors import GrapheneAssetNotFoundError
-from dagster_graphql.schema.freshness import GrapheneInternalFreshnessPolicy
+from dagster_graphql.schema.freshness import (
+    GrapheneFreshnessStatusInfo,
+    GrapheneInternalFreshnessPolicy,
+)
 from dagster_graphql.schema.freshness_policy import (
     GrapheneAssetFreshnessInfo,
     GrapheneFreshnessPolicy,
@@ -271,6 +277,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     description = graphene.String()
     freshnessInfo = graphene.Field(GrapheneAssetFreshnessInfo)
     freshnessPolicy = graphene.Field(GrapheneFreshnessPolicy)
+    freshnessStatusInfo = graphene.Field(GrapheneFreshnessStatusInfo)
     internalFreshnessPolicy = graphene.Field(GrapheneInternalFreshnessPolicy)
     autoMaterializePolicy = graphene.Field(GrapheneAutoMaterializePolicy)
     automationCondition = graphene.Field(GrapheneAutomationCondition)
@@ -846,6 +853,26 @@ class GrapheneAssetNode(graphene.ObjectType):
         if self._asset_node_snap.legacy_freshness_policy:
             return GrapheneFreshnessPolicy(self._asset_node_snap.legacy_freshness_policy)
         return None
+
+    async def resolve_freshnessStatusInfo(
+        self, graphene_info: ResolveInfo
+    ) -> Optional[GrapheneFreshnessStatusInfo]:
+        from dagster_graphql.schema.asset_health import GrapheneAssetHealthFreshnessMeta
+
+        if not self._asset_node_snap.freshness_policy:
+            return None
+
+        freshness_status, freshness_status_metadata = await get_freshness_status_and_metadata(
+            graphene_info.context, self._asset_node_snap.asset_key
+        )
+        return GrapheneFreshnessStatusInfo(
+            freshnessStatus=freshness_status,
+            freshnessStatusMetadata=GrapheneAssetHealthFreshnessMeta(
+                lastMaterializedTimestamp=freshness_status_metadata.last_materialized_timestamp
+            )
+            if freshness_status_metadata
+            else None,
+        )
 
     def resolve_internalFreshnessPolicy(
         self, graphene_info: ResolveInfo

--- a/python_modules/dagster-graphql/dagster_graphql/schema/freshness.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/freshness.py
@@ -5,6 +5,19 @@ from dagster._core.definitions.freshness import (
     TimeWindowFreshnessPolicy,
 )
 
+from dagster_graphql.schema.asset_health import (
+    GrapheneAssetHealthFreshnessMeta,
+    GrapheneAssetHealthStatus,
+)
+
+
+class GrapheneFreshnessStatusInfo(graphene.ObjectType):
+    freshnessStatus = graphene.NonNull(GrapheneAssetHealthStatus)
+    freshnessStatusMetadata = graphene.Field(GrapheneAssetHealthFreshnessMeta)
+
+    class Meta:
+        name = "FreshnessStatusInfo"
+
 
 class GrapheneTimeWindowFreshnessPolicy(graphene.ObjectType):
     class Meta:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_internal_freshness.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_internal_freshness.py
@@ -2,11 +2,16 @@ from datetime import timedelta
 
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.freshness import InternalFreshnessPolicy
+from dagster._core.definitions.freshness import (
+    FreshnessState,
+    FreshnessStateChange,
+    InternalFreshnessPolicy,
+)
 from dagster._core.definitions.repository_definition.repository_definition import (
     RepositoryDefinition,
 )
 from dagster._core.test_utils import instance_for_test
+from dagster._time import get_current_timestamp
 from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql
 
 GET_INTERNAL_FRESHNESS_POLICY = """
@@ -21,6 +26,21 @@ query GetInternalFreshnessPolicy($assetKey: AssetKeyInput!) {
                 deadlineCron
                 lowerBoundDeltaSeconds
                 timezone
+            }
+        }
+    }
+}
+"""
+
+GET_FRESHNESS_STATUS_INFO = """
+query GetFreshnessStatusInfo($assetKey: AssetKeyInput!) {
+    assetNodes(assetKeys: [$assetKey]) {
+        freshnessStatusInfo {
+            freshnessStatus
+            freshnessStatusMetadata {
+                ... on AssetHealthFreshnessMeta {
+                    lastMaterializedTimestamp
+                }
             }
         }
     }
@@ -74,3 +94,35 @@ query getFreshnessEnabled {
                 variables={},
             )
             assert result.data["instance"]["freshnessEvaluationEnabled"] is False
+
+            # starts off with no status
+            result = execute_dagster_graphql(
+                graphql_context,
+                GET_FRESHNESS_STATUS_INFO,
+                variables={"assetKey": asset_with_freshness.key.to_graphql_input()},
+            )
+            assert result.data["assetNodes"][0]["freshnessStatusInfo"] is not None
+            assert (
+                result.data["assetNodes"][0]["freshnessStatusInfo"]["freshnessStatus"] == "UNKNOWN"
+            )
+
+            # now it's healthy
+            instance._report_runless_asset_event(  # noqa: SLF001
+                asset_event=FreshnessStateChange(
+                    key=asset_with_freshness.key,
+                    previous_state=FreshnessState.UNKNOWN,
+                    new_state=FreshnessState.PASS,
+                    state_change_timestamp=get_current_timestamp(),
+                )
+            )
+
+            # make sure it comes out as healthy
+            result = execute_dagster_graphql(
+                graphql_context,
+                GET_FRESHNESS_STATUS_INFO,
+                variables={"assetKey": asset_with_freshness.key.to_graphql_input()},
+            )
+            assert result.data["assetNodes"][0]["freshnessStatusInfo"] is not None
+            assert (
+                result.data["assetNodes"][0]["freshnessStatusInfo"]["freshnessStatus"] == "HEALTHY"
+            )


### PR DESCRIPTION
## Summary & Motivation

Adds a resolver that does not rely on AssetHealth to fetch freshness status info.

We should consider if we can rework how the AssetHealthStatus graphql layer works so that it can be more compatible with instances that don't support all of those queries, but for now we'll special-case this path

## How I Tested These Changes

## Changelog

NOCHANGELOG
