### PR TITLE
[CORE-280] Fix rendering of automation conditions without explicit labels

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -163,7 +163,7 @@ export const SidebarAssetInfo = ({graphNode}: {graphNode: GraphNode}) => {
                 automationData={liveAutomationData}
               >
                 <EvaluationUserLabel
-                  userLabel={liveAutomationData.automationCondition!.label!}
+                  userLabel={liveAutomationData.automationCondition!.label! || 'condition'}
                   expandedLabel={liveAutomationData.automationCondition!.expandedLabel}
                 />
               </AutomationConditionEvaluationLink>


### PR DESCRIPTION
## Summary & Motivation

As title. Previously, if you used a condition with no explicit label, it wouldn't show up in the sidebar.

## How I Tested These Changes

![Screenshot 2025-07-07 at 2 19 40 PM](https://github.com/user-attachments/assets/e138b201-db0c-4cc3-9c01-19e5f6d29e34)


## Changelog

NOCHANGELOG
