### PR TITLE
[fix] Fix `make dev_install`

### DIFF
--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -49,7 +49,6 @@ def main(
 
     # Supported on all Python versions.
     editable_target_paths = [
-        ".buildkite/dagster-buildkite",
         "python_modules/libraries/dagster-airlift[core,in-airflow,mwaa,test]",
         "integration_tests/python_modules/dagster-k8s-test-infra",
         "helm/dagster/schema[test]",


### PR DESCRIPTION
## Summary & Motivation

A recent change deleted the contents of the folder, which means you cannot editably install it anymore. That's fine, I don't think we should have been doing that to begin with, but it was causing an error.

## How I Tested These Changes

## Changelog

NOCHANGELOG
