### PR TITLE
Raise user_exception from None.

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_plan.py
@@ -315,7 +315,7 @@ def dagster_event_sequence_for_step(
         )
 
         if step_context.raise_on_error:
-            raise dagster_user_error.user_exception
+            raise dagster_user_error.user_exception from None
 
     # case (4) in top comment
     except (KeyboardInterrupt, DagsterExecutionInterruptedError) as interrupt_error:


### PR DESCRIPTION
## Summary & Motivation
 
The exception stack when executing the job in process was misleading.


Otherwise the error context was inverted, so the error message being printed was somehting like

``` Traceback (most recent call last): File
"/<path>/site-packages/dagster/_core/execution/plan/execute_plan.py",
line 246, in dagster_event_sequence_for_step yield from
check.generator(step_events) File
"/<path>/site-packages/dagster/_core/execution/plan/execute_step.py",
line 502, in core_dagster_event_sequence_for_step for user_event in
_step_output_error_checked_user_event_sequence( File
"/<path>/site-packages/dagster/_core/execution/plan/execute_step.py",
line 183, in _step_output_error_checked_user_event_sequence for
user_event in user_event_sequence: File
"/<path>/site-packages/dagster/_core/execution/plan/execute_step.py",
line 90, in _process_asset_results_to_events for user_event in
user_event_sequence: File
"/<path>/site-packages/dagster/_core/execution/plan/compute.py", line
187, in execute_core_compute for step_output in
_yield_compute_results(step_context, inputs, compute_fn,
compute_context): File
"/<path>/site-packages/dagster/_core/execution/plan/compute.py", line
156, in _yield_compute_results for event in iterate_with_context( File
"/<path>/site-packages/dagster/_utils/__init__.py", line 390, in
iterate_with_context with context_fn(): File "/<path>/contextlib.py",
line 155, in __exit__ self.gen.throw(typ, value, traceback) File
"/<path>/site-packages/dagster/_core/execution/plan/utils.py", line 87,
in op_execution_error_boundary raise error_cls(
dagster._core.errors.DagsterExecutionStepExecutionError: Error occurred
while executing op "..":

During handling of the above exception, another exception occurred:

<stack trace of actual user code error>

```

This change makes it so that the DagsterExecutionStepExecutionError doesn't show up later ( especially not the inverted `During handling of the above exception, another exception occurred:`


## How I Tested These Changes

ran execute_in_process locally

