### PR TITLE
Add CategoryScale import from chart.js

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetValueGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetValueGraph.tsx
@@ -1,6 +1,7 @@
 import {Colors} from '@dagster-io/ui-components';
 import {
   ActiveElement,
+  CategoryScale,
   ChartEvent,
   Chart as ChartJS,
   ChartOptions,
@@ -18,7 +19,7 @@ import {TimeContext} from '../app/time/TimeContext';
 import {timestampToString} from '../app/time/timestampToString';
 import {useRGBColorsForTheme} from '../app/useRGBColorsForTheme';
 
-ChartJS.register(LinearScale, LineElement, PointElement, TimeScale);
+ChartJS.register(CategoryScale, LinearScale, LineElement, PointElement, TimeScale);
 
 export interface AssetValueGraphData {
   minY: number;


### PR DESCRIPTION
## Summary & Motivation

Addresses this issue: https://github.com/dagster-io/dagster/issues/31017

This is the only chart.js I could find that doesn't register the CategoryScale so I'm assuming this is where the issue is coming from but it's hard to tell since the report has a minified stack trace.
