### PR TITLE
Fix certain partition mappings not being attached to graph asset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -972,7 +972,7 @@ def graph_asset_no_defaults(
     partition_mappings = {
         input_name: asset_in.partition_mapping
         for input_name, asset_in in ins.items()
-        if asset_in.partition_mapping
+        if asset_in.partition_mapping is not None
     }
 
     check_specs_by_output_name = validate_and_assign_output_names_to_check_specs(


### PR DESCRIPTION
## Summary & Motivation

Partition mappings such as `AllPartitionsMapping` or `LastPartitionMapping` are not attached to graph asset. This causes errors when running `Definitions.validate_loadable` tests in case there are dependencies between assets with different type of partitions. 

https://github.com/dagster-io/dagster/issues/30787

## How I Tested These Changes

Tested the change locally
