### PR TITLE
Add .md files and documentation to make Claude more effective in Dagster monorepo

### DIFF
--- a/.claude/coding_conventions.md
+++ b/.claude/coding_conventions.md
@@ -1,0 +1,35 @@
+# Coding Conventions
+
+## Overall Guidance and style
+
+- In the Dagster repository we bias towards functional-style programming with lightweight immutable objects.
+  Instead of modifying objects, we copy them and replace specific attributes (e.g. with `replace` in `dagster_shared.record`). "Result"
+  objects should be @record-annotated classes.
+- You do not need to create imports into `__init__.py` files unless 1) explicitly asked or 2) if this is a public API annotated with @public. For internal classes and functions we rely on absolute imports.
+
+## Type Annotations
+
+- Type hints required for all Python code
+- **ALWAYS use builtin types for annotations**: `dict`, `list`, `set`, `tuple` instead of `typing.Dict`, `typing.List`, `typing.Set`, `typing.Tuple`
+- **NEVER import or use** `typing.Dict`, `typing.List`, `typing.Set`, `typing.Tuple` - these are deprecated in Python 3.9+
+
+## Data Structures
+
+- **ALWAYS use `@record` for dataclasses, lightweight objects, and immutable objects in Dagster codebase except in specific circumstances**
+  - **Import**: `from dagster_shared.record import record `
+  - **DEFAULT CHOICE**: When creating any new class that holds data, use `@record` unless you have a specific reason not to
+  - Use `@record` for:
+    - Data transfer objects (DTOs) and result objects
+    - Configuration objects
+    - Error/mismatch reporting objects
+    - Analysis results and comparison objects
+    - Any immutable data structure
+    - Lightweight objects that hold related data
+    - Classes that represent findings, issues, or validation results
+  - ONLY use `@dataclass` when:
+    - Mutability is required
+    - Working with external libraries that expect dataclasses
+
+## Other conventions
+
+- Do not use `print` unless specifically requested. They are illegal in the code base unless mark with "# noqa: T201" on the same line.

--- a/.claude/dev_workflow.md
+++ b/.claude/dev_workflow.md
@@ -1,0 +1,50 @@
+# development workflow for claude
+
+## Use Ruff
+
+**CRITICAL**: After EVERY Python file edit (Write, Edit, MultiEdit), Claude MUST immediately:
+
+1. **Run ruff formatting/linting from git repository root directory**:
+
+   ```bash
+   make ruff
+   ```
+
+   MUST do after _every_ edit of a Python file.
+
+2. **Fix any remaining issues**: If ruff reports errors that were not automatically fixed, Claude must manually correct them to the best of its ability
+
+3. **Verify success**: Ensure `make ruff` passes cleanly before considering the task complete.
+
+### Style guidelines
+
+- **Formats code** using ruff formatter (replaces black)
+- **Sorts imports** combine imports, absolute imports only
+- **Enforces** 100-character line limit and other style rules
+
+### common manual fixes needed
+
+When ruff cannot auto-fix issues, Claude should address:
+
+- **Line length violations**: Break long lines appropriately
+- **Import organization**: Fix complex import sorting issues
+- **Type hints**: Add missing type annotations
+- **Docstring formatting**: Ensure proper Google-style docstrings
+- **Unused imports/variables**: Remove or fix usage
+
+### example workflow
+
+```bash
+# After editing any Python files from repository root:
+make ruff
+
+# If errors remain:
+# 1. Read the error messages
+# 2. Make necessary manual corrections
+# 3. Run make ruff again
+# 4. Repeat until clean
+```
+
+## Use Pytest
+
+* Always run pytest from the repository root and with the full path to the file being tested.

--- a/.claude/dev_workflow.md
+++ b/.claude/dev_workflow.md
@@ -47,4 +47,4 @@ make ruff
 
 ## Use Pytest
 
-* Always run pytest from the repository root and with the full path to the file being tested.
+- Always run pytest from the repository root and with the full path to the file being tested.

