### PR TITLE
Use click.echo instead of print

### DIFF
--- a/python_modules/automation/automation/docstring_lint/changed_validator.py
+++ b/python_modules/automation/automation/docstring_lint/changed_validator.py
@@ -5,6 +5,7 @@ import inspect
 from pathlib import Path
 from typing import Callable, Union
 
+import click
 from dagster._record import IHaveNew, record, record_custom
 
 from automation.docstring_lint.validator import DocstringValidator
@@ -199,16 +200,16 @@ def print_validation_results(
 
     for result in results:
         if result.has_errors() or result.has_warnings():
-            print(f"--- {result.symbol_info.symbol_path} ---")  # noqa: T201
+            click.echo(f"--- {result.symbol_info.symbol_path} ---")
 
             for error in result.errors:
-                print(f"  ERROR: {error}")  # noqa: T201
+                click.echo(f"  ERROR: {error}")
                 total_errors += 1
 
             for warning in result.warnings:
-                print(f"  WARNING: {warning}")  # noqa: T201
+                click.echo(f"  WARNING: {warning}")
                 total_warnings += 1
 
-            print()  # noqa: T201
+            click.echo()
 
     return total_errors, total_warnings

--- a/python_modules/automation/automation/docstring_lint/cli.py
+++ b/python_modules/automation/automation/docstring_lint/cli.py
@@ -55,7 +55,7 @@ def main(
         elif all_public:
             # Batch validation mode for all top-level exported symbols
             symbols = SymbolImporter.get_all_exported_symbols(symbol_path)
-            print(f"Validating {len(symbols)} top-level exported symbols in {symbol_path}\n")  # noqa: T201
+            click.echo(f"Validating {len(symbols)} public symbols in {symbol_path}\n")
 
             total_errors = 0
             total_warnings = 0
@@ -66,25 +66,25 @@ def main(
                 )
 
                 if result.has_errors() or result.has_warnings():
-                    print(f"--- {symbol_info.dotted_path} ---")  # noqa: T201
+                    click.echo(f"--- {symbol_info.dotted_path} ---")
 
                     for error in result.errors:
-                        print(f"  ERROR: {error}")  # noqa: T201
+                        click.echo(f"  ERROR: {error}")
                         total_errors += 1
 
                     for warning in result.warnings:
-                        print(f"  WARNING: {warning}")  # noqa: T201
+                        click.echo(f"  WARNING: {warning}")
                         total_warnings += 1
 
-                    print()  # noqa: T201
+                    click.echo()
 
-            print(f"Summary: {total_errors} errors, {total_warnings} warnings")  # noqa: T201
+            click.echo(f"Summary: {total_errors} errors, {total_warnings} warnings")
             return 1 if total_errors > 0 else 0
 
         elif public_methods:
             # Batch validation mode for @public-annotated methods on top-level exported classes
             methods = SymbolImporter.get_all_public_annotated_methods(symbol_path)
-            print(  # noqa: T201
+            click.echo(
                 f"Validating {len(methods)} @public-annotated methods on top-level exported classes in {symbol_path}\n"
             )
 
@@ -97,48 +97,48 @@ def main(
                 )
 
                 if result.has_errors() or result.has_warnings():
-                    print(f"--- {method_info.dotted_path} ---")  # noqa: T201
+                    click.echo(f"--- {method_info.dotted_path} ---")
 
                     for error in result.errors:
-                        print(f"  ERROR: {error}")  # noqa: T201
+                        click.echo(f"  ERROR: {error}")
                         total_errors += 1
 
                     for warning in result.warnings:
-                        print(f"  WARNING: {warning}")  # noqa: T201
+                        click.echo(f"  WARNING: {warning}")
                         total_warnings += 1
 
-                    print()  # noqa: T201
+                    click.echo()
 
-            print(f"Summary: {total_errors} errors, {total_warnings} warnings")  # noqa: T201
+            click.echo(f"Summary: {total_errors} errors, {total_warnings} warnings")
             return 1 if total_errors > 0 else 0
 
         else:
             # Single symbol validation (core use case)
             result = validator.validate_symbol_docstring(symbol_path)
 
-            print(f"Validating docstring for: {symbol_path}")  # noqa: T201
+            click.echo(f"Validating docstring for: {symbol_path}")
 
             if result.has_errors():
-                print("\nERRORS:")  # noqa: T201
+                click.echo("\nERRORS:")
                 for error in result.errors:
-                    print(f"  - {error}")  # noqa: T201
+                    click.echo(f"  - {error}")
 
             if result.has_warnings():
-                print("\nWARNINGS:")  # noqa: T201
+                click.echo("\nWARNINGS:")
                 for warning in result.warnings:
-                    print(f"  - {warning}")  # noqa: T201
+                    click.echo(f"  - {warning}")
 
             if result.is_valid() and not result.has_warnings():
-                print("✓ Docstring is valid!")  # noqa: T201
+                click.echo("✓ Docstring is valid!")
             elif result.is_valid():
-                print("✓ Docstring is valid (with warnings)")  # noqa: T201
+                click.echo("✓ Docstring is valid (with warnings)")
             else:
-                print("✗ Docstring validation failed")  # noqa: T201
+                click.echo("✗ Docstring validation failed")
 
             return 0 if result.is_valid() else 1
 
     except Exception as e:
-        print(f"Error: {e}")  # noqa: T201
+        click.echo(f"Error: {e}", err=True)
         if verbose:
             import traceback
 
@@ -148,28 +148,28 @@ def main(
 
 def _run_watch_mode(symbol_path: str, validator: DocstringValidator, verbose: bool) -> int:
     """Run the validation in watch mode, monitoring file changes."""
-    print(f"Setting up watch mode for symbol: {symbol_path}")  # noqa: T201
+    click.echo(f"Setting up watch mode for symbol: {symbol_path}")
 
     # First, resolve the symbol to get its file path
     try:
         symbol_info = SymbolImporter.import_symbol(symbol_path)
 
         if not symbol_info.file_path:
-            print(f"Error: Cannot determine source file for symbol '{symbol_path}'")  # noqa: T201
+            click.echo(f"Error: Cannot determine source file for symbol '{symbol_path}'", err=True)
             return 1
 
         target_file = Path(symbol_info.file_path)
         if not target_file.exists():
-            print(f"Error: Source file does not exist: {target_file}")  # noqa: T201
+            click.echo(f"Error: Source file does not exist: {target_file}", err=True)
             return 1
 
-        print(f"Watching file: {target_file}")  # noqa: T201
+        click.echo(f"Watching file: {target_file}")
         if verbose:
-            print("Debug mode enabled - will show file system events")  # noqa: T201
-        print("Press Ctrl+C to stop watching\n")  # noqa: T201
+            click.echo("Debug mode enabled - will show file system events")
+        click.echo("Press Ctrl+C to stop watching\n")
 
     except Exception as e:
-        print(f"Error resolving symbol: {e}")  # noqa: T201
+        click.echo(f"Error resolving symbol: {e}", err=True)
         if verbose:
             import traceback
 
@@ -179,36 +179,36 @@ def _run_watch_mode(symbol_path: str, validator: DocstringValidator, verbose: bo
     # Define validation callback
     def validate_and_report() -> None:
         timestamp = datetime.now().strftime("%H:%M:%S")
-        print(f"[{timestamp}] File changed, validating {symbol_path}...")  # noqa: T201
+        click.echo(f"[{timestamp}] File changed, validating {symbol_path}...")
 
         try:
             result = validator.validate_symbol_docstring(symbol_path)
 
             if result.has_errors():
-                print("ERRORS:")  # noqa: T201
+                click.echo("ERRORS:")
                 for error in result.errors:
-                    print(f"  - {error}")  # noqa: T201
+                    click.echo(f"  - {error}")
 
             if result.has_warnings():
-                print("WARNINGS:")  # noqa: T201
+                click.echo("WARNINGS:")
                 for warning in result.warnings:
-                    print(f"  - {warning}")  # noqa: T201
+                    click.echo(f"  - {warning}")
 
             if result.is_valid() and not result.has_warnings():
-                print("✓ Docstring is valid!")  # noqa: T201
+                click.echo("✓ Docstring is valid!")
             elif result.is_valid():
-                print("✓ Docstring is valid (with warnings)")  # noqa: T201
+                click.echo("✓ Docstring is valid (with warnings)")
             else:
-                print("✗ Docstring validation failed")  # noqa: T201
+                click.echo("✗ Docstring validation failed")
 
         except Exception as e:
-            print(f"Validation error: {e}")  # noqa: T201
+            click.echo(f"Validation error: {e}", err=True)
             if verbose:
                 import traceback
 
                 traceback.print_exc()
 
-        print("-" * 50)  # noqa: T201
+        click.echo("-" * 50)
 
     # Run initial validation
     validate_and_report()
@@ -218,7 +218,7 @@ def _run_watch_mode(symbol_path: str, validator: DocstringValidator, verbose: bo
 
     # Setup signal handler for graceful shutdown
     def signal_handler(signum, frame):
-        print("\nStopping file watcher...")  # noqa: T201
+        click.echo("\nStopping file watcher...")
         watcher.stop_watching()
         sys.exit(0)
 
@@ -231,7 +231,7 @@ def _run_watch_mode(symbol_path: str, validator: DocstringValidator, verbose: bo
         while True:
             time.sleep(1)
     except Exception as e:
-        print(f"Watch mode error: {e}")  # noqa: T201
+        click.echo(f"Watch mode error: {e}", err=True)
         if verbose:
             import traceback
 

--- a/python_modules/automation/automation/docstring_lint/watcher.py
+++ b/python_modules/automation/automation/docstring_lint/watcher.py
@@ -4,6 +4,7 @@ import time
 from pathlib import Path
 from typing import Callable
 
+import click
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
@@ -30,17 +31,17 @@ class DocstringValidationHandler(FileSystemEventHandler):
     def _handle_file_event(self, event_path: Path, event_type: str) -> None:
         """Handle file system events for the target file."""
         if self.verbose:
-            print(f"[DEBUG] {event_type} event: {event_path}")  # noqa: T201
+            click.echo(f"[DEBUG] {event_type} event: {event_path}")
 
         if event_path == self.target_file:
             current_time = time.time()
             if current_time - self.last_validation_time > self.debounce_delay:
                 self.last_validation_time = current_time
                 if self.verbose:
-                    print(f"[DEBUG] Triggering validation for {event_path}")  # noqa: T201
+                    click.echo(f"[DEBUG] Triggering validation for {event_path}")
                 self.validation_callback()
             elif self.verbose:
-                print("[DEBUG] Skipping validation (debounced)")  # noqa: T201
+                click.echo("[DEBUG] Skipping validation (debounced)")
 
     def on_modified(self, event) -> None:
         """Handle file modification events."""


### PR DESCRIPTION
## Summary & Motivation

Replace `print()` statements with `click.echo()` in the docstring linting tools. This change improves error handling by using Click's built-in functionality for output management, including proper stderr handling for error messages. Eliminates ruff noqa directives.

## How I Tested These Changes

BK

