### PR TITLE
Use a generic return type in AutomationCondition.replace()

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -2,7 +2,7 @@ import datetime
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence, Set
 from functools import cached_property
-from typing import TYPE_CHECKING, Generic, Optional, Union
+from typing import TYPE_CHECKING, Generic, Optional, TypeVar, Union
 
 from dagster_shared.serdes.serdes import is_whitelisted_for_serdes_object
 from typing_extensions import Self
@@ -295,10 +295,12 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
                 ).with_label("handled")
             )
 
+    T_ReplaceNew = TypeVar("T_ReplaceNew", bound="AutomationCondition")
+
     @public
     def replace(
-        self, old: Union["AutomationCondition", str], new: "AutomationCondition"
-    ) -> "AutomationCondition":
+        self, old: Union["AutomationCondition", str], new: T_ReplaceNew
+    ) -> Union[Self, T_ReplaceNew]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -54,6 +54,9 @@ if TYPE_CHECKING:
     )
 
 
+T_AutomationCondition = TypeVar("T_AutomationCondition", bound="AutomationCondition")
+
+
 class AutomationCondition(ABC, Generic[T_EntityKey]):
     """An AutomationCondition represents a condition of an asset that impacts whether it should be
     automatically executed. For example, you can have a condition which becomes true whenever the
@@ -295,12 +298,10 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
                 ).with_label("handled")
             )
 
-    T_ReplaceNew = TypeVar("T_ReplaceNew", bound="AutomationCondition")
-
     @public
     def replace(
-        self, old: Union["AutomationCondition", str], new: T_ReplaceNew
-    ) -> Union[Self, T_ReplaceNew]:
+        self, old: Union["AutomationCondition", str], new: T_AutomationCondition
+    ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -12,7 +12,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
     AutomationResult,
     BuiltinAutomationCondition,
-    T_ReplaceNew
+    T_AutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.declarative_automation.operators.utils import has_allow_ignore
@@ -77,8 +77,8 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
 
     @public
     def replace(
-        self, old: Union[AutomationCondition, str], new: T_ReplaceNew
-    ) -> Union[Self, T_ReplaceNew]:
+        self, old: Union[AutomationCondition, str], new: T_AutomationCondition
+    ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -184,8 +184,8 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
 
     @public
     def replace(
-        self, old: Union[AutomationCondition, str], new: T_ReplaceNew
-    ) -> Union[Self, T_ReplaceNew]:
+        self, old: Union[AutomationCondition, str], new: T_AutomationCondition
+    ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -279,8 +279,8 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
 
     @public
     def replace(
-        self, old: Union[AutomationCondition, str], new: T_ReplaceNew
-    ) -> Union[Self, T_ReplaceNew]:
+        self, old: Union[AutomationCondition, str], new: T_AutomationCondition
+    ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Union
 
 from dagster_shared.serdes import whitelist_for_serdes
+from typing_extensions import Self
 
 import dagster._check as check
 from dagster._annotations import public
@@ -11,6 +12,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
     AutomationResult,
     BuiltinAutomationCondition,
+    T_ReplaceNew
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.declarative_automation.operators.utils import has_allow_ignore
@@ -75,8 +77,8 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
 
     @public
     def replace(
-        self, old: Union[AutomationCondition, str], new: AutomationCondition
-    ) -> AutomationCondition:
+        self, old: Union[AutomationCondition, str], new: T_ReplaceNew
+    ) -> Union[Self, T_ReplaceNew]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -182,8 +184,8 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
 
     @public
     def replace(
-        self, old: Union[AutomationCondition, str], new: AutomationCondition
-    ) -> AutomationCondition:
+        self, old: Union[AutomationCondition, str], new: T_ReplaceNew
+    ) -> Union[Self, T_ReplaceNew]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -277,8 +279,8 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
 
     @public
     def replace(
-        self, old: Union[AutomationCondition, str], new: AutomationCondition
-    ) -> AutomationCondition:
+        self, old: Union[AutomationCondition, str], new: T_ReplaceNew
+    ) -> Union[Self, T_ReplaceNew]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -14,7 +14,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
     AutomationResult,
     BuiltinAutomationCondition,
-    T_ReplaceNew
+    T_AutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.declarative_automation.serialized_objects import OperatorType
@@ -68,8 +68,8 @@ class EntityMatchesCondition(
 
     @public
     def replace(
-        self, old: Union[AutomationCondition, str], new: T_ReplaceNew
-    ) -> Union[Self, T_ReplaceNew]:
+        self, old: Union[AutomationCondition, str], new: T_AutomationCondition
+    ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -164,8 +164,8 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
 
     @public
     def replace(
-        self, old: Union[AutomationCondition, str], new: T_ReplaceNew
-    ) -> Union[Self, T_ReplaceNew]:
+        self, old: Union[AutomationCondition, str], new: T_AutomationCondition
+    ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, AbstractSet, Any, Generic, Optional, Union  # noqa: UP035
 
 from dagster_shared.serdes import whitelist_for_serdes
+from typing_extensions import Self
 
 import dagster._check as check
 from dagster._annotations import public
@@ -13,6 +14,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
     AutomationResult,
     BuiltinAutomationCondition,
+    T_ReplaceNew
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.declarative_automation.serialized_objects import OperatorType
@@ -66,8 +68,8 @@ class EntityMatchesCondition(
 
     @public
     def replace(
-        self, old: Union[AutomationCondition, str], new: AutomationCondition
-    ) -> AutomationCondition:
+        self, old: Union[AutomationCondition, str], new: T_ReplaceNew
+    ) -> Union[Self, T_ReplaceNew]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching
@@ -162,8 +164,8 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
 
     @public
     def replace(
-        self, old: Union[AutomationCondition, str], new: AutomationCondition
-    ) -> AutomationCondition:
+        self, old: Union[AutomationCondition, str], new: T_ReplaceNew
+    ) -> Union[Self, T_ReplaceNew]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
     AutomationResult,
     BuiltinAutomationCondition,
-    T_ReplaceNew
+    T_AutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.declarative_automation.operators.utils import has_allow_ignore
@@ -139,8 +139,8 @@ class SinceCondition(BuiltinAutomationCondition[T_EntityKey]):
         )
 
     def replace(
-        self, old: Union[AutomationCondition, str], new: T_ReplaceNew
-    ) -> Union[Self, T_ReplaceNew]:
+        self, old: Union[AutomationCondition, str], new: T_AutomationCondition
+    ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 from dagster_shared.record import replace
 from dagster_shared.serdes import whitelist_for_serdes
+from typing_extensions import Self
 
 import dagster._check as check
 from dagster._annotations import public
@@ -12,6 +13,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
     AutomationResult,
     BuiltinAutomationCondition,
+    T_ReplaceNew
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.declarative_automation.operators.utils import has_allow_ignore
@@ -137,8 +139,8 @@ class SinceCondition(BuiltinAutomationCondition[T_EntityKey]):
         )
 
     def replace(
-        self, old: Union[AutomationCondition, str], new: AutomationCondition
-    ) -> AutomationCondition:
+        self, old: Union[AutomationCondition, str], new: T_ReplaceNew
+    ) -> Union[Self, T_ReplaceNew]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
         If ``old`` is a string, then conditions with a label matching

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
@@ -220,6 +220,15 @@ def test_replace_automation_condition_since() -> None:
     )
 
 
+def test_replace_automation_condition_with_label() -> None:
+    a = (
+        AutomationCondition.eager()
+        .replace("newly_updated", AutomationCondition.data_version_changed())
+        .with_label("eager_respecting_data_version")
+    )
+    assert a.get_label() == "eager_respecting_data_version"
+
+
 @pytest.mark.parametrize("method", ["allow", "ignore"])
 def test_filter_automation_condition(method: str) -> None:
     a = AutomationCondition.in_latest_time_window()


### PR DESCRIPTION
## Summary & Motivation

This introduces a generic TypeVar to represent the "new" Automation condition in `AutomationCondition.replace()`, and uses that TypeVar in the return type as well to give the caller more information about what class of `AutomationCondition` might be returned. 

This solves the problem where:

```python
dg.AutomationCondition.eager().replace(
    "newly_updated", dg.AutomationCondition.data_version_changed()
).with_label("eager_respecting_data_version")
```

fails typechecking. This happens today because `replace` always returns `AutomationCondition`, and hence we don't know that `with_label` will exist on it (that only exists on `BuiltinAutomationCondition`).

But we should be able to know that `with_label` exists; `replace` always returns either `Self` or the type of `new`, both of which are indeed `BuiltinAutomationCondition`.

## How I Tested These Changes

Added a unit test. The test fails `make pyright` before this change, and passes it after this change.

## Changelog

Updates AutomationCondition.replace type signature to provide callers more information about the returned AutomationCondition.
