### PR TITLE
RFC top level export ComponentTree

### DIFF
--- a/docs/sphinx/sections/api/apidocs/dagster/components.rst
+++ b/docs/sphinx/sections/api/apidocs/dagster/components.rst
@@ -12,6 +12,9 @@ Using Components
 .. autoclass:: ComponentLoadContext
    :members:
 
+.. autoclass:: ComponentTree
+   :members:
+
 
 Building Components
 -------------------

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -668,6 +668,7 @@ from dagster.components.core.load_defs import (
     load_defs as load_defs,
     load_from_defs_folder as load_from_defs_folder,
 )
+from dagster.components.core.tree import ComponentTree as ComponentTree
 from dagster.components.definitions import definitions as definitions
 from dagster.components.lib.shim_components.resources import resources as resources
 from dagster.components.resolved.base import Resolvable as Resolvable

--- a/python_modules/dagster/dagster/components/core/tree.py
+++ b/python_modules/dagster/dagster/components/core/tree.py
@@ -82,9 +82,11 @@ class ComponentTreeException(Exception):
     checked=False,  # cant handle ModuleType
 )
 class ComponentTree:
-    """Manages and caches the component loading process, including finding component decls
-    to build the initial decl tree, loading these components, and eventually building the
-    defs.
+    """The hierarchy of Component instances defined in the project.
+
+    Manages and caches the component loading process, including finding component declarations
+    to build the initial declaration tree, loading these Components, and eventually building the
+    Definitions.
     """
 
     defs_module: ModuleType


### PR DESCRIPTION
I think we consider this public API surface and expect users to interact with it when they need to get access to component instances during loading from python. 

## How I Tested These Changes

eyes
