### PR TITLE
Change the test to test all dagster symbols

### DIFF
--- a/python_modules/automation/automation/docstring_lint/validator.py
+++ b/python_modules/automation/automation/docstring_lint/validator.py
@@ -401,6 +401,7 @@ class DocstringValidator:
             "py:attr",
             "py:mod",
             "py:data",
+            "py:obj",
             "func",
             "class",
             "meth",
@@ -425,6 +426,8 @@ class DocstringValidator:
             "versionadded",
             "versionchanged",
             "deprecated",
+            "seealso",
+            "attribute",
         ]
 
         # Check for "Unknown interpreted text role" messages

--- a/python_modules/automation/automation_tests/docstring_lint_tests/test_known_valid_symbols.py
+++ b/python_modules/automation/automation_tests/docstring_lint_tests/test_known_valid_symbols.py
@@ -76,10 +76,8 @@ class TestKnownValidSymbols:
 
         # All symbols should have valid docstrings
         assert result.is_valid(), (
-
             f"Symbol {symbol_path} should have valid docstring but got errors: {result.errors}. "
             f"If this is a known issue, add it to SYMBOL_EXCLUDE_LIST."
-
         )
 
         # Log warnings for awareness

--- a/python_modules/automation/automation_tests/docstring_lint_tests/test_known_valid_symbols.py
+++ b/python_modules/automation/automation_tests/docstring_lint_tests/test_known_valid_symbols.py
@@ -1,16 +1,42 @@
 """Tests for symbols that are known to have valid docstrings.
 
-This test suite validates all the Dagster symbols that were tested during the
-development of the docstring validation tool and confirmed to render correctly
-on https://docs.dagster.io/api/dagster.
+This test suite validates all public symbols from the dagster package to ensure
+they have valid docstrings that render correctly in the documentation build.
 
-These tests serve as regression tests to ensure the validator doesn't produce
-false positives for docstrings that are known to work correctly in the full
-Sphinx build environment.
+These tests serve as comprehensive regression tests to ensure the validator
+doesn't produce false positives for any public API symbols.
 """
+
+import importlib
 
 import pytest
 from automation.docstring_lint.validator import DocstringValidator
+
+# Symbols with known docstring formatting issues that should be skipped until fixed
+# These symbols have docstring validation errors that need to be addressed in separate PRs
+SYMBOL_EXCLUDE_LIST = {
+    # Docstring formatting issues (indentation, etc.)
+    "dagster.ConfigurableLegacyIOManagerAdapter",  # Unexpected indentation errors
+    "dagster.FunctionComponent",  # Unexpected indentation errors
+    "dagster.JsonLogFormatter",  # Unexpected indentation errors
+    "dagster.PendingNodeInvocation",  # Unexpected indentation errors
+    # Import/module resolution issues (deprecated or aliased symbols)
+    "dagster.check_dagster_type",  # Module resolution error
+    "dagster.config_from_files",  # Module resolution error
+    "dagster.config_from_pkg_resources",  # Module resolution error
+    "dagster.config_from_yaml_strings",  # Module resolution error
+    "dagster.config_mapping",  # Module resolution error
+    "dagster.configured",  # Module resolution error
+    "dagster.scaffold_with",  # Module resolution error
+    "dagster.sys",  # Import issue (conflicts with built-in sys)
+}
+
+
+def _get_all_dagster_public_symbols():
+    """Get all public symbols from the dagster package."""
+    dagster_module = importlib.import_module("dagster")
+    public_symbols = [name for name in dir(dagster_module) if not name.startswith("_")]
+    return [f"dagster.{name}" for name in sorted(public_symbols)]
 
 
 class TestKnownValidSymbols:
@@ -21,68 +47,42 @@ class TestKnownValidSymbols:
         """Provide a DocstringValidator instance for tests."""
         return DocstringValidator()
 
-    @pytest.mark.parametrize(
-        "symbol_path",
-        [
-            # Core decorators and functions
-            "dagster.asset",
-            "dagster.job",
-            "dagster.op",
-            "dagster.graph",
-            "dagster.resource",
-            "dagster.schedule",
-            "dagster.sensor",
-            "dagster.multi_asset",
-            # Core classes
-            "dagster.AssetKey",
-            "dagster.OpDefinition",
-            "dagster.JobDefinition",
-            "dagster.GraphDefinition",
-            "dagster.ResourceDefinition",
-            "dagster.DagsterInstance",
-            "dagster.AssetMaterialization",
-            "dagster.AssetObservation",
-            "dagster.Output",
-            "dagster.In",
-            "dagster.Out",
-            "dagster.Config",
-            "dagster.Field",
-            "dagster.RetryPolicy",
-            "dagster.RunRequest",
-            "dagster.SkipReason",
-            "dagster.Failure",
-            "dagster.HookContext",
-            # Context builders
-            "dagster.build_hook_context",
-            "dagster.build_op_context",
-        ],
-    )
-    def test_known_valid_symbol_docstrings(self, validator, symbol_path):
-        """Test that known valid symbols pass docstring validation.
+    @pytest.mark.parametrize("symbol_path", _get_all_dagster_public_symbols())
+    def test_all_public_symbol_docstrings(self, validator, symbol_path):
+        """Test that all public dagster symbols have valid docstrings.
 
