### PR TITLE
Update `useAssetGraphData` loading state

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -19,6 +19,8 @@ import {weakMapMemoize} from '../util/weakMapMemoize';
 const BATCH_SIZE = 250;
 const PARALLEL_FETCHES = 4;
 
+const EMPTY_ARRAY: any[] = [];
+
 function init() {
   return liveDataFactory(
     () => {
@@ -102,7 +104,7 @@ export function useAssetsHealthData({
   skip?: boolean;
   loading?: boolean;
 }) {
-  const keys = memoizedAssetKeys(observeEnabled() ? assetKeys : []);
+  const keys = memoizedAssetKeys(observeEnabled() ? assetKeys : EMPTY_ARRAY);
   const result = AssetHealthData.useLiveData(keys, thread, skip);
   useBlockTraceUntilTrue(
     'useAssetsHealthData',

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -124,8 +124,6 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
 
   const {kinds, hideEdgesToNodesOutsideQuery} = options;
 
-  const [graphDataLoading, setGraphDataLoading] = useState(true);
-
   const {loading: supplementaryDataLoading, data: supplementaryData} =
     useAssetGraphSupplementaryData(opsQuery, allNodes);
 
@@ -138,8 +136,6 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
       setState({allAssetKeys: [], graphAssetKeys: [], assetGraphData: null});
       return;
     }
-
-    setGraphDataLoading(true);
 
     const data = computeGraphData({
       repoFilteredNodes,
@@ -164,8 +160,7 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
   ]);
 
   const loading =
-    !options.skip &&
-    (assetsLoading || graphDataLoading || !!supplementaryDataLoading || !!options.loading);
+    !options.skip && (assetsLoading || !!supplementaryDataLoading || !!options.loading);
   useBlockTraceUntilTrue('useAssetGraphData', !loading);
   return {
     loading,


### PR DESCRIPTION
## Summary & Motivation

We removed the worker for `useAssetGraphData` so the `graphDataLoading` state is no longer needed since it is synchronously calculated now.