### PR TITLE
Only query health data if necessary

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -108,8 +108,8 @@ export function useAssetsHealthData({
   const result = AssetHealthData.useLiveData(keys, thread, skip);
   useBlockTraceUntilTrue(
     'useAssetsHealthData',
-    !loading &&
-      (skip || !blockTrace || !!(Object.keys(result.liveDataByNode).length === assetKeys.length)),
+    !loading && (!blockTrace || !!(Object.keys(result.liveDataByNode).length === assetKeys.length)),
+    {skip},
   );
   return result;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx
@@ -13,10 +13,20 @@ export const useAssetGraphSupplementaryData = (
   selection: string,
   nodes: WorkspaceAssetFragment[],
 ): {loading: boolean; data: SupplementaryInformation} => {
+  const needsAssetHealthData = useMemo(() => {
+    try {
+      const filters = parseExpression(selection);
+      return filters.some((filter) => filter.field === 'status');
+    } catch {
+      return false;
+    }
+  }, [selection]);
+
   const {liveDataByNode} = useAssetsHealthData({
     assetKeys: useMemo(() => nodes.map((node) => node.assetKey), [nodes]),
     thread: 'AssetGraphSupplementaryData', // Separate thread to avoid starving UI
     blockTrace: false,
+    skip: !needsAssetHealthData,
   });
 
   const loading = Object.keys(liveDataByNode).length !== nodes.length;
@@ -39,15 +49,6 @@ export const useAssetGraphSupplementaryData = (
       {} as Record<string, AssetKey[]>,
     );
   }, [liveDataByNode, loading]);
-
-  const needsAssetHealthData = useMemo(() => {
-    try {
-      const filters = parseExpression(selection);
-      return filters.some((filter) => filter.field === 'status');
-    } catch {
-      return false;
-    }
-  }, [selection]);
 
   const data = useStableReferenceByHash(assetsByStatus, true);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/util.ts
@@ -123,4 +123,5 @@ export const unsupportedAttributeMessages = {
   column: 'column filtering is available in Dagster+',
   table_name: 'table_name filtering is available in Dagster+',
   changed_in_branch: 'changed_in_branch filtering is available in Dagster+ branch deployments',
+  status: 'status filtering is available in Dagster+',
 };


### PR DESCRIPTION
## Summary & Motivation
Skip querying health data if we don't need it. We only need it if the user explicitly types a `status` filter. 


## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
