### PR TITLE
support asset checks in run requests in schedules

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
@@ -57,6 +57,8 @@ export function useLaunchMultipleRunsWithTelemetry() {
             : paramsWithUIExecutionTags(variables.executionParamsList),
         };
 
+        console.log('finalized', finalized);
+
         const result = (await launchMultipleRuns({variables: finalized})).data?.launchMultipleRuns;
 
         if (result) {

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
@@ -57,8 +57,6 @@ export function useLaunchMultipleRunsWithTelemetry() {
             : paramsWithUIExecutionTags(variables.executionParamsList),
         };
 
-        console.log('finalized', finalized);
-
         const result = (await launchMultipleRuns({variables: finalized})).data?.launchMultipleRuns;
 
         if (result) {

--- a/js_modules/dagster-ui/packages/ui-core/src/util/buildExecutionParamsList.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/buildExecutionParamsList.ts
@@ -1,6 +1,7 @@
 import * as yaml from 'yaml';
 
 import {showCustomAlert} from '../app/CustomAlertProvider';
+import {asAssetKeyInput} from '../assets/asInput';
 import {ExecutionParams, ScheduleSelector, SensorSelector} from '../graphql/types';
 import {sanitizeConfigYamlString} from '../launchpad/yamlUtils';
 import {ScheduleDryRunInstigationTick} from '../ticks/EvaluateScheduleDialog';
@@ -33,6 +34,8 @@ export const buildExecutionParamsListSensor = (
       return;
     }
     const {repositoryLocationName, repositoryName} = sensorSelector;
+    console.log('build sensor params');
+    console.log(request.assetSelection);
 
     const executionParams: ExecutionParams = {
       runConfigData: configYamlOrEmpty,
@@ -40,7 +43,7 @@ export const buildExecutionParamsListSensor = (
         jobName: request.jobName ?? jobName, // get jobName from runRequest, fallback to jobName
         repositoryLocationName,
         repositoryName,
-        assetSelection: [],
+        assetSelection: request.assetSelection?.map(asAssetKeyInput) || [],
         assetCheckSelection: [],
         solidSelection: undefined,
       },
@@ -76,6 +79,8 @@ export const buildExecutionParamsListSchedule = (
       return;
     }
     const {repositoryLocationName, repositoryName} = scheduleSelector;
+    console.log('build schedule params');
+    console.log(request.assetSelection);
 
     const executionParams: ExecutionParams = {
       runConfigData: configYamlOrEmpty,
@@ -83,7 +88,7 @@ export const buildExecutionParamsListSchedule = (
         jobName: request.jobName ?? jobName, // get jobName from runRequest, fallback to jobName
         repositoryLocationName,
         repositoryName,
-        assetSelection: [],
+        assetSelection: request.assetSelection?.map(asAssetKeyInput) || [],
         assetCheckSelection: [],
         solidSelection: undefined,
       },

--- a/js_modules/dagster-ui/packages/ui-core/src/util/buildExecutionParamsList.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/buildExecutionParamsList.ts
@@ -34,8 +34,6 @@ export const buildExecutionParamsListSensor = (
       return;
     }
     const {repositoryLocationName, repositoryName} = sensorSelector;
-    console.log('build sensor params');
-    console.log(request.assetSelection);
 
     const executionParams: ExecutionParams = {
       runConfigData: configYamlOrEmpty,
@@ -79,8 +77,6 @@ export const buildExecutionParamsListSchedule = (
       return;
     }
     const {repositoryLocationName, repositoryName} = scheduleSelector;
-    console.log('build schedule params');
-    console.log(request.assetSelection);
 
     const executionParams: ExecutionParams = {
       runConfigData: configYamlOrEmpty,

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -88,12 +88,11 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
             all the assets in the selection. This argument is used to specify that only a subset of
             these assets should be launched, instead of all of them.
         asset_check_keys (Optional[Sequence[AssetCheckKey]]): A subselection of asset checks that
-            should be launched with this run. This is currently only supported on sensors. If the
-            sensor targets a job, then by default a RunRequest returned from it will launch all of
-            the asset checks in the job. If the sensor targets an asset selection, then by default a
-            RunRequest returned from it will launch all the asset checks in the selection. This
-            argument is used to specify that only a subset of these asset checks should be launched,
-            instead of all of them.
+            should be launched with this run. If the sensor/schedule targets a job, then by default a
+            RunRequest returned from it will launch all of the asset checks in the job. If the
+            sensor/schedule targets an asset selection, then by default a RunRequest returned from it
+            will launch all the asset checks in the selection. This argument is used to specify that
+            only a subset of these asset checks should be launched, instead of all of them.
         stale_assets_only (bool): Set to true to further narrow the asset
             selection to stale assets. If passed without an asset selection, all stale assets in the
             job will be materialized. If the job does not materialize assets, this flag is ignored.

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -1416,10 +1416,14 @@ def _create_sensor_run(
         remote_job_origin=remote_job.get_remote_origin(),
         job_code_origin=remote_job.get_python_origin(),
         asset_selection=(
-            frozenset(run_request.asset_selection) if run_request.asset_selection else None
+            frozenset(run_request.asset_selection)
+            if run_request.asset_selection is not None
+            else None
         ),
         asset_check_selection=(
-            frozenset(run_request.asset_check_keys) if run_request.asset_check_keys else None
+            frozenset(run_request.asset_check_keys)
+            if run_request.asset_check_keys is not None
+            else None
         ),
         asset_graph=code_location.get_repository(
             remote_job.repository_handle.repository_name

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -1055,10 +1055,14 @@ def _create_scheduler_run(
         remote_job_origin=remote_job.get_remote_origin(),
         job_code_origin=remote_job.get_python_origin(),
         asset_selection=(
-            frozenset(run_request.asset_selection) if run_request.asset_selection else None
+            frozenset(run_request.asset_selection)
+            if run_request.asset_selection is not None
+            else None
         ),
         asset_check_selection=(
-            frozenset(run_request.asset_check_keys) if run_request.asset_check_keys else None
+            frozenset(run_request.asset_check_keys)
+            if run_request.asset_check_keys is not None
+            else None
         ),
         asset_graph=code_location.get_repository(
             remote_job.repository_handle.repository_name

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -799,6 +799,7 @@ def _submit_run_request(
             job_name=remote_schedule.job_name,
             op_selection=remote_schedule.op_selection,
             asset_selection=run_request.asset_selection,
+            asset_check_selection=run_request.asset_check_keys,
         )
 
         # reload the code_location on each submission, request_context derived data can become out date
@@ -1056,7 +1057,9 @@ def _create_scheduler_run(
         asset_selection=(
             frozenset(run_request.asset_selection) if run_request.asset_selection else None
         ),
-        asset_check_selection=None,
+        asset_check_selection=(
+            frozenset(run_request.asset_check_keys) if run_request.asset_check_keys else None
+        ),
         asset_graph=code_location.get_repository(
             remote_job.repository_handle.repository_name
         ).asset_graph,

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -9,7 +9,8 @@ from typing import Optional, cast
 
 import dagster as dg
 import pytest
-from dagster import AssetExecutionContext, DefaultScheduleStatus, schedule
+from dagster import AssetExecutionContext, AssetKey, DefaultScheduleStatus, schedule
+from dagster._core.definitions.run_request import RunRequest
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import (
     CodeLocation,
@@ -478,6 +479,16 @@ def asset1():
     return "asset1"
 
 
+@dg.asset_check(asset=asset1)
+def asset_1_check_1():
+    return dg.AssetCheckResult(passed=True)
+
+
+@dg.asset_check(asset=asset1)
+def asset_1_check_2():
+    return dg.AssetCheckResult(passed=True)
+
+
 @dg.asset
 def asset2(asset1):
     return asset1 + "asset2"
@@ -489,6 +500,11 @@ asset_job = dg.define_asset_job("asset_job")
 @schedule(job=asset_job, cron_schedule="@daily")
 def asset_selection_schedule():
     return dg.RunRequest(asset_selection=[asset1.key])
+
+
+@schedule(job=asset_job, cron_schedule="@daily")
+def asset_check_selection_schedule():
+    return RunRequest(asset_selection=[asset1.key], asset_check_keys=[asset_1_check_1.check_key])
 
 
 @schedule(job=asset_job, cron_schedule="@daily")
@@ -598,8 +614,11 @@ def the_repo():
         empty_schedule,
         many_requests_schedule,
         [asset1, asset2, source_asset],
+        asset_1_check_1,
+        asset_1_check_2,
         asset_selection_schedule,
         stale_asset_selection_schedule,
+        asset_check_selection_schedule,
         source_asset_observation_schedule,
         static_partitioned_asset1,
         static_partitioned_asset1_schedule,
@@ -2873,6 +2892,55 @@ class TestSchedulerRun:
                 freeze_datetime,
                 TickStatus.SUCCESS,
                 [run.run_id for run in runs],
+            )
+
+    @pytest.mark.parametrize("executor", get_schedule_executors())
+    def test_asset_check_selection(
+        self,
+        scheduler_instance: DagsterInstance,
+        workspace_context: WorkspaceProcessContext,
+        remote_repo: RemoteRepository,
+        executor: ThreadPoolExecutor,
+    ):
+        # TestSchedulerRun::test_asset_check_selection
+        freeze_datetime = feb_27_2019_one_second_to_midnight()
+        schedule = remote_repo.get_schedule("asset_check_selection_schedule")
+        schedule_origin = schedule.get_remote_origin()
+
+        with freeze_time(freeze_datetime):
+            scheduler_instance.start_schedule(schedule)
+
+            ticks = scheduler_instance.get_ticks(schedule_origin.get_id(), schedule.selector_id)
+
+            # launch_scheduled_runs does nothing before the first tick
+            evaluate_schedules(workspace_context, executor, get_current_datetime())
+            scheduler_instance.get_ticks(schedule_origin.get_id(), schedule.selector_id)
+
+        freeze_datetime = freeze_datetime + relativedelta(seconds=2)
+        with freeze_time(freeze_datetime):
+            evaluate_schedules(workspace_context, executor, get_current_datetime())
+
+            assert scheduler_instance.get_runs_count() == 1
+            ticks = scheduler_instance.get_ticks(schedule_origin.get_id(), schedule.selector_id)
+            assert len(ticks) == 1
+
+            expected_datetime = create_datetime(year=2019, month=2, day=28)
+
+            validate_tick(
+                ticks[0],
+                schedule,
+                expected_datetime,
+                TickStatus.SUCCESS,
+                [run.run_id for run in scheduler_instance.get_runs()],
+            )
+
+            wait_for_all_runs_to_start(scheduler_instance)
+            run = next(iter(scheduler_instance.get_runs()))
+            assert run.asset_selection == {AssetKey("asset1")}
+            assert run.asset_check_selection == {asset_1_check_1.check_key}
+
+            validate_run_started(
+                scheduler_instance, run, execution_time=create_datetime(2019, 2, 28)
             )
 
     @pytest.mark.parametrize("executor", get_schedule_executors())


### PR DESCRIPTION
## Summary & Motivation
Turns out if you return a RunRequest that specifies a selection of asset check keys from a schedule, we don't respect that when launching the run 

## How I Tested These Changes
new unit tests

## Changelog
Schedules now support specifying a subset of asset checks to execute in a `RunRequest`.

