### PR TITLE
[dagster-databricks] Adds ability to represent unity catalog tables in the asset graph

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
@@ -34,10 +34,7 @@ from dagster_databricks.resources import (
     DatabricksClientResource as DatabricksClientResource,
     databricks_client as databricks_client,
 )
-from dagster_databricks.unity_catalog import (
-    unity_catalog_assets as unity_catalog_assets,
-)
-
+from dagster_databricks.unity_catalog import unity_catalog_assets as unity_catalog_assets
 from dagster_databricks.version import __version__
 
 DagsterLibraryRegistry.register("dagster-databricks", __version__)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/__init__.py
@@ -34,6 +34,10 @@ from dagster_databricks.resources import (
     DatabricksClientResource as DatabricksClientResource,
     databricks_client as databricks_client,
 )
+from dagster_databricks.unity_catalog import (
+    unity_catalog_assets as unity_catalog_assets,
+)
+
 from dagster_databricks.version import __version__
 
 DagsterLibraryRegistry.register("dagster-databricks", __version__)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/unity_catalog.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/unity_catalog.py
@@ -5,11 +5,12 @@ from typing import Optional, Sequence
 from dagster import AssetKey, AssetsDefinition, TableColumn, TableSchema
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.external_asset import external_asset_from_spec
+from dagster._annotations import preview
 from databricks.sdk import WorkspaceClient
 
 import requests
 
-
+@preview
 def unity_catalog_assets(
     client: WorkspaceClient,
     *,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/unity_catalog.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/unity_catalog.py
@@ -1,29 +1,31 @@
-from __future__ import annotations
-
-from typing import Optional, Sequence
-
-from dagster import AssetKey, AssetsDefinition, TableColumn, TableSchema
-from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.external_asset import external_asset_from_spec
-from dagster._annotations import preview
-from databricks.sdk import WorkspaceClient
+from typing import TYPE_CHECKING
 
 import requests
+from dagster import AssetKey, AssetsDefinition, TableColumn, TableSchema
+from dagster._annotations import preview
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.external_asset import external_asset_from_spec
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from databricks.sdk import WorkspaceClient
+    from databricks.sdk.service.catalog import TableInfo
+
 
 @preview
 def unity_catalog_assets(
-    client: WorkspaceClient,
+    client: "WorkspaceClient",
     *,
     catalog: str,
-    schema: Optional[str] = None,
+    schema: str | None = None,
     include_views: bool = True,
     with_lineage: bool = True,
     # Need to decide whether or not to keep the asset_key_prefix parameter.
-    asset_key_prefix: Sequence[str] = (),
-    group_name: Optional[str] = None,
+    asset_key_prefix: "Sequence[str]" = (),
+    group_name: str | None = None,
 ) -> list[AssetsDefinition]:
     """Return Dagster assets representing Unity Catalog tables and views."""
-
     assets: list[AssetsDefinition] = []
     tables = client.tables.list(catalog_name=catalog, schema_name=schema)
 
@@ -36,53 +38,55 @@ def unity_catalog_assets(
         upstream_keys: list[AssetKey] = []
 
         if with_lineage:
-            upstream_keys = _get_lineage_for_table(catalog=catalog,
-                                                   schema=schema,
-                                                   table=table.name,
-                                                   client=client)
+            upstream_keys = _get_lineage_for_table(
+                catalog=catalog, schema=schema, table=table.name, client=client
+            )
         columns = _get_schema_for_table(table)
-        spec = AssetSpec(key=key,
-                         deps=upstream_keys,
-                         owners=[table.owner],
-                         description=table.comment,
-                         kinds=["Databricks"],
-                         group_name=group_name,
-                         metadata ={
-                         "dagster/column_schema": TableSchema(columns)})
+        spec = AssetSpec(
+            key=key,
+            deps=upstream_keys,
+            owners=[table.owner],
+            description=table.comment,
+            kinds=["Databricks"],
+            group_name=group_name,
+            metadata={"dagster/column_schema": TableSchema(columns)},
+        )
         assets.append(external_asset_from_spec(spec))
 
     return assets
 
-def _get_lineage_for_table(catalog: str,
-                           schema: str,
-                           table: str,
-                           client: WorkspaceClient) -> List[AssetKey]:
+
+def _get_lineage_for_table(
+    catalog: str, schema: str, table: str, client: "WorkspaceClient"
+) -> list[AssetKey]:
     try:
         response = requests.get(
             f"{client.config.host}/api/2.0/lineage-tracking/table-lineage",
             headers={
                 "Authorization": f"Bearer {client.config.token}",
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
             },
-            params={"table_name": f"{catalog}.{schema}.{table}", "include_entity_lineage": "true"}
+            params={"table_name": f"{catalog}.{schema}.{table}", "include_entity_lineage": "true"},
         )
         response.raise_for_status()
         upstreams = response.json().get("upstreams", [])
         return [
-            AssetKey([
-                src["tableInfo"]["catalog_name"],
-                src["tableInfo"]["schema_name"],
-                src["tableInfo"]["name"]
-            ])
-            for src in upstreams if "tableInfo" in src
+            AssetKey(
+                [
+                    src["tableInfo"]["catalog_name"],
+                    src["tableInfo"]["schema_name"],
+                    src["tableInfo"]["name"],
+                ]
+            )
+            for src in upstreams
+            if "tableInfo" in src
         ]
     except Exception:
         return []
 
+
 def _get_schema_for_table(table: "TableInfo") -> list:
     columns = []
     for column in table.columns:
-        columns.append(TableColumn(column.name,
-                                      column.type_name.name,
-                                      description=column.comment))
+        columns.append(TableColumn(column.name, column.type_name.name, description=column.comment))
     return columns

--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -35,7 +35,8 @@ setup(
         f"dagster{pin}",
         f"dagster-pipes{pin}",
         f"dagster-pyspark{pin}",
-        "databricks-sdk<=0.17.0",  # dbt-databricks is pinned to this version
+        "databricks-sdk<=0.17.0",
+        "requests",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary & Motivation
This is the first in a series of PRs to update our Databricks integration. I suspect I'll need a lot of help making this follow Dagster patterns, but we all have to start somewhere. 

This specifically adds a method that calls the Databricks Python SDK to get a list of tables in a catalog + schema, and represent them in the asset graph. 

## How I Tested These Changes
I built the dagster_databricks integration locally and made a test asset using the new method 

```
from databricks.sdk import WorkspaceClient
from dagster import Definitions
from dagster_databricks import unity_catalog_assets

import os

client = WorkspaceClient()

DATABRICKS_HOST = os.getenv("DATABRICKS_HOSTNAME")
DATABRICKS_TOKEN = os.getenv("DATABRICKS_TOKEN")

assets = unity_catalog_assets(
    client,
    catalog="pauls-test-unity-catalog",
    schema="daggy_u",
    include_views=True,
    with_lineage=True,
    #asset_key_prefix=["databricks"],
    group_name="databricks_unity_catalog_assets",
)

defs = Definitions(assets=assets)
```
