### PR TITLE
Add comprehensive method docstring tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,3 +95,7 @@ yarn build-api-docs          # Build API docs after .rst changes
 
 - Code must be compatible with Python version 3.9 and later
 - For CLI output, use `click.echo()` instead of `print()` - this ensures proper output handling in CLI contexts and testing
+
+## Import Guidelines
+
+- Use top-level imports unless you need conditional imports or have performance concerns requiring lazy loading

--- a/python_modules/automation/automation/docs_cli/commands/check.py
+++ b/python_modules/automation/automation/docs_cli/commands/check.py
@@ -49,8 +49,7 @@ def _validate_package_symbols(validator: DocstringValidator, package: str) -> in
     Returns:
         0 if validation succeeded, 1 if there were errors
     """
-    importer = SymbolImporter()
-    symbols = importer.get_all_public_symbols(package)
+    symbols = SymbolImporter.get_all_public_symbols(package)
     click.echo(f"Validating {len(symbols)} public symbols in {package}\n")
 
     total_errors = 0

--- a/python_modules/automation/automation/docs_cli/commands/ls.py
+++ b/python_modules/automation/automation/docs_cli/commands/ls.py
@@ -16,8 +16,7 @@ def _list_package_symbols(package: str) -> None:
     Raises:
         ImportError: If the package cannot be imported
     """
-    importer = SymbolImporter()
-    symbols = importer.get_all_public_symbols(package)
+    symbols = SymbolImporter.get_all_public_symbols(package)
 
     for symbol_info in symbols:
         click.echo(symbol_info.dotted_path)

--- a/python_modules/automation/automation/docs_cli/commands/watch.py
+++ b/python_modules/automation/automation/docs_cli/commands/watch.py
@@ -22,8 +22,7 @@ def _resolve_symbol_file_path(symbol_path: str, verbose: bool) -> Path:
     Raises:
         Exception: If symbol cannot be resolved or file doesn't exist
     """
-    importer = SymbolImporter()
-    symbol_info = importer.import_symbol(symbol_path)
+    symbol_info = SymbolImporter.import_symbol(symbol_path)
 
     if not symbol_info.file_path:
         raise Exception(f"Cannot determine source file for symbol '{symbol_path}'")

--- a/python_modules/automation/automation/docstring_lint/changed_validator.py
+++ b/python_modules/automation/automation/docstring_lint/changed_validator.py
@@ -36,7 +36,7 @@ class ValidationConfig(IHaveNew):
 
 @record
 class SymbolInfo:
-    """Information about a symbol with a docstring."""
+    """Information about a top-level exported symbol with a docstring."""
 
     symbol_path: str
     file_path: Path
@@ -45,7 +45,7 @@ class SymbolInfo:
 
 @record
 class ValidationResult:
-    """Result of validating a single symbol's docstring."""
+    """Result of validating a single exported symbol's docstring."""
 
     symbol_info: SymbolInfo
     errors: list[str]
@@ -61,7 +61,7 @@ class ValidationResult:
 
 
 def extract_symbols_from_file(file_path: Path, module_path: str) -> set[SymbolInfo]:
-    """Extract symbols with docstrings from a file using dynamic import."""
+    """Extract top-level exported symbols with docstrings from a file using dynamic import."""
     try:
         # Create a unique module name to avoid conflicts
         module_name = f"temp_module_{hash(str(file_path))}"
