### PR TITLE
require asset graph argument to create_run

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/test_queued.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_queued.py
@@ -37,7 +37,7 @@ def test_queue_from_schedule_and_sensor(instance, foo_example_workspace, foo_exa
     instance.start_sensor(remote_sensor)
 
     with start_daemon(timeout=180, workspace_file=file_relative_path(__file__, "repo.py")):
-        run = create_run(instance, remote_job)
+        run = create_run(instance, remote_job, asset_graph=foo_example_workspace.asset_graph)
         instance.submit_run(run.run_id, foo_example_workspace)
 
         runs = [
@@ -67,7 +67,7 @@ def test_queued_runs(instance, foo_example_workspace, foo_example_repo):
     with start_daemon(workspace_file=file_relative_path(__file__, "repo.py")):
         remote_job = foo_example_repo.get_full_job("foo_job")
 
-        run = create_run(instance, remote_job)
+        run = create_run(instance, remote_job, asset_graph=foo_example_workspace.asset_graph)
 
         instance.submit_run(run.run_id, foo_example_workspace)
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1419,7 +1419,7 @@ class DagsterInstance(DynamicPartitionsStore):
         job_name: str,
         step: "ExecutionStepSnap",
         output: "ExecutionStepOutputSnap",
-        asset_graph: Optional["BaseAssetGraph"],
+        asset_graph: "BaseAssetGraph",
     ) -> None:
         from dagster._core.definitions.partitions.context import partition_loading_context
         from dagster._core.definitions.partitions.definition import DynamicPartitionsDefinition
@@ -1445,12 +1445,6 @@ class DagsterInstance(DynamicPartitionsStore):
                 raise DagsterInvariantViolationError(
                     f"Cannot have {ASSET_PARTITION_RANGE_START_TAG} or"
                     f" {ASSET_PARTITION_RANGE_END_TAG} set without the other"
-                )
-
-            if asset_graph is None:
-                raise DagsterInvariantViolationError(
-                    "Must provide asset_graph to create_run when creating "
-                    "a run with a partition range."
                 )
 
             partitions_def = asset_graph.get(asset_key).partitions_def
@@ -1517,7 +1511,7 @@ class DagsterInstance(DynamicPartitionsStore):
         self,
         dagster_run: DagsterRun,
         execution_plan_snapshot: "ExecutionPlanSnapshot",
-        asset_graph: Optional["BaseAssetGraph"],
+        asset_graph: "BaseAssetGraph",
     ) -> None:
         from dagster._core.events import DagsterEvent, DagsterEventType
 
@@ -1574,7 +1568,7 @@ class DagsterInstance(DynamicPartitionsStore):
         op_selection: Optional[Sequence[str]],
         remote_job_origin: Optional["RemoteJobOrigin"],
         job_code_origin: Optional[JobPythonOrigin],
-        asset_graph: Optional["BaseAssetGraph"],
+        asset_graph: "BaseAssetGraph",
     ) -> DagsterRun:
         from dagster._core.definitions.asset_key import AssetCheckKey
         from dagster._core.remote_representation.origin import RemoteJobOrigin

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -169,6 +169,8 @@ def create_run_for_test(
     op_selection=None,
     asset_graph=None,
 ):
+    from unittest import mock
+
     return instance.create_run(
         job_name=job_name,
         run_id=run_id,
@@ -187,7 +189,7 @@ def create_run_for_test(
         asset_selection=asset_selection,
         asset_check_selection=asset_check_selection,
         op_selection=op_selection,
-        asset_graph=asset_graph,
+        asset_graph=asset_graph or mock.MagicMock(),
     )
 
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -156,6 +156,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
             job_snapshot=subset_job.job_snapshot,
             parent_job_snapshot=subset_job.parent_job_snapshot,
             status=DagsterRunStatus.NOT_STARTED,
+            asset_graph=workspace.asset_graph,
             **kwargs,
         )
         instance.submit_run(run.run_id, workspace)
@@ -176,9 +177,18 @@ class QueuedRunCoordinatorDaemonTests(ABC):
 
     def test_attempt_to_launch_runs_filter(self, instance, workspace_context, daemon, job_handle):
         queued_run_id, non_queued_run_id = [make_new_run_id() for _ in range(2)]
