### PR TITLE
Support setting log format from environment variable for daemon, webserver

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -171,6 +171,7 @@ DEFAULT_POOL_MAX_OVERFLOW = 20
     required=False,
     default="colored",
     help="Format of the log output from the webserver",
+    envvar="DAGSTER_WEBSERVER_LOG_FORMAT",
 )
 @click.option(
     "--code-server-log-level",

--- a/python_modules/dagster/dagster/_daemon/cli/__init__.py
+++ b/python_modules/dagster/dagster/_daemon/cli/__init__.py
@@ -58,6 +58,7 @@ def _get_heartbeat_tolerance():
     required=False,
     default="colored",
     help="Format of the log output from the webserver",
+    envvar="DAGSTER_DAEMON_LOG_FORMAT",
 )
 @click.option(
     "--instance-ref",


### PR DESCRIPTION
## Summary & Motivation

Since the helm chart does not support overloading the startup command, environment variables are the only way we can control the logging format for the webserver, daemon.

## How I Tested These Changes

This is a two lines change on the click configuration, running the cli is enough to see that it works.

## Changelog

- dagster-daemon log format can now be configured by the environment variable `DAGSTER_DAEMON_LOG_FORMAT`.
- dagster-webserver log format can now be configured by the environment variable `DAGSTER_WEBSERVER_LOG_FORMAT`.
