### PR TITLE
pass through asset selection when launching a sensor/schedule preview

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
@@ -57,6 +57,8 @@ export function useLaunchMultipleRunsWithTelemetry() {
             : paramsWithUIExecutionTags(variables.executionParamsList),
         };
 
+        console.log('finalized', finalized);
+
         const result = (await launchMultipleRuns({variables: finalized})).data?.launchMultipleRuns;
 
         if (result) {

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
@@ -57,8 +57,6 @@ export function useLaunchMultipleRunsWithTelemetry() {
             : paramsWithUIExecutionTags(variables.executionParamsList),
         };
 
-        console.log('finalized', finalized);
-
         const result = (await launchMultipleRuns({variables: finalized})).data?.launchMultipleRuns;
 
         if (result) {

--- a/js_modules/dagster-ui/packages/ui-core/src/util/buildExecutionParamsList.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/buildExecutionParamsList.ts
@@ -1,6 +1,7 @@
 import * as yaml from 'yaml';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
+import {asAssetKeyInput} from '../assets/asInput';
 import {ExecutionParams, ScheduleSelector, SensorSelector} from '../graphql/types';
 import {sanitizeConfigYamlString} from '../launchpad/yamlUtils';
 import {ScheduleDryRunInstigationTick} from '../ticks/EvaluateScheduleDialog';
@@ -33,6 +34,8 @@ export const buildExecutionParamsListSensor = (
       return;
     }
     const {repositoryLocationName, repositoryName} = sensorSelector;
+    console.log('build sensor params');
+    console.log(request.assetSelection);
 
     const executionParams: ExecutionParams = {
       runConfigData: configYamlOrEmpty,
@@ -40,7 +43,7 @@ export const buildExecutionParamsListSensor = (
         jobName: request.jobName ?? jobName, // get jobName from runRequest, fallback to jobName
         repositoryLocationName,
         repositoryName,
-        assetSelection: [],
+        assetSelection: request.assetSelection?.map(asAssetKeyInput) || [],
         assetCheckSelection: [],
         solidSelection: undefined,
       },
@@ -76,6 +79,8 @@ export const buildExecutionParamsListSchedule = (
       return;
     }
     const {repositoryLocationName, repositoryName} = scheduleSelector;
+    console.log('build schedule params');
+    console.log(request.assetSelection);
 
     const executionParams: ExecutionParams = {
       runConfigData: configYamlOrEmpty,
@@ -83,7 +88,7 @@ export const buildExecutionParamsListSchedule = (
         jobName: request.jobName ?? jobName, // get jobName from runRequest, fallback to jobName
         repositoryLocationName,
         repositoryName,
-        assetSelection: [],
+        assetSelection: request.assetSelection?.map(asAssetKeyInput) || [],
         assetCheckSelection: [],
         solidSelection: undefined,
       },

--- a/js_modules/dagster-ui/packages/ui-core/src/util/buildExecutionParamsList.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/buildExecutionParamsList.ts
@@ -34,8 +34,6 @@ export const buildExecutionParamsListSensor = (
       return;
     }
     const {repositoryLocationName, repositoryName} = sensorSelector;
-    console.log('build sensor params');
-    console.log(request.assetSelection);
 
     const executionParams: ExecutionParams = {
       runConfigData: configYamlOrEmpty,
@@ -79,8 +77,6 @@ export const buildExecutionParamsListSchedule = (
       return;
     }
     const {repositoryLocationName, repositoryName} = scheduleSelector;
-    console.log('build schedule params');
-    console.log(request.assetSelection);
 
     const executionParams: ExecutionParams = {
       runConfigData: configYamlOrEmpty,


### PR DESCRIPTION
## Summary & Motivation
If a sensor specifies an asset selection, or if the RunRequest returned by a sensor or schedule evaluation specifies an asset selection, we should pass that asset selection through to the run execution in the dry run sensor/schedule ui flow. 

In fixing this, I noticed that we are not passing through asset check selections either, I'll fix that in a stacked PR (#30998). I also think the UI could use some help to display the selected assets better, so i'll take a stab at that too

fixes #27647 


## How I Tested These Changes
tested in local dev. I looked at writing a unit test, but it seemed like the mocks for the sensor dry run page hard code the execution parameters when launching a run, so i dont think i would be able to test that the results from evaluating the sensor are correctly transformed into the execution parameters. Maybe i'm missing another test file where testing this would be more appropriate. 