-        self.create_queued_run(instance, job_handle, run_id=queued_run_id)
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=queued_run_id,
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
         self.create_run(
-            instance, job_handle, run_id=non_queued_run_id, status=DagsterRunStatus.NOT_STARTED
+            instance,
+            job_handle,
+            run_id=non_queued_run_id,
+            status=DagsterRunStatus.NOT_STARTED,
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
 
         list(daemon.run_iteration(workspace_context))
@@ -190,9 +200,19 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     ):
         queued_run_id = make_new_run_id()
         non_queued_run_id = make_new_run_id()
-        self.create_run(instance, job_handle, run_id=queued_run_id, status=DagsterRunStatus.STARTED)
         self.create_run(
-            instance, job_handle, run_id=non_queued_run_id, status=DagsterRunStatus.NOT_STARTED
+            instance,
+            job_handle,
+            run_id=queued_run_id,
+            status=DagsterRunStatus.STARTED,
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_run(
+            instance,
+            job_handle,
+            run_id=non_queued_run_id,
+            status=DagsterRunStatus.NOT_STARTED,
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
 
         list(daemon.run_iteration(workspace_context))
@@ -230,6 +250,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
                 job_handle,
                 run_id=run_id,
                 status=status,
+                asset_graph=workspace_context.create_request_context().asset_graph,
             )
 
         # add more queued runs than should be launched
@@ -239,6 +260,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
                 instance,
                 job_handle,
                 run_id=run_id,
+                asset_graph=workspace_context.create_request_context().asset_graph,
             )
 
         list(daemon.run_iteration(workspace_context))
@@ -265,6 +287,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
                 job_handle,
                 run_id=run_id,
                 status=status,
+                asset_graph=workspace_context.create_request_context().asset_graph,
             )
 
         # add more queued runs
@@ -274,6 +297,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
                 instance,
                 job_handle,
                 run_id=run_id,
+                asset_graph=workspace_context.create_request_context().asset_graph,
             )
 
         list(daemon.run_iteration(workspace_context))
@@ -282,11 +306,27 @@ class QueuedRunCoordinatorDaemonTests(ABC):
 
     def test_priority(self, instance, workspace_context, job_handle, daemon):
         default_run_id, hi_pri_run_id, lo_pri_run_id = [make_new_run_id() for _ in range(3)]
