### PR TITLE
Fix filtering by automation condition on runs page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -264,7 +264,10 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
 
   const createdByValues = useMemo(
     () => [
-      tagToFilterValue(DagsterTag.Automaterialize, 'true'),
+      {
+        ...tagToFilterValue(DagsterTag.Automaterialize, 'true'),
+        final: true,
+      },
       ...[...sensorValues].sort((a, b) => COMMON_COLLATOR.compare(a.label, b.label)),
       ...[...scheduleValues].sort((a, b) => COMMON_COLLATOR.compare(a.label, b.label)),
       ...[...userValues].sort((a, b) => COMMON_COLLATOR.compare(a.label, b.label)),


### PR DESCRIPTION
## Summary & Motivation

We started using the `useSuggestionFilter` hook in https://github.com/dagster-io/dagster/pull/27288/  but didn't update the array of possible values to have `final: true` on automation condition resulting in the suggestion being made over and over again.

## How I Tested These Changes

locally.