### PR TITLE
Better error message for missing defs folder, allow list env without one

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
@@ -324,7 +324,9 @@ def test_scaffold_defs_component_command_with_non_matching_module_name():
             "scaffold", "defs", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result, exit_0=False)
-        assert "Cannot find module `foo_bar" in result.output
+        assert "Ensure folder `src/foo_bar/defs` exists in the project root." in str(
+            result.exception
+        )
 
 
 @pytest.mark.parametrize("in_workspace", [True, False])
@@ -376,7 +378,9 @@ def test_scaffold_defs_component_fails_defs_module_does_not_exist() -> None:
             "scaffold", "defs", "dagster_test.components.AllMetadataEmptyComponent", "qux"
         )
         assert_runner_result(result, exit_0=False)
-        assert "Cannot find module `foo_bar._defs`" in result.output
+        assert "Ensure folder `src/foo_bar/_defs` exists in the project root." in str(
+            result.exception
+        )
 
 
 def test_scaffold_defs_component_succeeds_scaffolded_component_type() -> None:

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/context.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/context.py
@@ -396,10 +396,21 @@ class DgContext:
         )
 
     @cached_property
+    def _defs_path(self) -> Path:
+        defs_module_name = self.defs_module_name
+        return self.get_path_for_local_module(defs_module_name, require_exists=False)
+
+    @cached_property
+    def has_defs_path(self) -> bool:
+        return self._defs_path.exists()
+
+    @property
     def defs_path(self) -> Path:
-        if not self.is_project:
-            raise DgError("`defs_path` is only available in a Dagster project context")
-        return self.get_path_for_local_module(self.defs_module_name)
+        if not self.has_defs_path:
+            raise DgError(
+                f"Defs folder not found. Ensure folder `{self._defs_path.relative_to(self.root_path)}` exists in the project root."
+            )
+        return self._defs_path
 
     def get_component_instance_names(self) -> Iterable[str]:
         return [
@@ -627,7 +638,7 @@ class DgContext:
         elif path.exists() or not require_exists:
             return path
 
-        exit_with_error(f"Cannot find module `{module_name}` in the current project.")
+        raise DgError(f"Cannot find module `{module_name}` in the current project.")
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/env.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/env.py
@@ -19,10 +19,14 @@ def get_project_specified_env_vars(dg_context: DgContext) -> Mapping[str, Sequen
     """Returns a mapping of environment variables to the components that specify
     requiring them.
     """
+    if not dg_context.has_defs_path:
+        return {}
+
     from dagster_shared.yaml_utils import parse_yamls_with_source_position
     from yaml.scanner import ScannerError
 
     env_vars = defaultdict(list)
+
     for component_dir in dg_context.defs_path.rglob("*"):
         component_path = component_dir / "defs.yaml"
 


### PR DESCRIPTION
## Summary

Addresses #30854. Adds a new `has_defs_path` property to the dg context which can be used to alter command behavior if a defs folder is not present. This is used for `dg list env`, which only uses the defs folder to populate the list of components consuming env vars, a secondary piece of functionality.

For cases where a defs folder is expected, `context.defs_path` will now raise a clearer user-facing error about the missing `defs` folder.

```sh
$ dg list env
┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┓
┃ Env Var ┃ Value ┃ Components ┃
┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━┩
│ FOO     │ ✓     │            │
└─────────┴───────┴────────────┘

$ dg check yaml
...
dagster_dg_core.error.DgError: Defs folder not found. Ensure folder `src/no_defs_demo/defs` exists in the project root.
```

## Test Plan

New unit tests for `dg list env` and for error messages with e.g. `dg check yaml`.

## Changelog

[dg] dg list env now works properly in projects without a defs folder.
