### PR TITLE
[ui] Fix list right-side control spacing on Catalog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryListItem.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryListItem.tsx
@@ -113,21 +113,15 @@ export const AssetSelectionSummaryListItemWithHealthStatus = React.memo(
                 control: loading ? (
                   <Spinner purpose="caption-text" />
                 ) : (
-                  <Box
-                    className={styles.statusCountListWrapper}
-                    border="right"
-                    padding={{right: 12}}
-                  >
-                    {statusJsx}
-                  </Box>
+                  <div className={styles.statusCountListWrapper}>{statusJsx}</div>
                 ),
               },
               {
                 key: 'count',
                 control: (
-                  <span>
+                  <Box padding={{left: 4}}>
                     {assetCount === 1 ? '1 asset' : `${numberFormatter.format(assetCount)} assets`}
-                  </span>
+                  </Box>
                 ),
               },
             ]}


### PR DESCRIPTION
## Summary & Motivation

In Catalog list view, fix the horizontal controls on the new list items. The `HorizontalControls` adds the line for us, so we can tidy it up a bit.

<img width="277" alt="Screenshot 2025-06-30 at 16 07 56" src="https://github.com/user-attachments/assets/fc45ad7c-0593-48f3-ac2c-32e8e2a34b4b" />


## How I Tested These Changes

Proxy, view Catalog list view. Verify that controls look more correct.