--- a/.claude/python_packages.md
+++ b/.claude/python_packages.md
@@ -1,0 +1,138 @@
+# python package locations
+
+Quick reference for Python packages in the Dagster repository.
+
+## core packages
+
+**dagster**: `python_modules/dagster`
+**dagster-graphql**: `python_modules/dagster-graphql`
+**dagster-pipes**: `python_modules/dagster-pipes`
+**dagster-webserver**: `python_modules/dagster-webserver`
+**dagit**: `python_modules/dagit`
+
+## test packages
+
+**automation**: `python_modules/automation`
+**dagster-test**: `python_modules/dagster-test`
+
+## cloud platforms
+
+**dagster-aws**: `python_modules/libraries/dagster-aws`
+**dagster-azure**: `python_modules/libraries/dagster-azure`
+**dagster-gcp**: `python_modules/libraries/dagster-gcp`
+**dagster-gcp-pandas**: `python_modules/libraries/dagster-gcp-pandas`
+**dagster-gcp-pyspark**: `python_modules/libraries/dagster-gcp-pyspark`
+
+## container orchestration
+
+**dagster-k8s**: `python_modules/libraries/dagster-k8s`
+**dagster-docker**: `python_modules/libraries/dagster-docker`
+**dagster-celery**: `python_modules/libraries/dagster-celery`
+**dagster-celery-docker**: `python_modules/libraries/dagster-celery-docker`
+**dagster-celery-k8s**: `python_modules/libraries/dagster-celery-k8s`
+
+## data processing
+
+**dagster-dask**: `python_modules/libraries/dagster-dask`
+**dagster-spark**: `python_modules/libraries/dagster-spark`
+**dagster-pyspark**: `python_modules/libraries/dagster-pyspark`
+**dagster-databricks**: `python_modules/libraries/dagster-databricks`
+
+## databases
+
+**dagster-postgres**: `python_modules/libraries/dagster-postgres`
+**dagster-mysql**: `python_modules/libraries/dagster-mysql`
+**dagster-duckdb**: `python_modules/libraries/dagster-duckdb`
+**dagster-duckdb-pandas**: `python_modules/libraries/dagster-duckdb-pandas`
+**dagster-duckdb-polars**: `python_modules/libraries/dagster-duckdb-polars`
+**dagster-duckdb-pyspark**: `python_modules/libraries/dagster-duckdb-pyspark`
+
+## data warehouses
+
+**dagster-snowflake**: `python_modules/libraries/dagster-snowflake`
+**dagster-snowflake-pandas**: `python_modules/libraries/dagster-snowflake-pandas`
+**dagster-snowflake-polars**: `python_modules/libraries/dagster-snowflake-polars`
+**dagster-snowflake-pyspark**: `python_modules/libraries/dagster-snowflake-pyspark`
+
+## data lakes
+
+**dagster-deltalake**: `python_modules/libraries/dagster-deltalake`
+**dagster-deltalake-pandas**: `python_modules/libraries/dagster-deltalake-pandas`
+**dagster-deltalake-polars**: `python_modules/libraries/dagster-deltalake-polars`
+
+## elt tools
+
+**dagster-dbt**: `python_modules/libraries/dagster-dbt`
+**dagster-airbyte**: `python_modules/libraries/dagster-airbyte`
+**dagster-fivetran**: `python_modules/libraries/dagster-fivetran`
+**dagster-sling**: `python_modules/libraries/dagster-sling`
+**dagster-dlt**: `python_modules/libraries/dagster-dlt`
+**dagster-embedded-elt**: `python_modules/libraries/dagster-embedded-elt`
+
+## migration tools
+
+**dagster-airflow**: `python_modules/libraries/dagster-airflow`
+**dagster-airlift**: `python_modules/libraries/dagster-airlift`
+
+## data processing libraries
+
+**dagster-pandas**: `python_modules/libraries/dagster-pandas`
+**dagster-pandera**: `python_modules/libraries/dagster-pandera`
+**dagstermill**: `python_modules/libraries/dagstermill`
+**dagster-ge**: `python_modules/libraries/dagster-ge`
+
+## bi tools
+
+**dagster-looker**: `python_modules/libraries/dagster-looker`
+**dagster-tableau**: `python_modules/libraries/dagster-tableau`
+**dagster-powerbi**: `python_modules/libraries/dagster-powerbi`
+**dagster-sigma**: `python_modules/libraries/dagster-sigma`
+
+## ml platforms
+
+**dagster-mlflow**: `python_modules/libraries/dagster-mlflow`
+**dagster-wandb**: `python_modules/libraries/dagster-wandb`
+**dagster-openai**: `python_modules/libraries/dagster-openai`
+
+## monitoring
+
+**dagster-datadog**: `python_modules/libraries/dagster-datadog`
+**dagster-prometheus**: `python_modules/libraries/dagster-prometheus`
+**dagster-papertrail**: `python_modules/libraries/dagster-papertrail`
+**dagster-pagerduty**: `python_modules/libraries/dagster-pagerduty`
+
+## notifications
+
+**dagster-slack**: `python_modules/libraries/dagster-slack`
+**dagster-msteams**: `python_modules/libraries/dagster-msteams`
+**dagster-twilio**: `python_modules/libraries/dagster-twilio`
+
+## utilities
+
+**dagster-shared**: `python_modules/libraries/dagster-shared`
+**dagster-ssh**: `python_modules/libraries/dagster-ssh`
+**dagster-github**: `python_modules/libraries/dagster-github`
+**dagster-datahub**: `python_modules/libraries/dagster-datahub`
+**dagster-census**: `python_modules/libraries/dagster-census`
+**dagster-managed-elements**: `python_modules/libraries/dagster-managed-elements`
+
+## cli tools
+
+**dagster-cloud-cli**: `python_modules/libraries/dagster-cloud-cli`
+**dagster-dg-cli**: `python_modules/libraries/dagster-dg-cli`
+**dagster-dg-core**: `python_modules/libraries/dagster-dg-core`
+**create-dagster**: `python_modules/libraries/create-dagster`
+
+## development packages
+
+**kitchen-sink** (airlift): `python_modules/libraries/dagster-airlift/kitchen-sink`
+**kitchen-sink** (dbt): `python_modules/libraries/dagster-dbt/kitchen-sink`
+**perf-harness**: `python_modules/libraries/dagster-airlift/perf-harness`
+
+## quick lookup patterns
+
+All paths are relative to the repository root and follow these patterns:
+
+- Core: `python_modules/{package-name}`
+- Libraries: `python_modules/libraries/{package-name}`
+- Testing: Most packages have `{package-name}_tests/` subdirectories

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # Dagster Development Guide
 
