### PR TITLE
Graphs with GraphIn inputs fail when no input is provided, even if the downstream op has a default

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -386,7 +386,7 @@ class _PlanBuilder:
         if input_config and input_name in input_config:
             return FromConfig(input_name=input_name, node_handle=None)
 
-        if input_def.dagster_type.is_nothing:
+        if input_def.dagster_type.is_nothing or input_def.dagster_type.is_nullable:
             return None
 
         # Otherwise we throw an error.

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -280,6 +280,10 @@ class DagsterType:
         return self.kind == DagsterTypeKind.ANY
 
     @property
+    def is_nullable(self) -> bool:
+        return self.kind == DagsterTypeKind.NULLABLE
+
+    @property
     def supports_fan_in(self) -> bool:
         return False
 


### PR DESCRIPTION
## Summary & Motivation
This PR fixes a bug where graphs with `GraphIn` inputs fail when no input is provided, even when the downstream op has a default value (issue #30581).

The solution was to update the `get_root_graph_input_source` function to return `None` for both `_Nothing` types and `OptionalType` types (determined by checking if the `DagsterTypeKind` is `NOTHING` or `NULLABLE`). This allows the input to fall back to the downstream op's default value.

## How I Tested These Changes

I ran the `python_modules/dagster/dagster_tests/core_tests` locally and everything passed. I am waiting for the `buildkite/unit-tests` to run.

## Changelog

Fixed a bug where graphs with `GraphIn` inputs would fail when no input was provided, even when the downstream op had a default value. The fix ensures that optional graph inputs properly fall back to downstream op defaults when no value is provided.