### PR TITLE
[dagster-tableau] Use AssetObservation instead of ObserveResult

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -136,7 +136,7 @@ class BaseTableauClient:
     @superseded(additional_warn_text="Use `refresh_and_poll` on the tableau resource instead.")
     def refresh_and_materialize_workbooks(
         self, specs: Sequence[AssetSpec], refreshable_workbook_ids: Optional[Sequence[str]]
-    ) -> Iterator[Union[Output, ObserveResult]]:
+    ) -> Iterator[Union[AssetObservation, Output]]:
         """Refreshes workbooks for the given workbook IDs and materializes workbook views given the asset specs."""
         refreshed_workbook_ids = set()
         for refreshable_workbook_id in refreshable_workbook_ids or []:
@@ -165,7 +165,7 @@ class BaseTableauClient:
     @superseded(additional_warn_text="Use `refresh_and_poll` on the tableau resource instead.")
     def refresh_and_materialize(
         self, specs: Sequence[AssetSpec], refreshable_data_source_ids: Optional[Sequence[str]]
-    ) -> Iterator[Union[Output, ObserveResult]]:
+    ) -> Iterator[Union[AssetObservation, Output]]:
         """Refreshes data sources for the given data source IDs and materializes Tableau assets given the asset specs.
         Only data sources with extracts can be refreshed.
         """

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -268,14 +268,14 @@ def refresh_workbook_fixture(workbook_id, job_id):
 
 
 @pytest.fixture(name="refresh_data_source", autouse=True)
-def refresh_data_source_fixture(embedded_data_source_id, job_id):
+def refresh_data_source_fixture(job_id):
     with patch(
         "dagster_tableau.resources.BaseTableauClient.refresh_data_source"
     ) as mocked_function:
         type(mocked_function.return_value).id = PropertyMock(return_value=job_id)
         type(mocked_function.return_value).finish_code = PropertyMock(return_value=-1)
         type(mocked_function.return_value).datasource_id = PropertyMock(
-            return_value=embedded_data_source_id
+            return_value=TEST_DATA_SOURCE_HIDDEN_SHEET_ID
         )
         yield mocked_function
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -247,13 +247,13 @@ def get_data_source_fixture(build_data_source_item):
 
 
 @pytest.fixture(name="get_job", autouse=True)
-def get_job_fixture(embedded_data_source_id, workbook_id, job_id):
+def get_job_fixture(workbook_id, job_id):
     with patch("dagster_tableau.resources.BaseTableauClient.get_job") as mocked_function:
         type(mocked_function.return_value).id = PropertyMock(return_value=job_id)
         type(mocked_function.return_value).finish_code = PropertyMock(return_value=0)
         type(mocked_function.return_value).workbook_id = PropertyMock(return_value=workbook_id)
         type(mocked_function.return_value).datasource_id = PropertyMock(
-            return_value=embedded_data_source_id
+            return_value=TEST_DATA_SOURCE_HIDDEN_SHEET_ID
         )
         yield mocked_function
 


### PR DESCRIPTION
## Summary & Motivation

Similar as #31260 but for data sources too, since using ObserveResults was emiting a materialization event.

## How I Tested These Changes

Updated tests with BK

## Changelog

> Insert changelog entry or delete this section.
