### PR TITLE
Add validate_partition_mappings support to 'dagster definitions validate'

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -30,7 +30,6 @@ from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.resolved_asset_deps import ResolvedAssetDependencies
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
-from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.selector.subset_selector import generate_asset_dep_graph
 from dagster._utils.warnings import disable_dagster_warnings
 
@@ -347,28 +346,6 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
                 *(ad for ad in self._assets_defs_by_check_key.values()),
             }
         )
-
-    def validate_partition_mappings(self):
-        for node in self.asset_nodes:
-            if node.is_external:
-                continue
-
-            parents = self.get_parents(node)
-            for parent in parents:
-                if parent.partitions_def is None or parent.is_external:
-                    continue
-
-                partition_mapping = self.get_partition_mapping(node.key, parent.key)
-
-                try:
-                    partition_mapping.validate_partition_mapping(
-                        parent.partitions_def,
-                        node.partitions_def,
-                    )
-                except Exception as e:
-                    raise DagsterInvalidDefinitionError(
-                        f"Invalid partition mapping from {node.key.to_user_string()} to {parent.key.to_user_string()}"
-                    ) from e
 
     def assets_defs_for_keys(self, keys: Iterable[EntityKey]) -> Sequence[AssetsDefinition]:
         return list({self.assets_def_for_key(key) for key in keys})

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -35,7 +35,7 @@ from dagster._core.definitions.time_window_partitions import (
     get_time_partition_key,
     get_time_partitions_def,
 )
-from dagster._core.errors import DagsterInvalidInvocationError
+from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.selector.subset_selector import DependencyGraph, fetch_sources
 from dagster._core.utils import toposort
@@ -652,6 +652,28 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
             and self.get(key).is_materializable
             and not self.has_materializable_parents(key)
         }
+
+    def validate_partition_mappings(self):
+        for node in self.asset_nodes:
+            if node.is_external:
+                continue
+
+            parents = self.get_parents(node)
+            for parent in parents:
+                if parent.partitions_def is None or parent.is_external:
+                    continue
+
+                partition_mapping = self.get_partition_mapping(node.key, parent.key)
+
+                try:
+                    partition_mapping.validate_partition_mapping(
+                        parent.partitions_def,
+                        node.partitions_def,
+                    )
+                except Exception as e:
+                    raise DagsterInvalidDefinitionError(
+                        f"Invalid partition mapping from {node.key.to_user_string()} to {parent.key.to_user_string()}"
+                    ) from e
 
     def upstream_key_iterator(self, asset_key: AssetKey) -> Iterator[AssetKey]:
         """Iterates through all asset keys which are upstream of the given key."""

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -718,6 +718,7 @@ class Definitions(IHaveNew):
         - No jobs, sensors, or schedules have conflicting names.
         - All asset jobs can be resolved.
         - All resource requirements are satisfied.
+        - All partition mappings are valid.
 
         Meant to be used in unit tests.
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_partition_mappings_workspace/defs1.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_partition_mappings_workspace/defs1.py
@@ -1,0 +1,8 @@
+import dagster as dg
+
+pacific = dg.DailyPartitionsDefinition(start_date="2020-01-01", timezone="US/Pacific")
+
+
+@dg.asset(partitions_def=pacific)
+def upstream_asset():
+    pass

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_partition_mappings_workspace/defs2.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_partition_mappings_workspace/defs2.py
@@ -1,0 +1,8 @@
+import dagster as dg
+
+utc = dg.DailyPartitionsDefinition(start_date="2020-01-01")
+
+
+@dg.asset(deps=[dg.AssetSpec(key="upstream_asset")], partitions_def=utc)
+def downstream_asset():
+    pass

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_partition_mappings_workspace/workspace.yaml
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/definitions_command_projects/invalid_partition_mappings_workspace/workspace.yaml
@@ -1,0 +1,3 @@
+load_from:
+  - python_file: defs1.py
+  - python_file: defs2.py

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_definitions_validate_command.py
@@ -9,6 +9,9 @@ from dagster._utils import file_relative_path, pushd
 EMPTY_PROJECT_PATH = file_relative_path(__file__, "definitions_command_projects/empty_project")
 VALID_PROJECT_PATH = file_relative_path(__file__, "definitions_command_projects/valid_project")
 INVALID_PROJECT_PATH = file_relative_path(__file__, "definitions_command_projects/invalid_project")
+INVALID_PARTITION_MAPPINGS_WORKSPACE_PATH = file_relative_path(
+    __file__, "definitions_command_projects/invalid_partition_mappings_workspace"
+)
 INVALID_PROJECT_PATH_WITH_EXCEPTION = file_relative_path(
     __file__, "definitions_command_projects/invalid_project_exc"
 )
@@ -130,6 +133,16 @@ def test_invalid_project_truncated_properly(verbose):
                 == 1
             )
             assert result.output.count("dagster system frames hidden") >= 1
+
+
+def test_invalid_partition_mapping_workspace(monkeypatch):
+    with monkeypatch.context() as m:
+        m.chdir(INVALID_PARTITION_MAPPINGS_WORKSPACE_PATH)
+        result = invoke_validate()
+        assert result.exit_code == 1
+        assert "Asset graph contained an invalid partition mapping" in result.output
+        assert "Invalid partition mapping from downstream_asset to upstream_asset" in result.output
+        assert "Timezones US/Pacific and UTC don't match" in result.output
 
 
 def test_env_var(monkeypatch):


### PR DESCRIPTION
## Summary & Motivation
Gives you a way to detect in CI that you have invalid partition mappings that could cause problems in backfills or DA.

## How I Tested These Changes
New test case

## Changelog
`dagster definitions validate` will now raise an exception if there are invalid partition mappings between any assets in your asset graph (for example, an upstream and downstream asset with time-based partitions definitions using different timezones)
