### PR TITLE
[dagster-tableau] Fix refreshable data source IDs in refresh_and_poll

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -641,7 +641,8 @@ class BaseTableauWorkspace(ConfigurableResource):
         refreshable_data_source_ids = [
             check.not_none(TableauDataSourceMetadataSet.extract(spec.metadata).id)
             for spec in specs
-            if TableauDataSourceMetadataSet.extract(spec.metadata).has_extracts
+            if check.inst(TableauTagSet.extract(spec.tags).asset_type, str) == "data_source"
+            and TableauDataSourceMetadataSet.extract(spec.metadata).has_extracts
         ]
 
         with self.get_client() as client:


### PR DESCRIPTION
## Summary & Motivation

Tableau spec must be of type data_source to be selected for refreshable data source IDs. 

Introducing new metadata keys in https://github.com/dagster-io/dagster/pull/31120 unveiled the issue - we were using `TableauDataSourceMetadataSet.extract(spec.metadata).has_extracts` to select, which was only selecting data sources with extracts, but adding the new metadata keys unveiled that we were not iterating on data sources, but all specs, so we must confirm that the spec is of type data_source before proceeding.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
