### PR TITLE
[partition-context] partition_loading_context guard

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/context.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/context.py
@@ -1,8 +1,15 @@
+import datetime
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Optional
+
+from dagster_shared.record import replace
 
 from dagster._core.definitions.temporal_context import TemporalContext
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._record import record
+from dagster._time import get_current_datetime
 
 
 @record
@@ -17,3 +24,72 @@ class PartitionLoadingContext:
 
     temporal_context: TemporalContext
     dynamic_partitions_store: Optional[DynamicPartitionsStore]
+
+    @property
+    def effective_dt(self) -> datetime.datetime:
+        return self.temporal_context.effective_dt
+
+    @staticmethod
+    def default() -> "PartitionLoadingContext":
+        return PartitionLoadingContext(
+            temporal_context=TemporalContext(
+                effective_dt=get_current_datetime(), last_event_id=None
+            ),
+            dynamic_partitions_store=None,
+        )
+
+    def updated(
+        self,
+        effective_dt: Optional[datetime.datetime],
+        dynamic_partitions_store: Optional[DynamicPartitionsStore],
+    ) -> "PartitionLoadingContext":
+        """Returns a new PartitionLoadingContext with the updated effective_dt and dynamic_partitions_store.
+        If the effective_dt and dynamic_partitions_store are unset, the existing context is returned.
+
+        Args:
+            effective_dt: The effective time for the partition loading.
+            dynamic_partitions_store: The DynamicPartitionsStore backing the partition loading.
+        """
+        if effective_dt is None and dynamic_partitions_store is None:
+            return self
+
+        return replace(
+            self,
+            temporal_context=replace(
+                self.temporal_context, effective_dt=effective_dt or self.effective_dt
+            ),
+            dynamic_partitions_store=dynamic_partitions_store or self.dynamic_partitions_store,
+        )
+
+
+_current_ctx: ContextVar[Optional[PartitionLoadingContext]] = ContextVar(
+    "current_partition_loading_context", default=None
+)
+
+
+@contextmanager
+def partition_loading_context(
+    effective_dt: Optional[datetime.datetime] = None,
+    dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+    *,
+    new_ctx: Optional[PartitionLoadingContext] = None,
+) -> Iterator[PartitionLoadingContext]:
+    """Context manager for setting the current partition loading context. The information is used
+    throughout a variety of PartitionsDefinition, PartitionMapping, and PartitionSubset methods.
+
+    Args:
+        effective_dt: The effective time for the partition loading.
+        dynamic_partitions_store: The DynamicPartitionsStore backing the partition loading.
+        ctx: The current partition loading context.
+    """
+    prev_ctx = _current_ctx.get() or PartitionLoadingContext.default()
+    new_ctx = new_ctx or PartitionLoadingContext.updated(
+        prev_ctx, effective_dt, dynamic_partitions_store
+    )
+
+    token = _current_ctx.set(new_ctx)
+
+    try:
+        yield new_ctx
+    finally:
+        _current_ctx.reset(token)

--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/dynamic.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/dynamic.py
@@ -8,7 +8,10 @@ from dagster._core.definitions.dynamic_partitions_request import (
     AddDynamicPartitionsRequest,
     DeleteDynamicPartitionsRequest,
 )
-from dagster._core.definitions.partitions.context import PartitionLoadingContext
+from dagster._core.definitions.partitions.context import (
+    PartitionLoadingContext,
+    partition_loading_context,
+)
 from dagster._core.definitions.partitions.definition.partitions_definition import (
     PartitionsDefinition,
 )