-        These symbols have been manually verified to:
-        1. Render correctly on https://docs.dagster.io/api/dagster
-        2. Build successfully in the full Sphinx documentation build
-        3. Have properly formatted Google-style docstrings
+        This test validates every public symbol in the dagster package to ensure:
+        1. The symbol can be imported successfully
+        2. The docstring has valid RST/Google-style formatting (unless in skip list)
+        3. No syntax errors that would break documentation builds
+
+        Symbols with known docstring issues are maintained in SYMBOLS_WITH_KNOWN_DOCSTRING_ISSUES
+        and should be addressed in separate PRs.
 
         Args:
             validator: DocstringValidator instance
             symbol_path: Dotted path to the symbol to test
         """
+        # Skip validation for symbols with known issues - check before validation
+        # to avoid import errors for symbols that are known to be problematic
+        if symbol_path in SYMBOL_EXCLUDE_LIST:
+            print(f"Skipping known problematic symbol: {symbol_path}")  # noqa: T201
+            return
+
         result = validator.validate_symbol_docstring(symbol_path)
 
-        # The symbol should be importable
+        # The symbol should be importable - this is the core requirement
         assert result.parsing_successful, f"Failed to parse {symbol_path}: {result.errors}"
 
-        # The symbol should have valid docstring syntax (no errors)
+        # All symbols should have valid docstrings
         assert result.is_valid(), (
-            f"Symbol {symbol_path} should have valid docstring but got errors: {result.errors}"
+            f"Symbol {symbol_path} should have valid docstring but got errors: {result.errors}. "
+            f"If this is a known issue, add it to SYMBOLS_WITH_KNOWN_DOCSTRING_ISSUES."
         )
 
-        # We allow warnings (e.g., for missing docstrings on some symbols)
-        # but errors indicate real parsing issues that would break the docs build
+        # Log warnings for awareness
         if result.has_warnings():
-            print(f"Warnings for {symbol_path}: {result.warnings}")  # noqa: T201
+            print(f"Docstring warnings for {symbol_path}: {result.warnings}")  # noqa: T201
 
     def test_nonexistent_symbol_produces_error(self, validator):
         """Test that attempting to validate a non-existent symbol produces an error."""

--- a/python_modules/automation/automation_tests/docstring_lint_tests/test_known_valid_symbols.py
+++ b/python_modules/automation/automation_tests/docstring_lint_tests/test_known_valid_symbols.py
@@ -56,7 +56,7 @@ class TestKnownValidSymbols:
         2. The docstring has valid RST/Google-style formatting (unless in skip list)
         3. No syntax errors that would break documentation builds
 
-        Symbols with known docstring issues are maintained in SYMBOLS_WITH_KNOWN_DOCSTRING_ISSUES
+        Symbols with known docstring issues are maintained in SYMBOL_EXCLUDE_LIST
         and should be addressed in separate PRs.
 
         Args:

--- a/python_modules/automation/automation_tests/docstring_lint_tests/test_known_valid_symbols.py
+++ b/python_modules/automation/automation_tests/docstring_lint_tests/test_known_valid_symbols.py
@@ -76,8 +76,10 @@ class TestKnownValidSymbols:
 
         # All symbols should have valid docstrings
         assert result.is_valid(), (
+
             f"Symbol {symbol_path} should have valid docstring but got errors: {result.errors}. "
-            f"If this is a known issue, add it to SYMBOLS_WITH_KNOWN_DOCSTRING_ISSUES."
+            f"If this is a known issue, add it to SYMBOL_EXCLUDE_LIST."
+
         )
 
         # Log warnings for awareness


### PR DESCRIPTION
## Summary & Motivation

This PR enhances the docstring validator to support additional Sphinx roles and directives, and improves the docstring testing framework to validate all public Dagster symbols.

The PR also completely revamps the docstring testing approach by:
- Automatically discovering and testing all public symbols from the Dagster package
- Creating an exclusion list for symbols with known docstring issues
- Providing more detailed error messages to help identify problematic docstrings

We will need to restructure these tests later to test *all* our integration libraries. I just want to get core functionality working.

## How I Tested These Changes

I ran the updated docstring validation tests against all public Dagster symbols and verified that:
1. The validator correctly identifies valid docstrings
2. Symbols with known issues are properly excluded
3. The new Sphinx roles and directives are properly recognized