### PR TITLE
feat: Add ability to click on partitions in the Asset side panel

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -280,26 +280,16 @@ const Header = ({assetNode, repoAddress}: HeaderProps) => {
       >
         <Box>{displayName}</Box>
       </SidebarTitle>
-      <Box flex={{direction: 'row', alignItems: 'center', gap: 10}}>
+      <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}>
         <Box flex={{direction: 'row', gap: 4}}>
-            <AnchorButton
-              to={assetDetailsPathForKey(assetNode.assetKey)}
-              icon={<Icon name="open_in_new" color={Colors.linkDefault()} />}
-            >
-              {'View in Asset Catalog '}
-            </AnchorButton>
-            <AddToFavoritesButton assetKey={assetNode.assetKey} />
+          <AnchorButton
+            to={assetDetailsPathForKey(assetNode.assetKey)}
+            icon={<Icon name="open_in_new" color={Colors.linkDefault()} />}
+          >
+            {'View in Asset Catalog '}
+          </AnchorButton>
+          <AddToFavoritesButton assetKey={assetNode.assetKey} />
         </Box>
-        {assetNode.partitionDefinition && (
-          <Box flex={{direction: 'row', gap: 4}}>
-            <AnchorButton
-              to={`${assetDetailsPathForKey(assetNode.assetKey)}view=partitions`}
-              icon={<Icon name="partition" color={Colors.linkDefault()} />}
-            >
-              {'View Partitions '}
-            </AnchorButton>
-          </Box>
-        )}
         {repoAddress && (
           <UnderlyingOpsOrGraph assetNode={assetNode} repoAddress={repoAddress} minimal />
         )}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -280,16 +280,26 @@ const Header = ({assetNode, repoAddress}: HeaderProps) => {
       >
         <Box>{displayName}</Box>
       </SidebarTitle>
-      <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}>
+      <Box flex={{direction: 'row', alignItems: 'center', gap: 10}}>
         <Box flex={{direction: 'row', gap: 4}}>
-          <AnchorButton
-            to={assetDetailsPathForKey(assetNode.assetKey)}
-            icon={<Icon name="open_in_new" color={Colors.linkDefault()} />}
-          >
-            {'View in Asset Catalog '}
-          </AnchorButton>
-          <AddToFavoritesButton assetKey={assetNode.assetKey} />
+            <AnchorButton
+              to={assetDetailsPathForKey(assetNode.assetKey)}
+              icon={<Icon name="open_in_new" color={Colors.linkDefault()} />}
+            >
+              {'View in Asset Catalog '}
+            </AnchorButton>
+            <AddToFavoritesButton assetKey={assetNode.assetKey} />
         </Box>
+        {assetNode.partitionDefinition && (
+          <Box flex={{direction: 'row', gap: 4}}>
+            <AnchorButton
+              to={`${assetDetailsPathForKey(assetNode.assetKey)}view=partitions`}
+              icon={<Icon name="partition" color={Colors.linkDefault()} />}
+            >
+              {'View Partitions '}
+            </AnchorButton>
+          </Box>
+        )}
         {repoAddress && (
           <UnderlyingOpsOrGraph assetNode={assetNode} repoAddress={repoAddress} minimal />
         )}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/MultipartitioningSupport.tsx
