### PR TITLE
[toys] Add schedule for random assets

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/asset_health.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_health.py
@@ -205,6 +205,16 @@ def materialize_no_def_materializable_job():
     checks_no_def_materializable()
 
 
+random_assets_job = dg.define_asset_job(
+    "random_assets_job", selection=dg.AssetSelection.assets(random_1, random_2, random_3)
+)
+
+random_assets_every_15m_schedule = dg.ScheduleDefinition(
+    job=random_assets_job,
+    cron_schedule="*/15 * * * *",
+)
+
+
 def get_assets_and_checks():
     return [
         random_1,
@@ -230,4 +240,6 @@ def get_assets_and_checks():
         insert_source_asset_materializations_job,
         materialize_no_def_materializable_job,
         observe_no_def_observable_job,
+        random_assets_job,
+        random_assets_every_15m_schedule,
     ]


### PR DESCRIPTION
Adding this so that random assets can be executed every 15m, to populate some time to resolution metrics.

## How I Tested These Changes
Locally loaded toys

## Changelog
NOCHANGELOG