### PR TITLE
[docs] Consistent `@dg.jobs` in Build/Jobs

### DIFF
--- a/docs/docs/guides/build/jobs/asset-jobs.md
+++ b/docs/docs/guides/build/jobs/asset-jobs.md
@@ -16,7 +16,7 @@ In this section, we'll demonstrate how to create a few asset jobs that target th
 
 <CodeExample path="docs_snippets/docs_snippets/guides/data-modeling/asset-jobs/asset-jobs.py" language="python" startAfter="start_marker_assets" endBefore="end_marker_assets" title="src/<project_name>/defs/assets.py" />
 
-To create an asset job, use the [`define_asset_job`](/api/dagster/assets#dagster.define_asset_job) method. An asset-based job is based on the assets the job targets and their dependencies.
+To create an asset job, use the <PyObject section="jobs" module="dagster" object="job" decorator /> decorator. An asset-based job is based on the assets the job targets and their dependencies.
 
 You can target one or multiple assets, or create multiple jobs that target overlapping sets of assets. In the following example, we have two jobs:
 
@@ -29,7 +29,9 @@ You can target one or multiple assets, or create multiple jobs that target overl
 
 Jobs are loaded automatically with [`dg`](/api/dg) and there is no need to explicity define a [`Definitions`](/api/dagster/definitions) object for them. If you include schedules or sensors, the [code location](/deployment/code-locations) will automatically include jobs that those schedules or sensors target.
 
-<CodeExample path="docs_snippets/docs_snippets/concepts/assets/jobs_to_definitions.py" title="src/<project_name>/defs/assets.py"/>
+<CodeExample path="docs_snippets/docs_snippets/concepts/assets/jobs_to_definitions.py" python="python" startAfter="start_marker_job" endBefore="end_marker_job" title="src/<project_name>/defs/assets.py"/>
+
+<CodeExample path="docs_snippets/docs_snippets/concepts/assets/jobs_to_definitions.py" python="python" startAfter="start_marker_job_definition" endBefore="end_marker_job_definition" title="src/<project_name>/defs/jobs.py"/>
 
 ## Testing asset jobs
 

--- a/docs/docs/guides/build/jobs/op-jobs.md
+++ b/docs/docs/guides/build/jobs/op-jobs.md
@@ -34,7 +34,7 @@ Op jobs can be created:
 
 ### Using the @job decorator
 
-The simplest way to create an op job is to use the <PyObject section="jobs" module="dagster" object="job" decorator />decorator.
+The simplest way to create an op job is to use the <PyObject section="jobs" module="dagster" object="job" decorator /> decorator.
 
 Within the decorated function body, you can use function calls to indicate the dependency structure between the ops/graphs. This allows you to explicitly define dependencies between ops when you define the job.
 
@@ -70,7 +70,7 @@ Then build op jobs from it using the <PyObject section="graphs" module="dagster"
 
 Ops and resources can accept [configuration](/guides/operate/configuration/run-configuration) that determines how they behave. By default, configuration is supplied at the time an op job is launched.
 
-When constructing an op job, you can customize how that configuration will be satisfied by passing a value to the `config` parameter of the <PyObject section="graphs" module="dagster" object="GraphDefinition.to_job" /> method or the <PyObject section="jobs" module="dagster" object="job" decorator />decorator.
+When constructing an op job, you can customize how that configuration will be satisfied by passing a value to the `config` parameter of the <PyObject section="graphs" module="dagster" object="GraphDefinition.to_job" /> method or the <PyObject section="jobs" module="dagster" object="job" decorator /> decorator.
 
 The options are discussed below:
 

--- a/examples/docs_snippets/docs_snippets/concepts/assets/jobs_to_definitions.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/jobs_to_definitions.py
@@ -1,3 +1,4 @@
+# start_marker_job
 import dagster as dg
 
 
@@ -10,6 +11,16 @@ def number_asset():
     )
 
 
-number_asset_job = dg.define_asset_job(
-    name="number_asset_job", selection="number_asset"
-)
+# end_marker_job
+
+
+# start_marker_job_definition
+import dagster as dg
+
+
+@dg.job
+def number_asset_job():
+    number_asset()
+
+
+# end_marker_job_definition

--- a/examples/docs_snippets/docs_snippets/guides/data-modeling/asset-jobs/asset-jobs.py
+++ b/examples/docs_snippets/docs_snippets/guides/data-modeling/asset-jobs/asset-jobs.py
@@ -22,10 +22,15 @@ def shopping_list() -> None:
 
 
 # start_marker_jobs
-all_assets_job = dg.define_asset_job(name="all_assets_job")
+@dg.job
+def all_assets_job():
+    sugary_cereals()
+    shopping_list()
 
-sugary_cereals_job = dg.define_asset_job(
-    name="sugary_cereals_job", selection="sugary_cereals"
-)
+
+@dg.job
+def sugary_cereals_job():
+    sugary_cereals()
+
 
 # end_marker_jobs


### PR DESCRIPTION
## Summary & Motivation
Consistently use `@dg.jobs` as the default in the Build/Jobs section

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
