### PR TITLE
[component tree] Read return annotation off of @component_instance fn

### DIFF
--- a/python_modules/dagster/dagster/components/core/tree.py
+++ b/python_modules/dagster/dagster/components/core/tree.py
@@ -296,6 +296,8 @@ class ComponentTree:
 
             if isinstance(child_decl, ComponentLoaderDecl):
                 name = child_decl.path.instance_key
+                if child_decl.component_node_fn.__annotations__.get("return"):
+                    component_type = child_decl.component_node_fn.__annotations__["return"].__name__
             elif isinstance(child_decl, YamlDecl):
                 file_path = file_path / "defs.yaml"
                 component_type = child_decl.component_cls.__name__

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/__snapshots__/test_list_commands.ambr
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/__snapshots__/test_list_commands.ambr
@@ -8,7 +8,7 @@
   └── pythonic_components
       └── my_component.py
           ├── first
-          └── second
+          └── second (PyComponent)
   '''
 # ---
 # name: test_list_defs_complex_assets_succeeds


### PR DESCRIPTION
## Summary

If a Pythonic component has a return type annotation showing what component type it returns, add that info to the component tree.

## Test Plan

Update snapshot from tests.
