### PR TITLE
don't always load every RemoteassetNode in every graphql asset query (instead, just fetch the keys)

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -1,6 +1,6 @@
 import datetime
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, AbstractSet, Optional, Union, cast  # noqa: UP035
 
 import dagster_shared.seven as seven
@@ -10,7 +10,6 @@ from dagster import (
     DagsterRun,
     _check as check,
 )
-from dagster._core.definitions.assets.graph.remote_asset_graph import RemoteAssetNode
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.partitions.definition import (
     MultiPartitionsDefinition,
@@ -119,17 +118,18 @@ def get_assets(
         materialized_keys = instance.get_asset_keys(
             prefix=prefix, limit=limit, cursor=normalized_cursor_str
         )
-        asset_nodes_by_asset_key = {
-            asset_key: asset_node
-            for asset_key, asset_node in _get_asset_nodes_by_asset_key(graphene_info).items()
-            if (not prefix or asset_key.path[: len(prefix)] == prefix)
-            and (not normalized_cursor_str or asset_key.to_string() > normalized_cursor_str)
-            and (not asset_keys or asset_key in asset_keys)
+
+        asset_graph_keys = {
+            asset_key
+            for asset_key in graphene_info.context.asset_graph.get_all_asset_keys()
+            if (
+                (not prefix or asset_key.path[: len(prefix)] == prefix)
+                and (not normalized_cursor_str or asset_key.to_string() > normalized_cursor_str)
+                and (not asset_keys or asset_key in asset_keys)
+            )
         }
 
-        merged_asset_keys = sorted(
-            set(materialized_keys).union(asset_nodes_by_asset_key.keys()), key=str
-        )
+        merged_asset_keys = sorted(set(materialized_keys).union(asset_graph_keys), key=str)
     else:
         merged_asset_keys = asset_keys
 
@@ -186,18 +186,6 @@ def get_asset_node_definition_collisions(
             )
 
     return results
-
-
-def _get_asset_nodes_by_asset_key(
-    graphene_info: "ResolveInfo",
-) -> Mapping[AssetKey, RemoteAssetNode]:
-    """If multiple repositories have asset nodes for the same asset key, chooses the asset node that
-    has an op.
-    """
-    return {
-        remote_node.key: remote_node
-        for remote_node in graphene_info.context.asset_graph.asset_nodes
-    }
 
 
 def get_asset_node(


### PR DESCRIPTION
Summary:
In a future where we can quickly generate just the full set of asset keys for the asset graph, this change will allow this codepath to take advantage of that and more efficiently paginate through the asset graph in chunks without having to fetch the full node for every key in the graph.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
