### PR TITLE
Fix component python scaffold import

### DIFF
--- a/python_modules/dagster/dagster/components/component/component_loader.py
+++ b/python_modules/dagster/dagster/components/component/component_loader.py
@@ -47,7 +47,7 @@ def component_instance(
             class MyComponent(dg.Component):
                 ...
 
-            @component_instance
+            @dg.component_instance
             def load(context: dg.ComponentLoadContext) -> MyComponent:
                 return MyComponent(...)
     """

--- a/python_modules/dagster/dagster/components/component_scaffolding.py
+++ b/python_modules/dagster/dagster/components/component_scaffolding.py
@@ -53,11 +53,11 @@ def scaffold_component(
             f.write(
                 textwrap.dedent(
                     f"""
-                        from dagster import component, ComponentLoadContext
+                        import dagster as dg
                         from {module_path} import {class_name}
 
-                        @component_instance
-                        def load(context: ComponentLoadContext) -> {class_name}: ...
+                        @dg.component_instance
+                        def load(context: dg.ComponentLoadContext) -> {class_name}: ...
                 """
                 ).lstrip()
             )

--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_component_defs.py
@@ -150,11 +150,11 @@ def test_scaffold_airlift_python():
         with open("bar/defs/qux/component.py") as f:
             file_contents = f.read()
             assert file_contents == (
-                """from dagster import component, ComponentLoadContext
+                """import dagster as dg
 from dagster_airlift.core.components import AirflowInstanceComponent
 
-@component_instance
-def load(context: ComponentLoadContext) -> AirflowInstanceComponent: ...
+@dg.component_instance
+def load(context: dg.ComponentLoadContext) -> AirflowInstanceComponent: ...
 """
             )
 


### PR DESCRIPTION
## Summary & Motivation

Fixes #30533 by dg-ifying the imports for a component definition scaffolded in python format.


## How I Tested These Changes

## Changelog


