### PR TITLE
[ui] Fix filtering by partition on asset events page FE-884

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -52,7 +52,7 @@
   "AssetOverviewMetadataEventsQuery": "114f8107c50306b1a96275b011beacf8b6422c88e387f479da4d0a45c4a08cca",
   "PartitionHealthQuery": "4f37a772c8f0e07cf2d76c18915a2a9c393fa8ea6a7b2ad355b80a225c8fe2af",
   "AssetJobPartitionSetsQuery": "43286e824ac1f7d1b30c6744ad472c034d8ed257675a720ac53bcf929e0bc7f7",
-  "RecentAssetEventsQuery": "87240002f2ea0a20f6767d8a8de10df1499443d4b1d667f667b8fcb7a56ec735",
+  "RecentAssetEventsQuery": "6459c0177836dfb98ba88222cdf6461c67b74bed82a41827449e6d47cfb35941",
   "AssetPartitionEventsQuery": "859d8d8bf982cc539c932d2fc071b373ca9836cfd083e3fab616d149e1b18646",
   "LatestAssetPartitionsQuery": "2568dc5d6ad01d1695e9b6028a69e20785b90e152b15e84efe76b7c2595707da",
   "ReportEventPartitionDefinitionQuery": "e306421344493a9986106de14bca90ec554505d6f1965991ba502725edc41c95",

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
@@ -53,7 +53,10 @@ export const AssetEvents = ({
   });
 
   const combinedParams = useMemo(() => {
-    const combinedParams: Parameters<typeof usePaginatedAssetEvents>[1] = {...(params as any)};
+    const combinedParams: Parameters<typeof usePaginatedAssetEvents>[1] = {
+      asOf: params.asOf,
+    };
+
     if (filterState.dateRange) {
       if (filterState.dateRange.end) {
         combinedParams.before = filterState.dateRange.end;
@@ -61,6 +64,9 @@ export const AssetEvents = ({
       if (filterState.dateRange.start) {
         combinedParams.after = filterState.dateRange.start;
       }
+    }
+    if (filterState.partitions) {
+      combinedParams.partitions = filterState.partitions;
     }
     if (filterState.status) {
       if (filterState.status.length === 1) {
@@ -70,7 +76,7 @@ export const AssetEvents = ({
       }
     }
     return combinedParams;
-  }, [params, filterState.dateRange, filterState.status]);
+  }, [params.asOf, filterState.dateRange, filterState.status, filterState.partitions]);
 
   const {events, fetchMore, fetchLatest, loading} = usePaginatedAssetEvents(
     assetKey,
@@ -86,6 +92,7 @@ export const AssetEvents = ({
     combinedParams.after,
     combinedParams.before,
     combinedParams.statuses,
+    combinedParams.partitions,
   ]);
 
   const grouped = useGroupedEvents('time', events, []);
@@ -124,8 +131,10 @@ export const AssetEvents = ({
 
   const hasFilter =
     !isEqual(combinedParams.statuses, ALL_EVENT_TYPES) ||
+    combinedParams.partitions !== undefined ||
     combinedParams.before !== undefined ||
     combinedParams.after !== undefined;
+
   if (!loading && !events.length && !hasFilter) {
     return (
       <Box padding={{horizontal: 24, vertical: 64}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useRecentAssetEvents.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useRecentAssetEvents.types.ts
@@ -545,6 +545,9 @@ export type RecentAssetEventsQueryVariables = Types.Exact<{
   before?: Types.InputMaybe<Types.Scalars['String']['input']>;
   after?: Types.InputMaybe<Types.Scalars['String']['input']>;
   cursor?: Types.InputMaybe<Types.Scalars['String']['input']>;
+  partitions?: Types.InputMaybe<
+    Array<Types.Scalars['String']['input']> | Types.Scalars['String']['input']
+  >;
 }>;
 
 export type RecentAssetEventsQuery = {
@@ -1432,7 +1435,7 @@ export type LatestAssetPartitionsQuery = {
     | {__typename: 'AssetNotFoundError'};
 };
 
-export const RecentAssetEventsQueryVersion = '87240002f2ea0a20f6767d8a8de10df1499443d4b1d667f667b8fcb7a56ec735';
+export const RecentAssetEventsQueryVersion = '6459c0177836dfb98ba88222cdf6461c67b74bed82a41827449e6d47cfb35941';
 
 export const AssetPartitionEventsQueryVersion = '859d8d8bf982cc539c932d2fc071b373ca9836cfd083e3fab616d149e1b18646';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetEventsFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetEventsFilters.tsx
@@ -90,7 +90,7 @@ export const useAssetEventsFilters = ({assetKey, assetNode}: Config) => {
   );
 
   const partitionsFilter = useStaticSetFilter({
-    name: 'Partitions',
+    name: 'Partition',
     icon: 'partition',
     allValues: partitionValues,
     renderLabel: ({value}) => (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/usePaginatedAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/usePaginatedAssetEvents.tsx
@@ -29,6 +29,7 @@ export function usePaginatedAssetEvents(
     before?: number;
     after?: number;
     statuses?: AssetEventHistoryEventTypeSelector[];
+    partitions?: string[];
   },
 ) {
   const initialAsOf = params.asOf ? `${Number(params.asOf) + 1}` : undefined;
@@ -45,7 +46,7 @@ export function usePaginatedAssetEvents(
   useEffect(() => {
     setEvents([]);
     setCursor(undefined);
-  }, [assetKey, params.before, params.after, params.statuses]);
+  }, [assetKey, params.before, params.after, params.statuses, params.partitions]);
 
   const fetch = useCallback(
     async (before = initialAsOf ?? beforeParam, cursor: string | undefined = undefined) => {
@@ -64,6 +65,7 @@ export function usePaginatedAssetEvents(
           cursor,
           before,
           after: afterParam,
+          partitions: params.partitions,
           eventTypeSelectors: params.statuses ?? [
             AssetEventHistoryEventTypeSelector.MATERIALIZATION,
             AssetEventHistoryEventTypeSelector.OBSERVATION,
@@ -85,7 +87,7 @@ export function usePaginatedAssetEvents(
 
       setCursor(asset?.assetEventHistory?.cursor);
     },
-    [initialAsOf, beforeParam, assetKey, client, afterParam, params.statuses],
+    [initialAsOf, beforeParam, assetKey, client, afterParam, params.statuses, params.partitions],
   );
 
   useBlockTraceUntilTrue('AssetEventsQuery', loaded);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
@@ -251,6 +251,7 @@ export const RECENT_ASSET_EVENTS_QUERY = gql`
     $before: String
     $after: String
     $cursor: String
+    $partitions: [String!]
   ) {
     assetsLatestInfo(assetKeys: [$assetKey]) {
       id
@@ -268,6 +269,7 @@ export const RECENT_ASSET_EVENTS_QUERY = gql`
           beforeTimestampMillis: $before
           eventTypeSelectors: $eventTypeSelectors
           cursor: $cursor
+          partitions: $partitions
         ) {
           results {
             ...AssetSuccessfulMaterializationFragment


### PR DESCRIPTION
## Summary & Motivation

We did a big refactor of the underlying fetch logic for this page, and it looks like the parittions filter was not wired up, but it is an available option on the new GraphQL resolver.

I also changed the name of the filter from “Partitions” to “Partition” to match “Date” and “Type”, and so it says “Partition is any of” instead of “Partitions is any of”


## How I Tested These Changes

app-proxy with `weekly_support_reminders`

<img width="966" alt="image" src="https://github.com/user-attachments/assets/0c19c198-b63d-47d7-8e45-546db8a1752b" />

## Changelog

[ui] Filtering by partition on the Asset Events view now works as expected