### PR TITLE
[ui] Ensure asset check evaluations are sorted by timestamp

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -298,8 +298,10 @@ const useHistoricalCheckExecutions = (
 
   const executionsLoading = queryResult.loading && !queryResult.data;
   const executions = React.useMemo(
-    // Remove first element since the latest execution info is already shown above
-    () => queryResult.data?.assetCheckExecutions || [],
+    () =>
+      [...(queryResult.data?.assetCheckExecutions || [])].sort((a, b) => {
+        return b.timestamp - a.timestamp;
+      }),
     [queryResult],
   );
   return {executions, executionsLoading, paginationProps};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -300,7 +300,7 @@ const useHistoricalCheckExecutions = (
   const executions = React.useMemo(
     () =>
       [...(queryResult.data?.assetCheckExecutions || [])].sort((a, b) => {
-        return b.timestamp - a.timestamp;
+        return (b.evaluation?.timestamp || b.timestamp) - (a.evaluation?.timestamp || a.timestamp);
       }),
     [queryResult],
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -299,6 +299,8 @@ const useHistoricalCheckExecutions = (
   const executionsLoading = queryResult.loading && !queryResult.data;
   const executions = React.useMemo(
     () =>
+      // Ideally, we'd sort this as part of the db query, but right now the db query
+      // paginates and sorts on the check ID rather than the timestamp.
       [...(queryResult.data?.assetCheckExecutions || [])].sort((a, b) => {
         return (b.evaluation?.timestamp || b.timestamp) - (a.evaluation?.timestamp || a.timestamp);
       }),


### PR DESCRIPTION
## Summary

Right now, asset check executions are displayed in the order they are returned from the db, which uses ids for pagination/sorting. In rare cases it appears that ids may not match with evaluation timestamps. This PR ensures that evaluations rendered on the page will always show the newest evaluation first.

