### PR TITLE
Allow assets without definitions to be wiped

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
@@ -56,7 +56,7 @@ export const AssetActionMenu = memo((props: Props) => {
   );
 
   const wipe = useWipeDialog(
-    repoAddress && definition ? {repository: definition.repository, assetKey: {path}} : null,
+    {repository: definition ? definition.repository : null, assetKey: {path}},
     onRefresh,
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -247,15 +247,7 @@ const AssetViewImpl = ({assetKey, headerBreadcrumbs, writeAssetVisit, currentPat
     setCurrentPage(({specificPath}) => ({specificPath, path: `${path}?view=${selectedTab}`}));
   }, [path, selectedTab, setCurrentPage]);
 
-  const wipe = useWipeDialog(
-    definition && !definition.isObservable
-      ? {
-          assetKey: definition.assetKey,
-          repository: definition.repository,
-        }
-      : null,
-    refresh,
-  );
+  const wipe = useWipeDialog({assetKey, repository: definition?.repository || null}, refresh);
 
   const dynamicPartitionsDelete = useDeleteDynamicPartitionsDialog(
     definition && repoAddress ? {assetKey: definition.assetKey, definition, repoAddress} : null,
@@ -321,17 +313,20 @@ const AssetViewImpl = ({assetKey, headerBreadcrumbs, writeAssetVisit, currentPat
             {reportEvents.element}
             {wipe.element}
             {dynamicPartitionsDelete.element}
-            {cachedOrLiveDefinition && cachedOrLiveDefinition.jobNames.length > 0 ? (
-              <LaunchAssetExecutionButton
-                scope={{all: [cachedOrLiveDefinition]}}
-                showChangedAndMissingOption={false}
-                additionalDropdownOptions={[
-                  ...reportEvents.dropdownOptions,
-                  ...wipe.dropdownOptions,
-                  ...dynamicPartitionsDelete.dropdownOptions,
-                ]}
-              />
-            ) : undefined}
+            <LaunchAssetExecutionButton
+              scope={{
+                single:
+                  cachedOrLiveDefinition && cachedOrLiveDefinition.jobNames.length > 0
+                    ? cachedOrLiveDefinition
+                    : null,
+              }}
+              showChangedAndMissingOption={false}
+              additionalDropdownOptions={[
+                ...reportEvents.dropdownOptions,
+                ...wipe.dropdownOptions,
+                ...dynamicPartitionsDelete.dropdownOptions,
+              ]}
+            />
           </Box>
         }
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetView.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetView.test.tsx
@@ -93,6 +93,7 @@ describe('AssetView', () => {
       await act(() => render(<Test path="/sda_asset" assetKey={{path: ['sda_asset']}} />));
       await waitFor(async () => {
         expect(await screen.findByText('Materialize')).toBeVisible();
+        expect(await screen.findByTestId('materialize-button')).toBeEnabled();
       });
     });
 
@@ -103,10 +104,11 @@ describe('AssetView', () => {
       expect(await screen.findByText('Observe')).toBeVisible();
     });
 
-    it('shows no button for a non-software defined asset', async () => {
+    it('shows a disabled button for a non-software defined asset', async () => {
       render(<Test path="/non_sda_asset" assetKey={{path: ['non_sda_asset']}} />);
       expect(screen.queryByText('Observe')).toBeNull();
-      expect(screen.queryByText('Materialize')).toBeNull();
+      expect(screen.queryByText('Materialize')).toBeVisible();
+      expect(await screen.findByTestId('materialize-button')).toBeDisabled();
     });
   });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -712,7 +712,15 @@ function renderButton({
   launchMock?: MockedResponse<Record<string, any>>;
   preferredJobName?: string;
 }) {
-  const assetKeys = ('all' in scope ? scope.all : scope.selected).map((s) => s.assetKey);
+  const assetKeys = (
+    'all' in scope
+      ? scope.all
+      : 'selected' in scope
+        ? scope.selected
+        : scope.single
+          ? [scope.single]
+          : []
+  ).map((s) => s.assetKey);
 
   const mocks: MockedResponse<Record<string, any>>[] = [
     LaunchAssetLoaderResourceJob7Mock,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useWipeDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useWipeDialog.tsx
@@ -7,13 +7,13 @@ import {usePermissionsForLocation} from '../app/Permissions';
 import {AssetKeyInput} from '../graphql/types';
 
 export function useWipeDialog(
-  opts: {assetKey: AssetKeyInput; repository: {location: {name: string}}} | null,
+  opts: {assetKey: AssetKeyInput; repository: {location: {name: string}} | null} | null,
   refresh?: () => void,
 ) {
   const [showing, setShowing] = useState(false);
   const {
     permissions: {canWipeAssets},
-  } = usePermissionsForLocation(opts ? opts.repository.location.name : null);
+  } = usePermissionsForLocation(opts && opts.repository ? opts.repository.location.name : null);
 
   const {
     featureContext: {canSeeWipeMaterializationAction},


### PR DESCRIPTION
Summary:
This fixes an issue where the wipe option was not being shown for external assets in the catalog.

The AssetView.tsx callsite still needs some changes after this to ensure that the resulting dropdown option is actually displayed, since it currently relies on the LaunchAssetExecutionButton component being rendered (and that button is not displayed for these assets).

Changelog:
[dagster-ui] Fixed an issue where a "wipe materializations" option was not being shown in the Dagster UI for assets not defined in code.