### PR TITLE
Add banner to Sling integration page

### DIFF
--- a/docs/docs/integrations/libraries/sling.md
+++ b/docs/docs/integrations/libraries/sling.md
@@ -12,7 +12,7 @@ partnerlink: https://slingdata.io/
 
 :::note
 
-If you are just getting started with the dlt integration, we recommend using the new [dlt component](/guides/build/components/integrations/sling-component-tutorial).
+If you are just getting started with the dlt integration, we recommend using the new [Sling component](/guides/build/components/integrations/sling-component-tutorial).
 
 :::
 

--- a/docs/docs/integrations/libraries/sling.md
+++ b/docs/docs/integrations/libraries/sling.md
@@ -10,6 +10,12 @@ sidebar_custom_props:
 partnerlink: https://slingdata.io/
 ---
 
+:::note
+
+If you are just getting started with the dlt integration, we recommend using the new [dlt component](/guides/build/components/integrations/sling-component-tutorial).
+
+:::
+
 <p>{frontMatter.description}</p>
 
 ## How it works


### PR DESCRIPTION
## Summary & Motivation

Add banner to point to tutorial for new component version of sling integration.

## How I Tested These Changes

Local build

## Changelog

> Insert changelog entry or delete this section.
