### PR TITLE
Asset selection perf improvements

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -901,18 +901,11 @@ class DownstreamAssetSelection(ChainedAssetSelection):
     ) -> AbstractSet[AssetKey]:
         selection = self.child.resolve_inner(asset_graph, allow_missing=allow_missing)
         return operator.sub(
-            reduce(
-                operator.or_,
-                [
-                    {asset_key}
-                    | fetch_connected(
-                        item=asset_key,
-                        graph=asset_graph.asset_dep_graph,
-                        direction="downstream",
-                        depth=self.depth,
-                    )
-                    for asset_key in selection
-                ],
+            (
+                selection
+                | fetch_connected(
+                    selection, asset_graph.asset_dep_graph, direction="downstream", depth=self.depth
+                )
             ),
             selection if not self.include_self else set(),
         )
@@ -1331,19 +1324,11 @@ def _fetch_all_upstream(
     include_self: bool = True,
 ) -> AbstractSet[AssetKey]:
     return operator.sub(
-        reduce(
-            operator.or_,
-            [
-                {asset_key}
-                | fetch_connected(
-                    item=asset_key,
-                    graph=asset_graph.asset_dep_graph,
-                    direction="upstream",
-                    depth=depth,
-                )
-                for asset_key in selection
-            ],
-            set(),
+        (
+            selection
+            | fetch_connected(
+                selection, asset_graph.asset_dep_graph, direction="upstream", depth=depth
+            )
         ),
         selection if not include_self else set(),
     )

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -157,10 +157,10 @@ class Traverser(Generic[T_Hashable]):
 
     # `depth=None` is infinite depth
     def _fetch_items(
-        self, item_name: T_Hashable, depth: int, direction: Direction
+        self, item_names: Iterable[T_Hashable], depth: int, direction: Direction
     ) -> AbstractSet[T_Hashable]:
         dep_graph = self.graph[direction]
-        stack = deque([item_name])
+        stack = deque(item_names)
         result: set[T_Hashable] = set()
         curr_depth = 0
         while stack:
@@ -179,17 +179,25 @@ class Traverser(Generic[T_Hashable]):
             curr_depth += 1
         return result
 
+    def fetch_upstream_multiple(
+        self, item_names: Iterable[T_Hashable], depth: int
+    ) -> AbstractSet[T_Hashable]:
+        return self._fetch_items(item_names, depth, "upstream")
+
+    def fetch_downstream_multiple(
+        self, item_names: Iterable[T_Hashable], depth: int
+    ) -> AbstractSet[T_Hashable]:
+        return self._fetch_items(item_names, depth, "downstream")
+
     def fetch_upstream(self, item_name: T_Hashable, depth: int) -> AbstractSet[T_Hashable]:
-        # return a set of ancestors of the given item, up to the given depth
-        return self._fetch_items(item_name, depth, "upstream")
+        return self.fetch_upstream_multiple({item_name}, depth)
 
     def fetch_downstream(self, item_name: T_Hashable, depth: int) -> AbstractSet[T_Hashable]:
-        # return a set of descendants of the given item, down to the given depth
-        return self._fetch_items(item_name, depth, "downstream")
+        return self.fetch_downstream_multiple({item_name}, depth)
 
 
 def fetch_connected(
-    item: T_Hashable,
+    items: Iterable[T_Hashable],
     graph: DependencyGraph[T_Hashable],
     *,
     direction: Direction,
@@ -198,9 +206,9 @@ def fetch_connected(
     if depth is None:
         depth = MAX_NUM
     if direction == "downstream":
-        return Traverser(graph).fetch_downstream(item, depth)
+        return Traverser(graph).fetch_downstream_multiple(items, depth)
     elif direction == "upstream":
-        return Traverser(graph).fetch_upstream(item, depth)
+        return Traverser(graph).fetch_upstream_multiple(items, depth)
 
 
 def fetch_sinks(
@@ -247,9 +255,7 @@ def fetch_connected_assets_definitions(
 ) -> frozenset["AssetsDefinition"]:
     depth = MAX_NUM if depth is None else depth
     names = [asset_key.to_user_string() for asset_key in asset.keys]
-    connected_names = [
-        n for name in names for n in fetch_connected(name, graph, direction=direction, depth=depth)
-    ]
+    connected_names = [n for n in fetch_connected(names, graph, direction=direction, depth=depth)]
     return frozenset(name_to_definition_map[n] for n in connected_names)
 
 

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -255,7 +255,7 @@ def fetch_connected_assets_definitions(
 ) -> frozenset["AssetsDefinition"]:
     depth = MAX_NUM if depth is None else depth
     names = [asset_key.to_user_string() for asset_key in asset.keys]
-    connected_names = [n for n in fetch_connected(names, graph, direction=direction, depth=depth)]
+    connected_names = list(fetch_connected(names, graph, direction=direction, depth=depth))
     return frozenset(name_to_definition_map[n] for n in connected_names)
 
 


### PR DESCRIPTION
## Summary

Small tweak to asset selection evaluation which might marginally improve performance. When finding upstream or downstream assets for certain selections, we iterate over every asset in the selection and find its upstreams. This means we conduct `n` BFSes for `n` assets, duplicating work if they share parents/children. This change simply merges the BFSes for those `n` assets into a single search, which should marginally improve performance for large interconnected graphs.

## Test Plan

Existing tests.

## Changelog

Deduplicated asset graph traversals when evaluating upstream or downstream asset selections for a large set of assets, substantially speeding up some selection evaluations.