### PR TITLE
[ui] Update styles for Insights v2

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogActivityChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogActivityChart.tsx
@@ -3,11 +3,13 @@ import {
   BodyLarge,
   BodySmall,
   Box,
+  Colors,
   Mono,
   Popover,
   Spinner,
   Subheading,
 } from '@dagster-io/ui-components';
+import clsx from 'clsx';
 import React from 'react';
 
 import styles from './AssetCatalogInsights.module.css';
@@ -133,13 +135,11 @@ const ActivityChartRow = React.memo(
                 targetTagName="div"
                 interactionKind="hover"
                 popoverClassName={styles.Popover}
+                placement="top"
                 content={
                   <TooltipCard>
-                    <Box
-                      flex={{direction: 'column', gap: 4}}
-                      padding={{vertical: 8, horizontal: 12}}
-                    >
-                      <Box border="bottom" padding={{bottom: 4}} margin={{bottom: 4}}>
+                    <Box flex={{direction: 'column'}}>
+                      <Box border="bottom" padding={{horizontal: 12, vertical: 8}}>
                         <Subheading>
                           {formatDate(new Date(date + index * 60 * 60 * 1000), {
                             month: 'short',
@@ -149,27 +149,36 @@ const ActivityChartRow = React.memo(
                           })}
                         </Subheading>
                       </Box>
-                      <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+                      <Box
+                        flex={{direction: 'row', alignItems: 'center', gap: 4}}
+                        padding={{horizontal: 12, vertical: 8}}
+                      >
                         <Mono>{numberFormatter.format(value)}</Mono>
-                        <Body>{unit}</Body>
+                        <Body color={Colors.textLight()}>{unit}</Body>
                       </Box>
-                      {value > 0 && <BodySmall>Click for asset breakdown</BodySmall>}
+                      {value > 0 ? (
+                        <Box padding={{horizontal: 12, vertical: 8}} border="top">
+                          <Body color={Colors.textLight()}>Click to view details</Body>
+                        </Box>
+                      ) : null}
                     </Box>
                   </TooltipCard>
                 }
               >
-                <div className={styles.TileContainer}>
-                  <div className={styles.Tile} />
+                <div
+                  className={clsx(styles.TileContainer, opacity ? styles.clickable : null)}
+                  style={
+                    {
+                      '--tile-hover-color': hoverColor,
+                      '--tile-color': color,
+                    } as React.CSSProperties
+                  }
+                >
+                  <div className={styles.placeholderTile} />
                   {opacity ? (
-                    <div
-                      className={styles.Tile}
-                      style={
-                        {
-                          '--tile-color': color,
-                          '--tile-hover-color': hoverColor,
-                          opacity,
-                        } as React.CSSProperties
-                      }
+                    <button
+                      className={styles.tileButton}
+                      style={{opacity}}
                       onClick={() => {
                         onClick({
                           before: date / 1000 + index * 60 * 60,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsights.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsights.module.css
@@ -2,18 +2,36 @@
   position: relative;
   width: 100%;
   height: 100%;
+  border-radius: 2px;
+  cursor: pointer;
 }
 
-.Tile {
+.placeholderTile {
   position: absolute;
   width: 100%;
   height: 100%;
   border-radius: 2px;
+  background-color: var(--color-background-light);
+}
 
-  background-color: var(--tile-color, var(--color-background-light));
-  &:hover {
-    background-color: var(--tile-hover-color, var(--color-background-light-hover));
-  }
+.TileContainer:hover .placeholderTile {
+  box-shadow: inset 0 0 0 1px var(--tile-hover-color);
+}
+
+.tileButton {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 2px;
+  border: 0;
+  transition: background-color 150ms;
+  background-color: var(--tile-color);
+  cursor: pointer;
+  padding: 0;
+}
+
+.tileButton:hover {
+  background-color: var(--tile-hover-color);
 }
 
 .Tooltip {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
@@ -1,9 +1,10 @@
 import {
+  Body,
   BodySmall,
   Box,
-  CaptionMono,
   Colors,
   FontFamily,
+  Mono,
   Spinner,
   Subheading,
 } from '@dagster-io/ui-components';
@@ -81,6 +82,8 @@ const getDataset = (
         backgroundColor: 'transparent',
         pointRadius: 0,
         borderWidth: 2,
+        pointHoverRadius: 6,
+        pointHoverBorderColor: metrics.currentPeriod.color,
       },
       {
         label: metrics.prevPeriod.label,
@@ -89,6 +92,8 @@ const getDataset = (
         backgroundColor: 'transparent',
         pointRadius: 0,
         borderWidth: 1,
+        pointHoverRadius: 6,
+        pointHoverBorderColor: metrics.prevPeriod.color,
       },
     ],
   };
@@ -134,11 +139,11 @@ export const AssetCatalogInsightsLineChart = React.memo(
           const currentPeriodMetric = metrics.currentPeriod.data[currentPeriodDataPoint.dataIndex];
           return (
             <TooltipCard>
-              <Box flex={{direction: 'column', gap: 8}} padding={{vertical: 8, horizontal: 12}}>
-                <Box border="bottom" padding={{bottom: 8}}>
+              <Box flex={{direction: 'column'}}>
+                <Box border="bottom" padding={{horizontal: 12, vertical: 8}}>
                   <Subheading>{date}</Subheading>
                 </Box>
-                <div>
+                <Box padding={{horizontal: 16, vertical: 12}}>
                   <Box
                     flex={{direction: 'row', justifyContent: 'space-between'}}
                     margin={{bottom: 4}}
@@ -146,39 +151,41 @@ export const AssetCatalogInsightsLineChart = React.memo(
                     <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
                       <div
                         style={{
-                          width: 12,
-                          height: 12,
+                          width: 8,
+                          height: 8,
                           backgroundColor: metrics.currentPeriod.color,
                           borderRadius: '50%',
                         }}
                       />
-                      <BodySmall>Current period</BodySmall>
+                      <Body>Current period</Body>
                     </Box>
                     <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-                      <CaptionMono>{currentPeriodDataPoint?.formattedValue ?? 0}</CaptionMono>
-                      <BodySmall color={Colors.textLight()}>{unitTypeToLabel[unitType]}</BodySmall>
+                      <Mono>{currentPeriodDataPoint?.formattedValue ?? 0}</Mono>
+                      <Body color={Colors.textLight()}>{unitTypeToLabel[unitType]}</Body>
                     </Box>
                   </Box>
                   <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
                     <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
                       <div
                         style={{
-                          width: 12,
-                          height: 12,
+                          width: 8,
+                          height: 8,
                           backgroundColor: metrics.prevPeriod.color,
                           borderRadius: '50%',
                         }}
                       />
-                      <BodySmall>Previous period</BodySmall>
+                      <Body>Previous period</Body>
                     </Box>
                     <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-                      <CaptionMono>{prevPeriodDataPoint?.formattedValue ?? 0}</CaptionMono>
-                      <BodySmall color={Colors.textLight()}>{unitTypeToLabel[unitType]}</BodySmall>
+                      <Mono>{prevPeriodDataPoint?.formattedValue ?? 0}</Mono>
+                      <Body color={Colors.textLight()}>{unitTypeToLabel[unitType]}</Body>
                     </Box>
                   </Box>
-                </div>
+                </Box>
                 {currentPeriodMetric ? (
-                  <BodySmall color={Colors.textLight()}>Click for asset breakdown</BodySmall>
+                  <Box padding={{horizontal: 12, vertical: 8}} border="top">
+                    <Body color={Colors.textLight()}>Click to view details</Body>
+                  </Box>
                 ) : null}
               </Box>
             </TooltipCard>
@@ -206,6 +213,9 @@ export const AssetCatalogInsightsLineChart = React.memo(
         },
         scales: {
           x: {
+            grid: {
+              display: false,
+            },
             ticks: {
               color: rgbColors[Colors.textLight()],
               maxRotation: 0,
@@ -215,6 +225,9 @@ export const AssetCatalogInsightsLineChart = React.memo(
             },
           },
           y: {
+            border: {
+              display: false,
+            },
             grid: {color: rgbColors[Colors.keylineDefault()]},
             beginAtZero: true,
             ticks: {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogLineChart.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogLineChart.module.css
@@ -16,6 +16,7 @@
 .chartGraph {
   flex-grow: 1;
   min-height: 160px;
+  cursor: pointer;
 }
 
 .chartHeader {
@@ -24,8 +25,8 @@
 }
 
 .chartCount {
-  font-size: 32px;
-  font-weight: 600;
+  font-size: 24px;
+  font-weight: 500;
   margin-bottom: 4px;
   display: flex;
   align-items: center;

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsChartShared.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsChartShared.tsx
@@ -42,5 +42,5 @@ export const TooltipCard = styled.div`
   cursor: default;
   overflow: hidden;
   user-select: none;
-  width: 240px;
+  width: 320px;
 `;


### PR DESCRIPTION
## Summary & Motivation

A few style changes to Insights charts and graphs.

- Asset activity charts
  - Add a hover outline to tiles
  - `top` placement for hover popover
  - Use `cursor: pointer`
- Line chart
  - Remove vertical grid lines (super noisy in light mode)
  - Remove y-axis line
  - Updated style for hover popover
  - Larger hover circle on graph line
  - Fix blue hover circle color
  - Use `cursor: pointer`
  - Make large number text use same style as other parts of the UI

<img width="585" alt="Screenshot 2025-06-27 at 14 09 20" src="https://github.com/user-attachments/assets/a0049dbc-a805-44d0-83db-2449cd3b8426" />

<img width="511" alt="Screenshot 2025-06-27 at 14 09 30" src="https://github.com/user-attachments/assets/51215ee9-7add-4d30-abf1-59e4c4768667" />

## How I Tested These Changes

Proxy to elementl, verify UI changes described above.