### PR TITLE
[graph] allow omitting input when destinations have defaults

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -389,6 +389,9 @@ class _PlanBuilder:
         if input_def.dagster_type.is_nothing:
             return None
 
+        if job_def.graph.input_has_default(input_name):
+            return None
+
         # Otherwise we throw an error.
         raise DagsterInvariantViolationError(
             f"In top-level graph of {self.job_def.describe_target()}, input {input_name} "


### PR DESCRIPTION
fixes #30581

## How I Tested These Changes

added test

## Changelog

[bugfix] `@graph` now correctly allows omitting inputs when the destinations of an input mapping have a default value
