### PR TITLE
Increase agent heartbeat timeout on serverless ci deploy calls

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/workspace/__init__.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/workspace/__init__.py
@@ -125,7 +125,7 @@ def wait_for_load(
     client,
     locations,
     location_load_timeout=DEFAULT_LOCATION_LOAD_TIMEOUT,
-    agent_heartbeat_timeout=DEFAULT_LOCATION_LOAD_TIMEOUT,
+    agent_heartbeat_timeout: Optional[int] = DEFAULT_LOCATION_LOAD_TIMEOUT,
     url: Optional[str] = None,
 ):
     start_time = time.time()
@@ -140,7 +140,7 @@ def wait_for_load(
     iterations = 0
     while True:
         if not has_agent_heartbeat:
-            if time.time() - start_time > agent_heartbeat_timeout:
+            if agent_heartbeat_timeout and time.time() - start_time > agent_heartbeat_timeout:
                 raise ui.error(
                     "No Dagster Cloud agent is actively heartbeating. Make sure that you have a"
                     " Dagster Cloud agent running."

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/gql.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/gql.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager, suppress
+from enum import Enum
 from typing import Any, Optional, cast
 
 from dagster_cloud_cli.core.graphql_client import (
@@ -119,8 +120,28 @@ query CliAgentStatus {
 """
 
 
+class DagsterPlusDeploymentAgentType(Enum):
+    SERVERLESS = "SERVERLESS"
+    HYBRID = "HYBRID"
+
+
 def fetch_agent_status(client: DagsterCloudGraphQLClient) -> list[Any]:
     return client.execute(AGENT_STATUS_QUERY)["data"]["agents"]
+
+
+AGENT_TYPE_QUERY = """
+query DeploymentInfoQuery {
+	currentDeployment {
+        agentType
+    }
+}
+"""
+
+
+def fetch_agent_type(client: DagsterCloudGraphQLClient) -> DagsterPlusDeploymentAgentType:
+    return DagsterPlusDeploymentAgentType(
+        client.execute(AGENT_TYPE_QUERY)["data"]["currentDeployment"]["agentType"]
+    )
 
 
 WORKSPACE_ENTRIES_QUERY = """

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy_session.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy_session.py
@@ -270,5 +270,5 @@ def finish_deploy_session(dg_context: DgContext, statedir: str, location_names: 
         statedir=str(statedir),
         location_name=list(location_names),
         location_load_timeout=get_location_load_timeout(),
-        agent_heartbeat_timeout=get_agent_heartbeat_timeout(),
+        agent_heartbeat_timeout=get_agent_heartbeat_timeout(default_timeout=None),
     )


### PR DESCRIPTION
This fixes the remaining blocker to moving serverless over to use the new github action templates by default, which was the initial deploy failing while it was waiting for the agent to initially heartbeat.

The old github action worked around this by detecting the first github action run and bumping up the timeout for that case, which is fairly hacky. Instead lets just elevate it a bit for all serverless deploys.

This check was intended to quickly error out for users who forgot to set up a hybrid agent before running CI/CD or misconfigured their agent, which should not be as common of an issue for serverless deployments since the agent is automatically spun up for you.