### PR TITLE
[docs] ETL Tutorial tests

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/etl_tutorial_tests/test_pipeline.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/etl_tutorial_tests/test_pipeline.py
@@ -1,77 +1,47 @@
+import pytest
+from dagster_duckdb import DuckDBResource
+
 import dagster as dg
 import docs_snippets.guides.tutorials.etl_tutorial.src.etl_tutorial.defs
+from docs_snippets.guides.tutorials.etl_tutorial.src.etl_tutorial.defs import assets
 
 
-# TODO: Enable when project structure is finalized
-# def test_defs():
-#     defs = dg.load_defs(
-#         docs_snippets.guides.tutorials.etl_tutorial.src.etl_tutorial.defs
-#     )
-#     assert defs.success
+@pytest.fixture()
+def defs():
+    return dg.Definitions.merge(
+        dg.components.load_defs(
+            docs_snippets.guides.tutorials.etl_tutorial.src.etl_tutorial.defs
+        )
+    )
 
 
-# @pytest.fixture()
-# def duckdb_resource():
-#     return DuckDBResource(
-#         database="docs_snippets/guides/tutorials/etl_tutorial/data/mydb.duckdb"
-#     )
+@pytest.fixture()
+def duckdb_resource():
+    return DuckDBResource(database="/tmp/jaffle_platform.duckdb")
 
 
-# def test_etl_assets_monthly_partition(duckdb_resource):
-#     result = dg.materialize(
-#         assets=[
-#             assets.products,
-#             assets.sales_reps,
-#             assets.sales_data,
-#             assets.joined_data,
-#             assets.monthly_sales_performance,
-#         ],
-#         resources={
-#             "duckdb": duckdb_resource,
-#         },
-#         partition_key="2024-01-01",
-#     )
-#     assert result.success
+def test_defs(defs):
+    assert defs
+    assert len(defs.assets) == 7
+    assert len(defs.asset_checks) == 1
+    assert defs.resources["duckdb"] is not None
+    assert len(defs.sensors) == 1
 
 
-# def test_etl_assets_static_partition(duckdb_resource):
-#     result = dg.materialize(
-#         assets=[
-#             assets.products,
-#             assets.sales_reps,
-#             assets.sales_data,
-#             assets.joined_data,
-#             assets.product_performance,
-#         ],
-#         resources={
-#             "duckdb": duckdb_resource,
-#         },
-#         partition_key="Books",
-#     )
-#     assert result.success
-
-
-# def test_etl_assets_ad_hoc(duckdb_resource):
-#     result = dg.materialize(
-#         assets=[
-#             assets.products,
-#             assets.sales_reps,
-#             assets.sales_data,
-#             assets.joined_data,
-#             assets.adhoc_request,
-#         ],
-#         resources={
-#             "duckdb": duckdb_resource,
-#         },
-#         run_config=dg.RunConfig(
-#             {
-#                 "adhoc_request": assets.AdhocRequestConfig(
-#                     department="South",
-#                     product="Driftwood Denim Jacket",
-#                     start_date="2024-01-01",
-#                     end_date="2024-06-05",
-#                 ),
-#             }
-#         ),
-#     )
-#     assert result.success
+def test_materialize_partition(defs, duckdb_resource):
+    result = dg.materialize(
+        assets=[
+            defs.get_assets_def(dg.AssetKey(["target", "main", "raw_customers"])),
+            defs.get_assets_def(dg.AssetKey(["target", "main", "raw_orders"])),
+            defs.get_assets_def(dg.AssetKey(["target", "main", "raw_payments"])),
+            defs.get_assets_def(dg.AssetKey(["target", "main", "stg_customers"])),
+            defs.get_assets_def(dg.AssetKey(["target", "main", "stg_orders"])),
+            defs.get_assets_def(dg.AssetKey(["target", "main", "stg_payments"])),
+            defs.get_assets_def("monthly_orders"),
+        ],
+        resources={
+            "duckdb": duckdb_resource,
+        },
+        partition_key="2024-01-01",
+    )
+    assert result.success

--- a/examples/docs_snippets/setup.py
+++ b/examples/docs_snippets/setup.py
@@ -41,6 +41,7 @@ setup(
             "xgboost",
             "apache-airflow<3.0.0",
             "pytest-httpserver",
+            "dagster-evidence",
         ],
     },
 )


### PR DESCRIPTION
## Summary & Motivation
Tests for the ETL Tutorial, focusing on:

* All objects in the Definitions can load properly
* E2E run of the partitioned asset job (leaving out execution of the Evidence asset for now due to `npm` dependencies)

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
