### PR TITLE
Make dagster-dg-cli depend directly on dagster

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/tutorials/etl_tutorial/pyproject.toml
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/etl_tutorial/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "dagster-webserver",
-    "dagster-dg-cli[local]",
+    "dagster-dg-cli",
 ]
 
 [build-system]
@@ -32,5 +32,3 @@ root_module = "etl_tutorial"
 registry_modules = [
     "etl_tutorial.components.*",
 ]
-
-

--- a/python_modules/libraries/create-dagster/create_dagster/scaffold.py
+++ b/python_modules/libraries/create-dagster/create_dagster/scaffold.py
@@ -194,7 +194,7 @@ EDITABLE_DAGSTER_DEV_DEPENDENCIES = [
 
 PYPI_DAGSTER_DEV_DEPENDENCIES = [
     "dagster-webserver",
-    "dagster-dg-cli[local]",
+    "dagster-dg-cli",
 ]
 
 

--- a/python_modules/libraries/create-dagster/create_dagster_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/create-dagster/create_dagster_tests/test_scaffold_commands.py
@@ -369,7 +369,7 @@ def validate_published_pyproject_toml(
     ) == {
         "dev": [
             "dagster-webserver",
-            "dagster-dg-cli[local]",
+            "dagster-dg-cli",
         ]
     }
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/check.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/check.py
@@ -6,13 +6,7 @@ import click
 from dagster_dg_core.config import normalize_cli_config
 from dagster_dg_core.context import DgContext
 from dagster_dg_core.shared_options import dg_global_options, dg_path_options
-from dagster_dg_core.utils import (
-    DgClickCommand,
-    DgClickGroup,
-    exit_with_error,
-    pushd,
-    validate_dagster_availability,
-)
+from dagster_dg_core.utils import DgClickCommand, DgClickGroup, exit_with_error, pushd
 from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
 
 from dagster_dg_cli.cli.utils import create_temp_workspace_file
@@ -134,8 +128,6 @@ def check_definitions_command(
 
     cli_config = normalize_cli_config(global_options, context)
     dg_context = DgContext.for_workspace_or_project_environment(target_path, cli_config)
-
-    validate_dagster_availability()
 
     if check_yaml is True and not dg_context.is_project:
         exit_with_error("--check-yaml is not currently supported in a workspace context")

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/dev.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/dev.py
@@ -8,12 +8,7 @@ import click
 from dagster_dg_core.config import normalize_cli_config
 from dagster_dg_core.context import DgContext
 from dagster_dg_core.shared_options import dg_global_options, dg_path_options
-from dagster_dg_core.utils import (
-    DgClickCommand,
-    exit_with_error,
-    pushd,
-    validate_dagster_availability,
-)
+from dagster_dg_core.utils import DgClickCommand, exit_with_error, pushd
 from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
 from dagster_shared.cli import WorkspaceOpts, dg_workspace_options
 
@@ -95,7 +90,6 @@ def dev_command(
     """
     from dagster_dg_core.check import check_yaml as check_yaml_fn
 
-    validate_dagster_availability()
     workspace_opts = WorkspaceOpts.extract_from_cli_options(other_options)
 
     # If we got CLI flags that specify a target jump right to dagster core

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/docs.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/docs.py
@@ -56,7 +56,7 @@ def serve_docs_command(
 ) -> None:
     """Serve the Dagster components docs, to be viewed in a browser."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_defined_registry_environment(target_path, cli_config)
+    dg_context = DgContext.from_file_discovery_and_command_line_config(target_path, cli_config)
     registry = EnvRegistry.from_dg_context(dg_context)
 
     component_key = None
@@ -123,7 +123,7 @@ def build_docs_command(
 ) -> None:
     """Build a static version of the Dagster components docs, to be served by a static file server."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_defined_registry_environment(target_path, cli_config)
+    dg_context = DgContext.from_file_discovery_and_command_line_config(target_path, cli_config)
     registry = EnvRegistry.from_dg_context(dg_context)
 
     with pushd(ACTIVE_DOCS_DIR):

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/launch.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/launch.py
@@ -7,7 +7,7 @@ import click
 from dagster_dg_core.config import normalize_cli_config
 from dagster_dg_core.context import DgContext
 from dagster_dg_core.shared_options import dg_global_options, dg_path_options
-from dagster_dg_core.utils import DgClickCommand, validate_dagster_availability
+from dagster_dg_core.utils import DgClickCommand
 from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
 from dagster_shared import check
 from dagster_shared.cli import PythonPointerOpts, python_pointer_options
@@ -63,7 +63,6 @@ def launch_command(
     # dev/OSS, and executes the selected assets in process using the "dagster asset materialize"
     # command.
 
-    validate_dagster_availability()
     pointer_opts = PythonPointerOpts.extract_from_cli_options(copy(other_options))
 
     if pointer_opts.specifies_target():

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/list.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/list.py
@@ -12,12 +12,7 @@ from dagster_dg_core.config import normalize_cli_config
 from dagster_dg_core.context import DgContext
 from dagster_dg_core.env import ProjectEnvVars, get_project_specified_env_vars
 from dagster_dg_core.shared_options import dg_global_options, dg_path_options
-from dagster_dg_core.utils import (
-    DgClickCommand,
-    DgClickGroup,
-    capture_stdout,
-    validate_dagster_availability,
-)
+from dagster_dg_core.utils import DgClickCommand, DgClickGroup, capture_stdout
 from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
 from dagster_shared.plus.config import DagsterPlusCliConfig
 from dagster_shared.serdes.objects.definition_metadata import (
@@ -112,7 +107,7 @@ def list_components_command(
 ) -> None:
     """List all available Dagster component types in the current Python environment."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_defined_registry_environment(target_path, cli_config)
+    dg_context = DgContext.from_file_discovery_and_command_line_config(target_path, cli_config)
     registry = EnvRegistry.from_dg_context(dg_context)
 
     # Get all components (objects that have the 'component' feature)
@@ -168,7 +163,7 @@ def list_registry_modules_command(
     from rich.console import Console
 
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_defined_registry_environment(target_path, cli_config)
+    dg_context = DgContext.from_file_discovery_and_command_line_config(target_path, cli_config)
     registry = EnvRegistry.from_dg_context(dg_context)
 
     if output_json:
@@ -401,8 +396,6 @@ def list_defs_command(
 
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_project_environment(target_path, cli_config)
-
-    validate_dagster_availability()
 
     from dagster.components.list import list_definitions
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold.py
@@ -33,7 +33,6 @@ from dagster_dg_core.utils import (
     not_none,
     parse_json_option,
     snakecase,
-    validate_dagster_availability,
 )
 from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
 from dagster_shared import check
@@ -109,7 +108,7 @@ class ScaffoldDefsGroup(DgClickGroup):
         if not has_config_on_cli_context(cli_context):
             cli_context.invoke(not_none(self.callback), **cli_context.params)
         config = get_config_from_cli_context(cli_context)
-        dg_context = DgContext.for_defined_registry_environment(Path.cwd(), config)
+        dg_context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), config)
 
         registry = EnvRegistry.from_dg_context(dg_context)
 
@@ -279,8 +278,6 @@ class ScaffoldDefsGroup(DgClickGroup):
         return check.not_none(super().get_command(ctx, selected_cmd))
 
     def _try_load_input_as_registry_object(self, input_str: str) -> Optional[EnvRegistryObjectSnap]:
-        validate_dagster_availability()
-
         from dagster.components.core.snapshot import get_package_entry_snap
 
         if not EnvRegistryKey.is_valid_typename(input_str):

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
@@ -155,7 +155,7 @@ def inspect_component_type_command(
 ) -> None:
     """Get detailed information on a registered Dagster component type."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_defined_registry_environment(target_path, cli_config)
+    dg_context = DgContext.from_file_discovery_and_command_line_config(target_path, cli_config)
     registry = EnvRegistry.from_dg_context(dg_context)
     component_key = EnvRegistryKey.from_typename(component_type)
     if not registry.has(component_key):

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/scaffold.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, Optional
 import click
 import dagster_shared.check as check
 from dagster_dg_core.context import DgContext
-from dagster_dg_core.utils import snakecase, validate_dagster_availability
+from dagster_dg_core.utils import snakecase
 from dagster_shared.scaffold import scaffold_subtree
 from dagster_shared.serdes.objects.package_entry import EnvRegistryKey
 from dagster_shared.seven import match_module_pattern
@@ -123,7 +123,6 @@ def scaffold_registry_object(
     dg_context: "DgContext",
     scaffold_format: ScaffoldFormatOptions,
 ) -> None:
-    validate_dagster_availability()
     from dagster.components.component_scaffolding import scaffold_object
 
     scaffold_object(

--- a/python_modules/libraries/dagster-dg-cli/setup.py
+++ b/python_modules/libraries/dagster-dg-cli/setup.py
@@ -36,6 +36,7 @@ setup(
     include_package_data=True,
     install_requires=[
         f"dagster-dg-core{pin}",
+        f"dagster{pin}",
     ],
     entry_points={
         "console_scripts": [
@@ -43,9 +44,6 @@ setup(
         ]
     },
     extras_require={
-        "local": [
-            f"dagster{pin}",
-        ],
         "mcp": [
             "mcp",
         ],

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/component.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/component.py
@@ -16,7 +16,6 @@ from dagster_shared.serdes.objects.package_entry import (
 )
 from packaging.version import Version
 
-from dagster_dg_core.utils import validate_dagster_availability
 from dagster_dg_core.utils.warnings import emit_warning
 
 if TYPE_CHECKING:
@@ -131,7 +130,6 @@ class EnvRegistry:
 
 def all_components_schema_from_dg_context(dg_context: "DgContext") -> Mapping[str, Any]:
     """Generate a schema for all components in the current environment."""
-    validate_dagster_availability()
     from dagster.components.list import list_all_components_schema
 
     return list_all_components_schema(entry_points=True, extra_modules=())
@@ -175,11 +173,9 @@ def _load_module_registry_objects(
 # can compute a EnvRegistryManifest from the list[EnvRegistryObjectSnap], but it
 # won't include any modules that register an entry point but don't expose any plugin objects.
 def _fetch_plugin_manifest(entry_points: bool, extra_modules: Sequence[str]) -> EnvRegistryManifest:
+    from dagster.components.list import list_plugins
     from rich.console import Console
     from rich.panel import Panel
-
-    validate_dagster_availability()
-    from dagster.components.list import list_plugins
 
     result = list_plugins(entry_points=entry_points, extra_modules=extra_modules)
 

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/context.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/context.py
@@ -42,7 +42,6 @@ from dagster_dg_core.utils import (
     has_toml_node,
     msg_with_potential_paths,
     set_toml_node,
-    validate_dagster_availability,
 )
 from dagster_dg_core.utils.warnings import emit_warning
 
@@ -177,23 +176,10 @@ class DgContext:
     ) -> Self:
         context = cls.from_file_discovery_and_command_line_config(path, command_line_config)
 
-        # Commands that operate on a component library need to be run (a) with dagster
-        # available; (b) in a component library context.
-        validate_dagster_availability()
+        # Commands that operate on a component library need to be run in a component library context.
 
         if not context.has_registry_module_entry_point and not context.is_project:
             exit_with_error(NOT_COMPONENT_LIBRARY_ERROR_MESSAGE)
-        return context
-
-    @classmethod
-    def for_defined_registry_environment(
-        cls, path: Path, command_line_config: DgRawCliConfig
-    ) -> Self:
-        context = cls.from_file_discovery_and_command_line_config(path, command_line_config)
-
-        # Commands that access the component registry need to be run with dagster
-        # available.
-        validate_dagster_availability()
         return context
 
     @classmethod

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/__init__.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/__init__.py
@@ -661,13 +661,6 @@ def _get_new_container_node(
     return [] if isinstance(representative_key, int) else {}
 
 
-def validate_dagster_availability() -> None:
-    try:
-        import dagster  # noqa
-    except ImportError:
-        raise Exception("dagster package must be installed to run this command.")
-
-
 @contextlib.contextmanager
 def capture_stdout() -> Iterator[TextIO]:
     """Capture stdout and return it as a string."""


### PR DESCRIPTION
Summary:
Right now dagster-dg-cli only brings in dagster if you use the local extra. This was I think intended to preserve option value for a more lightweight version of dg. But in practice it just makes it easy to accidentally install dg with invalid dependencies. For example if you do pip install -U dagster-dg-cli it won't realize that it also needs to upgrade dagster and will leave things in a broken state with confusing error messages.

This also means we don't need validate_dagster_availability anymore.

## How I Tested These Changes
BK
