### PR TITLE
Preliminary: add the cursor to the return type

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
@@ -113,6 +113,7 @@ class GraphenePipelineRuns(graphene.Interface):
 class GrapheneRuns(graphene.ObjectType):
     results = non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneRun")
     count = graphene.Int()
+    cursor = graphene.String()
 
     class Meta:
         interfaces = (GraphenePipelineRuns,)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/runs.py
@@ -125,12 +125,28 @@ class GrapheneRuns(graphene.ObjectType):
         self._filters = filters
         self._cursor = cursor
         self._limit = limit
+        self._cached_results = None
 
     def resolve_results(self, graphene_info: ResolveInfo):
-        return get_runs(graphene_info, self._filters, self._cursor, self._limit)
+        if self._cached_results is None:
+            results = get_runs(graphene_info, self._filters, self._cursor, self._limit)
+            self._cached_results = results
+            return results
+        return self._cached_results
 
     def resolve_count(self, graphene_info: ResolveInfo):
         return get_runs_count(graphene_info, self._filters)
+
+    def resolve_cursor(self, graphene_info: ResolveInfo):
+        # Handle if you only every query cursor.
+        # Handle if you only ever query cursor.
+        if self._cached_results is None:
+            self._cached_results = get_runs(
+                graphene_info, self._filters, self._cursor, self._limit
+            )
+        if len(self._cached_results) == 0:
+            return self._cursor
+        return self._cached_results[-1].dagster_run.run_id
 
 
 class GrapheneRunsOrError(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -134,6 +134,30 @@ ALL_RUNS_QUERY = """
   }
 }
 """
+ALL_RUNS_PAGINATED_QUERY = """
+query PaginatedRunsQuery($cursor: String, $limit: Int) {
+  runsOrError(
+    cursor: $cursor
+    limit: $limit
+  ) {
+    ... on Runs {
+      results {
+        runId
+      }
+      cursor
+    }
+  }
+}
+"""
+JUST_CURSOR_QUERY = """
+query JustCursorRunsQuery($cursor: String, $limit: Int) {
+  runsOrError(cursor: $cursor, limit: $limit) {
+    ... on Runs {
+      cursor
+    }
+  }
+}
+"""
 
 
 FILTERED_RUN_QUERY = """
@@ -672,6 +696,64 @@ def test_runs_over_time():
                 "name": "evolving_job",
                 "solidSelection": None,
             }
+
+
+def test_just_cursor():
+    with instance_for_test() as instance:
+        repo = get_repo_at_time_1()
+        run_id = (
+            repo.get_job("foo_job")
+            .execute_in_process(instance=instance, tags={"run": "run"})
+            .run_id
+        )
+        with define_out_of_process_context(
+            __file__, "get_repo_at_time_2", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                JUST_CURSOR_QUERY,
+                variables={"cursor": None, "limit": 1},
+            )
+            assert result.data
+            assert result.data["runsOrError"]["cursor"] == run_id
+
+
+def test_cursor_pagination():
+    with instance_for_test() as instance:
+        run_ids = []
+        repo = get_repo_at_time_1()
+        for i in range(10):
+            run_ids.append(
+                repo.get_job("foo_job")
+                .execute_in_process(instance=instance, tags={"run": f"run_{i}"})
+                .run_id
+            )
+
+        with define_out_of_process_context(
+            __file__, "get_repo_at_time_2", instance
+        ) as context_at_time_2:
+            found_run_ids = []
+            cursor = None
+            # Note run for longer than possible.
+            for i in range(10):
+                result = execute_dagster_graphql(
+                    context_at_time_2,
+                    ALL_RUNS_PAGINATED_QUERY,
+                    variables={"limit": 2, "cursor": cursor},
+                )
+                assert result.data
+                found_run_ids.extend(
+                    [run["runId"] for run in result.data["runsOrError"]["results"]]
+                )
+                if result.data["runsOrError"]["cursor"] == cursor:
+                    assert len(result.data["runsOrError"]["results"]) == 0, (
+                        "When the cursor is the last runId, there should be no results."
+                    )
+                    break
+                else:
+                    cursor = result.data["runsOrError"]["cursor"]
+            found_run_ids.reverse()
+            assert found_run_ids == run_ids, (found_run_ids, run_ids)
 
 
 def test_filtered_runs():


### PR DESCRIPTION
## Summary & Motivation
Hi,

I really like the dagster project and thought I would spend some time this morning looking through the Issues list.
I saw Issue #31024, which as far as I can tell does raise a good point that the runs query isn't able to be paginated.

I'm mainly looking to help out, and I had a bit of fun digging through the code and hacking away a bit I think I have a solution, however, I'm not sure about the result cacheing, I haven't used the Graphene library before, so I would appreciate a look.

This issue might not be a real issue as there is the `runsFeedOrError` query.
## How I Tested These Changes
- **Happy Path Test** Run ten jobs in sequence, query them in batches of two, assert the runs are returned in order.
- **No run data, cache test** test the case where the query doesn't fetch run data, but there is a cursor requested. 
## Changelog
- Add cursor to the response type of `RunsOrError`
- Implement run_id cursor based pagination.

> Insert changelog entry or delete this section.
