### PR TITLE
Allow bulk favoriting assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -105,15 +105,6 @@ export const AssetCatalogTableV2 = React.memo(() => {
     return Object.values(liveDataByNode).length !== filtered.length;
   }, [liveDataByNode, filtered]);
 
-  console.log({
-    healthDataLoading,
-    loading,
-    filtered,
-    liveDataByNode,
-    assetsLoading,
-    favoritesLoading,
-  });
-
   const groupedByStatus = useMemo(() => {
     const byStatus: Record<AssetHealthStatusString, (typeof liveDataByNode)[string][]> = {
       Degraded: [],

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -19,6 +19,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
 import {CreateCatalogViewButton} from 'shared/assets/CreateCatalogViewButton.oss';
+import {useCatalogExtraDropdownOptions} from 'shared/assets/catalog/useCatalogExtraDropdownOptions.oss';
 import {AssetCatalogInsights} from 'shared/assets/insights/AssetCatalogInsights.oss';
 import {useFavoriteAssets} from 'shared/assets/useFavoriteAssets.oss';
 
@@ -103,6 +104,15 @@ export const AssetCatalogTableV2 = React.memo(() => {
   const healthDataLoading = useMemo(() => {
     return Object.values(liveDataByNode).length !== filtered.length;
   }, [liveDataByNode, filtered]);
+
+  console.log({
+    healthDataLoading,
+    loading,
+    filtered,
+    liveDataByNode,
+    assetsLoading,
+    favoritesLoading,
+  });
 
   const groupedByStatus = useMemo(() => {
     const byStatus: Record<AssetHealthStatusString, (typeof liveDataByNode)[string][]> = {
@@ -354,6 +364,8 @@ const Table = React.memo(
       };
     }, [assets, checkedDisplayKeys]);
 
+    const extraDropdownOptions = useCatalogExtraDropdownOptions({scope});
+
     return (
       <>
         <IndeterminateLoadingBar $loading={loading || healthDataLoading} />
@@ -424,7 +436,10 @@ const Table = React.memo(
               {loading ? (
                 <Skeleton $width={300} $height={21} />
               ) : (
-                <LaunchAssetExecutionButton scope={scope} />
+                <LaunchAssetExecutionButton
+                  scope={scope}
+                  additionalDropdownOptions={extraDropdownOptions}
+                />
               )}
             </Box>
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/useCatalogExtraDropdownOptions.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/useCatalogExtraDropdownOptions.oss.tsx
@@ -1,0 +1,3 @@
+export const useCatalogExtraDropdownOptions = (_: {scope: any}) => {
+  return [];
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useSelectionReducer.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useSelectionReducer.ts
@@ -1,4 +1,4 @@
-import {useReducer} from 'react';
+import {useLayoutEffect, useReducer} from 'react';
 
 type State = {
   checkedIds: Set<string>;
@@ -11,11 +11,19 @@ type Action =
       type: 'toggle-slice';
       payload: {checked: boolean; id: string; allIds: string[]};
     }
-  | {type: 'toggle-all'; payload: {checked: boolean; allIds: string[]}};
+  | {type: 'toggle-all'; payload: {checked: boolean; allIds: string[]}}
+  | {type: 'set-all-ids'; payload: {allIds: string[]}};
 
 const reducer = (state: State, action: Action): State => {
-  const copy = new Set(Array.from(state.checkedIds));
+  const copy = new Set(state.checkedIds);
   switch (action.type) {
+    case 'set-all-ids': {
+      const allIdsSet = new Set(action.payload.allIds);
+      return {
+        checkedIds: new Set(Array.from(state.checkedIds).filter((id) => allIdsSet.has(id))),
+        lastCheckedId: state.lastCheckedId,
+      };
+    }
     case 'toggle-one': {
       const {checked, id} = action.payload;
       if (checked) {
@@ -68,6 +76,10 @@ const initialState: State = {
 
 export function useSelectionReducer(allIds: string[]) {
   const [state, dispatch] = useReducer(reducer, initialState);
+
+  useLayoutEffect(() => {
+    dispatch({type: 'set-all-ids', payload: {allIds}});
+  }, [allIds]);
 
   const onToggleFactory = (id: string) => (values: {checked: boolean; shiftKey: boolean}) => {
     const {checked, shiftKey} = values;


### PR DESCRIPTION
## Summary & Motivation

Allow bulk favoriting assets in observe

<img width="1482" alt="Screenshot 2025-07-02 at 9 41 37 AM" src="https://github.com/user-attachments/assets/7e918611-e1d8-4f4b-8de7-95b28a878cef" />

## How I Tested These Changes

https://dagsterlabs.slack.com/archives/C03CCE471E0/p1751461383903719?thread_ts=1751313414.274309&cid=C03CCE471E0

## Changelog
[ui][observe] You can now bulk add/remove assets to/from your favorites.