### PR TITLE
Bring back "ensure that execution_type is always set on the ExecutionPlanSnapshot for all step outputs that correspond to asset keys (#31248)"

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/base_asset_graph.py
@@ -38,6 +38,7 @@ from dagster._core.utils import toposort
 from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.assets.definition.asset_spec import AssetExecutionType
     from dagster._core.definitions.assets.graph.asset_graph_subset import AssetGraphSubset
     from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
     from dagster._core.definitions.declarative_automation.automation_condition import (
@@ -126,6 +127,10 @@ class BaseAssetNode(BaseEntityNode[AssetKey]):
     @property
     @abstractmethod
     def is_executable(self) -> bool: ...
+
+    @property
+    @abstractmethod
+    def execution_type(self) -> "AssetExecutionType": ...
 
     @property
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/remote_asset_graph.py
@@ -86,6 +86,10 @@ class RemoteAssetNode(BaseAssetNode, ABC):
         return self.resolve_to_singular_repo_scoped_node().asset_node_snap.metadata
 
     @property
+    def execution_type(self) -> AssetExecutionType:
+        return self.resolve_to_singular_repo_scoped_node().asset_node_snap.execution_type
+
+    @property
     def pools(self) -> Optional[set[str]]:
         return self.resolve_to_singular_repo_scoped_node().pools
 

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/execution_plan_snapshot_without_execution_type.json
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/execution_plan_snapshot_without_execution_type.json
@@ -1,0 +1,58 @@
+{
+  "__class__": "ExecutionPlanSnapshot",
+  "artifacts_persisted": true,
+  "executor_name": "multi_or_in_process_executor",
+  "initial_known_state": {
+    "__class__": "KnownExecutionState",
+    "dynamic_mappings": {},
+    "parent_state": null,
+    "previous_retry_attempts": {},
+    "ready_outputs": { "__frozenset__": [] },
+    "step_output_versions": []
+  },
+  "pipeline_snapshot_id": "9a5b4119d1943a5cc594da3f86e813f44bfb5549",
+  "snapshot_version": 1,
+  "step_keys_to_execute": ["noop_asset"],
+  "steps": [
+    {
+      "__class__": "ExecutionStepSnap",
+      "inputs": [],
+      "key": "noop_asset",
+      "kind": { "__enum__": "StepKind.COMPUTE" },
+      "metadata_items": [],
+      "outputs": [
+        {
+          "__class__": "ExecutionStepOutputSnap",
+          "dagster_type_key": "Any",
+          "name": "result",
+          "properties": {
+            "__class__": "StepOutputProperties",
+            "asset_check_key": null,
+            "asset_key": { "__class__": "AssetKey", "path": ["noop_asset"] },
+            "is_asset": true,
+            "is_asset_partitioned": true,
+            "is_dynamic": false,
+            "is_required": true,
+            "should_materialize": false
+          },
+          "solid_handle": {
+            "__class__": "SolidHandle",
+            "name": "noop_asset",
+            "parent": null
+          }
+        }
+      ],
+      "solid_handle_id": "noop_asset",
+      "step_handle": {
+        "__class__": "StepHandle",
+        "key": "noop_asset",
+        "solid_handle": {
+          "__class__": "SolidHandle",
+          "name": "noop_asset",
+          "parent": null
+        }
+      },
+      "tags": {}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary & Motivation
Now with better type hinting and better testing.

## How I Tested These Changes
New test case that was failing before and better matches the actual workflow (changed to a remote asset graph)

