### PR TITLE
[ui] Handle null text value for MiddleTruncate

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode2025.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode2025.tsx
@@ -204,8 +204,8 @@ export const AssetNodeAutomationRowWithData = ({
       return (
         <AutomationConditionEvaluationLink definition={definition} automationData={automationData}>
           <EvaluationUserLabel
-            userLabel={automationData.automationCondition!.label!}
-            expandedLabel={automationData.automationCondition!.expandedLabel}
+            userLabel={automationData.automationCondition?.label ?? 'condition'}
+            expandedLabel={automationData.automationCondition?.expandedLabel ?? []}
             small
           />
         </AutomationConditionEvaluationLink>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -163,8 +163,8 @@ export const SidebarAssetInfo = ({graphNode}: {graphNode: GraphNode}) => {
                 automationData={liveAutomationData}
               >
                 <EvaluationUserLabel
-                  userLabel={liveAutomationData.automationCondition!.label! || 'condition'}
-                  expandedLabel={liveAutomationData.automationCondition!.expandedLabel}
+                  userLabel={liveAutomationData.automationCondition?.label ?? 'condition'}
+                  expandedLabel={liveAutomationData.automationCondition?.expandedLabel ?? []}
                 />
               </AutomationConditionEvaluationLink>
             </AttributeAndValue>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AutomationDetailsSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AutomationDetailsSection.tsx
@@ -76,8 +76,8 @@ export const AutomationDetailsSection = ({
       label: 'Automation condition',
       children: assetNode?.automationCondition?.label ? (
         <EvaluationUserLabel
-          userLabel={assetNode?.automationCondition.label}
-          expandedLabel={assetNode?.automationCondition.expandedLabel}
+          userLabel={assetNode.automationCondition.label}
+          expandedLabel={assetNode.automationCondition.expandedLabel}
         />
       ) : null,
     },


### PR DESCRIPTION
## Summary & Motivation

For some reason, `MiddleTruncate` is sometimes being rendered with `text={null}`, which TypeScript should be guarding against. It may be that something is being `any`'d upstream of this.

This is surfacing as runtime errors that crash the asset graph.

To resolve this, guard against `null` for `text` and just treat it as empty strings instead.

## How I Tested These Changes

View lineage tab for affected asset group, verify that the asset graph renders, with no errors related to `MiddleTruncate`.

## Changelog

[ui] Fix errors that can sometimes crash the asset graph view on an asset's lineage tab.