### PR TITLE
[dagster-tableau] Support dashboards and data sources with hidden sheets

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -282,6 +282,20 @@ class DagsterTableauTranslator:
             for sheet_id in sheet_ids
         ]
 
+        dashboard_upstream_data_source_ids = data.properties.get("data_source_ids", [])
+
+        data_source_keys = [
+            self.get_asset_spec(
+                TableauTranslatorData(
+                    content_data=data.workspace_data.data_sources_by_id[data_source_id],
+                    workspace_data=data.workspace_data,
+                )
+            ).key
+            for data_source_id in dashboard_upstream_data_source_ids
+        ]
+
+        upstream_keys = sheet_keys + data_source_keys
+
         workbook_id = data.properties["workbook"]["luid"]
         workbook_data = data.workspace_data.workbooks_by_id[workbook_id]
         asset_key = AssetKey(
@@ -294,7 +308,7 @@ class DagsterTableauTranslator:
 
         return AssetSpec(
             key=asset_key,
-            deps=sheet_keys if sheet_keys else None,
+            deps=upstream_keys if upstream_keys else None,
             tags={"dagster/storage_kind": "tableau", **TableauTagSet(asset_type="dashboard")},
             metadata={
                 **TableauViewMetadataSet(

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -15,6 +15,7 @@ FAKE_POD_NAME = "fake_pod_name"
 
 TEST_DATA_SOURCE_ID = "0f5660c7-2b05-4ff0-90ce-3199226956c6"
 TEST_EMBEDDED_DATA_SOURCE_ID = "1f5660c7-3b05-5ff0-90ce-4199226956c6"
+TEST_DATA_SOURCE_HIDDEN_SHEET_ID = "test_data_source_hidden_sheet_id"
 
 TEST_WORKBOOK_ID = "b75fc023-a7ca-4115-857b-4342028640d0"
 TEST_PROJECT_NAME = "test_project_name"
@@ -36,8 +37,17 @@ SAMPLE_EMBEDDED_DATA_SOURCE = {
     "workbook": {"luid": TEST_WORKBOOK_ID},
 }
 
+SAMPLE_DATA_SOURCE_HIDDEN_SHEET = {
+    "luid": TEST_DATA_SOURCE_HIDDEN_SHEET_ID,
+    "name": "Hidden Sheet Datasource",
+    "hasExtracts": True,
+    "isPublished": True,
+}
+
+
 SAMPLE_SHEET = {
     "luid": "ae8a5f27-8b2f-44e9-aec3-94fe6c638f4f",
+    "id": "sample_sheet_1_metadata_id",
     "name": "Sales",
     "createdAt": "2024-09-05T21:33:26Z",
     "updatedAt": "2024-09-13T00:15:23Z",
@@ -56,6 +66,7 @@ SAMPLE_SHEET = {
 
 SAMPLE_SHEET_2 = {
     "luid": "be8a5f27-9b2f-54e9-bec3-84fe6c638f4f",
+    "id": "sample_sheet_2_metadata_id",
     "name": "Account",
     "createdAt": "2024-09-06T22:33:26Z",
     "updatedAt": "2024-09-14T01:15:23Z",
@@ -66,9 +77,26 @@ SAMPLE_SHEET_2 = {
     "workbook": {"luid": TEST_WORKBOOK_ID},
 }
 
-SHEET_LIST = []
-SHEET_LIST += [SAMPLE_SHEET]
-SHEET_LIST += [SAMPLE_SHEET_2]
+SAMPLE_HIDDEN_SHEET = {
+    "luid": None,
+    "id": "sample_hidden_sheet_metadata_id",
+    "name": "hidden",
+    "createdAt": "2024-09-06T22:33:26Z",
+    "updatedAt": "2024-09-14T01:15:23Z",
+    "path": "TestWorkbook/Account",
+    "parentEmbeddedDatasources": [
+        {
+            "parentPublishedDatasources": [
+                {
+                    **SAMPLE_DATA_SOURCE_HIDDEN_SHEET,
+                }
+            ]
+        }
+    ],
+    "workbook": {"luid": TEST_WORKBOOK_ID},
+}
+
+SHEET_LIST = [SAMPLE_SHEET, SAMPLE_SHEET_2, SAMPLE_HIDDEN_SHEET]
 
 SAMPLE_DASHBOARD = {
     "luid": "c9bf8403-5daf-427a-b3d6-2ce9bed7798f",
@@ -76,7 +104,16 @@ SAMPLE_DASHBOARD = {
     "createdAt": "2024-09-06T14:38:42Z",
     "updatedAt": "2024-09-13T00:15:23Z",
     "path": "TestWorkbook/Dashboard_Sales",
-    "sheets": [{"luid": "ae8a5f27-8b2f-44e9-aec3-94fe6c638f4f"}],
+    "sheets": [
+        {
+            "luid": "ae8a5f27-8b2f-44e9-aec3-94fe6c638f4f",
+            "id": "sample_sheet_1_metadata_id",
+        },
+        {
+            "luid": None,
+            "id": "sample_hidden_sheet_metadata_id",
+        },
+    ],
     "workbook": {"luid": TEST_WORKBOOK_ID},
 }
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -172,8 +172,13 @@ def test_translator_spec(
             if "workbook" in spec.key.path[0] and "dashboard" in spec.key.path[1]
         )
         assert dashboard_asset_spec.key.path == ["test_workbook", "dashboard", "dashboard_sales"]
-        assert list(dashboard_asset_spec.deps)[0].asset_key.path == ["test_workbook", "sheet", "sales"]
-        assert list(dashboard_asset_spec.deps)[1].asset_key.path == ["hidden_sheet_datasource"]
+        asset_deps_iter = iter(dashboard_asset_spec.deps)
+        assert next(asset_deps_iter).asset_key.path == [
+            "test_workbook",
+            "sheet",
+            "sales",
+        ]
+        assert next(asset_deps_iter).asset_key.path == ["hidden_sheet_datasource"]
 
         iter_data_source = iter(spec for spec in all_assets if "datasource" in spec.key.path[0])
         published_data_source_asset_spec = next(iter_data_source)

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -172,8 +172,8 @@ def test_translator_spec(
             if "workbook" in spec.key.path[0] and "dashboard" in spec.key.path[1]
         )
         assert dashboard_asset_spec.key.path == ["test_workbook", "dashboard", "dashboard_sales"]
-        assert dashboard_asset_spec.deps[0].asset_key.path == ["test_workbook", "sheet", "sales"]
-        assert dashboard_asset_spec.deps[1].asset_key.path == ["hidden_sheet_datasource"]
+        assert list(dashboard_asset_spec.deps)[0].asset_key.path == ["test_workbook", "sheet", "sales"]
+        assert list(dashboard_asset_spec.deps)[1].asset_key.path == ["hidden_sheet_datasource"]
 
         iter_data_source = iter(spec for spec in all_assets if "datasource" in spec.key.path[0])
         published_data_source_asset_spec = next(iter_data_source)

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -59,7 +59,7 @@ def test_fetch_tableau_workspace_data(
     assert len(actual_workspace_data.workbooks_by_id) == 1
     assert len(actual_workspace_data.sheets_by_id) == 2
     assert len(actual_workspace_data.dashboards_by_id) == 1
-    assert len(actual_workspace_data.data_sources_by_id) == 2
+    assert len(actual_workspace_data.data_sources_by_id) == 3
 
 
 @responses.activate
@@ -154,9 +154,9 @@ def test_translator_spec(
         all_assets = load_tableau_asset_specs(resource)
         all_assets_keys = [asset.key for asset in all_assets]
 
-        # 2 sheet, 1 dashboard and 2 data source as external assets
-        assert len(all_assets) == 5
-        assert len(all_assets_keys) == 5
+        # 2 sheet, 1 dashboard and 3 data source as external assets
+        assert len(all_assets) == 6
+        assert len(all_assets_keys) == 6
 
         # Sanity check outputs, translator tests cover details here
         sheet_asset_spec = next(
@@ -172,6 +172,8 @@ def test_translator_spec(
             if "workbook" in spec.key.path[0] and "dashboard" in spec.key.path[1]
         )
         assert dashboard_asset_spec.key.path == ["test_workbook", "dashboard", "dashboard_sales"]
+        assert dashboard_asset_spec.deps[0].asset_key.path == ["test_workbook", "sheet", "sales"]
+        assert dashboard_asset_spec.deps[1].asset_key.path == ["hidden_sheet_datasource"]
 
         iter_data_source = iter(spec for spec in all_assets if "datasource" in spec.key.path[0])
         published_data_source_asset_spec = next(iter_data_source)
@@ -301,7 +303,7 @@ def test_parse_asset_specs(
                 specs=all_assets, include_data_sources_with_extracts=False
             )
         )
-        assert len(external_asset_specs) == 2
+        assert len(external_asset_specs) == 3
         assert len(materializable_asset_specs) == 3
 
         # Data source with extracts are considered as materializable assets
@@ -311,7 +313,7 @@ def test_parse_asset_specs(
             )
         )
         assert len(external_asset_specs) == 1
-        assert len(materializable_asset_specs) == 4
+        assert len(materializable_asset_specs) == 5
 
 
 @responses.activate

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
@@ -223,8 +223,8 @@ def test_load_assets_workspace_data_refreshable_workbooks(
         assert get_job.call_count == 0
         assert cancel_job.call_count == 0
 
-        # 2 Tableau external assets and 3 Tableau materializable assets
-        assert len(init_repository_def.assets_defs_by_key) == 2 + 3
+        # 3 Tableau external assets and 3 Tableau materializable assets
+        assert len(init_repository_def.assets_defs_by_key) == 3 + 3
 
         repository_load_data = init_repository_def.repository_load_data
 
@@ -233,7 +233,7 @@ def test_load_assets_workspace_data_refreshable_workbooks(
             pointer,
             repository_load_data,
         )
-        assert len(recon_repository_def.assets_defs_by_key) == 2 + 3
+        assert len(recon_repository_def.assets_defs_by_key) == 3 + 3
 
         # no additional calls after a fresh load
         assert sign_in.call_count == 1
@@ -324,8 +324,8 @@ def test_load_assets_workspace_data_refreshable_data_sources(
         assert get_job.call_count == 0
         assert cancel_job.call_count == 0
 
-        # 2 Tableau external assets and 3 Tableau materializable assets
-        assert len(init_repository_def.assets_defs_by_key) == 2 + 3
+        # 3 Tableau external assets and 3 Tableau materializable assets
+        assert len(init_repository_def.assets_defs_by_key) == 3 + 3
 
         repository_load_data = init_repository_def.repository_load_data
 
@@ -334,7 +334,7 @@ def test_load_assets_workspace_data_refreshable_data_sources(
             pointer,
             repository_load_data,
         )
-        assert len(recon_repository_def.assets_defs_by_key) == 2 + 3
+        assert len(recon_repository_def.assets_defs_by_key) == 3 + 3
 
         # no additional calls after a fresh load
         assert sign_in.call_count == 1
@@ -372,7 +372,7 @@ def test_load_assets_workspace_data_refreshable_data_sources(
         asset_materializations = [
             event for event in events if event.event_type == DagsterEventType.ASSET_MATERIALIZATION
         ]
-        assert len(asset_materializations) == 4
+        assert len(asset_materializations) == 5
 
         # 3 calls to create the defs + 8 calls to materialize the Tableau assets
         # with 1 data source to refresh, 2 sheets and 1 dashboard
@@ -380,7 +380,7 @@ def test_load_assets_workspace_data_refreshable_data_sources(
         assert get_workbooks.call_count == 1
         assert get_workbook.call_count == 1
         assert get_view.call_count == 3
-        assert get_data_source.call_count == 1
+        assert get_data_source.call_count == 2
         assert refresh_data_source.call_count == 1
         assert get_job.call_count == 2
         # The finish_code of the mocked get_job is 0, so no cancel_job is not called
@@ -427,8 +427,8 @@ def test_load_assets_workspace_data(
         assert get_job.call_count == 0
         assert cancel_job.call_count == 0
 
-        # 2 Tableau external assets and 3 Tableau materializable assets
-        assert len(init_repository_def.assets_defs_by_key) == 2 + 3
+        # 3 Tableau external assets and 3 Tableau materializable assets
+        assert len(init_repository_def.assets_defs_by_key) == 3 + 3
 
         repository_load_data = init_repository_def.repository_load_data
 
@@ -437,7 +437,7 @@ def test_load_assets_workspace_data(
             pointer,
             repository_load_data,
         )
-        assert len(recon_repository_def.assets_defs_by_key) == 2 + 3
+        assert len(recon_repository_def.assets_defs_by_key) == 3 + 3
 
         # no additional calls after a fresh load
         assert sign_in.call_count == 1
@@ -509,7 +509,7 @@ def test_load_assets_workspace_data_translator(
             )
         )
 
-        assert len(repository_def.assets_defs_by_key) == 5
+        assert len(repository_def.assets_defs_by_key) == 6
         assert all(
             key.path[0] == "my_prefix" for key in repository_def.assets_defs_by_key.keys()
         ), repository_def.assets_defs_by_key
@@ -518,7 +518,7 @@ def test_load_assets_workspace_data_translator(
 @pytest.mark.parametrize(
     "job_name, expected_asset_materializations, expected_asset_observations",
     [
-        ("all_asset_job", 1, 3),
+        ("all_asset_job", 2, 3),
         ("subset_asset_job", 1, 0),
     ],
     ids=[
@@ -550,7 +550,7 @@ def test_load_assets_workspace_asset_decorator_with_context(
         )
 
         # 4 Tableau materializable assets
-        assert len(repository_def.assets_defs_by_key) == 4
+        assert len(repository_def.assets_defs_by_key) == 5
 
         repository_load_data = repository_def.repository_load_data
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
@@ -140,7 +140,7 @@ def test_fetch_tableau_workspace_data(
 
     assert get_workbooks.call_count == 1
     assert get_workbook.call_count == 1
-    assert response.data_sources_by_id.__len__() == 2
+    assert response.data_sources_by_id.__len__() == 3
     assert (
         response.data_sources_by_id.get("0f5660c7-2b05-4ff0-90ce-3199226956c6").properties.get(  # type: ignore
             "name"


### PR DESCRIPTION
## Summary & Motivation

When fetching workbook details via the Tableau Metadata API (GraphQL), sheets for which the LUID is missing are considered hidden. Previously, we were discarding them, but also discarding their data sources in the process.

In Tableau, dashboards can contain hidden sheets - we want to make sure we represent these dashboards as it should, with their upstream data sources, even if sheets between these dashboards and upstream data sources are hidden. 

This PR updates the code so that we represent upstream data sources as direct deps of these dashboards in the asset lineage.

## How I Tested These Changes

Updated tests with BK

## Changelog

[dagster-tableau] Dashboards containing hidden sheets are now correctly linked to upstream data sources.
