### PR TITLE
Remove conditional docstring_parser availability check

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/inference.py
+++ b/python_modules/dagster/dagster/_core/definitions/inference.py
@@ -2,12 +2,10 @@ from collections.abc import Mapping, Sequence
 from inspect import Parameter, Signature, isgeneratorfunction, signature
 from typing import Any, Callable, NamedTuple, Optional
 
-from dagster_shared.seven import is_module_available
+from docstring_parser import parse
 
 from dagster._core.decorator_utils import get_type_hints
 from dagster._core.definitions.utils import NoValueSentinel
-
-IS_DOCSTRING_PARSER_AVAILABLE = is_module_available("docstring_parser")
 
 
 class InferredInputProps(NamedTuple):
@@ -28,10 +26,8 @@ class InferredOutputProps(NamedTuple):
 
 def _infer_input_description_from_docstring(fn: Callable[..., Any]) -> Mapping[str, Optional[str]]:
     doc_str = fn.__doc__
-    if not IS_DOCSTRING_PARSER_AVAILABLE or doc_str is None:
+    if doc_str is None:
         return {}
-
-    from docstring_parser import parse
 
     try:
         docstring = parse(doc_str)
@@ -42,9 +38,8 @@ def _infer_input_description_from_docstring(fn: Callable[..., Any]) -> Mapping[s
 
 def _infer_output_description_from_docstring(fn: Callable[..., Any]) -> Optional[str]:
     doc_str = fn.__doc__
-    if not IS_DOCSTRING_PARSER_AVAILABLE or doc_str is None:
+    if doc_str is None:
         return None
-    from docstring_parser import parse
 
     try:
         docstring = parse(doc_str)


### PR DESCRIPTION
## Summary & Motivation

This commit removes the IS_DOCSTRING_PARSER_AVAILABLE conditional check
and moves to direct imports of docstring_parser, since it's now a hard
dependency.

Historical context:
- Originally added in PR #2689 (Aug 2020) with conditional check because
  docstring_parser was Python 3.6+ only while Dagster supported Python 2
- Performance optimization in PR #10127 (Oct 2022) cached the availability
  check to avoid 35% performance penalty with large asset graphs
- Python 2 support was later dropped, making the conditional check unnecessary

Changes:
- Removed IS_DOCSTRING_PARSER_AVAILABLE constant
- Moved docstring_parser import to top level
- Simplified both _infer_input_description_from_docstring and
  _infer_output_description_from_docstring functions
- Maintained same error handling behavior for robustness

## How I Tested These Changes

Unit tests