### PR TITLE
chore: bump `databricks-sdk` version for `dagster-databricks`

### DIFF
--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -35,7 +35,7 @@ setup(
         f"dagster{pin}",
         f"dagster-pipes{pin}",
         f"dagster-pyspark{pin}",
-        "databricks-sdk<=0.17.0",  # dbt-databricks is pinned to this version
+        "databricks-sdk>=0.41, <0.48.0",  # dbt-databricks is pinned to this version
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
Match the `databricks-sdk` version in `dagster-databricks` to the latest version range found in `dbt-databricks`: https://github.com/databricks/dbt-databricks/blob/main/pyproject.toml#L25
