### PR TITLE
Use static array for default event types + rely on defaults in RecentEventUpdates

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -49,6 +49,9 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
+const OBSERVATION_EVENT_TYPE_SELECTOR = [AssetEventHistoryEventTypeSelector.OBSERVATION];
+const MATERIALIZATION_EVENT_TYPE_SELECTOR = [AssetEventHistoryEventTypeSelector.MATERIALIZATION];
+
 export const SidebarAssetInfo = ({graphNode}: {graphNode: GraphNode}) => {
   const {assetKey, definition} = graphNode;
   const {liveData} = useAssetLiveData(assetKey, 'sidebar');
@@ -67,11 +70,11 @@ export const SidebarAssetInfo = ({graphNode}: {graphNode: GraphNode}) => {
   const {lastMaterialization} = liveData || {};
   const asset = data?.assetNodeOrError.__typename === 'AssetNode' ? data.assetNodeOrError : null;
 
-  const recentEvents = useRecentAssetEvents(asset?.assetKey, 1, [
-    definition.isObservable
-      ? AssetEventHistoryEventTypeSelector.OBSERVATION
-      : AssetEventHistoryEventTypeSelector.MATERIALIZATION,
-  ]);
+  const recentEvents = useRecentAssetEvents(
+    asset?.assetKey,
+    1,
+    definition.isObservable ? OBSERVATION_EVENT_TYPE_SELECTOR : MATERIALIZATION_EVENT_TYPE_SELECTOR,
+  );
 
   if (!asset) {
     return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataPlots.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataPlots.tsx
@@ -9,6 +9,11 @@ import {
 } from './useRecentAssetEvents';
 import {AssetEventHistoryEventTypeSelector} from '../graphql/types';
 
+const EVENT_TYPE_SELECTORS = [
+  AssetEventHistoryEventTypeSelector.MATERIALIZATION,
+  AssetEventHistoryEventTypeSelector.OBSERVATION,
+];
+
 export const AssetTimeMetadataPlots = ({
   assetKey,
   limit,
@@ -20,10 +25,7 @@ export const AssetTimeMetadataPlots = ({
   asSidebarSection?: boolean;
   columnCount?: number;
 }) => {
-  const {events, loading} = useRecentAssetEvents(assetKey, limit, [
-    AssetEventHistoryEventTypeSelector.MATERIALIZATION,
-    AssetEventHistoryEventTypeSelector.OBSERVATION,
-  ]);
+  const {events, loading} = useRecentAssetEvents(assetKey, limit, EVENT_TYPE_SELECTORS);
   const grouped = useGroupedEvents('time', events, undefined);
 
   if (loading) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
@@ -22,7 +22,6 @@ import {useRefreshAtInterval} from '../app/QueryRefresh';
 import {Timestamp} from '../app/time/Timestamp';
 import {AssetLatestInfoFragment} from '../asset-data/types/AssetBaseDataProvider.types';
 import {AssetHealthFragment} from '../asset-data/types/AssetHealthDataProvider.types';
-import {AssetEventHistoryEventTypeSelector} from '../graphql/types';
 import {TimeFromNow} from '../ui/TimeFromNow';
 
 export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: AssetHealthFragment}) => {
@@ -33,11 +32,7 @@ export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: AssetHealthF
     latestInfo,
     loading,
     refetch,
-  } = useRecentAssetEvents(shouldQuery ? asset.key : undefined, 5, [
-    AssetEventHistoryEventTypeSelector.MATERIALIZATION,
-    AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE,
-    AssetEventHistoryEventTypeSelector.OBSERVATION,
-  ]);
+  } = useRecentAssetEvents(shouldQuery ? asset.key : undefined, 5);
 
   const {events} = useMemo(() => {
     if (!latestInfo?.inProgressRunIds.length && !latestInfo?.unstartedRunIds.length) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
@@ -20,7 +20,6 @@ import {AssetKey} from './types';
 import {useRecentAssetEvents} from './useRecentAssetEvents';
 import {Timestamp} from '../app/time/Timestamp';
 import {AssetRunLink} from '../asset-graph/AssetRunLinking';
-import {AssetEventHistoryEventTypeSelector} from '../graphql/types';
 import {RunStatusWithStats} from '../runs/RunStatusDots';
 import {titleForRun} from '../runs/RunUtils';
 import {useFormatDateTime} from '../ui/useFormatDateTime';
@@ -37,11 +36,7 @@ type Props = {
 };
 
 export const RecentUpdatesTimelineForAssetKey = memo((props: {assetKey: AssetKey}) => {
-  const data = useRecentAssetEvents(props.assetKey, 100, [
-    AssetEventHistoryEventTypeSelector.MATERIALIZATION,
-    AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE,
-    AssetEventHistoryEventTypeSelector.OBSERVATION,
-  ]);
+  const data = useRecentAssetEvents(props.assetKey, 100);
   return (
     <RecentUpdatesTimeline assetKey={props.assetKey} events={data.events} loading={data.loading} />
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
@@ -51,10 +51,16 @@ export function useLatestAssetPartitions(assetKey: AssetKey | undefined, limit: 
   return value;
 }
 
+const DEFAULT_EVENT_TYPE_SELECTORS = [
+  AssetEventHistoryEventTypeSelector.MATERIALIZATION,
+  AssetEventHistoryEventTypeSelector.OBSERVATION,
+  AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE,
+];
+
 export function useRecentAssetEvents(
   assetKey: AssetKey | undefined,
   limit: number,
-  eventTypeSelectors: AssetEventHistoryEventTypeSelector[],
+  eventTypeSelectors?: AssetEventHistoryEventTypeSelector[],
 ) {
   const queryResult = useQuery<RecentAssetEventsQuery, RecentAssetEventsQueryVariables>(
     RECENT_ASSET_EVENTS_QUERY,
@@ -64,11 +70,7 @@ export function useRecentAssetEvents(
       variables: {
         assetKey: {path: assetKey?.path || []},
         limit,
-        eventTypeSelectors: eventTypeSelectors || [
-          AssetEventHistoryEventTypeSelector.MATERIALIZATION,
-          AssetEventHistoryEventTypeSelector.OBSERVATION,
-          AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE,
-        ],
+        eventTypeSelectors: eventTypeSelectors || DEFAULT_EVENT_TYPE_SELECTORS,
       },
     },
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
@@ -58,22 +58,27 @@ const DEFAULT_EVENT_TYPE_SELECTORS = [
 ];
 
 export function useRecentAssetEvents(
-  assetKey: AssetKey | undefined,
+  _assetKey: AssetKey | undefined,
   limit: number,
   eventTypeSelectors: AssetEventHistoryEventTypeSelector[] = DEFAULT_EVENT_TYPE_SELECTORS,
 ) {
+  const assetKeyHash = useMemo(() => JSON.stringify(_assetKey?.path || []), [_assetKey]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const assetKey = useMemo(() => ({path: _assetKey?.path || []}), [assetKeyHash]);
+
   const queryResult = useQuery<RecentAssetEventsQuery, RecentAssetEventsQueryVariables>(
     RECENT_ASSET_EVENTS_QUERY,
     {
       skip: !assetKey,
       fetchPolicy: 'cache-and-network',
       variables: {
-        assetKey: useMemo(() => ({path: assetKey?.path || []}), [assetKey]),
+        assetKey,
         limit,
         eventTypeSelectors,
       },
     },
   );
+
   const {data, loading, refetch} = queryResult;
 
   const value = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
@@ -60,7 +60,7 @@ const DEFAULT_EVENT_TYPE_SELECTORS = [
 export function useRecentAssetEvents(
   assetKey: AssetKey | undefined,
   limit: number,
-  eventTypeSelectors?: AssetEventHistoryEventTypeSelector[],
+  eventTypeSelectors: AssetEventHistoryEventTypeSelector[] = DEFAULT_EVENT_TYPE_SELECTORS,
 ) {
   const queryResult = useQuery<RecentAssetEventsQuery, RecentAssetEventsQueryVariables>(
     RECENT_ASSET_EVENTS_QUERY,
@@ -70,7 +70,7 @@ export function useRecentAssetEvents(
       variables: {
         assetKey: {path: assetKey?.path || []},
         limit,
-        eventTypeSelectors: eventTypeSelectors || DEFAULT_EVENT_TYPE_SELECTORS,
+        eventTypeSelectors,
       },
     },
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
@@ -68,7 +68,7 @@ export function useRecentAssetEvents(
       skip: !assetKey,
       fetchPolicy: 'cache-and-network',
       variables: {
-        assetKey: {path: assetKey?.path || []},
+        assetKey: useMemo(() => ({path: assetKey?.path || []}), [assetKey]),
         limit,
         eventTypeSelectors,
       },


### PR DESCRIPTION
## Summary & Motivation
Trying to avoid changing `eventTypeSelectors` on ever render.

## How I Tested These Changes

app proxy