### PR TITLE
minimal asset materialization health class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
@@ -91,7 +91,7 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
     failed_subset: SerializableEntitySubset[AssetKey]
     partitions_snap: Optional[PartitionsSnap]
     latest_terminal_run_id: Optional[str]
-    latest_materialization_timestamp: Optional[float]
+    latest_materialization_timestamp: Optional[float] = None
 
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:


### PR DESCRIPTION
## Summary & Motivation
Adds a smaller class that we can use to derive the materialization health state for an asset. This class just stores the number of failed partitions and currently materialized partitions for each asset (this treats non-partitioned assets as if they are a partitioned asset of 1 partition). We can compute the health status for an asset from this information, which allows us to bypass deserializing potentially large EntitySubsets 

Also adds a `last_materialization_timestamp` attr to `AssetMaterializationHealth` and the smaller class. 


