### PR TITLE
Redshift Resource: Suppressed very verbose logs when inserting a large number of rows

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/redshift/resources.py
@@ -71,7 +71,7 @@ class RedshiftClient(BaseRedshiftClient):
         with self._get_conn() as conn:
             with self._get_cursor(conn, cursor_factory=cursor_factory) as cursor:
                 try:
-                    self.log.info(f"Executing query '{query}'")
+                    self.log.debug(f"Executing query '{query}'")
                     cursor.execute(query)
 
                     if fetch_results and cursor.rowcount > 0:
@@ -133,7 +133,7 @@ class RedshiftClient(BaseRedshiftClient):
             with self._get_cursor(conn, cursor_factory=cursor_factory) as cursor:
                 for query in queries:
                     try:
-                        self.log.info(f"Executing query '{query}'")
+                        self.log.debug(f"Executing query '{query}'")
                         cursor.execute(query)
 
                         if fetch_results and cursor.rowcount > 0:


### PR DESCRIPTION
## Summary & Motivation
When inserting a large number of rows in AWS RedShift, the full INSERT SQL was dumped in the logs.

## How I Tested These Changes
I've moved to a debug log, tested on a separate resource with context.log.debug

## Changelog

> changed from log.info to log.debug
