### PR TITLE
[dg cli] docs for component by type

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/ai.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/ai.py
@@ -82,9 +82,7 @@ dg check defs # Validate definitions by loading them fully (slower)
 
 # Scaffolding
 dg scaffold defs <component type> # Create an instance of a Component type. Available types found via `dg list components`.
-dg scaffold defs dagster.asset # Create asset
-dg scaffold defs dagster.job # Create job
-dg scaffold defs dagster.schedule # Create schedule
+dg scaffold defs dagster.<asset|job|schedule|sensor> # Create a new definition of a given type.
 dg scaffold component <name> # Create a new custom Component type
 
 # Searching
@@ -92,6 +90,7 @@ dg list defs # Show project definitions
 dg list defs --assets <asset selection> # Show selected asset definitions
 dg list component-tree # Show the component tree
 dg list components # Show available component types
+dg docs component <component type> # Show documentation for a component type
 ```
 * The `dg` CLI will be effective in accomplishing tasks. Use --help to better understand how to use commands.
 * Prefer `dg list defs` over searching the files system when looking for Dagster definitions.

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_docs_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_docs_commands.py
@@ -260,3 +260,17 @@ def test_build_docs_success_matches_graphql():
 
             finally:
                 assert_projects_loaded_and_exit({"foo-bar"}, port, dev_process)
+
+
+def test_docs_component_type_json():
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(
+            runner,
+            in_workspace=False,
+        ),
+    ):
+        result = runner.invoke("docs", "component", "dagster.FunctionComponent", "--json")
+        assert_runner_result(result)
+        output_json = json.loads(result.output)
+        assert output_json["type"] == "dagster.FunctionComponent"


### PR DESCRIPTION
Add a cli entry point for getting the details of a specfiic component type 

## How I Tested These Changes

added test

example non-json output 
```
$ dg docs component dagster.UvRunComponent

Type: dagster.UvRunComponent
Description: Represents a Python script, alongside the set of assets or asset checks that it is responsible for executing.

Accepts a path to a Python script which will be executed in a dagster-pipes subprocess using the `uv run` command.

Example:
```yaml
type: dagster.UvRunComponent
attributes:
  execution:
    path: update_table.py
  assets:
    - key: my_table
```
```