+## Quick References
+
+- **Package Locations**: [.claude/python_packages.md](./.claude/python_packages.md) - Comprehensive list of all Python packages and their filesystem paths. **ALWAYS check this file first when looking for package locations.**
+- **Development Workflow**: [.claude/dev_workflow.md](./.claude/dev_workflow.md) - Documentation of developer workflows in the Dagster OSS repo.
+- **Coding Conventions**: [.claude/coding_conventions.md](./.claude/coding_conventions.md) - Type annotations and code style conventions. **ALWAYS check this before writing data structures - use @record instead of @dataclass.**
+
 ## Environment Setup
 
 See [docs/docs/about/contributing.md](docs/docs/about/contributing.md) for full setup instructions.
@@ -32,8 +38,6 @@ make sanity_check          # Check for non-editable installs
 - **Python**: Core framework in `python_modules/dagster/`, libraries in `python_modules/libraries/`
 - **UI**: React/TypeScript in `js_modules/dagster-ui/`
 - **Docs**: Docusaurus in `docs/`
-- **Line width**: 100 characters
-- **Type checking**: Required for all Python code
 - **Testing**: pytest preferred, use tox for environment isolation
 
 ## UI Development
@@ -58,8 +62,22 @@ yarn build-api-docs          # Build API docs after .rst changes
 
 ## Code Style
 
