### PR TITLE
[definitions] rm assertion for unresolved definitions, add merge_unbound_defs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -731,6 +731,20 @@ class Definitions(IHaveNew):
         """
         defs.get_repository_def().validate_loadable()
 
+    @staticmethod
+    def merge_unbound_defs(*def_sets: "Definitions") -> "Definitions":
+        """Variant of merge with some more strict checks on input Definitions objects,
+        including that they have not been resolved.
+        """
+        for i, def_set in enumerate(def_sets):
+            check.invariant(
+                not def_set.has_resolved_repository_def(),
+                f"Definitions object {i} has previously been resolved."
+                " merge_unbound_defs should only be used on definitions that have not been resolved.",
+            )
+
+        return Definitions.merge(*def_sets)
+
     @public
     @staticmethod
     def merge(*def_sets: "Definitions") -> "Definitions":
@@ -812,10 +826,6 @@ class Definitions(IHaveNew):
 
                 component_tree = def_set.component_tree
 
-            check.invariant(
-                not def_set.has_resolved_repository_def(),
-                "Definitions object should have been resolved",
-            )
         return Definitions(
             assets=assets,
             schedules=schedules,

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -733,8 +733,10 @@ class Definitions(IHaveNew):
 
     @staticmethod
     def merge_unbound_defs(*def_sets: "Definitions") -> "Definitions":
-        """Variant of merge with some more strict checks on input Definitions objects,
-        including that they have not been resolved.
+        """Merges multiple Definitions objects into a single Definitions object.
+
+        Asserts that input Definitions objects have not yet had their asset graphs resolved,
+        intended for internal use-cases to safeguard against unnecessarily resolving subgraphs.
         """
         for i, def_set in enumerate(def_sets):
             check.invariant(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -903,6 +903,19 @@ def test_executor_conflict_on_merge():
         Definitions.merge(defs1, defs2)
 
 
+def test_merge_resolved_defs():
+    defs1 = dg.Definitions(assets=[dg.AssetSpec("asset1")])
+    defs2 = dg.Definitions(assets=[dg.AssetSpec("asset2")])
+
+    merged_one = Definitions.merge_unbound_defs(defs1, defs2)
+
+    defs1.resolve_all_asset_specs()
+
+    merged_two = Definitions.merge(defs1, defs2)
+
+    assert merged_one.__dict__ == merged_two.__dict__
+
+
 def test_merge_unbound_defs_err_resolved():
     defs1 = dg.Definitions(assets=[dg.AssetSpec("asset1")])
     defs2 = dg.Definitions(assets=[dg.AssetSpec("asset2")])

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -903,6 +903,20 @@ def test_executor_conflict_on_merge():
         Definitions.merge(defs1, defs2)
 
 
+def test_merge_unbound_defs_err_resolved():
+    defs1 = dg.Definitions(assets=[dg.AssetSpec("asset1")])
+    defs2 = dg.Definitions(assets=[dg.AssetSpec("asset2")])
+
+    Definitions.merge_unbound_defs(defs1, defs2)
+
+    defs1.resolve_all_asset_specs()
+    with pytest.raises(
+        CheckError,
+        match="Definitions object 0 has previously been resolved.",
+    ):
+        Definitions.merge_unbound_defs(defs1, defs2)
+
+
 def test_executor_conflict_on_merge_same_value():
     defs1 = dg.Definitions(executor=in_process_executor)
     defs2 = dg.Definitions(executor=in_process_executor)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_load_context.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_load_context.py
@@ -64,7 +64,7 @@ def metadata_defs():
 
     all_asset_job = dg.define_asset_job("all_assets", selection=AssetSelection.all())
 
-    return Definitions.merge(
+    return Definitions.merge_unbound_defs(
         _get_foo_integration_defs(context, WORKSPACE_ID),
         dg.Definitions(assets=[regular_asset], jobs=[all_asset_job]),
     )

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/components/airflow_instance/component.py
@@ -281,7 +281,7 @@ def apply_mappings(defs: Definitions, mappings: Sequence[AirflowDagMapping]) -> 
             return spec.merge_attributes(metadata={handle.metadata_key: [handle.as_dict]})
         return spec
 
-    return Definitions.merge(
+    return Definitions.merge_unbound_defs(
         defs.map_resolved_asset_specs(func=spec_mapper), Definitions(assets=additional_assets)
     )
 

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -250,7 +250,7 @@ def build_defs_from_airflow_instance(
         defs=defs, assets=fully_resolved_assets_definitions
     )
 
-    return Definitions.merge(
+    return Definitions.merge_unbound_defs(
         defs_with_airflow_assets,
         Definitions(
             sensors=[

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
@@ -43,7 +43,7 @@ def test_snowflake_sql_component(snowflake_connect):
     with setup_snowflake_component(
         component_body=BASIC_SNOWFLAKE_COMPONENT_BODY,
     ) as (component, defs):
-        defs_with_resource = Definitions.merge(
+        defs_with_resource = Definitions.merge_unbound_defs(
             defs,
             Definitions(
                 resources={
@@ -113,7 +113,7 @@ def test_snowflake_sql_component_with_templates(snowflake_connect, sql_template)
         with setup_snowflake_component(
             component_body=component_body,
         ) as (component, defs):
-            defs_with_resource = Definitions.merge(
+            defs_with_resource = Definitions.merge_unbound_defs(
                 defs,
                 Definitions(
                     resources={
@@ -170,7 +170,7 @@ def test_snowflake_sql_component_with_execution(snowflake_connect):
     with setup_snowflake_component(
         component_body=component_body,
     ) as (component, defs):
-        defs_with_resource = Definitions.merge(
+        defs_with_resource = Definitions.merge_unbound_defs(
             defs,
             Definitions(
                 resources={


### PR DESCRIPTION
## Summary

Allows `Definitions.merge` to merge objects which have previously had the asset graph built, which currently triggers a check error.

The check error is currently blocking cross-component access in #30446. For cross-component accesses, a component triggers the a `Definitions` object to be built for another component, and subsequently accesses properties of that `Definitions` object. If that property requires resolution, such as the list of asset keys, it will cause the subsequent merging of `Definitions` objects at the folder level to fail this check.

Adds a new internal `merge_unbound_defs` which contains the assertion.

## Test Plan

New unit tests.