### PR TITLE
Fix incorrect link in "Next Steps" section of ETL pipeline tutorial for issue [#31081]

### DIFF
--- a/docs/docs/etl-pipeline-tutorial/3-data-quality.md
+++ b/docs/docs/etl-pipeline-tutorial/3-data-quality.md
@@ -72,4 +72,4 @@ But there are now data checks on the assets we have created to help ensure the q
 
 ## Next steps
 
-- Continue this tutorial with [creating and materializing partitioned assets](/etl-pipeline-tutorial/automate-your-pipeline)
+- Continue this tutorial with [creating and materializing partitioned assets](/etl-pipeline-tutorial/partition-asset)


### PR DESCRIPTION
## Summary & Motivation
This pull request address [#31081](https://github.com/dagster-io/dagster/issues/31081) and fixes an incorrect link in the Next Steps section of the 3-data-quality.md tutorial page. The link previously pointed to the "Automate your pipeline" lesson, causing users to skip the intended next step, "Create and materialize partitioned assets." This fix updates the link to correctly guide users through the tutorial in the right order.

## How I Tested These Changes
I verified the updated link points to the correct tutorial page (/etl-pipeline-tutorial/partition-asset) by visiting the URL and the page loads as expected.

## Changelog
Fixed broken tutorial link in 3-data-quality.md

