### PR TITLE
[dagster-databricks] Update dagster-sdk version pin

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -94,12 +94,17 @@ class WorkspaceClientFactory:
                 host=host,
                 client_id=oauth_client_id,
                 client_secret=oauth_client_secret,
-                credentials_provider=oauth_service_principal,
-                **product_info,
+                credentials_strategy=oauth_service_principal,
+                **product_info,  # pyright: ignore[reportArgumentType]
             )
         elif auth_type == AuthTypeEnum.PAT:
             host = self._resolve_host(host)
-            c = Config(host=host, token=token, credentials_provider=pat_auth, **product_info)
+            c = Config(
+                host=host,
+                token=token,
+                credentials_strategy=pat_auth,
+                **product_info,  # pyright: ignore[reportArgumentType]
+            )
         elif auth_type == AuthTypeEnum.AZURE_CLIENT_SECRET:
             host = self._resolve_host(host)
             c = Config(
@@ -107,8 +112,8 @@ class WorkspaceClientFactory:
                 azure_client_id=azure_client_id,
                 azure_client_secret=azure_client_secret,
                 azure_tenant_id=azure_tenant_id,
-                credentials_provider=azure_service_principal,
-                **product_info,
+                credentials_strategy=azure_service_principal,
+                **product_info,  # pyright: ignore[reportArgumentType]
             )
         elif auth_type == AuthTypeEnum.DEFAULT:
             # Can be used to automatically read credentials from environment or ~/.databrickscfg file. This is common
@@ -116,11 +121,19 @@ class WorkspaceClientFactory:
             if host is not None:
                 # This allows for explicit override of the host, while letting other credentials be read from the
                 # environment or ~/.databrickscfg file
-                c = Config(host=host, credentials_provider=DefaultCredentials(), **product_info)  # type: ignore  # (bad stubs)
+                c = Config(
+                    host=host,
+                    credentials_strategy=DefaultCredentials(),  # pyright: ignore[reportArgumentType]
+                    **product_info,  # pyright: ignore[reportArgumentType]
+                )
             else:
                 # The initialization machinery in the Config object will look for the host and other auth info in the
                 # environment, as long as no values are provided for those attributes (including None)
-                c = Config(credentials_provider=DefaultCredentials(), **product_info)  # type: ignore  # (bad stubs)
+                c = Config(
+                    host=host,
+                    credentials_strategy=DefaultCredentials(),  # pyright: ignore[reportArgumentType]
+                    **product_info,  # pyright: ignore[reportArgumentType]
+                )
         else:
             raise ValueError(f"Unexpected auth type {auth_type}")
         self.config = c

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -123,7 +123,7 @@ class WorkspaceClientFactory:
                 # environment or ~/.databrickscfg file
                 c = Config(
                     host=host,
-                    credentials_strategy=DefaultCredentials(),  # pyright: ignore[reportArgumentType]
+                    credentials_strategy=DefaultCredentials(),
                     **product_info,  # pyright: ignore[reportArgumentType]
                 )
             else:
@@ -131,7 +131,7 @@ class WorkspaceClientFactory:
                 # environment, as long as no values are provided for those attributes (including None)
                 c = Config(
                     host=host,
-                    credentials_strategy=DefaultCredentials(),  # pyright: ignore[reportArgumentType]
+                    credentials_strategy=DefaultCredentials(),
                     **product_info,  # pyright: ignore[reportArgumentType]
                 )
         else:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -66,7 +66,7 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
     )
 
     databricks_run_config["install_default_libraries"] = False
-    expected_task.libraries = None
+    expected_task.libraries = []
 
     runner.submit_run(databricks_run_config, task)
     mock_submit_run.assert_called_with(
@@ -135,6 +135,7 @@ def test_databricks_submit_job_new_cluster(mock_submit_run, databricks_run_confi
         spark_version=NEW_CLUSTER["spark_version"],
         num_workers=NEW_CLUSTER["size"]["num_workers"],
         custom_tags={"__dagster_version": dagster.__version__},
+        init_scripts=[],
     )
     expected_task.libraries = [
         compute.Library(pypi=compute.PythonPyPiLibrary(package=f"dagster=={dagster.__version__}")),

--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -35,7 +35,7 @@ setup(
         f"dagster{pin}",
         f"dagster-pipes{pin}",
         f"dagster-pyspark{pin}",
-        "databricks-sdk<=0.17.0",  # dbt-databricks is pinned to this version
+        "databricks-sdk>=0.41,<0.48.0",  # dbt-databricks is pinned to this version
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
Bumps the `databricks-sdk` version from `v0.17.0` to `v0.47.0`, to go alongside the pin in `dbt-databricks`, and bring the SDK to something more modern. Mimics attempts made in https://github.com/dagster-io/dagster/pull/30920 and https://github.com/dagster-io/dagster/pull/29132. 

Some changes were made when instantiating `Config` objects - `credentials_provider` has been deprecated in favour of `credentials_strategy`. This appears to be a drop-in replacement, but some pyright warnings had to be suppressed.

Some changes to the mocks and types were required to get the tests to pass locally, as pagination in `JobsAPI.get_run` introduced in `v0.38` was causing tests to indefinitely hang via a stuck Python thread. The step launcher has been further tested on my own Databricks instance and performs as expected.
