### PR TITLE
Split up loading variable in WorkspaceContext

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/BaseFallthroughRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/BaseFallthroughRoot.tsx
@@ -23,7 +23,7 @@ const getVisibleJobs = (r: DagsterRepoOption) =>
 
 const FinalRedirectOrLoadingRoot = () => {
   const workspaceContext = useContext(WorkspaceContext);
-  const {allRepos, loading, locationEntries} = workspaceContext;
+  const {allRepos, loadingNonAssets: loading, locationEntries} = workspaceContext;
 
   if (loading) {
     return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAllAssets.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAllAssets.test.tsx
@@ -84,7 +84,11 @@ describe('useAllAssets', () => {
 
     const {result} = renderHook(() => useAllAssets({batchLimit: 2}), {
       wrapper(props) {
-        return <MockedProvider mocks={[mock, mock2, mock3]}>{props.children}</MockedProvider>;
+        return (
+          <MockedProvider mocks={[mock, mock2, mock3, ...buildWorkspaceMocks([], {delay: 10})]}>
+            <WorkspaceProvider>{props.children}</WorkspaceProvider>
+          </MockedProvider>
+        );
       },
     });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/MergedAutomationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/MergedAutomationRoot.tsx
@@ -67,7 +67,7 @@ export const MergedAutomationRoot = () => {
   const {
     allRepos,
     visibleRepos,
-    loading: workspaceLoading,
+    loadingNonAssets: workspaceLoading,
     data: cachedData,
   } = useContext(WorkspaceContext);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsRoot.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 export const CodeLocationDefinitionsRoot = (props: Props) => {
   const {repoAddress, repository} = props;
-  const {locationEntries, loading} = useContext(WorkspaceContext);
+  const {locationEntries, loadingNonAssets: loading} = useContext(WorkspaceContext);
   const locationEntry = locationEntries.find((entry) => entry.name === repoAddress.location);
 
   if (!locationEntry) {

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDocsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDocsRoot.tsx
@@ -32,7 +32,7 @@ export const CodeLocationDocsRoot = (props: Props) => {
   }>();
 
   const {repoAddress} = props;
-  const {locationEntries, loading} = useContext(WorkspaceContext);
+  const {locationEntries, loadingNonAssets: loading} = useContext(WorkspaceContext);
   const locationEntry = locationEntries.find((entry) => entry.name === repoAddress.location);
 
   if (!locationEntry) {

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationOverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationOverviewRoot.tsx
@@ -177,7 +177,11 @@ export const CodeLocationOverviewRoot = (props: Props) => {
 };
 
 const QueryfulCodeLocationOverviewRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
-  const {locationEntries, locationStatuses, loading} = useContext(WorkspaceContext);
+  const {
+    locationEntries,
+    locationStatuses,
+    loadingNonAssets: loading,
+  } = useContext(WorkspaceContext);
   const locationEntry = locationEntries.find((entry) => entry.name === repoAddress.location);
   const locationStatus = locationStatuses[repoAddress.location];
 

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationPageHeader.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationPageHeader.oss.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export const CodeLocationPageHeader = ({repoAddress}: Props) => {
-  const {locationEntries, loading} = useContext(WorkspaceContext);
+  const {locationEntries, loadingNonAssets: loading} = useContext(WorkspaceContext);
   const locationEntry = locationEntries.find((entry) => entry.name === repoAddress.location);
   return (
     <PageHeader

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/useCodeLocationPageFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/useCodeLocationPageFilters.tsx
@@ -13,7 +13,7 @@ import {WorkspaceContext} from '../workspace/WorkspaceContext/WorkspaceContext';
 const STATUS_VALUES: Set<string> = new Set(Object.values(CodeLocationRowStatusType));
 
 export const useCodeLocationPageFilters = () => {
-  const {loading, locationEntries} = useContext(WorkspaceContext);
+  const {loadingNonAssets: loading, locationEntries} = useContext(WorkspaceContext);
   const codeLocationStatusData = useRecoilValue(codeLocationStatusAtom);
   const [searchValue, setSearchValue] = useState('');
 

--- a/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
@@ -30,7 +30,12 @@ import {RepoAddress} from '../workspace/types';
 const FILTER_FIELDS = ['jobs', 'tags', 'codeLocations'] as const;
 
 export const JobsPageContent = () => {
-  const {allRepos, visibleRepos, loading, data: cachedData} = useContext(WorkspaceContext);
+  const {
+    allRepos,
+    visibleRepos,
+    loadingNonAssets: loading,
+    data: cachedData,
+  } = useContext(WorkspaceContext);
   const repoCount = allRepos.length;
   // Batch up the data and bucket by repo.
   const repoBuckets = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNavRepositorySection.tsx
@@ -78,9 +78,8 @@ const EmptyState = styled.div`
 `;
 
 export const LeftNavRepositorySection = memo(() => {
-  const {allRepos, loadingNonAssets, loadingAssets, visibleRepos, toggleVisible} =
-    useContext(WorkspaceContext);
-  if (loadingNonAssets || loadingAssets) {
+  const {allRepos, loadingNonAssets, visibleRepos, toggleVisible} = useContext(WorkspaceContext);
+  if (loadingNonAssets) {
     return <div style={{flex: 1}} />;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNavRepositorySection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNavRepositorySection.tsx
@@ -78,8 +78,9 @@ const EmptyState = styled.div`
 `;
 
 export const LeftNavRepositorySection = memo(() => {
-  const {allRepos, loading, visibleRepos, toggleVisible} = useContext(WorkspaceContext);
-  if (loading && !visibleRepos) {
+  const {allRepos, loadingNonAssets, loadingAssets, visibleRepos, toggleVisible} =
+    useContext(WorkspaceContext);
+  if (loadingNonAssets || loadingAssets) {
     return <div style={{flex: 1}} />;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/RepoOptionVisibility.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/RepoOptionVisibility.test.tsx
@@ -20,7 +20,7 @@ describe('Repo option visibility', () => {
   });
 
   const Test = () => {
-    const {visibleRepos, loading} = useContext(WorkspaceContext);
+    const {visibleRepos, loadingNonAssets: loading} = useContext(WorkspaceContext);
     return (
       <div data-testid={testId('target')}>
         {loading

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
@@ -26,7 +26,7 @@ export const codeLocationStatusAtom = atom<CodeLocationStatusQuery | undefined>(
 });
 
 export const useCodeLocationsStatus = (): StatusAndMessage | null => {
-  const {locationEntries, loading, data} = useContext(WorkspaceContext);
+  const {locationEntries, loadingNonAssets: loading, data} = useContext(WorkspaceContext);
   const [previousEntriesById, setPreviousEntriesById] = useState<EntriesById | null>(null);
 
   const history = useHistory();

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesRoot.tsx
@@ -32,7 +32,7 @@ export const OverviewResourcesRoot = () => {
   const {
     allRepos,
     visibleRepos,
-    loading: workspaceLoading,
+    loadingNonAssets: workspaceLoading,
     data: cachedData,
   } = useContext(WorkspaceContext);
   const [searchValue, setSearchValue] = useQueryPersistedState<string>({

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOrJobDisambiguationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOrJobDisambiguationRoot.tsx
@@ -17,7 +17,7 @@ export const PipelineOrJobDisambiguationRoot = (props: Props) => {
   const location = useLocation();
   const {pipelinePath} = useParams<{pipelinePath: string}>();
 
-  const {loading} = useContext(WorkspaceContext);
+  const {loadingNonAssets: loading} = useContext(WorkspaceContext);
   const {loading: permissionsLoading} = useContext(PermissionsContext);
   const repo = useRepository(repoAddress);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/LocationBaseDataFetcher.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/LocationBaseDataFetcher.ts
@@ -49,11 +49,11 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
               const nextData = {...this.data};
               delete nextData[location];
               this.data = nextData;
-              this.notifySubscribers();
               clearCachedData({
                 key: `${this.key}/${location}`,
               });
             }
+            this.notifySubscribers();
           }
           await Promise.all(promises);
           this.notifySubscribers();

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/LocationBaseDataFetcher.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/LocationBaseDataFetcher.ts
@@ -124,6 +124,8 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
         nextData[location] = data;
         this.data = nextData;
         this.notifySubscribers();
+      } else {
+        console.error('No data or error returned from fetchLocationData');
       }
     });
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/LocationBaseDataFetcher.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/LocationBaseDataFetcher.ts
@@ -53,9 +53,9 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
                 key: `${this.key}/${location}`,
               });
             }
-            this.notifySubscribers();
           }
           await Promise.all(promises);
+          this.notifySubscribers();
         });
       },
     );
@@ -123,8 +123,6 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
         nextData[location] = data;
         this.data = nextData;
         this.notifySubscribers();
-      } else {
-        console.error('No data or error returned from fetchLocationData');
       }
     });
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/LocationBaseDataFetcher.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/LocationBaseDataFetcher.ts
@@ -49,6 +49,7 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
               const nextData = {...this.data};
               delete nextData[location];
               this.data = nextData;
+              this.notifySubscribers();
               clearCachedData({
                 key: `${this.key}/${location}`,
               });

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceContext.tsx
@@ -152,7 +152,6 @@ const WorkspaceProviderImpl = ({children}: {children: React.ReactNode}) => {
       getData,
       setCodeLocationStatusAtom,
       setData: ({locationStatuses, locationEntries, assetEntries}) => {
-        console.log('setting data', {locationEntries, assetEntries, locationStatuses});
         if (locationEntries) {
           setLocationWorkspaceData(locationEntries);
         }

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceManager.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceManager.ts
@@ -10,11 +10,11 @@ import {
 } from './types/WorkspaceQueries.types';
 import {useGetData} from '../../search/useIndexedDBCachedQuery';
 
-type Data = {
+type Data = Partial<{
   locationStatuses: Record<string, LocationStatusEntryFragment>;
   locationEntries: Record<string, LocationWorkspaceQuery>;
   assetEntries: Record<string, LocationWorkspaceAssetsQuery>;
-};
+}>;
 export class WorkspaceManager {
   private statusPoller: WorkspaceStatusPoller;
   private readonly client: ApolloClient<any>;
@@ -65,14 +65,13 @@ export class WorkspaceManager {
 
     Object.entries(this.dataFetchers).forEach(([key, fetcher]) => {
       fetcher.subscribe((data) => {
-        this.data[key as keyof Data] = data as any;
-        this.setData(this.data);
+        this.setData({[key]: data});
       });
     });
 
     this.statusPoller.subscribe(async ({locationStatuses}) => {
       this.data.locationStatuses = locationStatuses;
-      this.setData(this.data);
+      this.setData({locationStatuses});
     });
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceStatusPoller.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceStatusPoller.ts
@@ -113,7 +113,6 @@ export class WorkspaceStatusPoller {
     this.statuses = nextStatuses;
     this.lastChanged = {added, updated, removed};
     if (added.length > 0 || updated.length > 0 || removed.length > 0 || !this.hasNotifiedOnce) {
-      console.log('notifying subscribers', {added, updated, removed});
       this.hasNotifiedOnce = true;
       await this.notifySubscribers();
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceStatusPoller.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceStatusPoller.ts
@@ -17,7 +17,6 @@ export const CODE_LOCATION_STATUS_QUERY_KEY = '/CodeLocationStatusQuery';
 
 export class WorkspaceStatusPoller {
   private statuses: Record<string, LocationStatusEntryFragment> = {};
-  private readonly localCacheIdPrefix: string | undefined;
   private readonly getData: ReturnType<typeof useGetData>;
   private lastChanged: {added: string[]; updated: string[]; removed: string[]} = EMPTY_CHANGES;
   private hasNotifiedOnce = false;
@@ -38,7 +37,6 @@ export class WorkspaceStatusPoller {
     setCodeLocationStatusAtom: (status: CodeLocationStatusQuery) => void;
   }) {
     this.key = `${args.localCacheIdPrefix}${CODE_LOCATION_STATUS_QUERY_KEY}`;
-    this.localCacheIdPrefix = args.localCacheIdPrefix;
     this.getData = args.getData;
     this.setCodeLocationStatusAtom = args.setCodeLocationStatusAtom;
     this.subscribers = new Set();
@@ -115,6 +113,7 @@ export class WorkspaceStatusPoller {
     this.statuses = nextStatuses;
     this.lastChanged = {added, updated, removed};
     if (added.length > 0 || updated.length > 0 || removed.length > 0 || !this.hasNotifiedOnce) {
+      console.log('notifying subscribers', {added, updated, removed});
       this.hasNotifiedOnce = true;
       await this.notifySubscribers();
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceContext.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceContext.test.tsx
@@ -191,7 +191,8 @@ describe('WorkspaceContext', () => {
 
     expect(result.current.allRepos).toEqual([]);
     expect(result.current.data).toEqual({});
-    expect(result.current.loading).toEqual(true);
+    expect(result.current.loadingNonAssets).toEqual(true);
+    expect(result.current.loadingAssets).toEqual(true);
 
     await act(async () => {
       await jest.runOnlyPendingTimersAsync();
@@ -209,7 +210,8 @@ describe('WorkspaceContext', () => {
 
     expect(result.current.allRepos).toEqual([]);
     expect(result.current.data).toEqual({});
-    expect(result.current.loading).toEqual(true);
+    expect(result.current.loadingNonAssets).toEqual(true);
+    expect(result.current.loadingAssets).toEqual(true);
 
     // Runs the individual location queries
     await act(async () => {
@@ -226,7 +228,8 @@ describe('WorkspaceContext', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.loading).toEqual(false);
+      expect(result.current.loadingNonAssets).toEqual(false);
+      expect(result.current.loadingAssets).toEqual(false);
     });
     expect(result.current.allRepos).toEqual([
       ...repoLocationToRepos(repositoryLocation1),
@@ -293,7 +296,8 @@ describe('WorkspaceContext', () => {
     await waitFor(async () => {
       drainMockLoadFromServerQueue();
       drainMockHandleStatusUpdateQueue();
-      expect(result.current.loading).toEqual(false);
+      expect(result.current.loadingNonAssets).toEqual(false);
+      expect(result.current.loadingAssets).toEqual(false);
     });
     // We queries for code location statuses but saw we were up to date
     // so we didn't call any the location queries
@@ -472,7 +476,8 @@ describe('WorkspaceContext', () => {
 
     await waitFor(async () => {
       drainMockHandleStatusUpdateQueue();
-      expect(result.current.loading).toEqual(false);
+      expect(result.current.loadingNonAssets).toEqual(false);
+      expect(result.current.loadingAssets).toEqual(false);
     });
 
     // We return the cached data
@@ -544,7 +549,10 @@ describe('WorkspaceContext', () => {
 
     const {result} = renderWithMocks(mocks);
 
-    expect(result.current.loading).toEqual(true);
+    await waitFor(() => {
+      expect(result.current.loadingNonAssets).toEqual(true);
+      expect(result.current.loadingAssets).toEqual(true);
+    });
 
     // Run the code location status query
     await act(async () => {
@@ -564,7 +572,8 @@ describe('WorkspaceContext', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.loading).toEqual(false);
+      expect(result.current.loadingNonAssets).toEqual(false);
+      expect(result.current.loadingAssets).toEqual(false);
     });
 
     expect(result.current.data).toEqual({
@@ -585,12 +594,24 @@ describe('WorkspaceContext', () => {
     caches.codeLocationStatusQuery.has.mockResolvedValue(false);
 
     const mocks = buildWorkspaceMocks([], {delay: 10});
+    mocks[0]!.maxUsageCount = 9999;
 
     const {result} = renderWithMocks(mocks);
-    expect(result.current.loading).toEqual(true);
 
     await waitFor(() => {
-      expect(result.current.loading).toEqual(false);
+      expect(result.current.loadingNonAssets).toEqual(true);
+      expect(result.current.loadingAssets).toEqual(true);
+    });
+
+    await act(async () => {
+      await jest.runOnlyPendingTimersAsync();
+    });
+
+    await waitFor(() => {
+      drainMockHandleStatusUpdateQueue();
+      drainMockLoadFromServerQueue();
+      expect(result.current.loadingNonAssets).toEqual(false);
+      expect(result.current.loadingAssets).toEqual(false);
     });
 
     expect(result.current.allRepos).toEqual([]);
@@ -613,12 +634,16 @@ describe('WorkspaceContext', () => {
 
     expect(result.current.allRepos).toEqual([]);
     expect(result.current.data).toEqual({});
-    expect(result.current.loading).toEqual(true);
+    await waitFor(() => {
+      expect(result.current.loadingNonAssets).toEqual(true);
+      expect(result.current.loadingAssets).toEqual(true);
+    });
 
     await waitFor(() => {
       drainMockHandleStatusUpdateQueue();
       drainMockLoadFromServerQueue();
-      expect(result.current.loading).toEqual(false);
+      expect(result.current.loadingNonAssets).toEqual(false);
+      expect(result.current.loadingAssets).toEqual(false);
     });
 
     await waitFor(() => {
@@ -655,7 +680,8 @@ describe('WorkspaceContext', () => {
     await waitFor(() => {
       drainMockHandleStatusUpdateQueue();
       drainMockLoadFromServerQueue();
-      expect(result.current.loading).toEqual(false);
+      expect(result.current.loadingNonAssets).toEqual(false);
+      expect(result.current.loadingAssets).toEqual(false);
     });
 
     expect(mockCbs[0]).toHaveBeenCalledTimes(1);
@@ -710,7 +736,8 @@ describe('WorkspaceContext', () => {
     await waitFor(() => {
       drainMockHandleStatusUpdateQueue();
       drainMockLoadFromServerQueue();
-      expect(result.current.loading).toEqual(false);
+      expect(result.current.loadingNonAssets).toEqual(false);
+      expect(result.current.loadingAssets).toEqual(false);
     });
 
     await waitFor(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceManager.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceManager.test.ts
@@ -105,8 +105,6 @@ describe('WorkspaceManager', () => {
     expect(mockSetData).toHaveBeenCalledWith(
       expect.objectContaining({
         locationEntries: {foo: 'bar'},
-        locationStatuses: {},
-        assetEntries: {},
       }),
     );
 
@@ -114,8 +112,6 @@ describe('WorkspaceManager', () => {
     assetsFetcherCallback({foo: 'bar'});
     expect(mockSetData).toHaveBeenCalledWith(
       expect.objectContaining({
-        locationEntries: {foo: 'bar'},
-        locationStatuses: {},
         assetEntries: {foo: 'bar'},
       }),
     );
@@ -125,8 +121,6 @@ describe('WorkspaceManager', () => {
     expect(mockSetData).toHaveBeenCalledWith(
       expect.objectContaining({
         locationStatuses: {loc1: {name: 'loc1', versionKey: 'v1'}},
-        locationEntries: {foo: 'bar'},
-        assetEntries: {foo: 'bar'},
       }),
     );
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/util.ts
@@ -111,7 +111,7 @@ export const getRepositoryOptionHash = (a: DagsterRepoOption) =>
   `${a.repository.name}:${a.repositoryLocation.name}`;
 
 export const useRepositoryOptions = () => {
-  const {allRepos: options, loading} = React.useContext(WorkspaceContext);
+  const {allRepos: options, loadingNonAssets: loading} = React.useContext(WorkspaceContext);
   return {options, loading};
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceRoot.tsx
@@ -22,7 +22,7 @@ const RepoRouteContainer = () => {
   const workspaceState = useContext(WorkspaceContext);
   const addressForPath = repoAddressFromPath(repoPath);
 
-  const {loading} = workspaceState;
+  const {loadingNonAssets: loading} = workspaceState;
 
   // A RepoAddress could not be created for this path, which means it's invalid.
   if (!addressForPath) {


### PR DESCRIPTION
## Summary & Motivation

After adding assets to the WorkspaceContext we changed the loading variable to include the loading of assets. This is making non-asset related pages wait for assets and in the case of kraftheinz (over bad internet) their page load time on a fresh load (no indexeddb cache) is like 5 minutes. I added `loadingNonAssets` which is equivalent to the previous loading state and `loadingAssets` so that asset pages only depend on assets loading.

## How I Tested These Changes

jest. local app proxy
