### PR TITLE
[ui] Update the asset event filters to fix type filtering

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEvents.tsx
@@ -1,5 +1,4 @@
 import {Box, ErrorBoundary, NonIdealState, Spinner} from '@dagster-io/ui-components';
-import isEqual from 'lodash/isEqual';
 import * as React from 'react';
 import {useMemo} from 'react';
 
@@ -16,12 +15,6 @@ import {useAssetEventsFilters} from './useAssetEventsFilters';
 import {usePaginatedAssetEvents} from './usePaginatedAssetEvents';
 import {LiveDataForNode, stepKeyForAsset} from '../asset-graph/Utils';
 import {AssetEventHistoryEventTypeSelector, RepositorySelector} from '../graphql/types';
-
-const ALL_EVENT_TYPES = [
-  AssetEventHistoryEventTypeSelector.MATERIALIZATION,
-  AssetEventHistoryEventTypeSelector.OBSERVATION,
-  AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE,
-];
 
 interface Props {
   assetKey: AssetKey;
@@ -68,15 +61,43 @@ export const AssetEvents = ({
     if (filterState.partitions) {
       combinedParams.partitions = filterState.partitions;
     }
-    if (filterState.status) {
-      if (filterState.status.length === 1) {
-        combinedParams.statuses = [filterState.status[0] as AssetEventHistoryEventTypeSelector];
-      } else {
-        combinedParams.statuses = ALL_EVENT_TYPES;
-      }
+    if (filterState.status?.length === 1) {
+      const status = filterState.status[0];
+      const statusesForStatus =
+        status === 'Success'
+          ? [
+              AssetEventHistoryEventTypeSelector.MATERIALIZATION,
+              AssetEventHistoryEventTypeSelector.OBSERVATION,
+            ]
+          : [AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE];
+
+      combinedParams.statuses = combinedParams.statuses
+        ? combinedParams.statuses.filter((c) => statusesForStatus.includes(c))
+        : statusesForStatus;
+    }
+
+    if (filterState.type?.length === 1) {
+      const type = filterState.type[0];
+      const statusesForType =
+        type === 'Materialization'
+          ? [
+              AssetEventHistoryEventTypeSelector.MATERIALIZATION,
+              AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE,
+            ]
+          : [AssetEventHistoryEventTypeSelector.OBSERVATION];
+
+      combinedParams.statuses = combinedParams.statuses
+        ? combinedParams.statuses.filter((c) => statusesForType.includes(c))
+        : statusesForType;
     }
     return combinedParams;
-  }, [params.asOf, filterState.dateRange, filterState.status, filterState.partitions]);
+  }, [
+    params.asOf,
+    filterState.dateRange,
+    filterState.status,
+    filterState.type,
+    filterState.partitions,
+  ]);
 
   const {events, fetchMore, fetchLatest, loading} = usePaginatedAssetEvents(
     assetKey,
@@ -129,11 +150,7 @@ export const AssetEvents = ({
 
   const def = definition ?? cachedDefinition;
 
-  const hasFilter =
-    !isEqual(combinedParams.statuses, ALL_EVENT_TYPES) ||
-    combinedParams.partitions !== undefined ||
-    combinedParams.before !== undefined ||
-    combinedParams.after !== undefined;
+  const hasFilter = Object.keys(combinedParams).length > 0;
 
   if (!loading && !events.length && !hasFilter) {
     return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetEventsFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetEventsFilters.tsx
@@ -3,7 +3,6 @@ import React, {useCallback, useMemo} from 'react';
 import {observeEnabled} from 'shared/app/observeEnabled.oss';
 
 import {AssetKey} from './types';
-import {AssetEventHistoryEventTypeSelector} from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {TruncatedTextWithFullTextOnHover} from '../nav/getLeftNavItemsForOption';
 import {useFilters} from '../ui/BaseFilters';
@@ -12,14 +11,17 @@ import {AssetViewDefinitionNodeFragment} from './types/AssetView.types';
 import {useStaticSetFilter} from '../ui/BaseFilters/useStaticSetFilter';
 import {useTimeRangeFilter} from '../ui/BaseFilters/useTimeRangeFilter';
 
+type StatusFilterOption = 'Success' | 'Failure';
+type TypeFilterOption = 'Materialization' | 'Observation';
+
 type FilterState = {
   partitions?: string[];
   dateRange?: {
     start: number | null;
     end: number | null;
   };
-  status?: string[];
-  type?: string[];
+  status?: StatusFilterOption[];
+  type?: TypeFilterOption[];
 };
 
 type Config = {
@@ -37,8 +39,8 @@ export const useAssetEventsFilters = ({assetKey, assetNode}: Config) => {
       if (!raw?.partitions && !raw?.status && !raw?.type && !raw?.dateRange) {
         return {
           partitions: [],
-          status: statusValues.map((s) => s.key),
-          type: typeValues.map((t) => t.key),
+          status: statusValues.map((s) => s.value),
+          type: typeValues.map((t) => t.value),
         };
       }
 
@@ -53,8 +55,8 @@ export const useAssetEventsFilters = ({assetKey, assetNode}: Config) => {
       return {
         partitions: Array.isArray(raw?.partitions) ? raw.partitions.map(String) : [],
         dateRange,
-        status: Array.isArray(raw?.status) ? raw.status.map(String) : [],
-        type: Array.isArray(raw?.type) ? raw.type.map(String) : [],
+        status: Array.isArray(raw?.status) ? (raw.status.map(String) as StatusFilterOption[]) : [],
+        type: Array.isArray(raw?.type) ? (raw.type.map(String) as TypeFilterOption[]) : [],
       };
     },
     encode: (raw) => ({
@@ -95,7 +97,7 @@ export const useAssetEventsFilters = ({assetKey, assetNode}: Config) => {
     allValues: partitionValues,
     renderLabel: ({value}) => (
       <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-        <Icon name="job" />
+        <Icon name="partition" />
         <TruncatedTextWithFullTextOnHover text={value} />
       </Box>
     ),
@@ -112,19 +114,14 @@ export const useAssetEventsFilters = ({assetKey, assetNode}: Config) => {
     allValues: statusValues,
     renderLabel: ({value}) => (
       <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-        <Icon name="job" />
         <TruncatedTextWithFullTextOnHover text={value} />
       </Box>
     ),
-    getStringValue: (x) => {
-      if (x === AssetEventHistoryEventTypeSelector.MATERIALIZATION) {
-        return 'Success';
-      } else if (x === AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE) {
-        return 'Failure';
-      }
-      return x;
-    },
-    state: React.useMemo(() => new Set(filterState.status ?? emptyArray), [filterState.status]),
+    getStringValue: (x) => x,
+    state: React.useMemo(
+      () => new Set((filterState.status ?? emptyArray) as StatusFilterOption[]),
+      [filterState.status],
+    ),
     onStateChanged: (values) => {
       setFilterState({status: Array.from(values)});
     },
@@ -138,12 +135,19 @@ export const useAssetEventsFilters = ({assetKey, assetNode}: Config) => {
     allValues: typeValues,
     renderLabel: ({value}) => (
       <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-        <Icon name="job" />
+        {value === 'Materialization' ? (
+          <Icon name="materialization" />
+        ) : (
+          <Icon name="observation" />
+        )}
         <TruncatedTextWithFullTextOnHover text={value} />
       </Box>
     ),
     getStringValue: (x) => x,
-    state: React.useMemo(() => new Set(filterState.type ?? emptyArray), [filterState.type]),
+    state: React.useMemo(
+      () => new Set((filterState.type ?? emptyArray) as TypeFilterOption[]),
+      [filterState.type],
+    ),
     onStateChanged: (values) => {
       setFilterState({type: Array.from(values)});
     },
@@ -175,16 +179,17 @@ export const useAssetEventsFilters = ({assetKey, assetNode}: Config) => {
 
   const filters = useMemo(() => {
     const filters = [];
-    if (observeEnabled()) {
-      filters.push(statusFilter);
-    }
     filters.push(dateRangeFilter);
     if (assetNode?.partitionDefinition) {
       filters.push(partitionsFilter);
     }
     if (assetNode?.isMaterializable) {
-      // No need to show the type filter for assets without materializations
+      // No need to show the type filter for assets with only observations
+      // No need to show the status filter, only failed materializations count as Failure
       filters.push(typeFilter);
+      if (observeEnabled()) {
+        filters.push(statusFilter);
+      }
     }
     return filters;
   }, [
@@ -203,18 +208,26 @@ export const useAssetEventsFilters = ({assetKey, assetNode}: Config) => {
 
 const statusValues = [
   {
-    key: AssetEventHistoryEventTypeSelector.MATERIALIZATION,
-    value: AssetEventHistoryEventTypeSelector.MATERIALIZATION,
+    key: 'Success',
+    value: 'Success' as StatusFilterOption,
     match: ['Success'],
   },
   {
-    key: AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE,
-    value: AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE,
+    key: 'Failure',
+    value: 'Failure' as StatusFilterOption,
     match: ['Failure'],
   },
 ];
 
 const typeValues = [
-  {key: 'Materialization', value: 'Materialization', match: ['Materialization']},
-  {key: 'Observation', value: 'Observation', match: ['Observation']},
+  {
+    key: 'Materialization',
+    value: 'Materialization' as TypeFilterOption,
+    match: ['Materialization'],
+  },
+  {
+    key: 'Observation',
+    value: 'Observation' as TypeFilterOption,
+    match: ['Observation'],
+  },
 ];


### PR DESCRIPTION
Context:
https://dagsterlabs.slack.com/archives/C03CCE471E0/p1751466532317749

This is a bit odd - we present both “Type” (Materialization / Observation) and “Status” (Success / Failure) filters, but under the hood these map to three event types in our system, and Status only exists in the new Observe UI.

This fixes support for the Type filter, which was being ignored, and allows you to use the two filters together. Type=Materialization gives you `FAILED_TO_MATERIALIZE` and `MATERIALIZATION` events, and adding Status=Success filters that to just the latter. There is no “failed observation” event, and filtering to that yields no results.

I also fixed the icons used in the submenus of this filter picker since they were all "job"

I also hid the "Status" filter for non-materializable assets, since there is no Failure event for observations

FE-884

## How I Tested These Changes

I tested this by visiting an asset and making selections in the filter menu and confirming that I see the right params being sent to the graphql resolver for different selections.

## Changelog

[ui] The "type" filter on the asset events view now behaves as expected in all scenarios.
