### PR TITLE
Fix AssetGraph -> Webworker infinite loop

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -131,9 +131,11 @@ export const useFeatureFlags = (): Readonly<Record<FeatureFlag, boolean>> => {
  * Function to update feature flags.
  * Updates the in-memory cache, persists to localStorage, and broadcasts the change.
  */
-export const setFeatureFlags = (flags: FeatureFlagMap) => {
+export const setFeatureFlags = (flags: FeatureFlagMap, broadcast: boolean = true) => {
   setFeatureFlagsInternal(flags);
-  featureFlagsChannel.postMessage('updated');
+  if (broadcast) {
+    featureFlagsChannel.postMessage('updated');
+  }
 };
 
 export const toggleFeatureFlag = (flag: FeatureFlag) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useDebugChanged.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useDebugChanged.tsx
@@ -38,7 +38,7 @@ export const useDebugChanged = <T,>(objects: T[]): void => {
     const changes: Changes<T>[] = [];
 
     objects.forEach((obj, index) => {
-      if (!isEqual(obj, previousObjects[index])) {
+      if (obj !== previousObjects[index]) {
         changes.push({
           index,
           previous: previousObjects[index]!,

--- a/js_modules/dagster-ui/packages/ui-core/src/workers/WorkerThread.oss.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workers/WorkerThread.oss.ts
@@ -7,7 +7,9 @@ export const createWorkerThread = (
   self.addEventListener('message', async (event) => {
     try {
       if (event.data[WEB_WORKER_FEATURE_FLAGS_KEY]) {
-        setFeatureFlags(event.data[WEB_WORKER_FEATURE_FLAGS_KEY]);
+        // Don't broadcast the feature flags update to the main thread.
+        // or we will end up in an infinite loop.
+        setFeatureFlags(event.data[WEB_WORKER_FEATURE_FLAGS_KEY], false);
       } else {
         await onMessage(self.postMessage, event.data);
       }


### PR DESCRIPTION
## Summary & Motivation
When we spawn a webworker it [receives the feature flags from the main thread](https://github.com/dagster-io/dagster/blob/5f69e4093ab41f627b5bd84df179bbec7e07f83a/js_modules/dagster-ui/packages/ui-core/src/workers/WorkerThread.oss.ts#L12) and [calls a function](https://github.com/dagster-io/dagster/blob/5f69e4093ab41f627b5bd84df179bbec7e07f83a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx#L134) to set feature flags that [ends up broadcasting those same flags back the main thread](https://github.com/dagster-io/dagster/blob/5f69e4093ab41f627b5bd84df179bbec7e07f83a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx#L137). Then [useFeatureFlags](https://github.com/dagster-io/dagster/blob/ae5344f8aec26a9205e57dd92d3d7f2e5f2dc34a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts#L199) causes a re-render which triggers the [layout effect](https://github.com/dagster-io/dagster/blob/ae5344f8aec26a9205e57dd92d3d7f2e5f2dc34a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts#L210) to spawn a new worker starting the cycle all over and causing an infinite loop. Heavy memoization was masking the issue... But seems sometimes the memoization doesn't stop the cycle and each new webworker kills the previous one leading to an infinite loading state.


## How I Tested These Changes

local testing