### PR TITLE
[ui] Skeleton CSS tweak

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Skeleton.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Skeleton.module.css
@@ -1,37 +1,36 @@
 .skeleton {
-    display: block;
-    min-height: 1.5em;
-    border-radius: 6px;
-    position: relative;
-    overflow: hidden;
-    contain: paint layout style size;
-    isolation: isolate;
-    background: var(--skeleton-bg);
+  display: block;
+  min-height: 10px;
+  border-radius: 6px;
+  position: relative;
+  overflow: hidden;
+  contain: paint layout style size;
+  isolation: isolate;
+  background: var(--skeleton-bg);
+}
+
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    var(--skeleton-bg) 0%,
+    var(--skeleton-bg-hover) 50%,
+    var(--skeleton-bg) 100%
+  );
+  animation: shimmer 1.4s ease infinite;
+  will-change: transform;
+  contain: paint layout style size;
+  isolation: isolate;
+  pointer-events: none;
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
   }
-  
-  .skeleton::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(
-      90deg,
-      var(--skeleton-bg) 0%,
-      var(--skeleton-bg-hover) 50%,
-      var(--skeleton-bg) 100%
-    );
-    animation: shimmer 1.4s ease infinite;
-    will-change: transform;
-    contain: paint layout style size;
-    isolation: isolate;
-    pointer-events: none;
+  100% {
+    transform: translateX(100%);
   }
-  
-  @keyframes shimmer {
-    0% {
-      transform: translateX(-100%);
-    }
-    100% {
-      transform: translateX(100%);
-    }
-  }
-  
+}


### PR DESCRIPTION
## Summary & Motivation

Fix some odd indentation in `Skeleton.module.css`, and use a pixel min-height instead of an `em`-based one, since that's what we do for widths/heights elsewhere.

## How I Tested These Changes

Verify correct skeleton rendering in new automations table.