### PR TITLE
Increase batch size and parallelism for asset health queries

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -9,6 +9,7 @@ import {tokenForAssetKey, tokenToAssetKey} from '../asset-graph/Utils';
 import {AssetKeyInput} from '../graphql/types';
 import {liveDataFactory} from '../live-data-provider/Factory';
 import {LiveDataThreadID} from '../live-data-provider/LiveDataThread';
+import {THREAD_ID} from '../live-data-provider/util';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {
   AssetHealthFragment,
@@ -92,7 +93,7 @@ const memoizedAssetKeys = weakMapMemoize((assetKeys: AssetKeyInput[]) => {
 
 export function useAssetsHealthData(
   assetKeys: AssetKeyInput[],
-  thread: LiveDataThreadID = 'AssetHealth', // Use AssetHealth to get 250 batch size
+  thread: LiveDataThreadID = THREAD_ID.ASSET_HEALTH, // Use AssetHealth to get 250 batch size
 ) {
   const keys = memoizedAssetKeys(featureEnabled(FeatureFlag.flagUseNewObserveUIs) ? assetKeys : []);
   const result = AssetHealthData.useLiveData(keys, thread);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
@@ -31,6 +31,7 @@ import {CalculateUnsyncedDialog} from '../assets/CalculateUnsyncedDialog';
 import {useMaterializationAction} from '../assets/LaunchAssetExecutionButton';
 import {AssetKey} from '../assets/types';
 import {AssetHealthStatus} from '../graphql/types';
+import {THREAD_ID} from '../live-data-provider/util';
 import {numberFormatter} from '../ui/formatters';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 
@@ -142,7 +143,7 @@ const GroupNodeAssetStatusCountsAssetHealth = ({
 }) => {
   const assetKeys = React.useMemo(() => group.assets.map((node) => node.assetKey), [group.assets]);
 
-  const {liveDataByNode} = useAssetsHealthData(assetKeys, 'group-node');
+  const {liveDataByNode} = useAssetsHealthData(assetKeys, THREAD_ID.GROUP_NODE);
   const statuses = React.useMemo(() => {
     return Object.values(liveDataByNode).reduce(
       (acc, liveData) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
@@ -1,8 +1,8 @@
 import {LiveDataScheduler} from './LiveDataScheduler';
 import {LiveDataThreadManager} from './LiveDataThreadManager';
-import {BATCH_PARALLEL_FETCHES, BATCH_SIZE, threadIDToLimits} from './util';
+import {BATCH_PARALLEL_FETCHES, BATCH_SIZE, THREAD_ID, threadIDToLimits} from './util';
 
-export type LiveDataThreadID = string;
+export type LiveDataThreadID = string | THREAD_ID;
 
 export class LiveDataThread<T> {
   private listenersCount: {[key: string]: number};

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/util.ts
@@ -9,9 +9,22 @@ export const BATCH_PARALLEL_FETCHES = isNaN(batchThreads) ? 2 : batchThreads;
 export const SUBSCRIPTION_IDLE_POLL_RATE = 30 * 1000;
 export const SUBSCRIPTION_MAX_POLL_RATE = 2 * 1000;
 
+export enum THREAD_ID {
+  ASSET_HEALTH = 'asset-health',
+  ASSET_SELECTION_SUPPLEMENTARY_DATA = 'asset-selection',
+  GROUP_NODE = 'group-node',
+}
+
 export const threadIDToLimits = {
-  ['AssetHealth' as string]: {
+  [THREAD_ID.ASSET_HEALTH as string]: {
     batchSize: 250,
+    parallelThreads: 4,
+  },
+  [THREAD_ID.ASSET_SELECTION_SUPPLEMENTARY_DATA]: {
+    batchSize: 250,
+    parallelThreads: 4,
+  },
+  [THREAD_ID.GROUP_NODE]: {
     parallelThreads: 4,
   },
 };


### PR DESCRIPTION
Increase batch size and parallelism for asset health queries from the selection syntax status filtering thread and increase the number of parallel request for fetching data for group nodes in the asset graph.

On the catalog page
Before this change: 4 parallel requests x 250 batch size (asset health thread) + 2 parallel requests x 10 batch size (selection syntax thread which was using defaults).

After this change: 4 parallel requests x 250 batch size (asset health thread) + 4 parallel requests x 250 batch size (selection syntax thread with our updates values)

Note the reason for the 2 threads is so that the selection syntax input (which fetches the status of everything in order to support status filtering) doesn't starve the catalog page (which fetches the status of specific selections). What would happen is we would prioritize assets that were not part of the visible catalog selection and that would cause it to load slowly since it was waiting for the selection syntax input to get ALL health statuses

on the asset graph, for fetching the LiveData of group nodes we went up to 4 threads from the default of 2 while keeping the default batch size of 10.

## How I Tested These Changes

app-proxy with elementl.