### PR TITLE
remove AssetKey __iter__ exception

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_key.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_key.py
@@ -8,7 +8,6 @@ from dagster_pipes import to_assey_key_path
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, public
-from dagster._core.errors import DagsterInvariantViolationError
 from dagster._record import IHaveNew, record_custom
 from dagster._serdes import whitelist_for_serdes
 
@@ -174,21 +173,6 @@ class AssetKey(IHaveNew):
     def with_prefix(self, prefix: "CoercibleToAssetKeyPrefix") -> "AssetKey":
         prefix = key_prefix_from_coercible(prefix)
         return AssetKey(list(prefix) + list(self.path))
-
-    if not TYPE_CHECKING:
-        # hide these from type checker so it doesn't believe AssetKey is iterable/indexable
-        def __iter__(self):
-            raise DagsterInvariantViolationError(
-                "You have attempted to iterate a single AssetKey object. "
-                "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug."
-            )
-
-        def __getitem__(self, _):
-            raise DagsterInvariantViolationError(
-                "You have attempted to index directly in to the AssetKey object. "
-                "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug. "
-                "Use asset_key.path instead to access the list of key components."
-            )
 
 
 CoercibleToAssetKey = Union[AssetKey, str, Sequence[str]]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2432,9 +2432,8 @@ def test_multiple_keys_per_output_name():
 def test_iterate_over_single_key() -> None:
     key = AssetKey("ouch")
     with pytest.raises(
-        DagsterInvariantViolationError,
-        match="You have attempted to iterate a single AssetKey object. "
-        "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug.",
+        Exception,
+        match="Iteration is not allowed",
     ):
         [_ for _ in key]  # type: ignore # good job type checker
 
@@ -2442,10 +2441,8 @@ def test_iterate_over_single_key() -> None:
 def test_index_in_to_key() -> None:
     key = AssetKey("ouch")
     with pytest.raises(
-        DagsterInvariantViolationError,
-        match="You have attempted to index directly in to the AssetKey object. "
-        "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug. "
-        "Use asset_key.path instead to access the list of key components.",
+        Exception,
+        match="Index access is not allowed",
     ):
         key[0][0]  # type: ignore # good job type checker
 


### PR DESCRIPTION
well past 1.9, clean this up as it prevents viewing keys in the debugger

## How I Tested These Changes

updated test