### PR TITLE
[refactor] simplify imports

### DIFF
--- a/integration_tests/test_suites/auto_materialize_perf_tests/partition_mappings_galore_perf_scenario.py
+++ b/integration_tests/test_suites/auto_materialize_perf_tests/partition_mappings_galore_perf_scenario.py
@@ -11,7 +11,7 @@ from dagster import (
     TimeWindowPartitionMapping,
     asset,
 )
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
 )

--- a/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
+++ b/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
@@ -9,7 +9,7 @@ from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.declarative_automation.automation_condition_evaluator import (
     AutomationConditionEvaluator,
 )
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
 )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -11,15 +11,14 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.data_time import CachingDataTimeResolver
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
+from dagster._core.definitions.partitions.definition import (
+    MultiPartitionsDefinition,
+    PartitionsDefinition,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
-from dagster._core.definitions.partitions.utils import PartitionRangeStatus
+from dagster._core.definitions.partitions.subset import PartitionsSubset, TimeWindowPartitionsSubset
 from dagster._core.definitions.partitions.utils.time_window import (
+    PartitionRangeStatus,
     fetch_flattened_time_window_ranges,
 )
 from dagster._core.definitions.remote_asset_graph import RemoteAssetNode

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 from dagster import _check as check
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.utils.dynamic import CachingDynamicPartitionsLoader
+from dagster._core.definitions.partitions.subset import PartitionsSubset
+from dagster._core.definitions.partitions.utils import CachingDynamicPartitionsLoader
 from dagster._core.remote_representation.external_data import AssetNodeSnap
 from dagster._core.storage.partition_status_cache import get_partition_subsets
 from dagster._core.workspace.context import WorkspaceRequestContext

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -21,7 +21,7 @@ from typing import (
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.remote_asset_graph import RemoteWorkspaceAssetGraph
 from dagster._core.definitions.selector import GraphSelector, JobSubsetSelector
 from dagster._core.execution.backfill import PartitionBackfill

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -20,8 +20,8 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionSnapshot,
 )
 from dagster._core.definitions.partitions.context import PartitionLoadingContext
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
+from dagster._core.definitions.partitions.mapping import PartitionMapping
 from dagster._core.definitions.remote_asset_graph import RemoteAssetNode, RemoteWorkspaceAssetNode
 from dagster._core.definitions.selector import JobSelector
 from dagster._core.definitions.sensor_definition import SensorType

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -8,8 +8,7 @@ import graphene
 from dagster import AssetKey
 from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
+from dagster._core.definitions.partitions.subset import PartitionsSubset, TimeWindowPartitionsSubset
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.asset_backfill import (
     AssetBackfillStatus,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_mappings.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_mappings.py
@@ -1,5 +1,5 @@
 import graphene
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping
+from dagster._core.definitions.partitions.mapping import PartitionMapping
 
 
 class GraphenePartitionMapping(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, AbstractSet, Optional, cast  # noqa: UP035
 import dagster._check as check
 import graphene
 from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.partitions.definition import MultiPartitionsDefinition
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.remote_representation import RemoteJob, RemotePartitionSet, RepositoryHandle
 from dagster._core.remote_representation.external_data import (

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -96,12 +96,12 @@ from dagster._core.definitions.freshness import InternalFreshnessPolicy
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import MetadataValue
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
     WeeklyPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partitioned_config import (

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -3,10 +3,10 @@ from unittest import mock
 
 from dagster import AssetKey, Definitions, asset
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.repository_definition.repository_definition import (
     RepositoryDefinition,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -13,8 +13,10 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionNodeSnapshot,
     HistoricalAllPartitionsSubsetSentinel,
 )
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import (
+    PartitionsDefinition,
+    StaticPartitionsDefinition,
+)
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -24,12 +24,12 @@ from dagster._core.definitions.events import (
     AssetMaterializationFailureType,
     AssetObservation,
 )
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import (
     AssetFailedToMaterializeData,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
@@ -16,10 +16,10 @@ from dagster._core.definitions.data_version import DATA_VERSION_TAG, DataVersion
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetKey, Output
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.test_utils import instance_for_test, wait_for_runs_to_finish

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_job_partitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_job_partitions.py
@@ -1,5 +1,5 @@
 from dagster import AssetKey, ConfigurableResource, Definitions, asset, job, op
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.partitions.partitioned_config import static_partitioned_config
 from dagster._core.definitions.repository_definition import SINGLETON_REPOSITORY_NAME
 from dagster._core.test_utils import ensure_dagster_tests_import, instance_for_test

--- a/python_modules/dagster-test/dagster_test/benchmarks/partition_stale_status.py
+++ b/python_modules/dagster-test/dagster_test/benchmarks/partition_stale_status.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.data_version import (
     CachingStaleStatusResolver,
     StaleStatus,
 )
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance_for_test import instance_for_test

--- a/python_modules/dagster-test/dagster_test/toys/asset_checks.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_checks.py
@@ -24,9 +24,7 @@ from dagster import (
     multi_asset,
     op,
 )
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 
 
 @asset(key_prefix="test_prefix", group_name="asset_checks")

--- a/python_modules/dagster-test/dagster_test/toys/asset_sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_sensors.py
@@ -11,7 +11,7 @@ from dagster import (
     multi_asset_sensor,
     op,
 )
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 
 
 @asset

--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/large_graph.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/large_graph.py
@@ -14,10 +14,10 @@ from dagster import (
     asset,
     repository,
 )
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._utils.warnings import disable_dagster_warnings

--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/lazy_repo_1.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/lazy_repo_1.py
@@ -1,7 +1,5 @@
 from dagster import AutoMaterializePolicy, asset, repository
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 
 daily_partitions_def = DailyPartitionsDefinition(start_date="2023-02-01")
 

--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/lazy_repo_2.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/lazy_repo_2.py
@@ -1,8 +1,6 @@
 from dagster import AssetKey, AutoMaterializePolicy, SourceAsset, asset, repository
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 
 ### Non partitioned ###
 

--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_1.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_1.py
@@ -1,8 +1,8 @@
 from dagster import AutoMaterializePolicy, asset, repository
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
 )
 
 ### Non partitioned ##

--- a/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_2.py
+++ b/python_modules/dagster-test/dagster_test/toys/auto_materializing/repo_2.py
@@ -1,7 +1,5 @@
 from dagster import AssetKey, AutoMaterializePolicy, SourceAsset, asset, repository
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 
 eager_downstream_1_source = SourceAsset(AssetKey(["eager_downstream_1"]))
 

--- a/python_modules/dagster-test/dagster_test/toys/many_partitions_ranged_backfill.py
+++ b/python_modules/dagster-test/dagster_test/toys/many_partitions_ranged_backfill.py
@@ -5,9 +5,7 @@ unnecessary writes.
 """
 
 from dagster import AssetExecutionContext, BackfillPolicy, Definitions, IOManager, asset
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    HourlyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import HourlyPartitionsDefinition
 
 partitions_def = HourlyPartitionsDefinition(
     start_date="2023-01-01-00:00", end_date="2024-01-01-00:00"

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/different_static_partitions.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/different_static_partitions.py
@@ -1,6 +1,6 @@
 from dagster import AssetIn, asset
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.mapping import StaticPartitionMapping
 
 
 @asset(partitions_def=StaticPartitionsDefinition(["a", "b", "c"]))

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/dynamic_asset_partitions.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/dynamic_asset_partitions.py
@@ -1,9 +1,9 @@
 import click
 from dagster import AssetSelection, DagsterInstance, asset, define_asset_job
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
 )
 
 customers_partitions_def = DynamicPartitionsDefinition(name="customers")

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/failing_partitions.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/failing_partitions.py
@@ -1,10 +1,10 @@
 from random import random
 
 from dagster import asset
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 
 from dagster_test.toys.partitioned_assets.dynamic_asset_partitions import (

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/hourly_and_daily_and_unpartitioned.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/hourly_and_daily_and_unpartitioned.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from dagster import MetadataValue, asset
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
 )

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/hourly_partitions_to_daily.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/hourly_partitions_to_daily.py
@@ -1,5 +1,5 @@
 from dagster import asset
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
 )

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/single_partitions_to_multi.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/single_partitions_to_multi.py
@@ -1,7 +1,9 @@
 from dagster import asset
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import (
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
+)
 
 abc_def = StaticPartitionsDefinition(["a", "b", "c"])
 

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/with_backfill_policies.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/with_backfill_policies.py
@@ -1,7 +1,5 @@
 from dagster import BackfillPolicy, MaterializeResult, asset
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 
 
 @asset(

--- a/python_modules/dagster-test/dagster_test_tests/toys_tests/partitioned_assets_tests/test_dynamic_asset_partitions.py
+++ b/python_modules/dagster-test/dagster_test_tests/toys_tests/partitioned_assets_tests/test_dynamic_asset_partitions.py
@@ -1,5 +1,5 @@
 from dagster import DagsterInstance, materialize_to_memory
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster_test.toys.partitioned_assets.dynamic_asset_partitions import (
     customers_dynamic_partitions_asset1,
     customers_dynamic_partitions_asset2,

--- a/python_modules/dagster-test/dagster_test_tests/toys_tests/partitioned_assets_tests/test_single_partitions_to_multi.py
+++ b/python_modules/dagster-test/dagster_test_tests/toys_tests/partitioned_assets_tests/test_single_partitions_to_multi.py
@@ -1,7 +1,7 @@
 import tempfile
 
 from dagster import DagsterInstance, materialize
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster_test.toys.partitioned_assets.single_partitions_to_multi import (
     multi_partitions,
     single_partitions,

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -342,53 +342,27 @@ from dagster._core.definitions.output import (
     Out as Out,
     OutputMapping as OutputMapping,
 )
-from dagster._core.definitions.partitions.definition.base import (
-    PartitionsDefinition as PartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.dynamic import (
-    DynamicPartitionsDefinition as DynamicPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.multi import (
-    MultiPartitionsDefinition as MultiPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.static import (
-    StaticPartitionsDefinition as StaticPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.time_window import (
-    TimeWindowPartitionsDefinition as TimeWindowPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition as DailyPartitionsDefinition,
+    DynamicPartitionsDefinition as DynamicPartitionsDefinition,
     HourlyPartitionsDefinition as HourlyPartitionsDefinition,
     MonthlyPartitionsDefinition as MonthlyPartitionsDefinition,
+    MultiPartitionsDefinition as MultiPartitionsDefinition,
+    PartitionsDefinition as PartitionsDefinition,
+    StaticPartitionsDefinition as StaticPartitionsDefinition,
+    TimeWindowPartitionsDefinition as TimeWindowPartitionsDefinition,
     WeeklyPartitionsDefinition as WeeklyPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.all import (
+from dagster._core.definitions.partitions.mapping import (
     AllPartitionMapping as AllPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping as PartitionMapping
-from dagster._core.definitions.partitions.mapping.identity import (
-    IdentityPartitionMapping as IdentityPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.last import (
-    LastPartitionMapping as LastPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.multi.base import (
     DimensionPartitionMapping as DimensionPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import (
+    IdentityPartitionMapping as IdentityPartitionMapping,
+    LastPartitionMapping as LastPartitionMapping,
     MultiPartitionMapping as MultiPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.multi.multi_to_single import (
     MultiToSingleDimensionPartitionMapping as MultiToSingleDimensionPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.specific_partitions import (
+    PartitionMapping as PartitionMapping,
     SpecificPartitionsPartitionMapping as SpecificPartitionsPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.static import (
     StaticPartitionMapping as StaticPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.time_window_partition_mapping import (
     TimeWindowPartitionMapping as TimeWindowPartitionMapping,
 )
 from dagster._core.definitions.partitions.partition import Partition as Partition
@@ -407,8 +381,10 @@ from dagster._core.definitions.partitions.partitioned_config import (
 from dagster._core.definitions.partitions.partitioned_schedule import (
     build_schedule_from_partitioned_job as build_schedule_from_partitioned_job,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey as MultiPartitionKey
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow as TimeWindow
+from dagster._core.definitions.partitions.utils import (
+    MultiPartitionKey as MultiPartitionKey,
+    TimeWindow as TimeWindow,
+)
 from dagster._core.definitions.policy import (
     Backoff as Backoff,
     Jitter as Jitter,

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -18,19 +18,21 @@ from dagster._core.asset_graph_view.serializable_entity_subset import Serializab
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey, EntityKey, T_EntityKey
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
+from dagster._core.definitions.partitions.definition import (
+    MultiPartitionsDefinition,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.base import UpstreamPartitionsResult
-from dagster._core.definitions.partitions.subset.all import AllPartitionsSubset
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
-from dagster._core.definitions.partitions.utils.multi import (
+from dagster._core.definitions.partitions.mapping import UpstreamPartitionsResult
+from dagster._core.definitions.partitions.subset import (
+    AllPartitionsSubset,
+    TimeWindowPartitionsSubset,
+)
+from dagster._core.definitions.partitions.utils import (
     MultiPartitionKey,
     PartitionDimensionDefinition,
+    TimeWindow,
     get_time_partitions_def,
 )
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
 from dagster._core.definitions.temporal_context import TemporalContext
 from dagster._core.loader import LoadingContext
 from dagster._time import get_current_datetime
@@ -43,7 +45,7 @@ if TYPE_CHECKING:
         ValidAssetSubset,
     )
     from dagster._core.definitions.definitions_class import Definitions
-    from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+    from dagster._core.definitions.partitions.definition import PartitionsDefinition
     from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
     from dagster._core.instance import DagsterInstance
     from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionResolvedStatus

--- a/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
@@ -20,7 +20,7 @@ from dagster._core.asset_graph_view.serializable_entity_subset import (
 )
 from dagster._core.definitions.asset_key import AssetCheckKey, EntityKey, T_EntityKey
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
+from dagster._core.definitions.partitions.subset import PartitionsSubset
 from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:

--- a/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
@@ -9,11 +9,13 @@ from typing_extensions import Self
 import dagster._check as check
 from dagster._core.definitions.asset_key import T_EntityKey
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.subset.all import AllPartitionsSubset
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.subset.default import DefaultPartitionsSubset
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
+from dagster._core.definitions.partitions.subset import (
+    AllPartitionsSubset,
+    DefaultPartitionsSubset,
+    PartitionsSubset,
+    TimeWindowPartitionsSubset,
+)
 
 EntitySubsetValue = Union[bool, PartitionsSubset]
 

--- a/python_modules/dagster/dagster/_core/definitions/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/__init__.py
@@ -88,34 +88,20 @@ from dagster._core.definitions.output import (
     OutputDefinition as OutputDefinition,
     OutputMapping as OutputMapping,
 )
-from dagster._core.definitions.partitions.definition.dynamic import (
-    DynamicPartitionsDefinition as DynamicPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.static import (
-    StaticPartitionsDefinition as StaticPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition as DailyPartitionsDefinition,
+    DynamicPartitionsDefinition as DynamicPartitionsDefinition,
     HourlyPartitionsDefinition as HourlyPartitionsDefinition,
     MonthlyPartitionsDefinition as MonthlyPartitionsDefinition,
+    StaticPartitionsDefinition as StaticPartitionsDefinition,
     WeeklyPartitionsDefinition as WeeklyPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.all import (
+from dagster._core.definitions.partitions.mapping import (
     AllPartitionMapping as AllPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.identity import (
-    IdentityPartitionMapping as IdentityPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.last import (
-    LastPartitionMapping as LastPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.multi.base import (
     DimensionPartitionMapping as DimensionPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import (
+    IdentityPartitionMapping as IdentityPartitionMapping,
+    LastPartitionMapping as LastPartitionMapping,
     MultiPartitionMapping as MultiPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.multi.multi_to_single import (
     MultiToSingleDimensionPartitionMapping as MultiToSingleDimensionPartitionMapping,
 )
 from dagster._core.definitions.partitions.partition import Partition as Partition
@@ -128,7 +114,7 @@ from dagster._core.definitions.partitions.partitioned_config import (
     static_partitioned_config as static_partitioned_config,
     weekly_partitioned_config as weekly_partitioned_config,
 )
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow as TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow as TimeWindow
 from dagster._core.definitions.reconstruct import (
     ReconstructableJob as ReconstructableJob,
     build_reconstructable_job as build_reconstructable_job,
@@ -200,14 +186,12 @@ from dagster._core.definitions.module_loaders.load_assets_from_modules import (
     load_assets_from_package_name as load_assets_from_package_name,
 )
 from dagster._core.definitions.op_definition import OpDefinition as OpDefinition
-from dagster._core.definitions.partitions.definition.base import (
+from dagster._core.definitions.partitions.definition import (
     PartitionsDefinition as PartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.time_window import (
     TimeWindowPartitionsDefinition as TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping as PartitionMapping
-from dagster._core.definitions.partitions.mapping.time_window_partition_mapping import (
+from dagster._core.definitions.partitions.mapping import (
+    PartitionMapping as PartitionMapping,
     TimeWindowPartitionMapping as TimeWindowPartitionMapping,
 )
 from dagster._core.definitions.partitions.partition_key_range import (

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
@@ -28,9 +28,7 @@ from dagster._core.definitions.metadata import (
     MetadataValue,
     TimestampMetadataValue,
 )
-from dagster._core.definitions.partitions.definition.time_window import (
-    TimeWindowPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import TimeWindowPartitionsDefinition
 from dagster._core.execution.context.compute import AssetCheckExecutionContext
 from dagster._time import datetime_from_timestamp, get_current_timestamp
 from dagster._utils.schedules import (

--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -5,8 +5,8 @@ import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping
-from dagster._core.definitions.partitions.utils.mapping import warn_if_partition_mapping_not_builtin
+from dagster._core.definitions.partitions.mapping import PartitionMapping
+from dagster._core.definitions.partitions.utils import warn_if_partition_mapping_not_builtin
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._utils.warnings import deprecation_warning
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -25,8 +25,8 @@ from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness import InternalFreshnessPolicy
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
+from dagster._core.definitions.partitions.mapping import PartitionMapping
 from dagster._core.definitions.resolved_asset_deps import ResolvedAssetDependencies
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
@@ -379,8 +379,8 @@ def executable_in_same_run(
     asset_graph: BaseAssetGraph, child_key: EntityKey, parent_key: EntityKey
 ):
     """Returns whether a child asset can be materialized in the same run as a parent asset."""
-    from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-    from dagster._core.definitions.partitions.mapping.time_window_partition_mapping import (
+    from dagster._core.definitions.partitions.mapping import (
+        IdentityPartitionMapping,
         TimeWindowPartitionMapping,
     )
     from dagster._core.definitions.remote_asset_graph import RemoteWorkspaceAssetGraph

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -15,10 +15,8 @@ from dagster._core.asset_graph_view.entity_subset import EntitySubset
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.time_window import (
-    TimeWindowPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
+from dagster._core.definitions.partitions.definition import TimeWindowPartitionsDefinition
+from dagster._core.definitions.partitions.subset import PartitionsSubset
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.instance import DynamicPartitionsStore
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
@@ -8,7 +8,7 @@ import dagster._check as check
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.definitions.asset_health.asset_health import AssetHealthStatus
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.loader import LoadableBy, LoadingContext
 from dagster._core.remote_representation.external_data import PartitionsSnap
 from dagster._core.storage.dagster_run import RunRecord

--- a/python_modules/dagster/dagster/_core/definitions/asset_in.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_in.py
@@ -10,7 +10,7 @@ from dagster._core.definitions.events import (
 )
 from dagster._core.definitions.input import NoValueSentinel
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping
+from dagster._core.definitions.partitions.mapping import PartitionMapping
 from dagster._core.types.dagster_type import DagsterType, resolve_dagster_type
 
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_job.py
@@ -28,7 +28,7 @@ from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.job_definition import JobDefinition, default_job_io_manager
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.definitions.metadata import RawMetadataValue
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_definition import ResourceDefinition

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -12,7 +12,7 @@ from dagster._core.errors import DagsterInvariantViolationError
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_graph import AssetGraph, AssetNode
     from dagster._core.definitions.assets import AssetsDefinition
-    from dagster._core.definitions.partitions.mapping.base import PartitionMapping
+    from dagster._core.definitions.partitions.mapping import PartitionMapping
 
 
 class AssetLayer(NamedTuple):

--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -24,7 +24,7 @@ from dagster._core.definitions.freshness import InternalFreshnessPolicy
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.input import NoValueSentinel
 from dagster._core.definitions.output import Out
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.utils import resolve_automation_condition
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterType

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -29,8 +29,8 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.freshness import InternalFreshnessPolicy
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
+from dagster._core.definitions.partitions.mapping import PartitionMapping
 from dagster._core.definitions.utils import (
     resolve_automation_condition,
     validate_asset_owner,

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -43,17 +43,17 @@ from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.node_definition import NodeDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.op_invocation import direct_invocation_result
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
+from dagster._core.definitions.partitions.definition import (
+    MultiPartitionsDefinition,
+    PartitionsDefinition,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import MultiPartitionMapping
-from dagster._core.definitions.partitions.mapping.time_window_partition_mapping import (
+from dagster._core.definitions.partitions.mapping import (
+    MultiPartitionMapping,
+    PartitionMapping,
     TimeWindowPartitionMapping,
 )
-from dagster._core.definitions.partitions.utils.mapping import (
+from dagster._core.definitions.partitions.utils import (
     infer_partition_mapping,
     warn_if_partition_mapping_not_builtin,
 )

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -22,12 +22,11 @@ from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.freshness_based_auto_materialize import (
     freshness_evaluation_results_for_asset_key,
 )
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
+from dagster._core.definitions.partitions.definition import (
+    MultiPartitionsDefinition,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import get_time_partitions_def
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow, get_time_partitions_def
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import AssetRecordsFilter
 from dagster._core.storage.dagster_run import IN_PROGRESS_RUN_STATUSES, RunsFilter

--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -24,7 +24,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionEvaluation,
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.storage.tags import (

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -24,17 +24,14 @@ from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.freshness import InternalFreshnessPolicy
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.mapping.base import (
-    PartitionMapping,
-    UpstreamPartitionsResult,
-)
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
+from dagster._core.definitions.partitions.mapping import PartitionMapping, UpstreamPartitionsResult
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.utils.mapping import infer_partition_mapping
-from dagster._core.definitions.partitions.utils.multi import (
+from dagster._core.definitions.partitions.subset import PartitionsSubset
+from dagster._core.definitions.partitions.utils import (
     get_time_partition_key,
     get_time_partitions_def,
+    infer_partition_mapping,
 )
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from dagster._core.instance import DynamicPartitionsStore

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     from dagster._core.definitions.assets import AssetsDefinition
     from dagster._core.definitions.executor_definition import ExecutorDefinition
     from dagster._core.definitions.job_definition import JobDefinition
-    from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+    from dagster._core.definitions.partitions.definition import PartitionsDefinition
     from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
     from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
     from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -28,10 +28,8 @@ from dagster._core.definitions.data_version import (
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessMinutes
-from dagster._core.definitions.partitions.definition.time_window import (
-    TimeWindowPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
+from dagster._core.definitions.partitions.definition import TimeWindowPartitionsDefinition
+from dagster._core.definitions.partitions.subset import TimeWindowPartitionsSubset
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventLogRecord
 from dagster._core.storage.dagster_run import FINISHED_STATUSES, DagsterRunStatus, RunsFilter

--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -714,10 +714,8 @@ class CachingStaleStatusResolver:
         self, *, key: "AssetKeyPartitionKey"
     ) -> Sequence["AssetKeyPartitionKey"]:
         from dagster._core.definitions.events import AssetKeyPartitionKey
-        from dagster._core.definitions.partitions.definition.time_window import (
-            TimeWindowPartitionsDefinition,
-        )
-        from dagster._core.definitions.partitions.mapping.all import AllPartitionMapping
+        from dagster._core.definitions.partitions.definition import TimeWindowPartitionsDefinition
+        from dagster._core.definitions.partitions.mapping import AllPartitionMapping
 
         asset_deps = self.asset_graph.get(key.asset_key).parent_keys
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -27,8 +27,10 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     OperatorType,
     get_serializable_candidate_subset,
 )
-from dagster._core.definitions.partitions.subset.all import AllPartitionsSubset
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
+from dagster._core.definitions.partitions.subset import (
+    AllPartitionsSubset,
+    TimeWindowPartitionsSubset,
+)
 from dagster._record import copy, record
 from dagster._time import get_current_timestamp
 from dagster._utils.schedules import is_valid_cron_schedule

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -25,7 +25,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     StructuredCursor,
 )
 from dagster._core.definitions.metadata import MetadataMapping
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._time import get_current_datetime
 
 if TYPE_CHECKING:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
@@ -23,7 +23,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.metadata import MetadataValue
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._time import get_current_timestamp
 
 if TYPE_CHECKING:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/valid_asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/valid_asset_subset.py
@@ -11,9 +11,11 @@ from dagster._core.asset_graph_view.serializable_entity_subset import (
     SerializableEntitySubset,
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.subset.all import AllPartitionsSubset
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
+from dagster._core.definitions.partitions.subset import (
+    AllPartitionsSubset,
+    TimeWindowPartitionsSubset,
+)
 
 if TYPE_CHECKING:
     from dagster._core.instance import DynamicPartitionsStore

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
@@ -19,7 +19,7 @@ from dagster._core.asset_graph_view.serializable_entity_subset import Serializab
 from dagster._core.definitions.asset_key import T_EntityKey
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataMapping, MetadataValue
-from dagster._core.definitions.partitions.subset.all import AllPartitionsSubset
+from dagster._core.definitions.partitions.subset import AllPartitionsSubset
 from dagster._record import record
 from dagster._time import datetime_from_timestamp
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -40,7 +40,7 @@ from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.input import GraphIn
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping, RawMetadataMapping
 from dagster._core.definitions.output import GraphOut
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.utils import (

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -30,8 +30,8 @@ from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.input import In
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.output import Out
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
+from dagster._core.definitions.partitions.mapping import PartitionMapping
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import ResourceDefinition

--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -24,7 +24,7 @@ from dagster._utils.tags import normalize_tags
 
 if TYPE_CHECKING:
     from dagster._core.definitions.executor_definition import ExecutorDefinition
-    from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+    from dagster._core.definitions.partitions.definition import PartitionsDefinition
     from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
     from dagster._core.definitions.run_config import RunConfig
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -20,7 +20,7 @@ from dagster._core.definitions.decorators.decorator_assets_definition_builder im
 from dagster._core.definitions.events import CoercibleToAssetKey, CoercibleToAssetKeyPrefix
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.metadata import RawMetadataMapping
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.source_asset import SourceAsset, SourceAssetObserveFunction

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -505,7 +505,7 @@ class AssetMaterialization(
         partition: Optional[str] = None,
         tags: Optional[Mapping[str, str]] = None,
     ):
-        from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+        from dagster._core.definitions.partitions.utils import MultiPartitionKey
 
         if isinstance(asset_key, AssetKey):
             check.inst_param(asset_key, "asset_key", AssetKey)

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -17,7 +17,7 @@ from dagster._core.definitions.declarative_automation.legacy.valid_asset_subset 
 )
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._utils.schedules import cron_string_iterator
 
 if TYPE_CHECKING:

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
     from dagster._core.definitions.executor_definition import ExecutorDefinition
     from dagster._core.definitions.job_definition import JobDefinition
     from dagster._core.definitions.op_definition import OpDefinition
-    from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+    from dagster._core.definitions.partitions.definition import PartitionsDefinition
     from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
     from dagster._core.definitions.run_config import RunConfig
     from dagster._core.definitions.source_asset import SourceAsset

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -37,8 +37,10 @@ from dagster._core.definitions.metadata import MetadataValue, RawMetadataValue, 
 from dagster._core.definitions.node_definition import NodeDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.op_selection import OpSelection, get_graph_subset
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
+from dagster._core.definitions.partitions.definition import (
+    DynamicPartitionsDefinition,
+    PartitionsDefinition,
+)
 from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_definition import ResourceDefinition

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -10,7 +10,7 @@ from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import RawMetadataMapping
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.run_request import RunRequest, SensorResult, SkipReason

--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/__init__.py
@@ -1,0 +1,21 @@
+from dagster._core.definitions.partitions.definition.base import (
+    PartitionsDefinition as PartitionsDefinition,
+)
+from dagster._core.definitions.partitions.definition.dynamic import (
+    DynamicPartitionsDefinition as DynamicPartitionsDefinition,
+)
+from dagster._core.definitions.partitions.definition.multi import (
+    MultiPartitionsDefinition as MultiPartitionsDefinition,
+)
+from dagster._core.definitions.partitions.definition.static import (
+    StaticPartitionsDefinition as StaticPartitionsDefinition,
+)
+from dagster._core.definitions.partitions.definition.time_window import (
+    TimeWindowPartitionsDefinition as TimeWindowPartitionsDefinition,
+)
+from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+    DailyPartitionsDefinition as DailyPartitionsDefinition,
+    HourlyPartitionsDefinition as HourlyPartitionsDefinition,
+    MonthlyPartitionsDefinition as MonthlyPartitionsDefinition,
+    WeeklyPartitionsDefinition as WeeklyPartitionsDefinition,
+)

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/__init__.py
@@ -1,0 +1,30 @@
+from dagster._core.definitions.partitions.mapping.all import (
+    AllPartitionMapping as AllPartitionMapping,
+)
+from dagster._core.definitions.partitions.mapping.base import PartitionMapping as PartitionMapping
+from dagster._core.definitions.partitions.mapping.identity import (
+    IdentityPartitionMapping as IdentityPartitionMapping,
+)
+from dagster._core.definitions.partitions.mapping.last import (
+    LastPartitionMapping as LastPartitionMapping,
+)
+from dagster._core.definitions.partitions.mapping.multi.base import (
+    DimensionDependency as DimensionDependency,
+    DimensionPartitionMapping as DimensionPartitionMapping,
+    UpstreamPartitionsResult as UpstreamPartitionsResult,
+)
+from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import (
+    MultiPartitionMapping as MultiPartitionMapping,
+)
+from dagster._core.definitions.partitions.mapping.multi.multi_to_single import (
+    MultiToSingleDimensionPartitionMapping as MultiToSingleDimensionPartitionMapping,
+)
+from dagster._core.definitions.partitions.mapping.specific_partitions import (
+    SpecificPartitionsPartitionMapping as SpecificPartitionsPartitionMapping,
+)
+from dagster._core.definitions.partitions.mapping.static import (
+    StaticPartitionMapping as StaticPartitionMapping,
+)
+from dagster._core.definitions.partitions.mapping.time_window_partition_mapping import (
+    TimeWindowPartitionMapping as TimeWindowPartitionMapping,
+)

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/multi/multi_to_single.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/multi/multi_to_single.py
@@ -52,9 +52,7 @@ def get_infer_single_to_multi_dimension_deps_result(
     downstream_partitions_def: PartitionsDefinition,
     partition_dimension_name: Optional[str] = None,
 ) -> InferSingleToMultiDimensionDepsResult:
-    from dagster._core.definitions.partitions.mapping.time_window_partition_mapping import (
-        TimeWindowPartitionMapping,
-    )
+    from dagster._core.definitions.partitions.mapping import TimeWindowPartitionMapping
 
     upstream_is_multipartitioned = isinstance(upstream_partitions_def, MultiPartitionsDefinition)
 

--- a/python_modules/dagster/dagster/_core/definitions/partitions/partitioned_config/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/partitioned_config/__init__.py
@@ -15,13 +15,3 @@ from dagster._core.definitions.partitions.partitioned_config.time_window import 
     monthly_partitioned_config as monthly_partitioned_config,
     weekly_partitioned_config as weekly_partitioned_config,
 )
-
-__all__ = [
-    "PartitionedConfig",
-    "daily_partitioned_config",
-    "dynamic_partitioned_config",
-    "hourly_partitioned_config",
-    "monthly_partitioned_config",
-    "static_partitioned_config",
-    "weekly_partitioned_config",
-]

--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/__init__.py
@@ -1,0 +1,10 @@
+from dagster._core.definitions.partitions.subset.all import (
+    AllPartitionsSubset as AllPartitionsSubset,
+)
+from dagster._core.definitions.partitions.subset.base import PartitionsSubset as PartitionsSubset
+from dagster._core.definitions.partitions.subset.default import (
+    DefaultPartitionsSubset as DefaultPartitionsSubset,
+)
+from dagster._core.definitions.partitions.subset.time_window import (
+    TimeWindowPartitionsSubset as TimeWindowPartitionsSubset,
+)

--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/all.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/all.py
@@ -6,7 +6,6 @@ import dagster._check as check
 from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
 from dagster._core.instance import DynamicPartitionsStore
 
 
@@ -87,9 +86,8 @@ class AllPartitionsSubset(
         return other
 
     def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset":
-        from dagster._core.definitions.partitions.definition.time_window import (
-            TimeWindowPartitionsDefinition,
-        )
+        from dagster._core.definitions.partitions.definition import TimeWindowPartitionsDefinition
+        from dagster._core.definitions.partitions.subset import TimeWindowPartitionsSubset
 
         if self == other:
             return self.partitions_def.empty_subset()

--- a/python_modules/dagster/dagster/_core/definitions/partitions/utils/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/utils/__init__.py
@@ -1,11 +1,21 @@
 from dagster._core.definitions.partitions.utils.base import (
+    generate_partition_key_based_definition_id as generate_partition_key_based_definition_id,
     raise_error_on_duplicate_partition_keys as raise_error_on_duplicate_partition_keys,
     raise_error_on_invalid_partition_key_substring as raise_error_on_invalid_partition_key_substring,
 )
 from dagster._core.definitions.partitions.utils.dynamic import (
     CachingDynamicPartitionsLoader as CachingDynamicPartitionsLoader,
 )
+from dagster._core.definitions.partitions.utils.mapping import (
+    get_builtin_partition_mapping_types as get_builtin_partition_mapping_types,
+    infer_partition_mapping as infer_partition_mapping,
+    warn_if_partition_mapping_not_builtin as warn_if_partition_mapping_not_builtin,
+)
 from dagster._core.definitions.partitions.utils.multi import (
+    MultiPartitionKey as MultiPartitionKey,
+    PartitionDimensionDefinition as PartitionDimensionDefinition,
+    get_multipartition_key_from_tags as get_multipartition_key_from_tags,
+    get_tags_from_multi_partition_key as get_tags_from_multi_partition_key,
     get_time_partition_key as get_time_partition_key,
     get_time_partitions_def as get_time_partitions_def,
     has_one_dimension_time_window_partitioning as has_one_dimension_time_window_partitioning,
@@ -13,5 +23,6 @@ from dagster._core.definitions.partitions.utils.multi import (
 from dagster._core.definitions.partitions.utils.time_window import (
     PartitionRangeStatus as PartitionRangeStatus,
     PartitionTimeWindowStatus as PartitionTimeWindowStatus,
+    PersistedTimeWindow as PersistedTimeWindow,
     TimeWindow as TimeWindow,
 )

--- a/python_modules/dagster/dagster/_core/definitions/partitions/utils/mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/utils/mapping.py
@@ -1,34 +1,28 @@
 import warnings
 from functools import lru_cache
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
-    TimeWindowPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.mapping.all import AllPartitionMapping
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.mapping.last import LastPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import MultiPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_single import (
-    MultiToSingleDimensionPartitionMapping,
-    get_infer_single_to_multi_dimension_deps_result,
-)
-from dagster._core.definitions.partitions.mapping.specific_partitions import (
-    SpecificPartitionsPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
 from dagster._utils.warnings import disable_dagster_warnings
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.partitions.definition import PartitionsDefinition
+    from dagster._core.definitions.partitions.mapping import PartitionMapping
 
 
 def infer_partition_mapping(
-    partition_mapping: Optional[PartitionMapping],
-    downstream_partitions_def: Optional[PartitionsDefinition],
-    upstream_partitions_def: Optional[PartitionsDefinition],
-) -> PartitionMapping:
-    from dagster._core.definitions.partitions.mapping.time_window_partition_mapping import (
+    partition_mapping: Optional["PartitionMapping"],
+    downstream_partitions_def: Optional["PartitionsDefinition"],
+    upstream_partitions_def: Optional["PartitionsDefinition"],
+) -> "PartitionMapping":
+    from dagster._core.definitions.partitions.definition import TimeWindowPartitionsDefinition
+    from dagster._core.definitions.partitions.mapping import (
+        AllPartitionMapping,
+        IdentityPartitionMapping,
         TimeWindowPartitionMapping,
+    )
+    from dagster._core.definitions.partitions.mapping.multi.multi_to_single import (
+        MultiToSingleDimensionPartitionMapping,
+        get_infer_single_to_multi_dimension_deps_result,
     )
 
     if partition_mapping is not None:
@@ -50,8 +44,15 @@ def infer_partition_mapping(
 
 
 @lru_cache(maxsize=1)
-def get_builtin_partition_mapping_types() -> tuple[type[PartitionMapping], ...]:
-    from dagster._core.definitions.partitions.mapping.time_window_partition_mapping import (
+def get_builtin_partition_mapping_types() -> tuple[type["PartitionMapping"], ...]:
+    from dagster._core.definitions.partitions.mapping import (
+        AllPartitionMapping,
+        IdentityPartitionMapping,
+        LastPartitionMapping,
+        MultiPartitionMapping,
+        MultiToSingleDimensionPartitionMapping,
+        SpecificPartitionsPartitionMapping,
+        StaticPartitionMapping,
         TimeWindowPartitionMapping,
     )
 
@@ -67,7 +68,7 @@ def get_builtin_partition_mapping_types() -> tuple[type[PartitionMapping], ...]:
     )
 
 
-def warn_if_partition_mapping_not_builtin(partition_mapping: PartitionMapping) -> None:
+def warn_if_partition_mapping_not_builtin(partition_mapping: "PartitionMapping") -> None:
     builtin_partition_mappings = get_builtin_partition_mapping_types()
     if not isinstance(partition_mapping, builtin_partition_mappings):
         warnings.warn(

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -38,8 +38,8 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 from dagster._core.definitions.freshness import InternalFreshnessPolicy
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
+from dagster._core.definitions.partitions.mapping import PartitionMapping
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.handle import InstigatorHandle, RepositoryHandle

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -24,11 +24,11 @@ from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
+from dagster._core.definitions.partitions.definition import (
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    PartitionsDefinition,
+    StaticPartitionsDefinition,
     TimeWindowPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partitioned_schedule import (

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -949,9 +949,7 @@ class ScheduleDefinition(IHasInternalInit):
             ScheduleExecutionData: Contains list of run requests, or skip message if present.
 
         """
-        from dagster._core.definitions.partitions.utils.dynamic import (
-            CachingDynamicPartitionsLoader,
-        )
+        from dagster._core.definitions.partitions.utils import CachingDynamicPartitionsLoader
 
         check.inst_param(context, "context", ScheduleEvaluationContext)
         execution_fn: Callable[..., ScheduleEvaluationFunctionReturn]

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -32,7 +32,7 @@ from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import RawMetadataMapping, normalize_metadata
 from dagster._core.definitions.metadata.metadata_value import MetadataValue
-from dagster._core.definitions.partitions.utils.dynamic import CachingDynamicPartitionsLoader
+from dagster._core.definitions.partitions.utils import CachingDynamicPartitionsLoader
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import Resources
 from dagster._core.definitions.run_request import (

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -23,7 +23,7 @@ from dagster._core.definitions.metadata import (
     normalize_metadata,
 )
 from dagster._core.definitions.op_definition import OpDefinition
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.resource_requirement import (

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -16,8 +16,10 @@ from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.metadata import RawMetadataValue
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
+from dagster._core.definitions.partitions.definition import (
+    DynamicPartitionsDefinition,
+    PartitionsDefinition,
+)
 from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_definition import ResourceDefinition

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -52,7 +52,7 @@ from dagster._core.definitions.metadata import (
     RawMetadataValue,
     normalize_metadata,
 )
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
+from dagster._core.definitions.partitions.subset import PartitionsSubset
 from dagster._core.errors import DagsterInvariantViolationError, HookExecutionError
 from dagster._core.execution.context.system import IPlanContext, IStepContext, StepExecutionContext
 from dagster._core.execution.plan.handle import ResolvedFromDynamicStepHandle, StepHandle

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -26,17 +26,16 @@ from dagster._core.definitions.automation_tick_evaluation_context import (
 )
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph, BaseAssetNode
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
+from dagster._core.definitions.partitions.definition import (
+    PartitionsDefinition,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.mapping.time_window_partition_mapping import (
+from dagster._core.definitions.partitions.mapping import (
+    IdentityPartitionMapping,
     TimeWindowPartitionMapping,
 )
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
+from dagster._core.definitions.partitions.subset import PartitionsSubset, TimeWindowPartitionsSubset
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph, RemoteWorkspaceAssetGraph
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.selector import PartitionsByAssetSelector

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -7,7 +7,7 @@ from dagster import _check as check
 from dagster._core.definitions import AssetKey
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
+from dagster._core.definitions.partitions.subset import PartitionsSubset
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.selector import PartitionsByAssetSelector
 from dagster._core.definitions.utils import check_valid_title

--- a/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
@@ -10,9 +10,9 @@ from dagster._core.definitions.dependency import Node, NodeHandle
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey, UserEvent
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.op_definition import OpDefinition
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.definitions.repository_definition.repository_definition import (
     RepositoryDefinition,
 )

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -7,8 +7,8 @@ from dagster._annotations import deprecated, deprecated_param, public
 from dagster._core.definitions.events import AssetKey, AssetObservation, CoercibleToAssetKey
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping, MetadataValue
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.subset import PartitionsSubset
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
 from dagster._utils.warnings import normalize_renamed_param

--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -18,10 +18,10 @@ from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.utils.multi import (
+from dagster._core.definitions.partitions.utils import (
+    TimeWindow,
     has_one_dimension_time_window_partitioning,
 )
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
 from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.definitions.resource_definition import (
     IContainsGenerator,
@@ -49,8 +49,8 @@ from dagster._utils.merger import merge_dicts
 
 if TYPE_CHECKING:
     from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
-    from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-    from dagster._core.definitions.partitions.definition.time_window import (
+    from dagster._core.definitions.partitions.definition import (
+        MultiPartitionsDefinition,
         TimeWindowPartitionsDefinition,
     )
 

--- a/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
@@ -22,9 +22,9 @@ from dagster._core.definitions.events import (
 )
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.op_definition import OpDefinition
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.definitions.repository_definition.repository_definition import (
     RepositoryDefinition,
 )

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -17,7 +17,7 @@ from dagster._core.definitions.metadata import (
     RawMetadataValue,
 )
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.errors import DagsterInvalidMetadata, DagsterInvariantViolationError
 from dagster._core.execution.plan.utils import build_resources_for_manager
 from dagster._utils.warnings import normalize_renamed_param

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -20,18 +20,18 @@ from dagster._core.definitions.job_base import IJob
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import RawMetadataValue
 from dagster._core.definitions.op_definition import OpDefinition
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
+from dagster._core.definitions.partitions.definition import (
+    MultiPartitionsDefinition,
+    PartitionsDefinition,
     TimeWindowPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.utils.mapping import infer_partition_mapping
-from dagster._core.definitions.partitions.utils.multi import (
+from dagster._core.definitions.partitions.subset import PartitionsSubset
+from dagster._core.definitions.partitions.utils import (
+    TimeWindow,
     has_one_dimension_time_window_partitioning,
+    infer_partition_mapping,
 )
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.definitions.repository_definition.repository_definition import (
@@ -67,9 +67,7 @@ from dagster._core.types.dagster_type import DagsterType
 if TYPE_CHECKING:
     from dagster._core.definitions.data_version import DataVersion
     from dagster._core.definitions.dependency import NodeHandle
-    from dagster._core.definitions.partitions.definition.time_window import (
-        TimeWindowPartitionsDefinition,
-    )
+    from dagster._core.definitions.partitions.definition import TimeWindowPartitionsDefinition
     from dagster._core.definitions.resource_definition import Resources
     from dagster._core.execution.context.hook import HookContext
     from dagster._core.execution.plan.plan import ExecutionPlan
@@ -971,9 +969,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     @property
     def partition_key(self) -> str:
-        from dagster._core.definitions.partitions.utils.multi import (
-            get_multipartition_key_from_tags,
-        )
+        from dagster._core.definitions.partitions.utils import get_multipartition_key_from_tags
 
         if not self.has_partitions:
             raise DagsterInvariantViolationError(
@@ -1003,9 +999,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
     @property
     def partition_key_range(self) -> PartitionKeyRange:
-        from dagster._core.definitions.partitions.utils.multi import (
-            get_multipartition_key_from_tags,
-        )
+        from dagster._core.definitions.partitions.utils import get_multipartition_key_from_tags
 
         if not self.has_partitions:
             raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 
 import dagster._check as check
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.errors import DagsterBackfillFailedError, DagsterInvariantViolationError

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -34,7 +34,7 @@ from dagster._core.definitions.data_version import (
 from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
 from dagster._core.definitions.events import DynamicOutput
 from dagster._core.definitions.metadata import MetadataValue, normalize_metadata
-from dagster._core.definitions.partitions.utils.multi import (
+from dagster._core.definitions.partitions.utils import (
     MultiPartitionKey,
     get_tags_from_multi_partition_key,
 )

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Callable, Optional, cast
 import dagster._check as check
 from dagster._config import Field, StringSource
 from dagster._core.code_pointer import FileCodePointer, ModuleCodePointer
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
+from dagster._core.definitions.partitions.definition import DynamicPartitionsDefinition
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
 from dagster._core.definitions.step_launcher import StepLauncher, StepRunRef

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -124,7 +124,7 @@ if TYPE_CHECKING:
     from dagster._core.definitions.asset_key import EntityKey
     from dagster._core.definitions.base_asset_graph import BaseAssetGraph
     from dagster._core.definitions.job_definition import JobDefinition
-    from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+    from dagster._core.definitions.partitions.definition import PartitionsDefinition
     from dagster._core.definitions.repository_definition.repository_definition import (
         RepositoryLoadData,
     )
@@ -365,7 +365,7 @@ class DynamicPartitionsStore(Protocol):
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool: ...
 
     def get_dynamic_partitions_definition_id(self, partitions_def_name: str) -> str:
-        from dagster._core.definitions.partitions.utils.base import (
+        from dagster._core.definitions.partitions.utils import (
             generate_partition_key_based_definition_id,
         )
 
@@ -1420,9 +1420,7 @@ class DagsterInstance(DynamicPartitionsStore):
         output: "ExecutionStepOutputSnap",
         asset_graph: Optional["BaseAssetGraph"],
     ) -> None:
-        from dagster._core.definitions.partitions.definition.dynamic import (
-            DynamicPartitionsDefinition,
-        )
+        from dagster._core.definitions.partitions.definition import DynamicPartitionsDefinition
         from dagster._core.events import AssetMaterializationPlannedData, DagsterEvent
 
         partition_tag = dagster_run.tags.get(PARTITION_NAME_TAG)
@@ -2591,7 +2589,7 @@ class DagsterInstance(DynamicPartitionsStore):
             partitions_def_name (str): The name of the `DynamicPartitionsDefinition`.
             partition_keys (Sequence[str]): Partition keys to add.
         """
-        from dagster._core.definitions.partitions.utils.base import (
+        from dagster._core.definitions.partitions.utils import (
             raise_error_on_invalid_partition_key_substring,
         )
 

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -37,10 +37,10 @@ from dagster._core.definitions.metadata import (
     metadata_map_from_external,
 )
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.utils.multi import (
+from dagster._core.definitions.partitions.utils import (
+    TimeWindow,
     has_one_dimension_time_window_partitioning,
 )
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.errors import DagsterInvariantViolationError, DagsterPipesExecutionError
 from dagster._core.events import EngineEventData

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -19,7 +19,7 @@ from dagster._core.definitions.automation_condition_sensor_definition import (
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataValue
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
 from dagster._core.definitions.selector import (

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -71,15 +71,15 @@ from dagster._core.definitions.metadata import (
     normalize_metadata,
 )
 from dagster._core.definitions.op_definition import OpDefinition
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
+from dagster._core.definitions.partitions.definition import (
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.base import PartitionMapping
+from dagster._core.definitions.partitions.mapping import PartitionMapping
 from dagster._core.definitions.partitions.schedule_type import ScheduleType
-from dagster._core.definitions.partitions.utils.mapping import get_builtin_partition_mapping_types
+from dagster._core.definitions.partitions.utils import get_builtin_partition_mapping_types
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.resource_requirement import ResourceKeyRequirement
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus

--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -7,11 +7,11 @@ import dagster._check as check
 from dagster._check import CheckError
 from dagster._core.definitions.metadata import RawMetadataValue
 from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
+from dagster._core.definitions.partitions.definition import (
+    MultiPartitionsDefinition,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import MultiPartitionKey, TimeWindow
 from dagster._core.errors import DagsterInvalidMetadata, DagsterInvariantViolationError
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -9,7 +9,7 @@ from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness import FreshnessStateRecord
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.event_api import (
     AssetRecordsFilter,
     EventHandlerFn,

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -13,15 +13,15 @@ from dagster import (
 )
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.asset_graph_view.entity_subset import EntitySubset, _ValidatedEntitySubsetValue
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
+from dagster._core.definitions.partitions.definition import (
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    PartitionsDefinition,
+    StaticPartitionsDefinition,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.subset import PartitionsSubset
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.loader import LoadableBy, LoadingContext
 from dagster._core.storage.dagster_run import FINISHED_STATUSES, RunsFilter

--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -11,7 +11,7 @@ from dagster import (
     OutputContext,
     _check as check,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.storage.io_manager import IOManager
 
 if TYPE_CHECKING:

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -400,7 +400,7 @@ def log_repo_stats(
     repo: Optional[ReconstructableRepository] = None,
 ) -> None:
     from dagster._core.definitions.assets import AssetsDefinition
-    from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
+    from dagster._core.definitions.partitions.definition import DynamicPartitionsDefinition
 
     check.inst_param(instance, "instance", DagsterInstance)
     check.str_param(source, "source")

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -16,7 +16,7 @@ from dagster._config.snap import ConfigTypeSnap
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.data_version import CachingStaleStatusResolver
-from dagster._core.definitions.partitions.utils.dynamic import CachingDynamicPartitionsLoader
+from dagster._core.definitions.partitions.utils import CachingDynamicPartitionsLoader
 from dagster._core.definitions.remote_asset_graph import RemoteRepositoryAssetNode
 from dagster._core.definitions.selector import (
     JobSelector,

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -15,9 +15,11 @@ from dagster._core.definitions import ScheduleEvaluationContext
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
+from dagster._core.definitions.partitions.definition import (
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    PartitionsDefinition,
+)
 from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.definitions.repository_definition import RepositoryDefinition

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -13,11 +13,12 @@ from dagster._core.definitions.declarative_automation.legacy.valid_asset_subset 
     ValidAssetSubset,
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.time_window import (
+from dagster._core.definitions.partitions.definition import (
+    PartitionsDefinition,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.utils.multi import (
+from dagster._core.definitions.partitions.subset import PartitionsSubset
+from dagster._core.definitions.partitions.utils import (
     get_time_partition_key,
     get_time_partitions_def,
 )

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -12,7 +12,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataValue
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.remote_representation import (
     ManagedGrpcPythonEnvCodeLocationOrigin,
     RemoteRepositoryOrigin,

--- a/python_modules/dagster/dagster/components/resolved/core_models.py
+++ b/python_modules/dagster/dagster/components/resolved/core_models.py
@@ -13,14 +13,12 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
 )
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
-    TimeWindowPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    PartitionsDefinition,
+    StaticPartitionsDefinition,
+    TimeWindowPartitionsDefinition,
     WeeklyPartitionsDefinition,
 )
 from dagster.components.resolved.base import Resolvable, resolve_fields

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -14,7 +14,7 @@ from dagster_shared.merger import deep_merge_dicts
 
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster.components.core.tree import ComponentTree
 
 """Testing utilities for components."""

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -17,8 +17,10 @@ from dagster import (
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.decorators.sensor_decorator import sensor
 from dagster._core.definitions.metadata.metadata_value import MetadataValue
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import (
+    DynamicPartitionsDefinition,
+    StaticPartitionsDefinition,
+)
 from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.storage.tags import EXTERNAL_JOB_SOURCE_TAG_KEY

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
@@ -9,7 +9,7 @@ from dagster._api.snapshot_partition import (
     sync_get_external_partition_tags_grpc,
 )
 from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.repository_definition import SINGLETON_REPOSITORY_NAME
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_asset_slice.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_asset_slice.py
@@ -11,11 +11,11 @@ from dagster import (
     serialize_value,
 )
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, SerializableEntitySubset
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 
 partitions_defs = [

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
@@ -6,16 +6,20 @@ from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.mapping.last import LastPartitionMapping
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
-from dagster._core.definitions.partitions.subset.all import AllPartitionsSubset
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
-from dagster._core.definitions.partitions.utils.time_window import PersistedTimeWindow, TimeWindow
+from dagster._core.definitions.partitions.mapping import (
+    IdentityPartitionMapping,
+    LastPartitionMapping,
+    StaticPartitionMapping,
+)
+from dagster._core.definitions.partitions.subset import (
+    AllPartitionsSubset,
+    TimeWindowPartitionsSubset,
+)
+from dagster._core.definitions.partitions.utils import PersistedTimeWindow, TimeWindow
 from dagster._core.instance import DagsterInstance
 from dagster._time import create_datetime, get_current_datetime
 from dagster._utils.partitions import DEFAULT_DATE_FORMAT

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_bfs.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_bfs.py
@@ -17,13 +17,13 @@ from dagster._core.asset_graph_view.bfs import (
 )
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.mapping import IdentityPartitionMapping
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._time import create_datetime
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_latest_time_window.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_latest_time_window.py
@@ -1,12 +1,12 @@
 from dagster import Definitions, asset
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.execution.context.compute import AssetExecutionContext
 from dagster._core.instance import DagsterInstance
 from dagster._time import create_datetime

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -30,31 +30,28 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
     WeeklyPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.all import AllPartitionMapping
-from dagster._core.definitions.partitions.mapping.base import (
+from dagster._core.definitions.partitions.mapping import (
+    AllPartitionMapping,
+    IdentityPartitionMapping,
+    LastPartitionMapping,
+    MultiToSingleDimensionPartitionMapping,
     PartitionMapping,
+    SpecificPartitionsPartitionMapping,
     UpstreamPartitionsResult,
 )
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.mapping.last import LastPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_single import (
-    MultiToSingleDimensionPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.specific_partitions import (
-    SpecificPartitionsPartitionMapping,
-)
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.subset.default import DefaultPartitionsSubset
-from dagster._core.definitions.partitions.utils.mapping import get_builtin_partition_mapping_types
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.subset import DefaultPartitionsSubset, PartitionsSubset
+from dagster._core.definitions.partitions.utils import (
+    MultiPartitionKey,
+    get_builtin_partition_mapping_types,
+)
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.test_utils import assert_namedtuple_lists_equal
 from dagster._time import create_datetime

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -13,27 +13,25 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
     WeeklyPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.all import AllPartitionMapping
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.base import DimensionPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import MultiPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_single import (
+from dagster._core.definitions.partitions.mapping import (
+    AllPartitionMapping,
+    DimensionPartitionMapping,
+    IdentityPartitionMapping,
+    MultiPartitionMapping,
     MultiToSingleDimensionPartitionMapping,
-)
-from dagster._core.definitions.partitions.mapping.specific_partitions import (
     SpecificPartitionsPartitionMapping,
+    StaticPartitionMapping,
 )
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.subset.default import DefaultPartitionsSubset
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.subset import DefaultPartitionsSubset
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.test_utils import instance_for_test
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
@@ -1,7 +1,7 @@
 import pytest
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
-from dagster._core.definitions.partitions.subset.default import DefaultPartitionsSubset
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.mapping import StaticPartitionMapping
+from dagster._core.definitions.partitions.subset import DefaultPartitionsSubset
 from dagster_shared.serdes import deserialize_value, serialize_value
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -4,16 +4,18 @@ from typing import Optional
 
 import pytest
 from dagster import TimeWindowPartitionMapping, TimeWindowPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
     MonthlyPartitionsDefinition,
     WeeklyPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.subset.all import AllPartitionsSubset
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.subset import (
+    AllPartitionsSubset,
+    TimeWindowPartitionsSubset,
+)
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._time import create_datetime
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps.py
@@ -15,7 +15,7 @@ from dagster._check import ParameterCheckError
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_in import AssetIn
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
+from dagster._core.definitions.partitions.mapping import IdentityPartitionMapping
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterTypeKind
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -29,16 +29,18 @@ from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.base_asset_graph import AssetCheckNode, BaseAssetGraph, BaseAssetNode
 from dagster._core.definitions.decorators.asset_check_decorator import asset_check
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    PartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.base import UpstreamPartitionsResult
-from dagster._core.definitions.partitions.mapping.last import LastPartitionMapping
+from dagster._core.definitions.partitions.mapping import (
+    LastPartitionMapping,
+    UpstreamPartitionsResult,
+)
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
+from dagster._core.definitions.partitions.subset import PartitionsSubset
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
@@ -51,7 +53,7 @@ from dagster._time import create_datetime, get_current_datetime
 from dagster_shared.serdes import deserialize_value, serialize_value
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
+    from dagster._core.definitions.partitions.subset import TimeWindowPartitionsSubset
 
 
 def to_remote_asset_graph(assets, asset_checks=None) -> RemoteAssetGraph:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
@@ -43,7 +43,7 @@ from dagster._core.definitions.data_version import DataVersion
 from dagster._core.definitions.decorators.asset_check_decorator import asset_check
 from dagster._core.definitions.dependency import NodeHandle, NodeInvocation
 from dagster._core.definitions.executor_definition import in_process_executor
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.errors import DagsterInvalidSubsetError
 from dagster._core.execution.api import execute_run_iterator

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -48,14 +48,16 @@ from dagster._core.definitions.asset_selection import (
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.base import DimensionPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import MultiPartitionMapping
+from dagster._core.definitions.partitions.mapping import (
+    DimensionPartitionMapping,
+    IdentityPartitionMapping,
+    MultiPartitionMapping,
+)
 from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.external_data import RepositorySnap
 from dagster._core.remote_representation.handle import RepositoryHandle

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -53,11 +53,11 @@ from dagster._core.definitions.auto_materialize_policy import AutoMaterializePol
 from dagster._core.definitions.decorators.hook_decorator import success_hook
 from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.definitions.metadata.metadata_value import TextMetadataValue
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
+from dagster._core.definitions.partitions.mapping import (
+    IdentityPartitionMapping,
+    LastPartitionMapping,
 )
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.mapping.last import LastPartitionMapping
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -34,15 +34,17 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
 )
 from dagster._core.definitions.decorators.config_mapping_decorator import config_mapping
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.all import AllPartitionMapping
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.base import DimensionPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import MultiPartitionMapping
+from dagster._core.definitions.partitions.mapping import (
+    AllPartitionMapping,
+    DimensionPartitionMapping,
+    IdentityPartitionMapping,
+    MultiPartitionMapping,
+)
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_requirement import ensure_requirements_satisfied
 from dagster._core.definitions.tags import build_kind_tag

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_entity_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_entity_subset.py
@@ -8,16 +8,18 @@ from dagster._core.definitions.declarative_automation.legacy.valid_asset_subset 
     ValidAssetSubset,
 )
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.subset.all import AllPartitionsSubset
-from dagster._core.definitions.partitions.subset.default import DefaultPartitionsSubset
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
-from dagster._core.definitions.partitions.utils.time_window import PersistedTimeWindow
+from dagster._core.definitions.partitions.subset import (
+    AllPartitionsSubset,
+    DefaultPartitionsSubset,
+    TimeWindowPartitionsSubset,
+)
+from dagster._core.definitions.partitions.utils import PersistedTimeWindow
 from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._time import create_datetime

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -21,12 +21,14 @@ from dagster._core.definitions.auto_materialize_policy import AutoMaterializePol
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
+from dagster._core.definitions.partitions.mapping import (
+    IdentityPartitionMapping,
+    StaticPartitionMapping,
+)
 from dagster._core.remote_representation import InProcessCodeLocationOrigin
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
@@ -29,9 +29,7 @@ from dagster import (
     resource,
     with_resources,
 )
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 from dagster._core.test_utils import ignore_warning, instance_for_test, raise_exception_on_warnings
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize_to_memory.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize_to_memory.py
@@ -21,9 +21,7 @@ from dagster import (
     op,
     with_resources,
 )
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 from dagster._core.errors import DagsterInvalidInvocationError
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
@@ -7,7 +7,7 @@ from dagster._core.definitions.decorators.source_asset_decorator import observab
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import TextMetadataValue
 from dagster._core.definitions.observe import observe
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.resource_definition import ResourceDefinition, resource
 from dagster._core.definitions.result import ObserveResult
 from dagster._core.errors import (

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -30,20 +30,19 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.metadata.metadata_value import IntMetadataValue, TextMetadataValue
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.partitioned_config.time_window import (
+from dagster._core.definitions.partitions.partitioned_config import (
     daily_partitioned_config,
     hourly_partitioned_config,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import MultiPartitionKey, TimeWindow
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventRecordsFilter
 from dagster._core.events import DagsterEventType

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -2,21 +2,20 @@ from typing import cast
 from unittest.mock import Mock
 
 import pytest
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
-    TimeWindowPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
+    TimeWindowPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.subset.all import AllPartitionsSubset
-from dagster._core.definitions.partitions.subset.default import DefaultPartitionsSubset
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
-from dagster._core.definitions.partitions.utils.time_window import PersistedTimeWindow
+from dagster._core.definitions.partitions.subset import (
+    AllPartitionsSubset,
+    DefaultPartitionsSubset,
+    TimeWindowPartitionsSubset,
+)
+from dagster._core.definitions.partitions.utils import MultiPartitionKey, PersistedTimeWindow
 from dagster._core.errors import DagsterInvalidDeserializationVersionError
 from dagster._core.test_utils import freeze_time
 from dagster._serdes import deserialize_value, serialize_value

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -7,7 +7,7 @@ from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.errors import DagsterInvalidDefinitionError

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -24,10 +24,10 @@ from dagster._core.definitions import asset, multi_asset
 from dagster._core.definitions.decorators.hook_decorator import failure_hook, success_hook
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.metadata.metadata_value import TextMetadataValue
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partitioned_config import static_partitioned_config
 from dagster._core.definitions.partitions.partitioned_schedule import (

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/assets.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/assets.py
@@ -1,8 +1,8 @@
 from dagster import AssetExecutionContext, Config, asset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -29,7 +29,7 @@ from dagster._cli.run import (
 )
 from dagster._cli.workspace.cli_target import PythonPointerOpts, WorkspaceOpts
 from dagster._core.definitions.decorators.sensor_decorator import sensor
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -23,11 +23,11 @@ from dagster import (
     resource,
 )
 from dagster._cli.job import job_execute_command
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.reconstruct import get_ephemeral_repository_name
 from dagster._core.definitions.resource_definition import dagster_maintained_resource

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolvable_transformer.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolvable_transformer.py
@@ -10,13 +10,11 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
 )
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
-    TimeWindowPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    StaticPartitionsDefinition,
+    TimeWindowPartitionsDefinition,
     WeeklyPartitionsDefinition,
 )
 from dagster.components.resolved.context import ResolutionContext

--- a/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
@@ -2,10 +2,10 @@ import pytest
 from dagster import AssetKey
 from dagster._check import CheckError
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.test_utils import instance_for_test
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_object.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_definitions_object.py
@@ -18,9 +18,7 @@ from dagster._core.definitions.decorators.source_asset_decorator import (
     observable_source_asset,
 )
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster_shared.check.functions import CheckError
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_run_request.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_run_request.py
@@ -3,7 +3,7 @@ from typing import Union, cast
 
 import pytest
 from dagster import AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest, RunRequest, job
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
+from dagster._core.definitions.partitions.definition import DynamicPartitionsDefinition
 from dagster._core.errors import DagsterUnknownPartitionError
 from dagster._core.test_utils import instance_for_test
 

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -31,12 +31,12 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.errors import (
     DagsterConfigMappingFunctionError,
     DagsterInvalidConfigError,

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph_source_asset_input.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph_source_asset_input.py
@@ -12,7 +12,7 @@ from dagster import (
     job,
     op,
 )
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 
 
 def make_io_manager(asset: Union[SourceAsset, AssetSpec], input_value=5, expected_metadata={}):

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -22,14 +22,12 @@ from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.external_asset import external_assets_from_specs
 from dagster._core.definitions.metadata import MetadataValue, TextMetadataValue, normalize_metadata
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
-    TimeWindowPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
+    TimeWindowPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.schedule_type import ScheduleType
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -26,9 +26,9 @@ from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluatio
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetMaterialization, AssetObservation
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.errors import (

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -10,12 +10,12 @@ from dagster import (
     job,
 )
 from dagster._check import CheckError
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.test_utils import get_paginated_partition_keys, instance_for_test
 from dagster._serdes import serialize_value

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_io_manager.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_io_manager.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 from dagster import DagsterTypeCheckDidNotPass, asset, materialize
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
 )

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_job.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 from dagster import DagsterUnknownPartitionError, job, op
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.partitions.partitioned_config import (
     daily_partitioned_config,
     dynamic_partitioned_config,

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -24,9 +24,7 @@ from dagster._core.definitions.decorators.source_asset_decorator import observab
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.observe import observe
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 from dagster._core.test_utils import create_test_asset_job, freeze_time
 from dagster._time import create_datetime, get_current_datetime
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -26,14 +26,13 @@ from dagster import (
     op,
     resource,
 )
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partitions.utils.multi import get_time_partitions_def
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow, get_time_partitions_def
 from dagster._core.errors import (
     DagsterInvalidConfigError,
     DagsterInvalidDefinitionError,

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -49,15 +49,15 @@ from dagster._core.definitions.instigation_logger import get_instigation_log_rec
 from dagster._core.definitions.multi_asset_sensor_definition import (
     MultiAssetSensorEvaluationContext,
 )
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
     WeeklyPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.definitions.run_request import InstigatorType, SensorResult
 from dagster._core.definitions.run_status_sensor_definition import run_status_sensor
 from dagster._core.definitions.sensor_definition import (

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_asset_checks.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_asset_checks.py
@@ -10,9 +10,7 @@ from dagster import (
     asset_check,
     sensor,
 )
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
 from dagster._core.test_utils import create_test_daemon_workspace_context, load_remote_repo

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
@@ -11,8 +11,10 @@ from dagster import (
 )
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import (
+    DynamicPartitionsDefinition,
+    StaticPartitionsDefinition,
+)
 from dagster._core.definitions.run_request import InstigatorType, RunRequest
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
 from dagster._core.test_utils import create_test_daemon_workspace_context, load_remote_repo

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -41,14 +41,13 @@ from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.all import AllPartitionMapping
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
+from dagster._core.definitions.partitions.mapping import AllPartitionMapping, StaticPartitionMapping
 from dagster._core.definitions.partitions.partitioned_config import (
     PartitionedConfig,
     daily_partitioned_config,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/base_job_name_changes_locations/location_1.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/base_job_name_changes_locations/location_1.py
@@ -1,5 +1,5 @@
 from dagster import asset
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     HourlyPartitionsDefinition,
     WeeklyPartitionsDefinition,
 )

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/base_job_name_changes_locations/location_2.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/base_job_name_changes_locations/location_2.py
@@ -1,5 +1,5 @@
 from dagster import asset
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
 )

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/partitions_defs_changes_locations/location_1.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/partitions_defs_changes_locations/location_1.py
@@ -1,7 +1,7 @@
 from dagster import asset
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/partitions_defs_changes_locations/location_2.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/partitions_defs_changes_locations/location_2.py
@@ -1,7 +1,7 @@
 from dagster import asset
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/unloadable_location.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/unloadable_location.py
@@ -1,7 +1,5 @@
 from dagster import AssetIn, Definitions, TimeWindowPartitionMapping, asset
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 
 
 @asset(

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_data_version_changed.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_data_version_changed.py
@@ -12,9 +12,9 @@ from dagster import (
     evaluate_automation_conditions,
 )
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_eager_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_eager_condition.py
@@ -14,13 +14,15 @@ from dagster import (
     asset_check,
     evaluate_automation_conditions,
 )
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.multi.base import DimensionPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import MultiPartitionMapping
+from dagster._core.definitions.partitions.mapping import (
+    DimensionPartitionMapping,
+    MultiPartitionMapping,
+)
 from dagster._core.instance_for_test import instance_for_test
 
 from dagster_tests.declarative_automation_tests.scenario_utils.automation_condition_scenario import (

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_requested_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_requested_condition.py
@@ -12,9 +12,7 @@ from dagster import (
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
 from dagster._core.definitions.declarative_automation.operands import NewlyRequestedCondition
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 
 from dagster_tests.declarative_automation_tests.automation_condition_tests.builtins.test_dep_condition import (
     get_hardcoded_condition,

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition_tester.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition_tester.py
@@ -14,9 +14,9 @@ from dagster import (
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.events import AssetMaterialization
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     HourlyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.instance import DagsterInstance
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
@@ -5,9 +5,7 @@ from dagster import (
     AutomationCondition as SC,
 )
 from dagster._core.definitions.asset_selection import AssetSelection
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 
 from dagster_tests.declarative_automation_tests.scenario_utils.automation_condition_scenario import (
     AutomationConditionScenarioState,

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/500_eager_assets.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/500_eager_assets.py
@@ -1,5 +1,5 @@
 from dagster import AutomationCondition, AutomationConditionSensorDefinition, Definitions
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
 )

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_cursor.py
@@ -7,7 +7,7 @@ from dagster._core.definitions.asset_daemon_cursor import (
     backcompat_deserialize_asset_daemon_cursor_str,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster_shared.serdes import deserialize_value, serialize_value
 
 partitions = StaticPartitionsDefinition(partition_keys=["a", "b", "c"])

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_fast.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_fast.py
@@ -1,8 +1,6 @@
 import pytest
 from dagster import AssetMaterialization, AssetSelection, DagsterInstance, job, op
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    HourlyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import HourlyPartitionsDefinition
 
 from dagster_tests.declarative_automation_tests.legacy_tests.scenarios.scenarios import (
     ASSET_RECONCILIATION_SCENARIOS,

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/active_run_scenarios.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/active_run_scenarios.py
@@ -4,7 +4,7 @@ from typing import Optional
 from dagster import PartitionKeyRange
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
 )

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/asset_graphs.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/asset_graphs.py
@@ -1,14 +1,16 @@
 from dagster import BackfillPolicy, TimeWindowPartitionMapping
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.base import DimensionPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import MultiPartitionMapping
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
+from dagster._core.definitions.partitions.mapping import (
+    DimensionPartitionMapping,
+    IdentityPartitionMapping,
+    MultiPartitionMapping,
+    StaticPartitionMapping,
+)
 
 from dagster_tests.declarative_automation_tests.scenario_utils.base_scenario import asset_def
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/auto_observe_scenarios.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/auto_observe_scenarios.py
@@ -3,7 +3,7 @@ import datetime
 from dagster import DataVersion, DataVersionsByPartition, asset, observable_source_asset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._time import create_datetime
 
 from dagster_tests.declarative_automation_tests.scenario_utils.base_scenario import (

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/freshness_policy_scenarios.py
@@ -4,9 +4,7 @@ from dagster import AssetSelection
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import TextRuleEvaluationData
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 
 from dagster_tests.declarative_automation_tests.scenario_utils.base_scenario import (
     AssetEvaluationSpec,

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/partition_scenarios.py
@@ -2,14 +2,14 @@ from dagster import AssetKey, PartitionKeyRange
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import AutoMaterializeRuleEvaluation
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
+from dagster._core.definitions.partitions.subset import TimeWindowPartitionsSubset
 from dagster._time import create_datetime
 
 from dagster_tests.declarative_automation_tests.scenario_utils.base_scenario import (

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/version_scenarios.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/version_scenarios.py
@@ -1,4 +1,4 @@
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 
 from dagster_tests.declarative_automation_tests.scenario_utils.base_scenario import (
     AssetReconciliationScenario,

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/updated_scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/updated_scenarios/partition_scenarios.py
@@ -4,9 +4,11 @@ from dagster import AssetDep, AutoMaterializePolicy, AutoMaterializeRule, TimeWi
 from dagster._core.definitions.auto_materialize_rule_impls import (
     DiscardOnMaxMaterializationsExceededRule,
 )
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.base import DimensionPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import MultiPartitionMapping
+from dagster._core.definitions.partitions.mapping import (
+    DimensionPartitionMapping,
+    IdentityPartitionMapping,
+    MultiPartitionMapping,
+)
 from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._record import copy
 

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/perf_tests/test_perf.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/perf_tests/test_perf.py
@@ -8,7 +8,7 @@ from dagster import (
     evaluate_automation_conditions,
 )
 from dagster._core.definitions.automation_tick_evaluation_context import build_run_requests
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
 )

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -53,8 +53,8 @@ from dagster._core.definitions.events import CoercibleToAssetKey
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.partitions.schedule_type import ScheduleType
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.utils.multi import get_time_partitions_def
+from dagster._core.definitions.partitions.subset import PartitionsSubset
+from dagster._core.definitions.partitions.utils import get_time_partitions_def
 from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._core.events import AssetMaterializationPlannedData, DagsterEvent, DagsterEventType
 from dagster._core.events.log import EventLogEntry

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/scenario_specs.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/scenario_specs.py
@@ -6,18 +6,18 @@ from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
     AssetExecutionType,
 )
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
-from dagster._core.definitions.partitions.mapping.time_window_partition_mapping import (
+from dagster._core.definitions.partitions.mapping import (
+    StaticPartitionMapping,
     TimeWindowPartitionMapping,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._time import parse_time_string
 
 from dagster_tests.declarative_automation_tests.scenario_utils.scenario_state import (

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset_decorator.py
@@ -5,7 +5,7 @@ from dagster._core.definitions.decorators.source_asset_decorator import observab
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.observe import observe
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.io_manager import io_manager
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_partition_freshness.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_partition_freshness.py
@@ -22,10 +22,10 @@ from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import JsonMetadataValue, TimestampMetadataValue
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -50,11 +50,11 @@ from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.logger_definition import logger
 from dagster._core.definitions.metadata.metadata_value import MetadataValue, TextMetadataValue
 from dagster._core.definitions.partitions.context import PartitionLoadingContext
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    PartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.definitions.sensor_definition import SensorDefinition

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
@@ -13,7 +13,7 @@ from dagster import (
     materialize_to_memory,
 )
 from dagster._check import CheckError
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
+from dagster._core.definitions.partitions.definition import DynamicPartitionsDefinition
 from dagster._core.definitions.partitions.partition import Partition
 from dagster._core.test_utils import get_paginated_partition_keys, instance_for_test
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
@@ -24,9 +24,7 @@ from dagster._core.definitions.external_asset import (
     external_assets_from_specs,
 )
 from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 
 
 def test_external_asset_basic_creation() -> None:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_flatten_time_window_ranges.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_flatten_time_window_ranges.py
@@ -1,13 +1,13 @@
 from typing import TYPE_CHECKING, cast
 
 from dagster import PartitionKeyRange
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.utils.time_window import (
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
+from dagster._core.definitions.partitions.utils import (
     PartitionRangeStatus,
     PartitionTimeWindowStatus,
     TimeWindow,
+)
+from dagster._core.definitions.partitions.utils.time_window import (
     fetch_flattened_time_window_ranges,
 )
 from dagster._time import parse_time_string

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_materialize_result.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_materialize_result.py
@@ -20,7 +20,7 @@ from dagster import (
     multi_asset,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.errors import (
     DagsterInvariantViolationError,
     DagsterStepOutputNotFoundError,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -15,20 +15,22 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.partitions.context import PartitionLoadingContext
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.identity import IdentityPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.base import DimensionPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import MultiPartitionMapping
-from dagster._core.definitions.partitions.utils.multi import (
+from dagster._core.definitions.partitions.mapping import (
+    DimensionPartitionMapping,
+    IdentityPartitionMapping,
+    MultiPartitionMapping,
+)
+from dagster._core.definitions.partitions.utils import (
     MultiPartitionKey,
+    TimeWindow,
     get_time_partitions_def,
 )
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
 from dagster._core.definitions.temporal_context import TemporalContext
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.storage.tags import get_multidimensional_partition_tag

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_observe_result.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_observe_result.py
@@ -17,7 +17,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.observe import observe
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.result import ObserveResult
 from dagster._core.errors import DagsterInvariantViolationError, DagsterStepOutputNotFoundError
 from dagster._core.execution.context.invocation import build_asset_context

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_partitioned_schedule.py
@@ -15,16 +15,16 @@ from dagster import (
     repository,
     weekly_partitioned_config,
 )
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partitioned_schedule import (
     build_schedule_from_partitioned_job,
 )
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.test_utils import freeze_time
 from dagster._time import create_datetime, parse_time_string
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -35,9 +35,9 @@ from dagster._core.definitions.automation_condition_sensor_definition import (
 from dagster._core.definitions.decorators.asset_check_decorator import asset_check
 from dagster._core.definitions.executor_definition import multi_or_in_process_executor
 from dagster._core.definitions.metadata.metadata_value import TextMetadataValue
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
 from dagster._core.errors import DagsterInvalidSubsetError

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule.py
@@ -20,9 +20,7 @@ from dagster._core.definitions.metadata.metadata_value import (
     MetadataValue,
     TextMetadataValue,
 )
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 from dagster._core.definitions.partitions.partitioned_schedule import (
     UnresolvedPartitionedAssetScheduleDefinition,
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule_invocation.py
@@ -12,8 +12,10 @@ from dagster import (
     schedule,
 )
 from dagster._config.pythonic_config import ConfigurableResource
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import (
+    DynamicPartitionsDefinition,
+    StaticPartitionsDefinition,
+)
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import instance_for_test

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -41,10 +41,10 @@ from dagster._config.pythonic_config import ConfigurableResource
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.decorators.asset_check_decorator import asset_check
 from dagster._core.definitions.metadata import MetadataValue
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.partitioned_config import static_partitioned_config
 from dagster._core.definitions.resource_annotation import ResourceParam

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -8,21 +8,21 @@ import pytest
 from dagster import DagsterInvalidDefinitionError, PartitionKeyRange, TimeWindowPartitionsDefinition
 from dagster._check import CheckError
 from dagster._core.definitions.partitions.context import PartitionLoadingContext
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
     MonthlyPartitionsDefinition,
     WeeklyPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.partitioned_config.time_window import (
+from dagster._core.definitions.partitions.partitioned_config import (
     daily_partitioned_config,
     hourly_partitioned_config,
     monthly_partitioned_config,
     weekly_partitioned_config,
 )
 from dagster._core.definitions.partitions.schedule_type import ScheduleType
-from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
-from dagster._core.definitions.partitions.utils.time_window import PersistedTimeWindow, TimeWindow
+from dagster._core.definitions.partitions.subset import TimeWindowPartitionsSubset
+from dagster._core.definitions.partitions.utils import PersistedTimeWindow, TimeWindow
 from dagster._core.definitions.temporal_context import TemporalContext
 from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._core.test_utils import freeze_time, get_paginated_partition_keys

--- a/python_modules/dagster/dagster_tests/execution_tests/context_tests/test_output.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/context_tests/test_output.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from dagster import AssetKey, AssetSpec, IOManager, OutputContext, build_output_context, materialize
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.execution.context.input import InputContext
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_asset_backfill.py
@@ -36,14 +36,16 @@ from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.decorators.repository_decorator import repository
 from dagster._core.definitions.events import AssetKeyPartitionKey
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    StaticPartitionsDefinition,
     WeeklyPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.last import LastPartitionMapping
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
+from dagster._core.definitions.partitions.mapping import (
+    LastPartitionMapping,
+    StaticPartitionMapping,
+)
 from dagster._core.definitions.remote_asset_graph import RemoteWorkspaceAssetGraph
 from dagster._core.definitions.selector import (
     PartitionRangeSelector,

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -11,10 +11,10 @@ from dagster import (
     TimeWindowPartitionMapping,
     asset,
 )
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    StaticPartitionsDefinition,
     WeeklyPartitionsDefinition,
 )
 from dagster._core.execution.asset_backfill import AssetBackfillData, AssetBackfillStatus

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -49,7 +49,7 @@ from dagster._core.definitions.metadata.table import (
     TableRecord,
     TableSchema,
 )
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
+from dagster._core.definitions.partitions.definition import DynamicPartitionsDefinition
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.reconstruct import reconstructable
 from dagster._core.errors import DagsterInvariantViolationError, DagsterPipesExecutionError

--- a/python_modules/dagster/dagster_tests/execution_tests/versioning_tests/test_data_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/versioning_tests/test_data_versions.py
@@ -33,12 +33,12 @@ from dagster._core.definitions.data_version import (
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey, Output
 from dagster._core.definitions.observe import observe
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.all import AllPartitionMapping
-from dagster._core.definitions.partitions.mapping.time_window_partition_mapping import (
+from dagster._core.definitions.partitions.mapping import (
+    AllPartitionMapping,
     TimeWindowPartitionMapping,
 )
 from dagster._core.events import DagsterEventType

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/partitioned_asset_graph/base_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/partitioned_asset_graph/base_asset_graph.py
@@ -1,10 +1,10 @@
 from dagster import AssetIn, Definitions, TimeWindowPartitionMapping, asset
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
+from dagster._core.definitions.partitions.mapping import StaticPartitionMapping
 
 daily_partitions_def = DailyPartitionsDefinition(start_date="2024-02-01")
 static_partitions_def = StaticPartitionsDefinition(["apple", "orange", "banana"])

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/partitioned_asset_graph/branch_deployment_change_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/partitioned_asset_graph/branch_deployment_change_partition_mappings.py
@@ -1,12 +1,14 @@
 from dagster import AssetIn, Definitions, TimeWindowPartitionMapping, asset
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.multi.base import DimensionPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import MultiPartitionMapping
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
+from dagster._core.definitions.partitions.mapping import (
+    DimensionPartitionMapping,
+    MultiPartitionMapping,
+    StaticPartitionMapping,
+)
 
 daily_partitions_def = DailyPartitionsDefinition(start_date="2024-02-01")
 static_partitions_def = StaticPartitionsDefinition(["apple", "orange", "banana"])

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/partitioned_asset_graph/branch_deployment_change_partitions_def.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/partitioned_asset_graph/branch_deployment_change_partitions_def.py
@@ -1,10 +1,10 @@
 from dagster import AssetIn, Definitions, TimeWindowPartitionMapping, asset
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
+from dagster._core.definitions.partitions.mapping import StaticPartitionMapping
 
 daily_partitions_def = DailyPartitionsDefinition(
     start_date="2024-01-01"

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -26,7 +26,7 @@ from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.events import UNDEFINED_ASSET_KEY_PATH, AssetLineageInfo
 from dagster._core.definitions.metadata import MetadataValue
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.events import DagsterEvent, DagsterEventType, StepMaterializationData
 from dagster._core.events.log import EventLogEntry

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/grpc_repo.py
@@ -13,7 +13,7 @@ from dagster import (
     sensor,
     usable_as_dagster_type,
 )
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.partitions.partitioned_config import PartitionedConfig
 
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -27,7 +27,7 @@ from dagster import (
 )
 from dagster._core.definitions.data_version import DataVersion
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import (

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_partitioned_branching_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/test_partitioned_branching_io_manager.py
@@ -13,8 +13,8 @@ from dagster import (
     job,
     op,
 )
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.mapping import StaticPartitionMapping
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.storage.branching.branching_io_manager import BranchingIOManager
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_events.py
@@ -1,7 +1,7 @@
 from dagster import AssetKey, AssetObservation, In, asset, build_input_context, job, materialize, op
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetLineageInfo
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.events import DagsterEventType
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.input_manager import input_manager

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_value_loader.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_value_loader.py
@@ -16,9 +16,7 @@ from dagster import (
     resource,
     with_resources,
 )
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 from dagster._core.test_utils import instance_for_test
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_db_io_manager.py
@@ -3,11 +3,11 @@ from unittest.mock import MagicMock
 import pytest
 from dagster import AssetKey, InputContext, OutputContext, asset, build_output_context
 from dagster._check import CheckError
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.db_io_manager import (
     DbClient,

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -28,14 +28,14 @@ from dagster import (
 from dagster._core.definitions import AssetIn, asset, multi_asset
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.base import UpstreamPartitionsResult
-from dagster._core.definitions.partitions.subset.base import PartitionsSubset
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.mapping import UpstreamPartitionsResult
+from dagster._core.definitions.partitions.subset import PartitionsSubset
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.storage.fs_io_manager import fs_io_manager

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -36,9 +36,7 @@ from dagster._check import CheckError
 from dagster._core.definitions.events import Output
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 from dagster._core.errors import DagsterInvalidMetadata
 from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.execution.context.compute import AssetExecutionContext

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -27,14 +27,14 @@ from dagster import (
     io_manager,
     materialize,
 )
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.all import AllPartitionMapping
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.mapping import AllPartitionMapping
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.events import HandledOutputData
 from dagster._core.storage.io_manager import IOManagerDefinition
 from dagster._core.storage.upath_io_manager import UPathIOManager

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -65,14 +65,14 @@ from dagster._core.definitions.events import (
     AssetMaterializationFailureType,
 )
 from dagster._core.definitions.job_base import InMemoryJob
-from dagster._core.definitions.partitions.definition.base import PartitionKeyRange
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.subset.all import AllPartitionsSubset
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
+from dagster._core.definitions.partitions.subset import AllPartitionsSubset
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
 from dagster._core.event_api import EventLogCursor, EventRecordsResult, RunStatusChangeRecordsFilter

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/partition_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/partition_status_cache.py
@@ -12,14 +12,14 @@ from dagster import (
     define_asset_job,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
     HourlyPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.events import (
     AssetMaterializationPlannedData,
     DagsterEvent,

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
@@ -13,9 +13,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.partitions.definition.time_window import (
-    TimeWindowPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import TimeWindowPartitionsDefinition
 from dagster._time import datetime_from_timestamp, get_current_timestamp
 
 from dagster_airlift.constants import (

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_sensor.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_sensor.py
@@ -19,9 +19,7 @@ from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.definitions.materialize import materialize
 from dagster._core.definitions.metadata.metadata_value import TimestampMetadataValue
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 from dagster._core.definitions.sensor_definition import SensorEvaluationContext
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult

--- a/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
+++ b/python_modules/libraries/dagster-airlift/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
@@ -3,9 +3,7 @@ from datetime import timedelta
 from dagster import Definitions, asset, define_asset_job, multi_asset
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._time import get_current_datetime_midnight
 from dagster_airlift.core import (

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
@@ -19,7 +19,7 @@ from dagster import (
 )
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
@@ -23,7 +23,7 @@ from dagster import (
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.job_base import InMemoryJob
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.events import DagsterEventType

--- a/python_modules/libraries/dagster-celery/example/example_code/definitions.py
+++ b/python_modules/libraries/dagster-celery/example/example_code/definitions.py
@@ -10,7 +10,7 @@ from dagster import (
     job,
     op,
 )
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 
 example_partition_def = StaticPartitionsDefinition(
     partition_keys=[str(i) for i in range(1, 32)],

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -21,7 +21,7 @@ from dagster._core.definitions.metadata.source_code import (
     CodeReferencesMetadataValue,
     LocalFileCodeReference,
 )
-from dagster._core.definitions.partitions.definition.base import PartitionsDefinition
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._utils.tags import is_valid_tag_key
 from dagster.components.resolved.base import Resolvable
 from dagster_shared import check

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/freshness_builder.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/freshness_builder.py
@@ -21,9 +21,7 @@ from dagster._core.definitions.asset_check_factories.utils import (
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
-from dagster._core.definitions.partitions.definition.time_window import (
-    TimeWindowPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import TimeWindowPartitionsDefinition
 from dagster._core.errors import DagsterInvariantViolationError
 
 if TYPE_CHECKING:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -16,9 +16,7 @@ from dagster import (
 )
 from dagster._config.field_utils import EnvVar
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 from dagster._core.test_utils import environ, instance_for_test
 from dagster_dbt import (
     DagsterDbtCloudJobInvariantViolationError,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -26,14 +26,16 @@ from dagster import (
     materialize,
 )
 from dagster._core.definitions.dependency import BlockingAssetChecksDependencyDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping.last import LastPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.base import DimensionPartitionMapping
-from dagster._core.definitions.partitions.mapping.multi.multi_to_multi import MultiPartitionMapping
-from dagster._core.definitions.partitions.mapping.static import StaticPartitionMapping
+from dagster._core.definitions.partitions.mapping import (
+    DimensionPartitionMapping,
+    LastPartitionMapping,
+    MultiPartitionMapping,
+    StaticPartitionMapping,
+)
 from dagster._core.definitions.tags import build_kind_tag, has_kind
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.execution.context.compute import AssetExecutionContext

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_freshness_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_freshness_checks.py
@@ -12,9 +12,7 @@ from dagster._core.definitions.asset_check_factories.utils import (
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.metadata.metadata_value import JsonMetadataValue
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    DailyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import DailyPartitionsDefinition
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.freshness_builder import build_freshness_checks_from_dbt_assets
 

--- a/python_modules/libraries/dagster-deltalake-pandas/dagster_deltalake_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-deltalake-pandas/dagster_deltalake_pandas_tests/test_type_handler.py
@@ -16,13 +16,13 @@ from dagster import (
     op,
 )
 from dagster._check import CheckError
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster_deltalake import DELTA_DATE_FORMAT, LocalConfig
 from dagster_deltalake_pandas import DeltaLakePandasIOManager
 from deltalake import DeltaTable

--- a/python_modules/libraries/dagster-deltalake-polars/dagster_deltalake_polars_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-deltalake-polars/dagster_deltalake_polars_tests/test_type_handler.py
@@ -14,13 +14,13 @@ from dagster import (
     op,
 )
 from dagster._check import CheckError
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster_deltalake import DELTA_DATE_FORMAT, LocalConfig
 from dagster_deltalake.io_manager import WriteMode
 from dagster_deltalake_polars import DeltaLakePolarsIOManager

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
@@ -24,7 +24,7 @@ except ImportError:
 from dagster_deltalake.io_manager import DELTA_DATE_FORMAT, DELTA_DATETIME_FORMAT, TableConnection
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+    from dagster._core.definitions.partitions.utils import TimeWindow
 
 T = TypeVar("T")
 ArrowTypes: TypeAlias = Union[pa.Table, pa.RecordBatchReader]

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
@@ -8,7 +8,7 @@ from typing import Optional, TypedDict, Union, cast
 
 from dagster import OutputContext
 from dagster._config.pythonic_config import ConfigurableIOManagerFactory
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_io_manager.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import pytest
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.storage.db_io_manager import TablePartitionDimension
 from dagster_deltalake.handler import partition_dimensions_to_dnf
 from deltalake.schema import Field, PrimitiveType, Schema

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler.py
@@ -16,13 +16,13 @@ from dagster import (
     op,
 )
 from dagster._check import CheckError
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster_deltalake import DELTA_DATE_FORMAT, DeltaLakePyarrowIOManager, LocalConfig
 from deltalake import DeltaTable
 

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
@@ -23,10 +23,10 @@ from dagster._core.definitions.metadata.metadata_value import (
     TextMetadataValue,
 )
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     MonthlyPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
 from dagster._core.definitions.tags import build_kind_tag, has_kind
 from dagster._core.errors import DagsterInvariantViolationError

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_fetch_metadata.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_fetch_metadata.py
@@ -3,9 +3,7 @@ from unittest import mock
 
 from dagster import AssetExecutionContext, AssetKey
 from dagster._core.definitions.materialize import materialize
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
-    MonthlyPartitionsDefinition,
-)
+from dagster._core.definitions.partitions.definition import MonthlyPartitionsDefinition
 from dagster_dlt import DagsterDltResource, dlt_assets
 from dlt import Pipeline
 

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas_tests/test_type_handler.py
@@ -19,13 +19,13 @@ from dagster import (
     op,
 )
 from dagster._check import CheckError
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster_duckdb_pandas import DuckDBPandasIOManager, duckdb_pandas_io_manager
 
 if TYPE_CHECKING:

--- a/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-polars/dagster_duckdb_polars_tests/test_type_handler.py
@@ -16,13 +16,13 @@ from dagster import (
     op,
 )
 from dagster._check import CheckError
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster_duckdb_polars import DuckDBPolarsIOManager, duckdb_polars_io_manager
 
 

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark_tests/test_type_handler.py
@@ -16,13 +16,13 @@ from dagster import (
     op,
 )
 from dagster._check import CheckError
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster_duckdb_pyspark import DuckDBPySparkIOManager, duckdb_pyspark_io_manager
 from pyspark.sql import (
     DataFrame as SparkDF,

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, cast
 import duckdb
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._config.pythonic_config import ConfigurableIOManagerFactory
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb_tests/test_io_manager.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.storage.db_io_manager import TablePartitionDimension, TableSlice
 from dagster_duckdb.io_manager import DuckDbClient, _get_cleanup_statement
 

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -23,13 +23,13 @@ from dagster import (
     materialize,
     op,
 )
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster_gcp_pandas import BigQueryPandasIOManager, bigquery_pandas_io_manager
 from google.cloud import bigquery
 

--- a/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/dagster_gcp_pyspark_tests/bigquery/test_type_handler.py
@@ -26,13 +26,13 @@ from dagster import (
     materialize,
     op,
 )
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.storage.db_io_manager import TableSlice
 from dagster_gcp import build_bigquery_io_manager
 from dagster_gcp_pyspark import (

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -6,7 +6,7 @@ from typing import Optional, cast
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._annotations import beta
 from dagster._config.pythonic_config import ConfigurableIOManagerFactory
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_io_manager.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import pytest
 from dagster import InputContext, OutputContext, asset, materialize
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.storage.db_io_manager import DbTypeHandler, TablePartitionDimension, TableSlice
 from dagster_gcp.bigquery.io_manager import (
     BigQueryClient,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
@@ -23,7 +23,7 @@ from dagster import (
 )
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.job_base import InMemoryJob
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.events import DagsterEventType

--- a/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
@@ -15,7 +15,7 @@ from dagster import (
     multi_asset,
     op,
 )
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.context.init import build_init_resource_context
 from dagster._utils.test import wrap_op_in_graph_and_execute

--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas_tests/test_snowflake_pandas_type_handler.py
@@ -27,13 +27,13 @@ from dagster import (
     materialize,
     op,
 )
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.db_io_manager import TableSlice
 from dagster_snowflake import build_snowflake_io_manager

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_snowflake_pyspark_type_handler.py
@@ -27,13 +27,13 @@ from dagster import (
     materialize,
     op,
 )
-from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
-from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
-from dagster._core.definitions.partitions.definition.static import StaticPartitionsDefinition
-from dagster._core.definitions.partitions.definition.time_window_subclasses import (
+from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
 from dagster._core.storage.db_io_manager import TableSlice
 from dagster_snowflake import build_snowflake_io_manager
 from dagster_snowflake.resources import SnowflakeResource

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, cast
 
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._config.pythonic_config import ConfigurableIOManagerFactory
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from dagster._core.definitions import materialize
 from dagster._core.definitions.decorators import asset
-from dagster._core.definitions.partitions.utils.time_window import TimeWindow
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.storage.db_io_manager import DbTypeHandler, TablePartitionDimension, TableSlice
 from dagster_snowflake.snowflake_io_manager import (
     SnowflakeDbClient,


### PR DESCRIPTION
## Summary & Motivation

After breaking up these big files, a lot of the imports through the rest of the codebase get a little messier. This allows you to import from slightly-less specific modules

## How I Tested These Changes

## Changelog

NOCHANGELOG