@@ -151,29 +154,25 @@ class DynamicPartitionsDefinition(
         Returns:
             Sequence[str]
         """
-        if self.partition_fn:
-            partitions = self.partition_fn(current_time)
-            if all(isinstance(partition, Partition) for partition in partitions):
-                return [partition.name for partition in partitions]  # type: ignore  # (illegible conditional)
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            if self.partition_fn:
+                partitions = self.partition_fn(current_time)
+                if all(isinstance(partition, Partition) for partition in partitions):
+                    return [partition.name for partition in partitions]  # type: ignore  # (illegible conditional)
+                else:
+                    return partitions  # type: ignore  # (illegible conditional)
             else:
-                return partitions  # type: ignore  # (illegible conditional)
-        else:
-            check.opt_inst_param(
-                dynamic_partitions_store, "dynamic_partitions_store", DynamicPartitionsStore
-            )
-
-            dynamic_partitions_store = self._ensure_dynamic_partitions_store(
-                dynamic_partitions_store
-            )
-            return dynamic_partitions_store.get_dynamic_partitions(
-                partitions_def_name=self._validated_name()
-            )
+                return self._ensure_dynamic_partitions_store(
+                    ctx.dynamic_partitions_store
+                ).get_dynamic_partitions(partitions_def_name=self._validated_name())
 
     def get_serializable_unique_identifier(
         self, dynamic_partitions_store: Optional[DynamicPartitionsStore] = None
     ) -> str:
-        dynamic_partitions_store = self._ensure_dynamic_partitions_store(dynamic_partitions_store)
-        return dynamic_partitions_store.get_dynamic_partitions_definition_id(self._validated_name())
+        with partition_loading_context(dynamic_partitions_store=dynamic_partitions_store) as ctx:
+            return self._ensure_dynamic_partitions_store(
+                ctx.dynamic_partitions_store
+            ).get_dynamic_partitions_definition_id(self._validated_name())
 
     def get_paginated_partition_keys(
         self,
@@ -182,14 +181,13 @@ class DynamicPartitionsDefinition(
         ascending: bool,
         cursor: Optional[str] = None,
     ) -> PaginatedResults[str]:
-        current_time = context.temporal_context.effective_dt
-        dynamic_partitions_store = context.dynamic_partitions_store
-        partition_keys = self.get_partition_keys(
-            current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
-        )
-        return PaginatedResults.create_from_sequence(
-            partition_keys, limit=limit, ascending=ascending, cursor=cursor
-        )
+        with partition_loading_context(new_ctx=context) as ctx:
+            partition_keys = self.get_partition_keys(
+                current_time=ctx.effective_dt, dynamic_partitions_store=ctx.dynamic_partitions_store
+            )
+            return PaginatedResults.create_from_sequence(
+                partition_keys, limit=limit, ascending=ascending, cursor=cursor
+            )
 
     def has_partition_key(
         self,
@@ -197,21 +195,22 @@ class DynamicPartitionsDefinition(
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> bool:
-        if self.partition_fn:
-            return partition_key in self.get_partition_keys(current_time)
-        else:
-            if dynamic_partitions_store is None:
-                check.failed(
-                    "The instance is not available to load partitions. You may be seeing this error"
-                    " when using dynamic partitions with a version of dagster-webserver or"
-                    " dagster-cloud that is older than 1.1.18. The other possibility is that an"
-                    " internal framework error where a dynamic partitions store was not properly"
-                    " threaded down a call stack."
-                )
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            if self.partition_fn:
+                return partition_key in self.get_partition_keys(ctx.effective_dt)
+            else:
+                if ctx.dynamic_partitions_store is None:
+                    check.failed(
+                        "The instance is not available to load partitions. You may be seeing this error"
+                        " when using dynamic partitions with a version of dagster-webserver or"
+                        " dagster-cloud that is older than 1.1.18. The other possibility is that an"
+                        " internal framework error where a dynamic partitions store was not properly"
+                        " threaded down a call stack."
+                    )
 
-            return dynamic_partitions_store.has_dynamic_partition(
-                partitions_def_name=self._validated_name(), partition_key=partition_key
-            )
+                return ctx.dynamic_partitions_store.has_dynamic_partition(
+                    partitions_def_name=self._validated_name(), partition_key=partition_key
+                )
 
     def build_add_request(self, partition_keys: Sequence[str]) -> AddDynamicPartitionsRequest:
         check.sequence_param(partition_keys, "partition_keys", of_type=str)

--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/multi.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/multi.py
@@ -9,7 +9,10 @@ from dagster_shared.check.functions import CheckError
 
 import dagster._check as check
 from dagster._annotations import public
-from dagster._core.definitions.partitions.context import PartitionLoadingContext
+from dagster._core.definitions.partitions.context import (
+    PartitionLoadingContext,
+    partition_loading_context,
+)
 from dagster._core.definitions.partitions.definition.dynamic import DynamicPartitionsDefinition
 from dagster._core.definitions.partitions.definition.partitions_definition import (
     PartitionsDefinition,
@@ -20,7 +23,6 @@ from dagster._core.definitions.partitions.definition.time_window import (
 )
 from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partitions.subset.default import DefaultPartitionsSubset
-from dagster._core.definitions.partitions.subset.partitions_subset import PartitionsSubset
 from dagster._core.definitions.partitions.utils.multi import (
     INVALID_STATIC_PARTITIONS_KEY_CHARACTERS,
     MULTIPARTITION_KEY_DELIMITER,
@@ -38,7 +40,9 @@ from dagster._core.errors import (
 )
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.types.pagination import PaginatedResults
-from dagster._time import get_current_datetime
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.partitions.subset.partitions_subset import PartitionsSubset
 
 if TYPE_CHECKING:
     from dagster._core.definitions.partitions.subset.partitions_subset import PartitionsSubset
@@ -139,40 +143,45 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
         partition_key_range: PartitionKeyRange,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[str]:
-        start: MultiPartitionKey = self.get_partition_key_from_str(partition_key_range.start)
-        end: MultiPartitionKey = self.get_partition_key_from_str(partition_key_range.end)
+        with partition_loading_context(dynamic_partitions_store=dynamic_partitions_store) as ctx:
+            start: MultiPartitionKey = self.get_partition_key_from_str(partition_key_range.start)
+            end: MultiPartitionKey = self.get_partition_key_from_str(partition_key_range.end)
 
-        partition_key_sequences = [
-            partition_dim.partitions_def.get_partition_keys_in_range(
-                PartitionKeyRange(
-                    start.keys_by_dimension[partition_dim.name],
-                    end.keys_by_dimension[partition_dim.name],
-                ),
-                dynamic_partitions_store=dynamic_partitions_store,
-            )
-            for partition_dim in self._partitions_defs
-        ]
+            partition_key_sequences = [
+                partition_dim.partitions_def.get_partition_keys_in_range(
+                    PartitionKeyRange(
+                        start.keys_by_dimension[partition_dim.name],
+                        end.keys_by_dimension[partition_dim.name],
+                    ),
+                    dynamic_partitions_store=ctx.dynamic_partitions_store,
+                )
+                for partition_dim in self._partitions_defs
+            ]
 
-        return [
-            MultiPartitionKey(
-                {self._partitions_defs[i].name: key for i, key in enumerate(partition_key_tuple)}
-            )
-            for partition_key_tuple in itertools.product(*partition_key_sequences)
-        ]
+            return [
+                MultiPartitionKey(
+                    {
+                        self._partitions_defs[i].name: key
+                        for i, key in enumerate(partition_key_tuple)
+                    }
+                )
+                for partition_key_tuple in itertools.product(*partition_key_sequences)
+            ]
 
     def get_serializable_unique_identifier(
         self, dynamic_partitions_store: Optional[DynamicPartitionsStore] = None
     ) -> str:
-        return hashlib.sha1(
-            str(
-                {
-                    dim_def.name: dim_def.partitions_def.get_serializable_unique_identifier(
-                        dynamic_partitions_store
-                    )
-                    for dim_def in self.partitions_defs
-                }
-            ).encode("utf-8")
-        ).hexdigest()
+        with partition_loading_context(dynamic_partitions_store=dynamic_partitions_store) as ctx:
+            return hashlib.sha1(
+                str(
+                    {
+                        dim_def.name: dim_def.partitions_def.get_serializable_unique_identifier(
+                            ctx.dynamic_partitions_store
+                        )
+                        for dim_def in self.partitions_defs
+                    }
+                ).encode("utf-8")
+            ).hexdigest()
 
     @property
     def partition_dimension_names(self) -> list[str]:
@@ -195,45 +204,51 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> bool:
-        if isinstance(partition_key, str):
-            try:
-                partition_key = self.get_partition_key_from_str(partition_key)
-            except CheckError:
-                return False
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            if isinstance(partition_key, str):
+                try:
+                    partition_key = self.get_partition_key_from_str(partition_key)
+                except CheckError:
+                    return False
 
-        if partition_key.keys_by_dimension.keys() != set(self.partition_dimension_names):
-            raise DagsterUnknownPartitionError(
-                f"Invalid partition key {partition_key}. The dimensions of the partition key are"
-                " not the dimensions of the partitions definition."
-            )
+            if partition_key.keys_by_dimension.keys() != set(self.partition_dimension_names):
+                raise DagsterUnknownPartitionError(
+                    f"Invalid partition key {partition_key}. The dimensions of the partition key are"
+                    " not the dimensions of the partitions definition."
+                )
 
-        for dimension in self.partitions_defs:
-            if not dimension.partitions_def.has_partition_key(
-                partition_key.keys_by_dimension[dimension.name],
-                current_time=current_time,
-                dynamic_partitions_store=dynamic_partitions_store,
-            ):
-                return False
-        return True
+            for dimension in self.partitions_defs:
+                if not dimension.partitions_def.has_partition_key(
+                    partition_key.keys_by_dimension[dimension.name],
+                    current_time=ctx.effective_dt,
+                    dynamic_partitions_store=ctx.dynamic_partitions_store,
+                ):
+                    return False
+            return True
 
     # store results for repeated calls with the same current_time
     @lru_cache(maxsize=1)
     def _get_partition_keys(
         self, current_time: datetime, dynamic_partitions_store: Optional[DynamicPartitionsStore]
     ) -> Sequence[MultiPartitionKey]:
-        partition_key_sequences = [
-            partition_dim.partitions_def.get_partition_keys(
-                current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
-            )
-            for partition_dim in self._partitions_defs
-        ]
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            partition_key_sequences = [
+                partition_dim.partitions_def.get_partition_keys(
+                    current_time=ctx.effective_dt,
+                    dynamic_partitions_store=ctx.dynamic_partitions_store,
+                )
+                for partition_dim in self._partitions_defs
+            ]
 
-        return [
-            MultiPartitionKey(
-                {self._partitions_defs[i].name: key for i, key in enumerate(partition_key_tuple)}
-            )
-            for partition_key_tuple in itertools.product(*partition_key_sequences)
-        ]
+            return [
+                MultiPartitionKey(
+                    {
+                        self._partitions_defs[i].name: key
+                        for i, key in enumerate(partition_key_tuple)
+                    }
+                )
+                for partition_key_tuple in itertools.product(*partition_key_sequences)
+            ]
 
     @public
     def get_partition_keys(
@@ -255,9 +270,10 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
         Returns:
             Sequence[MultiPartitionKey]
         """
-        return self._get_partition_keys(
-            current_time or get_current_datetime(), dynamic_partitions_store
-        )
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            return self._get_partition_keys(
+                current_time=ctx.effective_dt, dynamic_partitions_store=ctx.dynamic_partitions_store
+            )
 
     def get_paginated_partition_keys(
         self,
@@ -276,57 +292,59 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
         Returns:
             PaginatedResults[MultiPartitionKey]
         """
-        partition_keys = []
-        iterator = MultiDimensionalPartitionKeyIterator(
-            context=context,
-            partition_defs=self._partitions_defs,
-            cursor=MultiPartitionCursor.from_cursor(cursor),
-            ascending=ascending,
-        )
-        next_cursor = cursor
-        while iterator.has_next():
-            partition_key = next(iterator)
-            if not partition_key:
-                break
+        with partition_loading_context(new_ctx=context) as ctx:
+            partition_keys = []
+            iterator = MultiDimensionalPartitionKeyIterator(
+                context=ctx,
+                partition_defs=self._partitions_defs,
+                cursor=MultiPartitionCursor.from_cursor(cursor),
+                ascending=ascending,
+            )
+            next_cursor = cursor
+            while iterator.has_next():
+                partition_key = next(iterator)
+                if not partition_key:
+                    break
 
-            partition_keys.append(partition_key)
-            next_cursor = iterator.cursor().to_string()
-            if len(partition_keys) >= limit:
-                break
+                partition_keys.append(partition_key)
+                next_cursor = iterator.cursor().to_string()
+                if len(partition_keys) >= limit:
+                    break
 
-        if not next_cursor:
-            next_cursor = MultiPartitionCursor(last_seen_key=None).to_string()
+            if not next_cursor:
+                next_cursor = MultiPartitionCursor(last_seen_key=None).to_string()
 
-        return PaginatedResults(
-            results=partition_keys, cursor=next_cursor, has_more=iterator.has_next()
-        )
+            return PaginatedResults(
+                results=partition_keys, cursor=next_cursor, has_more=iterator.has_next()
+            )
 
     def filter_valid_partition_keys(
         self, partition_keys: set[str], dynamic_partitions_store: DynamicPartitionsStore
     ) -> set[MultiPartitionKey]:
-        partition_keys_by_dimension = {
-            dim.name: dim.partitions_def.get_partition_keys(
-                dynamic_partitions_store=dynamic_partitions_store
-            )
-            for dim in self.partitions_defs
-        }
-        validated_partitions = set()
-        for partition_key in partition_keys:
-            partition_key_strs = partition_key.split(MULTIPARTITION_KEY_DELIMITER)
-            if len(partition_key_strs) != len(self.partitions_defs):
-                continue
+        with partition_loading_context(dynamic_partitions_store=dynamic_partitions_store) as ctx:
+            partition_keys_by_dimension = {
+                dim.name: dim.partitions_def.get_partition_keys(
+                    dynamic_partitions_store=ctx.dynamic_partitions_store
+                )
+                for dim in self.partitions_defs
+            }
+            validated_partitions = set()
+            for partition_key in partition_keys:
+                partition_key_strs = partition_key.split(MULTIPARTITION_KEY_DELIMITER)
+                if len(partition_key_strs) != len(self.partitions_defs):
+                    continue
 
-            multipartition_key = MultiPartitionKey(
-                {dim.name: partition_key_strs[i] for i, dim in enumerate(self._partitions_defs)}
-            )
+                multipartition_key = MultiPartitionKey(
+                    {dim.name: partition_key_strs[i] for i, dim in enumerate(self._partitions_defs)}
+                )
 
-            if all(
-                key in partition_keys_by_dimension.get(dim, [])
-                for dim, key in multipartition_key.keys_by_dimension.items()
-            ):
-                validated_partitions.add(partition_key)
+                if all(
+                    key in partition_keys_by_dimension.get(dim, [])
+                    for dim, key in multipartition_key.keys_by_dimension.items()
+                ):
+                    validated_partitions.add(partition_key)
 
-        return validated_partitions
+            return validated_partitions
 
     def __eq__(self, other):
         return (
@@ -455,51 +473,55 @@ class MultiPartitionsDefinition(PartitionsDefinition[MultiPartitionKey]):
         check.str_param(dimension_name, "dimension_name")
         check.str_param(dimension_partition_key, "dimension_partition_key")
 
-        matching_dimensions = [
-            dimension for dimension in self.partitions_defs if dimension.name == dimension_name
-        ]
-        other_dimensions = [
-            dimension for dimension in self.partitions_defs if dimension.name != dimension_name
-        ]
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            matching_dimensions = [
+                dimension for dimension in self.partitions_defs if dimension.name == dimension_name
+            ]
+            other_dimensions = [
+                dimension for dimension in self.partitions_defs if dimension.name != dimension_name
+            ]
 
-        check.invariant(
-            len(matching_dimensions) == 1,
-            f"Dimension {dimension_name} not found in MultiPartitionsDefinition with dimensions"
-            f" {[dim.name for dim in self.partitions_defs]}",
-        )
-
-        partition_sequences = [
-            partition_dim.partitions_def.get_partition_keys(
-                current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
+            check.invariant(
+                len(matching_dimensions) == 1,
+                f"Dimension {dimension_name} not found in MultiPartitionsDefinition with dimensions"
+                f" {[dim.name for dim in self.partitions_defs]}",
             )
-            for partition_dim in other_dimensions
-        ] + [[dimension_partition_key]]
 
-        # Names of partitions dimensions in the same order as partition_sequences
-        partition_dim_names = [dim.name for dim in other_dimensions] + [dimension_name]
+            partition_sequences = [
+                partition_dim.partitions_def.get_partition_keys(
+                    current_time=ctx.effective_dt,
+                    dynamic_partitions_store=ctx.dynamic_partitions_store,
+                )
+                for partition_dim in other_dimensions
+            ] + [[dimension_partition_key]]
 
-        return [
-            MultiPartitionKey(
-                {
-                    partition_dim_names[i]: partition_key
-                    for i, partition_key in enumerate(partitions_tuple)
-                }
-            )
-            for partitions_tuple in itertools.product(*partition_sequences)
-        ]
+            # Names of partitions dimensions in the same order as partition_sequences
+            partition_dim_names = [dim.name for dim in other_dimensions] + [dimension_name]
+
+            return [
+                MultiPartitionKey(
+                    {
+                        partition_dim_names[i]: partition_key
+                        for i, partition_key in enumerate(partitions_tuple)
+                    }
+                )
+                for partitions_tuple in itertools.product(*partition_sequences)
+            ]
 
     def get_num_partitions(
         self,
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> int:
-        # Static partitions definitions can contain duplicate keys (will throw error in 1.3.0)
-        # In the meantime, relying on get_num_partitions to handle duplicates to display
-        # correct counts in the Dagster UI.
-        dimension_counts = [
-            dim.partitions_def.get_num_partitions(
-                current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
-            )
-            for dim in self.partitions_defs
-        ]
-        return reduce(lambda x, y: x * y, dimension_counts, 1)
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            # Static partitions definitions can contain duplicate keys (will throw error in 1.3.0)
+            # In the meantime, relying on get_num_partitions to handle duplicates to display
+            # correct counts in the Dagster UI.
+            dimension_counts = [
+                dim.partitions_def.get_num_partitions(
+                    current_time=ctx.effective_dt,
+                    dynamic_partitions_store=ctx.dynamic_partitions_store,
+                )
+                for dim in self.partitions_defs
+            ]
+            return reduce(lambda x, y: x * y, dimension_counts, 1)

--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/static.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/static.py
@@ -4,7 +4,10 @@ from typing import Optional
 
 import dagster._check as check
 from dagster._annotations import public
-from dagster._core.definitions.partitions.context import PartitionLoadingContext
+from dagster._core.definitions.partitions.context import (
+    PartitionLoadingContext,
+    partition_loading_context,
+)
 from dagster._core.definitions.partitions.definition.partitions_definition import (
     PartitionsDefinition,
 )
@@ -77,14 +80,13 @@ class StaticPartitionsDefinition(PartitionsDefinition[str]):
         ascending: bool,
         cursor: Optional[str] = None,
     ) -> PaginatedResults[str]:
-        current_time = context.temporal_context.effective_dt
-        dynamic_partitions_store = context.dynamic_partitions_store
-        partition_keys = self.get_partition_keys(
-            current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
-        )
-        return PaginatedResults.create_from_sequence(
-            partition_keys, limit=limit, ascending=ascending, cursor=cursor
-        )
+        with partition_loading_context(new_ctx=context) as ctx:
+            partition_keys = self.get_partition_keys(
+                current_time=ctx.effective_dt, dynamic_partitions_store=ctx.dynamic_partitions_store
+            )
+            return PaginatedResults.create_from_sequence(
+                partition_keys, limit=limit, ascending=ascending, cursor=cursor
+            )
 
     def __hash__(self):
         return hash(self.__repr__())
@@ -102,7 +104,8 @@ class StaticPartitionsDefinition(PartitionsDefinition[str]):
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> int:
-        # We don't currently throw an error when a duplicate partition key is defined
-        # in a static partitions definition, though we will at 1.3.0.
-        # This ensures that partition counts are correct in the Dagster UI.
-        return len(set(self.get_partition_keys(current_time, dynamic_partitions_store)))
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            # We don't currently throw an error when a duplicate partition key is defined
+            # in a static partitions definition, though we will at 1.3.0.
+            # This ensures that partition counts are correct in the Dagster UI.
+            return len(set(self.get_partition_keys(ctx.effective_dt, ctx.dynamic_partitions_store)))

--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, Optional, Union, cast
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, public
-from dagster._core.definitions.partitions.context import PartitionLoadingContext
+from dagster._core.definitions.partitions.context import (
+    PartitionLoadingContext,
+    partition_loading_context,
+)
 from dagster._core.definitions.partitions.definition.partitions_definition import (
     PartitionsDefinition,
 )
@@ -227,15 +230,16 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> int:
-        last_partition_window = self.get_last_partition_window(current_time)
-        first_partition_window = self.get_first_partition_window(current_time)
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            last_partition_window = self.get_last_partition_window(ctx.effective_dt)
+            first_partition_window = self.get_first_partition_window(ctx.effective_dt)
 
-        if not last_partition_window or not first_partition_window:
-            return 0
+            if not last_partition_window or not first_partition_window:
+                return 0
 
-        return self.get_num_partitions_in_window(
-            TimeWindow(start=first_partition_window.start, end=last_partition_window.end)
-        )
+            return self.get_num_partitions_in_window(
+                TimeWindow(start=first_partition_window.start, end=last_partition_window.end)
+            )
 
     def get_partition_keys_between_indexes(
         self, start_idx: int, end_idx: int, current_time: Optional[datetime] = None
@@ -244,70 +248,78 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
         # Start index is inclusive, end index is exclusive.
         # Method added for performance reasons, to only string format
         # partition keys included within the indices.
-        current_timestamp = self._get_current_timestamp(current_time=current_time)
+        with partition_loading_context(current_time) as ctx:
+            current_timestamp = self._get_current_timestamp(current_time=ctx.effective_dt)
 
-        partitions_past_current_time = 0
-        partition_keys = []
-        reached_end = False
+            partitions_past_current_time = 0
+            partition_keys = []
+            reached_end = False
 
-        for idx, time_window in enumerate(self._iterate_time_windows(self.start_timestamp)):
-            if time_window.end.timestamp() >= current_timestamp:
-                reached_end = True
-            if self.end_timestamp is not None and time_window.end.timestamp() > self.end_timestamp:
-                reached_end = True
-            if (
-                time_window.end.timestamp() <= current_timestamp
-                or partitions_past_current_time < self.end_offset
-            ):
-                if idx >= start_idx and idx < end_idx:
-                    partition_keys.append(
-                        dst_safe_strftime(
-                            time_window.start, self.timezone, self.fmt, self.cron_schedule
+            for idx, time_window in enumerate(self._iterate_time_windows(self.start_timestamp)):
+                if time_window.end.timestamp() >= current_timestamp:
+                    reached_end = True
+                if (
+                    self.end_timestamp is not None
+                    and time_window.end.timestamp() > self.end_timestamp
+                ):
+                    reached_end = True
+                if (
+                    time_window.end.timestamp() <= current_timestamp
+                    or partitions_past_current_time < self.end_offset
+                ):
+                    if idx >= start_idx and idx < end_idx:
+                        partition_keys.append(
+                            dst_safe_strftime(
+                                time_window.start, self.timezone, self.fmt, self.cron_schedule
+                            )
                         )
-                    )
-                if time_window.end.timestamp() > current_timestamp:
-                    partitions_past_current_time += 1
-            else:
-                break
-            if len(partition_keys) >= end_idx - start_idx:
-                break
+                    if time_window.end.timestamp() > current_timestamp:
+                        partitions_past_current_time += 1
+                else:
+                    break
+                if len(partition_keys) >= end_idx - start_idx:
+                    break
 
-        if reached_end and self.end_offset < 0:
-            partition_keys = partition_keys[: self.end_offset]
+            if reached_end and self.end_offset < 0:
+                partition_keys = partition_keys[: self.end_offset]
 
-        return partition_keys
+            return partition_keys
 
     def get_partition_keys(
         self,
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Sequence[str]:
-        current_timestamp = self._get_current_timestamp(current_time=current_time)
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            current_timestamp = self._get_current_timestamp(current_time=ctx.effective_dt)
 
-        partitions_past_current_time = 0
-        partition_keys: list[str] = []
-        for time_window in self._iterate_time_windows(self.start_timestamp):
-            if self.end_timestamp is not None and time_window.end.timestamp() > self.end_timestamp:
-                break
-            if (
-                time_window.end.timestamp() <= current_timestamp
-                or partitions_past_current_time < self.end_offset
-            ):
-                partition_keys.append(
-                    dst_safe_strftime(
-                        time_window.start, self.timezone, self.fmt, self.cron_schedule
+            partitions_past_current_time = 0
+            partition_keys: list[str] = []
+            for time_window in self._iterate_time_windows(self.start_timestamp):
+                if (
+                    self.end_timestamp is not None
+                    and time_window.end.timestamp() > self.end_timestamp
+                ):
+                    break
+                if (
+                    time_window.end.timestamp() <= current_timestamp
+                    or partitions_past_current_time < self.end_offset
+                ):
+                    partition_keys.append(
+                        dst_safe_strftime(
+                            time_window.start, self.timezone, self.fmt, self.cron_schedule
+                        )
                     )
-                )
 
-                if time_window.end.timestamp() > current_timestamp:
-                    partitions_past_current_time += 1
-            else:
-                break
+                    if time_window.end.timestamp() > current_timestamp:
+                        partitions_past_current_time += 1
+                else:
+                    break
 
-        if self.end_offset < 0:
-            partition_keys = partition_keys[: self.end_offset]
+            if self.end_offset < 0:
+                partition_keys = partition_keys[: self.end_offset]
 
-        return partition_keys
+            return partition_keys
 
     def get_paginated_partition_keys(
         self,
@@ -316,131 +328,132 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
         ascending: bool,
         cursor: Optional[str] = None,
     ) -> PaginatedResults[str]:
-        current_timestamp = self._get_current_timestamp(context.temporal_context.effective_dt)
+        with partition_loading_context(new_ctx=context) as ctx:
+            current_timestamp = self._get_current_timestamp(current_time=ctx.effective_dt)
 
-        if cursor:
-            time_window_cursor = TimeWindowCursor.from_cursor(cursor)
-            start_timestamp = time_window_cursor.start_timestamp
-            end_timestamp = time_window_cursor.end_timestamp
-            offset_partitions_count = time_window_cursor.offset_partition_count
-        else:
-            start_timestamp = self.start_timestamp
-            end_timestamp = current_timestamp
-            offset_partitions_count = 0
+            if cursor:
+                time_window_cursor = TimeWindowCursor.from_cursor(cursor)
+                start_timestamp = time_window_cursor.start_timestamp
+                end_timestamp = time_window_cursor.end_timestamp
+                offset_partitions_count = time_window_cursor.offset_partition_count
+            else:
+                start_timestamp = self.start_timestamp
+                end_timestamp = current_timestamp
+                offset_partitions_count = 0
 
-        partition_keys: list[str] = []
-        has_more = False
+            partition_keys: list[str] = []
+            has_more = False
 
-        if not ascending:
-            offset_time_windows = []
-            if self.end_offset > 0 and self.end_offset > offset_partitions_count:
-                last_no_offset_time_window = next(
-                    iter(self._reverse_iterate_time_windows(end_timestamp)), None
-                )
-                lookforward_time = (
-                    last_no_offset_time_window.end.timestamp()
-                    if last_no_offset_time_window
-                    else end_timestamp
-                )
-                for time_window in self._iterate_time_windows(lookforward_time):
-                    if (
-                        self.end_timestamp is not None
-                        and time_window.end.timestamp() > self.end_timestamp
-                    ):
-                        break
+            if not ascending:
+                offset_time_windows = []
+                if self.end_offset > 0 and self.end_offset > offset_partitions_count:
+                    last_no_offset_time_window = next(
+                        iter(self._reverse_iterate_time_windows(end_timestamp)), None
+                    )
+                    lookforward_time = (
+                        last_no_offset_time_window.end.timestamp()
+                        if last_no_offset_time_window
+                        else end_timestamp
+                    )
+                    for time_window in self._iterate_time_windows(lookforward_time):
+                        if (
+                            self.end_timestamp is not None
+                            and time_window.end.timestamp() > self.end_timestamp
+                        ):
+                            break
 
-                    if len(offset_time_windows) >= self.end_offset - offset_partitions_count:
-                        break
+                        if len(offset_time_windows) >= self.end_offset - offset_partitions_count:
+                            break
 
-                    offset_time_windows.append(
-                        dst_safe_strftime(
-                            time_window.start, self.timezone, self.fmt, self.cron_schedule
+                        offset_time_windows.append(
+                            dst_safe_strftime(
+                                time_window.start, self.timezone, self.fmt, self.cron_schedule
+                            )
                         )
-                    )
 
-            partition_keys = list(reversed(offset_time_windows))[:limit]
-            offset_partitions_count += len(partition_keys)
+                partition_keys = list(reversed(offset_time_windows))[:limit]
+                offset_partitions_count += len(partition_keys)
 
-            for time_window in self._reverse_iterate_time_windows(end_timestamp):
-                if len(partition_keys) >= limit - min(0, self.end_offset):
-                    has_more = True
-                    break
+                for time_window in self._reverse_iterate_time_windows(end_timestamp):
+                    if len(partition_keys) >= limit - min(0, self.end_offset):
+                        has_more = True
+                        break
 
-                if time_window.start.timestamp() < start_timestamp:
-                    break
+                    if time_window.start.timestamp() < start_timestamp:
+                        break
 
-                partition_keys.append(
-                    dst_safe_strftime(
-                        time_window.start, self.timezone, self.fmt, self.cron_schedule
-                    )
-                )
-
-            if self.end_offset < 0 and not cursor:
-                # only subset if we did not have a cursor... if we did have a cursor, we've already
-                # applied the offset to the end, since we're moving backwards from the end
-                partition_keys = partition_keys[-1 * min(0, self.end_offset) :]
-
-        else:
-            for time_window in self._iterate_time_windows(start_timestamp):
-                if (
-                    self.end_timestamp is not None
-                    and time_window.end.timestamp() > self.end_timestamp
-                ):
-                    break
-                if (
-                    time_window.end.timestamp() <= end_timestamp
-                    or offset_partitions_count < self.end_offset
-                ):
                     partition_keys.append(
                         dst_safe_strftime(
                             time_window.start, self.timezone, self.fmt, self.cron_schedule
                         )
                     )
-                    if time_window.end.timestamp() > end_timestamp:
-                        offset_partitions_count += 1
-                    if len(partition_keys) >= limit - min(0, self.end_offset):
-                        has_more = True
+
+                if self.end_offset < 0 and not cursor:
+                    # only subset if we did not have a cursor... if we did have a cursor, we've already
+                    # applied the offset to the end, since we're moving backwards from the end
+                    partition_keys = partition_keys[-1 * min(0, self.end_offset) :]
+
+            else:
+                for time_window in self._iterate_time_windows(start_timestamp):
+                    if (
+                        self.end_timestamp is not None
+                        and time_window.end.timestamp() > self.end_timestamp
+                    ):
                         break
-                else:
-                    break
+                    if (
+                        time_window.end.timestamp() <= end_timestamp
+                        or offset_partitions_count < self.end_offset
+                    ):
+                        partition_keys.append(
+                            dst_safe_strftime(
+                                time_window.start, self.timezone, self.fmt, self.cron_schedule
+                            )
+                        )
+                        if time_window.end.timestamp() > end_timestamp:
+                            offset_partitions_count += 1
+                        if len(partition_keys) >= limit - min(0, self.end_offset):
+                            has_more = True
+                            break
+                    else:
+                        break
 
-            if has_more:
-                # exited due to limit; subset in case we overshot (if end_offset < 0)
-                partition_keys = partition_keys[:limit]
-            elif self.end_offset < 0:
-                # only subset if we did not eject early due to the limit
-                partition_keys = partition_keys[: self.end_offset]
+                if has_more:
+                    # exited due to limit; subset in case we overshot (if end_offset < 0)
+                    partition_keys = partition_keys[:limit]
+                elif self.end_offset < 0:
+                    # only subset if we did not eject early due to the limit
+                    partition_keys = partition_keys[: self.end_offset]
 
-        if not partition_keys:
-            next_cursor = TimeWindowCursor(
-                start_timestamp=int(start_timestamp),
-                end_timestamp=int(end_timestamp),
-                offset_partition_count=offset_partitions_count,
-            )
-        elif ascending:
-            last_partition_key = partition_keys[-1]
-            last_time_window = self.time_window_for_partition_key(last_partition_key)
-            next_cursor = TimeWindowCursor(
-                start_timestamp=int(last_time_window.end.timestamp()),
-                end_timestamp=int(end_timestamp),
-                offset_partition_count=offset_partitions_count,
-            )
-        else:
-            last_partition_key = partition_keys[-1]
-            last_time_window = self.time_window_for_partition_key(last_partition_key)
-            next_cursor = TimeWindowCursor(
-                start_timestamp=int(start_timestamp),
-                end_timestamp=int(end_timestamp)
-                if self.end_offset > 0 and offset_partitions_count < self.end_offset
-                else int(last_time_window.start.timestamp()),
-                offset_partition_count=offset_partitions_count,
-            )
+            if not partition_keys:
+                next_cursor = TimeWindowCursor(
+                    start_timestamp=int(start_timestamp),
+                    end_timestamp=int(end_timestamp),
+                    offset_partition_count=offset_partitions_count,
+                )
+            elif ascending:
+                last_partition_key = partition_keys[-1]
+                last_time_window = self.time_window_for_partition_key(last_partition_key)
+                next_cursor = TimeWindowCursor(
+                    start_timestamp=int(last_time_window.end.timestamp()),
+                    end_timestamp=int(end_timestamp),
+                    offset_partition_count=offset_partitions_count,
+                )
+            else:
+                last_partition_key = partition_keys[-1]
+                last_time_window = self.time_window_for_partition_key(last_partition_key)
+                next_cursor = TimeWindowCursor(
+                    start_timestamp=int(start_timestamp),
+                    end_timestamp=int(end_timestamp)
+                    if self.end_offset > 0 and offset_partitions_count < self.end_offset
+                    else int(last_time_window.start.timestamp()),
+                    offset_partition_count=offset_partitions_count,
+                )
 
-        return PaginatedResults(
-            results=partition_keys,
-            cursor=str(next_cursor),
-            has_more=has_more,
-        )
+            return PaginatedResults(
+                results=partition_keys,
+                cursor=str(next_cursor),
+                has_more=has_more,
+            )
 
     def __str__(self) -> str:
         schedule_str = (
@@ -480,50 +493,54 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
         validate: bool = True,
         current_time: Optional[datetime] = None,
     ) -> Sequence[TimeWindow]:
-        if len(partition_keys) == 0:
-            return []
+        with partition_loading_context(current_time) as ctx:
+            if len(partition_keys) == 0:
+                return []
 
-        sorted_pks = sorted(
-            partition_keys,
-            key=lambda pk: dst_safe_strptime(pk, self.timezone, self.fmt).timestamp(),
-        )
-        cur_windows_iterator = iter(
-            self._iterate_time_windows(
-                dst_safe_strptime(sorted_pks[0], self.timezone, self.fmt).timestamp()
+            sorted_pks = sorted(
+                partition_keys,
+                key=lambda pk: dst_safe_strptime(pk, self.timezone, self.fmt).timestamp(),
             )
-        )
-        partition_key_time_windows: list[TimeWindow] = []
-        for partition_key in sorted_pks:
-            next_window = next(cur_windows_iterator)
-            if (
-                dst_safe_strftime(next_window.start, self.timezone, self.fmt, self.cron_schedule)
-                == partition_key
-            ):
-                partition_key_time_windows.append(next_window)
-            else:
-                cur_windows_iterator = iter(
-                    self._iterate_time_windows(
-                        dst_safe_strptime(partition_key, self.timezone, self.fmt).timestamp()
-                    )
+            cur_windows_iterator = iter(
+                self._iterate_time_windows(
+                    dst_safe_strptime(sorted_pks[0], self.timezone, self.fmt).timestamp()
                 )
-                partition_key_time_windows.append(next(cur_windows_iterator))
+            )
+            partition_key_time_windows: list[TimeWindow] = []
+            for partition_key in sorted_pks:
+                next_window = next(cur_windows_iterator)
+                if (
+                    dst_safe_strftime(
+                        next_window.start, self.timezone, self.fmt, self.cron_schedule
+                    )
+                    == partition_key
+                ):
+                    partition_key_time_windows.append(next_window)
+                else:
+                    cur_windows_iterator = iter(
+                        self._iterate_time_windows(
+                            dst_safe_strptime(partition_key, self.timezone, self.fmt).timestamp()
+                        )
+                    )
+                    partition_key_time_windows.append(next(cur_windows_iterator))
 
-        if validate:
-            start_time_window = self.get_first_partition_window(current_time=current_time)
-            end_time_window = self.get_last_partition_window(current_time=current_time)
+            if validate:
+                start_time_window = self.get_first_partition_window(current_time=ctx.effective_dt)
+                end_time_window = self.get_last_partition_window(current_time=ctx.effective_dt)
 
-            if start_time_window is None or end_time_window is None:
-                check.failed("No partitions in the PartitionsDefinition")
+                if start_time_window is None or end_time_window is None:
+                    check.failed("No partitions in the PartitionsDefinition")
 
-            start_timestamp = start_time_window.start.timestamp()
-            end_timestamp = end_time_window.end.timestamp()
+                start_timestamp = start_time_window.start.timestamp()
+                end_timestamp = end_time_window.end.timestamp()
 
-            partition_key_time_windows = [
-                tw
-                for tw in partition_key_time_windows
-                if tw.start.timestamp() >= start_timestamp and tw.end.timestamp() <= end_timestamp
-            ]
-        return partition_key_time_windows
+                partition_key_time_windows = [
+                    tw
+                    for tw in partition_key_time_windows
+                    if tw.start.timestamp() >= start_timestamp
+                    and tw.end.timestamp() <= end_timestamp
+                ]
+            return partition_key_time_windows
 
     def start_time_for_partition_key(self, partition_key: str) -> datetime:
         partition_key_dt = dst_safe_strptime(partition_key, self.timezone, self.fmt)
@@ -537,34 +554,36 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
     def get_next_partition_key(
         self, partition_key: str, current_time: Optional[datetime] = None
     ) -> Optional[str]:
-        last_partition_window = self.get_last_partition_window(current_time)
-        if last_partition_window is None:
-            return None
+        with partition_loading_context(current_time) as ctx:
+            last_partition_window = self.get_last_partition_window(ctx.effective_dt)
+            if last_partition_window is None:
+                return None
 
-        partition_key_dt = dst_safe_strptime(partition_key, self.timezone, self.fmt)
-        windows_iter = iter(self._iterate_time_windows(partition_key_dt.timestamp()))
-        next(windows_iter)
-        start_time = next(windows_iter).start
-        if start_time.timestamp() >= last_partition_window.end.timestamp():
-            return None
-        else:
-            return dst_safe_strftime(start_time, self.timezone, self.fmt, self.cron_schedule)
+            partition_key_dt = dst_safe_strptime(partition_key, self.timezone, self.fmt)
+            windows_iter = iter(self._iterate_time_windows(partition_key_dt.timestamp()))
+            next(windows_iter)
+            start_time = next(windows_iter).start
+            if start_time.timestamp() >= last_partition_window.end.timestamp():
+                return None
+            else:
+                return dst_safe_strftime(start_time, self.timezone, self.fmt, self.cron_schedule)
 
     def get_next_partition_window(
         self, end_dt: datetime, current_time: Optional[datetime] = None, respect_bounds: bool = True
     ) -> Optional[TimeWindow]:
-        windows_iter = iter(self._iterate_time_windows(end_dt.timestamp()))
-        next_window = next(windows_iter)
+        with partition_loading_context(current_time) as ctx:
+            windows_iter = iter(self._iterate_time_windows(end_dt.timestamp()))
+            next_window = next(windows_iter)
 
-        if respect_bounds:
-            last_partition_window = self.get_last_partition_window(current_time)
-            if last_partition_window is None:
-                return None
+            if respect_bounds:
+                last_partition_window = self.get_last_partition_window(ctx.effective_dt)
+                if last_partition_window is None:
+                    return None
 
-            if next_window.start.timestamp() >= last_partition_window.end.timestamp():
-                return None
+                if next_window.start.timestamp() >= last_partition_window.end.timestamp():
+                    return None
 
-        return next_window
+            return next_window
 
     def get_prev_partition_window(
         self, start_dt: datetime, respect_bounds: bool = True
@@ -615,8 +634,9 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
     def get_first_partition_window(
         self, current_time: Optional[datetime] = None
     ) -> Optional[TimeWindow]:
-        current_timestamp = self._get_current_timestamp(current_time)
-        return self._get_first_partition_window(current_timestamp=current_timestamp)
+        with partition_loading_context(current_time) as ctx:
+            current_timestamp = self._get_current_timestamp(current_time=ctx.effective_dt)
+            return self._get_first_partition_window(current_timestamp=current_timestamp)
 
     @functools.lru_cache(maxsize=256)
     def _get_last_partition_window(self, *, current_timestamp: float) -> Optional[TimeWindow]:
@@ -642,28 +662,33 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
     def get_last_partition_window(
         self, current_time: Optional[datetime] = None
     ) -> Optional[TimeWindow]:
-        current_timestamp = self._get_current_timestamp(current_time)
-        return self._get_last_partition_window(current_timestamp=current_timestamp)
+        with partition_loading_context(current_time) as ctx:
+            current_timestamp = self._get_current_timestamp(current_time=ctx.effective_dt)
+            return self._get_last_partition_window(current_timestamp=current_timestamp)
 
     def get_first_partition_key(
         self,
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Optional[str]:
-        first_window = self.get_first_partition_window(current_time)
-        if first_window is None:
-            return None
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            first_window = self.get_first_partition_window(current_time=ctx.effective_dt)
+            if first_window is None:
+                return None
 
-        return dst_safe_strftime(first_window.start, self.timezone, self.fmt, self.cron_schedule)
+            return dst_safe_strftime(
+                first_window.start, self.timezone, self.fmt, self.cron_schedule
+            )
 
     def get_last_partition_key(
         self,
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Optional[str]:
-        last_window = self.get_last_partition_window(current_time)
-        if last_window is None:
-            return None
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            last_window = self.get_last_partition_window(current_time=ctx.effective_dt)
+            if last_window is None:
+                return None
 
         return dst_safe_strftime(last_window.start, self.timezone, self.fmt, self.cron_schedule)
 
@@ -937,16 +962,17 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> "PartitionsSubset":
-        first_window = self.get_first_partition_window(current_time)
-        last_window = self.get_last_partition_window(current_time)
-        windows = (
-            []
-            if first_window is None or last_window is None
-            else [TimeWindow(first_window.start, last_window.end)]
-        )
-        return self.partitions_subset_class(
-            partitions_def=self, num_partitions=None, included_time_windows=windows
-        )
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            first_window = self.get_first_partition_window(current_time=ctx.effective_dt)
+            last_window = self.get_last_partition_window(current_time=ctx.effective_dt)
+            windows = (
+                []
+                if first_window is None or last_window is None
+                else [TimeWindow(first_window.start, last_window.end)]
+            )
+            return self.partitions_subset_class(
+                partitions_def=self, num_partitions=None, included_time_windows=windows
+            )
 
     def get_serializable_unique_identifier(
         self, dynamic_partitions_store: Optional[DynamicPartitionsStore] = None
@@ -960,27 +986,30 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> bool:
         """Returns a boolean representing if the given partition key is valid."""
-        try:
-            partition_start_time = self.start_time_for_partition_key(partition_key)
-            partition_start_timestamp = partition_start_time.timestamp()
-        except ValueError:
-            # unparseable partition key
-            return False
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            try:
+                partition_start_time = self.start_time_for_partition_key(partition_key)
+                partition_start_timestamp = partition_start_time.timestamp()
+            except ValueError:
+                # unparseable partition key
+                return False
 
-        first_partition_window = self.get_first_partition_window(current_time=current_time)
-        last_partition_window = self.get_last_partition_window(current_time=current_time)
-        return not (
-            # no partitions at all
-            first_partition_window is None
-            or last_partition_window is None
-            # partition starts before the first valid partition
-            or partition_start_timestamp < first_partition_window.start.timestamp()
-            # partition starts after the last valid partition
-            or partition_start_timestamp > last_partition_window.start.timestamp()
-            # partition key string does not represent the start of an actual partition
-            or dst_safe_strftime(partition_start_time, self.timezone, self.fmt, self.cron_schedule)
-            != partition_key
-        )
+            first_partition_window = self.get_first_partition_window(current_time=ctx.effective_dt)
+            last_partition_window = self.get_last_partition_window(current_time=ctx.effective_dt)
+            return not (
+                # no partitions at all
+                first_partition_window is None
+                or last_partition_window is None
+                # partition starts before the first valid partition
+                or partition_start_timestamp < first_partition_window.start.timestamp()
+                # partition starts after the last valid partition
+                or partition_start_timestamp > last_partition_window.start.timestamp()
+                # partition key string does not represent the start of an actual partition
+                or dst_safe_strftime(
+                    partition_start_time, self.timezone, self.fmt, self.cron_schedule
+                )
+                != partition_key
+            )
 
     def equal_except_for_start_or_end(self, other: "TimeWindowPartitionsDefinition") -> bool:
         """Returns True iff this is identical to other, except they're allowed to have different

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/identity.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/identity.py
@@ -2,9 +2,8 @@ from datetime import datetime
 from typing import NamedTuple, Optional
 
 import dagster._check as check
-from dagster._core.definitions.partitions.definition.partitions_definition import (
-    PartitionsDefinition,
-)
+from dagster._core.definitions.partitions.context import partition_loading_context
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.partitions.mapping.partition_mapping import (
     PartitionMapping,
     UpstreamPartitionsResult,
@@ -41,33 +40,34 @@ class IdentityPartitionMapping(PartitionMapping, NamedTuple("_IdentityPartitionM
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> UpstreamPartitionsResult:
-        if downstream_partitions_subset is None:
-            check.failed("downstream asset is not partitioned")
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            if downstream_partitions_subset is None:
+                check.failed("downstream asset is not partitioned")
 
-        if downstream_partitions_def == upstream_partitions_def:
+            if downstream_partitions_def == upstream_partitions_def:
+                return UpstreamPartitionsResult(
+                    partitions_subset=downstream_partitions_subset,
+                    required_but_nonexistent_subset=upstream_partitions_def.empty_subset(),
+                )
+
+            # must list out the keys before combining them since they might be from
+            # different asset keys
+            upstream_partition_keys = set(
+                upstream_partitions_def.get_partition_keys(
+                    current_time=ctx.effective_dt,
+                    dynamic_partitions_store=ctx.dynamic_partitions_store,
+                )
+            )
+            downstream_partition_keys = set(downstream_partitions_subset.get_partition_keys())
+
             return UpstreamPartitionsResult(
-                partitions_subset=downstream_partitions_subset,
-                required_but_nonexistent_subset=upstream_partitions_def.empty_subset(),
+                partitions_subset=upstream_partitions_def.subset_with_partition_keys(
+                    list(upstream_partition_keys & downstream_partition_keys)
+                ),
+                required_but_nonexistent_subset=DefaultPartitionsSubset(
+                    downstream_partition_keys - upstream_partition_keys,
+                ),
             )
-
-        # must list out the keys before combining them since they might be from
-        # different asset keys
-        upstream_partition_keys = set(
-            upstream_partitions_def.get_partition_keys(
-                current_time=current_time,
-                dynamic_partitions_store=dynamic_partitions_store,
-            )
-        )
-        downstream_partition_keys = set(downstream_partitions_subset.get_partition_keys())
-
-        return UpstreamPartitionsResult(
-            partitions_subset=upstream_partitions_def.subset_with_partition_keys(
-                list(upstream_partition_keys & downstream_partition_keys)
-            ),
-            required_but_nonexistent_subset=DefaultPartitionsSubset(
-                downstream_partition_keys - upstream_partition_keys,
-            ),
-        )
 
     def get_downstream_partitions_for_partitions(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/last.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/last.py
@@ -1,9 +1,8 @@
 from datetime import datetime
 from typing import NamedTuple, Optional
 
-from dagster._core.definitions.partitions.definition.partitions_definition import (
-    PartitionsDefinition,
-)
+from dagster._core.definitions.partitions.context import partition_loading_context
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.partitions.mapping.partition_mapping import (
     PartitionMapping,
     UpstreamPartitionsResult,
@@ -36,18 +35,19 @@ class LastPartitionMapping(PartitionMapping, NamedTuple("_LastPartitionMapping",
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> UpstreamPartitionsResult:
-        last = upstream_partitions_def.get_last_partition_key(
-            current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
-        )
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            last = upstream_partitions_def.get_last_partition_key(
+                current_time=ctx.effective_dt, dynamic_partitions_store=ctx.dynamic_partitions_store
+            )
 
-        upstream_subset = upstream_partitions_def.empty_subset()
-        if last is not None:
-            upstream_subset = upstream_subset.with_partition_keys([last])
+            upstream_subset = upstream_partitions_def.empty_subset()
+            if last is not None:
+                upstream_subset = upstream_subset.with_partition_keys([last])
 
-        return UpstreamPartitionsResult(
-            partitions_subset=upstream_subset,
-            required_but_nonexistent_subset=upstream_partitions_def.empty_subset(),
-        )
+            return UpstreamPartitionsResult(
+                partitions_subset=upstream_subset,
+                required_but_nonexistent_subset=upstream_partitions_def.empty_subset(),
+            )
 
     def get_downstream_partitions_for_partitions(
         self,
@@ -57,15 +57,17 @@ class LastPartitionMapping(PartitionMapping, NamedTuple("_LastPartitionMapping",
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> PartitionsSubset:
-        last_upstream_partition = upstream_partitions_def.get_last_partition_key(
-            current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
-        )
-        if last_upstream_partition and last_upstream_partition in upstream_partitions_subset:
-            return downstream_partitions_def.subset_with_all_partitions(
-                current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            last_upstream_partition = upstream_partitions_def.get_last_partition_key(
+                current_time=ctx.effective_dt, dynamic_partitions_store=ctx.dynamic_partitions_store
             )
-        else:
-            return downstream_partitions_def.empty_subset()
+            if last_upstream_partition and last_upstream_partition in upstream_partitions_subset:
+                return downstream_partitions_def.subset_with_all_partitions(
+                    current_time=ctx.effective_dt,
+                    dynamic_partitions_store=ctx.dynamic_partitions_store,
+                )
+            else:
+                return downstream_partitions_def.empty_subset()
 
     @property
     def description(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/specific_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/specific_partitions.py
@@ -3,9 +3,8 @@ from datetime import datetime
 from typing import NamedTuple, Optional
 
 from dagster._annotations import PublicAttr
-from dagster._core.definitions.partitions.definition.partitions_definition import (
-    PartitionsDefinition,
-)
+from dagster._core.definitions.partitions.context import partition_loading_context
+from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.partitions.mapping.partition_mapping import (
     PartitionMapping,
     UpstreamPartitionsResult,
@@ -57,12 +56,13 @@ class SpecificPartitionsPartitionMapping(
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> UpstreamPartitionsResult:
-        return UpstreamPartitionsResult(
-            partitions_subset=upstream_partitions_def.subset_with_partition_keys(
-                self.partition_keys
-            ),
-            required_but_nonexistent_subset=upstream_partitions_def.empty_subset(),
-        )
+        with partition_loading_context(current_time, dynamic_partitions_store):
+            return UpstreamPartitionsResult(
+                partitions_subset=upstream_partitions_def.subset_with_partition_keys(
+                    self.partition_keys
+                ),
+                required_but_nonexistent_subset=upstream_partitions_def.empty_subset(),
+            )
 
     def get_downstream_partitions_for_partitions(
         self,
@@ -72,13 +72,15 @@ class SpecificPartitionsPartitionMapping(
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> PartitionsSubset:
-        # if any of the partition keys in this partition mapping are contained within the upstream
-        # partitions subset, then all partitions of the downstream asset are dependencies
-        if any(key in upstream_partitions_subset for key in self.partition_keys):
-            return downstream_partitions_def.subset_with_all_partitions(
-                dynamic_partitions_store=dynamic_partitions_store
-            )
-        return downstream_partitions_def.empty_subset()
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            # if any of the partition keys in this partition mapping are contained within the upstream
+            # partitions subset, then all partitions of the downstream asset are dependencies
+            if any(key in upstream_partitions_subset for key in self.partition_keys):
+                return downstream_partitions_def.subset_with_all_partitions(
+                    current_time=ctx.effective_dt,
+                    dynamic_partitions_store=ctx.dynamic_partitions_store,
+                )
+            return downstream_partitions_def.empty_subset()
 
     @property
     def description(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/time_window.py
@@ -4,10 +4,9 @@ from typing import NamedTuple, Optional, cast
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, beta_param
-from dagster._core.definitions.partitions.definition.partitions_definition import (
+from dagster._core.definitions.partitions.context import partition_loading_context
+from dagster._core.definitions.partitions.definition import (
     PartitionsDefinition,
-)
-from dagster._core.definitions.partitions.definition.time_window import (
     TimeWindowPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.mapping.partition_mapping import (
@@ -158,21 +157,22 @@ class TimeWindowPartitionMapping(
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> UpstreamPartitionsResult:
-        return self._map_partitions(
-            from_partitions_def=self._validated_input_partitions_def(
-                "downstream_partitions_def", downstream_partitions_def
-            ),
-            to_partitions_def=self._validated_input_partitions_def(
-                "upstream_partitions_def", upstream_partitions_def
-            ),
-            from_partitions_subset=self._validated_input_partitions_subset(
-                "downstream_partitions_subset", downstream_partitions_subset
-            ),
-            start_offset=self.start_offset,
-            end_offset=self.end_offset,
-            current_time=current_time,
-            mapping_downstream_to_upstream=True,
-        )
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            return self._map_partitions(
+                from_partitions_def=self._validated_input_partitions_def(
+                    "downstream_partitions_def", downstream_partitions_def
+                ),
+                to_partitions_def=self._validated_input_partitions_def(
+                    "upstream_partitions_def", upstream_partitions_def
+                ),
+                from_partitions_subset=self._validated_input_partitions_subset(
+                    "downstream_partitions_subset", downstream_partitions_subset
+                ),
+                start_offset=self.start_offset,
+                end_offset=self.end_offset,
+                current_time=ctx.effective_dt,
+                mapping_downstream_to_upstream=True,
+            )
 
     def validate_partition_mapping(
         self,
@@ -212,21 +212,22 @@ class TimeWindowPartitionMapping(
         Filters for partitions that exist at the given current_time, fetching the current time
         if not provided.
         """
-        return self._map_partitions(
-            from_partitions_def=self._validated_input_partitions_def(
-                "upstream_partitions_def", upstream_partitions_def
-            ),
-            to_partitions_def=self._validated_input_partitions_def(
-                "downstream_partitions_def", downstream_partitions_def
-            ),
-            from_partitions_subset=self._validated_input_partitions_subset(
-                "upstream_partitions_subset", upstream_partitions_subset
-            ),
-            end_offset=-self.start_offset,
-            start_offset=-self.end_offset,
-            current_time=current_time,
-            mapping_downstream_to_upstream=False,
-        ).partitions_subset
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            return self._map_partitions(
+                from_partitions_def=self._validated_input_partitions_def(
+                    "upstream_partitions_def", upstream_partitions_def
+                ),
+                to_partitions_def=self._validated_input_partitions_def(
+                    "downstream_partitions_def", downstream_partitions_def
+                ),
+                from_partitions_subset=self._validated_input_partitions_subset(
+                    "upstream_partitions_subset", upstream_partitions_subset
+                ),
+                end_offset=-self.start_offset,
+                start_offset=-self.end_offset,
+                current_time=ctx.effective_dt,
+                mapping_downstream_to_upstream=False,
+            ).partitions_subset
 
     def _merge_time_windows(self, time_windows: Sequence[TimeWindow]) -> Sequence[TimeWindow]:
         """Takes a list of potentially-overlapping TimeWindows and merges any overlapping windows."""
@@ -284,135 +285,140 @@ class TimeWindowPartitionMapping(
                 f"Timezones {to_partitions_def.timezone} and {from_partitions_def.timezone} don't match"
             )
 
-        result = self._do_cheap_partition_mapping_if_possible(
-            from_partitions_def=from_partitions_def,
-            to_partitions_def=to_partitions_def,
-            from_partitions_subset=from_partitions_subset,
-            start_offset=start_offset,
-            end_offset=end_offset,
-            current_time=current_time,
-        )
-        if result is not None:
-            return result
+        with partition_loading_context(current_time) as ctx:
+            result = self._do_cheap_partition_mapping_if_possible(
+                from_partitions_def=from_partitions_def,
+                to_partitions_def=to_partitions_def,
+                from_partitions_subset=from_partitions_subset,
+                start_offset=start_offset,
+                end_offset=end_offset,
+                current_time=ctx.effective_dt,
+            )
+            if result is not None:
+                return result
 
-        first_window = to_partitions_def.get_first_partition_window(current_time=current_time)
-        last_window = to_partitions_def.get_last_partition_window(current_time=current_time)
-        full_window = (
-            TimeWindow(first_window.start, last_window.end)
-            if first_window is not None and last_window is not None
-            else None
-        )
-
-        time_windows = []
-        for from_partition_time_window in from_partitions_subset.included_time_windows:
-            from_start_dt, from_end_dt = (
-                from_partition_time_window.start,
-                from_partition_time_window.end,
+            first_window = to_partitions_def.get_first_partition_window(
+                current_time=ctx.effective_dt
+            )
+            last_window = to_partitions_def.get_last_partition_window(current_time=ctx.effective_dt)
+            full_window = (
+                TimeWindow(first_window.start, last_window.end)
+                if first_window is not None and last_window is not None
+                else None
             )
 
-            if mapping_downstream_to_upstream:
-                offsetted_from_start_dt = _offsetted_datetime_with_bounds(
-                    from_partitions_def, from_start_dt, start_offset, full_window
-                )
-                offsetted_from_end_dt = _offsetted_datetime_with_bounds(
-                    from_partitions_def, from_end_dt, end_offset, full_window
-                )
-            else:
-                # we'll apply the offsets later, after we've found the corresponding windows
-                offsetted_from_start_dt = from_start_dt
-                offsetted_from_end_dt = from_end_dt
-
-            # Align the windows to partition boundaries in the target PartitionsDefinition
-            if (from_partitions_def.cron_schedule == to_partitions_def.cron_schedule) or (
-                from_partitions_def.is_basic_daily and to_partitions_def.is_basic_hourly
-            ):
-                # If the above conditions hold true, then we're confident that the partition
-                # boundaries in the PartitionsDefinition that we're mapping from match up with
-                # boundaries in the PartitionsDefinition that we're mapping to. That means
-                # we can just use these boundaries directly instead of finding nearby boundaries.
-                to_start_dt = offsetted_from_start_dt
-                to_end_dt = offsetted_from_end_dt
-            else:
-                # The partition boundaries that we're mapping from might land in the middle of
-                # partitions that we're mapping to, so find those partitions.
-                to_start_partition_key = to_partitions_def.get_partition_key_for_timestamp(
-                    offsetted_from_start_dt.timestamp(), end_closed=False
-                )
-                to_end_partition_key = to_partitions_def.get_partition_key_for_timestamp(
-                    offsetted_from_end_dt.timestamp(), end_closed=True
+            time_windows = []
+            for from_partition_time_window in from_partitions_subset.included_time_windows:
+                from_start_dt, from_end_dt = (
+                    from_partition_time_window.start,
+                    from_partition_time_window.end,
                 )
 
-                to_start_dt = to_partitions_def.start_time_for_partition_key(to_start_partition_key)
-                to_end_dt = to_partitions_def.end_time_for_partition_key(to_end_partition_key)
+                if mapping_downstream_to_upstream:
+                    offsetted_from_start_dt = _offsetted_datetime_with_bounds(
+                        from_partitions_def, from_start_dt, start_offset, full_window
+                    )
+                    offsetted_from_end_dt = _offsetted_datetime_with_bounds(
+                        from_partitions_def, from_end_dt, end_offset, full_window
+                    )
+                else:
+                    # we'll apply the offsets later, after we've found the corresponding windows
+                    offsetted_from_start_dt = from_start_dt
+                    offsetted_from_end_dt = from_end_dt
 
-            if mapping_downstream_to_upstream:
-                offsetted_to_start_dt = to_start_dt
-                offsetted_to_end_dt = to_end_dt
-            else:
-                offsetted_to_start_dt = _offsetted_datetime_with_bounds(
-                    to_partitions_def, to_start_dt, start_offset, full_window
-                )
-                offsetted_to_end_dt = _offsetted_datetime_with_bounds(
-                    to_partitions_def, to_end_dt, end_offset, full_window
-                )
-
-            if offsetted_to_start_dt.timestamp() < offsetted_to_end_dt.timestamp():
-                time_windows.append(TimeWindow(offsetted_to_start_dt, offsetted_to_end_dt))
-
-        filtered_time_windows = []
-        required_but_nonexistent_subset = to_partitions_def.empty_subset()
-
-        for time_window in time_windows:
-            if (
-                first_window
-                and last_window
-                and time_window.start.timestamp() <= last_window.start.timestamp()
-                and time_window.end.timestamp() >= first_window.end.timestamp()
-            ):
-                window_start = max(
-                    time_window.start, first_window.start, key=lambda d: d.timestamp()
-                )
-                window_end = min(time_window.end, last_window.end, key=lambda d: d.timestamp())
-                filtered_time_windows.append(TimeWindow(window_start, window_end))
-
-            if self.allow_nonexistent_upstream_partitions:
-                # If allowed to have nonexistent upstream partitions, do not consider
-                # out of range partitions to be invalid
-                continue
-            else:
-                invalid_time_window = None
-                if not (first_window and last_window) or (
-                    time_window.start.timestamp() < first_window.start.timestamp()
-                    and time_window.end.timestamp() > last_window.end.timestamp()
+                # Align the windows to partition boundaries in the target PartitionsDefinition
+                if (from_partitions_def.cron_schedule == to_partitions_def.cron_schedule) or (
+                    from_partitions_def.is_basic_daily and to_partitions_def.is_basic_hourly
                 ):
-                    invalid_time_window = time_window
-                elif time_window.start.timestamp() < first_window.start.timestamp():
-                    invalid_time_window = TimeWindow(
-                        time_window.start,
-                        min(time_window.end, first_window.start, key=lambda d: d.timestamp()),
+                    # If the above conditions hold true, then we're confident that the partition
+                    # boundaries in the PartitionsDefinition that we're mapping from match up with
+                    # boundaries in the PartitionsDefinition that we're mapping to. That means
+                    # we can just use these boundaries directly instead of finding nearby boundaries.
+                    to_start_dt = offsetted_from_start_dt
+                    to_end_dt = offsetted_from_end_dt
+                else:
+                    # The partition boundaries that we're mapping from might land in the middle of
+                    # partitions that we're mapping to, so find those partitions.
+                    to_start_partition_key = to_partitions_def.get_partition_key_for_timestamp(
+                        offsetted_from_start_dt.timestamp(), end_closed=False
                     )
-                elif time_window.end.timestamp() > last_window.end.timestamp():
-                    invalid_time_window = TimeWindow(
-                        max(time_window.start, last_window.end, key=lambda d: d.timestamp()),
-                        time_window.end,
+                    to_end_partition_key = to_partitions_def.get_partition_key_for_timestamp(
+                        offsetted_from_end_dt.timestamp(), end_closed=True
                     )
 
-                if invalid_time_window:
-                    required_but_nonexistent_subset = (
-                        required_but_nonexistent_subset
-                        | to_partitions_def.get_partition_subset_in_time_window(
-                            time_window=invalid_time_window
+                    to_start_dt = to_partitions_def.start_time_for_partition_key(
+                        to_start_partition_key
+                    )
+                    to_end_dt = to_partitions_def.end_time_for_partition_key(to_end_partition_key)
+
+                if mapping_downstream_to_upstream:
+                    offsetted_to_start_dt = to_start_dt
+                    offsetted_to_end_dt = to_end_dt
+                else:
+                    offsetted_to_start_dt = _offsetted_datetime_with_bounds(
+                        to_partitions_def, to_start_dt, start_offset, full_window
+                    )
+                    offsetted_to_end_dt = _offsetted_datetime_with_bounds(
+                        to_partitions_def, to_end_dt, end_offset, full_window
+                    )
+
+                if offsetted_to_start_dt.timestamp() < offsetted_to_end_dt.timestamp():
+                    time_windows.append(TimeWindow(offsetted_to_start_dt, offsetted_to_end_dt))
+
+            filtered_time_windows = []
+            required_but_nonexistent_subset = to_partitions_def.empty_subset()
+
+            for time_window in time_windows:
+                if (
+                    first_window
+                    and last_window
+                    and time_window.start.timestamp() <= last_window.start.timestamp()
+                    and time_window.end.timestamp() >= first_window.end.timestamp()
+                ):
+                    window_start = max(
+                        time_window.start, first_window.start, key=lambda d: d.timestamp()
+                    )
+                    window_end = min(time_window.end, last_window.end, key=lambda d: d.timestamp())
+                    filtered_time_windows.append(TimeWindow(window_start, window_end))
+
+                if self.allow_nonexistent_upstream_partitions:
+                    # If allowed to have nonexistent upstream partitions, do not consider
+                    # out of range partitions to be invalid
+                    continue
+                else:
+                    invalid_time_window = None
+                    if not (first_window and last_window) or (
+                        time_window.start.timestamp() < first_window.start.timestamp()
+                        and time_window.end.timestamp() > last_window.end.timestamp()
+                    ):
+                        invalid_time_window = time_window
+                    elif time_window.start.timestamp() < first_window.start.timestamp():
+                        invalid_time_window = TimeWindow(
+                            time_window.start,
+                            min(time_window.end, first_window.start, key=lambda d: d.timestamp()),
                         )
-                    )
+                    elif time_window.end.timestamp() > last_window.end.timestamp():
+                        invalid_time_window = TimeWindow(
+                            max(time_window.start, last_window.end, key=lambda d: d.timestamp()),
+                            time_window.end,
+                        )
 
-        return UpstreamPartitionsResult(
-            partitions_subset=TimeWindowPartitionsSubset(
-                to_partitions_def,
-                num_partitions=None,
-                included_time_windows=self._merge_time_windows(filtered_time_windows),
-            ),
-            required_but_nonexistent_subset=required_but_nonexistent_subset,
-        )
+                    if invalid_time_window:
+                        required_but_nonexistent_subset = (
+                            required_but_nonexistent_subset
+                            | to_partitions_def.get_partition_subset_in_time_window(
+                                time_window=invalid_time_window
+                            )
+                        )
+
+            return UpstreamPartitionsResult(
+                partitions_subset=TimeWindowPartitionsSubset(
+                    to_partitions_def,
+                    num_partitions=None,
+                    included_time_windows=self._merge_time_windows(filtered_time_windows),
+                ),
+                required_but_nonexistent_subset=required_but_nonexistent_subset,
+            )
 
     def _do_cheap_partition_mapping_if_possible(
         self,
@@ -428,92 +434,97 @@ class TimeWindowPartitionMapping(
         This method covers a set of easy cases where these operations aren't required. It returns
         None if the mapping doesn't fit into any of these cases.
         """
-        if from_partitions_subset.is_empty:
-            return UpstreamPartitionsResult(
-                partitions_subset=to_partitions_def.empty_subset(),
-                required_but_nonexistent_subset=to_partitions_def.empty_subset(),
-            )
-
-        if start_offset != 0 or end_offset != 0:
-            return None
-
-        # Same PartitionsDefinitions
-        if from_partitions_def == to_partitions_def:
-            return UpstreamPartitionsResult(
-                partitions_subset=from_partitions_subset,
-                required_but_nonexistent_subset=to_partitions_def.empty_subset(),
-            )
-
-        # Same PartitionsDefinitions except for start and end dates
-        if (
-            from_partitions_def.equal_except_for_start_or_end(to_partitions_def)
-            and (
-                from_partitions_def.start.timestamp() >= to_partitions_def.start.timestamp()
-                or from_partitions_subset.first_start.timestamp()
-                >= to_partitions_def.start.timestamp()
-            )
-            and (
-                to_partitions_def.end is None
-                or (
-                    from_partitions_def.end is not None
-                    and to_partitions_def.end.timestamp() >= from_partitions_def.end.timestamp()
+        with partition_loading_context(current_time) as ctx:
+            if from_partitions_subset.is_empty:
+                return UpstreamPartitionsResult(
+                    partitions_subset=to_partitions_def.empty_subset(),
+                    required_but_nonexistent_subset=to_partitions_def.empty_subset(),
                 )
-            )
-        ):
-            return UpstreamPartitionsResult(
-                partitions_subset=from_partitions_subset.with_partitions_def(to_partitions_def),
-                required_but_nonexistent_subset=to_partitions_def.empty_subset(),
-            )
 
-        # Daily to hourly
-        from_last_partition_window = from_partitions_def.get_last_partition_window(current_time)
-        to_last_partition_window = to_partitions_def.get_last_partition_window(current_time)
-        if (
-            from_partitions_def.is_basic_daily
-            and to_partitions_def.is_basic_hourly
-            and (
-                from_partitions_def.start.timestamp() >= to_partitions_def.start.timestamp()
-                or from_partitions_subset.first_start.timestamp()
-                >= to_partitions_def.start.timestamp()
-            )
-            and (
-                from_last_partition_window is not None
-                and to_last_partition_window is not None
-                and from_last_partition_window.end.timestamp()
-                <= to_last_partition_window.end.timestamp()
-            )
-        ):
-            return UpstreamPartitionsResult(
-                partitions_subset=TimeWindowPartitionsSubset(
-                    partitions_def=to_partitions_def,
-                    num_partitions=None,
-                    included_time_windows=from_partitions_subset.included_time_windows,
-                ),
-                required_but_nonexistent_subset=to_partitions_def.empty_subset(),
-            )
+            if start_offset != 0 or end_offset != 0:
+                return None
 
-        # The subset we're mapping from doesn't exist in the PartitionsDefinition we're mapping to
-        if from_partitions_subset.cheap_ends_before(
-            to_partitions_def.start, to_partitions_def.cron_schedule
-        ):
-            if self.allow_nonexistent_upstream_partitions:
-                required_but_nonexistent_subset = to_partitions_def.empty_subset()
-            else:
-                required_but_nonexistent_subset = to_partitions_def.empty_subset()
-                for time_window in from_partitions_subset.included_time_windows:
-                    required_but_nonexistent_subset = (
-                        required_but_nonexistent_subset
-                        | to_partitions_def.get_partition_subset_in_time_window(
-                            time_window.to_public_time_window()
-                        )
+            # Same PartitionsDefinitions
+            if from_partitions_def == to_partitions_def:
+                return UpstreamPartitionsResult(
+                    partitions_subset=from_partitions_subset,
+                    required_but_nonexistent_subset=to_partitions_def.empty_subset(),
+                )
+
+            # Same PartitionsDefinitions except for start and end dates
+            if (
+                from_partitions_def.equal_except_for_start_or_end(to_partitions_def)
+                and (
+                    from_partitions_def.start.timestamp() >= to_partitions_def.start.timestamp()
+                    or from_partitions_subset.first_start.timestamp()
+                    >= to_partitions_def.start.timestamp()
+                )
+                and (
+                    to_partitions_def.end is None
+                    or (
+                        from_partitions_def.end is not None
+                        and to_partitions_def.end.timestamp() >= from_partitions_def.end.timestamp()
                     )
+                )
+            ):
+                return UpstreamPartitionsResult(
+                    partitions_subset=from_partitions_subset.with_partitions_def(to_partitions_def),
+                    required_but_nonexistent_subset=to_partitions_def.empty_subset(),
+                )
 
-            return UpstreamPartitionsResult(
-                partitions_subset=to_partitions_def.empty_subset(),
-                required_but_nonexistent_subset=required_but_nonexistent_subset,
+            # Daily to hourly
+            from_last_partition_window = from_partitions_def.get_last_partition_window(
+                current_time=ctx.effective_dt
             )
+            to_last_partition_window = to_partitions_def.get_last_partition_window(
+                current_time=ctx.effective_dt
+            )
+            if (
+                from_partitions_def.is_basic_daily
+                and to_partitions_def.is_basic_hourly
+                and (
+                    from_partitions_def.start.timestamp() >= to_partitions_def.start.timestamp()
+                    or from_partitions_subset.first_start.timestamp()
+                    >= to_partitions_def.start.timestamp()
+                )
+                and (
+                    from_last_partition_window is not None
+                    and to_last_partition_window is not None
+                    and from_last_partition_window.end.timestamp()
+                    <= to_last_partition_window.end.timestamp()
+                )
+            ):
+                return UpstreamPartitionsResult(
+                    partitions_subset=TimeWindowPartitionsSubset(
+                        partitions_def=to_partitions_def,
+                        num_partitions=None,
+                        included_time_windows=from_partitions_subset.included_time_windows,
+                    ),
+                    required_but_nonexistent_subset=to_partitions_def.empty_subset(),
+                )
 
-        return None
+            # The subset we're mapping from doesn't exist in the PartitionsDefinition we're mapping to
+            if from_partitions_subset.cheap_ends_before(
+                to_partitions_def.start, to_partitions_def.cron_schedule
+            ):
+                if self.allow_nonexistent_upstream_partitions:
+                    required_but_nonexistent_subset = to_partitions_def.empty_subset()
+                else:
+                    required_but_nonexistent_subset = to_partitions_def.empty_subset()
+                    for time_window in from_partitions_subset.included_time_windows:
+                        required_but_nonexistent_subset = (
+                            required_but_nonexistent_subset
+                            | to_partitions_def.get_partition_subset_in_time_window(
+                                time_window.to_public_time_window()
+                            )
+                        )
+
+                return UpstreamPartitionsResult(
+                    partitions_subset=to_partitions_def.empty_subset(),
+                    required_but_nonexistent_subset=required_but_nonexistent_subset,
+                )
+
+            return None
 
 
 def _offsetted_datetime_with_bounds(

--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/default.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/default.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import NamedTuple, Optional
 
 import dagster._check as check
+from dagster._core.definitions.partitions.context import partition_loading_context
 from dagster._core.definitions.partitions.definition.partitions_definition import (
     PartitionsDefinition,
 )
@@ -36,11 +37,13 @@ class DefaultPartitionsSubset(
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> Iterable[str]:
-        return set(
-            partitions_def.get_partition_keys(
-                current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
-            )
-        ) - set(self.subset)
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            return set(
+                partitions_def.get_partition_keys(
+                    current_time=ctx.effective_dt,
+                    dynamic_partitions_store=ctx.dynamic_partitions_store,
+                )
+            ) - set(self.subset)
 
     def get_partition_keys(self) -> Iterable[str]:
         return self.subset
@@ -71,55 +74,57 @@ class DefaultPartitionsSubset(
     ) -> Sequence[PartitionKeyRange]:
         from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
 
-        if isinstance(partitions_def, MultiPartitionsDefinition):
-            # For multi-partitions, we construct the ranges by holding one dimension constant
-            # and constructing the range for the other dimension
-            primary_dimension = partitions_def.primary_dimension
-            secondary_dimension = partitions_def.secondary_dimension
+        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
+            if isinstance(partitions_def, MultiPartitionsDefinition):
+                # For multi-partitions, we construct the ranges by holding one dimension constant
+                # and constructing the range for the other dimension
+                primary_dimension = partitions_def.primary_dimension
+                secondary_dimension = partitions_def.secondary_dimension
 
-            primary_keys_in_subset = set()
-            secondary_keys_in_subset = set()
-            for partition_key in self.subset:
-                primary_keys_in_subset.add(
-                    partitions_def.get_partition_key_from_str(partition_key).keys_by_dimension[
-                        primary_dimension.name
-                    ]
+                primary_keys_in_subset = set()
+                secondary_keys_in_subset = set()
+                for partition_key in self.subset:
+                    primary_keys_in_subset.add(
+                        partitions_def.get_partition_key_from_str(partition_key).keys_by_dimension[
+                            primary_dimension.name
+                        ]
+                    )
+                    secondary_keys_in_subset.add(
+                        partitions_def.get_partition_key_from_str(partition_key).keys_by_dimension[
+                            secondary_dimension.name
+                        ]
+                    )
+
+                # for efficiency, group the keys by whichever dimension has fewer distinct keys
+                grouping_dimension = (
+                    primary_dimension
+                    if len(primary_keys_in_subset) <= len(secondary_keys_in_subset)
+                    else secondary_dimension
                 )
-                secondary_keys_in_subset.add(
-                    partitions_def.get_partition_key_from_str(partition_key).keys_by_dimension[
-                        secondary_dimension.name
-                    ]
+                grouping_keys = (
+                    primary_keys_in_subset
+                    if grouping_dimension == primary_dimension
+                    else secondary_keys_in_subset
                 )
 
-            # for efficiency, group the keys by whichever dimension has fewer distinct keys
-            grouping_dimension = (
-                primary_dimension
-                if len(primary_keys_in_subset) <= len(secondary_keys_in_subset)
-                else secondary_dimension
-            )
-            grouping_keys = (
-                primary_keys_in_subset
-                if grouping_dimension == primary_dimension
-                else secondary_keys_in_subset
-            )
+                results = []
+                for grouping_key in grouping_keys:
+                    keys = partitions_def.get_multipartition_keys_with_dimension_value(
+                        dimension_name=grouping_dimension.name,
+                        dimension_partition_key=grouping_key,
+                        current_time=ctx.effective_dt,
+                        dynamic_partitions_store=ctx.dynamic_partitions_store,
+                    )
+                    results.extend(self.get_ranges_for_keys(keys))
+                return results
 
-            results = []
-            for grouping_key in grouping_keys:
-                keys = partitions_def.get_multipartition_keys_with_dimension_value(
-                    dimension_name=grouping_dimension.name,
-                    dimension_partition_key=grouping_key,
-                    current_time=current_time,
-                    dynamic_partitions_store=dynamic_partitions_store,
+            else:
+                partition_keys = partitions_def.get_partition_keys(
+                    current_time=ctx.effective_dt,
+                    dynamic_partitions_store=ctx.dynamic_partitions_store,
                 )
-                results.extend(self.get_ranges_for_keys(keys))
-            return results
 
-        else:
-            partition_keys = partitions_def.get_partition_keys(
-                current_time, dynamic_partitions_store=dynamic_partitions_store
-            )
-
-            return self.get_ranges_for_keys(partition_keys)
+                return self.get_ranges_for_keys(partition_keys)
 
     def with_partition_keys(self, partition_keys: Iterable[str]) -> "DefaultPartitionsSubset":
         return DefaultPartitionsSubset(

--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/partitions_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/partitions_subset.py
@@ -6,6 +6,7 @@ from typing import Generic, Optional
 from typing_extensions import TypeVar
 
 from dagster._annotations import public
+from dagster._core.definitions.partitions.context import partition_loading_context
 from dagster._core.definitions.partitions.definition.partitions_definition import (
     PartitionsDefinition,
 )
@@ -51,11 +52,12 @@ class PartitionsSubset(ABC, Generic[T_str]):
         partition_key_range: PartitionKeyRange,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> "PartitionsSubset[T_str]":
-        return self.with_partition_keys(
-            partitions_def.get_partition_keys_in_range(
-                partition_key_range, dynamic_partitions_store=dynamic_partitions_store
+        with partition_loading_context(dynamic_partitions_store=dynamic_partitions_store) as ctx:
+            return self.with_partition_keys(
+                partitions_def.get_partition_keys_in_range(
+                    partition_key_range, dynamic_partitions_store=ctx.dynamic_partitions_store
+                )
             )
-        )
 
     def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset":
         from dagster._core.definitions.partitions.subset.all import AllPartitionsSubset


### PR DESCRIPTION
## Summary & Motivation

Now we (finally) get to the meat of this stack. We have hit a glut of performance and runtime error landmine type issues due to the somewhat silly way all the partition-related methods work.

Basically all of our public methods (and private ones), take two optional parameters: `current_time` and `dynamic_partitions_store`. The curent time argument is only relevant for time-window partitions, and even then most methods function fine without it being set. However, if it is not set, then it becomes very easy to hit perf bottlenecks, specifically around getting the last partition key available. This of course depends on the current time, and so if we're constantly invalidating the cache then this means we have to do a moderately-expensive calculation many times. There are also correctness issues that are in principle possible here, where the current time passes a partition boundary during the course of evaluation. The performance thing in general has bitten us a lot, because it's impossible for us to enforce that the current time is threaded through everywhere, as again these parameters are optional. There are also cases where properties or things like `__len__` are actually dependent on the current time but have no way to define arguments.

Similarly, the dynamic partitions store argument is only used for dynamic partitions definitions, and we've had multiple cases where nobody had attempted to use certain code paths with a dynamic partitions defintiion for quite awhile, leaving a landmine where once someone finally did, they hit an error because the argument was not properly threaded through.

This PR creates a context var that stores a PartitionLoadingContext that is used across all the partition-related functions. Whenever a method is invoked that has these arguments, it *adds* the passed-in context to whatever context was already set externally.

This means that if you're defining an operation that is going to be doing a lot of partition-related operations (e.g. a backfill or declarative automation evaluation), as long as you set this context guard outside of your main computation, ALL partition-related operations will be guaranteed to have the current_time / dynamic_partitions_store set. This effectively eliminates an entire class of bugs and performance issues -- as long as you set this up once, it's impossible for inner invocations to mess this up, no matter how obscure the invocations are.

## How I Tested These Changes

## Changelog

NOCHANGELOG
