### PR TITLE
[dagster-tableau] Yield AssetObservation events for sheets and dashboards

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
@@ -5,6 +5,7 @@ from typing import Any, Union
 import tableauserverclient as TSC
 from dagster import (
     AssetKey,
+    AssetObservation,
     AssetSpec,
     ObserveResult,
     Output,
@@ -120,6 +121,16 @@ def create_data_source_asset_event(
         )
 
 
+def create_view_asset_observation(
+    view: TSC.ViewItem,
+    spec: AssetSpec,
+) -> Iterator[Union[AssetObservation]]:
+    asset_key = spec.key
+    yield from create_asset_observation(
+        asset_key=asset_key, data=view, additional_metadata={"workbook_id": view.workbook_id}
+    )
+
+
 def create_asset_output(
     asset_key: AssetKey,
     data: Union[TSC.DatasourceItem, TSC.ViewItem],
@@ -145,6 +156,24 @@ def create_asset_observe_result(
     additional_metadata: Mapping[str, Any],
 ) -> Iterator[ObserveResult]:
     yield ObserveResult(
+        asset_key=asset_key,
+        metadata={
+            **additional_metadata,
+            "owner_id": data.owner_id,
+            "name": data.name,
+            "contentUrl": data.content_url,
+            "createdAt": data.created_at.strftime("%Y-%m-%dT%H:%M:%S") if data.created_at else None,
+            "updatedAt": data.updated_at.strftime("%Y-%m-%dT%H:%M:%S") if data.updated_at else None,
+        },
+    )
+
+
+def create_asset_observation(
+    asset_key: AssetKey,
+    data: Union[TSC.DatasourceItem, TSC.ViewItem],
+    additional_metadata: Mapping[str, Any],
+) -> Iterator[AssetObservation]:
+    yield AssetObservation(
         asset_key=asset_key,
         metadata={
             **additional_metadata,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
@@ -124,7 +124,7 @@ def create_data_source_asset_event(
 def create_view_asset_observation(
     view: TSC.ViewItem,
     spec: AssetSpec,
-) -> Iterator[Union[AssetObservation]]:
+) -> Iterator[AssetObservation]:
     asset_key = spec.key
     yield from create_asset_observation(
         asset_key=asset_key, data=view, additional_metadata={"workbook_id": view.workbook_id}

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -12,6 +12,7 @@ import requests
 import tableauserverclient as TSC
 from dagster import (
     AssetExecutionContext,
+    AssetObservation,
     AssetSpec,
     ConfigurableResource,
     Definitions,
@@ -20,7 +21,6 @@ from dagster import (
     Output,
     _check as check,
     get_dagster_logger,
-    AssetObservation,
 )
 from dagster._annotations import beta, beta_param, superseded
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -20,6 +20,7 @@ from dagster import (
     Output,
     _check as check,
     get_dagster_logger,
+    AssetObservation,
 )
 from dagster._annotations import beta, beta_param, superseded
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
@@ -642,7 +643,7 @@ class BaseTableauWorkspace(ConfigurableResource):
 
     def refresh_and_poll(
         self, context: AssetExecutionContext
-    ) -> Iterator[Union[Output, ObserveResult]]:
+    ) -> Iterator[Union[Output, ObserveResult, AssetObservation]]:
         """Executes a refresh and poll process to materialize Tableau assets,
         including data sources with extracts, views and workbooks.
         This method can only be used in the context of an asset execution.

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
@@ -516,10 +516,10 @@ def test_load_assets_workspace_data_translator(
 
 
 @pytest.mark.parametrize(
-    "job_name, expected_asset_materializations",
+    "job_name, expected_asset_materializations, expected_asset_observations",
     [
-        ("all_asset_job", 4),
-        ("subset_asset_job", 1),
+        ("all_asset_job", 1, 3),
+        ("subset_asset_job", 1, 0),
     ],
     ids=[
         "all_asset_job",
@@ -529,6 +529,7 @@ def test_load_assets_workspace_data_translator(
 def test_load_assets_workspace_asset_decorator_with_context(
     job_name: str,
     expected_asset_materializations: int,
+    expected_asset_observations: int,
     sign_in: MagicMock,
     get_workbooks: MagicMock,
     get_workbook: MagicMock,
@@ -580,3 +581,8 @@ def test_load_assets_workspace_asset_decorator_with_context(
             event for event in events if event.event_type == DagsterEventType.ASSET_MATERIALIZATION
         ]
         assert len(asset_materializations) == expected_asset_materializations
+
+        asset_observations = [
+            event for event in events if event.event_type == DagsterEventType.ASSET_OBSERVATION
+        ]
+        assert len(asset_observations) == expected_asset_observations


### PR DESCRIPTION
## Summary & Motivation

This PR changes the behavior of `refresh_and_poll` so that we emit asset observation events for sheets and dashboards.

In Tableau, only data sources with extracts can be materialized (refreshed). Other data sources are live connections, and sheets/dashboards are views of their underlying data sources.

Because of that, sheets and dashboards are not directly materialized via Dagster. We can observe these assets and update the metadata accordingly as a workaround.

## How I Tested These Changes

Updated tests with BK.

## Changelog

[dagster-tableau] Tableau sheets and dashboards are now being observed and instead of being materialized when using `refresh_and_poll` inside the `@tableau_assets` asset decorator.
