### PR TITLE
convert tuple of groups to a list of groups

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -241,7 +241,9 @@ class AssetSelection(ABC):
                 selection.
         """
         check.tuple_param(group_strs, "group_strs", of_type=str)
-        return GroupsAssetSelection(selected_groups=group_strs, include_sources=include_sources)
+        return GroupsAssetSelection(
+            selected_groups=list(group_strs), include_sources=include_sources
+        )
 
     @public
     @staticmethod


### PR DESCRIPTION
## Summary & Motivation
I was getting test failure errors like 
```

Full diff:
--
  | [
  | -     AssetSelectionTarget(asset_selection=AndAssetSelection(operands=[GroupsAssetSelection(selected_groups=('the-asset-group',), include_sources=False), CodeLocationAssetSelection(selected_code_location='the-repo@the-location')])),
  | +     AssetSelectionTarget(asset_selection=AndAssetSelection(operands=[GroupsAssetSelection(selected_groups=['the-asset-group'], include_sources=False), CodeLocationAssetSelection(selected_code_location='the-repo@the-location')])),
  | ]

```
important bit 
```
GroupsAssetSelection(selected_groups=('the-asset-group',)
GroupsAssetSelection(selected_groups=['the-asset-group']
```
 
because the group selection gets a list in some situations and a tuple in some situations. So I switched the tuple to a list. All the tests seem to work now, so i think it's ok? Not sure if this is actually a big change to be making

## How I Tested These Changes
existing unit tests

