### PR TITLE
[ui] wrong `dg scaffold  ...` command in the docs

### DIFF
--- a/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentScaffolding.tsx
+++ b/js_modules/dagster-ui/packages/dg-docs-components/src/ComponentScaffolding.tsx
@@ -2,7 +2,7 @@ import CopyButton from './CopyButton';
 import styles from './css/ComponentScaffolding.module.css';
 
 export default function ComponentScaffolding({componentName}: {componentName: string}) {
-  const command = `dg scaffold ${componentName} {component_name}`;
+  const command = `dg scaffold defs ${componentName} {component_name}`;
   return (
     <div className={styles.container}>
       <div>


### PR DESCRIPTION
This should be `dg scaffold defs Component {component_name}` instead of `dg scaffold Component {component_name}`

## Summary & Motivation
![firefox_bCHG41syr1](https://github.com/user-attachments/assets/5989fc7c-ef32-4897-b7b8-a26fcdfb12bb)

## How I Tested These Changes
/