### PR TITLE
[partition-context] asset backfill and declarative automation use context guard

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -17,6 +17,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.partitions.context import partition_loading_context
 from dagster._core.instance import DagsterInstance
 from dagster._time import get_current_datetime
 
@@ -104,7 +105,10 @@ class AutomationConditionEvaluator:
         self.logger.info("Done prefetching asset records.")
 
     def evaluate(self) -> tuple[Sequence[AutomationResult], Sequence[EntitySubset[EntityKey]]]:
-        return asyncio.run(self.async_evaluate())
+        with partition_loading_context(
+            effective_dt=self.evaluation_time, dynamic_partitions_store=self.instance_queryer
+        ):
+            return asyncio.run(self.async_evaluate())
 
     async def async_evaluate(
         self,

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -30,6 +30,7 @@ from dagster._core.definitions.automation_tick_evaluation_context import (
     build_run_requests_with_backfill_policies,
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.partitions.context import partition_loading_context
 from dagster._core.definitions.partitions.definition import (
     PartitionsDefinition,
     TimeWindowPartitionsDefinition,
@@ -1437,6 +1438,23 @@ def execute_asset_backfill_iteration_inner(
     This is a generator so that we can return control to the daemon and let it heartbeat during
     expensive operations.
     """
+    # ensures that all partition operations use the same effective_dt and share a dynamic partition cache
+    with partition_loading_context(
+        effective_dt=asset_graph_view.effective_dt,
+        dynamic_partitions_store=asset_graph_view.get_inner_queryer_for_back_compat(),
+    ):
+        return _execute_asset_backfill_iteration_inner(
+            backfill_id, asset_backfill_data, asset_graph_view, backfill_start_timestamp, logger
+        )
+
+
+def _execute_asset_backfill_iteration_inner(
+    backfill_id: str,
+    asset_backfill_data: AssetBackfillData,
+    asset_graph_view: AssetGraphView,
+    backfill_start_timestamp: float,
+    logger: logging.Logger,
+) -> AssetBackfillIterationResult:
     instance_queryer = asset_graph_view.get_inner_queryer_for_back_compat()
     asset_graph: RemoteWorkspaceAssetGraph = cast(
         "RemoteWorkspaceAssetGraph", asset_graph_view.asset_graph


### PR DESCRIPTION
## Summary & Motivation

Adds the context guard to the two main areas where we do a lot of partition-related computations.

## How I Tested These Changes

## Changelog

NOCHANGELOG
