### PR TITLE
[Asset graph] Workaround fix for long loading times

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -8,6 +8,7 @@ import {asyncMemoize, indexedDBAsyncMemoize} from '../app/Util';
 import {GraphData} from '../asset-graph/Utils';
 import {AssetGraphLayout, LayoutAssetGraphOptions, layoutAssetGraph} from '../asset-graph/layout';
 import {useDangerousRenderEffect} from '../hooks/useDangerousRenderEffect';
+import {useUpdatingRef} from '../hooks/useUpdatingRef';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {hashObject} from '../util/hashObject';
 import {weakMapMemoize} from '../util/weakMapMemoize';
@@ -200,6 +201,9 @@ export function useAssetLayout(
   const graphData = useMemo(() => ({..._graphData, expandedGroups}), [expandedGroups, _graphData]);
 
   const cacheKey = useMemo(() => _assetLayoutCacheKey(graphData, opts), [graphData, opts]);
+
+  const nextCacheKeyRef = useUpdatingRef(cacheKey);
+
   const nodeCount = Object.keys(graphData.nodes).length;
   const runAsync = nodeCount >= ASYNC_LAYOUT_SOLID_COUNT;
 
@@ -216,7 +220,8 @@ export function useAssetLayout(
       } else {
         layout = await asyncGetFullAssetLayout(graphData, opts);
       }
-      if (canceled) {
+      if (canceled && cacheKey !== nextCacheKeyRef.current) {
+        // Only throw away layout data if the cache key changes.
         return;
       }
       dispatch({type: 'layout', payload: {layout, cacheKey}});
@@ -232,7 +237,7 @@ export function useAssetLayout(
     return () => {
       canceled = true;
     };
-  }, [cacheKey, graphData, runAsync, flags, opts, dataLoading]);
+  }, [cacheKey, graphData, runAsync, flags, opts, dataLoading, nextCacheKeyRef]);
 
   const uid = useRef(0);
   useDangerousRenderEffect(() => {


### PR DESCRIPTION
## Summary & Motivation

Currently the asset graph is sometimes ending up in an infinite loading state.

From my repro I was able to see that we were marking asset layout requests as cancelled (which happens in the return of layout effect) yet another layout effect does not fire... this means we end up throwing away the layout without scheduling a new layout. While debugging I saw we were throwing it away even though the layout cache key hasn't changed so add a check of the layout cache key as a further check that the layout should really be cancelled.


## How I Tested These Changes

local testing