### PR TITLE
[docs] Consistent `@dg.schedules` in Automate/Schedules

### DIFF
--- a/docs/docs/guides/automate/schedules/index.md
+++ b/docs/docs/guides/automate/schedules/index.md
@@ -18,21 +18,18 @@ To follow the steps in this guide, you'll need:
 
 ## Basic schedule
 
-A basic schedule is defined by a `JobDefinition` and a `cron_schedule` using the `ScheduleDefinition` class. A job can be thought of as a selection of assets or operations executed together.
+A basic schedule is defined by a <PyObject section="schedules" module="dagster" object="schedule" decorator /> decorator. A schedule can be thought of as a selection of assets or operations executed together at a specific time.
 
 <CodeExample path="docs_snippets/docs_snippets/guides/automation/simple-schedule-example.py" language="python" title="src/<project_name>/defs/assets.py" />
 
 ## Run schedules in a different timezone
 
-By default, schedules without a timezone will run in Coordinated Universal Time (UTC). To run a schedule in a different timezone, set the `timezone` parameter:
+By default, schedules without a timezone will run in Coordinated Universal Time (UTC). To run a schedule in a different timezone, set the `execution_timezone` parameter:
 
 ```python
-daily_schedule = ScheduleDefinition(
-    job=daily_refresh_job,
-    cron_schedule="0 0 * * *",
-    # highlight-next-line
-    timezone="America/Los_Angeles",
-)
+@dg.schedule
+def daily_schedule(job=daily_refresh_job, cron_schedule="0 0 * * *", execution_timezone="America/Los_Angeles"):
+    ...
 ```
 
 For more information, see "[Customizing a schedule's execution timezone](/guides/automate/schedules/customizing-execution-timezone)".

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedules.py
@@ -54,9 +54,9 @@ def configurable_job_schedule(context: dg.ScheduleEvaluationContext):
 
 
 # start_timezone
-my_timezone_schedule = dg.ScheduleDefinition(
-    job=my_job, cron_schedule="0 9 * * *", execution_timezone="America/Los_Angeles"
-)
+@dg.schedule(cron_schedule="0 9 * * *", execution_timezone="America/Los_Angeles")
+def my_timezone_schedule(): ...
+
 
 # end_timezone
 

--- a/examples/docs_snippets/docs_snippets/guides/automation/simple-schedule-example.py
+++ b/examples/docs_snippets/docs_snippets/guides/automation/simple-schedule-example.py
@@ -9,13 +9,15 @@ def customer_data(): ...
 def sales_report(): ...
 
 
-daily_refresh_job = dg.define_asset_job(
-    "daily_refresh", selection=["customer_data", "sales_report"]
-)
+@dg.job
+def daily_refresh():
+    customer_data()
+    sales_report()
+
 
 # highlight-start
-daily_schedule = dg.ScheduleDefinition(
-    job=daily_refresh_job,
-    cron_schedule="0 0 * * *",  # Runs at midnight daily
-)
+@dg.schedule(cron_schedule="0 0 * * *")
+def daily_refresh_job(): ...
+
+
 # highlight-end


### PR DESCRIPTION
## Summary & Motivation
Consistently use `@dg.schedules` as the default in the Automate/Schedules section

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
