### PR TITLE
[backfills] allow run config in PartitionBackfill

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2578,6 +2578,7 @@ input LaunchBackfillParams {
   forceSynchronousSubmission: Boolean
   title: String
   description: String
+  runConfigData: RunConfigData
 }
 
 input PartitionSetSelector {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2454,6 +2454,7 @@ export type LaunchBackfillParams = {
   partitionNames?: InputMaybe<Array<Scalars['String']['input']>>;
   partitionsByAssets?: InputMaybe<Array<InputMaybe<PartitionsByAssetSelector>>>;
   reexecutionSteps?: InputMaybe<Array<Scalars['String']['input']>>;
+  runConfigData?: InputMaybe<Scalars['RunConfigData']['input']>;
   selector?: InputMaybe<PartitionSetSelector>;
   tags?: InputMaybe<Array<ExecutionTag>>;
   title?: InputMaybe<Scalars['String']['input']>;
@@ -10256,6 +10257,8 @@ export const buildLaunchBackfillParams = (
         : [],
     reexecutionSteps:
       overrides && overrides.hasOwnProperty('reexecutionSteps') ? overrides.reexecutionSteps! : [],
+    runConfigData:
+      overrides && overrides.hasOwnProperty('runConfigData') ? overrides.runConfigData! : 'sit',
     selector:
       overrides && overrides.hasOwnProperty('selector')
         ? overrides.selector!

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -89,6 +89,7 @@ def create_and_launch_partition_backfill(
 ) -> Union["GrapheneLaunchBackfillSuccess", "GraphenePartitionSetNotFoundError"]:
     from dagster_graphql.schema.backfill import GrapheneLaunchBackfillSuccess
     from dagster_graphql.schema.errors import GraphenePartitionSetNotFoundError
+    from dagster_graphql.schema.runs import parse_run_config_input
 
     backfill_id = make_new_backfill_id()
     backfill_timestamp = get_current_timestamp()
@@ -124,6 +125,12 @@ def create_and_launch_partition_backfill(
     tags = {**tags, **graphene_info.context.get_viewer_tags()}
 
     title = check_valid_title(backfill_params.get("title"))
+    parsed_run_config = (
+        parse_run_config_input(backfill_params["runConfigData"], raise_on_error=False)
+        if "runConfigData" in backfill_params
+        else None
+    )
+    run_config = parsed_run_config if isinstance(parsed_run_config, dict) else None
 
     if backfill_params.get("selector") is not None:  # job backfill
         partition_set_selector = backfill_params["selector"]
@@ -181,6 +188,7 @@ def create_and_launch_partition_backfill(
             asset_selection=asset_selection,
             title=title,
             description=backfill_params.get("description"),
+            run_config=run_config,
         )
         assert_valid_job_partition_backfill(
             graphene_info,
@@ -237,6 +245,7 @@ def create_and_launch_partition_backfill(
             all_partitions=backfill_params.get("allPartitions", False),
             title=title,
             description=backfill_params.get("description"),
+            run_config=run_config,
         )
         assert_valid_asset_partition_backfill(
             graphene_info,
@@ -273,6 +282,7 @@ def create_and_launch_partition_backfill(
             partitions_by_assets=partitions_by_assets,
             title=title,
             description=backfill_params.get("description"),
+            run_config=run_config,
         )
         assert_valid_asset_partition_backfill(
             graphene_info,
@@ -386,6 +396,7 @@ def retry_partition_backfill(
             backfill_timestamp=get_current_timestamp(),
             title=f"Re-execution of {backfill.title}" if backfill.title else None,
             description=backfill.description,
+            run_config=backfill.run_config,
         )
     else:  # job backfill
         partition_set_origin = check.not_none(backfill.partition_set_origin)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -207,6 +207,7 @@ class GrapheneLaunchBackfillParams(graphene.InputObjectType):
     forceSynchronousSubmission = graphene.Boolean()
     title = graphene.String()
     description = graphene.String()
+    runConfigData = graphene.InputField(GrapheneRunConfigData)
 
     class Meta:
         name = "LaunchBackfillParams"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -255,6 +255,7 @@ def _execute_asset_backfill_iteration_no_side_effects(graphql_context, backfill_
             asset_graph_view=asset_graph_view,
             backfill_start_timestamp=asset_backfill_data.backfill_start_timestamp,
             logger=logging.getLogger("fake_logger"),
+            run_config=None,
         )
 
     updated_backfill = backfill.with_asset_backfill_data(

--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -22,6 +22,7 @@ class JobSubsetSelector(IHaveNew):
     op_selection: Optional[Sequence[str]]
     asset_selection: Optional[AbstractSet[AssetKey]]
     asset_check_selection: Optional[AbstractSet[AssetCheckKey]]
+    run_config: Optional[Mapping[str, Any]]
 
     def __new__(
         cls,
@@ -31,6 +32,7 @@ class JobSubsetSelector(IHaveNew):
         op_selection: Optional[Sequence[str]],
         asset_selection: Optional[Iterable[AssetKey]] = None,
         asset_check_selection: Optional[Iterable[AssetCheckKey]] = None,
+        run_config: Optional[Mapping[str, Any]] = None,
     ):
         # coerce iterables to sets
         asset_selection = frozenset(asset_selection) if asset_selection else None
@@ -45,6 +47,7 @@ class JobSubsetSelector(IHaveNew):
             op_selection=op_selection,
             asset_selection=asset_selection,
             asset_check_selection=asset_check_selection,
+            run_config=run_config,
         )
 
     def to_graphql_input(self):

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, NamedTuple, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union, cast
 
 import dagster._check as check
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, TemporalContext
@@ -1053,6 +1053,7 @@ async def execute_asset_backfill_iteration(
                 asset_graph_view=asset_graph_view,
                 backfill_start_timestamp=backfill.backfill_timestamp,
                 logger=logger,
+                run_config=backfill.run_config,
             )
 
             # Write the updated asset backfill data with in progress run requests before we launch anything, for idempotency
@@ -1425,6 +1426,7 @@ def execute_asset_backfill_iteration_inner(
     asset_graph_view: AssetGraphView,
     backfill_start_timestamp: float,
     logger: logging.Logger,
+    run_config: Optional[Mapping[str, Any]],
 ) -> AssetBackfillIterationResult:
     """Core logic of a backfill iteration. Has no side effects.
 
@@ -1440,7 +1442,12 @@ def execute_asset_backfill_iteration_inner(
         dynamic_partitions_store=asset_graph_view.get_inner_queryer_for_back_compat(),
     ):
         return _execute_asset_backfill_iteration_inner(
-            backfill_id, asset_backfill_data, asset_graph_view, backfill_start_timestamp, logger
+            backfill_id,
+            asset_backfill_data,
+            asset_graph_view,
+            backfill_start_timestamp,
+            logger,
+            run_config,
         )
 
 
@@ -1481,6 +1488,7 @@ def _execute_asset_backfill_iteration_inner(
     asset_graph_view: AssetGraphView,
     backfill_start_timestamp: float,
     logger: logging.Logger,
+    run_config: Optional[Mapping[str, Any]],
 ) -> AssetBackfillIterationResult:
     instance_queryer = asset_graph_view.get_inner_queryer_for_back_compat()
     asset_graph: RemoteWorkspaceAssetGraph = cast(
@@ -1587,11 +1595,14 @@ def _execute_asset_backfill_iteration_inner(
             f"The following assets were considered for materialization but not requested:\n\n{not_requested_str}"
         )
 
-    run_requests = build_run_requests_with_backfill_policies(
-        asset_partitions=asset_partitions_to_request,
-        asset_graph=asset_graph,
-        dynamic_partitions_store=instance_queryer,
-    )
+    run_requests = [
+        rr._replace(run_config=run_config)
+        for rr in build_run_requests_with_backfill_policies(
+            asset_partitions=asset_partitions_to_request,
+            asset_graph=asset_graph,
+            dynamic_partitions_store=instance_queryer,
+        )
+    ]
 
     if request_roots:
         check.invariant(

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -3,7 +3,7 @@ import os
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
@@ -108,6 +108,7 @@ class PartitionBackfill(
             ("asset_selection", Optional[Sequence[AssetKey]]),
             ("title", Optional[str]),
             ("description", Optional[str]),
+            ("run_config", Optional[Mapping[str, Any]]),
             # fields that are only used by job backfills
             ("partition_set_origin", Optional[RemotePartitionSetOrigin]),
             ("partition_names", Optional[Sequence[str]]),
@@ -134,6 +135,7 @@ class PartitionBackfill(
         asset_selection: Optional[Sequence[AssetKey]] = None,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        run_config: Optional[Mapping[str, Any]] = None,
         partition_set_origin: Optional[RemotePartitionSetOrigin] = None,
         partition_names: Optional[Sequence[str]] = None,
         last_submitted_partition_name: Optional[str] = None,
@@ -169,6 +171,7 @@ class PartitionBackfill(
             ),
             title=check_valid_title(title),
             description=check.opt_str_param(description, "description"),
+            run_config=check.opt_mapping_param(run_config, "run_config", key_type=str),
             partition_set_origin=check.opt_inst_param(
                 partition_set_origin, "partition_set_origin", RemotePartitionSetOrigin
             ),
@@ -441,6 +444,7 @@ class PartitionBackfill(
         all_partitions: bool,
         title: Optional[str],
         description: Optional[str],
+        run_config: Optional[Mapping[str, Any]],
     ) -> "PartitionBackfill":
         """If all the selected assets that have PartitionsDefinitions have the same partitioning, then
         the backfill will target the provided partition_names for all those assets.
@@ -469,6 +473,7 @@ class PartitionBackfill(
             asset_backfill_data=asset_backfill_data,
             title=title,
             description=description,
+            run_config=run_config,
         )
 
     @classmethod
@@ -482,6 +487,7 @@ class PartitionBackfill(
         partitions_by_assets: Sequence[PartitionsByAssetSelector],
         title: Optional[str],
         description: Optional[str],
+        run_config: Optional[Mapping[str, Any]],
     ):
         asset_backfill_data = AssetBackfillData.from_partitions_by_assets(
             asset_graph=asset_graph,
@@ -500,6 +506,7 @@ class PartitionBackfill(
             asset_selection=[selector.asset_key for selector in partitions_by_assets],
             title=title,
             description=description,
+            run_config=run_config,
         )
 
     @classmethod
@@ -512,6 +519,7 @@ class PartitionBackfill(
         asset_graph_subset: AssetGraphSubset,
         title: Optional[str],
         description: Optional[str],
+        run_config: Optional[Mapping[str, Any]],
     ):
         asset_backfill_data = AssetBackfillData.from_asset_graph_subset(
             asset_graph_subset=asset_graph_subset,
@@ -529,6 +537,7 @@ class PartitionBackfill(
             asset_selection=list(asset_graph_subset.asset_keys),
             title=title,
             description=description,
+            run_config=run_config,
         )
 
 

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -353,6 +353,7 @@ def submit_backfill_runs(
             job_name=partition_set.job_name,
             op_selection=None,
             asset_selection=backfill_job.asset_selection,
+            run_config=backfill_job.run_config,
         )
         remote_job = code_location.get_job(pipeline_selector)
     else:
@@ -378,7 +379,16 @@ def submit_backfill_runs(
     tags_by_key_or_range: Mapping[Union[str, PartitionKeyRange], Mapping[str, str]]
     run_config_by_key_or_range: Mapping[Union[str, PartitionKeyRange], Mapping[str, Any]]
     if isinstance(partition_names_or_ranges[0], PartitionKeyRange):
-        run_config = partition_set_execution_data.partition_data[0].run_config
+        partition_set_run_config = partition_set_execution_data.partition_data[0].run_config
+
+        if partition_set_run_config and backfill_job.run_config:
+            raise DagsterInvariantViolationError(
+                "Cannot specify both partition-scoped run config and backfill-scoped run config. This can happen "
+                "if you explicitly set a PartitionSet on your job and also specify run config when launching a backfill.",
+            )
+
+        run_config = partition_set_run_config or backfill_job.run_config or {}
+
         tags = {
             k: v
             for k, v in partition_set_execution_data.partition_data[0].tags.items()
@@ -395,7 +405,8 @@ def submit_backfill_runs(
         }
     else:
         run_config_by_key_or_range = {
-            pd.name: pd.run_config for pd in partition_set_execution_data.partition_data
+            pd.name: pd.run_config or backfill_job.run_config or {}
+            for pd in partition_set_execution_data.partition_data
         }
         tags_by_key_or_range = {
             pd.name: pd.tags for pd in partition_set_execution_data.partition_data

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -88,6 +88,7 @@ async def get_job_execution_data_from_run_request(
         asset_selection=run_request.asset_selection,
         asset_check_selection=run_request.asset_check_keys,
         op_selection=None,
+        run_config=run_request.run_config or {},
     )
 
     if pipeline_selector not in run_request_execution_data_cache:
@@ -193,7 +194,7 @@ async def _create_asset_run(
                 run_id=run_id,
                 resolved_op_selection=None,
                 op_selection=None,
-                run_config={},
+                run_config=run_request.run_config or {},
                 step_keys_to_execute=None,
                 tags=run_request.tags,
                 root_run_id=None,
@@ -245,7 +246,6 @@ async def submit_asset_run(
     submits the existing run. If the run does not exist, creates a new run and submits it, ensuring
     that the created run targets the given asset selection.
     """
-    check.invariant(not run_request.run_config, "Asset run requests have no custom run config")
     entity_keys: Sequence[EntityKey] = [
         *(run_request.asset_selection or []),
         *(run_request.asset_check_keys or []),

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -743,7 +743,7 @@ class RemoteExecutionPlan(LoadableBy[JobSubsetSelector, "BaseWorkspaceRequestCon
         tasks = [
             context.gen_execution_plan(
                 check.not_none(remote_jobs_by_key[key]),
-                run_config={},
+                run_config=key.run_config or {},
                 step_keys_to_execute=None,
                 known_state=None,
             )

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -1184,6 +1184,7 @@ class AssetDaemon(DagsterDaemon):
                         },
                         title=f"Run for Declarative Automation evaluation ID {evaluation_id}",
                         description=None,
+                        run_config=run_request.run_config,
                     )
                 )
             return reserved_run_id, check.not_none(asset_graph_subset.asset_keys)

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -1241,6 +1241,7 @@ def _submit_backfill_request(
             # would need to add these as params to RunRequest
             title=None,
             description=None,
+            run_config=run_request.run_config,
         )
     )
     return SubmitRunRequestResult(

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -141,6 +141,31 @@ def partitions_defs_changes_location_1_fixture(
         yield workspace_context
 
 
+def run_config_assets_workspace_1_load_target(attribute=None):
+    return InProcessTestWorkspaceLoadTarget(
+        InProcessCodeLocationOrigin(
+            loadable_target_origin=LoadableTargetOrigin(
+                executable_path=sys.executable,
+                module_name="dagster_tests.daemon_tests.test_locations.run_config_assets_workspace",
+                working_directory=os.getcwd(),
+                attribute=attribute,
+            ),
+            location_name="run_config_assets",
+        )
+    )
+
+
+@pytest.fixture(name="run_config_assets_workspace_context", scope="module")
+def run_config_assets_workspace_context(
+    instance_module_scoped,
+) -> Iterator[WorkspaceProcessContext]:
+    with create_test_daemon_workspace_context(
+        workspace_load_target=run_config_assets_workspace_1_load_target(),
+        instance=instance_module_scoped,
+    ) as workspace_context:
+        yield workspace_context
+
+
 def partitions_def_changes_workspace_2_load_target(attribute=None):
     return InProcessTestWorkspaceLoadTarget(
         InProcessCodeLocationOrigin(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -14,6 +14,7 @@ import dagster as dg
 import dagster._check as check
 import pytest
 from dagster import AssetExecutionContext, DagsterInstance
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets.graph.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
@@ -1207,6 +1208,7 @@ def test_asset_backfill_retryable_error(instance, workspace_context):
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     )
     instance.add_backfill(backfill)
     assert instance.get_runs_count() == 0
@@ -1301,6 +1303,7 @@ def test_unloadable_backfill_retry(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -1433,6 +1436,7 @@ def test_pure_asset_backfill_with_multiple_assets_selected(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -1498,6 +1502,7 @@ def test_pure_asset_backfill(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -1587,6 +1592,7 @@ def test_asset_backfill_cancellation(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -1653,6 +1659,7 @@ def test_asset_backfill_submit_runs_in_chunks(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -1703,6 +1710,7 @@ def test_asset_backfill_mid_iteration_cancel(
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     )
     instance.add_backfill(backfill)
     assert instance.get_runs_count() == 0
@@ -1771,6 +1779,7 @@ def test_asset_backfill_forcible_mark_as_canceled_during_canceling_iteration(
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     ).with_status(BulkActionStatus.CANCELING)
     instance.add_backfill(
         # Add some partitions in a "requested" state to mock that certain partitions are hanging
@@ -1845,6 +1854,7 @@ def test_asset_backfill_mid_iteration_code_location_unreachable_error(
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     )
     instance.add_backfill(backfill)
     assert instance.get_runs_count() == 0
@@ -1977,6 +1987,7 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_no_runs_
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     )
     instance.add_backfill(backfill)
     assert instance.get_runs_count() == 0
@@ -2065,6 +2076,7 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_some_run
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     )
     instance.add_backfill(backfill)
     assert instance.get_runs_count() == 0
@@ -2168,6 +2180,7 @@ def test_backfill_warns_when_runs_completed_but_partitions_marked_as_in_progress
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     )
     instance.add_backfill(backfill)
     assert instance.get_runs_count() == 0
@@ -2396,6 +2409,7 @@ def test_asset_backfill_with_single_run_backfill_policy(
         ],
         title=None,
         description=None,
+        run_config=None,
     )
     instance.add_backfill(backfill)
 
@@ -2439,6 +2453,7 @@ def test_asset_backfill_from_asset_graph_subset_with_single_run_backfill_policy(
         dynamic_partitions_store=instance,
         title=None,
         description=None,
+        run_config=None,
     )
     instance.add_backfill(backfill)
 
@@ -2480,6 +2495,7 @@ def test_asset_backfill_with_multi_run_backfill_policy(
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     )
     instance.add_backfill(backfill)
 
@@ -2541,6 +2557,7 @@ def test_complex_asset_with_backfill_policy(
         ],
         title=None,
         description=None,
+        run_config=None,
     )
     instance.add_backfill(backfill)
 
@@ -2626,6 +2643,7 @@ def test_error_code_location(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
 
@@ -2670,6 +2688,7 @@ def test_raise_error_on_asset_backfill_partitions_defs_changes(
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     )
 
     if backcompat_serialization:
@@ -2722,6 +2741,7 @@ def test_raise_error_on_partitions_defs_removed(
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     )
 
     if backcompat_serialization:
@@ -2769,6 +2789,7 @@ def test_raise_error_on_target_static_partition_removed(
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     )
     instance.add_backfill(backfill)
     # When a static partitions def is changed, but all target partitions still exist,
@@ -2794,6 +2815,7 @@ def test_raise_error_on_target_static_partition_removed(
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     )
     instance.add_backfill(backfill)
     # When a static partitions def is changed, but any target partitions is removed,
@@ -2834,6 +2856,7 @@ def test_partitions_def_changed_backfill_retry_envvar_set(
         all_partitions=False,
         title=None,
         description=None,
+        run_config=None,
     )
 
     instance.add_backfill(backfill)
@@ -2875,6 +2898,7 @@ def test_asset_backfill_logging(caplog, instance, workspace_context):
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -2924,6 +2948,7 @@ def test_asset_backfill_failure_logging(caplog, instance, workspace_context):
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -3009,6 +3034,7 @@ def test_backfill_with_title_and_description(
             all_partitions=False,
             title="Custom title",
             description="this backfill is fancy",
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -3049,6 +3075,212 @@ def test_backfill_with_title_and_description(
     runs = instance.get_runs()
 
     assert all([run.status == DagsterRunStatus.SUCCESS] for run in runs)
+
+
+def test_asset_backfill_with_run_config_simple(
+    instance: DagsterInstance, run_config_assets_workspace_context: WorkspaceProcessContext
+):
+    hourly_partitions_def = dg.HourlyPartitionsDefinition("2023-10-01-00:00")
+    daily_partitions_def = dg.DailyPartitionsDefinition("2023-10-01")
+    hourly_subset = hourly_partitions_def.empty_subset().with_partition_key_range(
+        hourly_partitions_def, dg.PartitionKeyRange("2023-11-01-00:00", "2023-11-01-03:00")
+    )
+    daily_subset = daily_partitions_def.empty_subset().with_partition_key_range(
+        daily_partitions_def, dg.PartitionKeyRange("2023-11-01", "2023-11-01")
+    )
+
+    run_config = {
+        "ops": {
+            "hourly": {"config": {"a": 0}},
+            "daily": {"config": {"b": "b"}},
+        },
+    }
+    instance.add_backfill(
+        PartitionBackfill.from_asset_graph_subset(
+            backfill_id="run_config_backfill",
+            backfill_timestamp=get_current_timestamp(),
+            tags={},
+            asset_graph_subset=AssetGraphSubset(
+                partitions_subsets_by_asset_key={
+                    AssetKey("hourly"): hourly_subset,
+                    AssetKey("daily"): daily_subset,
+                }
+            ),
+            dynamic_partitions_store=instance,
+            title="Custom title",
+            description="this backfill is fancy",
+            run_config=run_config,
+        )
+    )
+    assert instance.get_runs_count() == 0
+    backfill = instance.get_backfill("run_config_backfill")
+    assert backfill
+    assert backfill.status == BulkActionStatus.REQUESTED
+    assert backfill.run_config == run_config
+
+    assert all(
+        not error
+        for error in list(
+            execute_backfill_iteration(
+                run_config_assets_workspace_context, get_default_daemon_logger("BackfillDaemon")
+            )
+        )
+    )
+    assert instance.get_runs_count() == 4
+    wait_for_all_runs_to_start(instance, timeout=30)
+    wait_for_all_runs_to_finish(instance, timeout=30)
+
+    assert all(
+        not error
+        for error in list(
+            execute_backfill_iteration(
+                run_config_assets_workspace_context, get_default_daemon_logger("BackfillDaemon")
+            )
+        )
+    )
+    assert instance.get_runs_count() == 5
+    wait_for_all_runs_to_start(instance, timeout=30)
+    wait_for_all_runs_to_finish(instance, timeout=30)
+
+    runs = instance.get_runs()
+
+    assert all([run.status == DagsterRunStatus.SUCCESS] for run in runs)
+
+
+def test_asset_backfill_with_run_config_complex(
+    instance: DagsterInstance, run_config_assets_workspace_context: WorkspaceProcessContext
+):
+    daily_partitions_def = dg.DailyPartitionsDefinition("2023-10-01")
+    daily_partitions_def_2 = dg.DailyPartitionsDefinition("2023-10-02")
+    daily_subset = daily_partitions_def.empty_subset().with_partition_key_range(
+        daily_partitions_def, dg.PartitionKeyRange("2023-11-01", "2023-11-04")
+    )
+    daily_subset_2 = daily_partitions_def_2.empty_subset().with_partition_key_range(
+        daily_partitions_def_2, dg.PartitionKeyRange("2023-11-01", "2023-11-04")
+    )
+
+    run_config = {
+        "ops": {
+            "c_and_d_asset": {"config": {"a": 0}},
+        },
+    }
+    instance.add_backfill(
+        PartitionBackfill.from_asset_graph_subset(
+            backfill_id="run_config_backfill",
+            backfill_timestamp=get_current_timestamp(),
+            tags={},
+            asset_graph_subset=AssetGraphSubset(
+                partitions_subsets_by_asset_key={
+                    AssetKey("C"): daily_subset,
+                    AssetKey("middle"): daily_subset_2,
+                    AssetKey("D"): daily_subset,
+                }
+            ),
+            dynamic_partitions_store=instance,
+            title="Custom title",
+            description="this backfill is fancy",
+            run_config=run_config,
+        )
+    )
+    assert instance.get_runs_count() == 0
+    backfill = instance.get_backfill("run_config_backfill")
+    assert backfill
+    assert backfill.status == BulkActionStatus.REQUESTED
+    assert backfill.run_config == run_config
+
+    assert all(
+        not error
+        for error in list(
+            execute_backfill_iteration(
+                run_config_assets_workspace_context, get_default_daemon_logger("BackfillDaemon")
+            )
+        )
+    )
+    assert instance.get_runs_count() == 4
+    wait_for_all_runs_to_start(instance, timeout=30)
+    wait_for_all_runs_to_finish(instance, timeout=30)
+
+    assert all(
+        not error
+        for error in list(
+            execute_backfill_iteration(
+                run_config_assets_workspace_context, get_default_daemon_logger("BackfillDaemon")
+            )
+        )
+    )
+    assert instance.get_runs_count() == 8
+    wait_for_all_runs_to_start(instance, timeout=30)
+    wait_for_all_runs_to_finish(instance, timeout=30)
+
+    assert all(
+        not error
+        for error in list(
+            execute_backfill_iteration(
+                run_config_assets_workspace_context, get_default_daemon_logger("BackfillDaemon")
+            )
+        )
+    )
+    assert instance.get_runs_count() == 12
+    wait_for_all_runs_to_start(instance, timeout=30)
+    wait_for_all_runs_to_finish(instance, timeout=30)
+
+    runs = instance.get_runs()
+
+    assert all([run.status == DagsterRunStatus.SUCCESS] for run in runs)
+    assert all([run.run_config == run_config] for run in runs)
+
+
+def test_job_backfill_with_run_config(
+    instance: DagsterInstance,
+    run_config_assets_workspace_context: WorkspaceProcessContext,
+    remote_repo: RemoteRepository,
+):
+    code_location = cast(
+        "CodeLocation",
+        next(
+            iter(
+                run_config_assets_workspace_context.create_request_context()
+                .get_code_location_entries()
+                .values()
+            )
+        ).code_location,
+    )
+    run_config = {
+        "ops": {
+            "daily": {"config": {"b": "b"}},
+            "other_daily": {"config": {"b": "b"}},
+        },
+    }
+    partition_set = code_location.get_repository("__repository__").get_partition_set(
+        "daily_job_partition_set"
+    )
+    instance.add_backfill(
+        PartitionBackfill(
+            backfill_id="run_config_backfill",
+            partition_set_origin=partition_set.get_remote_origin(),
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["2023-11-01", "2023-11-02"],
+            from_failure=False,
+            reexecution_steps=None,
+            tags=None,
+            backfill_timestamp=get_current_timestamp(),
+            run_config=run_config,
+        )
+    )
+    assert instance.get_runs_count() == 0
+
+    list(
+        execute_backfill_iteration(
+            run_config_assets_workspace_context, get_default_daemon_logger("BackfillDaemon")
+        )
+    )
+
+    assert instance.get_runs_count() == 2
+    runs = instance.get_runs()
+    two, one = runs
+
+    assert two.run_config == run_config
+    assert one.run_config == run_config
 
 
 def test_old_dynamic_partitions_job_backfill(
@@ -3101,6 +3333,7 @@ def test_asset_backfill_logs(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -3183,6 +3416,7 @@ def test_asset_backfill_from_asset_graph_subset(
             title=None,
             description=None,
             asset_graph_subset=asset_graph_subset,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -3280,6 +3514,7 @@ def test_asset_backfill_from_asset_graph_subset_with_static_and_time_partitions(
             title=None,
             description=None,
             asset_graph_subset=asset_graph_subset,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -3334,6 +3569,7 @@ def test_asset_backfill_not_complete_until_retries_complete(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -3422,6 +3658,7 @@ def test_asset_backfill_not_complete_if_automatic_retry_could_happen(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -3496,6 +3733,7 @@ def test_asset_backfill_fails_if_retries_fail(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -3586,6 +3824,7 @@ def test_asset_backfill_retries_make_downstreams_runnable(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -3677,6 +3916,7 @@ def test_run_retry_not_part_of_completed_backfill(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -3763,6 +4003,7 @@ def test_multi_partitioned_asset_backfill(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0
@@ -3810,6 +4051,7 @@ def test_multi_partitioned_asset_with_single_run_bp_backfill(
             all_partitions=False,
             title=None,
             description=None,
+            run_config=None,
         )
     )
     assert instance.get_runs_count() == 0

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/run_config_assets_workspace.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/run_config_assets_workspace.py
@@ -1,0 +1,60 @@
+import dagster as dg
+
+hourly_partitions_def = dg.HourlyPartitionsDefinition("2023-10-01-00:00")
+daily_partitions_def = dg.DailyPartitionsDefinition("2023-10-01")
+
+
+class ConfigA(dg.Config):
+    a: int
+
+
+class ConfigB(dg.Config):
+    b: str
+
+
+class ConfigCrazy(dg.Config):
+    c: ConfigA
+    d: ConfigB
+    e: float
+
+
+@dg.asset(partitions_def=hourly_partitions_def)
+def hourly(config: ConfigA):
+    pass
+
+
+@dg.asset(partitions_def=daily_partitions_def, deps=[hourly])
+def daily(config: ConfigB):
+    pass
+
+
+@dg.asset(partitions_def=daily_partitions_def, deps=[daily])
+def other_daily(config: ConfigB):
+    pass
+
+
+@dg.asset(partitions_def=daily_partitions_def, deps=[hourly])
+def unrelated(config: ConfigCrazy):
+    pass
+
+
+@dg.asset(partitions_def=dg.DailyPartitionsDefinition("2023-10-02"), deps=["C"])
+def middle(): ...
+
+
+@dg.multi_asset(
+    specs=[
+        dg.AssetSpec("C", partitions_def=daily_partitions_def),
+        dg.AssetSpec("D", partitions_def=daily_partitions_def, deps=[middle]),
+    ],
+    can_subset=True,
+)
+def c_and_d_asset(context: dg.AssetExecutionContext, config: ConfigA):
+    for asset_key in context.selected_asset_keys:
+        yield dg.MaterializeResult(asset_key=asset_key)
+
+
+defs = dg.Definitions(
+    assets=[hourly, daily, other_daily, unrelated, c_and_d_asset, middle],
+    jobs=[dg.define_asset_job("daily_job", selection=[daily, other_daily])],
+)

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_asset_backfill.py
@@ -1614,6 +1614,7 @@ def execute_asset_backfill_iteration_consume_generator(
             ),
             backfill_start_timestamp=asset_backfill_data.backfill_start_timestamp,
             logger=logging.getLogger("fake_logger"),
+            run_config=None,
         )
         assert counter.counts().get("DagsterInstance.get_dynamic_partitions", 0) <= 1
         return result


### PR DESCRIPTION
## Summary & Motivation

This is a hotly-requested feature. This PR allows runConfig to be set when creating a PartitionBackfill, and has that run config set on all runs for that backfill. This is similar to how we handle backfill tags.

I was originally concerned that there would be complications with supplying too much config to these runs (not all runs will contain all ops), but it turns out that our config system handles that without issue, as seen in the added tests.

Also adds this to the graphql schema, but does not update the UI to allow for this.

## How I Tested These Changes

## Changelog

NOCHANGELOG