### PR TITLE
[asset health] update health calculations to use minimal health state

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
@@ -75,7 +75,7 @@ class MinimalAssetMaterializationHealthState(LoadableBy[AssetKey]):
         cls, keys: Iterable[AssetKey], context: LoadingContext
     ) -> Iterable[Optional["MinimalAssetMaterializationHealthState"]]:
         asset_materialization_health_states = (
-            context.instance.get_asset_materialization_health_state_for_assets(list(keys))
+            context.instance.get_minimal_asset_materialization_health_state_for_assets(list(keys))
         )
 
         if asset_materialization_health_states is None:
@@ -131,6 +131,19 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
             return AssetHealthStatus.DEGRADED
         else:
             return AssetHealthStatus.HEALTHY
+
+    @classmethod
+    def _blocking_batch_load(
+        cls, keys: Iterable[AssetKey], context: LoadingContext
+    ) -> Iterable[Optional["AssetMaterializationHealthState"]]:
+        asset_materialization_health_states = (
+            context.instance.get_asset_materialization_health_state_for_assets(list(keys))
+        )
+
+        if asset_materialization_health_states is None:
+            return [None for _ in keys]
+        else:
+            return [asset_materialization_health_states.get(key) for key in keys]
 
     @classmethod
     async def compute_for_asset(

--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
@@ -64,6 +64,12 @@ class MinimalAssetMaterializationHealthState(LoadableBy[AssetKey]):
             partitions_snap=asset_materialization_health_state.partitions_snap,
         )
 
