### PR TITLE
[changelog] Add freshness discussion link to `1.11.0` changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@ The `dg` CLI provides a single surface for scaffolding, local iteration, executi
   - **`BackfillPolicy`** is now GA
   - Backfills can now use a threadpool for more efficient run submission. By default, the daemon will now use 4 workers.
 - **Concurrency enhancements** – run blocking is now on by default for concurrency pools, preventing oversubscription when scheduling runs.
-- **FreshnessPolicy** — A new **`FreshnessPolicy`** API is introduced, replacing the deprecated `FreshnessPolicy` API (which has been renamed to `LegacyFreshnessPolicy`). The API is under active development, and will eventually also supersede freshness checks as the primary way of specifying and evaluating asset freshness. For more details, check out the docs: https://docs.dagster.io/guides/labs/freshness
+- **FreshnessPolicy** — A new **`FreshnessPolicy`** API is introduced, replacing the deprecated `FreshnessPolicy` API (which has been renamed to `LegacyFreshnessPolicy`). The API is under active development, and will eventually also supersede freshness checks as the primary way of specifying and evaluating asset freshness. For more details, check out the [GitHub announcement](https://github.com/dagster-io/dagster/discussions/30934) and the [docs](https://docs.dagster.io/guides/labs/freshness).
 
 ### UI
 


### PR DESCRIPTION
## Summary & Motivation
Just adding a link to a discussion that was created after the `1.11` release went out.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