-        self.create_run(instance, job_handle, run_id=default_run_id, status=DagsterRunStatus.QUEUED)
-        self.create_queued_run(
-            instance, job_handle, run_id=lo_pri_run_id, tags={PRIORITY_TAG: "-1"}
+        self.create_run(
+            instance,
+            job_handle,
+            run_id=default_run_id,
+            status=DagsterRunStatus.QUEUED,
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
-        self.create_queued_run(instance, job_handle, run_id=hi_pri_run_id, tags={PRIORITY_TAG: "3"})
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=lo_pri_run_id,
+            tags={PRIORITY_TAG: "-1"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=hi_pri_run_id,
+            tags={PRIORITY_TAG: "3"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
 
         list(daemon.run_iteration(workspace_context))
 
@@ -303,6 +343,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
             job_handle,
             run_id=bad_pri_run_id,
             tags={PRIORITY_TAG: "foobar"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
 
         list(daemon.run_iteration(workspace_context))
@@ -326,12 +367,26 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     )
     def test_tag_limits(self, workspace_context, job_handle, daemon, instance):
         tiny_run_id, tiny_run_id_2, large_run_id = [make_new_run_id() for _ in range(3)]
-        self.create_queued_run(instance, job_handle, run_id=tiny_run_id, tags={"database": "tiny"})
         self.create_queued_run(
-            instance, job_handle, run_id=tiny_run_id_2, tags={"database": "tiny"}
+            instance,
+            job_handle,
+            run_id=tiny_run_id,
+            tags={"database": "tiny"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
         self.create_queued_run(
-            instance, job_handle, run_id=large_run_id, tags={"database": "large"}
+            instance,
+            job_handle,
+            run_id=tiny_run_id_2,
+            tags={"database": "tiny"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=large_run_id,
+            tags={"database": "large"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
 
         list(daemon.run_iteration(workspace_context))
@@ -360,12 +415,26 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     )
     def test_tag_limits_just_key(self, workspace_context, job_handle, daemon, instance):
         tiny_run_id, tiny_run_id_2, large_run_id = [make_new_run_id() for _ in range(3)]
-        self.create_queued_run(instance, job_handle, run_id=tiny_run_id, tags={"database": "tiny"})
         self.create_queued_run(
-            instance, job_handle, run_id=tiny_run_id_2, tags={"database": "tiny"}
+            instance,
+            job_handle,
+            run_id=tiny_run_id,
+            tags={"database": "tiny"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
         self.create_queued_run(
-            instance, job_handle, run_id=large_run_id, tags={"database": "large"}
+            instance,
+            job_handle,
+            run_id=tiny_run_id_2,
+            tags={"database": "tiny"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=large_run_id,
+            tags={"database": "large"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
 
         list(daemon.run_iteration(workspace_context))
@@ -407,24 +476,28 @@ class QueuedRunCoordinatorDaemonTests(ABC):
             job_handle,
             run_id=run_id_1,
             tags={"database": "tiny", "user": "johann"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
         self.create_queued_run(
             instance,
             job_handle,
             run_id=run_id_2,
             tags={"database": "tiny"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
         self.create_queued_run(
             instance,
             job_handle,
             run_id=run_id_3,
             tags={"user": "johann"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
         self.create_queued_run(
             instance,
             job_handle,
             run_id=run_id_4,
             tags={"user": "johann"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
 
         list(daemon.run_iteration(workspace_context))
@@ -455,10 +528,34 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     )
     def test_overlapping_tag_limits(self, workspace_context, daemon, job_handle, instance):
         run_id_1, run_id_2, run_id_3, run_id_4 = [make_new_run_id() for _ in range(4)]
-        self.create_queued_run(instance, job_handle, run_id=run_id_1, tags={"foo": "bar"})
-        self.create_queued_run(instance, job_handle, run_id=run_id_2, tags={"foo": "bar"})
-        self.create_queued_run(instance, job_handle, run_id=run_id_3, tags={"foo": "other"})
-        self.create_queued_run(instance, job_handle, run_id=run_id_4, tags={"foo": "other"})
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_1,
+            tags={"foo": "bar"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_2,
+            tags={"foo": "bar"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_3,
+            tags={"foo": "other"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_4,
+            tags={"foo": "other"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
 
         list(daemon.run_iteration(workspace_context))
 
@@ -486,17 +583,36 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     )
     def test_limits_per_unique_value(self, workspace_context, job_handle, daemon, instance):
         run_id_1, run_id_2, run_id_3, run_id_4 = [make_new_run_id() for _ in range(4)]
-        self.create_queued_run(instance, job_handle, run_id=run_id_1, tags={"foo": "bar"})
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_1,
+            tags={"foo": "bar"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
         self.create_queued_run(
             instance,
             job_handle,
             run_id=run_id_2,
             tags={"foo": "bar"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
         list(daemon.run_iteration(workspace_context))
 
-        self.create_queued_run(instance, job_handle, run_id=run_id_3, tags={"foo": "other"})
-        self.create_queued_run(instance, job_handle, run_id=run_id_4, tags={"foo": "other"})
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_3,
+            tags={"foo": "other"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_4,
+            tags={"foo": "other"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
 
         list(daemon.run_iteration(workspace_context))
 
@@ -532,10 +648,34 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         instance,
     ):
         run_id_1, run_id_2, run_id_3, run_id_4 = [make_new_run_id() for _ in range(4)]
-        self.create_queued_run(instance, job_handle, run_id=run_id_1, tags={"foo": "bar"})
-        self.create_queued_run(instance, job_handle, run_id=run_id_2, tags={"foo": "bar"})
-        self.create_queued_run(instance, job_handle, run_id=run_id_3, tags={"foo": "other"})
-        self.create_queued_run(instance, job_handle, run_id=run_id_4, tags={"foo": "other-2"})
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_1,
+            tags={"foo": "bar"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_2,
+            tags={"foo": "bar"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_3,
+            tags={"foo": "other"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_4,
+            tags={"foo": "other-2"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
 
         list(daemon.run_iteration(workspace_context))
 
@@ -571,11 +711,41 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         instance,
     ):
         run_id_1, run_id_2, run_id_3, run_id_4, run_id_5 = [make_new_run_id() for _ in range(5)]
-        self.create_queued_run(instance, job_handle, run_id=run_id_1, tags={"foo": "bar"})
-        self.create_queued_run(instance, job_handle, run_id=run_id_2, tags={"foo": "baz"})
-        self.create_queued_run(instance, job_handle, run_id=run_id_3, tags={"foo": "bar"})
-        self.create_queued_run(instance, job_handle, run_id=run_id_4, tags={"foo": "baz"})
-        self.create_queued_run(instance, job_handle, run_id=run_id_5, tags={"foo": "baz"})
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_1,
+            tags={"foo": "bar"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_2,
+            tags={"foo": "baz"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_3,
+            tags={"foo": "bar"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_4,
+            tags={"foo": "baz"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=run_id_5,
+            tags={"foo": "baz"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
 
         list(daemon.run_iteration(workspace_context))
 
@@ -591,8 +761,18 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     ):
         """Verifies that no repository location is created when runs are dequeued."""
         queued_run_id_1, queued_run_id_2 = [make_new_run_id() for _ in range(2)]
-        self.create_queued_run(instance, job_handle, run_id=queued_run_id_1)
-        self.create_queued_run(instance, job_handle, run_id=queued_run_id_2)
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=queued_run_id_1,
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=queued_run_id_2,
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
 
         original_method = GrpcServerCodeLocation.__init__
 
@@ -640,9 +820,24 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     )
     def test_skip_error_runs(self, job_handle, daemon, instance, workspace_context):
         good_run_id = make_new_run_id()
-        self.create_queued_run(instance, job_handle, run_id=BAD_RUN_ID_UUID)
-        self.create_queued_run(instance, job_handle, run_id=good_run_id)
-        self.create_queued_run(instance, job_handle, run_id=BAD_USER_CODE_RUN_ID_UUID)
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=BAD_RUN_ID_UUID,
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=good_run_id,
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=BAD_USER_CODE_RUN_ID_UUID,
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
 
         list(daemon.run_iteration(workspace_context))
 
@@ -667,9 +862,24 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         ]
         fixed_iteration_time = time.time() - 3600 * 24 * 365
 
-        self.create_queued_run(instance, job_handle, run_id=BAD_RUN_ID_UUID)
-        self.create_queued_run(instance, job_handle, run_id=good_run_id)
-        self.create_queued_run(instance, job_handle, run_id=BAD_USER_CODE_RUN_ID_UUID)
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=BAD_RUN_ID_UUID,
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=good_run_id,
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
+        self.create_queued_run(
+            instance,
+            job_handle,
+            run_id=BAD_USER_CODE_RUN_ID_UUID,
+            asset_graph=workspace_context.create_request_context().asset_graph,
+        )
 
         list(daemon.run_iteration(workspace_context, fixed_iteration_time=fixed_iteration_time))
 
@@ -687,11 +897,13 @@ class QueuedRunCoordinatorDaemonTests(ABC):
             tags={
                 "dagster/priority": "5",
             },
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
         self.create_queued_run(
             instance,
             other_location_job_handle,
             run_id=good_run_other_location_id,
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
         list(daemon.run_iteration(workspace_context, fixed_iteration_time=fixed_iteration_time))
 
@@ -759,6 +971,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
             instance,
             job_handle,
             run_id=BAD_USER_CODE_RUN_ID_UUID,
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
 
         # fails on initial dequeue
@@ -804,6 +1017,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
             job_handle,
             run_id=run_id_1,
             tags={"other-tag": "value", "test": "value"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
 
         self.create_queued_run(
@@ -811,6 +1025,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
             job_handle,
             run_id=run_id_2,
             tags={"other-tag": "value", "test": "value"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
 
         list(daemon.run_iteration(workspace_context))
@@ -837,12 +1052,14 @@ class QueuedRunCoordinatorDaemonTests(ABC):
             job_handle,
             run_id=lo_pri_run_id,
             tags={"test": "value", PRIORITY_TAG: "-100"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
         self.create_queued_run(
             instance,
             job_handle,
             run_id=hi_pri_run_id,
             tags={"test": "value", PRIORITY_TAG: "100"},
+            asset_graph=workspace_context.create_request_context().asset_graph,
         )
 
         list(daemon.run_iteration(workspace_context))


### PR DESCRIPTION
Summary:
Every callsite outside of tests passes this in, and this is not a public method. Being able to safely assume this is always set gives us fewer cases to worry about.
