### PR TITLE
[component loading] Properly load pythonic components from ordinary defs Python files

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -103,10 +103,9 @@ from dagster._time import datetime_from_timestamp
 from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.warnings import suppress_dagster_warnings
 from dagster.components.core.defs_module import (
-    CompositeComponent,
     CompositeYamlComponent,
-    DagsterDefsComponent,
     DefsFolderComponent,
+    PythonFileComponent,
 )
 from dagster.components.core.tree import ComponentTree
 
@@ -1950,8 +1949,7 @@ class ComponentTreeSnap:
                 (
                     DefsFolderComponent,
                     CompositeYamlComponent,
-                    CompositeComponent,
-                    DagsterDefsComponent,
+                    PythonFileComponent,
                 ),
             ):
                 cls = comp_inst.__class__

--- a/python_modules/dagster/dagster/components/core/decl.py
+++ b/python_modules/dagster/dagster/components/core/decl.py
@@ -26,10 +26,9 @@ from dagster.components.core.defs_module import (
     EXPLICITLY_IGNORED_GLOB_PATTERNS,
     ComponentFileModel,
     ComponentPath,
-    CompositeComponent,
     CompositeYamlComponent,
-    DagsterDefsComponent,
     DefsFolderComponent,
+    PythonFileComponent,
     asset_post_processor_list_from_post_processing_dict,
     context_with_injected_scope,
     find_defs_or_component_yaml,
@@ -80,19 +79,20 @@ class ComponentLoaderDecl(ComponentDecl[Component]):
 
 
 @record
-class CompositePythonDecl(ComponentDecl[CompositeComponent]):
-    """Declaration of a Python CompositeComponent, corresponding to a Python file with one or more
-    ComponentLoaderDecls.
+class PythonFileDecl(ComponentDecl[PythonFileComponent]):
+    """Declaration of a PythonFileComponent, corresponding to a Python file with zero or more
+    ComponentLoaderDecls and zero or more plain Dagster defs.
     """
 
     decls: Mapping[str, ComponentLoaderDecl]
 
-    def _load_component(self) -> "CompositeComponent":
-        return CompositeComponent(
+    def _load_component(self) -> "PythonFileComponent":
+        return PythonFileComponent(
             components={
                 attr: self.context.load_structural_component_at_path(decl.path)
                 for attr, decl in self.decls.items()
-            }
+            },
+            path=self.path.file_path,
         )
 
     def iterate_child_component_decls(self) -> Iterator["ComponentDecl"]:
@@ -238,12 +238,6 @@ class YamlFileDecl(ComponentDecl[CompositeYamlComponent]):
 
 
 @record
-class DagsterDefsDecl(ComponentDecl[DagsterDefsComponent]):
-    def _load_component(self) -> DagsterDefsComponent:
-        return DagsterDefsComponent(path=self.path.file_path)
-
-
-@record
 class DefsFolderDecl(YamlBackedComponentDecl[DefsFolderComponent]):
     children: Mapping[Path, ComponentDecl]
 
@@ -281,25 +275,19 @@ def build_component_decl_from_context(context: ComponentDeclLoadContext) -> Opti
     # yaml component
     if find_defs_or_component_yaml(context.path):
         return build_component_decl_from_yaml_file_backcompat(context)
-    # pythonic component
-    elif (
-        context.terminate_autoloading_on_keyword_files and (context.path / "component.py").exists()
-    ):
-        return build_component_decl_from_python_file(context)
     # defs
     elif (
         context.terminate_autoloading_on_keyword_files
         and (context.path / "definitions.py").exists()
+        and not (context.path / "component.py").exists()
     ):
-        return DagsterDefsDecl(
+        return PythonFileDecl(
             context=context,
             path=ComponentPath(file_path=context.path / "definitions.py", instance_key=None),
+            decls={},
         )
     elif context.path.suffix == ".py":
-        return DagsterDefsDecl(
-            context=context,
-            path=ComponentPath(file_path=context.path, instance_key=None),
-        )
+        return build_component_decl_from_python_file(context)
     # folder
     elif context.path.is_dir():
         children = build_component_decls_from_directory_items(context, None)
@@ -337,33 +325,24 @@ def build_component_decls_from_directory_items(
 
 def build_component_decl_from_python_file(
     context: ComponentDeclLoadContext,
-) -> Union[ComponentLoaderDecl, CompositePythonDecl]:
+) -> Union[ComponentLoaderDecl, PythonFileDecl]:
     # backcompat for component.yaml
-    component_def_path = context.path / "component.py"
+    component_def_path = context.path
     module = context.load_defs_relative_python_module(component_def_path)
     component_loaders = list(inspect.getmembers(module, is_component_loader))
-    if len(component_loaders) == 0:
-        raise DagsterInvalidDefinitionError("No component nodes found in module")
-    elif len(component_loaders) == 1:
-        _, component_loader = component_loaders[0]
-        return ComponentLoaderDecl(
-            context=context,
-            component_node_fn=component_loader,
-            path=ComponentPath(file_path=context.path, instance_key=None),
-        )
-    else:
-        return CompositePythonDecl(
-            path=ComponentPath(file_path=context.path, instance_key=None),
-            context=context,
-            decls={
-                attr: ComponentLoaderDecl(
-                    context=context,
-                    component_node_fn=component_loader,
-                    path=ComponentPath(file_path=context.path, instance_key=attr),
-                )
-                for attr, component_loader in component_loaders
-            },
-        )
+
+    return PythonFileDecl(
+        path=ComponentPath(file_path=context.path, instance_key=None),
+        context=context,
+        decls={
+            attr: ComponentLoaderDecl(
+                context=context,
+                component_node_fn=component_loader,
+                path=ComponentPath(file_path=context.path, instance_key=attr),
+            )
+            for attr, component_loader in component_loaders
+        },
+    )
 
 
 def build_component_decl_from_yaml_file_backcompat(

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -136,19 +136,6 @@ class CompositeYamlComponent(Component):
         return Definitions.merge(*defs_list)
 
 
-class CompositeComponent(Component):
-    def __init__(self, components: Mapping[str, Component]):
-        self.components = components
-
-    def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        return Definitions.merge(
-            *[
-                context.build_defs_at_path(child_decl.path)
-                for child_decl in context.component_decl.iterate_child_component_decls()
-            ]
-        )
-
-
 @record
 class ComponentPath:
     """Identifier for where a Component instance was defined:
@@ -221,9 +208,9 @@ class DefsFolderComponent(Component):
             │       └── defs.yaml
             └── data_ingestion/        # DefsFolderComponent
                 ├── api_sources/       # DefsFolderComponent
-                │   └── some_defs.py   # DagsterDefsComponent
+                │   └── some_defs.py   # PythonFileComponent
                 └── file_sources/      # DefsFolderComponent
-                    └── files.py       # DagsterDefsComponent
+                    └── files.py       # PythonFileComponent
 
     Args:
         path: The filesystem path to the directory containing child components.
@@ -330,7 +317,7 @@ class DefsFolderComponent(Component):
                 for idx, inner_comp in enumerate(component.components):
                     yield ComponentPath(file_path=path, instance_key=idx), inner_comp
 
-            if isinstance(component, CompositeComponent):
+            if isinstance(component, PythonFileComponent):
                 for attr, inner_comp in component.components.items():
                     yield ComponentPath(file_path=path, instance_key=attr), inner_comp
 
@@ -354,12 +341,14 @@ def find_components_from_context(context: ComponentLoadContext) -> Mapping[Path,
 
 
 @dataclass
-class DagsterDefsComponent(Component):
-    """A Python module containing Dagster definitions. Used for implicit loading of
-    Dagster definitions from Python files in the defs folder.
+class PythonFileComponent(Component):
+    """A Python module containing Dagster definitions or Pythonic
+    components. Used for implicit loading of Dagster definitions from
+    Python files in the defs folder.
     """
 
     path: Path
+    components: Mapping[str, Component]
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
         module = context.load_defs_relative_python_module(self.path)
@@ -393,7 +382,13 @@ class DagsterDefsComponent(Component):
         if len(lazy_def_objects) > 1:
             return Definitions.merge(*[lazy_def(context) for lazy_def in lazy_def_objects])
 
-        return load_definitions_from_module(module)
+        return Definitions.merge(
+            *[
+                context.build_defs_at_path(child_decl.path)
+                for child_decl in context.component_decl.iterate_child_component_decls()
+            ],
+            load_definitions_from_module(module),
+        )
 
 
 def invoke_inline_template_var(context: ComponentDeclLoadContext, tv: Callable) -> Any:

--- a/python_modules/dagster/dagster/components/core/tree.py
+++ b/python_modules/dagster/dagster/components/core/tree.py
@@ -19,7 +19,7 @@ from dagster.components.core.context import ComponentDeclLoadContext, ComponentL
 from dagster.components.core.decl import (
     ComponentDecl,
     ComponentLoaderDecl,
-    DagsterDefsDecl,
+    PythonFileDecl,
     YamlDecl,
     build_component_decl_from_context,
 )
@@ -379,19 +379,22 @@ class ComponentTree:
 
         total = len(decls)
         for idx, child_decl in enumerate(decls):
-            if isinstance(child_decl, DagsterDefsDecl) and hide_plain_defs:
+            if isinstance(child_decl, PythonFileDecl) and not child_decl.decls and hide_plain_defs:
                 continue
 
             component_type = None
             file_path = child_decl.path.file_path.relative_to(parent_path)
+
             if isinstance(child_decl, ComponentLoaderDecl):
-                file_path = file_path / "component.py"
-            if isinstance(child_decl, YamlDecl):
+                name = child_decl.path.instance_key
+            elif isinstance(child_decl, YamlDecl):
                 file_path = file_path / "defs.yaml"
                 component_type = child_decl.component_cls.__name__
 
-            if child_decl.path.instance_key is not None and len(decls) > 1:
-                name = f"{file_path}[{child_decl.path.instance_key}]"
+                if child_decl.path.instance_key is not None and len(decls) > 1:
+                    name = f"{file_path}[{child_decl.path.instance_key}]"
+                else:
+                    name = file_path
             else:
                 name = str(file_path)
 
@@ -432,7 +435,10 @@ class ComponentTree:
         if (
             hide_plain_defs
             and len(decls) > 0
-            and all(isinstance(child_decl, DagsterDefsDecl) for child_decl in decls)
+            and all(
+                isinstance(child_decl, PythonFileDecl) and not child_decl.decls
+                for child_decl in decls
+            )
         ):
             lines.append(f"{prefix}└── ...")
 

--- a/python_modules/dagster/dagster/components/core/tree.py
+++ b/python_modules/dagster/dagster/components/core/tree.py
@@ -394,7 +394,7 @@ class ComponentTree:
                 if child_decl.path.instance_key is not None and len(decls) > 1:
                     name = f"{file_path}[{child_decl.path.instance_key}]"
                 else:
-                    name = file_path
+                    name = str(file_path)
             else:
                 name = str(file_path)
 

--- a/python_modules/dagster/dagster/components/core/tree.py
+++ b/python_modules/dagster/dagster/components/core/tree.py
@@ -386,7 +386,7 @@ class ComponentTree:
             file_path = child_decl.path.file_path.relative_to(parent_path)
 
             if isinstance(child_decl, ComponentLoaderDecl):
-                name = child_decl.path.instance_key
+                name = str(child_decl.path.instance_key)
             elif isinstance(child_decl, YamlDecl):
                 file_path = file_path / "defs.yaml"
                 component_type = child_decl.component_cls.__name__

--- a/python_modules/dagster/dagster/components/lib/definitions_component/__init__.py
+++ b/python_modules/dagster/dagster/components/lib/definitions_component/__init__.py
@@ -4,7 +4,7 @@ from typing import Optional
 from dagster._core.definitions.definitions_class import Definitions
 from dagster.components.component.component import Component
 from dagster.components.core.context import ComponentLoadContext
-from dagster.components.core.defs_module import DagsterDefsComponent
+from dagster.components.core.defs_module import PythonFileComponent
 from dagster.components.resolved.base import Resolvable
 from dagster.components.resolved.model import Model
 
@@ -19,5 +19,7 @@ class DefinitionsComponent(Component, Model, Resolvable):
     path: Optional[str]
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
-        component = DagsterDefsComponent(Path(self.path) if self.path else context.path)
+        component = PythonFileComponent(
+            Path(self.path) if self.path else context.path, components={}
+        )
         return component.build_defs(context)

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/both_python_defs_and_components/dg.toml
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/both_python_defs_and_components/dg.toml
@@ -1,0 +1,2 @@
+[project]
+defs_module = "dagster_tests.components_tests.integration_tests.integration_test_defs.definitions.both_python_defs_and_components"

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/both_python_defs_and_components/top_level.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/integration_test_defs/definitions/both_python_defs_and_components/top_level.py
@@ -1,0 +1,21 @@
+import dagster as dg
+
+
+@dg.asset
+def top_level() -> None: ...
+
+
+class AComponent(dg.Component):
+    """A simple component class for demonstration purposes."""
+
+    def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
+        @dg.asset
+        def asset_in_component_py() -> None: ...
+
+        return dg.Definitions(assets=[asset_in_component_py])
+
+
+@dg.component_instance
+def load(context: dg.ComponentLoadContext) -> dg.Component:
+    """A component that loads a component from the same module."""
+    return AComponent()

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
@@ -6,12 +6,7 @@ from typing import Union
 import dagster as dg
 import pytest
 from dagster._utils.env import environ
-from dagster.components.core.decl import (
-    ComponentDecl,
-    DagsterDefsDecl,
-    DefsFolderDecl,
-    YamlFileDecl,
-)
+from dagster.components.core.decl import ComponentDecl, DefsFolderDecl, PythonFileDecl, YamlFileDecl
 from dagster.components.core.defs_module import ComponentPath, CompositeYamlComponent
 from dagster.components.core.tree import (
     ComponentTree,
@@ -79,10 +74,10 @@ def test_definitions_component_with_explicit_file_relative_imports(
         component_tree,
         {
             ".": DefsFolderDecl,
-            "__init__.py": DagsterDefsDecl,
+            "__init__.py": PythonFileDecl,
             "explicit_file_relative_imports": DefsFolderDecl,
-            "explicit_file_relative_imports/some_file.py": DagsterDefsDecl,
-            "explicit_file_relative_imports/some_other_file.py": DagsterDefsDecl,
+            "explicit_file_relative_imports/some_file.py": PythonFileDecl,
+            "explicit_file_relative_imports/some_other_file.py": PythonFileDecl,
         },
     )
     defs = component_tree.build_defs()
@@ -103,10 +98,10 @@ def test_definitions_component_with_explicit_file_relative_imports_init(
         component_tree,
         {
             ".": DefsFolderDecl,
-            "__init__.py": DagsterDefsDecl,
+            "__init__.py": PythonFileDecl,
             "explicit_file_relative_imports_init": DefsFolderDecl,
-            "explicit_file_relative_imports_init/__init__.py": DagsterDefsDecl,
-            "explicit_file_relative_imports_init/some_other_file.py": DagsterDefsDecl,
+            "explicit_file_relative_imports_init/__init__.py": PythonFileDecl,
+            "explicit_file_relative_imports_init/some_other_file.py": PythonFileDecl,
         },
     )
     defs = component_tree.build_defs()
@@ -127,12 +122,12 @@ def test_definitions_component_with_explicit_file_relative_imports_complex(
         component_tree,
         {
             ".": DefsFolderDecl,
-            "__init__.py": DagsterDefsDecl,
-            "explicit_file_relative_imports_complex/definitions.py": DagsterDefsDecl,  # no folder bc definitions.py special name
+            "__init__.py": PythonFileDecl,
+            "explicit_file_relative_imports_complex/definitions.py": PythonFileDecl,  # no folder bc definitions.py special name
             # rest not loaded because of definitions.py
-            # "explicit_file_relative_imports_complex/some_other_file.py": DagsterDefsDecl,
+            # "explicit_file_relative_imports_complex/some_other_file.py": CompositePythonDecl,
             # "explicit_file_relative_imports_complex/submodule": DefsFolderDecl,
-            # "explicit_file_relative_imports_complex/submodule/__init__.py": DagsterDefsDecl,
+            # "explicit_file_relative_imports_complex/submodule/__init__.py": CompositePythonDecl,
         },
     )
     defs = component_tree.build_defs()
@@ -224,19 +219,19 @@ def test_autoload_definitions_nested(component_tree: ComponentTree) -> None:
         component_tree,
         {
             ".": DefsFolderDecl,
-            "__init__.py": DagsterDefsDecl,
+            "__init__.py": PythonFileDecl,
             "definitions_at_levels": DefsFolderDecl,
-            "definitions_at_levels/top_level.py": DagsterDefsDecl,
-            "definitions_at_levels/defs_object/definitions.py": DagsterDefsDecl,  # no folder bc definitions.py special name
+            "definitions_at_levels/top_level.py": PythonFileDecl,
+            "definitions_at_levels/defs_object/definitions.py": PythonFileDecl,  # no folder bc definitions.py special name
             "definitions_at_levels/loose_defs": DefsFolderDecl,
-            "definitions_at_levels/loose_defs/asset.py": DagsterDefsDecl,
+            "definitions_at_levels/loose_defs/asset.py": PythonFileDecl,
             "definitions_at_levels/loose_defs/inner": DefsFolderDecl,
-            "definitions_at_levels/loose_defs/inner/asset.py": DagsterDefsDecl,
+            "definitions_at_levels/loose_defs/inner/asset.py": PythonFileDecl,
             "definitions_at_levels/loose_defs/inner/innerer": DefsFolderDecl,
-            "definitions_at_levels/loose_defs/inner/innerer/asset.py": DagsterDefsDecl,
-            "definitions_at_levels/loose_defs/inner/innerer/innerest/definitions.py": DagsterDefsDecl,  # no folder bc definitions.py special name
+            "definitions_at_levels/loose_defs/inner/innerer/asset.py": PythonFileDecl,
+            "definitions_at_levels/loose_defs/inner/innerer/innerest/definitions.py": PythonFileDecl,  # no folder bc definitions.py special name
             "definitions_at_levels/loose_defs/inner/innerer/in_init": DefsFolderDecl,
-            "definitions_at_levels/loose_defs/inner/innerer/in_init/__init__.py": DagsterDefsDecl,
+            "definitions_at_levels/loose_defs/inner/innerer/in_init/__init__.py": PythonFileDecl,
         },
     )
     defs = component_tree.build_defs()
@@ -314,24 +309,24 @@ def test_ignored_empty_dir():
             {
                 ".": YamlFileDecl,
                 ComponentPath(file_path=Path("."), instance_key=0): DefsFolderDecl,
-                "top_level.py": DagsterDefsDecl,
+                "top_level.py": PythonFileDecl,
                 "loose_defs": YamlFileDecl,
                 ComponentPath(file_path=Path("loose_defs"), instance_key=0): DefsFolderDecl,
-                "loose_defs/asset.py": DagsterDefsDecl,
+                "loose_defs/asset.py": PythonFileDecl,
                 "loose_defs/inner": DefsFolderDecl,
-                "loose_defs/inner/asset.py": DagsterDefsDecl,
+                "loose_defs/inner/asset.py": PythonFileDecl,
                 "loose_defs/inner/innerer": DefsFolderDecl,
-                "loose_defs/inner/innerer/asset.py": DagsterDefsDecl,
+                "loose_defs/inner/innerer/asset.py": PythonFileDecl,
                 "loose_defs/inner/innerer/another_level": YamlFileDecl,
                 ComponentPath(
                     file_path=Path("loose_defs/inner/innerer/another_level"), instance_key=0
                 ): DefsFolderDecl,
                 "loose_defs/inner/innerer/another_level/in_init": DefsFolderDecl,
-                "loose_defs/inner/innerer/another_level/in_init/__init__.py": DagsterDefsDecl,
-                "loose_defs/inner/innerer/another_level/innerest/definitions.py": DagsterDefsDecl,  # no folder bc definitions.py special name
+                "loose_defs/inner/innerer/another_level/in_init/__init__.py": PythonFileDecl,
+                "loose_defs/inner/innerer/another_level/innerest/definitions.py": PythonFileDecl,  # no folder bc definitions.py special name
                 "defs_object": YamlFileDecl,
                 ComponentPath(file_path=Path("defs_object"), instance_key=0): DefsFolderDecl,
-                "defs_object/defs_object/definitions.py": DagsterDefsDecl,  # no folder bc definitions.py special name
+                "defs_object/defs_object/definitions.py": PythonFileDecl,  # no folder bc definitions.py special name
             },
         )
 
@@ -361,18 +356,20 @@ def test_autoload_backcompat_components(component_tree: ComponentTree) -> None:
                 dg.AssetKey("asset_in_definitions_py"),
                 dg.AssetKey("asset_in_component_py"),
                 dg.AssetKey("top_level"),
+                # This is technically a breaking change, but it feels uncommon enough to me
+                dg.AssetKey("asset_only_in_asset_py_with_component_py"),
             },
         ),
         (
             False,
             {
-                # asset_in_component_py is not included
                 dg.AssetKey("asset_in_definitions_py"),
                 dg.AssetKey("top_level"),
                 dg.AssetKey("asset_in_inner"),
                 dg.AssetKey("asset_only_in_asset_py_with_component_py"),
                 dg.AssetKey("defs_obj_outer"),
                 dg.AssetKey("not_included"),
+                dg.AssetKey("asset_in_component_py"),
             },
         ),
     ],
@@ -398,3 +395,17 @@ def test_autoload_definitions_new_flag(
         )
 
     assert {spec.key for spec in defs.resolve_all_asset_specs()} == expected_keys
+
+
+def test_combined_python_defs_and_components() -> None:
+    defs = dg.load_from_defs_folder(
+        project_root=Path(__file__).parent
+        / "integration_test_defs"
+        / "definitions"
+        / "both_python_defs_and_components",
+    )
+
+    assert {spec.key for spec in defs.resolve_all_asset_specs()} == {
+        dg.AssetKey("asset_in_component_py"),
+        dg.AssetKey("top_level"),
+    }

--- a/python_modules/dagster/dagster_tests/components_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/components_tests/test_definitions.py
@@ -101,8 +101,8 @@ def test_component_tree():
 
     inst_map = {snap.key: snap.full_type_name for snap in repo_snap.component_tree.leaf_instances}
     assert inst_map == {
-        "composites/python[first]": "dagster_test.dg_defs.composites.python.component.PyComponent",
-        "composites/python[second]": "dagster_test.dg_defs.composites.python.component.PyComponent",
+        "composites/python/component.py[first]": "dagster_test.dg_defs.composites.python.component.PyComponent",
+        "composites/python/component.py[second]": "dagster_test.dg_defs.composites.python.component.PyComponent",
         "composites/yaml[0]": "dagster_test.components.simple_asset.SimpleAssetComponent",
         "composites/yaml[1]": "dagster_test.components.simple_asset.SimpleAssetComponent",
     }

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/__snapshots__/test_pipes_subprocess_script_collection.ambr
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/__snapshots__/test_pipes_subprocess_script_collection.ambr
@@ -1,0 +1,79 @@
+# serializer version: 1
+# name: test_load_from_path
+  '''
+  ├── multiple_component_instances
+  │   └── component.py
+  │       ├── bar
+  │       └── foo
+  ├── multiple_component_instances_defs_py
+  │   └── component.py
+  │       ├── bar
+  │       └── foo
+  ├── multiple_definitions_calls
+  │   └── defs.py
+  ├── script_python_decl
+  │   ├── component.py
+  │   │   └── load
+  │   └── cool_script.py
+  ├── scripts
+  │   ├── defs.yaml[0] (PythonScriptComponent)
+  │   ├── defs.yaml[1] (PythonScriptComponent)
+  │   └── defs.yaml[2] (PythonScriptComponent)
+  └── triple_dash_scripts
+      ├── defs.yaml[0] (PythonScriptComponent)
+      ├── defs.yaml[1] (PythonScriptComponent)
+      └── defs.yaml[2] (PythonScriptComponent)
+  '''
+# ---
+# name: test_load_from_path.1
+  '''
+  ├── multiple_component_instances (loaded)
+  │   └── component.py (loaded)
+  │       ├── bar (loaded)
+  │       └── foo (loaded)
+  ├── multiple_component_instances_defs_py (loaded)
+  │   └── component.py (loaded)
+  │       ├── bar (loaded)
+  │       └── foo (loaded)
+  ├── multiple_definitions_calls (loaded)
+  │   └── defs.py (loaded)
+  ├── script_python_decl (loaded)
+  │   ├── component.py (loaded)
+  │   │   └── load (loaded)
+  │   └── cool_script.py (loaded)
+  ├── scripts (loaded)
+  │   ├── defs.yaml[0] (PythonScriptComponent) (loaded)
+  │   ├── defs.yaml[1] (PythonScriptComponent) (loaded)
+  │   └── defs.yaml[2] (PythonScriptComponent) (loaded)
+  └── triple_dash_scripts (loaded)
+      ├── defs.yaml[0] (PythonScriptComponent) (loaded)
+      ├── defs.yaml[1] (PythonScriptComponent) (loaded)
+      └── defs.yaml[2] (PythonScriptComponent) (loaded)
+  '''
+# ---
+# name: test_load_from_path.2
+  '''
+  ├── multiple_component_instances (built)
+  │   └── component.py (built)
+  │       ├── bar (built)
+  │       └── foo (built)
+  ├── multiple_component_instances_defs_py (built)
+  │   └── component.py (built)
+  │       ├── bar (built)
+  │       └── foo (built)
+  ├── multiple_definitions_calls (built)
+  │   └── defs.py (built)
+  ├── script_python_decl (built)
+  │   ├── component.py (built)
+  │   │   └── load (built)
+  │   └── cool_script.py (built)
+  ├── scripts (built)
+  │   ├── defs.yaml[0] (PythonScriptComponent) (built)
+  │   ├── defs.yaml[1] (PythonScriptComponent) (built)
+  │   └── defs.yaml[2] (PythonScriptComponent) (built)
+  └── triple_dash_scripts (built)
+      ├── defs.yaml[0] (PythonScriptComponent) (built)
+      ├── defs.yaml[1] (PythonScriptComponent) (built)
+      └── defs.yaml[2] (PythonScriptComponent) (built)
+  '''
+# ---

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
@@ -8,10 +8,10 @@ from dagster.components.core.context import ComponentLoadContext
 from dagster.components.core.decl import (
     ComponentDecl,
     ComponentLoaderDecl,
-    CompositePythonDecl,
     DefsFolderDecl,
+    PythonFileDecl,
 )
-from dagster.components.core.defs_module import ComponentPath, CompositeComponent
+from dagster.components.core.defs_module import ComponentPath, PythonFileComponent
 from dagster.components.core.tree import ComponentTree
 from dagster_shared.record import record
 
@@ -61,7 +61,7 @@ def test_composite_python_decl(component_tree: MockComponentTree):
         path=ComponentPath(file_path=Path(__file__).parent, instance_key="my_component"),
         component_node_fn=lambda context: my_component,
     )
-    decl = CompositePythonDecl(
+    decl = PythonFileDecl(
         path=ComponentPath(file_path=Path(__file__).parent, instance_key=None),
         context=component_tree.decl_load_context,
         decls={"my_component": loader_decl},
@@ -69,7 +69,7 @@ def test_composite_python_decl(component_tree: MockComponentTree):
 
     component_tree.set_root_decl(decl)
     loaded_component = component_tree.load_root_component()
-    assert isinstance(loaded_component, CompositeComponent)
+    assert isinstance(loaded_component, PythonFileComponent)
     assert loaded_component.components["my_component"] == my_component
 
 

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_pipes_subprocess_script_collection.py
@@ -1,5 +1,4 @@
 import importlib
-import textwrap
 from pathlib import Path
 
 import dagster as dg
@@ -8,62 +7,16 @@ from dagster.components.core.tree import LegacyAutoloadingComponentTree
 LOCATION_PATH = Path(__file__).parent.parent / "code_locations" / "python_script_location"
 
 
-def test_load_from_path() -> None:
+def test_load_from_path(snapshot) -> None:
     module = importlib.import_module(
         "dagster_tests.components_tests.code_locations.python_script_location.defs"
     )
     tree = LegacyAutoloadingComponentTree.from_module(
         defs_module=module, project_root=Path(__file__).parent
     )
-    assert (
-        tree.to_string_representation(include_load_and_build_status=True)
-        == textwrap.dedent(
-            """
-            ├── multiple_component_instances
-            │   ├── component.py[bar]
-            │   └── component.py[foo]
-            ├── multiple_component_instances_defs_py
-            │   ├── component.py[bar]
-            │   └── component.py[foo]
-            ├── multiple_definitions_calls
-            │   └── defs.py
-            ├── script_python_decl/component.py
-            ├── scripts
-            │   ├── defs.yaml[0] (PythonScriptComponent)
-            │   ├── defs.yaml[1] (PythonScriptComponent)
-            │   └── defs.yaml[2] (PythonScriptComponent)
-            └── triple_dash_scripts
-                ├── defs.yaml[0] (PythonScriptComponent)
-                ├── defs.yaml[1] (PythonScriptComponent)
-                └── defs.yaml[2] (PythonScriptComponent)
-            """
-        ).strip()
-    )
+    snapshot.assert_match(tree.to_string_representation(include_load_and_build_status=True))
     tree.load_root_component()
-    assert (
-        tree.to_string_representation(include_load_and_build_status=True)
-        == textwrap.dedent(
-            """
-            ├── multiple_component_instances (loaded)
-            │   ├── component.py[bar] (loaded)
-            │   └── component.py[foo] (loaded)
-            ├── multiple_component_instances_defs_py (loaded)
-            │   ├── component.py[bar] (loaded)
-            │   └── component.py[foo] (loaded)
-            ├── multiple_definitions_calls (loaded)
-            │   └── defs.py (loaded)
-            ├── script_python_decl/component.py (loaded)
-            ├── scripts (loaded)
-            │   ├── defs.yaml[0] (PythonScriptComponent) (loaded)
-            │   ├── defs.yaml[1] (PythonScriptComponent) (loaded)
-            │   └── defs.yaml[2] (PythonScriptComponent) (loaded)
-            └── triple_dash_scripts (loaded)
-                ├── defs.yaml[0] (PythonScriptComponent) (loaded)
-                ├── defs.yaml[1] (PythonScriptComponent) (loaded)
-                └── defs.yaml[2] (PythonScriptComponent) (loaded)
-            """
-        ).strip()
-    )
+    snapshot.assert_match(tree.to_string_representation(include_load_and_build_status=True))
 
     defs = tree.build_defs()
     assert defs.resolve_asset_graph().get_all_asset_keys() == {
@@ -89,30 +42,7 @@ def test_load_from_path() -> None:
     }
     assert defs.component_tree
 
-    assert (
-        tree.to_string_representation(include_load_and_build_status=True)
-        == textwrap.dedent(
-            """
-            ├── multiple_component_instances (built)
-            │   ├── component.py[bar] (built)
-            │   └── component.py[foo] (built)
-            ├── multiple_component_instances_defs_py (built)
-            │   ├── component.py[bar] (built)
-            │   └── component.py[foo] (built)
-            ├── multiple_definitions_calls (built)
-            │   └── defs.py (built)
-            ├── script_python_decl/component.py (built)
-            ├── scripts (built)
-            │   ├── defs.yaml[0] (PythonScriptComponent) (built)
-            │   ├── defs.yaml[1] (PythonScriptComponent) (built)
-            │   └── defs.yaml[2] (PythonScriptComponent) (built)
-            └── triple_dash_scripts (built)
-                ├── defs.yaml[0] (PythonScriptComponent) (built)
-                ├── defs.yaml[1] (PythonScriptComponent) (built)
-                └── defs.yaml[2] (PythonScriptComponent) (built)
-            """
-        ).strip()
-    )
+    snapshot.assert_match(tree.to_string_representation(include_load_and_build_status=True))
 
 
 def test_load_from_location_path() -> None:

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/__snapshots__/test_list_commands.ambr
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/__snapshots__/test_list_commands.ambr
@@ -3,8 +3,12 @@
   '''
   ├── assets
   │   └── ...
-  └── my_function
-      └── defs.yaml (FunctionComponent)
+  ├── my_function
+  │   └── defs.yaml (FunctionComponent)
+  └── pythonic_components
+      └── my_component.py
+          ├── first
+          └── second
   '''
 # ---
 # name: test_list_defs_complex_assets_succeeds

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
@@ -304,6 +304,29 @@ def test_list_component_tree_succeeds(snapshot):
             Path("src/foo_bar/defs/assets").mkdir(parents=True, exist_ok=True)
             Path("src/foo_bar/defs/assets/asset.py").touch()
 
+            Path("src/foo_bar/defs/pythonic_components").mkdir(parents=True, exist_ok=True)
+            Path("src/foo_bar/defs/pythonic_components/my_component.py").write_text(
+                textwrap.dedent(
+                    """
+                    import dagster as dg
+
+                    class PyComponent(dg.Component, dg.Model, dg.Resolvable):
+                        asset: dg.ResolvedAssetSpec
+
+                        def build_defs(self, context):
+                            return dg.Definitions(assets=[self.asset])
+
+                    @dg.component_instance
+                    def first(_):
+                        return PyComponent(asset=dg.AssetSpec("first_py"))
+
+                    @dg.component_instance
+                    def second(_) -> PyComponent:
+                        return PyComponent(asset=dg.AssetSpec("second_py"))
+                    """
+                )
+            )
+
             result = subprocess.run(
                 ["dg", "list", "component-tree"], check=True, capture_output=True
             )


### PR DESCRIPTION
## Summary

Properly handles loading plain-old-Python definitions and Python component instances from `.py` files in the default, non `terminate_autoloading_on_keyword_files` world.

This actually simplifies our Decl codepaths a bit by combining the composite component with the python defs component to a single component which represents a Python file (and may hold plain defs or other components).



## Test Plan

New unit test.

## Changelog

> [components] Python component instances are now properly loaded from ordinary Python files.
