### PR TITLE
enable loading asset values from AssetExecutionContext

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
@@ -604,11 +604,9 @@ class AssetExecutionContext:
         *,
         python_type: Optional[type] = None,
         partition_key: Optional[str] = None,
-        metadata: Optional[dict[str, Any]] = None,
     ) -> Any:
         return self.op_execution_context.load_asset_value(
             asset_key=asset_key,
             python_type=python_type,
             partition_key=partition_key,
-            metadata=metadata,
         )

--- a/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
@@ -596,3 +596,19 @@ class AssetExecutionContext:
     @_copy_docs_from_op_execution_context
     def set_requires_typed_event_stream(self, *, error_message: Optional[str] = None) -> None:
         self.op_execution_context.set_requires_typed_event_stream(error_message=error_message)
+
+    @_copy_docs_from_op_execution_context
+    def load_asset_value(
+        self,
+        asset_key: AssetKey,
+        *,
+        python_type: Optional[type] = None,
+        partition_key: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        return self.op_execution_context.load_asset_value(
+            asset_key=asset_key,
+            python_type=python_type,
+            partition_key=partition_key,
+            metadata=metadata,
+        )

--- a/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
@@ -1279,7 +1279,6 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         *,
         python_type: Optional[type] = None,
         partition_key: Optional[str] = None,
-        metadata: Optional[dict[str, Any]] = None,
     ) -> Any:
         from dagster._core.definitions.input import InputDefinition
         from dagster._core.execution.plan.plan import FromLoadableAsset
@@ -1293,7 +1292,6 @@ class OpExecutionContext(AbstractComputeExecutionContext):
                 dagster_type=resolve_dagster_type(python_type),
                 asset_key=asset_key,
                 asset_partitions={partition_key} if partition_key else None,
-                metadata=metadata,
             ),
         ):
             if isinstance(event_or_input_value, DagsterEvent):

--- a/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
@@ -1279,6 +1279,21 @@ class OpExecutionContext(AbstractComputeExecutionContext):
         python_type: Optional[type] = None,
         partition_key: Optional[str] = None,
     ) -> Any:
+        """Loads the value of an asset by key.
+
+        Args:
+            asset_key (AssetKey): The key of the asset to load.
+            python_type (Optional[type]): The python type to load the asset as. This is what will
+                be returned inside `load_input` by `context.dagster_type.typing_type`.
+            partition_key (Optional[str]): The partition of the asset to load.
+
+        Example:
+            .. code-block:: python
+
+                @dg.asset(deps=[dg.AssetKey("upstream_asset")])
+                def my_asset(context: dg.AssetExecutionContext):
+                    return context.load_asset_value(dg.AssetKey("upstream_asset")) * 2
+        """
         from dagster._core.storage.asset_value_loader import AssetValueLoader
 
         loader = AssetValueLoader(

--- a/python_modules/dagster/dagster/_core/execution/plan/inputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/inputs.py
@@ -112,7 +112,7 @@ class FromLoadableAsset(StepInputSource):
 
         asset_layer = step_context.job_def.asset_layer
 
-        input_asset_key = asset_layer.get_asset_key_for_node_input(
+        input_asset_key = input_def.hardcoded_asset_key or asset_layer.get_asset_key_for_node_input(
             step_context.node_handle, input_name=input_def.name
         )
         assert input_asset_key is not None


### PR DESCRIPTION
## Summary

Implementation of #29898. Adds a new `AssetExecutionContext.load_asset_value` fn which can be used to dynamically load an asset's value in an asset body, rather than loading as part of the input parameters.

```python
    @dg.asset(deps=[the_asset])
    def the_downstream_asset(context: dg.AssetExecutionContext):
        return context.load_asset_value(dg.AssetKey("the_asset"))
```

## Test Plan

Unit tests.

## Changelog

- Introduced `AssetExecutionContext.load_asset_value`, which enables loading asset values from the IO manager dynamically rather than requiring asset values be loaded as parameters to the asset function. For example:
    
  ```python
  @dg.asset(deps=[the_asset])
  def the_downstream_asset(context: dg.AssetExecutionContext):
      return context.load_asset_value(dg.AssetKey("the_asset"))
  ```