### PR TITLE
remove asset_graph argument from AssetGraphSubset.get_asset_subset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -1056,14 +1056,19 @@ class SkipOnBackfillInProgressRule(
             AutomationResult,
         )
 
+        # this backfilling subset is aware of the current partitions definitions, and so will
+        # be valid
+        asset_subset = (
+            context.legacy_context.instance_queryer.get_active_backfill_target_asset_graph_subset().get_asset_subset(
+                context.legacy_context.asset_key
+            )
+            or context.asset_graph_view.get_empty_subset(
+                key=context.legacy_context.asset_key
+            ).convert_to_serializable_subset()
+        )
+
         backfilling_subset = ValidAssetSubset.coerce_from_subset(
-            # this backfilling subset is aware of the current partitions definitions, and so will
-            # be valid
-            (
-                context.legacy_context.instance_queryer.get_active_backfill_target_asset_graph_subset()
-            ).get_asset_subset(
-                context.legacy_context.asset_key, context.legacy_context.asset_graph
-            ),
+            asset_subset,
             context.legacy_context.partitions_def,
         )
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1961,8 +1961,16 @@ def _get_cant_run_because_of_parent_reason(
     if parent_node.partitions_def != candidate_node.partitions_def:
         return f"parent {parent_node.key.to_user_string()} and {candidate_node.key.to_user_string()} have different partitions definitions so they cannot be materialized in the same run. {candidate_node.key.to_user_string()} can be materialized once {parent_node.key.to_user_string()} is materialized."
 
-    parent_target_subset = target_subset.get_asset_subset(parent_asset_key, asset_graph)
-    candidate_target_subset = target_subset.get_asset_subset(candidate_asset_key, asset_graph)
+    parent_target_subset = (
+        target_subset.get_asset_subset(parent_asset_key)
+        or asset_graph_view.get_empty_subset(key=parent_asset_key).convert_to_serializable_subset()
+    )
+    candidate_target_subset = (
+        target_subset.get_asset_subset(candidate_asset_key)
+        or asset_graph_view.get_empty_subset(
+            key=candidate_asset_key
+        ).convert_to_serializable_subset()
+    )
 
     num_parent_partitions_being_requested_this_tick = parent_being_requested_this_tick_subset.size
 


### PR DESCRIPTION
Summary:
Goal is to move as much as possible of the asset-graph-dependant logic here to AssetGraphView and treat AssetGraphSubset as a relatively dumb data class.

Test Plan: BK