### PR TITLE
Resolve ForwardRef issue on 3.12.(<4)

### DIFF
--- a/python_modules/libraries/dagster-shared/dagster_shared/check/builder.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/check/builder.py
@@ -125,13 +125,13 @@ class EvalContext(NamedTuple):
                     globalns=self.get_merged_ns(),
                     localns={},
                 )
-            elif sys.version_info <= (3, 12):
+            elif sys.version_info < (3, 12, 4):
                 return ref._evaluate(  # noqa
                     globalns=self.get_merged_ns(),
                     localns={},
                     recursive_guard=frozenset(),
                 )
-            else:  # Python 3.13+
+            else:  # type_params added in 3.12.4
                 return ref._evaluate(  # noqa
                     globalns=self.get_merged_ns(),
                     localns={},


### PR DESCRIPTION
## Summary & Motivation

I ran into issues when my venv python version was 3.12.1 the other day. Digging in, it looks like the `type_params` parameter to `ForwardRef._evaluate` was only added in 3.12.4, but after #28960 we're using it in 3.12.(<4)

(@alangenfeld ran into something similar in #22986, it looks like).

This moves the non-`type_params` branch to `< (3, 12, 4)`, and keeps the `type_params` branch in the else.

## How I Tested These Changes

Make a venv for 3.12.1, build, and run:

```sh
uv venv --python 3.12.1
source .venv/bin/activate
make dev_install
dagster --version
```

Before, the following error would occur:

```
TypeError: ForwardRef._evaluate() got an unexpected keyword argument 'type_params'
```

After, you correctly see "dagster, version 1!0+dev"