### PR TITLE
Revert "ensure that execution_type is always set on the ExecutionPlanSnapshot for all step outputs that correspond to asset keys (#31248)"

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1288,7 +1288,6 @@ class DagsterInstance(DynamicPartitionsStore):
         op_selection: Optional[Sequence[str]] = None,
         remote_job_origin: Optional["RemoteJobOrigin"] = None,
         job_code_origin: Optional[JobPythonOrigin] = None,
-        asset_graph: Optional["BaseAssetGraph"] = None,
     ) -> DagsterRun:
         # https://github.com/dagster-io/dagster/issues/2403
         if tags and IS_AIRFLOW_INGEST_PIPELINE_STR in tags:
@@ -1310,34 +1309,6 @@ class DagsterInstance(DynamicPartitionsStore):
             if job_snapshot
             else None
         )
-
-        # ensure that all asset outputs list their execution type, even if the snapshot was
-        # created on an older version before it was being set
-        if execution_plan_snapshot and asset_graph:
-            adjusted_steps = []
-            for step in execution_plan_snapshot.steps:
-                adjusted_outputs = []
-                for output in step.outputs:
-                    asset_key = output.properties.asset_key if output.properties else None
-                    adjusted_output = output
-
-                    if (
-                        output.properties is not None
-                        and asset_key
-                        and asset_graph.has(asset_key)
-                        and output.properties.asset_execution_type is None
-                    ):
-                        adjusted_output = output._replace(
-                            properties=output.properties._replace(
-                                asset_execution_type=asset_graph.get(asset_key).execution_type
-                            )
-                        )
-
-                    adjusted_outputs.append(adjusted_output)
-
-                adjusted_steps.append(step._replace(outputs=adjusted_outputs))
-
-            execution_plan_snapshot = execution_plan_snapshot._replace(steps=adjusted_steps)
 
         execution_plan_snapshot_id = (
             self._ensure_persisted_execution_plan_snapshot(
@@ -1727,7 +1698,6 @@ class DagsterInstance(DynamicPartitionsStore):
             parent_job_snapshot=parent_job_snapshot,
             remote_job_origin=remote_job_origin,
             job_code_origin=job_code_origin,
-            asset_graph=asset_graph,
         )
 
         dagster_run = self._run_storage.add_run(dagster_run)

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -16,7 +16,6 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._cli.utils import get_instance_for_cli
-from dagster._core.definitions.assets.definition.asset_spec import AssetExecutionType
 from dagster._core.errors import DagsterHomeNotSetError
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.instance import DagsterInstance, InstanceRef
@@ -328,54 +327,6 @@ def test_submit_run():
 
             assert len(instance.run_coordinator.queue()) == 1  # pyright: ignore[reportAttributeAccessIssue]
             assert instance.run_coordinator.queue()[0].run_id == run.run_id  # pyright: ignore[reportAttributeAccessIssue]
-
-
-def test_create_run_without_asset_execution_type_on_snapshot():
-    # verify that even runs created on older versions of dagster still store the
-    # execution type on the execution plan snapshot
-    with dg.instance_for_test() as instance:
-        execution_plan = create_execution_plan(noop_asset_job)
-
-        ep_snapshot = snapshot_from_execution_plan(
-            execution_plan, noop_asset_job.get_job_snapshot_id()
-        )
-
-        # simulate legacy snapshot with no execution type
-        ep_snapshot = ep_snapshot._replace(
-            steps=[
-                step._replace(
-                    outputs=[
-                        output._replace(
-                            properties=check.not_none(output.properties)._replace(
-                                asset_execution_type=None
-                            )
-                        )
-                        for output in step.outputs
-                    ]
-                )
-                for step in ep_snapshot.steps
-            ]
-        )
-
-        run = create_run_for_test(
-            instance=instance,
-            job_name="foo",
-            execution_plan_snapshot=ep_snapshot,
-            job_snapshot=noop_asset_job.get_job_snapshot(),
-            tags={ASSET_PARTITION_RANGE_START_TAG: "bar", ASSET_PARTITION_RANGE_END_TAG: "foo"},
-            asset_graph=noop_asset_job.asset_layer.asset_graph,
-        )
-
-        assert run.execution_plan_snapshot_id is not None
-
-        stored_snapshot = instance.get_execution_plan_snapshot(run.execution_plan_snapshot_id)
-
-        assert all(
-            check.not_none(output.properties).asset_execution_type
-            == AssetExecutionType.MATERIALIZATION
-            for step in stored_snapshot.steps
-            for output in step.outputs
-        )
 
 
 def test_create_run_with_asset_partitions():


### PR DESCRIPTION
This reverts commit a8a0bc9b0c14d463c65e35cd8c6d74a654348dc0. Test here is insufficient because it tests on an AssetGraph and needs to be testing on a RemoteAssetGraph. Will follow up in the subsequent fix about why pyright didn't catch a glaring type error.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
