### PR TITLE
[ui] Fix Catalog list view loading state

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogV2VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogV2VirtualizedTable.tsx
@@ -108,7 +108,11 @@ export const AssetCatalogV2VirtualizedTable = React.memo(
               );
 
               if ('shimmer' in item) {
-                return wrapper(<Skeleton $height={21} $width="45%" />);
+                return wrapper(
+                  <Box padding={{top: 12, horizontal: 20}}>
+                    <Skeleton $height={30} $width="100%" />
+                  </Box>,
+                );
               }
 
               if ('header' in item) {


### PR DESCRIPTION
## Summary & Motivation

I broke the `Skeleton` rows on the new asset catalog table loading state. Fix them.

<img width="1151" alt="Screenshot 2025-06-30 at 16 16 03" src="https://github.com/user-attachments/assets/afa92c1d-319d-42be-9ad6-71fe8d779ab3" />

## How I Tested These Changes

Force loading state to be true, verify better rendering.