### PR TITLE
Allow pyspark v4 (Rolling back #30211)

### DIFF
--- a/python_modules/libraries/dagster-pyspark/setup.py
+++ b/python_modules/libraries/dagster-pyspark/setup.py
@@ -27,6 +27,8 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],

--- a/python_modules/libraries/dagster-pyspark/setup.py
+++ b/python_modules/libraries/dagster-pyspark/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         f"dagster_spark{pin}",
-        "pyspark>=3,<4",
+        "pyspark>=3,<5",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary & Motivation
Address #30816. It appears that #30211 was made about a month ago due to some failing tests (described in #30207) in dagster-duckdb-pyspark. I've confirmed that those failing tests do not affect dagster-pyspark or dagster-databricks, so it seems reasonable to remove the constraint on pyspark<4. This would allow users of these libraries who aren't using dagster-duckdb-pyspark to still use spark v4.

If y'all would prefer me putting a minor version bound on 4.something instead of <5 to be more conservative I'm happy to, but it also seems that with the very limited way the dagster-pyspark and dagster-databricks libraries interact with spark that it's relatively unlikely a minor version bump will break them.

I also updated the python classifiers in the setup.py file just because I was in there and noticed it. If it'd be better I can move that to a different PR or just take it out entirely, definitely not super important.

## How I Tested These Changes
Put together a basic pipeline that uses the pyspark step launcher and pyspark resource t from dagster-databricks and dagster-pyspark to do some basic dataframe operations. I successfully ran it with the step launcher configured for DRB 17.0.0 (Spark v4.0.0). Also ensured unit tests complete

## Changelog

Allow pyspark v4 for dagster-pyspark
