### PR TITLE
[ui] Observe rollout banner

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/overview/ObserveRolloutBanner.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/ObserveRolloutBanner.oss.tsx
@@ -1,0 +1,1 @@
+export const ObserveRolloutBanner = () => null;

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageHeader.tsx
@@ -1,6 +1,7 @@
 import {Box, PageHeader} from '@dagster-io/ui-components';
 import React from 'react';
 import {observeEnabled} from 'shared/app/observeEnabled.oss';
+import {ObserveRolloutBanner} from 'shared/overview/ObserveRolloutBanner.oss';
 
 import {OverviewTabs} from './OverviewTabs';
 
@@ -17,13 +18,16 @@ export const OverviewPageHeader = ({
   }
 
   return (
-    <PageHeader
-      tabs={
-        <Box flex={{direction: 'column', gap: 8}}>
-          <OverviewTabs tab={tab} queryData={queryData} refreshState={refreshState} />
-        </Box>
-      }
-      {...rest}
-    />
+    <div>
+      <ObserveRolloutBanner />
+      <PageHeader
+        tabs={
+          <Box flex={{direction: 'column', gap: 8}}>
+            <OverviewTabs tab={tab} queryData={queryData} refreshState={refreshState} />
+          </Box>
+        }
+        {...rest}
+      />
+    </div>
   );
 };


### PR DESCRIPTION
## Summary & Motivation

OSS counterpart to https://github.com/dagster-io/internal/pull/16713. Insert the banner into the Timeline page.

## How I Tested These Changes

See internal PR.