### PR TITLE
[Observe][insights] Make units adapt to scale

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogActivityChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogActivityChart.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import styles from './AssetCatalogInsights.module.css';
 import {AssetCatalogMetricNames} from './AssetCatalogMetricUtils';
 import {TooltipCard} from '../../insights/InsightsChartShared';
+import {formatDuration} from '../../ui/formatDuration';
 import {numberFormatter} from '../../ui/formatters';
 import {useFormatDateTime} from '../../ui/useFormatDateTime';
 
@@ -129,6 +130,14 @@ const ActivityChartRow = React.memo(
               return <div key={index} />;
             }
             const opacity = value / (max || 1);
+
+            const {value: displayValue, unit: displayUnit} = (() => {
+              const unitLower = unit.toLowerCase();
+              if (unitLower === 'seconds' || unitLower === 'milliseconds') {
+                return formatDuration(value, {unit: unitLower})[0];
+              }
+              return {value, unit};
+            })();
             return (
               <Popover
                 key={index}
@@ -153,8 +162,8 @@ const ActivityChartRow = React.memo(
                         flex={{direction: 'row', alignItems: 'center', gap: 4}}
                         padding={{horizontal: 12, vertical: 8}}
                       >
-                        <Mono>{numberFormatter.format(value)}</Mono>
-                        <Body color={Colors.textLight()}>{unit}</Body>
+                        <Mono>{numberFormatter.format(displayValue)}</Mono>
+                        <Body color={Colors.textLight()}>{displayUnit}</Body>
                       </Box>
                       {value > 0 ? (
                         <Box padding={{horizontal: 12, vertical: 8}} border="top">

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogActivityChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogActivityChart.tsx
@@ -16,7 +16,7 @@ import styles from './AssetCatalogInsights.module.css';
 import {AssetCatalogMetricNames} from './AssetCatalogMetricUtils';
 import {TooltipCard} from '../../insights/InsightsChartShared';
 import {formatDuration} from '../../ui/formatDuration';
-import {numberFormatter} from '../../ui/formatters';
+import {numberFormatterWithMaxFractionDigits} from '../../ui/formatters';
 import {useFormatDateTime} from '../../ui/useFormatDateTime';
 
 type MetricsDialogData = {
@@ -162,7 +162,7 @@ const ActivityChartRow = React.memo(
                         flex={{direction: 'row', alignItems: 'center', gap: 4}}
                         padding={{horizontal: 12, vertical: 8}}
                       >
-                        <Mono>{numberFormatter.format(displayValue)}</Mono>
+                        <Mono>{numberFormatterWithMaxFractionDigits(2).format(displayValue)}</Mono>
                         <Body color={Colors.textLight()}>{displayUnit}</Body>
                       </Box>
                       {value > 0 ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
@@ -30,7 +30,7 @@ import {TooltipCard} from '../../insights/InsightsChartShared';
 import {formatMetric} from '../../insights/formatMetric';
 import {ReportingUnitType} from '../../insights/types';
 import {formatDuration} from '../../ui/formatDuration';
-import {numberFormatter, percentFormatter} from '../../ui/formatters';
+import {numberFormatterWithMaxFractionDigits, percentFormatter} from '../../ui/formatters';
 import {useFormatDateTime} from '../../ui/useFormatDateTime';
 
 ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Tooltip);
@@ -328,7 +328,9 @@ export const AssetCatalogInsightsLineChart = React.memo(
         <Box flex={{direction: 'column', justifyContent: 'space-between'}}>
           <div className={styles.chartCount}>
             {metrics.currentPeriod.aggregateValue
-              ? numberFormatter.format(Math.round(currentPeriodDisplayValueAndUnit.value))
+              ? numberFormatterWithMaxFractionDigits(2).format(
+                  currentPeriodDisplayValueAndUnit.value,
+                )
               : 0}
             <Body color={Colors.textDefault()}>{currentPeriodDisplayValueAndUnit.unit}</Body>
           </div>
@@ -338,7 +340,9 @@ export const AssetCatalogInsightsLineChart = React.memo(
           >
             <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
               {metrics.prevPeriod.aggregateValue
-                ? numberFormatter.format(Math.round(prevPeriodDisplayValueAndUnit.value))
+                ? numberFormatterWithMaxFractionDigits(2).format(
+                    prevPeriodDisplayValueAndUnit.value,
+                  )
                 : 0}
               <span> previous period</span>
             </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
@@ -311,9 +311,11 @@ export const AssetCatalogInsightsLineChart = React.memo(
     }
 
     const currentPeriodDisplayValueAndUnit = getDisplayValueAndUnit(
-      metrics.currentPeriod.aggregateValue,
+      metrics.currentPeriod.aggregateValue ?? 0,
     );
-    const prevPeriodDisplayValueAndUnit = getDisplayValueAndUnit(metrics.prevPeriod.aggregateValue);
+    const prevPeriodDisplayValueAndUnit = getDisplayValueAndUnit(
+      metrics.prevPeriod.aggregateValue ?? 0,
+    );
 
     return (
       <div className={styles.chartContainer}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
@@ -29,6 +29,7 @@ import {useRGBColorsForTheme} from '../../app/useRGBColorsForTheme';
 import {TooltipCard} from '../../insights/InsightsChartShared';
 import {formatMetric} from '../../insights/formatMetric';
 import {ReportingUnitType} from '../../insights/types';
+import {formatDuration} from '../../ui/formatDuration';
 import {numberFormatter, percentFormatter} from '../../ui/formatters';
 import {useFormatDateTime} from '../../ui/useFormatDateTime';
 
@@ -302,6 +303,18 @@ export const AssetCatalogInsightsLineChart = React.memo(
       }
     };
 
+    function getDisplayValueAndUnit(value: number) {
+      if (unitType === ReportingUnitType.TIME_MS) {
+        return formatDuration(value, {unit: 'milliseconds'})[0];
+      }
+      return {value, unit: unitTypeToLabel[unitType]};
+    }
+
+    const currentPeriodDisplayValueAndUnit = getDisplayValueAndUnit(
+      metrics.currentPeriod.aggregateValue,
+    );
+    const prevPeriodDisplayValueAndUnit = getDisplayValueAndUnit(metrics.prevPeriod.aggregateValue);
+
     return (
       <div className={styles.chartContainer}>
         <div className={styles.chartHeader}>
@@ -313,9 +326,9 @@ export const AssetCatalogInsightsLineChart = React.memo(
         <Box flex={{direction: 'column', justifyContent: 'space-between'}}>
           <div className={styles.chartCount}>
             {metrics.currentPeriod.aggregateValue
-              ? numberFormatter.format(Math.round(metrics.currentPeriod.aggregateValue))
+              ? numberFormatter.format(Math.round(currentPeriodDisplayValueAndUnit.value))
               : 0}
-            <Body color={Colors.textDefault()}>{unitTypeToLabel[unitType]}</Body>
+            <Body color={Colors.textDefault()}>{currentPeriodDisplayValueAndUnit.unit}</Body>
           </div>
           <Box
             className={styles.chartChange}
@@ -323,7 +336,7 @@ export const AssetCatalogInsightsLineChart = React.memo(
           >
             <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
               {metrics.prevPeriod.aggregateValue
-                ? numberFormatter.format(Math.round(metrics.prevPeriod.aggregateValue))
+                ? numberFormatter.format(Math.round(prevPeriodDisplayValueAndUnit.value))
                 : 0}
               <span> previous period</span>
             </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.tsx
@@ -2,6 +2,7 @@ import {BodyLarge, Box, Colors, Icon, Spinner} from '@dagster-io/ui-components';
 import React from 'react';
 
 import styles from './AssetCatalogRateCard.module.css';
+import {formatDuration, unitToShortLabel} from '../../ui/formatDuration';
 import {percentFormatter} from '../../ui/formatters';
 
 export interface AssetCatalogRateCardProps {
@@ -25,11 +26,6 @@ function pctChange(x: number, y: number): number {
   }
   return -(1 - y / x);
 }
-
-const secondsFormatter = new Intl.NumberFormat(navigator.language, {
-  style: 'unit',
-  unit: 'second',
-});
 
 function formatValues(
   valueOrNull: number | null,
@@ -57,9 +53,12 @@ function formatValues(
     };
   }
 
+  const currValueAndUnit = formatDuration(value, {unit})[0];
+  const prevValueAndUnit = formatDuration(prevValue, {unit})[0];
+
   return {
-    currValueString: secondsFormatter.format(value),
-    prevValueString: secondsFormatter.format(prevValue),
+    currValueString: `${currValueAndUnit.value} ${unitToShortLabel[currValueAndUnit.unit]}`,
+    prevValueString: `${prevValueAndUnit.value} ${unitToShortLabel[prevValueAndUnit.unit]}`,
     absDeltaString: percentFormatter.format(absDelta),
     hasNegativeDelta,
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import styles from './AssetCatalogRateCard.module.css';
 import {formatDuration, unitToShortLabel} from '../../ui/formatDuration';
-import {percentFormatter} from '../../ui/formatters';
+import {numberFormatter, percentFormatter} from '../../ui/formatters';
 
 export interface AssetCatalogRateCardProps {
   title: string;
@@ -57,8 +57,8 @@ function formatValues(
   const prevValueAndUnit = formatDuration(prevValue, {unit})[0];
 
   return {
-    currValueString: `${currValueAndUnit.value} ${unitToShortLabel[currValueAndUnit.unit]}`,
-    prevValueString: `${prevValueAndUnit.value} ${unitToShortLabel[prevValueAndUnit.unit]}`,
+    currValueString: `${numberFormatter.format(currValueAndUnit.value)} ${unitToShortLabel[currValueAndUnit.unit]}`,
+    prevValueString: `${numberFormatter.format(prevValueAndUnit.value)} ${unitToShortLabel[prevValueAndUnit.unit]}`,
     absDeltaString: percentFormatter.format(absDelta),
     hasNegativeDelta,
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import styles from './AssetCatalogRateCard.module.css';
 import {formatDuration, unitToShortLabel} from '../../ui/formatDuration';
-import {numberFormatter, percentFormatter} from '../../ui/formatters';
+import {numberFormatterWithMaxFractionDigits, percentFormatter} from '../../ui/formatters';
 
 export interface AssetCatalogRateCardProps {
   title: string;
@@ -57,8 +57,8 @@ function formatValues(
   const prevValueAndUnit = formatDuration(prevValue, {unit})[0];
 
   return {
-    currValueString: `${numberFormatter.format(currValueAndUnit.value)} ${unitToShortLabel[currValueAndUnit.unit]}`,
-    prevValueString: `${numberFormatter.format(prevValueAndUnit.value)} ${unitToShortLabel[prevValueAndUnit.unit]}`,
+    currValueString: `${numberFormatterWithMaxFractionDigits(2).format(currValueAndUnit.value)} ${unitToShortLabel[currValueAndUnit.unit]}`,
+    prevValueString: `${numberFormatterWithMaxFractionDigits(2).format(prevValueAndUnit.value)} ${unitToShortLabel[prevValueAndUnit.unit]}`,
     absDeltaString: percentFormatter.format(absDelta),
     hasNegativeDelta,
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
@@ -29,8 +29,8 @@ import styles from './AssetCatalogTopAssetsChart.module.css';
 import {Context, useRenderChartTooltip} from './renderChartTooltip';
 import {useRGBColorsForTheme} from '../../app/useRGBColorsForTheme';
 import {TooltipCard} from '../../insights/InsightsChartShared';
-import {numberFormatter} from '../../ui/formatters';
 import {formatDuration} from '../../ui/formatDuration';
+import {numberFormatter} from '../../ui/formatters';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
@@ -80,7 +80,7 @@ export const AssetCatalogTopAssetsChart = React.memo(
           const {tooltip} = context;
           const d = tooltip.dataPoints[0];
 
-          const {value, unit} = useMemo(() => {
+          const {value, unit} = (() => {
             const typeLower = unitType.toLowerCase();
             if (d && (typeLower === 'milliseconds' || typeLower === 'seconds')) {
               const [result] = formatDuration(d.raw as number, {
@@ -90,7 +90,7 @@ export const AssetCatalogTopAssetsChart = React.memo(
               return {value: result.value, unit: result.unit};
             }
             return {value: d?.raw as number, unit: unitType};
-          }, [unitType, d]);
+          })();
           return (
             <TooltipCard>
               <Box flex={{direction: 'column', gap: 4}} padding={{vertical: 8, horizontal: 12}}>
@@ -98,7 +98,7 @@ export const AssetCatalogTopAssetsChart = React.memo(
                   <Subheading>{d?.label}</Subheading>
                 </Box>
                 <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-                  <Mono>{value == undefined ? null : numberFormatter.format(value)}</Mono>
+                  <Mono>{numberFormatter.format(value)}</Mono>
                   <Body>{unit}</Body>
                 </Box>
               </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
@@ -30,6 +30,7 @@ import {Context, useRenderChartTooltip} from './renderChartTooltip';
 import {useRGBColorsForTheme} from '../../app/useRGBColorsForTheme';
 import {TooltipCard} from '../../insights/InsightsChartShared';
 import {numberFormatter} from '../../ui/formatters';
+import {formatDuration} from '../../ui/formatDuration';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
@@ -78,6 +79,18 @@ export const AssetCatalogTopAssetsChart = React.memo(
         ({context}: {context: Context}) => {
           const {tooltip} = context;
           const d = tooltip.dataPoints[0];
+
+          const {value, unit} = useMemo(() => {
+            const typeLower = unitType.toLowerCase();
+            if (d && (typeLower === 'milliseconds' || typeLower === 'seconds')) {
+              const [result] = formatDuration(d.raw as number, {
+                unit: typeLower,
+              });
+
+              return {value: result.value, unit: result.unit};
+            }
+            return {value: d?.raw as number, unit: unitType};
+          }, [unitType, d]);
           return (
             <TooltipCard>
               <Box flex={{direction: 'column', gap: 4}} padding={{vertical: 8, horizontal: 12}}>
@@ -85,8 +98,8 @@ export const AssetCatalogTopAssetsChart = React.memo(
                   <Subheading>{d?.label}</Subheading>
                 </Box>
                 <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-                  <Mono>{d?.formattedValue}</Mono>
-                  <Body>{unitType}</Body>
+                  <Mono>{value == undefined ? null : numberFormatter.format(value)}</Mono>
+                  <Body>{unit}</Body>
                 </Box>
               </Box>
             </TooltipCard>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
@@ -30,7 +30,7 @@ import {Context, useRenderChartTooltip} from './renderChartTooltip';
 import {useRGBColorsForTheme} from '../../app/useRGBColorsForTheme';
 import {TooltipCard} from '../../insights/InsightsChartShared';
 import {formatDuration} from '../../ui/formatDuration';
-import {numberFormatter} from '../../ui/formatters';
+import {numberFormatter, numberFormatterWithMaxFractionDigits} from '../../ui/formatters';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
@@ -98,7 +98,7 @@ export const AssetCatalogTopAssetsChart = React.memo(
                   <Subheading>{d?.label}</Subheading>
                 </Box>
                 <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-                  <Mono>{numberFormatter.format(value)}</Mono>
+                  <Mono>{numberFormatterWithMaxFractionDigits(2).format(value)}</Mono>
                   <Body>{unit}</Body>
                 </Box>
               </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/__tests__/formatDuration.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/__tests__/formatDuration.test.ts
@@ -63,62 +63,91 @@ describe('formatDuration', () => {
   describe('obeys maxValueBeforeNextUnit', () => {
     it('should avoid showing 1000+ of any unit', () => {
       // 1000 seconds should become minutes
-      expect(formatDuration(1000000)).toEqual([{value: 16, unit: 'minutes'}]);
+      const result = formatDuration(1000000);
+      expect(result).toHaveLength(1);
+      expect(result[0].unit).toBe('minutes');
+      expect(result[0].value).toBeCloseTo(16.666666666666668, 10);
 
       // 1000 minutes should become hours
-      expect(formatDuration(60000000)).toEqual([{value: 16, unit: 'hours'}]);
+      const result2 = formatDuration(60000000);
+      expect(result2).toHaveLength(1);
+      expect(result2[0].unit).toBe('hours');
+      expect(result2[0].value).toBeCloseTo(16.666666666666668, 10);
 
       // 1000 hours should become days
-      expect(formatDuration(3600000000)).toEqual([{value: 5, unit: 'weeks'}]);
+      const result3 = formatDuration(3600000000);
+      expect(result3).toHaveLength(1);
+      expect(result3[0].unit).toBe('weeks');
+      expect(result3[0].value).toBeCloseTo(5.9523809523809526, 10);
     });
   });
 
   describe('single significant digit (default)', () => {
     it('should show only the largest unit', () => {
-      expect(formatDuration(1500)).toEqual([{value: 1, unit: 'second'}]);
-      expect(formatDuration(65000)).toEqual([{value: 1, unit: 'minute'}]);
-      expect(formatDuration(3665000)).toEqual([{value: 1, unit: 'hour'}]);
+      expect(formatDuration(1500)).toEqual([{value: 1.5, unit: 'seconds'}]);
+
+      const result = formatDuration(65000);
+      expect(result).toHaveLength(1);
+      expect(result[0].unit).toBe('minutes');
+      expect(result[0].value).toBeCloseTo(1.0833333333333333, 10);
+
+      const result2 = formatDuration(3665000);
+      expect(result2).toHaveLength(1);
+      expect(result2[0].unit).toBe('hours');
+      expect(result2[0].value).toBeCloseTo(1.0180555555555556, 10);
+
       expect(formatDuration(90000000)).toEqual([{value: 25, unit: 'hours'}]);
     });
 
     it('should round down to the nearest whole unit', () => {
-      expect(formatDuration(1999)).toEqual([{value: 1, unit: 'second'}]);
-      expect(formatDuration(119999)).toEqual([{value: 1, unit: 'minute'}]);
-      expect(formatDuration(7199999)).toEqual([{value: 1, unit: 'hour'}]);
+      const result = formatDuration(1999);
+      expect(result).toHaveLength(1);
+      expect(result[0].unit).toBe('seconds');
+      expect(result[0].value).toBeCloseTo(1.999, 10);
+
+      // Test structure and unit separately from the floating-point value
+      const result2 = formatDuration(119999);
+      expect(result2).toHaveLength(1);
+      expect(result2[0].unit).toBe('minutes');
+      expect(result2[0].value).toBeCloseTo(1.999983333333333, 10);
+
+      // Test floating-point hours value
+      const hoursResult = formatDuration(7199999);
+      expect(hoursResult).toHaveLength(1);
+      expect(hoursResult[0].unit).toBe('hours');
+      expect(hoursResult[0].value).toBeCloseTo(1.9999997222222223, 10);
     });
   });
 
   describe('two significant digits', () => {
     it('should show two units when remainder exists', () => {
-      expect(formatDuration(1500, {significantDigits: 2})).toEqual([
+      expect(formatDuration(1500, {significantUnits: 2})).toEqual([
         {value: 1, unit: 'second'},
         {value: 500, unit: 'milliseconds'},
       ]);
-      expect(formatDuration(65000, {significantDigits: 2})).toEqual([
+      expect(formatDuration(65000, {significantUnits: 2})).toEqual([
         {value: 1, unit: 'minute'},
         {value: 5, unit: 'seconds'},
       ]);
-      expect(formatDuration(3665000, {significantDigits: 2})).toEqual([
+      expect(formatDuration(3665000, {significantUnits: 2})).toEqual([
         {value: 1, unit: 'hour'},
         {value: 1, unit: 'minute'},
       ]);
-      expect(formatDuration(90000000, {significantDigits: 2})).toEqual([
-        {unit: 'hours', value: 25},
-      ]);
+      expect(formatDuration(90000000, {significantUnits: 2})).toEqual([{unit: 'hours', value: 25}]);
     });
 
     it('should show only one unit when no remainder', () => {
-      expect(formatDuration(1000, {significantDigits: 2})).toEqual([{value: 1, unit: 'second'}]);
-      expect(formatDuration(60000, {significantDigits: 2})).toEqual([{value: 1, unit: 'minute'}]);
-      expect(formatDuration(3600000, {significantDigits: 2})).toEqual([{value: 1, unit: 'hour'}]);
+      expect(formatDuration(1000, {significantUnits: 2})).toEqual([{value: 1, unit: 'second'}]);
+      expect(formatDuration(60000, {significantUnits: 2})).toEqual([{value: 1, unit: 'minute'}]);
+      expect(formatDuration(3600000, {significantUnits: 2})).toEqual([{value: 1, unit: 'hour'}]);
     });
 
     it('should handle complex durations', () => {
-      expect(formatDuration(3723000, {significantDigits: 2})).toEqual([
+      expect(formatDuration(3723000, {significantUnits: 2})).toEqual([
         {value: 1, unit: 'hour'},
         {value: 2, unit: 'minutes'},
       ]);
-      expect(formatDuration(93784000, {significantDigits: 2})).toEqual([
+      expect(formatDuration(93784000, {significantUnits: 2})).toEqual([
         {value: 26, unit: 'hours'},
         {value: 3, unit: 'minutes'},
       ]);
@@ -134,15 +163,15 @@ describe('formatDuration', () => {
     });
 
     it('should work with two significant digits', () => {
-      expect(formatDuration(1000, {unit: 'seconds', significantDigits: 2})).toEqual([
+      expect(formatDuration(1000, {unit: 'seconds', significantUnits: 2})).toEqual([
         {value: 16, unit: 'minutes'},
         {value: 40, unit: 'seconds'},
       ]);
-      expect(formatDuration(3665, {unit: 'seconds', significantDigits: 2})).toEqual([
+      expect(formatDuration(3665, {unit: 'seconds', significantUnits: 2})).toEqual([
         {value: 1, unit: 'hour'},
         {value: 1, unit: 'minute'},
       ]);
-      expect(formatDuration(90000, {unit: 'seconds', significantDigits: 2})).toEqual([
+      expect(formatDuration(90000, {unit: 'seconds', significantUnits: 2})).toEqual([
         {value: 25, unit: 'hours'},
       ]);
     });
@@ -155,12 +184,21 @@ describe('formatDuration', () => {
     });
 
     it('should handle very large values', () => {
-      expect(formatDuration(Number.MAX_SAFE_INTEGER)).toEqual([{value: 285616, unit: 'years'}]);
+      // Test floating-point years value
+      const largeResult = formatDuration(Number.MAX_SAFE_INTEGER);
+      expect(largeResult).toHaveLength(1);
+      expect(largeResult[0].unit).toBe('years');
+      expect(largeResult[0].value).toBeCloseTo(285616.41472415626, 10);
     });
 
     it('should handle fractional milliseconds by flooring', () => {
-      expect(formatDuration(1500.7)).toEqual([{value: 1, unit: 'second'}]);
-      expect(formatDuration(1500.7, {significantDigits: 2})).toEqual([
+      // Test floating-point seconds value
+      const fractionalResult = formatDuration(1500.7);
+      expect(fractionalResult).toHaveLength(1);
+      expect(fractionalResult[0].unit).toBe('seconds');
+      expect(fractionalResult[0].value).toBeCloseTo(1.5007000000000001, 10);
+
+      expect(formatDuration(1500.7, {significantUnits: 2})).toEqual([
         {value: 1, unit: 'second'},
         {value: 500, unit: 'milliseconds'},
       ]);
@@ -181,9 +219,13 @@ describe('formatDuration', () => {
       // API response time
       expect(formatDuration(247)).toEqual([{value: 247, unit: 'milliseconds'}]);
 
-      // Video duration
-      expect(formatDuration(215000)).toEqual([{value: 3, unit: 'minutes'}]);
-      expect(formatDuration(215000, {significantDigits: 2})).toEqual([
+      // Video duration - test floating-point minutes value
+      const videoResult = formatDuration(215000);
+      expect(videoResult).toHaveLength(1);
+      expect(videoResult[0].unit).toBe('minutes');
+      expect(videoResult[0].value).toBeCloseTo(3.5833333333333335, 10);
+
+      expect(formatDuration(215000, {significantUnits: 2})).toEqual([
         {value: 3, unit: 'minutes'},
         {value: 35, unit: 'seconds'},
       ]);
@@ -197,9 +239,13 @@ describe('formatDuration', () => {
       // Session timeout
       expect(formatDuration(1800, {unit: 'seconds'})).toEqual([{value: 30, unit: 'minutes'}]);
 
-      // Long-running job
-      expect(formatDuration(7532000)).toEqual([{value: 2, unit: 'hours'}]);
-      expect(formatDuration(7532000, {significantDigits: 2})).toEqual([
+      // Long-running job - test floating-point hours value
+      const jobResult = formatDuration(7532000);
+      expect(jobResult).toHaveLength(1);
+      expect(jobResult[0].unit).toBe('hours');
+      expect(jobResult[0].value).toBeCloseTo(2.0922222222222224, 10);
+
+      expect(formatDuration(7532000, {significantUnits: 2})).toEqual([
         {value: 2, unit: 'hours'},
         {value: 5, unit: 'minutes'},
       ]);

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/formatDuration.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/formatDuration.ts
@@ -45,13 +45,35 @@ const UNITS: Array<[number, UnitType, PluralUnitType]> = [
   [1, 'millisecond', 'milliseconds'],
 ];
 
+export const unitToShortLabel: Record<UnitType | PluralUnitType, string> = {
+  year: 'yr',
+  years: 'yr',
+  month: 'mo',
+  months: 'mo',
+  week: 'wk',
+  weeks: 'wk',
+  day: 'day',
+  days: 'day',
+  hour: 'hr',
+  hours: 'hr',
+  minute: 'min',
+  minutes: 'min',
+  second: 'sec',
+  seconds: 'sec',
+  millisecond: 'ms',
+  milliseconds: 'ms',
+};
+
 /**
  * Converts a duration in milliseconds or seconds to a human-readable format
  * @param duration - The duration in milliseconds (default) or seconds
  * @param options - Configuration options
  * @returns Human-readable duration string
  */
-export function formatDuration(duration: number, options: DurationOptions = {}): DurationPart[] {
+export function formatDuration(
+  duration: number,
+  options: DurationOptions = {},
+): [DurationPart] | [DurationPart, DurationPart] {
   const {
     maxValueBeforeNextUnit = defaultMaxValueBeforeNextUnit,
     significantDigits = 1,

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/formatDuration.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/formatDuration.ts
@@ -172,5 +172,5 @@ export function formatDuration(
     return [{value: 0, unit: 'milliseconds'}];
   }
 
-  return parts;
+  return parts as [DurationPart] | [DurationPart, DurationPart];
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/formatDuration.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/formatDuration.ts
@@ -64,6 +64,8 @@ export const unitToShortLabel: Record<UnitType | PluralUnitType, string> = {
   milliseconds: 'ms',
 };
 
+type NonEmptyArray<T> = [T, ...T[]];
+
 /**
  * Converts a duration in milliseconds or seconds to a human-readable format
  * @param duration - The duration in milliseconds (default) or seconds
@@ -73,7 +75,7 @@ export const unitToShortLabel: Record<UnitType | PluralUnitType, string> = {
 export function formatDuration(
   duration: number,
   options: DurationOptions = {},
-): [DurationPart] | [DurationPart, DurationPart] {
+): NonEmptyArray<DurationPart> {
   const {
     maxValueBeforeNextUnit = defaultMaxValueBeforeNextUnit,
     significantDigits = 1,
@@ -172,5 +174,5 @@ export function formatDuration(
     return [{value: 0, unit: 'milliseconds'}];
   }
 
-  return parts as [DurationPart] | [DurationPart, DurationPart];
+  return parts as NonEmptyArray<DurationPart>;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/formatters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/formatters.tsx
@@ -1,9 +1,17 @@
+import {weakMapMemoize} from '../util/weakMapMemoize';
+
 const compactFormatter = new Intl.NumberFormat(navigator.language, {
   compactDisplay: 'short',
   notation: 'compact',
 });
 
 export const numberFormatter = new Intl.NumberFormat(navigator.language, {});
+export const numberFormatterWithMaxFractionDigits = weakMapMemoize(
+  (fractionDigits: number) =>
+    new Intl.NumberFormat(navigator.language, {
+      maximumFractionDigits: fractionDigits,
+    }),
+);
 export const percentFormatter = new Intl.NumberFormat(navigator.language, {
   style: 'percent',
   minimumFractionDigits: 0,


### PR DESCRIPTION
## Summary & Motivation

We definitely need to make some tweaks here. I think for the rate cards we should probably be more precise?

## How I Tested These Changes

Before:
<img width="3456" height="7344" alt="screencapture-elementl-dagster-cloud-prod-insights-overview-2025-07-22-14_44_58" src="https://github.com/user-attachments/assets/cf2e289a-1ea6-4a0e-8bbd-890da1caae5f" />



After:
<img width="3456" height="7850" alt="screencapture-localhost-5002-elementl-prod-selection-all-assets-assets-2025-07-22-14_44_46" src="https://github.com/user-attachments/assets/3ef27709-30e7-452e-a15c-597262f119d7" />