+    @property
+    def partitions_def(self) -> Optional[PartitionsDefinition]:
+        if self.partitions_snap is None:
+            return None
+        return self.partitions_snap.get_partitions_definition()
+
     @classmethod
     def _blocking_batch_load(
         cls, keys: Iterable[AssetKey], context: LoadingContext

--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 @whitelist_for_serdes
 @record.record
-class MinimalAssetMaterializationHealthState:
+class MinimalAssetMaterializationHealthState(LoadableBy[AssetKey]):
     """Minimal object for computing the health status for the materialization state of an asset.
     This object is intended to be small and quick to deserialize. Deserializing AssetMaterializationHealthState
     can be slow if there is a large entity subset. Rather than storing entity subsets, we store the number
@@ -63,6 +63,19 @@ class MinimalAssetMaterializationHealthState:
             num_currently_materialized_partitions=asset_materialization_health_state.currently_materialized_subset.size,
             partitions_snap=asset_materialization_health_state.partitions_snap,
         )
+
+    @classmethod
+    def _blocking_batch_load(
+        cls, keys: Iterable[AssetKey], context: LoadingContext
+    ) -> Iterable[Optional["MinimalAssetMaterializationHealthState"]]:
+        asset_materialization_health_states = (
+            context.instance.get_asset_materialization_health_state_for_assets(list(keys))
+        )
+
+        if asset_materialization_health_states is None:
+            return [None for _ in keys]
+        else:
+            return [asset_materialization_health_states.get(key) for key in keys]
 
 
 @whitelist_for_serdes
@@ -211,19 +224,6 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
             latest_materialization_timestamp=latest_materialization_timestamp,
         )
 
-    @classmethod
-    def _blocking_batch_load(
-        cls, keys: Iterable[AssetKey], context: LoadingContext
-    ) -> Iterable[Optional["AssetMaterializationHealthState"]]:
-        asset_materialization_health_states = (
-            context.instance.get_asset_materialization_health_state_for_assets(list(keys))
-        )
-
-        if asset_materialization_health_states is None:
-            return [None for _ in keys]
-        else:
-            return [asset_materialization_health_states.get(key) for key in keys]
-
 
 async def _get_is_currently_failed_and_latest_terminal_run_id(
     loading_context: LoadingContext, asset_record: AssetRecord
@@ -320,7 +320,7 @@ async def get_materialization_status_and_metadata(
     needed to power the UIs. Metadata is fetched from the AssetLatestMaterializationState object, again
     either via streamline or by computing it based on the state of the DB.
     """
-    asset_materialization_health_state = await AssetMaterializationHealthState.gen(
+    asset_materialization_health_state = await MinimalAssetMaterializationHealthState.gen(
         context, asset_key
     )
     # captures streamline disabled or consumer state doesn't exist
@@ -358,11 +358,14 @@ async def get_materialization_status_and_metadata(
                 return AssetHealthStatus.HEALTHY, None
             return AssetHealthStatus.UNKNOWN, None
 
+        big_materialization_health_state = await AssetMaterializationHealthState.compute_for_asset(
+            asset_key,
+            node_snap.partitions_def,
+            context,
+        )
         asset_materialization_health_state = (
-            await AssetMaterializationHealthState.compute_for_asset(
-                asset_key,
-                node_snap.partitions_def,
-                context,
+            MinimalAssetMaterializationHealthState.from_asset_materialization_health_state(
+                big_materialization_health_state
             )
         )
 
@@ -374,11 +377,11 @@ async def get_materialization_status_and_metadata(
                 total_num_partitions = (
                     asset_materialization_health_state.partitions_def.get_num_partitions()
                 )
-            # asset is health, so no partitions are failed
-            num_materialized = len(
-                asset_materialization_health_state.materialized_subset.subset_value
+            # asset is healthy, so no partitions are failed
+            num_missing = (
+                total_num_partitions
+                - asset_materialization_health_state.num_currently_materialized_partitions
             )
-            num_missing = total_num_partitions - num_materialized
         if num_missing > 0 and total_num_partitions > 0:
             meta = AssetHealthMaterializationHealthyPartitionedMeta(
                 num_missing_partitions=num_missing,
@@ -394,13 +397,13 @@ async def get_materialization_status_and_metadata(
                 total_num_partitions = (
                     asset_materialization_health_state.partitions_def.get_num_partitions()
                 )
-            num_failed = len(asset_materialization_health_state.failed_subset.subset_value)
-            num_materialized = len(
-                asset_materialization_health_state.currently_materialized_subset.subset_value
+            num_missing = (
+                total_num_partitions
+                - asset_materialization_health_state.num_currently_materialized_partitions
+                - asset_materialization_health_state.num_failed_partitions
             )
-            num_missing = total_num_partitions - num_materialized - num_failed
             meta = AssetHealthMaterializationDegradedPartitionedMeta(
-                num_failed_partitions=num_failed,
+                num_failed_partitions=asset_materialization_health_state.num_failed_partitions,
                 num_missing_partitions=num_missing,
                 total_num_partitions=total_num_partitions,
             )

--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
@@ -64,12 +64,6 @@ class MinimalAssetMaterializationHealthState(LoadableBy[AssetKey]):
             partitions_snap=asset_materialization_health_state.partitions_snap,
         )
 
-    @property
-    def partitions_def(self) -> Optional[PartitionsDefinition]:
-        if self.partitions_snap is None:
-            return None
-        return self.partitions_snap.get_partitions_definition()
-
     @classmethod
     def _blocking_batch_load(
         cls, keys: Iterable[AssetKey], context: LoadingContext
@@ -131,19 +125,6 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
             return AssetHealthStatus.DEGRADED
         else:
             return AssetHealthStatus.HEALTHY
-
-    @classmethod
-    def _blocking_batch_load(
-        cls, keys: Iterable[AssetKey], context: LoadingContext
-    ) -> Iterable[Optional["AssetMaterializationHealthState"]]:
-        asset_materialization_health_states = (
-            context.instance.get_asset_materialization_health_state_for_assets(list(keys))
-        )
-
-        if asset_materialization_health_states is None:
-            return [None for _ in keys]
-        else:
-            return [asset_materialization_health_states.get(key) for key in keys]
 
     @classmethod
     async def compute_for_asset(
@@ -242,6 +223,19 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
             latest_terminal_run_id=latest_terminal_run_id,
             latest_materialization_timestamp=latest_materialization_timestamp,
         )
+
+    @classmethod
+    def _blocking_batch_load(
+        cls, keys: Iterable[AssetKey], context: LoadingContext
+    ) -> Iterable[Optional["AssetMaterializationHealthState"]]:
+        asset_materialization_health_states = (
+            context.instance.get_asset_materialization_health_state_for_assets(list(keys))
+        )
+
+        if asset_materialization_health_states is None:
+            return [None for _ in keys]
+        else:
+            return [asset_materialization_health_states.get(key) for key in keys]
 
 
 async def _get_is_currently_failed_and_latest_terminal_run_id(

--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -118,6 +118,7 @@ if TYPE_CHECKING:
     )
     from dagster._core.definitions.asset_health.asset_materialization_health import (
         AssetMaterializationHealthState,
+        MinimalAssetMaterializationHealthState,
     )
     from dagster._core.definitions.asset_key import EntityKey
     from dagster._core.definitions.assets.graph.base_asset_graph import (
@@ -3589,4 +3590,9 @@ class DagsterInstance(DynamicPartitionsStore):
     def get_asset_materialization_health_state_for_assets(
         self, asset_keys: Sequence[AssetKey]
     ) -> Optional[Mapping[AssetKey, Optional["AssetMaterializationHealthState"]]]:
+        return None
+
+    def get_minimal_asset_materialization_health_state_for_assets(
+        self, asset_keys: Sequence[AssetKey]
+    ) -> Optional[Mapping[AssetKey, Optional["MinimalAssetMaterializationHealthState"]]]:
         return None


### PR DESCRIPTION
## Summary & Motivation
Updates the asset materialization health computation function to use the minimal asset materialization health class introduced in the previous pr 

## How I Tested These Changes
existing test suite in https://github.com/dagster-io/internal/pull/16833 should cover this
