### PR TITLE
[components] fix scaffolding python components

### DIFF
--- a/docs/docs/guides/build/components/building-pipelines-with-components/adding-component-definitions.md
+++ b/docs/docs/guides/build/components/building-pipelines-with-components/adding-component-definitions.md
@@ -65,7 +65,9 @@ To scaffold a component definition formatted in Python instead of YAML, you can 
 dg scaffold defs dagster_dbt.DbtProjectComponent jdbt --project-path dbt/jdbt --format python
 ```
 
-<CliInvocationExample path="docs_snippets/docs_snippets/guides/components/python-components/tree.txt" title="component.py" />
+<CliInvocationExample path="docs_snippets/docs_snippets/guides/components/python-components/tree.txt" />
+
+<CodeExample path="docs_snippets/docs_snippets/guides/components/python-components/python-component.py" title="component.py" language="python" />
 
 ## Configuration
 

--- a/examples/docs_snippets/docs_snippets/guides/components/python-components/python-component.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/python-components/python-component.py
@@ -1,0 +1,5 @@
+import dagster as dg
+from dagster_dbt import DbtProjectComponent
+
+@dg.component_instance
+def load(context: dg.ComponentLoadContext) -> DbtProjectComponent: ...

--- a/examples/docs_snippets/docs_snippets/guides/components/python-components/tree.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/python-components/tree.txt
@@ -2,8 +2,6 @@ cd src/hello_world && tree
 
 .
 ├── __init__.py
-├── __pycache__
-│   └── __init__.cpython-312.pyc
 ├── definitions.py
 ├── defs
 │   ├── __init__.py

--- a/examples/docs_snippets/pyproject.toml
+++ b/examples/docs_snippets/pyproject.toml
@@ -15,6 +15,7 @@ extend-exclude = [
   "docs_snippets/guides/dg/migrating-definitions/7-definitions-after-all.py",
   "docs_snippets/guides/components/integrations/dlt-component/5-loads.py",
   "docs_snippets/guides/components/integrations/dlt-component/7-customized-loads.py",
+  "docs_snippets/guides/components/python-components/python-component.py",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary

The rename of `@component` -> `@component_instance` didn't make its way through to the scaffold-generated import. Fixes this, and puts it under test.

Also showcases the scaffolded file in our Python component docs example.

## Test Plan

New unit test.

## Changelog

> [components] Fixed an incorrect import being generated when scaffolding a component in Python.