### PR TITLE
[dagster-dlt][components] fix asset key for default dlt scaffold

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
@@ -52,7 +52,9 @@ class ComponentDagsterDltTranslator(DagsterDltTranslator):
         table_name = data.resource.table_name
         if isinstance(table_name, Callable):
             table_name = data.resource.name
-        prefix = [data.pipeline.dataset_name] if data.pipeline else []
+        prefix = (
+            [data.pipeline.dataset_name] if data.pipeline and data.pipeline.dataset_name else []
+        )
         base_asset_spec = (
             super().get_asset_spec(data).replace_attributes(key=AssetKey(prefix + [table_name]))
         )


### PR DESCRIPTION
## Summary

Fix an issue where a `None` dataset name would be appended as an invalid asset key prefix.

`dataset_name` is theoretically non-`None`able, but seems in practice this can happen.

## Test Plan

e2e test

## Changelog

> [dagster-dlt][components] Fixed an issue where the default scaffolded dlt load lead to an invalid asset key.
