### PR TITLE
fix: inconsistencies btw registry_module names s/lib/components/

### DIFF
--- a/docs/docs/guides/build/projects/moving-to-components/migrating-project.md
+++ b/docs/docs/guides/build/projects/moving-to-components/migrating-project.md
@@ -95,7 +95,7 @@ point](https://packaging.python.org/en/latest/specifications/entry-points/) API
 to expose custom component types and other scaffoldable objects from user
 projects. Our entry point declaration will specify a submodule as the location
 where our project exposes registry modules. By convention, this submodule is
-named `<root_module>.lib`. In our case, it will be `my_existing_project.lib`.
+named `<root_module>.components`. In our case, it will be `my_existing_project.components`.
 Let's create this submodule now:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/migrating-project/6-create-lib.txt" />


### PR DESCRIPTION
## Summary & Motivation

The text mention: 
`By convention, this submodule is named <root_module>.lib. In our case, it will be my_existing_project.lib. Let's create this submodule now:`

And then, in the example, a folder `components` is created.

## How I Tested These Changes

/
