### PR TITLE
Improve record custom docs

### DIFF
--- a/python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/record/__init__.py
@@ -328,23 +328,33 @@ def record_custom(
     checked: bool = True,
     field_to_new_mapping: Optional[Mapping[str, str]] = None,
 ) -> Union[TType, Callable[[TType], TType]]:
-    """Variant of the record decorator to use to opt out of the dataclass_transform decorator behavior.
-    This is done when overriding __new__ so that the type checker knows that is what is used.
+    """Variant of the record decorator to use when overriding __new__.
 
-    @record_custom
-    class Coerced(IHaveNew):
-        name: str
+    Example:
+        @record_custom
+        class MyRecord(IHaveNew):
+            name: str
+            value: int
 
-        def __new__(cls, name: Optional[str] = None)
-            if not name:
-                name = "bob"
+            def __new__(cls, name: str, value: int = 42):
+                # Custom logic here
+                if not name:
+                    name = "default"
+                return super().__new__(
+                    cls,
+                    name=name,
+                    value=value,
+                )
 
-            return super().__new__(
-                cls,
-                name=name,
-            )
+    Important requirements:
+    - Must inherit from IHaveNew
+    - Must define a custom __new__ method
+    - Must call super().__new__(cls, **kwargs) with keyword arguments
+    - Keyword arguments must match the field names exactly
+    - Cannot be used with @record inheritance
 
-
+    This approach is useful when you need custom validation, default value logic,
+    or type coercion in the constructor that can't be handled with simple defaults.
 
     It would have been cool if we could do that with an argument and @overload but
     from https://peps.python.org/pep-0681/ "When applied to an overload,


### PR DESCRIPTION
## Summary & Motivation

Improved the documentation for the `record_custom` decorator in the `dagster_shared.record` module. The updated docstring provides clearer guidance on how to use this decorator when overriding `__new__` methods, including:

- A more comprehensive example showing proper usage
- Explicit requirements for using the decorator
- Explanation of when this approach is useful
- Clear instructions on how to call `super().__new__` with keyword arguments

This change helps developers and agents understand the correct way to use `record_custom` with custom constructors, reducing potential errors and improving code quality.

## How I Tested These Changes

Read