### PR TITLE
[Asset Graph] Fix infinite loading asset graph edge case

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -213,10 +213,10 @@ export const indexedDBAsyncMemoize = <R, U extends (...args: any[]) => Promise<R
     return await lru.has(hashKey);
   };
   ret.clearEntry = async (...args: Parameters<U>) => {
-    const hashKey = await genHashKey(...args);
     if (!lru) {
       return;
     }
+    const hashKey = await genHashKey(...args);
     delete hashToPromise[hashKey];
     await lru.delete(hashKey);
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -152,6 +152,7 @@ export const indexedDBAsyncMemoize = <R, U extends (...args: any[]) => Promise<R
   hashFn?: (...args: Parameters<U>) => any,
 ): U & {
   isCached: (...args: Parameters<U>) => Promise<boolean>;
+  clearEntry: (...args: Parameters<U>) => Promise<void>;
 } => {
   let lru: ReturnType<typeof cache<R>> | undefined;
   try {
@@ -163,9 +164,9 @@ export const indexedDBAsyncMemoize = <R, U extends (...args: any[]) => Promise<R
 
   const hashToPromise: Record<string, Promise<R>> = {};
 
-  const genHashKey = async (...args: Parameters<U>) => {
+  const genHashKey = weakMapMemoize(async (...args: Parameters<U>) => {
     return hashFn ? hashFn(...args) : hashObject(args);
-  };
+  });
 
   const ret = weakMapMemoize(async (...args: Parameters<U>) => {
     return new Promise<R>(async (resolve, reject) => {
@@ -190,6 +191,7 @@ export const indexedDBAsyncMemoize = <R, U extends (...args: any[]) => Promise<R
               delete hashToPromise[hashKey];
             }
           } catch (e) {
+            delete hashToPromise[hashKey];
             rej(e);
           }
         });
@@ -198,6 +200,7 @@ export const indexedDBAsyncMemoize = <R, U extends (...args: any[]) => Promise<R
         const result = await hashToPromise[hashKey]!;
         resolve(result);
       } catch (e) {
+        delete hashToPromise[hashKey];
         reject(e);
       }
     });
@@ -208,6 +211,14 @@ export const indexedDBAsyncMemoize = <R, U extends (...args: any[]) => Promise<R
       return false;
     }
     return await lru.has(hashKey);
