### PR TITLE
[Observe][Perf Telemetry] Wait for asset health data to load

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -94,17 +94,20 @@ export function useAssetsHealthData({
   thread = 'AssetHealth', // Use AssetHealth to get 250 batch size
   blockTrace = true,
   skip = false,
+  loading = false,
 }: {
   assetKeys: AssetKeyInput[];
   thread?: LiveDataThreadID;
   blockTrace?: boolean;
   skip?: boolean;
+  loading?: boolean;
 }) {
   const keys = memoizedAssetKeys(observeEnabled() ? assetKeys : []);
   const result = AssetHealthData.useLiveData(keys, thread, skip);
   useBlockTraceUntilTrue(
     'useAssetsHealthData',
-    skip || !blockTrace || !!(Object.keys(result.liveDataByNode).length === assetKeys.length),
+    !loading &&
+      (skip || !blockTrace || !!(Object.keys(result.liveDataByNode).length === assetKeys.length)),
   );
   return result;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -236,7 +236,9 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
     options.skip,
   ]);
 
-  const loading = assetsLoading || graphDataLoading || supplementaryDataLoading;
+  const loading =
+    !options.skip &&
+    (assetsLoading || graphDataLoading || supplementaryDataLoading || options.loading);
   useBlockTraceUntilTrue('useAssetGraphData', !loading);
   return {
     loading,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -89,7 +89,7 @@ export function useFullAssetGraphData(
       });
   }, [allNodes, options.loading, options.useWorker, spawnBuildGraphDataWorker]);
 
-  return {fullAssetGraphData, loading: loading || options.loading};
+  return {fullAssetGraphData, loading: loading || !!options.loading};
 }
 
 export type GraphDataState = {
@@ -238,7 +238,7 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
 
   const loading =
     !options.skip &&
-    (assetsLoading || graphDataLoading || supplementaryDataLoading || options.loading);
+    (assetsLoading || graphDataLoading || !!supplementaryDataLoading || !!options.loading);
   useBlockTraceUntilTrue('useAssetGraphData', !loading);
   return {
     loading,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -98,6 +98,7 @@ export const AssetCatalogTableV2 = React.memo(() => {
 
   const {liveDataByNode} = useAssetsHealthData({
     assetKeys: useMemo(() => filtered.map((asset) => asAssetKeyInput(asset.key)), [filtered]),
+    loading,
   });
 
   const healthDataLoading = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/useSelectionHealthData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/useSelectionHealthData.tsx
@@ -115,6 +115,7 @@ const SelectionHealthDataObserver = React.memo(
       assetKeys: useMemo(() => filtered.map((asset) => asset.key), [filtered]),
       thread: getSelectionThreadId(selection),
       skip: skipHealth,
+      loading: filterLoading || skipFilters,
     });
 
     const isLoading = loading || filtered.length !== Object.keys(liveDataByNode).length;


### PR DESCRIPTION
## Summary & Motivation

We weren't waiting for asset health data to load because the condition `(Object.keys(result.liveDataByNode).length === assetKeys.length` would be immediately true while assets were loading/being filtered (0 assets). To fix this add a loading prop to `useAssetsHealthData` so that we can wait until asset keys are calculated and passed in before checking the condition.

## How I Tested These Changes
Datadog: https://app.datadoghq.com/rum/sessions?query=%40type%3Aview%20%40view.id%3A56ef928b-2476-40fd-bb76-5440055245d5&fromUser=false&from_ts=1751396498033&to_ts=1751482898033&live=true