### PR TITLE
FE-858: Hide the product tour modal on the getting started page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/HelpMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/HelpMenu.tsx
@@ -22,14 +22,19 @@ import DagsterUniversityImage from './dagster_university.svg';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {useVersionNumber} from '../nav/VersionNumber';
 import {CopyIconButton} from '../ui/CopyButton';
+import {useRouteMatch} from 'react-router-dom';
 
 interface Props {
   showContactSales?: boolean;
   onShareFeedback?: () => void;
 }
 
+const TOUR_BLOCKED_ROUTES = ['/getting-started'];
+
 export const HelpMenu = ({showContactSales = true, onShareFeedback}: Props) => {
   const [isOpen, setIsOpen] = useState(false);
+
+  const isTourBlocked = useRouteMatch(TOUR_BLOCKED_ROUTES);
 
   const onInteraction = useCallback((open: boolean) => setIsOpen(open), []);
 
@@ -48,7 +53,7 @@ export const HelpMenu = ({showContactSales = true, onShareFeedback}: Props) => {
         title="Master the Dagster basics"
         description="Learn the basics of Dagster with the free Dagster Essentials course from Dagster University"
         position={ProductTourPosition.BOTTOM_LEFT}
-        canShow={!isOpen && !didDismissDaggyU}
+        canShow={!isOpen && !didDismissDaggyU && !isTourBlocked}
         img={DagsterUniversityImage.src}
         actions={{
           custom: (


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/FE-858/dont-show-daggy-u-popup-on-nux-page

Made this an array of route matches so we can block it on additional pages. Verified using app-cloud and the proxy that this works in cloud.