### PR TITLE
Prefer sensor tag to automation condition tag when both are set on a run

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/getAutomationForRun.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/getAutomationForRun.tsx
@@ -8,6 +8,7 @@ export const getAutomationForRun = (
   run: RunTimelineFragment,
 ): RunAutomation | null => {
   const {tags = []} = run;
+  // First check for schedules or sensors
   for (const tag of tags) {
     if (tag.key === DagsterTag.ScheduleName) {
       return {type: 'schedule', repoAddress, name: tag.value};
@@ -15,9 +16,14 @@ export const getAutomationForRun = (
     if (tag.key === DagsterTag.SensorName) {
       return {type: 'sensor', repoAddress, name: tag.value};
     }
+  }
+
+  // Then check if it was launched by an automation condition without a sensor
+  for (const tag of tags) {
     if (tag.key === DagsterTag.Automaterialize) {
       return {type: 'legacy-amp'};
     }
   }
+
   return null;
 };


### PR DESCRIPTION
Summary:
This fixes an issue where runs launched by DA sensors are lumped in the 'automation condition' row instead of correctly attributed to their specific sensor.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