@@ -76,7 +76,7 @@ def extract_symbols_from_file(file_path: Path, module_path: str) -> set[SymbolIn
 
         symbols = set()
 
-        # Extract symbols using introspection
+        # Extract top-level exported symbols using introspection
         for name, obj in inspect.getmembers(module):
             if name.startswith("_"):
                 continue
@@ -139,7 +139,7 @@ def extract_symbols_from_file(file_path: Path, module_path: str) -> set[SymbolIn
 def validate_symbols(
     symbols: set[SymbolInfo], validator: DocstringValidator
 ) -> list[ValidationResult]:
-    """Validate docstrings for a set of symbols."""
+    """Validate docstrings for a set of top-level exported symbols."""
     results = []
 
     for symbol_info in symbols:
@@ -174,7 +174,7 @@ def validate_changed_files(
 
     all_symbols = set()
 
-    # Extract symbols from all changed files
+    # Extract top-level exported symbols from all changed files
     for file_path in changed_files:
         if not config.file_filter(file_path):
             continue
@@ -186,7 +186,7 @@ def validate_changed_files(
         symbols = extract_symbols_from_file(file_path, module_path)
         all_symbols.update(symbols)
 
-    # Validate all symbols
+    # Validate all exported symbols
     return validate_symbols(all_symbols, validator)
 
 

--- a/python_modules/automation/automation/docstring_lint/public_symbol_utils.py
+++ b/python_modules/automation/automation/docstring_lint/public_symbol_utils.py
@@ -1,0 +1,68 @@
+"""Utilities for working with @public-annotated symbols in the Dagster codebase."""
+
+import inspect
+from typing import Any, Optional
+
+from dagster._annotations import is_public
+
+
+def is_valid_public_method(method: Any) -> tuple[bool, Optional[Any]]:
+    """Check if a method is valid and @public-annotated.
+
+    This function handles the different types of methods (properties, static methods,
+    class methods, and regular methods) and determines if they have the @public
+    annotation from dagster._annotations.
+
+    Args:
+        method: The method object to check
+
+    Returns:
+        A tuple of (is_valid_and_public, target_for_public_check) where:
+        - is_valid_and_public: True if the method is valid and has @public annotation
+        - target_for_public_check: The object that was checked for @public annotation
+    """
+    is_valid_method = False
+    target_for_public_check = method
+
+    if isinstance(method, property):
+        # For properties, check the @public decorator on the getter function
+        is_valid_method = True
+        target_for_public_check = method.fget
+    elif isinstance(method, (staticmethod, classmethod)):
+        # For static/class methods, check the decorator on the underlying function
+        is_valid_method = True
+        target_for_public_check = method
+    elif callable(method) and (inspect.ismethod(method) or inspect.isfunction(method)):
+        # For regular instance methods and functions
+        is_valid_method = True
+        target_for_public_check = method
+
+    # Only return True if the method is valid and has @public annotation
+    if is_valid_method and is_public(target_for_public_check):
+        return True, target_for_public_check
+
+    return False, target_for_public_check
+
+
+def get_public_methods_from_class(cls: Any, class_dotted_path: str) -> list[str]:
+    """Get all @public-annotated methods from a class.
+
+    Args:
+        cls: The class object to inspect
+        class_dotted_path: The dotted path to the class (e.g., 'dagster.AssetExecutionContext')
+
+    Returns:
+        List of dotted paths to @public methods (e.g., ['dagster.AssetExecutionContext.log'])
+    """
+    methods = []
+
+    for method_name in dir(cls):
+        if not method_name.startswith("_"):
+            method = getattr(cls, method_name)
+            is_valid_and_public, _ = is_valid_public_method(method)
+
+            if is_valid_and_public:
+                full_path = f"{class_dotted_path}.{method_name}"
+                methods.append(full_path)
+
+    return methods

--- a/python_modules/automation/automation/docstring_lint/validator.py
+++ b/python_modules/automation/automation/docstring_lint/validator.py
@@ -1,8 +1,10 @@
 """Core docstring validation logic using Sphinx parsing pipeline."""
 
+# Import the is_public function to check for @public decorator
 import importlib
 import inspect
 import io
+import re
 import sys
 import warnings
 from pathlib import Path
@@ -10,9 +12,12 @@ from typing import Any, Optional
 
 import docutils.core
 import docutils.utils
+from dagster._annotations import is_public
 from dagster_shared.record import record
 from sphinx.ext.napoleon import GoogleDocstring
 from sphinx.util.docutils import docutils_namespace
+
+from automation.docstring_lint.public_symbol_utils import get_public_methods_from_class
 
 # Filter out Sphinx role errors and warnings that are valid in the full Sphinx build context
 # but appear as errors in standalone docutils validation. These roles like :py:class:,
@@ -20,6 +25,67 @@ from sphinx.util.docutils import docutils_namespace
 # Sphinx extensions loaded, but docutils alone doesn't recognize them.
 # Set to False to see all role-related errors/warnings for debugging.
 DO_FILTER_OUT_SPHINX_ROLE_WARNINGS = True
+
+# Regex pattern for potential section headers: uppercase letter followed by letters/spaces, ending with colon
+# Examples: "Args:", "Example usage:", "See Also:" but not "http://", "def function():", etc.
+SECTION_HEADER_PATTERN = re.compile(r"^[A-Z][A-Za-z\s]{2,30}:$")
+
+# All section headers currently used in the Dagster codebase
+# Based on analysis of all public symbols
+ALLOWED_SECTION_HEADERS = {
+    # Standard Google-style sections
+    "Args:",
+    "Arguments:",
+    "Parameters:",
+    "Returns:",
+    "Return:",
+    "Yields:",
+    "Yield:",
+    "Raises:",
+    "Examples:",
+    "Example:",
+    "Note:",
+    "Notes:",
+    "Warning:",
+    "Warnings:",
+    "See Also:",
+    "Attributes:",
+    # Dagster-specific sections that are commonly used
+    "Example usage:",
+    "Example definition:",
+    "Definitions:",
+    # Common example section variations
+    "For example:",
+    "For example::",  # RST code block style
+    "Example enumeration:",
+}
+
+
+def extract_section_headers_from_docstring(docstring: str) -> list[str]:
+    """Extract all potential section headers from a docstring.
+
+    Uses the same regex pattern as the main validation logic to identify
+    lines that could be section headers.
+
+    Args:
+        docstring: The docstring text to analyze
+
+    Returns:
+        List of potential section header strings found in the docstring
+    """
+    if not docstring:
+        return []
+
+    headers = []
+    lines = docstring.split("\n")
+
+    for line in lines:
+        stripped = line.strip()
+        if SECTION_HEADER_PATTERN.match(stripped):
+            headers.append(stripped)
+
+    return headers
+
 
 # Setup paths to match Dagster's Sphinx configuration
 DAGSTER_ROOT = Path(__file__).parent.parent.parent.parent.parent
@@ -126,18 +192,19 @@ class SymbolInfo:
                             line_number = inspect.getsourcelines(symbol)[1]
                         except (OSError, TypeError):
                             pass
-                    else:
-                        # Fall back to inspect methods
-                        file_path = inspect.getfile(symbol)
-                        line_number = inspect.getsourcelines(symbol)[1]
-                else:
-                    # Fall back to inspect methods
-                    file_path = inspect.getfile(symbol)
-                    line_number = inspect.getsourcelines(symbol)[1]
-            else:
-                # No module info, fall back to inspect methods
-                file_path = inspect.getfile(symbol)
-                line_number = inspect.getsourcelines(symbol)[1]
+                        return SymbolInfo(
+                            symbol=symbol,
+                            dotted_path=dotted_path,
+                            name=name,
+                            module=module,
+                            docstring=docstring,
+                            file_path=file_path,
+                            line_number=line_number,
+                        )
+
+            # Single fallback: use inspect methods directly
+            file_path = inspect.getfile(symbol)
+            line_number = inspect.getsourcelines(symbol)[1]
         except (OSError, TypeError, ImportError):
             pass
 
@@ -528,30 +595,45 @@ class DocstringValidator:
         """Check basic docstring structure issues."""
         lines = docstring.split("\n")
 
-        # Check for common section headers
-        sections = [
-            "Args:",
-            "Arguments:",
-            "Parameters:",
-            "Returns:",
-            "Return:",
-            "Yields:",
-            "Yield:",
-            "Raises:",
-            "Examples:",
-            "Example:",
-        ]
-
         for i, line in enumerate(lines, 1):
             stripped = line.strip()
 
-            # Check for malformed section headers
-            for section in sections:
-                if section.lower() in stripped.lower() and section not in stripped:
-                    result = result.with_warning(
-                        f"Possible malformed section header: '{stripped}' (should be '{section}')",
+            # Use regex to identify potential section headers
+            if SECTION_HEADER_PATTERN.match(stripped):
+                # Skip if it's already in our allowed list
+                if stripped in ALLOWED_SECTION_HEADERS:
+                    continue
+
+                # Check for case-insensitive exact matches (wrong case)
+                exact_case_match = None
+                for section in ALLOWED_SECTION_HEADERS:
+                    if stripped.lower() == section.lower():
+                        exact_case_match = section
+                        break
+
+                if exact_case_match:
+                    result = result.with_error(
+                        f"Invalid section header: '{stripped}'. Did you mean '{exact_case_match}'?",
                         i,
                     )
+                else:
+                    # Check for obvious corruptions of known sections using simple string containment
+                    possible_match = None
+                    for section in ALLOWED_SECTION_HEADERS:
+                        section_base = section[:-1].lower()  # Remove colon, lowercase
+                        stripped_base = stripped[:-1].lower()  # Remove colon, lowercase
+
+                        # Check if the section name appears intact within the stripped version
+                        # This catches cases like "Argsdkjfkdjkfjd" containing "args"
+                        if len(section_base) >= 4 and section_base in stripped_base:
+                            possible_match = section
+                            break
+
+                    if possible_match:
+                        result = result.with_error(
+                            f"Invalid section header: '{stripped}'. Did you mean '{possible_match}'?",
+                            i,
+                        )
 
         return result
 
@@ -580,47 +662,101 @@ class SymbolImporter:
             module_path = ".".join(parts[:i])
             try:
                 module = importlib.import_module(module_path)
-
-                # If we imported the entire path as a module, return the module itself
-                if i == len(parts):
-                    return SymbolInfo.create(module, dotted_path)
-
-                # Otherwise, walk the remaining attribute path
-                symbol = module
-                for attr_name in parts[i:]:
-                    symbol = getattr(symbol, attr_name)
-
-                return SymbolInfo.create(symbol, dotted_path)
-
             except ImportError:
+                # This module path doesn't exist, try the next shorter one
                 continue
+
+            # If we imported the entire path as a module, return the module itself
+            if i == len(parts):
+                return SymbolInfo.create(module, dotted_path)
+
+            # Otherwise, walk the remaining attribute path
+            symbol = module
+            for attr_name in parts[i:]:
+                symbol = getattr(symbol, attr_name)
+
+            return SymbolInfo.create(symbol, dotted_path)
 
         raise ImportError(f"Could not import symbol '{dotted_path}'")
 
     @staticmethod
-    def get_all_public_symbols(module_path: str) -> list[SymbolInfo]:
-        """Get all public symbols from a module (those not starting with '_').
+    def get_all_exported_symbols(module_path: str) -> list[SymbolInfo]:
+        """Get all top-level exported symbols from a module (those not starting with '_').
 
         Args:
             module_path: The dotted path to the module
 
         Returns:
-            List of SymbolInfo objects for all public symbols
+            List of SymbolInfo objects for all top-level exported symbols
         """
-        try:
-            module = importlib.import_module(module_path)
-        except ImportError as e:
-            raise ImportError(f"Could not import module '{module_path}': {e}")
+        module = importlib.import_module(module_path)
 
         symbols = []
         for name in dir(module):
             if not name.startswith("_"):
-                try:
-                    symbol = getattr(module, name)
-                    full_path = f"{module_path}.{name}"
-                    symbols.append(SymbolInfo.create(symbol, full_path))
-                except Exception:
-                    # Skip symbols that can't be accessed
-                    continue
+                symbol = getattr(module, name)
+                full_path = f"{module_path}.{name}"
+                symbols.append(SymbolInfo.create(symbol, full_path))
 
         return symbols
+
+    @staticmethod
+    def get_all_public_annotated_methods(module_path: str) -> list[SymbolInfo]:
+        """Get all @public-annotated methods from top-level exported classes.
+
+        Args:
+            module_path: The dotted path to the module
+
+        Returns:
+            List of SymbolInfo objects for all @public-annotated methods on top-level exported classes
+        """
+        module = importlib.import_module(module_path)
+
+        methods = []
+        for name in dir(module):
+            if not name.startswith("_"):
+                symbol = getattr(module, name)
+                # Check if this symbol is a top-level exported class with @public annotation
+                if inspect.isclass(symbol) and is_public(symbol):
+                    # Get all @public-annotated methods from this top-level exported class
+                    class_dotted_path = f"{module_path}.{name}"
+                    method_paths = get_public_methods_from_class(symbol, class_dotted_path)
+
+                    for method_path in method_paths:
+                        # Extract method name and get the actual method object
+                        method_name = method_path.split(".")[-1]
+                        method = getattr(symbol, method_name)
+                        method_info = SymbolInfo.create(method, method_path)
+                        methods.append(method_info)
+
+        return methods
+
+    @staticmethod
+    def get_all_public_symbols(module_path: str) -> list[SymbolInfo]:
+        """Get all public symbols from a module (exported symbols marked @public + public-annotated methods).
+
+        Args:
+            module_path: The dotted path to the module
+
+        Returns:
+            List of SymbolInfo objects for all public symbols in the module.
+            Includes only top-level exported symbols that are marked with @public decorator
+            and all @public-annotated methods from @public classes.
+
+        Raises:
+            ImportError: If the module cannot be imported
+        """
+        public_symbols = []
+
+        # Get top-level exported symbols that are also marked with @public
+        exported_symbols = SymbolImporter.get_all_exported_symbols(module_path)
+        # Filter to only include symbols that are marked as @public
+        for symbol_info in exported_symbols:
+            if is_public(symbol_info.symbol):
+                public_symbols.append(symbol_info)
+
+        # Get all @public-annotated methods from @public classes
+        method_symbols = SymbolImporter.get_all_public_annotated_methods(module_path)
+        public_symbols.extend(method_symbols)
+
+        return public_symbols

--- a/python_modules/automation/automation_tests/docs_cli_tests/test_ls_commands.py
+++ b/python_modules/automation/automation_tests/docs_cli_tests/test_ls_commands.py
@@ -18,11 +18,11 @@ class TestLsCommands:
         # Should complete successfully
         assert result.exit_code == 0
 
-        # Should contain some well-known dagster symbols
+        # Should contain some @public-decorated dagster symbols
         output = result.output
-        assert "dagster.asset" in output
-        assert "dagster.op" in output
-        assert "dagster.job" in output
+        assert "dagster.Component" in output
+        assert "dagster.ComponentLoadContext" in output
+        assert "dagster.definitions" in output
 
     def test_ls_symbols_with_package_dagster_core(self):
         """Test listing symbols from dagster._core subpackage."""
@@ -31,8 +31,9 @@ class TestLsCommands:
         # Should complete successfully
         assert result.exit_code == 0
 
-        # Should contain some symbols (exact content may vary)
-        assert len(result.output.strip()) > 0
+        # This subpackage may have no @public symbols, which is valid
+        # The test passes as long as the command doesn't error
+        assert result.exit_code == 0
 
     def test_ls_symbols_with_nonexistent_package(self):
         """Test listing symbols from nonexistent package should fail."""

--- a/python_modules/automation/automation_tests/docstring_lint_tests/test_discover_section_headers.py
+++ b/python_modules/automation/automation_tests/docstring_lint_tests/test_discover_section_headers.py
@@ -1,0 +1,110 @@
+"""Discover all section headers currently used in the Dagster codebase.
+
+This test scans all public symbols to find section headers (lines ending with ':')
+and reports which ones are not in our current whitelist.
+"""
+
+# Get the actual docstring
+from collections import Counter
+
+from automation.docstring_lint.validator import (
+    ALLOWED_SECTION_HEADERS,
+    SymbolImporter,
+    extract_section_headers_from_docstring,
+)
+
+from automation_tests.docstring_lint_tests.test_known_valid_symbols import (
+    _get_all_dagster_public_symbols,
+)
+
+
+def test_discover_section_headers():
+    """Discover all section headers used in public Dagster docstrings."""
+    # Use the shared whitelist from the main validation code
+    whitelisted_sections = ALLOWED_SECTION_HEADERS
+
+    # Collect all section headers from the codebase
+    section_headers = Counter()
+    symbols_with_headers = {}  # Track which symbols use which headers
+
+    symbols = _get_all_dagster_public_symbols()
+    print(f"Scanning {len(symbols)} public symbols for section headers...")  # noqa: T201
+
+    for symbol_path in symbols:
+        try:
+            symbol_info = SymbolImporter.import_symbol(symbol_path)
+            docstring = symbol_info.docstring
+
+            if not docstring:
+                continue
+
+            # Use the shared utility function to extract section headers
+            headers = extract_section_headers_from_docstring(docstring)
+
+            # Count each header found and track locations for reporting
+            lines = docstring.split("\n")
+            for header in headers:
+                section_headers[header] += 1
+
+                # Find the line number for this header
+                for line_num, line in enumerate(lines, 1):
+                    if line.strip() == header:
+                        if header not in symbols_with_headers:
+                            symbols_with_headers[header] = []
+                        symbols_with_headers[header].append(f"{symbol_path}:{line_num}")
+                        break
+        except Exception:
+            # Skip symbols that can't be imported or analyzed
+            continue
+
+    # Print results
+    print(f"\nFound {len(section_headers)} unique section headers:")  # noqa: T201
+    print("=" * 60)  # noqa: T201
+
+    # Sort by frequency (most common first)
+    for header, count in section_headers.most_common():
+        status = "✓" if header in whitelisted_sections else "✗"
+        print(f"{status} {header:<20} ({count:>3} uses)")  # noqa: T201
+
+        # Show a few examples for non-whitelisted headers
+        if header not in whitelisted_sections and count <= 5:
+            examples = symbols_with_headers[header][:3]  # Show up to 3 examples
+            for example in examples:
+                print(f"    {example}")  # noqa: T201
+            if len(symbols_with_headers[header]) > 3:
+                print(f"    ... and {len(symbols_with_headers[header]) - 3} more")  # noqa: T201
+
+    # Summary
+    whitelisted_count = sum(
+        count for header, count in section_headers.items() if header in whitelisted_sections
+    )
+    non_whitelisted_count = sum(
+        count for header, count in section_headers.items() if header not in whitelisted_sections
+    )
+
+    print("\nSummary:")  # noqa: T201
+    print(  # noqa: T201
+        f"  Whitelisted headers: {len([h for h in section_headers if h in whitelisted_sections])} types, {whitelisted_count} total uses"
+    )
+    print(  # noqa: T201
+        f"  Non-whitelisted headers: {len([h for h in section_headers if h not in whitelisted_sections])} types, {non_whitelisted_count} total uses"
+    )
+
+    # Suggest additions to whitelist
+    common_non_whitelisted = [
+        header
+        for header, count in section_headers.most_common()
+        if header not in whitelisted_sections and count >= 3
+    ]
+
+    if common_non_whitelisted:
+        print("\nSuggested additions to whitelist (used 3+ times):")  # noqa: T201
+        for header in common_non_whitelisted:
+            print(f'    "{header}",')  # noqa: T201
+
+    # This test always passes, it's just for discovery
+    assert True
+
+
+if __name__ == "__main__":
+    test_discover_section_headers()

--- a/python_modules/automation/automation_tests/docstring_lint_tests/test_fixtures/__init__.py
+++ b/python_modules/automation/automation_tests/docstring_lint_tests/test_fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Test fixtures for docstring validation tests."""

--- a/python_modules/automation/automation_tests/docstring_lint_tests/test_fixtures/test_public_class.py
+++ b/python_modules/automation/automation_tests/docstring_lint_tests/test_fixtures/test_public_class.py
@@ -1,0 +1,81 @@
+"""Test fixtures for @public method validation.
+
+This module contains test classes with various combinations of public and non-public methods
+to verify that the docstring validator correctly identifies only @public methods on @public classes.
+"""
+
+from dagster._annotations import public
+
+
+@public
+class PublicClass:
+    """A public class with mixed public and non-public methods."""
+
+    @public
+    def public_instance_method(self):
+        """This is a public instance method that should be validated."""
+        return "public_instance"
+
+    def non_public_instance_method(self):
+        """This is a non-public instance method that should NOT be validated."""
+        return "non_public_instance"
+
+    @staticmethod
+    @public
+    def public_static_method():
+        """This is a public static method that should be validated."""
+        return "public_static"
+
+    @staticmethod
+    def non_public_static_method():
+        """This is a non-public static method that should NOT be validated."""
+        return "non_public_static"
+
+    @classmethod
+    @public
+    def public_class_method(cls):
+        """This is a public class method that should be validated."""
+        return "public_class"
+
+    @classmethod
+    def non_public_class_method(cls):
+        """This is a non-public class method that should NOT be validated."""
+        return "non_public_class"
+
+    @property
+    @public
+    def public_property(self):
+        """This is a public property that should be validated."""
+        return "public_property"
+
+    @property
+    def non_public_property(self):
+        """This is a non-public property that should NOT be validated."""
+        return "non_public_property"
+
+
+class NonPublicClass:
+    """A non-public class - none of its methods should be validated even if marked @public."""
+
+    @public
+    def public_method_on_non_public_class(self):
+        """This should NOT be validated because the class is not @public."""
+        return "should_not_validate"
+
+    def regular_method_on_non_public_class(self):
+        """This should NOT be validated."""
+        return "should_not_validate"
+
+
+@public
+class AnotherPublicClass:
+    """Another public class to test multiple classes."""
+
+    @public
+    def another_public_method(self):
+        """Another public method that should be validated."""
+        return "another_public"
+
+    def another_non_public_method(self):
+        """Another non-public method that should NOT be validated."""
+        return "another_non_public"

--- a/python_modules/automation/automation_tests/docstring_lint_tests/test_method_docstrings.py
+++ b/python_modules/automation/automation_tests/docstring_lint_tests/test_method_docstrings.py
@@ -1,0 +1,355 @@
+"""Tests for method docstring validation focusing on parameter handling."""
+
+import pytest
+from automation.docstring_lint.validator import DocstringValidator
+from dagster._annotations import public
+
+
+class TestMethodDocstringValidation:
+    """Test that method docstrings are validated correctly and self/cls parameters are handled properly."""
+
+    @pytest.fixture
+    def validator(self):
+        """Provide a DocstringValidator instance for tests."""
+        return DocstringValidator()
+
+    def test_instance_method_docstring_validation(self, validator):
+        """Test that instance method docstrings are validated correctly."""
+
+        @public
+        class TestClass:
+            @public
+            def process_data(self, data, options=None):
+                """Process the provided data with optional configuration.
+
+                Args:
+                    data: The data to process
+                    options: Optional processing configuration
+
+                Returns:
+                    Processed data result
+                """
+                pass
+
+            @public
+            def bad_method_with_self(self, data):
+                """Process data (incorrect style documenting self).
+
+                Args:
+                    self: The instance (should not be documented)
+                    data: Data to process
+
+                Returns:
+                    Processed data result
+                """
+                pass
+
+        # Test valid instance method docstring (doesn't document 'self')
+        result = validator.validate_docstring_text(
+            TestClass.process_data.__doc__, "TestClass.process_data"
+        )
+        assert result.is_valid(), f"Instance method should have valid docstring: {result.errors}"
+        assert result.parsing_successful
+
+        # Test that documenting 'self' is handled gracefully (not flagged as RST error)
+        result_with_self = validator.validate_docstring_text(
+            TestClass.bad_method_with_self.__doc__, "TestClass.bad_method_with_self"
+        )
+        # Should parse successfully even though it's bad style
+        assert result_with_self.parsing_successful
+
+    def test_static_method_docstring_validation(self, validator):
+        """Test that static method docstrings are validated correctly."""
+
+        @public
+        class TestClass:
+            @public
+            @staticmethod
+            def validate_email(email, strict=False):
+                """Validate email address format using regex.
+
+                Args:
+                    email: Email address to validate
+                    strict: Whether to use strict validation
+
+                Returns:
+                    True if valid, False otherwise
+                """
+                pass
+
+        result = validator.validate_docstring_text(
+            TestClass.validate_email.__doc__, "TestClass.validate_email"
+        )
+        assert result.is_valid(), f"Static method should have valid docstring: {result.errors}"
+        assert result.parsing_successful
+
+    def test_class_method_docstring_validation(self, validator):
+        """Test that class method docstrings are validated correctly."""
+
+        @public
+        class TestClass:
+            @public
+            @classmethod
+            def from_config(cls, config_file, validate=True):
+                """Create instance from configuration file.
+
+                Args:
+                    config_file: Path to configuration file
+                    validate: Whether to validate configuration
+
+                Returns:
+                    New instance of the class
+                """
+                pass
+
+            @public
+            @classmethod
+            def bad_method_with_cls(cls, config):
+                """Create instance with cls documented (incorrect style).
+
+                Args:
+                    cls: The class (should not be documented)
+                    config: Configuration data
+
+                Returns:
+                    New instance
+                """
+                pass
+
+        # Valid class method docstring (doesn't document 'cls')
+        result = validator.validate_docstring_text(
+            TestClass.from_config.__doc__, "TestClass.from_config"
+        )
+        assert result.is_valid(), f"Class method should have valid docstring: {result.errors}"
+        assert result.parsing_successful
+
+        # Test that documenting 'cls' is handled gracefully
+        result_with_cls = validator.validate_docstring_text(
+            TestClass.bad_method_with_cls.__doc__, "TestClass.bad_method_with_cls"
+        )
+        # Should parse successfully even though it's bad style
+        assert result_with_cls.parsing_successful
+
+    def test_property_docstring_validation(self, validator):
+        """Test that property docstrings are validated correctly."""
+
+        @public
+        class TestClass:
+            @public
+            @property
+            def status(self):
+                """Current status of the instance.
+
+                Returns:
+                    Status string indicating current state
+                """
+                return "active"
+
+        result = validator.validate_docstring_text(TestClass.status.__doc__, "TestClass.status")
+        assert result.is_valid(), f"Property should have valid docstring: {result.errors}"
+        assert result.parsing_successful
+
+    def test_docstring_formatting_errors(self, validator):
+        """Test that common docstring formatting errors are detected."""
+
+        @public
+        class TestClass:
+            @public
+            def method_with_invalid_section(self, data):
+                """Process data with invalid section header.
+
+                Arguments!:  # Invalid punctuation in section header
+                    data: Data to process
+
+                Returns:
+                    Result
+                """
+                pass
+
+            @public
+            def method_with_bad_indentation(self, data, options):
+                """Process data with missing parameter indentation.
+
+                Args:
+                data: Not indented properly
+                options: Also not indented
+
+                Returns:
+                    Result
+                """
+                pass
+
+        # Test an error that we know the validator catches - invalid section header
+        result = validator.validate_docstring_text(
+            TestClass.method_with_invalid_section.__doc__, "TestClass.method_with_invalid_section"
+        )
+        # This should either have warnings/errors or be parsing successfully
+        assert result.parsing_successful  # At minimum should parse
+
+        # Missing indentation in parameters
+        result = validator.validate_docstring_text(
+            TestClass.method_with_bad_indentation.__doc__, "TestClass.method_with_bad_indentation"
+        )
+        # This may or may not be flagged depending on RST parser behavior
+        assert result.parsing_successful  # At minimum should parse
+
+    def test_edge_case_docstrings(self, validator):
+        """Test edge cases with docstrings."""
+
+        @public
+        class TestClass:
+            @public
+            def empty_method(self):
+                """"""  # noqa: D419
+                pass
+
+            @public
+            def helper(self):
+                """Helper method."""
+                pass
+
+            @public
+            def whitespace_method(self):
+                """ """  # noqa: D419
+                pass
+
+        # Empty docstring should produce warning but not error
+        result_empty = validator.validate_docstring_text(
+            TestClass.empty_method.__doc__, "TestClass.empty_method"
+        )
+        assert result_empty.has_warnings()
+        assert "No docstring found" in str(result_empty.warnings)
+        assert result_empty.is_valid()  # Empty is valid, just warned
+
+        # Minimal but valid docstring
+        result_minimal = validator.validate_docstring_text(
+            TestClass.helper.__doc__, "TestClass.helper"
+        )
+        assert result_minimal.is_valid()
+        assert not result_minimal.has_errors()
+
+        # Whitespace-only docstring
+        result_whitespace = validator.validate_docstring_text(
+            TestClass.whitespace_method.__doc__, "TestClass.whitespace_method"
+        )
+        assert result_whitespace.has_warnings()
+        assert "No docstring found" in str(result_whitespace.warnings)
+
+    def test_complex_valid_docstring(self, validator):
+        """Test that complex but valid docstrings are handled correctly."""
+
+        @public
+        class TestClass:
+            @public
+            def execute_pipeline(self, pipeline_config, execution_mode, retry_policy=None):
+                """Execute multi-stage data processing pipeline.
+
+                This method performs comprehensive data processing through multiple
+                stages with configurable options and error handling.
+
+                Args:
+                    pipeline_config: Configuration dictionary containing:
+                        - stage_1: Initial data ingestion settings
+                        - stage_2: Data transformation parameters
+                        - stage_3: Export configuration options
+                    execution_mode: Mode selection ('sequential', 'parallel', 'adaptive')
+                    retry_policy: Error retry configuration
+
+                Returns:
+                    PipelineResult containing:
+                        - execution_summary: High-level statistics
+                        - stage_results: Detailed per-stage results
+                        - performance_metrics: Timing and resource data
+
+                Raises:
+                    PipelineConfigError: If configuration is invalid
+                    DataProcessingError: If processing fails at any stage
+                    ResourceError: If insufficient system resources
+
+                Examples:
+                    Basic usage:
+
+                    >>> config = {'stage_1': {...}, 'stage_2': {...}}
+                    >>> result = processor.execute_pipeline(config, 'sequential')
+                    >>> print(result.execution_summary)
+
+                Note:
+                    This method requires substantial computational resources for large
+                    datasets. Consider using batch processing for datasets larger
+                    than 100,000 records.
+                """
+                pass
+
+        result = validator.validate_docstring_text(
+            TestClass.execute_pipeline.__doc__, "TestClass.execute_pipeline"
+        )
+        # Should be valid despite complexity
+        assert result.is_valid() or not result.has_errors(), (
+            f"Complex docstring should be valid: {result.errors}"
+        )
+        assert result.parsing_successful
+
+    def test_mixed_method_types_in_single_class(self, validator):
+        """Test a class with all different types of methods."""
+
+        @public
+        class MixedMethodClass:
+            @public
+            def instance_method(self, data):
+                """Process data using instance state.
+
+                Args:
+                    data: Data to process
+
+                Returns:
+                    Processed result
+                """
+                pass
+
+            @public
+            @staticmethod
+            def utility_function(value):
+                """Utility function that doesn't need instance or class.
+
+                Args:
+                    value: Value to process
+
+                Returns:
+                    Processed value
+                """
+                pass
+
+            @public
+            @classmethod
+            def factory_method(cls, config):
+                """Create instance using factory pattern.
+
+                Args:
+                    config: Configuration for new instance
+
+                Returns:
+                    New instance of this class
+                """
+                pass
+
+            @public
+            @property
+            def computed_value(self):
+                """Computed value based on instance state.
+
+                Returns:
+                    Computed value
+                """
+                return 42
+
+        # Test that all method types validate correctly
+        methods_to_test = [
+            (MixedMethodClass.instance_method.__doc__, "MixedMethodClass.instance_method"),
+            (MixedMethodClass.utility_function.__doc__, "MixedMethodClass.utility_function"),
+            (MixedMethodClass.factory_method.__doc__, "MixedMethodClass.factory_method"),
+            (MixedMethodClass.computed_value.__doc__, "MixedMethodClass.computed_value"),
+        ]
+
+        for docstring, method_name in methods_to_test:
+            result = validator.validate_docstring_text(docstring, method_name)
+            assert result.is_valid(), f"{method_name} should have valid docstring: {result.errors}"

--- a/python_modules/automation/automation_tests/docstring_lint_tests/test_public_methods.py
+++ b/python_modules/automation/automation_tests/docstring_lint_tests/test_public_methods.py
@@ -1,0 +1,172 @@
+"""Tests for validating @public methods on @public classes."""
+
+import pytest
+from automation.docstring_lint.validator import SymbolImporter
+
+
+class TestPublicMethodFiltering:
+    """Test that only @public methods on @public classes are identified for validation."""
+
+    def test_identifies_only_public_methods_on_public_classes(self):
+        """Test that only @public methods on @public classes are found for validation.
+
+        This is the core test that verifies the main functionality:
+        - @public methods on @public classes should be included
+        - Non-public methods on @public classes should be excluded
+        - All methods on non-public classes should be excluded (even if marked @public)
+        - Different method types (instance, static, class, property) should all work
+        """
+        # Import our test module
+        module_path = "automation_tests.docstring_lint_tests.test_fixtures.test_public_class"
+
+        methods = SymbolImporter.get_all_public_annotated_methods(module_path)
+
+        # Extract just the method names from the full dotted paths for easier testing
+        method_names = [method.dotted_path.split(".")[-1] for method in methods]
+
+        # Methods that SHOULD be found (public methods on public classes)
+        expected_public_methods = {
+            "public_instance_method",
+            "public_static_method",
+            "public_class_method",
+            "public_property",
+            "another_public_method",  # From AnotherPublicClass
+        }
+
+        # Methods that should NOT be found
+        excluded_methods = {
+            # Non-public methods on public classes
+            "non_public_instance_method",
+            "non_public_static_method",
+            "non_public_class_method",
+            "non_public_property",
+            "another_non_public_method",
+            # Any methods from NonPublicClass (even if marked @public)
+            "public_method_on_non_public_class",
+            "regular_method_on_non_public_class",
+        }
+
+        # Verify that all expected public methods are found
+        for expected_method in expected_public_methods:
+            assert expected_method in method_names, (
+                f"Expected @public method '{expected_method}' was not found"
+            )
+
+        # Verify that excluded methods are NOT found
+        for excluded_method in excluded_methods:
+            assert excluded_method not in method_names, (
+                f"Non-public method '{excluded_method}' should not be found"
+            )
+
+        # Verify the total count matches expectations
+        assert len(methods) == len(expected_public_methods), (
+            f"Expected {len(expected_public_methods)} public methods, but found {len(methods)}. "
+            f"Found methods: {method_names}"
+        )
+
+    def test_method_types_are_correctly_handled(self):
+        """Test that different method types (instance, static, class, property) are all handled correctly."""
+        module_path = "automation_tests.docstring_lint_tests.test_fixtures.test_public_class"
+
+        methods = SymbolImporter.get_all_public_annotated_methods(module_path)
+
+        # Create a mapping of method names to their SymbolInfo objects
+        methods_by_name = {method.dotted_path.split(".")[-1]: method for method in methods}
+
+        # Verify we have the expected method types
+        assert "public_instance_method" in methods_by_name
+        assert "public_static_method" in methods_by_name
+        assert "public_class_method" in methods_by_name
+        assert "public_property" in methods_by_name
+
+        # Verify each method has the correct symbol type and docstring
+        instance_method = methods_by_name["public_instance_method"]
+        assert instance_method.docstring is not None
+        assert "public instance method" in instance_method.docstring
+
+        static_method = methods_by_name["public_static_method"]
+        assert static_method.docstring is not None
+        assert "public static method" in static_method.docstring
+
+        class_method = methods_by_name["public_class_method"]
+        assert class_method.docstring is not None
+        assert "public class method" in class_method.docstring
+
+        property_method = methods_by_name["public_property"]
+        assert property_method.docstring is not None
+        assert "public property" in property_method.docstring
+
+    def test_multiple_public_classes_are_handled(self):
+        """Test that methods from multiple @public classes in the same module are found."""
+        module_path = "automation_tests.docstring_lint_tests.test_fixtures.test_public_class"
+
+        methods = SymbolImporter.get_all_public_annotated_methods(module_path)
+
+        # Extract class names from the dotted paths
+        class_names = set()
+        for method in methods:
+            parts = method.dotted_path.split(".")
+            if len(parts) >= 2:
+                class_names.add(parts[-2])  # Second to last part is class name
+
+        # Should find methods from both public classes
+        expected_classes = {"PublicClass", "AnotherPublicClass"}
+        assert expected_classes.issubset(class_names), (
+            f"Expected to find methods from classes {expected_classes}, "
+            f"but only found classes {class_names}"
+        )
+
+        # Should NOT find any methods from NonPublicClass
+        assert "NonPublicClass" not in class_names, (
+            "Should not find any methods from NonPublicClass"
+        )
+
+    def test_nonexistent_module_raises_import_error(self):
+        """Test that trying to analyze a nonexistent module raises ModuleNotFoundError."""
+        with pytest.raises(ModuleNotFoundError, match="No module named"):
+            SymbolImporter.get_all_public_annotated_methods(
+                "nonexistent.module.that.does.not.exist"
+            )
+
+    def test_empty_module_returns_empty_list(self):
+        """Test that a module with no @public classes returns an empty list."""
+        # Use a standard library module that shouldn't have @public decorators
+        try:
+            methods = SymbolImporter.get_all_public_annotated_methods("json")
+            assert isinstance(methods, list)
+            # Should be empty since standard library modules don't use @public decorators
+            assert len(methods) == 0
+        except ImportError:
+            pytest.skip("json module not available for testing")
+
+    def test_dotted_paths_are_correctly_formed(self):
+        """Test that the dotted paths in SymbolInfo objects are correctly formed."""
+        module_path = "automation_tests.docstring_lint_tests.test_fixtures.test_public_class"
+
+        methods = SymbolImporter.get_all_public_annotated_methods(module_path)
+
+        for method in methods:
+            # Each dotted path should have the format: module.class.method
+            parts = method.dotted_path.split(".")
+            assert len(parts) >= 3, (
+                f"Dotted path '{method.dotted_path}' should have at least 3 parts"
+            )
+
+            # Module part should match what we requested
+            module_part = ".".join(parts[:-2])  # All but last 2 parts
+            assert module_part == module_path
+
+            # Class part should be one of our public classes
+            class_part = parts[-2]
+            assert class_part in {"PublicClass", "AnotherPublicClass"}
+
+            # Method part should be one of our expected public methods
+            method_part = parts[-1]
+            expected_methods = {
+                "public_instance_method",
+                "public_static_method",
+                "public_class_method",
+                "public_property",
+                "another_public_method",
+            }
+            assert method_part in expected_methods

--- a/python_modules/automation/automation_tests/docstring_lint_tests/test_public_symbol_utils.py
+++ b/python_modules/automation/automation_tests/docstring_lint_tests/test_public_symbol_utils.py
@@ -1,0 +1,343 @@
+"""Tests for public symbol utility functions."""
+
+from automation.docstring_lint.public_symbol_utils import (
+    get_public_methods_from_class,
+    is_valid_public_method,
+)
+from dagster._annotations import public
+
+
+class TestIsValidPublicMethod:
+    """Test the is_valid_public_method function."""
+
+    def test_regular_method_with_public_annotation(self):
+        """Test that a regular method with @public annotation is detected correctly."""
+
+        @public
+        def mock_method():
+            """A mock method."""
+            pass
+
+        is_valid, target = is_valid_public_method(mock_method)
+
+        assert is_valid is True
+        assert target is mock_method
+
+    def test_regular_method_without_public_annotation(self):
+        """Test that a regular method without @public annotation is not detected."""
+
+        def mock_method():
+            """A mock method."""
+            pass
+
+        is_valid, target = is_valid_public_method(mock_method)
+
+        assert is_valid is False
+        assert target is mock_method
+
+    def test_property_with_public_annotation(self):
+        """Test that a property with @public annotation is detected correctly."""
+
+        @public
+        @property
+        def mock_property(self):
+            """A mock property."""
+            return "value"
+
+        is_valid, target = is_valid_public_method(mock_property)
+
+        assert is_valid is True
+        assert target is mock_property.fget
+
+    def test_property_without_public_annotation(self):
+        """Test that a property without @public annotation is not detected."""
+
+        @property
+        def mock_property(self):
+            """A mock property."""
+            return "value"
+
+        is_valid, target = is_valid_public_method(mock_property)
+
+        assert is_valid is False
+        assert target is mock_property.fget
+
+    def test_staticmethod_with_public_annotation(self):
+        """Test that a staticmethod with @public annotation is detected correctly."""
+
+        @public
+        @staticmethod
+        def mock_staticmethod():
+            """A mock static method."""
+            pass
+
+        is_valid, target = is_valid_public_method(mock_staticmethod)
+
+        assert is_valid is True
+        assert target is mock_staticmethod
+
+    def test_staticmethod_without_public_annotation(self):
+        """Test that a staticmethod without @public annotation is not detected."""
+
+        @staticmethod
+        def mock_staticmethod():
+            """A mock static method."""
+            pass
+
+        is_valid, target = is_valid_public_method(mock_staticmethod)
+
+        assert is_valid is False
+        assert target is mock_staticmethod
+
+    def test_classmethod_with_public_annotation(self):
+        """Test that a classmethod with @public annotation is detected correctly."""
+
+        @public
+        @classmethod
+        def mock_classmethod(cls):
+            """A mock class method."""
+            pass
+
+        is_valid, target = is_valid_public_method(mock_classmethod)
+
+        assert is_valid is True
+        assert target is mock_classmethod
+
+    def test_classmethod_without_public_annotation(self):
+        """Test that a classmethod without @public annotation is not detected."""
+
+        @classmethod
+        def mock_classmethod(cls):
+            """A mock class method."""
+            pass
+
+        is_valid, target = is_valid_public_method(mock_classmethod)
+
+        assert is_valid is False
+        assert target is mock_classmethod
+
+    def test_non_callable_object(self):
+        """Test that non-callable objects are not considered valid methods."""
+        mock_object = "not_a_method"
+
+        is_valid, target = is_valid_public_method(mock_object)
+
+        assert is_valid is False
+        assert target is mock_object
+
+    def test_bound_method_with_public_annotation(self):
+        """Test that bound methods with @public annotation are detected correctly."""
+
+        class MockClass:
+            @public
+            def method(self):
+                """A mock method."""
+                pass
+
+        instance = MockClass()
+        bound_method = instance.method
+
+        is_valid, target = is_valid_public_method(bound_method)
+
+        assert is_valid is True
+        assert target is bound_method
+
+    def test_bound_method_without_public_annotation(self):
+        """Test that bound methods without @public annotation are not detected."""
+
+        class MockClass:
+            def method(self):
+                """A mock method."""
+                pass
+
+        instance = MockClass()
+        bound_method = instance.method
+
+        is_valid, target = is_valid_public_method(bound_method)
+
+        assert is_valid is False
+        assert target is bound_method
+
+
+class TestGetPublicMethodsFromClass:
+    """Test the get_public_methods_from_class function."""
+
+    def test_class_with_public_methods(self):
+        """Test extracting @public methods from a class."""
+
+        class MockClass:
+            @public
+            def public_method(self):
+                """A public method."""
+                pass
+
+            def private_method(self):
+                """A private method."""
+                pass
+
+            @public
+            @property
+            def public_property(self):
+                """A public property."""
+                return "value"
+
+            @public
+            @staticmethod
+            def public_static():
+                """A public static method."""
+                pass
+
+            @public
+            @classmethod
+            def public_class_method(cls):
+                """A public class method."""
+                pass
+
+            def _internal_method(self):
+                """An internal method (starts with underscore)."""
+                pass
+
+        methods = get_public_methods_from_class(MockClass, "test.MockClass")
+
+        expected_methods = [
+            "test.MockClass.public_method",
+            "test.MockClass.public_property",
+            "test.MockClass.public_static",
+            "test.MockClass.public_class_method",
+        ]
+
+        assert sorted(methods) == sorted(expected_methods)
+
+    def test_class_with_no_public_methods(self):
+        """Test a class with no @public methods."""
+
+        class MockClass:
+            def private_method(self):
+                """A private method."""
+                pass
+
+            def _internal_method(self):
+                """An internal method."""
+                pass
+
+            @property
+            def non_public_property(self):
+                """A non-public property."""
+                return "value"
+
+        methods = get_public_methods_from_class(MockClass, "test.MockClass")
+
+        assert methods == []
+
+    def test_class_with_attribute_access_errors(self):
+        """Test that the function handles attribute access errors gracefully."""
+
+        class MockClass:
+            @public
+            def good_method(self):
+                """A good method."""
+                pass
+
+        # Simulate an attribute that causes an exception when accessed
+        # We'll temporarily add a problematic attribute
+        def problematic_attr(self):
+            raise RuntimeError("Cannot access this attribute")
+
+        MockClass.problematic_attr = property(problematic_attr)  # type: ignore[misc]
+
+        try:
+            methods = get_public_methods_from_class(MockClass, "test.MockClass")
+
+            # Should still return the good method and not crash
+            assert methods == ["test.MockClass.good_method"]
+        finally:
+            # Clean up
+            delattr(MockClass, "problematic_attr")
+
+    def test_empty_class(self):
+        """Test an empty class with no methods."""
+
+        class EmptyClass:
+            pass
+
+        methods = get_public_methods_from_class(EmptyClass, "test.EmptyClass")
+
+        assert methods == []
+
+    def test_class_with_inherited_methods(self):
+        """Test that inherited methods are included in the results."""
+
+        class BaseClass:
+            @public
+            def base_method(self):
+                """A base method."""
+                pass
+
+        class DerivedClass(BaseClass):
+            @public
+            def derived_method(self):
+                """A derived method."""
+                pass
+
+        methods = get_public_methods_from_class(DerivedClass, "test.DerivedClass")
+
+        expected_methods = ["test.DerivedClass.base_method", "test.DerivedClass.derived_method"]
+
+        assert sorted(methods) == sorted(expected_methods)
+
+    def test_class_with_mixed_method_types(self):
+        """Test a class with various types of methods, some public, some not."""
+
+        class MixedClass:
+            @public
+            def public_instance_method(self):
+                """A public instance method."""
+                pass
+
+            def private_instance_method(self):
+                """A private instance method."""
+                pass
+
+            @public
+            @staticmethod
+            def public_static_method():
+                """A public static method."""
+                pass
+
+            @staticmethod
+            def private_static_method():
+                """A private static method."""
+                pass
+
+            @public
+            @classmethod
+            def public_class_method(cls):
+                """A public class method."""
+                pass
+
+            @classmethod
+            def private_class_method(cls):
+                """A private class method."""
+                pass
+
+            @public
+            @property
+            def public_property(self):
+                """A public property."""
+                return "value"
+
+            @property
+            def private_property(self):
+                """A private property."""
+                return "value"
+
+        methods = get_public_methods_from_class(MixedClass, "test.MixedClass")
+
+        expected_methods = [
+            "test.MixedClass.public_instance_method",
+            "test.MixedClass.public_static_method",
+            "test.MixedClass.public_class_method",
+            "test.MixedClass.public_property",
+        ]
+
+        assert sorted(methods) == sorted(expected_methods)


### PR DESCRIPTION
## Summary & Motivation

This PR adds support for validating `@public`-annotated methods on top-level exported classes. The changes include:

1. Improved docstring validation for top-level exported symbols
2. Added support for validating `@public`-annotated methods on classes
3. Enhanced section header detection with a more comprehensive list of allowed section headers
4. Added utilities for working with `@public`-annotated symbols

These improvements will help ensure consistent documentation quality across both top-level symbols and public methods, making the API documentation more complete and reliable.

## How I Tested These Changes

- Added comprehensive test suite for `@public` method detection and validation
- Created test fixtures with various method types (instance, static, class, property)
- Added tests for section header detection and validation
- Verified that only `@public` methods on `@public` classes are selected for validation
- Tested edge cases like empty docstrings and various method decorators

Manual test:

Injected error and confirmed got a message

![Screenshot 2025-07-23 at 2.00.34 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/d737fde4-1d5b-47a5-b690-70043474a8f3.png)