@@ -17,7 +17,9 @@ export function isTimeseriesDimension(dimension: PartitionHealthDimension) {
 export function isTimeseriesPartition(aPartitionKey = '') {
   return /\d{4}-\d{2}-\d{2}/.test(aPartitionKey); // cheak trick for now
 }
-
+export function isTimeBasedPartition(dimension: PartitionHealthDimension): boolean {
+  return dimension.type === PartitionDefinitionType.TIME_WINDOW; // check with type
+}
 /*
 This function takes the health of several assets and returns a single health object in which SUCCESS
 means that all the assets were in a SUCCESS state for that partition and SUCCESS_MISSING means only

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
@@ -3,7 +3,7 @@ import {memo, useCallback} from 'react';
 import {useHistory} from 'react-router-dom';
 
 import {isTimeseriesDimension} from './MultipartitioningSupport';
-import {AssetKey} from './types';
+import {AssetKey, AssetViewParams} from './types';
 import {PartitionHealthData} from './usePartitionHealthData';
 import {LiveDataForNode, displayNameForAssetKey} from '../asset-graph/Utils';
 import {PartitionStatus} from '../partitions/PartitionStatus';
@@ -29,7 +29,7 @@ export const PartitionHealthSummary = memo((props: Props) => {
       const lastPartition = selectedPartitions[selectedPartitions.length - 1]!;
 
       let defaultRange: string;
-      let queryParams: {view: string; default_range: string; partition?: string};
+      let queryParams: AssetViewParams;
 
       if (selectedPartitions.length === 1) {
         defaultRange = firstPartition;
@@ -42,6 +42,7 @@ export const PartitionHealthSummary = memo((props: Props) => {
         defaultRange = `[${firstPartition}...${lastPartition}]`;
         queryParams = {
           view: 'partitions',
+          partition: lastPartition,
           default_range: defaultRange,
         };
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
@@ -24,10 +24,14 @@ export const PartitionHealthSummary = memo((props: Props) => {
   const history = useHistory();
 
   const handlePartitionInteraction = useCallback((selectedPartitions: string[], dimension?: PartitionHealthDimension) => {
-
+    
     if (selectedPartitions.length > 0) {
-      const firstPartition = selectedPartitions[0]!;
-      const lastPartition = selectedPartitions[selectedPartitions.length - 1]!;
+      const firstPartition = selectedPartitions.length > 0 ? selectedPartitions[0] : null;
+      const lastPartition = selectedPartitions.length > 0 ? selectedPartitions[selectedPartitions.length - 1] : null;
+
+      if (!firstPartition || !lastPartition) {
+        return;
+      }
 
       let defaultRange: string;
       let queryParams: AssetViewParams;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
@@ -35,8 +35,8 @@ export const PartitionHealthSummary = memo((props: Props) => {
         defaultRange = firstPartition;
         queryParams = {
           view: 'partitions',
-          default_range: defaultRange,
           partition: firstPartition,
+          default_range: defaultRange,
         };
       } else {
         defaultRange = `[${firstPartition}...${lastPartition}]`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
@@ -25,36 +25,34 @@ export const PartitionHealthSummary = memo((props: Props) => {
 
   const handlePartitionInteraction = useCallback(
     (selectedPartitions: string[], dimension?: PartitionHealthDimension) => {
-      if (selectedPartitions.length > 0) {
-        const firstPartition = selectedPartitions[0] ?? null;
-        const lastPartition = selectedPartitions[selectedPartitions.length - 1] ?? null;
+      const firstPartition = selectedPartitions[0] ?? null;
+      const lastPartition = selectedPartitions[selectedPartitions.length - 1] ?? null;
 
-        if (!firstPartition || !lastPartition) {
-          return;
-        }
-
-        let defaultRange: string;
-        let queryParams: AssetViewParams;
-
-        if (selectedPartitions.length === 1) {
-          defaultRange = firstPartition;
-          queryParams = {
-            view: 'partitions',
-            partition: firstPartition,
-            default_range: defaultRange,
-          };
-        } else {
-          defaultRange = `[${firstPartition}...${lastPartition}]`;
-          queryParams = {
-            view: 'partitions',
-            ...(dimension && isTimeBasedPartition(dimension) ? {partition: lastPartition} : {}),
-            default_range: defaultRange,
-          };
-        }
-
-        const assetPath = assetDetailsPathForKey(assetKey, queryParams);
-        history.push(assetPath);
+      if (!firstPartition || !lastPartition) {
+        return;
       }
+
+      let defaultRange: string;
+      let queryParams: AssetViewParams;
+
+      if (selectedPartitions.length === 1) {
+        defaultRange = firstPartition;
+        queryParams = {
+          view: 'partitions',
+          partition: firstPartition,
+          default_range: defaultRange,
+        };
+      } else {
+        defaultRange = `[${firstPartition}...${lastPartition}]`;
+        queryParams = {
+          view: 'partitions',
+          ...(dimension && isTimeBasedPartition(dimension) ? {partition: lastPartition} : {}),
+          default_range: defaultRange,
+        };
+      }
+
+      const assetPath = assetDetailsPathForKey(assetKey, queryParams);
+      history.push(assetPath);
     },
     [assetKey, history],
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
@@ -26,7 +26,7 @@ export const PartitionHealthSummary = memo((props: Props) => {
   const handlePartitionInteraction = useCallback((selectedPartitions: string[], dimension?: PartitionHealthDimension) => {
     
     if (selectedPartitions.length > 0) {
-      const firstPartition = selectedPartitions.length > 0 ? selectedPartitions[0] : null;
+      const firstPartition = selectedPartitions[0] ?? null;
       const lastPartition = selectedPartitions.length > 0 ? selectedPartitions[selectedPartitions.length - 1] : null;
 
       if (!firstPartition || !lastPartition) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
@@ -2,9 +2,9 @@ import {Box, Caption, Spinner} from '@dagster-io/ui-components';
 import {memo, useCallback} from 'react';
 import {useHistory} from 'react-router-dom';
 
-import {isTimeseriesDimension} from './MultipartitioningSupport';
+import {isTimeBasedPartition, isTimeseriesDimension} from './MultipartitioningSupport';
 import {AssetKey, AssetViewParams} from './types';
-import {PartitionHealthData} from './usePartitionHealthData';
+import {PartitionHealthData, PartitionHealthDimension} from './usePartitionHealthData';
 import {LiveDataForNode, displayNameForAssetKey} from '../asset-graph/Utils';
 import {PartitionStatus} from '../partitions/PartitionStatus';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
@@ -23,7 +23,8 @@ export const PartitionHealthSummary = memo((props: Props) => {
   );
   const history = useHistory();
 
-  const handlePartitionInteraction = useCallback((selectedPartitions: string[]) => {
+  const handlePartitionInteraction = useCallback((selectedPartitions: string[], dimension?: PartitionHealthDimension) => {
+
     if (selectedPartitions.length > 0) {
       const firstPartition = selectedPartitions[0]!;
       const lastPartition = selectedPartitions[selectedPartitions.length - 1]!;
@@ -42,7 +43,7 @@ export const PartitionHealthSummary = memo((props: Props) => {
         defaultRange = `[${firstPartition}...${lastPartition}]`;
         queryParams = {
           view: 'partitions',
-          partition: lastPartition,
+          ...(dimension && isTimeBasedPartition(dimension) ? { partition: lastPartition } : {}),
           default_range: defaultRange,
         };
       }
@@ -73,8 +74,8 @@ export const PartitionHealthSummary = memo((props: Props) => {
               partitionNames={dimension.partitionKeys}
               splitPartitions={!isTimeseriesDimension(dimension)}
               selected={[]}
-              onSelect={(selectedPartitions) => handlePartitionInteraction(selectedPartitions)}
-              onClick={(partitionName) => handlePartitionInteraction([partitionName])}
+              onSelect={(selectedPartitions) => handlePartitionInteraction(selectedPartitions, dimension)}
+              onClick={(partitionName) => handlePartitionInteraction([partitionName], dimension)}
               health={{
                 ranges: assetData.rangesForSingleDimension(dimensionIdx, undefined),
               }}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
@@ -24,23 +24,27 @@ export const PartitionHealthSummary = memo((props: Props) => {
   const history = useHistory();
 
   const handlePartitionInteraction = useCallback((selectedPartitions: string[]) => {
-
     if (selectedPartitions.length > 0) {
       const firstPartition = selectedPartitions[0]!;
       const lastPartition = selectedPartitions[selectedPartitions.length - 1]!;
-      
+
       let defaultRange: string;
-      
+      let queryParams: {view: string; default_range: string; partition?: string};
+
       if (selectedPartitions.length === 1) {
         defaultRange = firstPartition;
+        queryParams = {
+          view: 'partitions',
+          default_range: defaultRange,
+          partition: firstPartition,
+        };
       } else {
         defaultRange = `[${firstPartition}...${lastPartition}]`;
+        queryParams = {
+          view: 'partitions',
+          default_range: defaultRange,
+        };
       }
-
-      const queryParams: {view: string; default_range: string} = {
-        view: 'partitions',
-        default_range: defaultRange,
-      };
 
       const assetPath = assetDetailsPathForKey(assetKey, queryParams);
       history.push(assetPath);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
@@ -27,7 +27,7 @@ export const PartitionHealthSummary = memo((props: Props) => {
     
     if (selectedPartitions.length > 0) {
       const firstPartition = selectedPartitions[0] ?? null;
-      const lastPartition = selectedPartitions.length > 0 ? selectedPartitions[selectedPartitions.length - 1] : null;
+      const lastPartition = selectedPartitions[selectedPartitions.length - 1] ?? null;
 
       if (!firstPartition || !lastPartition) {
         return;


### PR DESCRIPTION
## Summary & Motivation
Improved the navigation flow in the Dagster UI especially in the Asset side panel by making **Materialized/Partition bar** clickable/selectable with options single click and selection range requested by **Daniel**. As a result, this links directly to the specific partitions view depending on user mouse clicks/range. We also introduced additional feature like `isTimeBasedPartition` @ js_modules/dagster-ui/packages/ui-core/src/assets/MultipartitioningSupport.tsx which identity if current task is timebase with dimension type, opening option **range** for only timebase. As a result, the layout was also cleaned up by removing unnecessary steps, resulting in a clearer and more user-friendly interface.

## How I Tested These Changes
I tested the changes locally by running both the backend and frontend. For the backend, I launched the Dagster GraphQL server using **time_based_partitioning.py, static_partitioning.py** and files like those using `dagster dev -f time_based_partitioning.py -p 3333` for example. For the frontend, I ran the Dagster UI using `make dev_webapp`. And the Verified Outcomes:

- No more clicking unnecessary steps to reach to partition page
- The Materialized/Partition bar links correctly to the specific partitions view
- Specific partitions view with materialized info

Don't worry about code format, I did `make ruff` at root before PR. ^_^

> Made the **Materialized/Partition bar** @ Asset side panel, clickable

Resolves "View Partitions" features at asset sidebar #30979 
