### PR TITLE
Create a stub asset for upstream keys referenced by asset checks that are not in the graph

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/asset_graph.py
@@ -244,7 +244,14 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
         # definition was provided.
         all_referenced_asset_keys = {
             key for assets_def in assets_defs for key in assets_def.dependency_keys
-        }
+        }.union(
+            {
+                check_spec.key.asset_key
+                for assets_def in assets_defs
+                for check_spec in assets_def.node_check_specs_by_output_name.values()
+            }
+        )
+
         with disable_dagster_warnings():
             for key in all_referenced_asset_keys.difference(all_keys):
                 assets_defs.append(


### PR DESCRIPTION
## Summary & Motivation
The comment here claims that we covered the case in the new unit test, but we did not. Now we do.

## How I Tested These Changes
New test case

## Changelog
Fixed an issue where asset checks referencing asset keys that did not exist in the asset graph did not appear in the Dagster UI.