### PR TITLE
Raise an exception if you try to retry a run with no steps or assets or checks

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
@@ -2,6 +2,7 @@ import os
 
 import dagster as dg
 import pytest
+from dagster._core.errors import DagsterInvalidSubsetError
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.storage.dagster_run import DagsterRunStatus
@@ -86,6 +87,18 @@ def acd_checked(context: dg.AssetExecutionContext):
             yield dg.Output(None, selected)
 
 
+@dg.multi_asset(
+    specs=[
+        dg.AssetSpec("fail_after_materialize", skippable=True),
+    ],
+    can_subset=True,
+)
+def fail_after_materialize(context: dg.AssetExecutionContext):
+    context.log.info(f"{list(sorted(context.selected_output_names))}")
+    yield dg.AssetMaterialization(asset_key=dg.AssetKey("fail_after_materialize"))
+    raise Exception("I have failed")
+
+
 @dg.asset(deps=["a_checked"])
 def b_checked() -> None: ...
 
@@ -159,6 +172,7 @@ defs = dg.Definitions(
         a1_blocking_downstream,
         unsubsettable_checked,
         a1_unsubsettable_downstream,
+        fail_after_materialize,
     ],
     jobs=[
         conditional_fail_job,
@@ -174,6 +188,10 @@ defs = dg.Definitions(
         dg.define_asset_job(
             name="unsubsettable_job",
             selection=[unsubsettable_checked, a1_unsubsettable_downstream],
+        ),
+        dg.define_asset_job(
+            name="fail_after_materialize_job",
+            selection=[fail_after_materialize],
         ),
     ],
 )
@@ -193,6 +211,10 @@ def blocking_check_job():
 
 def unsubsettable_job():
     return defs.resolve_job_def("unsubsettable_job")
+
+
+def fail_after_materialize_job():
+    return defs.resolve_job_def("fail_after_materialize_job")
 
 
 @pytest.fixture(name="instance", scope="module")
@@ -240,6 +262,20 @@ def failed_run_fixture(instance):
     return instance.get_run_by_id(result.run_id)
 
 
+@pytest.fixture(scope="module")
+def success_run(instance):
+    # trigger failure in the conditionally_fail op
+    result = dg.execute_job(
+        dg.reconstructable(conditional_fail_job),
+        instance=instance,
+        tags={"fizz": "buzz", "foo": "not bar!", f"{SYSTEM_TAG_PREFIX}run_metrics": "true"},
+    )
+
+    assert result.success
+
+    return instance.get_run_by_id(result.run_id)
+
+
 def test_create_reexecuted_run_from_failure(
     instance: dg.DagsterInstance, workspace, code_location, remote_job, failed_run
 ):
@@ -259,6 +295,22 @@ def test_create_reexecuted_run_from_failure(
     assert step_did_not_run(instance, run, "before_failure")
     assert step_succeeded(instance, run, "conditional_fail")
     assert step_succeeded(instance, run, "after_failure")
+
+
+def test_create_reexecuted_run_from_failure_all_steps_succeeded(
+    instance: dg.DagsterInstance, code_location, remote_job, success_run
+):
+    failed_after_finish_run = success_run._replace(status=DagsterRunStatus.FAILURE)
+
+    with pytest.raises(
+        DagsterInvalidSubsetError, match="No steps needed to be retried in the failed run."
+    ):
+        instance.create_reexecuted_run(
+            parent_run=failed_after_finish_run,
+            code_location=code_location,
+            remote_job=remote_job,
+            strategy=ReexecutionStrategy.FROM_FAILURE,
+        )
 
 
 def test_create_reexecuted_run_from_failure_tags(
@@ -418,6 +470,31 @@ def test_create_reexecuted_run_from_multi_asset_check_failure(
         dg.AssetCheckKey(dg.AssetKey("c_checked"), "good"),
         dg.AssetCheckKey(dg.AssetKey("d_checked"), "good"),
     }
+
+
+def test_create_reexecuted_run_from_multi_asset_failure_after_all_assets_materialized(
+    instance: dg.DagsterInstance, workspace, code_location
+):
+    remote_job = code_location.get_repository("__repository__").get_full_job(
+        "fail_after_materialize_job"
+    )
+    result = dg.execute_job(dg.reconstructable(fail_after_materialize_job), instance=instance)
+    assert not result.success
+    failed_run = instance.get_run_by_id(result.run_id)
+    assert failed_run
+    assert _get_materialized_keys(instance, failed_run.run_id) == {
+        dg.AssetKey("fail_after_materialize"),
+    }
+    with pytest.raises(
+        DagsterInvalidSubsetError,
+        match="No assets or asset checks needed to be retried in the failed run.",
+    ):
+        instance.create_reexecuted_run(
+            parent_run=failed_run,
+            code_location=code_location,
+            remote_job=remote_job,
+            strategy=ReexecutionStrategy.FROM_ASSET_FAILURE,
+        )
 
 
 def test_create_reexecuted_run_from_multi_asset_check_failure_blocking_check(


### PR DESCRIPTION
## Summary & Motivation
It's possible for a run to do all of its intended work but still fail (for example, it finishes all its steps and then fails during run cleanup, or completes all its asset materializations but then the step fails). In this case, the retry logic will return an empty list of steps/assets/checks, and then either fail with an inscrutable error related to io managers, or worse, sometimes try to run every step (!) This fixes that by detecting the error and raising an informative exception.

## How I Tested These Changes
New test cases, simulate manually

## Changelog
Using the "Retry from Asset Failure" option when retrying a run that failed after materializing all of its assets will now correctly indicate that there is no work that needs to be retried.