-- Use ruff for formatting and import sorting
 - Follow Google-style docstrings
-- Import sorting: combine imports, absolute imports only
-- Type hints required for all Python code
-- Run `make ruff` before submitting PRs
+- **ALWAYS use `@record` from `dagster_shared.record` for data structures, result objects, and immutable classes**
+- Only use `@dataclass` when mutability is specifically required
+
+## Code Quality Requirements
+
+- **MANDATORY**: After any code changes, ALWAYS run `make ruff` to format, lint, and autofix code
+- **MANDATORY**: If `make ruff` makes any changes, re-run tests to ensure everything still works
+- **MANDATORY**: Address any linting issues before considering a task complete
+- Never skip this step - code quality checks are essential for all contributions
+
+## Package Management
+
+- Always use uv instead of pip
+
+## Code searching
+
+- DO NOT search for Python code (.py files) inside of .tox folders. These are temporary environments and this will only cause confusion.
+- Always search for package dependencies in setup.py files only. This is the current source of truth for dependencies in this repository.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -100,6 +100,7 @@ Other relevant parameter renames:
     window_start, window_end = context.partition_time_window
     in_an_hour = window_start.add(hours=1) # will break since add() is only defined in pendulum
   ```
+
   - could be changed to this in order to continue using pendulum datetimes:
 
   ```python

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -100,7 +100,6 @@ Other relevant parameter renames:
     window_start, window_end = context.partition_time_window
     in_an_hour = window_start.add(hours=1) # will break since add() is only defined in pendulum
   ```
-
   - could be changed to this in order to continue using pendulum datetimes:
 
   ```python

--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,18 @@ check_prettier:
 #NOTE: excludes symlinked md files
 	prettier `git ls-files \
 	'python_modules/*.yml' 'python_modules/*.yaml' 'helm/*.yml' 'helm/*.yaml' \
-	':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml' '*.md' ':!:docs/*.md' \
-	':!:README.md' ':!:CLAUDE.md' ':!:GEMINI.md'` --check
+	'*.md' '.claude/*.md' \
+	':!:docs/*.md' ':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml' \
+	':!:README.md' ':!:GEMINI.md'` \
+	--check
 
 prettier:
 	prettier `git ls-files \
 	'python_modules/*.yml' 'python_modules/*.yaml' 'helm/*.yml' 'helm/*.yaml' \
