### PR TITLE
[Observe] Fix status filtering by fixing duplicate SDAs returned by `useAllAssets`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAllAssets.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAllAssets.test.tsx
@@ -129,7 +129,7 @@ describe('useAllAssets', () => {
     });
   });
 
-  it('grabs assets from WorkspaceContext and dedupes SDAs that are defined in multiple locations', async () => {
+  it('dedupes SDAs that are defined in multiple locations and combines their definitions', async () => {
     const assetNode1 = buildAssetNode({
       assetKey: buildAssetKey({path: ['asset_key']}),
       kinds: ['dbt'],

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAllAssets.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAllAssets.test.tsx
@@ -1,9 +1,22 @@
 import {MockedProvider} from '@apollo/client/testing';
 import {renderHook, waitFor} from '@testing-library/react';
 
-import {buildAssetRecord, buildAssetRecordConnection} from '../../graphql/types';
+import {
+  buildAssetKey,
+  buildAssetNode,
+  buildAssetRecord,
+  buildAssetRecordConnection,
+  buildDefinitionTag,
+  buildRepository,
+  buildRepositoryLocation,
+  buildTeamAssetOwner,
+  buildUserAssetOwner,
+  buildWorkspaceLocationEntry,
+} from '../../graphql/types';
 import {buildQueryMock} from '../../testing/mocking';
 import {cache as mockedCache} from '../../util/idb-lru-cache';
+import {WorkspaceProvider} from '../../workspace/WorkspaceContext/WorkspaceContext';
+import {buildWorkspaceMocks} from '../../workspace/WorkspaceContext/__fixtures__/Workspace.fixtures';
 import {useAllAssets} from '../AssetsCatalogTable';
 import {AssetCatalogTableQueryVersion} from '../types/AssetsCatalogTable.types';
 import {AssetRecordsQuery, AssetRecordsQueryVariables} from '../types/useAllAssets.types';
@@ -114,5 +127,121 @@ describe('useAllAssets', () => {
     await waitFor(() => {
       expect(result.current.assets?.length).toBe(5);
     });
+  });
+
+  it('grabs assets from WorkspaceContext and dedupes SDAs that are defined in multiple locations', async () => {
+    const assetNode1 = buildAssetNode({
+      assetKey: buildAssetKey({path: ['asset_key']}),
+      kinds: ['dbt'],
+      groupName: 'default',
+      owners: [
+        buildTeamAssetOwner({team: 'my-team'}),
+        buildUserAssetOwner({email: 'fake-email@gmail.com'}),
+      ],
+      tags: [buildDefinitionTag({key: 'tag', value: 'value'})],
+      repository: buildRepository({
+        name: 'repoName',
+        location: buildRepositoryLocation({name: 'locationName'}),
+      }),
+      isMaterializable: true,
+      isObservable: false,
+    });
+
+    const assetNode2 = buildAssetNode({
+      assetKey: buildAssetKey({path: ['asset_key']}), // Same asset key
+      kinds: ['python'],
+      groupName: 'default',
+      owners: [buildTeamAssetOwner({team: 'another-team'})],
+      tags: [buildDefinitionTag({key: 'tag2', value: 'value2'})],
+      repository: buildRepository({
+        name: 'anotherRepoName',
+        location: buildRepositoryLocation({name: 'anotherLocationName'}),
+      }),
+      isMaterializable: false,
+      isObservable: true,
+    });
+
+    const workspaceWithDuplicateAssets = buildWorkspaceMocks([
+      buildWorkspaceLocationEntry({
+        id: 'location1',
+        name: 'location1',
+        locationOrLoadError: buildRepositoryLocation({
+          id: 'location1',
+          name: 'location1',
+          repositories: [
+            buildRepository({
+              id: 'repo1',
+              name: 'repoName',
+              assetNodes: [assetNode1],
+            }),
+          ],
+        }),
+      }),
+      buildWorkspaceLocationEntry({
+        id: 'location2',
+        name: 'location2',
+        locationOrLoadError: buildRepositoryLocation({
+          id: 'location2',
+          name: 'location2',
+          repositories: [
+            buildRepository({
+              id: 'repo2',
+              name: 'anotherRepoName',
+              assetNodes: [assetNode2],
+            }),
+          ],
+        }),
+      }),
+    ]);
+
+    // Mock the ASSET_RECORDS_QUERY to return empty data
+    const assetRecordsMock = createMock({
+      nodes: [],
+      returnedCursor: null,
+      limit: 1000,
+    });
+
+    const {result} = renderHook(() => useAllAssets({}), {
+      wrapper(props) {
+        return (
+          <MockedProvider mocks={[...workspaceWithDuplicateAssets, assetRecordsMock]}>
+            <WorkspaceProvider>{props.children}</WorkspaceProvider>
+          </MockedProvider>
+        );
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Should have exactly 1 asset (deduplicated)
+    expect(result.current.assets?.length).toBe(1);
+
+    const asset = result.current.assets?.[0];
+    expect(asset).toBeDefined();
+    expect(asset?.key.path).toEqual(['asset_key']);
+
+    // Should prefer materializable asset (assetNode1) as the base
+    expect(asset?.definition?.isMaterializable).toBe(true);
+
+    // Should merge boolean fields (OR of both values)
+    expect(asset?.definition?.isObservable).toBe(true);
+
+    // Should merge array fields (union of all values)
+    expect(asset?.definition?.kinds).toEqual(expect.arrayContaining(['dbt', 'python']));
+    expect(asset?.definition?.owners).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({team: 'my-team'}),
+        expect.objectContaining({email: 'fake-email@gmail.com'}),
+        expect.objectContaining({team: 'another-team'}),
+      ]),
+    );
+    expect(asset?.definition?.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({key: 'tag', value: 'value'}),
+        expect.objectContaining({key: 'tag2', value: 'value2'}),
+      ]),
+    );
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAllAssets.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAllAssets.tsx
@@ -286,6 +286,8 @@ const getAssets = weakMapMemoize((allAssetNodes: WorkspaceAssetFragment[]) => {
     id: string;
   }[] = [];
 
+  const addedKeys = new Set();
+
   softwareDefinedAssetsWithDuplicates.forEach((asset) => {
     /**
      * Return a materialization node if it exists, otherwise return an observable node if it
@@ -298,6 +300,11 @@ const getAssets = weakMapMemoize((allAssetNodes: WorkspaceAssetFragment[]) => {
      * materialization nodes shadowing observation nodes that would otherwise be exposed.
      */
     const key = tokenForAssetKey(asset.key);
+    const duplicate = addedKeys.has(key);
+    addedKeys.add(key);
+    if (duplicate) {
+      return;
+    }
     if (!keysWithMultipleDefinitions.has(key)) {
       softwareDefinedAssets.push(asset);
       return;


### PR DESCRIPTION
## Summary & Motivation

As titled. We were including duplicate SDAs in the list which led to [this line always being false ](https://github.com/dagster-io/dagster/blob/7bf506bd45531ed0d56aeb448b1f3b11af465664/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx#L22) since the array of nodes included duplicates causing status filtering to forever be in a loading state.

## How I Tested These Changes

jest. local testing
<img width="1728" alt="Screenshot 2025-06-30 at 3 58 31 PM" src="https://github.com/user-attachments/assets/0d155216-1b5d-428d-ad23-8d628669e72a" />


## Changelog
[ui][plus] Fixed an issue that prevented status filtering from working within the selection syntax.