### PR TITLE
Rm global cache in `useStableReferenceByHash`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphSupplementaryData.oss.tsx
@@ -50,7 +50,7 @@ export const useAssetGraphSupplementaryData = (
     );
   }, [liveDataByNode, loading]);
 
-  const data = useStableReferenceByHash(assetsByStatus, true);
+  const data = useStableReferenceByHash(assetsByStatus);
 
   return {
     loading: needsAssetHealthData && loading,

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useStableReferenceByHash.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useStableReferenceByHash.test.tsx
@@ -12,10 +12,8 @@ describe('useStableReferenceByHash', () => {
       initialProps: {value: firstObject},
     });
 
-    // Each hook should maintain its own reference
     expect(result.current).toEqual(firstObject);
 
-    // Test that references remain stable even when props change
     rerender({value: secondObject});
 
     expect(result.current).toEqual(firstObject);

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useStableReferenceByHash.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useStableReferenceByHash.test.tsx
@@ -6,30 +6,18 @@ describe('useStableReferenceByHash', () => {
   it('should maintain separate references for different hook instances', () => {
     // Create two objects with the same content
     const firstObject = {a: 1};
-    const secondObject = {a: 1}; // Same content as firstObject
+    const secondObject = {a: 1};
 
-    // Create two separate hook instances with storeInMap=false
-    const {result: firstResult, rerender: firstRerender} = renderHook(
-      ({value}) => useStableReferenceByHash(value),
-      {initialProps: {value: firstObject}},
-    );
-    const {result: secondResult, rerender: secondRerender} = renderHook(
-      ({value}) => useStableReferenceByHash(value),
-      {initialProps: {value: secondObject}},
-    );
+    const {result, rerender} = renderHook(({value}) => useStableReferenceByHash(value), {
+      initialProps: {value: firstObject},
+    });
 
     // Each hook should maintain its own reference
-    expect(firstResult.current).toEqual(firstObject);
-    expect(secondResult.current).toEqual(secondObject);
+    expect(result.current).toEqual(firstObject);
 
     // Test that references remain stable even when props change
-    firstRerender({value: secondObject});
-    secondRerender({value: firstObject});
+    rerender({value: secondObject});
 
-    // Each hook should maintain its original reference
-    // This demonstrates that the hook preserves the initial reference
-    // even when receiving new props
-    expect(firstResult.current).toEqual(firstObject);
-    expect(secondResult.current).toEqual(secondObject);
+    expect(result.current).toEqual(firstObject);
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useStableReferenceByHash.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useStableReferenceByHash.test.tsx
@@ -16,6 +16,8 @@ describe('useStableReferenceByHash', () => {
 
     rerender({value: secondObject});
 
-    expect(result.current).toEqual(firstObject);
+    const firstResult = result.current;
+    rerender({value: secondObject});
+    expect(result.current).toBe(firstResult);
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useStableReferenceByHash.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useStableReferenceByHash.test.tsx
@@ -3,52 +3,33 @@ import {renderHook} from '@testing-library/react-hooks';
 import {useStableReferenceByHash} from '../useStableReferenceByHash';
 
 describe('useStableReferenceByHash', () => {
-  describe('when storeInMap is true', () => {
-    it('should maintain reference stability across different hook instances for identical objects', () => {
-      // Create two objects with the same content
-      const firstObject = {a: 1};
-      const secondObject = {a: 1}; // Same content as firstObject
+  it('should maintain separate references for different hook instances', () => {
+    // Create two objects with the same content
+    const firstObject = {a: 1};
+    const secondObject = {a: 1}; // Same content as firstObject
 
-      // Create two separate hook instances with storeInMap=true
-      const {result: firstResult} = renderHook(() => useStableReferenceByHash(firstObject, true));
-      const {result: secondResult} = renderHook(() => useStableReferenceByHash(secondObject, true));
+    // Create two separate hook instances with storeInMap=false
+    const {result: firstResult, rerender: firstRerender} = renderHook(
+      ({value}) => useStableReferenceByHash(value),
+      {initialProps: {value: firstObject}},
+    );
+    const {result: secondResult, rerender: secondRerender} = renderHook(
+      ({value}) => useStableReferenceByHash(value),
+      {initialProps: {value: secondObject}},
+    );
 
-      // Both hooks should return the same reference (firstObject)
-      // This means the hook is maintaining reference stability across instances
-      expect(firstResult.current).toBe(firstObject);
-      expect(secondResult.current).toBe(firstObject);
-    });
-  });
+    // Each hook should maintain its own reference
+    expect(firstResult.current).toEqual(firstObject);
+    expect(secondResult.current).toEqual(secondObject);
 
-  describe('when storeInMap is false', () => {
-    it('should maintain separate references for different hook instances', () => {
-      // Create two objects with the same content
-      const firstObject = {a: 1};
-      const secondObject = {a: 1}; // Same content as firstObject
+    // Test that references remain stable even when props change
+    firstRerender({value: secondObject});
+    secondRerender({value: firstObject});
 
-      // Create two separate hook instances with storeInMap=false
-      const {result: firstResult, rerender: firstRerender} = renderHook(
-        ({value}) => useStableReferenceByHash(value, false),
-        {initialProps: {value: firstObject}},
-      );
-      const {result: secondResult, rerender: secondRerender} = renderHook(
-        ({value}) => useStableReferenceByHash(value, false),
-        {initialProps: {value: secondObject}},
-      );
-
-      // Each hook should maintain its own reference
-      expect(firstResult.current).toEqual(firstObject);
-      expect(secondResult.current).toEqual(secondObject);
-
-      // Test that references remain stable even when props change
-      firstRerender({value: secondObject});
-      secondRerender({value: firstObject});
-
-      // Each hook should maintain its original reference
-      // This demonstrates that the hook preserves the initial reference
-      // even when receiving new props
-      expect(firstResult.current).toEqual(firstObject);
-      expect(secondResult.current).toEqual(secondObject);
-    });
+    // Each hook should maintain its original reference
+    // This demonstrates that the hook preserves the initial reference
+    // even when receiving new props
+    expect(firstResult.current).toEqual(firstObject);
+    expect(secondResult.current).toEqual(secondObject);
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useStableReferenceByHash.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useStableReferenceByHash.tsx
@@ -8,23 +8,8 @@ import {hashObject} from '../util/hashObject';
  * It is also useful to avoid re-rendering the component when the value changes but the hash is the same.
  */
 
-const referenceCache = new Map<string, any>();
-
-export const useStableReferenceByHash = <T,>(
-  value: T,
-  storeInMap = false,
-  hashFn = hashObject,
-): T => {
+export const useStableReferenceByHash = <T,>(value: T, hashFn = hashObject): T => {
   const hash = useMemo(() => hashFn(value), [value, hashFn]);
-  return useMemo(() => {
-    const cached = referenceCache.get(hash);
-    if (cached) {
-      return cached;
-    }
-    if (storeInMap) {
-      referenceCache.set(hash, value);
-    }
-    return value;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hash]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => value, [hash]);
 };


### PR DESCRIPTION
## Summary & Motivation

Undo an earlier decision that theoretically leads to unbounded memory usage.

## How I Tested These Changes
existing jest test