### PR TITLE
[components] Augment component load/build errors with tree

### DIFF
--- a/examples/docs_snippets/docs_snippets/getting-started/quickstart/dg_check_defs.txt
+++ b/examples/docs_snippets/docs_snippets/getting-started/quickstart/dg_check_defs.txt
@@ -1,4 +1,4 @@
 dg check defs
 
-All components validated successfully.
+All component YAML validated successfully.
 All definitions loaded successfully.

--- a/examples/docs_snippets/docs_snippets/guides/components/index/23-dg-component-check.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/23-dg-component-check.txt
@@ -1,3 +1,3 @@
 dg check yaml
 
-All components validated successfully.
+All component YAML validated successfully.

--- a/examples/docs_snippets/docs_snippets/guides/components/index/31-dg-component-check-yaml.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/31-dg-component-check-yaml.txt
@@ -1,3 +1,3 @@
 dg check yaml
 
-All components validated successfully.
+All component YAML validated successfully.

--- a/examples/docs_snippets/docs_snippets/guides/components/index/32-dg-component-check-defs.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/32-dg-component-check-defs.txt
@@ -1,4 +1,4 @@
 dg check defs
 
-All components validated successfully.
+All component YAML validated successfully.
 All definitions loaded successfully.

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/11-dg-component-check-fixed.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/11-dg-component-check-fixed.txt
@@ -1,3 +1,3 @@
 dg check yaml
 
-All components validated successfully.
+All component YAML validated successfully.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/etl_tutorial/commands/dg-check-defs.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/etl_tutorial/commands/dg-check-defs.txt
@@ -1,4 +1,4 @@
 dg check defs
 
-All components validated successfully.
+All component YAML validated successfully.
 All definitions loaded successfully.

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/validation_tests/test_component_validation.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/validation_tests/test_component_validation.py
@@ -1,5 +1,6 @@
 import pytest
 from dagster._core.test_utils import ensure_dagster_tests_import
+from dagster.components.core.tree import ComponentTreeException
 from dagster.components.resolved.context import ResolutionException
 from dagster_test.components.test_utils.test_cases import (
     BASIC_COMPONENT_TYPE_FILEPATH,
@@ -68,14 +69,21 @@ def test_validation_messages(test_case: ComponentValidationTestCase) -> None:
     errors.
     """
     if test_case.should_error:
-        with pytest.raises((ValidationError, ScannerError, ResolutionException)) as e:
+        with pytest.raises(
+            (ValidationError, ScannerError, ResolutionException, ComponentTreeException)
+        ) as e:
             sync_load_test_component_defs(
                 str(test_case.component_path),
                 test_case.component_type_filepath,
             )
 
+        if isinstance(e.value, ComponentTreeException):
+            value = e.value.__cause__
+        else:
+            value = e.value
+
         assert test_case.validate_error_msg
-        test_case.validate_error_msg(str(e.value))
+        test_case.validate_error_msg(str(value))
     else:
         sync_load_test_component_defs(
             str(test_case.component_path),

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_check_yaml_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_check_yaml_command.py
@@ -238,7 +238,7 @@ def test_check_yaml_with_watch() -> None:
 
             stdout, stderr = check_process.communicate()
 
-            assert "All components validated successfully" in stdout.decode("utf-8")
+            assert "All component YAML validated successfully" in stdout.decode("utf-8")
             assert BASIC_INVALID_VALUE.check_error_msg
             BASIC_INVALID_VALUE.check_error_msg(stdout.decode("utf-8"))
 

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/check.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/check.py
@@ -193,6 +193,6 @@ def check_yaml(
             )
         return False
     else:
-        click.echo("All components validated successfully.")
+        click.echo("All component YAML validated successfully.")
 
         return True


### PR DESCRIPTION
## Summary

Augments any error raised in component load or defs building with the current state of the component load tree, e.g.

<img width="847" height="245" alt="Screenshot 2025-07-10 at 10 15 21 AM" src="https://github.com/user-attachments/assets/7bb121bb-9e0f-44bc-b9a6-dfb29a7906a2" />

## Test Plan

Update existing unit tests.