### PR TITLE
[partition-context] get_partition_keys_not_in_subset

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -11,6 +11,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.data_time import CachingDataTimeResolver
+from dagster._core.definitions.partitions.context import partition_loading_context
 from dagster._core.definitions.partitions.definition import (
     MultiPartitionsDefinition,
     PartitionsDefinition,
@@ -513,21 +514,23 @@ def build_partition_statuses(
             partitions_def,
         )
     elif partitions_def:
-        materialized_keys = materialized_partitions_subset.get_partition_keys()
-        failed_keys = failed_partitions_subset.get_partition_keys()
-        in_progress_keys = in_progress_partitions_subset.get_partition_keys()
+        with partition_loading_context(
+            dynamic_partitions_store=dynamic_partitions_store,
+        ):
+            materialized_keys = materialized_partitions_subset.get_partition_keys()
+            failed_keys = failed_partitions_subset.get_partition_keys()
+            in_progress_keys = in_progress_partitions_subset.get_partition_keys()
 
-        return GrapheneDefaultPartitionStatuses(
-            materializedPartitions=set(materialized_keys)
-            - set(failed_keys)
-            - set(in_progress_keys),
-            failedPartitions=failed_keys,
-            unmaterializedPartitions=materialized_partitions_subset.get_partition_keys_not_in_subset(
-                partitions_def=partitions_def,
-                dynamic_partitions_store=dynamic_partitions_store,
-            ),
-            materializingPartitions=in_progress_keys,
-        )
+            return GrapheneDefaultPartitionStatuses(
+                materializedPartitions=set(materialized_keys)
+                - set(failed_keys)
+                - set(in_progress_keys),
+                failedPartitions=failed_keys,
+                unmaterializedPartitions=materialized_partitions_subset.get_partition_keys_not_in_subset(
+                    partitions_def=partitions_def
+                ),
+                materializingPartitions=in_progress_keys,
+            )
     else:
         check.failed("Should not reach this point")
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/valid_asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/valid_asset_subset.py
@@ -27,22 +27,13 @@ class ValidAssetSubset(SerializableEntitySubset[AssetKey]):
     functionality is subsumed by EntitySubset.
     """
 
-    def inverse(
-        self,
-        partitions_def: Optional[PartitionsDefinition],
-        current_time: Optional[datetime.datetime] = None,
-        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
-    ) -> "ValidAssetSubset":
+    def inverse(self, partitions_def: Optional[PartitionsDefinition]) -> "ValidAssetSubset":
         """Returns the EntitySubset containing all asset partitions which are not in this EntitySubset."""
         if partitions_def is None:
             return replace(self, value=not self.bool_value)
         else:
             value = partitions_def.subset_with_partition_keys(
-                self.subset_value.get_partition_keys_not_in_subset(
-                    partitions_def,
-                    current_time=current_time,
-                    dynamic_partitions_store=dynamic_partitions_store,
-                )
+                self.subset_value.get_partition_keys_not_in_subset(partitions_def)
             )
             return replace(self, value=value)
 

--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/all.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/all.py
@@ -52,10 +52,7 @@ class AllPartitionsSubset(
         )
 
     def get_partition_keys_not_in_subset(
-        self,
-        partitions_def: PartitionsDefinition,
-        current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        self, partitions_def: PartitionsDefinition
     ) -> Iterable[str]:
         return set()
 

--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/default.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/default.py
@@ -32,18 +32,9 @@ class DefaultPartitionsSubset(
         return super().__new__(cls, subset or set())
 
     def get_partition_keys_not_in_subset(
-        self,
-        partitions_def: PartitionsDefinition,
-        current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        self, partitions_def: PartitionsDefinition
     ) -> Iterable[str]:
-        with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
-            return set(
-                partitions_def.get_partition_keys(
-                    current_time=ctx.effective_dt,
-                    dynamic_partitions_store=ctx.dynamic_partitions_store,
-                )
-            ) - set(self.subset)
+        return set(partitions_def.get_partition_keys()) - set(self.subset)
 
     def get_partition_keys(self) -> Iterable[str]:
         return self.subset

--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/partitions_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/partitions_subset.py
@@ -25,10 +25,7 @@ class PartitionsSubset(ABC, Generic[T_str]):
 
     @abstractmethod
     def get_partition_keys_not_in_subset(
-        self,
-        partitions_def: PartitionsDefinition[T_str],
-        current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        self, partitions_def: PartitionsDefinition[T_str]
     ) -> Iterable[T_str]: ...
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -660,10 +660,7 @@ class KeyRangeNoPartitionsDefPartitionsSubset(PartitionsSubset):
         self._key_range = key_range
 
     def get_partition_keys_not_in_subset(
-        self,
-        partitions_def: "PartitionsDefinition",
-        current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        self, partitions_def: "PartitionsDefinition"
     ) -> Iterable[str]:
         raise NotImplementedError()
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -7,7 +7,10 @@ import pytest
 from dagster import AssetExecutionContext
 from dagster._check import CheckError
 from dagster._core.definitions.assets.graph.asset_graph import AssetGraph
-from dagster._core.definitions.partitions.context import PartitionLoadingContext
+from dagster._core.definitions.partitions.context import (
+    PartitionLoadingContext,
+    partition_loading_context,
+)
 from dagster._core.definitions.partitions.utils import get_time_partitions_def
 from dagster._core.definitions.temporal_context import TemporalContext
 from dagster._core.storage.tags import get_multidimensional_partition_tag
@@ -261,9 +264,10 @@ def test_multipartitions_subset_addition(initial, added):
 
     assert initial_subset.get_partition_keys() == set(initial_subset_keys)
     assert added_subset.get_partition_keys() == set(added_subset_keys + initial_subset_keys)
-    assert added_subset.get_partition_keys_not_in_subset(
-        multipartitions_def, current_time=current_day
-    ) == set(expected_keys_not_in_updated_subset)
+    with partition_loading_context(effective_dt=current_day):
+        assert added_subset.get_partition_keys_not_in_subset(multipartitions_def) == set(
+            expected_keys_not_in_updated_subset
+        )
 
 
 def test_asset_partition_key_is_multipartition_key():


### PR DESCRIPTION
## Summary & Motivation

This is an internal-only method and now that we're using the context guard behavior we can clean this function up a bit and remove the extraneous parameters.

## How I Tested These Changes

## Changelog

NOCHANGELOG
