### PR TITLE
Add show_url_only to guide

### DIFF
--- a/docs/docs/deployment/dagster-plus/hybrid/azure/blob-compute-logs.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/azure/blob-compute-logs.md
@@ -26,7 +26,7 @@ We need to ensure that the AKS agent has the necessary permissions to write logs
 First, we'll enable the cluster to use workload identity. This will allow the AKS agent to use a managed identity to access Azure resources.
 
 ```bash
-az aks update --resource-group <resource-group> --name <cluster-name> --enable-workload-identity
+az aks update --resource-group <resource-group> --name <cluster-name> --enable-workload-identity --enable-oidc-issuer
 ```
 
 Then, we'll create a new managed identity for the AKS agent.
@@ -121,8 +121,8 @@ computeLogs:
       default_azure_credential:
         exclude_environment_credential: false
       prefix: dagster-logs
-      local_dir: '/tmp/cool'
       upload_interval: 30
+      show_url_only: true
 ```
 
 Finally, update your deployment with the new values:


### PR DESCRIPTION
When the default value of `show_url_only` changed here: https://github.com/dagster-io/dagster/pull/27010

We never updated this guide.

Also, include the `--enable-oidc-issuer` flag which I encountered while running through this guide on a fresh AKS cluster:

```
Enabling workload identity requires enabling OIDC issuer (--enable-oidc-issuer).
```