### PR TITLE
[dagster-dbt] Support multiple emails for a dbt owner

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -579,12 +579,14 @@ def default_owners_from_dbt_resource_props(
     if owners_config:
         return owners_config
 
-    owner: Optional[str] = (dbt_resource_props.get("group") or {}).get("owner", {}).get("email")
+    owner: Optional[Union[str, Sequence[str]]] = (
+        (dbt_resource_props.get("group") or {}).get("owner", {}).get("email")
+    )
 
     if not owner:
         return None
 
-    return [owner]
+    return [owner] if isinstance(owner, str) else owner
 
 
 def default_freshness_policy_fn(


### PR DESCRIPTION
## Summary & Motivation

dbt syntax supports multiple emails in the "owner" field, so we should too: https://docs.getdbt.com/docs/deploy/model-notifications#configure-groups

## How I Tested These Changes

## Changelog

[dagster-dbt] The `@dbt_assets` decorator and associated APIs no longer error when parsing dbt projects that contain an owner with multiple emails.
