### PR TITLE
[da] Fix bug with serialization of user-defined conditions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -37,6 +37,10 @@ class EntityMatchesCondition(
     def name(self) -> str:
         return self.key.to_user_string()
 
+    @property
+    def children(self) -> Sequence[AutomationCondition]:
+        return [self.operand]
+
     async def evaluate(  # pyright: ignore[reportIncompatibleMethodOverride]
         self, context: AutomationContext[T_EntityKey]
     ) -> AutomationResult[T_EntityKey]:
@@ -110,6 +114,10 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         if props:
             name += f"({','.join(props)})"
         return name
+
+    @property
+    def children(self) -> Sequence[AutomationCondition]:
+        return [self.operand]
 
     @property
     def requires_cursor(self) -> bool:

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/user_defined/test_user_defined_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/user_defined/test_user_defined_automation_condition.py
@@ -2,6 +2,7 @@ import logging
 
 import dagster as dg
 from dagster import AutomationContext, DagsterInstance
+from dagster._core.remote_representation.external_data import asset_node_snaps_from_repo
 
 
 def test_cursoring() -> None:
@@ -56,3 +57,20 @@ def test_logging(caplog) -> None:
     caplog.set_level(logging.DEBUG)
     dg.evaluate_automation_conditions(defs=[my_asset], instance=DagsterInstance.ephemeral())
     assert "DEBUG_THING" in caplog.text
+
+
+def test_any_deps_match() -> None:
+    class MyAutomationCondition(dg.AutomationCondition):
+        def evaluate(self, context: AutomationContext) -> dg.AutomationResult:
+            return dg.AutomationResult(context, true_subset=context.get_empty_subset())
+
+    @dg.asset(automation_condition=dg.AutomationCondition.any_deps_match(MyAutomationCondition()))
+    def my_asset() -> None: ...
+
+    defs = dg.Definitions(assets=[my_asset])
+
+    snaps = asset_node_snaps_from_repo(defs.get_repository_def())
+    assert len(snaps) == 1
+
+    serialized = dg.serialize_value(snaps)
+    assert len(dg.deserialize_value(serialized)) == 1  # type: ignore


### PR DESCRIPTION
## Summary & Motivation

Fixes an issue when attempting to serialize snapshot data as shown in the provided test case.

The core issue is that the `is_serializable` property was not properly recursing over the children of the referenced dep conditions.

## How I Tested These Changes

unit

## Changelog

Fixed a bug that could cause code locations to fail to load when a custom python AutomationCondition was used as the operand of `AutomationCondition.any_deps_match()` or `AutomationCondition.all_deps_match()`
