### PR TITLE
use asset materialization state for latest materialization timestamp if exists

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_freshness_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_freshness_health.py
@@ -6,6 +6,9 @@ from dagster_shared.serdes import whitelist_for_serdes
 
 import dagster._check as check
 from dagster._core.definitions.asset_health.asset_health import AssetHealthStatus
+from dagster._core.definitions.asset_health.asset_materialization_health import (
+    MinimalAssetMaterializationHealthState,
+)
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.freshness import FreshnessState, FreshnessStateRecord
 from dagster._core.loader import LoadableBy, LoadingContext
@@ -91,14 +94,22 @@ async def get_freshness_status_and_metadata(
             context,
         )
 
-    asset_record = await AssetRecord.gen(context, asset_key)
-    materialization_timestamp = (
-        asset_record.asset_entry.last_materialization.timestamp
-        if asset_record
-        and asset_record.asset_entry
-        and asset_record.asset_entry.last_materialization
-        else None
+    asset_materialization_health_state = await MinimalAssetMaterializationHealthState.gen(
+        context, asset_key
     )
+    if asset_materialization_health_state is None:
+        asset_record = await AssetRecord.gen(context, asset_key)
+        materialization_timestamp = (
+            asset_record.asset_entry.last_materialization.timestamp
+            if asset_record
+            and asset_record.asset_entry
+            and asset_record.asset_entry.last_materialization
+            else None
+        )
+    else:
+        materialization_timestamp = (
+            asset_materialization_health_state.latest_materialization_timestamp
+        )
 
     if asset_freshness_health_state.freshness_state == FreshnessState.PASS:
         return AssetHealthStatus.HEALTHY, AssetHealthFreshnessMetadata(


### PR DESCRIPTION
## Summary & Motivation

rather than fetch the asset record to get the latest materialization timestamp, we can get it from streamline now

Internal PR (for testing) <https://github.com/dagster-io/internal/pull/17085>