### PR TITLE
[dg][fix] fix check yaml for components which do not have an attributes key specified

### DIFF
--- a/python_modules/dagster-test/dagster_test/components/test_utils/test_cases.py
+++ b/python_modules/dagster-test/dagster_test/components/test_utils/test_cases.py
@@ -203,4 +203,9 @@ COMPONENT_VALIDATION_TEST_CASES = [
             "found character '@' that cannot start any token",
         ),
     ),
+    ComponentValidationTestCase(
+        component_path="validation/defs_folder_no_attributes",
+        component_type_filepath=None,
+        should_error=False,
+    ),
 ]

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/validation/defs_folder_no_attributes/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/validation/defs_folder_no_attributes/defs.yaml
@@ -1,0 +1,1 @@
+type: dagster.DefsFolderComponent

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/check.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/check.py
@@ -169,7 +169,7 @@ def check_yaml(
             json_schema = component_registry.get(key).component_schema or {}
 
             v = Draft202012Validator(json_schema)
-            for err in v.iter_errors(component_doc_tree.value["attributes"]):
+            for err in v.iter_errors(component_doc_tree.value.get("attributes", {})):
                 validation_errors.append(ErrorInput(key, err, component_doc_tree))
         except KeyError:
             # No matching component type found


### PR DESCRIPTION
## Summary

It is reasonable to want to specify some components without attributes, e.g. a `DefsFolderComponent` with only post-processing steps. Previously, such YAML files would trigger yaml check exceptions, since we explicitly index into the `attributes` key. This PR uses `.get` instead.

## Test Plan

New unit test.

## Changelog

[dg] Fixed an issue where `dg dev` and `dg check yaml` would error for YAML components lacking an `attributes` field.
