### PR TITLE
Remove dangling references to buildkite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@
 typeCheckingMode = "standard"
 
 include = [
-  ".buildkite/dagster-buildkite",
   "docs/sphinx/_ext/dagster-sphinx",
   "python_modules",
   "examples",

--- a/pyright/master/include.txt
+++ b/pyright/master/include.txt
@@ -1,4 +1,3 @@
-.buildkite/dagster-buildkite
 docs/sphinx/_ext/dagster-sphinx
 python_modules
 examples

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -49,7 +49,6 @@ def main(
 
     # Supported on all Python versions.
     editable_target_paths = [
-        ".buildkite/dagster-buildkite",
         "python_modules/libraries/dagster-airlift[core,in-airflow,mwaa,test]",
         "integration_tests/python_modules/dagster-k8s-test-infra",
         "helm/dagster/schema[test]",


### PR DESCRIPTION
https://github.com/dagster-io/dagster/pull/31126 consolidated some tooling but left a few dangling references that are standing in the way of successfully running `make dev_install`.