### PR TITLE
[components] adjust hint about yaml schema to mention python params

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/generated/2-shell-command-empty.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/generated/2-shell-command-empty.py
@@ -6,7 +6,7 @@ class ShellCommand(dg.Component, dg.Model, dg.Resolvable):
     COMPONENT DESCRIPTION HERE.
     """
 
-    # added fields here will define yaml schema via Model
+    # added fields here will define yaml schema via Model, and params when instantiated in Python
 
     def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
         # Add definition construction logic here.

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/generated/2-shell-command-empty.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/generated/2-shell-command-empty.py
@@ -6,7 +6,7 @@ class ShellCommand(dg.Component, dg.Model, dg.Resolvable):
     COMPONENT DESCRIPTION HERE.
     """
 
-    # added fields here will define yaml schema via Model, and params when instantiated in Python
+    # added fields here will define params when instantiated in Python, and yaml schema via Resolvable
 
     def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
         # Add definition construction logic here.

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -14,11 +14,11 @@ class {{ name }}(dg.Component, dg.Resolvable):
     """
 {% endif -%}
 {% if model %}
-    # added fields here will define yaml schema via Model, and params when instantiated in Python
+    # added fields here will define params when instantiated in Python, and yaml schema via Resolvable
 {% else %}
     def __init__(
         self,
-        # added arguments here will define yaml schema via Resolvable, and params when instantiated in Python
+        # added params here define needed arguments when instantiated in Python, and yaml schema via Resolvable
     ):
         pass
 {% endif %}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/COMPONENT_TYPE/COMPONENT_TYPE_NAME_PLACEHOLDER.py.jinja
@@ -14,11 +14,11 @@ class {{ name }}(dg.Component, dg.Resolvable):
     """
 {% endif -%}
 {% if model %}
-    # added fields here will define yaml schema via Model
+    # added fields here will define yaml schema via Model, and params when instantiated in Python
 {% else %}
     def __init__(
         self,
-        # added arguments here will define yaml schema via Resolvable
+        # added arguments here will define yaml schema via Resolvable, and params when instantiated in Python
     ):
         pass
 {% endif %}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
@@ -970,7 +970,7 @@ def test_scaffold_component_succeeds_scaffolded_no_model() -> None:
 
                 def __init__(
                     self,
-                    # added arguments here will define yaml schema via Resolvable, and params when instantiated in Python
+                    # added params here define needed arguments when instantiated in Python, and yaml schema via Resolvable
                 ):
                     pass
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
@@ -970,7 +970,7 @@ def test_scaffold_component_succeeds_scaffolded_no_model() -> None:
 
                 def __init__(
                     self,
-                    # added arguments here will define yaml schema via Resolvable
+                    # added arguments here will define yaml schema via Resolvable, and params when instantiated in Python
                 ):
                     pass
 


### PR DESCRIPTION
## Summary

Updates the default scaffolded component class to mention that listed fields define *both* the YAML schema and the set of Python params. This makes it a bit more clear in e.g. our docs for Python-centric components that defining params is still useful.