-	':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml' '*.md' '.claude/*.md' ':!:docs/*.md' \
-	':!:README.md' ':!:GEMINI.md'` --write
+	'*.md' '.claude/*.md' \
+	':!:docs/*.md' ':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml' \
+	':!:README.md' ':!:GEMINI.md'` \
+	--write
 
 install_dev_python_modules:
 	python scripts/install_dev_python_modules.py -q

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ check_prettier:
 prettier:
 	prettier `git ls-files \
 	'python_modules/*.yml' 'python_modules/*.yaml' 'helm/*.yml' 'helm/*.yaml' \
-	':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml' '*.md' ':!:docs/*.md' \
-	':!:README.md' ':!:CLAUDE.md' ':!:GEMINI.md'` --write
+	':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml' '*.md' '.claude/*.md' ':!:docs/*.md' \
+	':!:README.md' ':!:GEMINI.md'` --write
 
 install_dev_python_modules:
 	python scripts/install_dev_python_modules.py -q

--- a/python_modules/dagster-test/dagster_test_tests/test_package_registry.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_package_registry.py
@@ -1,0 +1,160 @@
+"""Test to ensure all Python packages in the repository are documented in python_packages.md."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+def get_repo_root() -> Path:
+    """Get the repository root directory."""
+    current_dir = Path(__file__).resolve()
+    # Navigate up from dagster-test/dagster_test_tests/ to repo root
+    return current_dir.parent.parent.parent.parent
+
+
+def parse_python_packages_md() -> dict[str, str]:
+    """Parse .claude/python_packages.md and extract package name to path mappings."""
+    repo_root = get_repo_root()
+    packages_file = repo_root / ".claude" / "python_packages.md"
+
+    if not packages_file.exists():
+        pytest.fail(f"python_packages.md not found at {packages_file}")
+
+    packages = {}
+    content = packages_file.read_text()
+
+    # Pattern to match: **package-name**: `/path/to/package`
+    pattern = r"\*\*([^*]+)\*\*:\s*`([^`]+)`"
+
+    for match in re.finditer(pattern, content):
+        package_name = match.group(1).strip()
+        package_path = match.group(2).strip()
+        packages[package_name] = package_path
+
+    return packages
+
+
+def find_actual_packages() -> dict[str, str]:
+    """Find all Python packages in the repository by looking for setup.py files."""
+    repo_root = get_repo_root()
+    python_modules_dir = repo_root / "python_modules"
+
+    if not python_modules_dir.exists():
+        pytest.fail(f"python_modules directory not found at {python_modules_dir}")
+
+    packages = {}
+
+    # Find all setup.py files in python_modules
+    for setup_file in python_modules_dir.rglob("setup.py"):
+        package_dir = setup_file.parent
+
+        # Get absolute path
+        abs_path = str(package_dir)
+
+        # Extract package name from directory name
+        package_name = package_dir.name
+
+        # Skip if this is a nested test package, build artifact, or kitchen-sink directory
+        if any(
+            part.endswith("_tests") or part == "build" or part == "kitchen-sink"
+            for part in package_dir.parts
+        ):
+            continue
+
+        packages[package_name] = abs_path
+
+    return packages
+
+
+def test_python_packages_md_completeness():
+    """Test that all Python packages in the repository are documented in python_packages.md."""
+    documented_packages = parse_python_packages_md()
+    actual_packages = find_actual_packages()
+
+    # Find packages that exist but aren't documented
+    missing_from_docs = set(actual_packages.keys()) - set(documented_packages.keys())
+
+    # Find packages that are documented but don't exist
+    extra_in_docs = set(documented_packages.keys()) - set(actual_packages.keys())
+
+    # Build error messages
+    errors = []
+
+    if missing_from_docs:
+        errors.append(f"Packages missing from python_packages.md: {sorted(missing_from_docs)}")
+
+    if extra_in_docs:
+        errors.append(
+            f"Packages in python_packages.md but not found in repository: {sorted(extra_in_docs)}"
+        )
+
+    # Check path accuracy for packages that exist in both
+    path_mismatches = []
+    for package in set(documented_packages.keys()) & set(actual_packages.keys()):
+        documented_path = documented_packages[package]
+        actual_path = actual_packages[package]
+        if documented_path != actual_path:
+            path_mismatches.append(
+                f"{package}: documented='{documented_path}' actual='{actual_path}'"
+            )
+
+    if path_mismatches:
+        errors.append(f"Path mismatches in python_packages.md: {path_mismatches}")
+
+    if errors:
+        pytest.fail("\n".join(errors))
+
+
+def test_python_packages_md_format():
+    """Test that python_packages.md follows the expected format."""
+    repo_root = get_repo_root()
+    packages_file = repo_root / ".claude" / "python_packages.md"
+
+    if not packages_file.exists():
+        pytest.fail(f"python_packages.md not found at {packages_file}")
+
+    content = packages_file.read_text()
+
+    # Check that file starts with expected header
+    assert content.startswith("# python package locations"), (
+        "File should start with '# python package locations'"
+    )
+
+    # Check that all package entries follow the expected format
+    package_pattern = r"\*\*([^*]+)\*\*:\s*`([^`]+)`"
+    matches = list(re.finditer(package_pattern, content))
+
+    assert len(matches) > 0, "No package entries found in expected format"
+
+    # Verify all paths are absolute and point to python_modules
+    for match in matches:
+        package_name = match.group(1)
+        package_path = match.group(2)
+
+        assert package_path.startswith("/"), (
+            f"Path for {package_name} should be absolute: {package_path}"
+        )
+        assert "python_modules" in package_path, (
+            f"Path for {package_name} should contain 'python_modules': {package_path}"
+        )
+
+
+def test_python_packages_md_exists():
+    """Test that the python_packages.md file exists in the expected location."""
+    repo_root = get_repo_root()
+    packages_file = repo_root / ".claude" / "python_packages.md"
+
+    assert packages_file.exists(), f"python_packages.md should exist at {packages_file}"
+    assert packages_file.is_file(), f"{packages_file} should be a file"
+
+    # Check that file is not empty
+    content = packages_file.read_text()
+    assert len(content.strip()) > 0, "python_packages.md should not be empty"
+
+
+if __name__ == "__main__":
+    # Allow running this test directly for debugging
+    test_python_packages_md_exists()
+    test_python_packages_md_format()
+    test_python_packages_md_completeness()

--- a/python_modules/dagster-test/dagster_test_tests/test_package_registry.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_package_registry.py
@@ -57,9 +57,23 @@ def find_actual_packages() -> dict[str, str]:
         # Extract package name from directory name
         package_name = package_dir.name
 
-        # Skip if this is a nested test package, build artifact, or kitchen-sink directory
+        # Skip if this is a nested test package, build artifact, or internal package
+        skip_patterns = {
+            "_tests",
+            "build",
+            "kitchen-sink",
+            "__pycache__",
+            ".tox",
+            ".pytest_cache",
+            "dist",
+            ".git",
+        }
+
+        # Skip CI-specific build artifacts that appear in CI but not locally
+        ci_build_artifacts = {"cython", "limited_api", "plugin"}
+
         if any(
-            part.endswith("_tests") or part == "build" or part == "kitchen-sink"
+            part.endswith("_tests") or part in skip_patterns or part in ci_build_artifacts
             for part in package_dir.parts
         ):
             continue

--- a/python_modules/dagster-test/dagster_test_tests/test_package_registry.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_package_registry.py
@@ -24,13 +24,15 @@ def parse_python_packages_md() -> dict[str, str]:
     packages = {}
     content = packages_file.read_text()
 
-    # Pattern to match: **package-name**: `/path/to/package`
+    # Pattern to match: **package-name**: `path/to/package`
     pattern = r"\*\*([^*]+)\*\*:\s*`([^`]+)`"
 
     for match in re.finditer(pattern, content):
         package_name = match.group(1).strip()
         package_path = match.group(2).strip()
-        packages[package_name] = package_path
+        # Convert relative path to absolute path for comparison
+        absolute_path = str(repo_root / package_path)
+        packages[package_name] = absolute_path
 
     return packages
 
@@ -127,13 +129,13 @@ def test_python_packages_md_format():
 
     assert len(matches) > 0, "No package entries found in expected format"
 
-    # Verify all paths are absolute and point to python_modules
+    # Verify all paths are relative and point to python_modules
     for match in matches:
         package_name = match.group(1)
         package_path = match.group(2)
 
-        assert package_path.startswith("/"), (
-            f"Path for {package_name} should be absolute: {package_path}"
+        assert not package_path.startswith("/"), (
+            f"Path for {package_name} should be relative, not absolute: {package_path}"
         )
         assert "python_modules" in package_path, (
             f"Path for {package_name} should contain 'python_modules': {package_path}"

--- a/python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py
@@ -267,6 +267,26 @@ def record(
     Args:
         checked: Whether or not to generate runtime type checked construction (default True).
         kw_only: Whether or not the generated __new__ is kwargs only (default True).
+
+    Example:
+        @record
+        class Person:
+            name: str
+            age: int
+
+        # Create instance
+        person = Person(name="Alice", age=30)
+
+        # Create modified copy using replace()
+        older_person = replace(person, age=31)
+
+        # Add items to lists using replace()
+        @record
+        class TaskList:
+            items: list[str]
+
+        tasks = TaskList(items=["task1"])
+        updated_tasks = replace(tasks, items=[*tasks.items, "task2"])
     """
     if cls:
         return _namedtuple_record_transform(
@@ -422,6 +442,38 @@ def replace(obj: TVal, **kwargs) -> TVal:
     new values specified by keyword args.
 
     This emulates the behavior of namedtuple _replace.
+
+    Example:
+        @record
+        class Config:
+            timeout: int
+            retries: int
+
+        config = Config(timeout=30, retries=3)
+
+        # Update single field
+        faster_config = replace(config, timeout=10)
+
+        # Update multiple fields
+        production_config = replace(config, timeout=60, retries=5)
+
+        # Add items to lists (use spread operator to avoid mutation)
+        @record
+        class Results:
+            errors: list[str]
+            warnings: list[str]
+
+        results = Results(errors=[], warnings=["deprecated API"])
+
+        # Add new error
+        updated_results = replace(results, errors=[*results.errors, "network timeout"])
+
+        # Add multiple items
+        final_results = replace(
+            updated_results,
+            errors=[*updated_results.errors, "connection failed"],
+            warnings=[*updated_results.warnings, "slow query"]
+        )
     """
     check.invariant(is_record(obj))
     cls = obj.__class__


### PR DESCRIPTION
# Summary & Motivation

This commit creates agent-parseable documentation to enable reliable code generation that follows Dagster OSS conventions and norms.

## New Documentation Files

**.claude/coding_conventions.md** (35 lines): Establishes coding standards requiring `@record` decorator instead of `@dataclass`, builtin types instead of typing module equivalents, and proper noqa markers for print statements.

**.claude/dev_workflow.md** (50 lines): Documents mandatory `make ruff` execution after Python edits, manual fix procedures, and pytest standards.

**.claude/python_packages.md** (138 lines): Maps 80+ repository packages to filesystem locations across core, cloud, database, ML, and utility categories.

## Enhanced Project Documentation

**CLAUDE.md** (30+ lines): Adds "Quick References" section linking to new documentation files and reinforces mandatory `@record` usage and code quality requirements.

## Code Infrastructure

**python_modules/dagster-test/dagster_test_tests/test_package_registry.py** (160 lines): Implements comprehensive test suite validating package documentation accuracy through regex parsing and filesystem scanning.

**python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py** (52 lines): Adds documentation to existing `@record` decorator functionality that provides immutable record classes with type checking and utility functions.

## Build and Migration Updates

**Makefile** (4 lines): Updates prettier to format `.claude/*.md` files.

**MIGRATION.md** (1 line): Removes extraneous whitespace.

This enhances developer experience through clear coding standards, automated documentation validation, and mandatory code quality enforcement.

## How I Tested These Changes

I was assessing the output of the following prompt to "one-shot" adding a reusable utility function within the context of the entire codebase using the following prompt:

- In the dagster-test package write a utility that takes a python function, inspects that function for it’s parameters name, parameter types and return type. Then compare that to the parameters, parameter types, and return type encoded in the docblock. Return an object that contains information what is wrong in the docblock. Missing parameters, extra parameters, type mismatches and so forth.
- Do this leveraging the docstring-parser package
- Name the function compare_docstring_parameters
- Write a test of compare_docstring_parameters that takes itself as an argument.
- Run the test and confirm that it works

https://github.com/dagster-io/dagster/pull/31242 is code of that prompt _without_ these changes.

https://github.com/dagster-io/dagster/pull/31241 is the code of the prompt _with_ these changes.

## Changelog

> Insert changelog entry or delete this section.