### PR TITLE
Make all dagster integration pins available on 3.12 and 3.13

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -701,7 +701,6 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "python_modules/libraries/dagster-wandb",
         unsupported_python_versions=[
-            # duckdb
             AvailablePythonVersion.V3_12,
             AvailablePythonVersion.V3_13,
         ],
@@ -710,11 +709,13 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "python_modules/libraries/dagstermill",
         pytest_tox_factors=["papermill1", "papermill2"],
         retries=2,  # Workaround for flaky kernel issues
-        unsupported_python_versions=[
-            # duckdb
-            AvailablePythonVersion.V3_12,
-            AvailablePythonVersion.V3_13,
-        ],
+        unsupported_python_versions=(
+            lambda tox_factor: (
+                [AvailablePythonVersion.V3_12, AvailablePythonVersion.V3_13]
+                if (tox_factor == "papermill1")
+                else []
+            )
+        ),
     ),
     PackageSpec(
         "python_modules/libraries/dagster-airlift/perf-harness",

--- a/examples/components_yaml_checks_dsl/pyproject.toml
+++ b/examples/components_yaml_checks_dsl/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "components_yaml_checks_dsl"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 version = "0.1.0"
 dependencies = [
     "dagster",

--- a/examples/docs_projects/project_ask_ai_dagster/pyproject.toml
+++ b/examples/docs_projects/project_ask_ai_dagster/pyproject.toml
@@ -3,7 +3,7 @@ name = "project_ask_ai_dagster"
 version = "0.0.1"
 description = "Project RAG"
 readme = "README.md"
-requires-python = ">=3.9,<=3.13.3"
+requires-python = ">=3.9,<3.14"
 dependencies = [
     "langchain",
     "langchain-core",

--- a/examples/docs_projects/project_atproto_dashboard/pyproject.toml
+++ b/examples/docs_projects/project_atproto_dashboard/pyproject.toml
@@ -3,7 +3,7 @@ name = "project_atproto_dashboard"
 version = "0.0.1"
 description = "Project Bluesky BI"
 readme = "README.md"
-requires-python = ">=3.9,<=3.13.3"
+requires-python = ">=3.9,<3.14"
 dependencies = [
     "atproto",
     "dagster",

--- a/examples/docs_projects/project_components_pdf_extraction/pyproject.toml
+++ b/examples/docs_projects/project_components_pdf_extraction/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project_components_pdf_extraction"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 version = "0.1.0"
 dependencies = [
     "dagster-dg-cli",

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/etl_tutorial/pyproject.toml
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/etl_tutorial/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "etl_tutorial"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 version = "0.1.0"
 dependencies = [
     "dagster",

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_adding_components_to_existing_project/my-existing-project/pyproject.toml
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_adding_components_to_existing_project/my-existing-project/pyproject.toml
@@ -3,7 +3,7 @@ name = "my_existing_project"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 dependencies = [
     "dagster",
 ]

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_creating_dg_plugin/my-library/pyproject.toml
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_creating_dg_plugin/my-library/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "my_library"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 version = "0.1.0"
 
 [build-system]

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_definitions/my-existing-project/pyproject.toml
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_definitions/my-existing-project/pyproject.toml
@@ -3,7 +3,7 @@ name = "my_existing_project"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.9,<=3.13.3"
+requires-python = ">=3.9,<3.14"
 dependencies = [
     "dagster",
 ]

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_project/my-existing-project-pip/setup.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_project/my-existing-project-pip/setup.py
@@ -4,7 +4,7 @@ setup(
     name="my_existing_project",
     version="0.1.0",
     description="Add your description here",
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     packages=find_packages(),
     install_requires=[
         "dagster",

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_project/my-existing-project-uv/pyproject.toml
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_project/my-existing-project-uv/pyproject.toml
@@ -3,7 +3,7 @@ name = "my_existing_project"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 dependencies = [
     "dagster",
 ]

--- a/examples/google_drive_factory/pyproject.toml
+++ b/examples/google_drive_factory/pyproject.toml
@@ -3,7 +3,7 @@ name = "google_drive_factory"
 version = "0.1.0"
 description = "Dagster project to show factory patterns"
 readme = "README.md"
-requires-python = ">=3.9,<=3.13.3"
+requires-python = ">=3.9,<3.14"
 dependencies = [
     "dagster",
     "dagster-cloud",
@@ -18,7 +18,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "dagster-webserver", 
+    "dagster-webserver",
     "pytest",
     "ruff",
 ]

--- a/python_modules/dagit/setup.py
+++ b/python_modules/dagit/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagit_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster-webserver{pin}",
     ],

--- a/python_modules/dagster-graphql/setup.py
+++ b/python_modules/dagster-graphql/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_graphql_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "graphene>=3,<4",

--- a/python_modules/dagster-pipes/setup.py
+++ b/python_modules/dagster-pipes/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_pipes_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     zip_safe=False,
     extras_require={
         "stubs": [

--- a/python_modules/dagster-test/setup.py
+++ b/python_modules/dagster-test/setup.py
@@ -16,7 +16,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_test_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         "dagster",
         "rich",

--- a/python_modules/dagster-webserver/setup.py
+++ b/python_modules/dagster-webserver/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_webserver_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         # cli
         "click>=7.0,<9.0",

--- a/python_modules/dagster/dagster/_generate/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
+++ b/python_modules/dagster/dagster/_generate/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
@@ -3,7 +3,7 @@ name = "{{ project_name }}"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.9,<=3.13.3"
+requires-python = ">=3.9,<3.14"
 dependencies = [
     "dagster",
     "dagster-cloud",
@@ -11,7 +11,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "dagster-webserver", 
+    "dagster-webserver",
     "pytest",
 ]
 

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -78,7 +78,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         # cli
         "click>=5.0,<8.2",

--- a/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
+++ b/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
@@ -1,6 +1,6 @@
 [project]
 name = "{{ project_name }}"
-requires-python = ">=3.9,<=3.13.3"
+requires-python = ">=3.9,<3.14"
 version = "0.1.0"
 {{ dependencies }}
 

--- a/python_modules/libraries/create-dagster/create_dagster/templates/WORKSPACE_NAME_PLACEHOLDER/deployments/local/pyproject.toml.jinja
+++ b/python_modules/libraries/create-dagster/create_dagster/templates/WORKSPACE_NAME_PLACEHOLDER/deployments/local/pyproject.toml.jinja
@@ -1,6 +1,6 @@
 [project]
 name = "{{ project_name }}_local"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 version = "0.1.0"
 {{ dependencies }}
 

--- a/python_modules/libraries/dagster-airbyte/setup.py
+++ b/python_modules/libraries/dagster-airbyte/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_airbyte_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "requests",

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_airflow_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "lazy_object_proxy",

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_aws_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         "boto3",
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-azure/setup.py
+++ b/python_modules/libraries/dagster-azure/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_azure_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         "azure-core<2.0.0,>=1.7.0",
         "azure-identity<2.0.0,>=1.7.0",

--- a/python_modules/libraries/dagster-celery-docker/setup.py
+++ b/python_modules/libraries/dagster-celery-docker/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_celery_docker_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-celery{pin}",

--- a/python_modules/libraries/dagster-celery-k8s/setup.py
+++ b/python_modules/libraries/dagster-celery-k8s/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_celery_k8s_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-k8s{pin}",

--- a/python_modules/libraries/dagster-celery/example/pyproject.toml
+++ b/python_modules/libraries/dagster-celery/example/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<=3.13.3"
+python = ">=3.10,<3.14"
 dagster = "^1.7.10"
 dagster-postgres = "^0.23.10"
 celery = {extras = ["redis"], version = "^5.4.0"}

--- a/python_modules/libraries/dagster-celery/setup.py
+++ b/python_modules/libraries/dagster-celery/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_celery_tests*"]),
     entry_points={"console_scripts": ["dagster-celery = dagster_celery.cli:main"]},
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "celery>=4.3.0",

--- a/python_modules/libraries/dagster-census/setup.py
+++ b/python_modules/libraries/dagster-census/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_census_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-dask/setup.py
+++ b/python_modules/libraries/dagster-dask/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_dask_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         "bokeh",
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_databricks_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-pipes{pin}",

--- a/python_modules/libraries/dagster-datadog/setup.py
+++ b/python_modules/libraries/dagster-datadog/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_datadog_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}", "datadog"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_datahub_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         "acryl-datahub[datahub-rest, datahub-kafka]",
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/pyproject.toml.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/pyproject.toml.jinja
@@ -3,7 +3,7 @@ name = "{{ project_name }}"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.9,<=3.13.3"
+requires-python = ">=3.9,<3.14"
 dependencies = [
     "dagster",
     "dagster-cloud",
@@ -16,7 +16,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "dagster-webserver", 
+    "dagster-webserver",
 ]
 
 [build-system]

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -38,7 +38,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_dbt_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core

--- a/python_modules/libraries/dagster-deltalake-pandas/setup.py
+++ b/python_modules/libraries/dagster-deltalake-pandas/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_deltalake_pandas_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-deltalake{pin}",

--- a/python_modules/libraries/dagster-deltalake-polars/setup.py
+++ b/python_modules/libraries/dagster-deltalake-polars/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_deltalake_polars_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-deltalake{pin}",

--- a/python_modules/libraries/dagster-deltalake/setup.py
+++ b/python_modules/libraries/dagster-deltalake/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_deltalake_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         "deltalake>=0.25.0,<1",
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-dlt/setup.py
+++ b/python_modules/libraries/dagster-dlt/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_dlt_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}", "dlt>=0.4"],
     zip_safe=False,
     extras_require={"test": ["duckdb", "dagster-dg-cli"]},

--- a/python_modules/libraries/dagster-docker/setup.py
+++ b/python_modules/libraries/dagster-docker/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_docker_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "docker",

--- a/python_modules/libraries/dagster-duckdb-pandas/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_duckdb_pandas_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-duckdb{pin}",

--- a/python_modules/libraries/dagster-duckdb-polars/setup.py
+++ b/python_modules/libraries/dagster-duckdb-polars/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_duckdb_polars_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-duckdb{pin}",

--- a/python_modules/libraries/dagster-duckdb-pyspark/setup.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_duckdb_pyspark_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-duckdb{pin}",

--- a/python_modules/libraries/dagster-duckdb/setup.py
+++ b/python_modules/libraries/dagster-duckdb/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_duckdb_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         "duckdb",
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-embedded-elt/setup.py
+++ b/python_modules/libraries/dagster-embedded-elt/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_embedded_elt_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}", f"dagster-sling{pin}", f"dagster-dlt{pin}"],
     zip_safe=False,
     extras_require={

--- a/python_modules/libraries/dagster-fivetran/setup.py
+++ b/python_modules/libraries/dagster-fivetran/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_fivetran_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}"],
     zip_safe=False,
     entry_points={

--- a/python_modules/libraries/dagster-gcp-pandas/setup.py
+++ b/python_modules/libraries/dagster-gcp-pandas/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_gcp_pandas_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-gcp{pin}",

--- a/python_modules/libraries/dagster-gcp-pyspark/setup.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_gcp_pyspark_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-gcp{pin}",

--- a/python_modules/libraries/dagster-gcp/setup.py
+++ b/python_modules/libraries/dagster-gcp/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_gcp_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster_pandas{pin}",

--- a/python_modules/libraries/dagster-ge/setup.py
+++ b/python_modules/libraries/dagster-ge/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_ge_tests*"]),
     include_package_data=True,
-    python_requires=">=3.10,<=3.13.3",
+    python_requires=">=3.10,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-pandas{pin}",

--- a/python_modules/libraries/dagster-github/setup.py
+++ b/python_modules/libraries/dagster-github/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_github_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         # Using a Github app requires signing your own JWT :(

--- a/python_modules/libraries/dagster-k8s/setup.py
+++ b/python_modules/libraries/dagster-k8s/setup.py
@@ -41,7 +41,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_k8s_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"kubernetes<{KUBERNETES_VERSION_UPPER_BOUND}",

--- a/python_modules/libraries/dagster-managed-elements/setup.py
+++ b/python_modules/libraries/dagster-managed-elements/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_managed_elements_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}", "requests", "click_spinner"],
     zip_safe=False,
     entry_points={

--- a/python_modules/libraries/dagster-mlflow/setup.py
+++ b/python_modules/libraries/dagster-mlflow/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_mlflow_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "mlflow",

--- a/python_modules/libraries/dagster-msteams/setup.py
+++ b/python_modules/libraries/dagster-msteams/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_msteams_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "requests>=2,<3",

--- a/python_modules/libraries/dagster-mysql/setup.py
+++ b/python_modules/libraries/dagster-mysql/setup.py
@@ -35,7 +35,7 @@ setup(
         ]
     },
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}", "mysql-connector-python"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-pagerduty/setup.py
+++ b/python_modules/libraries/dagster-pagerduty/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_pagerduty_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}", "pypd"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-pandas/setup.py
+++ b/python_modules/libraries/dagster-pandas/setup.py
@@ -45,7 +45,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_pandas_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "pandas",

--- a/python_modules/libraries/dagster-pandera/setup.py
+++ b/python_modules/libraries/dagster-pandera/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_pandera_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "pandas",

--- a/python_modules/libraries/dagster-papertrail/setup.py
+++ b/python_modules/libraries/dagster-papertrail/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_papertrail_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-postgres/setup.py
+++ b/python_modules/libraries/dagster-postgres/setup.py
@@ -38,7 +38,7 @@ setup(
         ]
     },
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}", "psycopg2-binary"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-powerbi/setup.py
+++ b/python_modules/libraries/dagster-powerbi/setup.py
@@ -38,7 +38,7 @@ setup(
         f"dagster{pin}",
     ],
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     zip_safe=False,
     extras_require={
         "test": [

--- a/python_modules/libraries/dagster-prometheus/setup.py
+++ b/python_modules/libraries/dagster-prometheus/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_prometheus_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}", "prometheus_client"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-pyspark/setup.py
+++ b/python_modules/libraries/dagster-pyspark/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_pyspark_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster_spark{pin}",

--- a/python_modules/libraries/dagster-sigma/setup.py
+++ b/python_modules/libraries/dagster-sigma/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[f"dagster{pin}", "sqlglot", "aiohttp"],
     extras_require={"test": ["aioresponses", "aiohttp<3.11"]},
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     entry_points={
         "console_scripts": [
             "dagster-sigma = dagster_sigma.cli:app",

--- a/python_modules/libraries/dagster-slack/setup.py
+++ b/python_modules/libraries/dagster-slack/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_slack_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "slack_sdk",

--- a/python_modules/libraries/dagster-sling/setup.py
+++ b/python_modules/libraries/dagster-sling/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_sling_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "sling>=1.1.5",

--- a/python_modules/libraries/dagster-snowflake-pandas/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_snowflake_pandas_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-snowflake{pin}",

--- a/python_modules/libraries/dagster-snowflake-polars/setup.py
+++ b/python_modules/libraries/dagster-snowflake-polars/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_snowflake_polars_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<3.13",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-snowflake{pin}",

--- a/python_modules/libraries/dagster-snowflake-pyspark/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_snowflake_pyspark_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         f"dagster-snowflake{pin}",

--- a/python_modules/libraries/dagster-snowflake/setup.py
+++ b/python_modules/libraries/dagster-snowflake/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_snowflake_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "snowflake-connector-python>=3.4.0",

--- a/python_modules/libraries/dagster-spark/setup.py
+++ b/python_modules/libraries/dagster-spark/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_spark_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-ssh/setup.py
+++ b/python_modules/libraries/dagster-ssh/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_ssh_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}", "sshtunnel", "paramiko"],
     extras_require={"test": ["cryptography==2.6.1", "pytest-sftpserver==1.2.0"]},
     zip_safe=False,

--- a/python_modules/libraries/dagster-tableau/setup.py
+++ b/python_modules/libraries/dagster-tableau/setup.py
@@ -41,6 +41,6 @@ setup(
         "tableauserverclient>=0.32",
     ],
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-twilio/setup.py
+++ b/python_modules/libraries/dagster-twilio/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_twilio_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<=3.13.3",
+    python_requires=">=3.9,<3.14",
     install_requires=[f"dagster{pin}", "twilio"],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-wandb/setup.py
+++ b/python_modules/libraries/dagster-wandb/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_wandb_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<3.12",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         "wandb>=0.15.11,<1.0",

--- a/python_modules/libraries/dagstermill/setup.py
+++ b/python_modules/libraries/dagstermill/setup.py
@@ -29,7 +29,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.9,<3.12",
+    python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
         # ipykernel 5.4.0 and 5.4.1 broke papermill


### PR DESCRIPTION
Summary:
For now i just matched our old behavior and allowed everything on the python version - I suspect if these do not work it is because of an issue with the underlying library rather than somethign in the dagster-xxx integration specifically?

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
