### PR TITLE
Mock SHELL in install completion tests

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_install_completion.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_install_completion.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-import shellingham
 from dagster_dg_core_tests.utils import ProxyRunner, assert_runner_result
 
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_install_completion.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_install_completion.py
@@ -7,15 +7,16 @@ from dagster_dg_core_tests.utils import ProxyRunner, assert_runner_result
 # It's quite difficult to have a true test of whether `install_completion` is working correctly,
 # because it modifies the home folder. Therefore we mock the actual installation routine here and
 # just ensure that the command executes and prints the correct output.
-def test_install_completion():
-    shell, _ = shellingham.detect_shell()
-    with ProxyRunner.test() as runner, runner.isolated_filesystem():
-        with patch("typer._completion_shared.install") as mock_install:
-            mock_install.return_value = shell, "/some/path"
-            result = runner.invoke("--install-completion")
-            if shell in ["cmd", "powershell"]:  # windows shells are not supported
-                assert_runner_result(result, exit_0=False)
-                assert f"Shell `{shell}` is not supported" in result.output
-            else:
-                assert_runner_result(result)
-                assert f"{shell} completion installed in /some/path" in result.output
+def test_install_completion(monkeypatch):
+    for shell in ["bash", "cmd", "powershell"]:
+        monkeypatch.setenv("SHELL", shell)
+        with ProxyRunner.test() as runner, runner.isolated_filesystem():
+            with patch("typer._completion_shared.install") as mock_install:
+                mock_install.return_value = shell, "/some/path"
+                result = runner.invoke("--install-completion")
+                if shell in ["cmd", "powershell"]:  # windows shells are not supported
+                    assert_runner_result(result, exit_0=False)
+                    assert f"Shell `{shell}` is not supported" in result.output
+                else:
+                    assert_runner_result(result)
+                    assert f"{shell} completion installed in /some/path" in result.output


### PR DESCRIPTION
When we refactored our divergent buildkite step builders into a single consolidated step builder, this test regressed.

The refactor cut down on implicitly passed env vars and I think that caused this particular test to start failing. I've had trouble running down the exact env var because, well, it wasn't explicitly being set...

But given what this test is doing, I think it's better that we mock our shell and actually test the different conditions here. Instead of having a test whose assertions are tied to the environment in which it's running.