### PR TITLE
[Observe] Disable materializing all assets in catalog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -344,12 +344,6 @@ const Table = React.memo(
   }: TableProps) => {
     const scope = useMemo(() => {
       const list = (assets ?? []).filter((a): a is AssetWithDefinition => !!a.definition);
-      if (checkedDisplayKeys.size === 0 || !assets) {
-        return {
-          all: list.map((a) => ({...a.definition, assetKey: a.key})),
-        };
-      }
-
       const selected = list.filter((a) => checkedDisplayKeys.has(JSON.stringify(a.key.path)));
       return {
         selected: selected.map((a) => ({...a.definition, assetKey: a.key})),


### PR DESCRIPTION
## Summary & Motivation

Similar to current catalog -- disable materializing all assets

<img width="1470" alt="Screenshot 2025-07-08 at 10 57 39 AM" src="https://github.com/user-attachments/assets/3195baf3-e2bd-4351-b305-348fe277fd32" />
<img width="1478" alt="Screenshot 2025-07-08 at 10 57 33 AM" src="https://github.com/user-attachments/assets/40624790-8d52-43ec-86cc-9e99e9d5a14e" />
<img width="1728" alt="Screenshot 2025-07-08 at 10 57 04 AM" src="https://github.com/user-attachments/assets/2984601c-79b2-4a4e-8d9c-5bce9a8f4af5" />