+  };
+  ret.clearEntry = async (...args: Parameters<U>) => {
+    const hashKey = await genHashKey(...args);
+    if (!lru) {
+      return;
+    }
+    delete hashToPromise[hashKey];
+    await lru.delete(hashKey);
   };
   return ret;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -176,7 +176,7 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
   }, [spawnComputeGraphDataWorker]);
 
   useLayoutEffect(() => {
-    if (options.loading || supplementaryDataLoading || options.skip) {
+    if (options.loading || supplementaryDataLoading || assetsLoading || options.skip) {
       return;
     }
 
@@ -234,6 +234,7 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
     spawnComputeGraphDataWorker,
     options.useWorker,
     options.skip,
+    assetsLoading,
   ]);
 
   const loading =

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -74,6 +74,11 @@ export const asyncGetFullAssetLayoutIndexDB = indexedDBAsyncMemoize(
       });
       worker.onTerminate(() => {
         setTimeout(() => {
+          // This timeout is because these workers are used as part of React and end up going through synchronous render loops.
+          // This means that the worker can't return any messages until that synchronous loop ends.
+          // To ensure at least one synchronous loop ends, we add a timeout 0.
+          // This helps us avoid throwing away useful results that were returned faster than the synchronous
+          // task we're in.
           if (!didResolveSuccessfully) {
             // Clear the cache entry if the worker is terminated without resolving
             // because the cache entry points to this terminated worker which will never resolve.

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -6,7 +6,6 @@ import {ILayoutOp, LayoutOpGraphOptions, OpGraphLayout, layoutOpGraph} from './l
 import {asyncMemoize, indexedDBAsyncMemoize} from '../app/Util';
 import {GraphData} from '../asset-graph/Utils';
 import {AssetGraphLayout, LayoutAssetGraphOptions, layoutAssetGraph} from '../asset-graph/layout';
-import {useUpdatingRef} from '../hooks/useUpdatingRef';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {hashObject} from '../util/hashObject';
 import {weakMapMemoize} from '../util/weakMapMemoize';
@@ -239,8 +238,6 @@ export function useAssetLayout(
 
   const cacheKey = useMemo(() => _assetLayoutCacheKey(graphData, opts), [graphData, opts]);
 
-  const nextCacheKeyRef = useUpdatingRef(cacheKey);
-
   const nodeCount = Object.keys(graphData.nodes).length;
   const runAsync = nodeCount >= ASYNC_LAYOUT_SOLID_COUNT;
 
@@ -283,17 +280,7 @@ export function useAssetLayout(
     } else {
       void runAsyncLayout();
     }
-  }, [
-    cacheKey,
-    graphData,
-    runAsync,
-    opts,
-    dataLoading,
-    nextCacheKeyRef,
-    state.cacheKey,
-    state.layout,
-    state.loadingCacheKey,
-  ]);
+  }, [cacheKey, graphData, runAsync, opts, dataLoading, state.cacheKey, state.loadingCacheKey]);
 
   const loading = state.loading || !state.layout || state.cacheKey !== cacheKey;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -162,6 +162,7 @@ const initialState: State = {
   loading: false,
   layout: null,
   cacheKey: '',
+  loadingCacheKey: undefined,
 };
 
 /**

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryAndLocalStoragePersistedState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryAndLocalStoragePersistedState.tsx
@@ -27,11 +27,12 @@ export const useQueryAndLocalStoragePersistedState = <T extends QueryPersistedDa
         const item = window.localStorage.getItem(localStorageKey);
         if (item) {
           const parsed = JSON.parse(item);
+          value = parsed;
           if (decode) {
             value = decode(parsed);
             return value;
           }
-          return value;
+          return parsed;
         }
       } catch (error) {
         console.error('Error reading from localStorage:', error);

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryAndLocalStoragePersistedState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryAndLocalStoragePersistedState.tsx
@@ -27,11 +27,7 @@ export const useQueryAndLocalStoragePersistedState = <T extends QueryPersistedDa
         const item = window.localStorage.getItem(localStorageKey);
         if (item) {
           const parsed = JSON.parse(item);
-          value = parsed;
-          if (decode) {
-            value = decode(parsed);
-          }
-          return value;
+          return decode ? decode(parsed) : parsed;
         }
       } catch (error) {
         console.error('Error reading from localStorage:', error);

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryAndLocalStoragePersistedState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryAndLocalStoragePersistedState.tsx
@@ -17,20 +17,27 @@ export const useQueryAndLocalStoragePersistedState = <T extends QueryPersistedDa
 ): [T, (setterOrState: React.SetStateAction<T>) => void] => {
   const {localStorageKey, isEmptyState, decode} = props;
 
-  const getInitialValueFromLocalStorage = React.useCallback((): T | undefined => {
-    try {
-      const item = window.localStorage.getItem(localStorageKey);
-      if (item) {
-        const parsed = JSON.parse(item);
-        if (decode) {
-          return decode(parsed);
-        }
-        return parsed;
+  const getInitialValueFromLocalStorage = React.useMemo(() => {
+    let value: T | undefined;
+    return () => {
+      if (value !== undefined) {
+        return value;
       }
-    } catch (error) {
-      console.error('Error reading from localStorage:', error);
-    }
-    return undefined;
+      try {
+        const item = window.localStorage.getItem(localStorageKey);
+        if (item) {
+          const parsed = JSON.parse(item);
+          if (decode) {
+            value = decode(parsed);
+            return value;
+          }
+          return value;
+        }
+      } catch (error) {
+        console.error('Error reading from localStorage:', error);
+      }
+      return undefined;
+    };
   }, [localStorageKey, decode]);
 
   const [state, setter] = useQueryPersistedState(props);

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryAndLocalStoragePersistedState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryAndLocalStoragePersistedState.tsx
@@ -30,9 +30,8 @@ export const useQueryAndLocalStoragePersistedState = <T extends QueryPersistedDa
           value = parsed;
           if (decode) {
             value = decode(parsed);
-            return value;
           }
-          return parsed;
+          return value;
         }
       } catch (error) {
         console.error('Error reading from localStorage:', error);

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryAndLocalStoragePersistedState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryAndLocalStoragePersistedState.tsx
@@ -15,31 +15,28 @@ export const useQueryAndLocalStoragePersistedState = <T extends QueryPersistedDa
     isEmptyState: (state: T) => boolean;
   },
 ): [T, (setterOrState: React.SetStateAction<T>) => void] => {
-  // Grab state from localStorage as "initialState"
-  const initialState = React.useMemo(() => {
+  const {localStorageKey, isEmptyState, decode} = props;
+
+  const getInitialValueFromLocalStorage = React.useCallback((): T | undefined => {
     try {
-      const value = localStorage.getItem(props.localStorageKey);
-      if (value) {
-        return props.decode?.(JSON.parse(value));
+      const item = window.localStorage.getItem(localStorageKey);
+      if (item) {
+        const parsed = JSON.parse(item);
+        if (decode) {
+          return decode(parsed);
+        }
+        return parsed;
       }
-    } catch {}
+    } catch (error) {
+      console.error('Error reading from localStorage:', error);
+    }
     return undefined;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.localStorageKey]);
+  }, [localStorageKey, decode]);
 
   const [state, setter] = useQueryPersistedState(props);
 
-  const isFirstRender = React.useRef(true);
-  React.useEffect(() => {
-    if (initialState && props.isEmptyState(state)) {
-      setter(initialState);
-    }
-    isFirstRender.current = false;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   return [
-    isFirstRender.current && initialState && props.isEmptyState(state) ? initialState : state,
+    isEmptyState(state) ? (getInitialValueFromLocalStorage() ?? state) : state,
     useSetStateUpdateCallback(state, (nextState) => {
       setter(nextState);
 


### PR DESCRIPTION
## Summary & Motivation
This PR resolves an infinite loading state caused by a race condition in the layout calculation system.
The Problem:
When useAssetLayout rapidly switches between different layout requests (e.g., from cache key A to B and back to A), the following sequence occurs:

Layout A starts calculating (state: {loading: true, layout: null, cacheKey: null})
Before A completes, a re-render triggers layout B
The worker for A gets terminated
When the component requests A again, it finds a cached promise that will never resolve (since its worker was terminated)

The Fix:
Added a clearEntry function that removes stale cache entries when their associated workers are terminated. This ensures subsequent requests for the same layout will start fresh rather than waiting on a promise from a dead worker.


BUT WAIT THERES MORE.
Why are we going from Layout A to Layout B and back to Layout A?

Turns out `useQueryAndLocalStoragePersistedState` had an issue where it would first render with the state from localStorage, then with the state from the query string, and then again with the winner being the query string if its not empty otherwise localStorage. I fixed these extra re-renders which was triggering the issue


## Test plan
I need to come up with a good way of testing this but it's a little challenging since any tests we write will need to simulate the timing/race conditions we encountered since there's no easy way to recreate it in jest with an actual webworker. This makes the test less valuable since it's not likely to catch a real issue.