### PR TITLE
add docblock for template_var

### DIFF
--- a/docs/sphinx/sections/api/apidocs/dagster/components.rst
+++ b/docs/sphinx/sections/api/apidocs/dagster/components.rst
@@ -8,6 +8,7 @@ Using Components
 
 .. autodecorator:: component_instance
 
+.. autodecorator:: template_var
 
 .. autoclass:: ComponentLoadContext
    :members:

--- a/python_modules/dagster/dagster/components/component/template_vars.py
+++ b/python_modules/dagster/dagster/components/component/template_vars.py
@@ -87,7 +87,6 @@ def template_var(
 
             # defs.yaml
             type: my_component.MyComponent
-            template_vars_module: .template_vars
             attributes:
               name: "{{ component_name }}"
               timestamp: "{{ current_timestamp }}"

--- a/python_modules/dagster/dagster/components/component/template_vars.py
+++ b/python_modules/dagster/dagster/components/component/template_vars.py
@@ -3,6 +3,8 @@ from typing import Any, Callable, Optional, Union, overload
 
 from typing_extensions import TypeAlias
 
+from dagster._annotations import public
+
 TemplateVarFn: TypeAlias = Callable[..., Any]
 
 TEMPLATE_VAR_ATTR = "__dagster_template_var"
@@ -16,6 +18,7 @@ def template_var(fn: TemplateVarFn) -> TemplateVarFn: ...
 def template_var() -> Callable[[TemplateVarFn], TemplateVarFn]: ...
 
 
+@public
 def template_var(
     fn: Optional[TemplateVarFn] = None,
 ) -> Union[TemplateVarFn, Callable[[TemplateVarFn], TemplateVarFn]]:

--- a/python_modules/dagster/dagster/components/component/template_vars.py
+++ b/python_modules/dagster/dagster/components/component/template_vars.py
@@ -39,9 +39,7 @@ def template_var(
 
     Functions decorated with @template_var can accept 0 or 1 parameters:
     - 0 parameters: Simple value generation or function factory
-    - 1 parameter: Receives ComponentDeclLoadContext for accessing component loading context. This
-      is for cases when the udf needs access to information about the project, such as its location
-      in the file system.
+    - 1 parameter: Receives ComponentDeclLoadContext for accessing component loading context. This is for cases when the udf needs access to information about the project, such as its location in the file system.
 
     Args:
         fn: The function to decorate as a template variable. If None, returns a decorator


### PR DESCRIPTION
## Summary & Motivation

Added comprehensive docstring to the `template_var` decorator in the Dagster component system. The docstring explains the purpose of template variables, how they can be used to inject dynamic values into component YAML configurations, and the different ways the decorator can be applied. It includes detailed examples showing basic usage, context parameter usage, returning functions for parameterized templates, and how to use template variables in component YAML files.

## How I Tested These Changes

Verified that the docstring renders correctly in the generated documentation and that the examples provided are syntactically correct and follow best practices.

## Changelog

Added comprehensive documentation for the `template_var` decorator to improve developer experience when working with Dagster component YAML templating.