### PR TITLE
[datafactory] use correct default log level

### DIFF
--- a/python_modules/dagster-test/dagster_test/utils/data_factory.py
+++ b/python_modules/dagster-test/dagster_test/utils/data_factory.py
@@ -36,7 +36,7 @@ from pydantic import UUID4
 
 def event_log(
     error_info: Optional[SerializableErrorInfo] = None,  # No error info by default
-    level: Union[str, int] = 1,  # Default to level `1`
+    level: Union[str, int] = "INFO",  # Default to level `INFO`
     user_message: str = "test rate limit",  # A default user message
     run_id: str = "missing",  # Default to `missing` if no run ID is provided
     timestamp: float = datetime.now().timestamp(),  # Default to the current timestamp


### PR DESCRIPTION
## Summary & Motivation

This data factory is supposed to produce valid objects for testing, but this log level is not valid.

## How I Tested These Changes

With another PR that depends on this being valid
