### PR TITLE
[components testing] Refactor components testing utils

### DIFF
--- a/docs/docs/guides/build/components/creating-new-components/testing-your-component.md
+++ b/docs/docs/guides/build/components/creating-new-components/testing-your-component.md
@@ -89,7 +89,7 @@ def test_snowflake_component():
         sandbox.scaffold_component(
             component_cls=SqlComponent,
             defs_path="sql_execution_component",
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster.TemplatedSqlComponent",
                 "attributes": {
                     "sql_template": "SELECT * FROM MY_TABLE;",
@@ -102,7 +102,7 @@ def test_snowflake_component():
         sandbox.scaffold_component(
             component_cls=SnowflakeConnectionComponent,
             defs_path="sql_connection_component",
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster_snowflake.SnowflakeConnectionComponent",
                 "attributes": {
                     "account": "test_account",

--- a/docs/docs/guides/build/components/creating-new-components/testing-your-component.md
+++ b/docs/docs/guides/build/components/creating-new-components/testing-your-component.md
@@ -39,7 +39,7 @@ def scaffold_component(
     defs_path: Optional[Union[Path, str]] = None,
     scaffold_params: Optional[dict[str, Any]] = None,
     scaffold_format: ScaffoldFormatOptions = "yaml",
-    component_body: Optional[dict[str, Any]] = None,
+    defs_yaml_contents: Optional[dict[str, Any]] = None,
 ) -> Path: ...
 ```
 
@@ -55,7 +55,7 @@ def test_scaffold_sling():
         assert (defs_path / "replication.yaml").exists()
 ```
 
-For ease of use, the `component_body` argument can be used to replace the contents of the `defs.yaml` file after the component has been scaffolded.
+For ease of use, the `defs_yaml_contents` argument can be used to replace the contents of the `defs.yaml` file after the component has been scaffolded.
 
 #### Loading and building definitions with `load_component_and_build_defs`
 

--- a/docs/docs/guides/build/components/creating-new-components/testing-your-component.md
+++ b/docs/docs/guides/build/components/creating-new-components/testing-your-component.md
@@ -8,92 +8,139 @@ title: Testing your component
 
 After you [create a new component](/guides/build/components/creating-new-components/creating-and-registering-a-component), we recommend testing scaffolding and runtime execution with the Dagster framework utilities outlined below.
 
-### The core workhorse: `scaffold_defs_sandbox`
+### Setting up a sandbox with `temp_components_sandbox`
 
-The function at the core of our testing workflows is `scaffold_defs_sandbox`.
+The function at the core of our testing workflows is `dagster.components.testing.temp_components_sandbox`. This context manager allows you to construct a temporary defs folder, which can be populated with components and loaded into Component objects or built into dagster Definitions just as they would be in a real Dagster project.
 
 The function signature is the following:
 
 ```python
 @contextmanager
-def scaffold_defs_sandbox(
+def temp_components_sandbox(
     *,
-    component_cls: type,
-    scaffold_params: Optional[dict[str, Any]] = None,
-    component_path: Optional[Union[Path, str]] = None,
-    scaffold_format: ScaffoldFormatOptions = "yaml",
     project_name: Optional[str] = None,
-) -> Iterator[DefsPathSandbox]: ...
+) -> Iterator[DefsSandbox]: ...
 ```
 
-For the purposes of this guide, we will only concern ourselves with `component_cls` and `scaffold_params`. Users are highly unlikely to require the other parameters.
+### The `DefsSandbox` object
 
-`scaffold_defs_sandbox` creates a lightweight sandbox to scaffold and instantiate a component in three steps:
-1. Creates an empty folder structure (with an auto-generated project name and component path by default) that mimics the `defs/` folder portion of a real Dagster project. Practically speaking, this means a single folder at `src/<<project_name>>/defs/<<component_path>>` and which contains the scaffolded files within that leaf directory.
-2. It then invokes the scaffolder on the component class in the context of that folder.
-3. `scaffold_defs_sandbox` yields a `DefsPathSandbox` object, which you can program against.
+Once created, the `DefsSandbox` object provides a number of useful utilities for scaffolding and loading components.
 
-Within the `with` block, you are free to assert facts about the scaffolded files.
+#### Creating a component with `scaffold_component`
 
-For example, in our test of our Sling component (which scaffolds a `replication.yaml` file):
+The `scaffold_component` method allows you to scaffold a component into the defs folder, just as a user would using the `dg scaffold component` CLI command.
+
+The signature is
+
+```python
+def scaffold_component(
+    self,
+    component_cls: Any,
+    component_path: Optional[Union[Path, str]] = None,
+    scaffold_params: Optional[dict[str, Any]] = None,
+    scaffold_format: ScaffoldFormatOptions = "yaml",
+    component_body: Optional[dict[str, Any]] = None,
+) -> Path: ...
+```
+
+The only required parameter is `component_cls`, which is the class of the component to scaffold - without providing any other parameters, this will scaffold a YAML component with a random name and default contents. Other parameters allow you to simulate passing parameters to the scaffolding CLI command, or to specify a specific path for the newly created component.
+
+This can be used to verify the behavior of a custom scaffolder. Here is an example of use in our test of our Sling component (which scaffolds a `replication.yaml` file):
 
 ```python
 def test_scaffold_sling():
-    with scaffold_defs_sandbox(component_cls=SlingReplicationCollectionComponent) as defs_sandbox:
-        assert (defs_sandbox.defs_folder_path / "defs.yaml").exists()
-        assert (defs_sandbox.defs_folder_path / "replication.yaml").exists()
+    with temp_components_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component(component_cls=SlingReplicationCollectionComponent)
+        assert (component_path / "defs.yaml").exists()
+        assert (component_path / "replication.yaml").exists()
 ```
 
-### DefsPathSandbox object
+For ease of use, the `component_body` argument can be used to replace the contents of the `defs.yaml` file after the component has been scaffolded.
 
-`scaffold_defs_sandbox` yields an object of type `DefsPathSandbox` as a context manager. You can use the object to load the component instance and the definitions it produces.
+#### Loading and building definitions with `load_component_and_build_defs_at_path`
 
-For example, the following is code from our tests of our [dlt component](/guides/build/components/integrations/dlt-component-tutorial) on already-created `DefsPathSandbox`. In this case, we ensure that the definitions have loaded, and that the correct asset keys have been created:
+To test instantiation of a component, and to validate the definitions it produces, you can use the `load_component_and_build_defs_at_path` method, which loads an already-scaffolded component and builds the corresponding Definitions.
 
-```python
-with defs_sandbox.load() as (component, defs):
-    assert isinstance(component, DltLoadCollectionComponent)
-    assert len(component.loads) == 1
-    assert defs.resolve_asset_graph().get_all_asset_keys() == {
-        AssetKey(["example", "hello_world"]),
-        AssetKey(["my_source_hello_world"]),
-    }
-```
-
-However, that is just using the default `defs.yaml` file. Usually, you will want to customize the body of `defs.yaml`. For that, there is the `component_body` argument to `load`, demonstrated in the code that tests our `PythonScriptComponent`:
+For example, the following is code from our tests of our [dlt component](/guides/build/components/integrations/dlt-component-tutorial). In this case, we ensure that the definitions have loaded, and that the correct asset keys have been created:
 
 ```python
-
-def test_pipes_subprocess_script_hello_world() -> None:
-    with scaffold_defs_sandbox(component_cls=PythonScriptComponent) as sandbox:
-        # Create the script we will execute
-        execute_path = sandbox.defs_folder_path / "script.py"
-        execute_path.write_text("print('hello world')")
-
-        # This will create a defs.yaml file in the sandboxed folder
-        with sandbox.load(
-            component_body={
-                "type": "dagster.components.lib.executable_component.python_script_component.PythonScriptComponent",
-                "attributes": {
-                    "execution": {
-                        "name": "op_name",
-                        "path": "script.py",
-                    },
-                    "assets": [
-                        {
-                            "key": "asset",
-                        }
-                    ],
-                },
+def test_dlt_component():
+    with temp_components_sandbox() as defs_sandbox:
+        component_path = defs_sandbox.scaffold_component(component_cls=DltLoadCollectionComponent)
+        with defs_sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+            component,
+            defs,
+        ):
+            assert isinstance(component, DltLoadCollectionComponent)
+            assert len(component.loads) == 1
+            assert defs.resolve_asset_graph().get_all_asset_keys() == {
+                AssetKey(["example", "hello_world"]),
+                AssetKey(["my_source_hello_world"]),
             }
-        ) as (component, defs):
-            assert isinstance(component, PythonScriptComponent)
-            assert isinstance(component.execution, ScriptSpec)
+```
 
-            # You can operate on definitions as normal
-            assets_def = defs.get_assets_def("asset")
-            result = materialize([assets_def])
-            assert result.success
-            mats = result.asset_materializations_for_node("op_name")
-            assert len(mats) == 1
+#### Scaffolding and building definitions in a single invocation with `scaffold_load_and_build_component_defs`
+
+The `DefsSandbox` object also provides a convenience method for creating a new component with custom `defs.yaml` contents and building the corresponding Definitions.
+This is the easiest way to test a fully configured component, such as the Fivetran component:
+
+```python
+def test_fivetran_component():
+    with temp_components_sandbox() as defs_sandbox:
+        with defs_sandbox.scaffold_load_and_build_component_defs(
+            component_cls=FivetranAccountComponent,
+            component_body={
+                "type": "dagster_fivetran.FivetranAccountComponent",
+                "attributes": {
+                    "workspace": {
+                        "api_key": "{{ env.FIVETRAN_API_KEY }}",
+                        "api_secret": "{{ env.FIVETRAN_API_SECRET }}",
+                        "account_id": "{{ env.FIVETRAN_ACCOUNT_ID }}",
+                    },
+                }
+            },
+        ) as (component, defs):
+            assert isinstance(component, FivetranAccountComponent)
+```
+
+
+#### Testing multiple components
+
+These utilities are also useful for testing multiple components in a single test. For example, testing the `TemplatedSqlComponent` with a Snowflake connection:
+
+```python
+def test_snowflake_component():
+    with temp_components_sandbox() as sandbox:
+        sandbox.scaffold_component(
+            component_cls=SqlComponent,
+            component_path="sql_execution_component",
+            component_body={
+                "type": "dagster.TemplatedSqlComponent",
+                "attributes": {
+                    "sql_template": "SELECT * FROM MY_TABLE;",
+                    "assets": [{"key": "TESTDB/TESTSCHEMA/TEST_TABLE"}],
+                    "connection": "{{ load_component_at_path('sql_connection_component') }}",
+                },
+            },
+        )
+
+        sandbox.scaffold_component(
+            component_cls=SnowflakeConnectionComponent,
+            component_path="sql_connection_component",
+            component_body={
+                "type": "dagster_snowflake.SnowflakeConnectionComponent",
+                "attributes": {
+                    "account": "test_account",
+                    "user": "test_user",
+                    "password": "test_password",
+                    "database": "TESTDB",
+                    "schema": "TESTSCHEMA",
+                },
+            },
+        )
+
+        with sandbox.build_all_defs() as defs:
+            assert defs.resolve_asset_graph().get_all_asset_keys() == {
+                AssetKey(["TESTDB", "TESTSCHEMA", "TEST_TABLE"])
+            }
 ```

--- a/docs/docs/guides/build/components/creating-new-components/testing-your-component.md
+++ b/docs/docs/guides/build/components/creating-new-components/testing-your-component.md
@@ -8,15 +8,15 @@ title: Testing your component
 
 After you [create a new component](/guides/build/components/creating-new-components/creating-and-registering-a-component), we recommend testing scaffolding and runtime execution with the Dagster framework utilities outlined below.
 
-### Setting up a sandbox with `defs_folder_sandbox`
+### Setting up a sandbox with `create_defs_folder_sandbox`
 
-The function at the core of our testing workflows is `dagster.components.testing.defs_folder_sandbox`. This context manager allows you to construct a temporary defs folder, which can be populated with components and loaded into Component objects or built into dagster Definitions just as they would be in a real Dagster project.
+The function at the core of our testing workflows is `dagster.components.testing.create_defs_folder_sandbox`. This context manager allows you to construct a temporary defs folder, which can be populated with components and loaded into Component objects or built into dagster Definitions just as they would be in a real Dagster project.
 
 The function signature is the following:
 
 ```python
 @contextmanager
-def defs_folder_sandbox(
+def create_defs_folder_sandbox(
     *,
     project_name: Optional[str] = None,
 ) -> Iterator[DefsFolderSandbox]: ...
@@ -49,7 +49,7 @@ This can be used to verify the behavior of a custom scaffolder. Here is an examp
 
 ```python
 def test_scaffold_sling():
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(component_cls=SlingReplicationCollectionComponent)
         assert (defs_path / "defs.yaml").exists()
         assert (defs_path / "replication.yaml").exists()
@@ -65,7 +65,7 @@ For example, the following is code from our tests of our [dlt component](/guides
 
 ```python
 def test_dlt_component():
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(component_cls=DltLoadCollectionComponent)
         with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
@@ -85,7 +85,7 @@ These utilities are also useful for testing multiple components in a single test
 
 ```python
 def test_snowflake_component():
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         sandbox.scaffold_component(
             component_cls=SqlComponent,
             defs_path="sql_execution_component",

--- a/python_modules/dagster/dagster/components/deprecated/testing.py
+++ b/python_modules/dagster/dagster/components/deprecated/testing.py
@@ -3,8 +3,9 @@ import sys
 from pathlib import Path
 
 import yaml
-from dagster._annotations import deprecated
 from dagster_shared import check
+
+from dagster._annotations import deprecated
 
 """Testing utilities for components."""
 

--- a/python_modules/dagster/dagster/components/deprecated/testing.py
+++ b/python_modules/dagster/dagster/components/deprecated/testing.py
@@ -102,7 +102,7 @@ class DefsPathSandbox:
 
 
 @deprecated(
-    additional_warn_text="Use dagster.components.testing.defs_folder_sandbox instead.",
+    additional_warn_text="Use dagster.components.testing.create_defs_folder_sandbox instead.",
     breaking_version="2.0.0",
 )
 @contextmanager

--- a/python_modules/dagster/dagster/components/deprecated/testing.py
+++ b/python_modules/dagster/dagster/components/deprecated/testing.py
@@ -173,7 +173,7 @@ def scaffold_defs_sandbox(
                 assert defs.get_asset_def("my_asset").key == AssetKey("my_asset")
 
         with scaffold_defs_sandbox(component_cls=MyComponent) as sandbox:
-            with sandbox.load(component_body={"type": "MyComponent", "attributes": {"asset_key": "different_asset_key"}}) as (component, defs):
+            with sandbox.load(defs_yaml_contents={"type": "MyComponent", "attributes": {"asset_key": "different_asset_key"}}) as (component, defs):
                 assert isinstance(component, MyComponent)
                 assert defs.get_asset_def("different_asset_key").key == AssetKey("different_asset_key")
     """

--- a/python_modules/dagster/dagster/components/deprecated/testing.py
+++ b/python_modules/dagster/dagster/components/deprecated/testing.py
@@ -1,0 +1,202 @@
+import shutil
+import sys
+from pathlib import Path
+
+import yaml
+from dagster._annotations import deprecated
+from dagster_shared import check
+
+"""Testing utilities for components."""
+
+import json
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._utils import alter_sys_path
+from dagster.components.component.component import Component
+from dagster.components.component_scaffolding import scaffold_object
+from dagster.components.scaffold.scaffold import ScaffoldFormatOptions
+
+
+@dataclass
+class DefsPathSandbox:
+    project_root: Path
+    defs_folder_path: Path
+    component_path: Path
+    project_name: str
+    component_format: ScaffoldFormatOptions
+
+    @contextmanager
+    def swap_defs_file(self, defs_path: Path, component_body: Optional[dict[str, Any]]):
+        check.invariant(
+            defs_path.suffix == ".yaml",
+            "Attributes are only supported for yaml components",
+        )
+        check.invariant(defs_path.exists(), "defs.yaml must exist")
+
+        # no need to override there is no component body
+        if component_body is None:
+            yield
+            return
+
+        temp_dir = Path(tempfile.mkdtemp())
+        temp_path = temp_dir / defs_path.name
+
+        try:
+            shutil.copy2(defs_path, temp_path)
+
+            defs_path.write_text(yaml.safe_dump(component_body))
+
+            yield
+
+        finally:
+            if temp_path.exists():
+                defs_path.unlink(missing_ok=True)
+                shutil.copy2(temp_path, defs_path)
+            shutil.rmtree(temp_dir)
+
+    @contextmanager
+    def load(
+        self, component_body: Optional[dict[str, Any]] = None
+    ) -> Iterator[tuple["Component", "Definitions"]]:
+        defs_path = self.defs_folder_path / "defs.yaml"
+
+        with self.swap_defs_file(defs_path, component_body):
+            with self.load_instance(0) as (component, defs):
+                yield component, defs
+
+    @contextmanager
+    def load_instance(
+        self, instance_key: Union[int, str]
+    ) -> Iterator[tuple[Component, Definitions]]:
+        assert isinstance(instance_key, int)  # only int for now
+        with self.load_all() as components:
+            yield components[instance_key][0], components[instance_key][1]
+
+    @contextmanager
+    def load_all(self) -> Iterator[list[tuple[Component, Definitions]]]:
+        from dagster.components.testing import (
+            get_all_components_defs_from_defs_path,
+            get_module_path,
+        )
+
+        with alter_sys_path(to_add=[str(self.project_root / "src")], to_remove=[]):
+            module_path = get_module_path(
+                defs_module_name=f"{self.project_name}.defs", component_path=self.component_path
+            )
+            try:
+                yield get_all_components_defs_from_defs_path(
+                    project_root=self.project_root,
+                    module_path=module_path,
+                )
+
+            finally:
+                modules_to_remove = [name for name in sys.modules if name.startswith(module_path)]
+                for name in modules_to_remove:
+                    del sys.modules[name]
+
+
+@deprecated(
+    additional_warn_text="Use dagster.components.testing.temp_components_sandbox instead.",
+    breaking_version="2.0.0",
+)
+@contextmanager
+def scaffold_defs_sandbox(
+    *,
+    component_cls: type,
+    component_path: Optional[Union[Path, str]] = None,
+    scaffold_params: Optional[dict[str, Any]] = None,
+    scaffold_format: ScaffoldFormatOptions = "yaml",
+    project_name: Optional[str] = None,
+) -> Iterator[DefsPathSandbox]:
+    """Create a lightweight sandbox to scaffold and instantiate a component. Useful
+    for those authoring component types.
+
+    Scaffold defs sandbox creates a temporary project that mimics the defs folder portion
+    of a real dagster project.
+
+    It then invokes the scaffolder on the component class that produces. After
+    scaffold_defs_sandbox yields a DefsPathSandbox object.
+
+    DefsPathSandbox has a few properties useful for different types of tests:
+
+    * defs_folder_path: The absolute path to the defs folder where the component
+      is scaffolded. The user can inspect and load files that the scaffolder has produced.
+      e.g. (defs_folder_path / "defs.yaml").exists()
+
+    * component_path: The relative path to the component within the defs folder. If not
+      provided, a random name is generated.
+
+    * project_name: If not provided, a random name is generated.
+
+    Once the sandbox is created the user has the option to load the definitions produced
+    by the component using the load method on DefsPathSandbox.
+
+    By default it will produce the component based on the persisted `defs.yaml` file. You
+    can also supply a component body to the load method to override the defs.yaml file with
+    an in-memory component body.
+
+    This sandbox does not provide complete environmental isolation, but does provide some isolation guarantees
+    to do its best to isolate the test from and restore the environment after the test.
+
+    * A file structure like this is created: <<temp folder>> / src / <<project_name>> / defs / <<component_path>>
+    * <<temp folder>> / src is placed in sys.path during the loading process
+    * The last element of the component path is loaded as a namespace package
+    * Any modules loaded during the process that descend from defs module are evicted from sys.modules on cleanup.
+
+    Args:
+        component_cls: The component class to scaffold
+        component_path: Optional path where the component should be scaffolded. It is relative to the defs folder. Defaults to a random name at the root of the defs folder.
+        scaffold_params: Optional parameters to pass to the scaffolder in dictionary form. E.g. if you scaffold a component with dg scaffold defs MyComponent --param-one value-one the scaffold_params should be {"param_one": "value-one"}.
+        scaffold_format: Format to use for scaffolding (default: "yaml"). Can also be "python".
+        project_name: Optional name for the project (default: random name).
+
+    Returns:
+        Iterator[DefsPathSandbox]: A context manager that yields a DefsPathSandbox
+
+    Example:
+
+    .. code-block:: python
+
+        with scaffold_defs_sandbox(component_cls=MyComponent) as sandbox:
+            assert (sandbox.defs_folder_path / "defs.yaml").exists()
+            assert (sandbox.defs_folder_path / "my_component_config_file.yaml").exists()  # produced by MyComponentScaffolder
+
+        with scaffold_defs_sandbox(component_cls=MyComponent, scaffold_params={"asset_key": "my_asset"}) as sandbox:
+            with sandbox.load() as (component, defs):
+                assert isinstance(component, MyComponent)
+                assert defs.get_asset_def("my_asset").key == AssetKey("my_asset")
+
+        with scaffold_defs_sandbox(component_cls=MyComponent) as sandbox:
+            with sandbox.load(component_body={"type": "MyComponent", "attributes": {"asset_key": "different_asset_key"}}) as (component, defs):
+                assert isinstance(component, MyComponent)
+                assert defs.get_asset_def("different_asset_key").key == AssetKey("different_asset_key")
+    """
+    from dagster.components.testing import get_original_module_name, random_importable_name
+
+    project_name = project_name or random_importable_name()
+    component_path = component_path or random_importable_name()
+    typename = get_original_module_name(component_cls)
+    with tempfile.TemporaryDirectory() as project_root_str:
+        project_root = Path(project_root_str)
+        defs_folder_path = project_root / "src" / project_name / "defs" / component_path
+        defs_folder_path.mkdir(parents=True, exist_ok=True)
+        scaffold_object(
+            path=defs_folder_path,
+            # obj=component_cls,
+            typename=typename,
+            json_params=json.dumps(scaffold_params) if scaffold_params else None,
+            scaffold_format=scaffold_format,
+            project_root=project_root,
+        )
+        yield DefsPathSandbox(
+            project_root=project_root,
+            defs_folder_path=defs_folder_path,
+            project_name=project_name,
+            component_path=Path(component_path),
+            component_format=scaffold_format,
+        )

--- a/python_modules/dagster/dagster/components/deprecated/testing.py
+++ b/python_modules/dagster/dagster/components/deprecated/testing.py
@@ -87,7 +87,7 @@ class DefsPathSandbox:
 
         with alter_sys_path(to_add=[str(self.project_root / "src")], to_remove=[]):
             module_path = get_module_path(
-                defs_module_name=f"{self.project_name}.defs", component_path=self.component_path
+                defs_module_name=f"{self.project_name}.defs", defs_path=self.component_path
             )
             try:
                 yield get_all_components_defs_from_defs_path(
@@ -102,7 +102,7 @@ class DefsPathSandbox:
 
 
 @deprecated(
-    additional_warn_text="Use dagster.components.testing.temp_components_sandbox instead.",
+    additional_warn_text="Use dagster.components.testing.defs_folder_sandbox instead.",
     breaking_version="2.0.0",
 )
 @contextmanager

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -226,7 +226,7 @@ class DefsFolderSandbox:
         defs_path: Optional[Union[Path, str]] = None,
         scaffold_params: Optional[dict[str, Any]] = None,
         scaffold_format: ScaffoldFormatOptions = "yaml",
-        component_body: Optional[dict[str, Any]] = None,
+        defs_yaml_contents: Optional[dict[str, Any]] = None,
     ) -> Path:
         """Scaffolds a component into the defs folder.
 
@@ -235,7 +235,7 @@ class DefsFolderSandbox:
             defs_path: The path to the component. (defaults to a random name)
             scaffold_params: The parameters to pass to the scaffolder.
             scaffold_format: The format to use for scaffolding.
-            component_body: The body of the component to update the defs.yaml file with.
+            defs_yaml_contents: The body of the component to update the defs.yaml file with.
 
         Returns:
             The path to the component.
@@ -257,12 +257,12 @@ class DefsFolderSandbox:
             scaffold_format=scaffold_format,
             project_root=self.project_root,
         )
-        if component_body:
-            (defs_path / "defs.yaml").write_text(yaml.safe_dump(component_body))
+        if defs_yaml_contents:
+            (defs_path / "defs.yaml").write_text(yaml.safe_dump(defs_yaml_contents))
         return defs_path
 
     @contextmanager
-    def swap_defs_file(self, defs_path: Path, component_body: Optional[dict[str, Any]]):
+    def swap_defs_file(self, defs_path: Path, defs_yaml_contents: Optional[dict[str, Any]]):
         check.invariant(
             defs_path.suffix == ".yaml",
             "Attributes are only supported for yaml components",
@@ -270,7 +270,7 @@ class DefsFolderSandbox:
         check.invariant(defs_path.exists(), "defs.yaml must exist")
 
         # no need to override there is no component body
-        if component_body is None:
+        if defs_yaml_contents is None:
             yield
             return
 
@@ -280,7 +280,7 @@ class DefsFolderSandbox:
         try:
             shutil.copy2(defs_path, temp_path)
 
-            defs_path.write_text(yaml.safe_dump(component_body))
+            defs_path.write_text(yaml.safe_dump(defs_yaml_contents))
 
             yield
 
@@ -438,7 +438,7 @@ def create_defs_folder_sandbox(
         with scaffold_defs_sandbox() as sandbox:
             defs_path = sandbox.scaffold_component(
                 component_cls=MyComponent,
-                component_body={"type": "MyComponent", "attributes": {"asset_key": "my_asset"}},
+                defs_yaml_contents={"type": "MyComponent", "attributes": {"asset_key": "my_asset"}},
             )
             with sandbox.load_component_and_build_defs(defs_path=defs_path) as (component, defs):
                 assert isinstance(component, MyComponent)

--- a/python_modules/dagster/dagster/components/testing.py
+++ b/python_modules/dagster/dagster/components/testing.py
@@ -391,7 +391,7 @@ def get_component_defs_from_defs_path(
 
 
 @contextmanager
-def defs_folder_sandbox(
+def create_defs_folder_sandbox(
     *,
     project_name: Optional[str] = None,
 ) -> Iterator[DefsFolderSandbox]:

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_executable_component_in_memory.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_executable_component_in_memory.py
@@ -10,7 +10,7 @@ from dagster.components.lib.executable_component.function_component import (
     FunctionComponent,
     FunctionSpec,
 )
-from dagster.components.testing import copy_code_to_file, scaffold_defs_sandbox
+from dagster.components.testing import copy_code_to_file, temp_components_sandbox
 
 
 def asset_in_component(
@@ -186,8 +186,8 @@ def test_local_import() -> None:
         def execute_fn_to_copy(context):
             return dg.MaterializeResult(metadata={"foo": "bar"})
 
-    with scaffold_defs_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component_and_update_defs_file(
+    with temp_components_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component(
             component_cls=FunctionComponent,
             component_path="function_component",
             component_body={

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_executable_component_in_memory.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_executable_component_in_memory.py
@@ -190,7 +190,7 @@ def test_local_import() -> None:
         component_path = sandbox.scaffold_component(
             component_cls=FunctionComponent,
             defs_path="function_component",
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster.FunctionComponent",
                 "attributes": {
                     "execution": {

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_executable_component_in_memory.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_executable_component_in_memory.py
@@ -10,7 +10,7 @@ from dagster.components.lib.executable_component.function_component import (
     FunctionComponent,
     FunctionSpec,
 )
-from dagster.components.testing import copy_code_to_file, temp_components_sandbox
+from dagster.components.testing import copy_code_to_file, defs_folder_sandbox
 
 
 def asset_in_component(
@@ -186,10 +186,10 @@ def test_local_import() -> None:
         def execute_fn_to_copy(context):
             return dg.MaterializeResult(metadata={"foo": "bar"})
 
-    with temp_components_sandbox() as sandbox:
+    with defs_folder_sandbox() as sandbox:
         component_path = sandbox.scaffold_component(
             component_cls=FunctionComponent,
-            component_path="function_component",
+            defs_path="function_component",
             component_body={
                 "type": "dagster.FunctionComponent",
                 "attributes": {
@@ -208,7 +208,7 @@ def test_local_import() -> None:
         execute_path = component_path / "execute.py"
         copy_code_to_file(code_to_copy, execute_path)
 
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+        with sandbox.load_component_and_build_defs(defs_path=component_path) as (
             component,
             defs,
         ):

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_executable_component_in_memory.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_executable_component_in_memory.py
@@ -10,7 +10,7 @@ from dagster.components.lib.executable_component.function_component import (
     FunctionComponent,
     FunctionSpec,
 )
-from dagster.components.testing import copy_code_to_file, defs_folder_sandbox
+from dagster.components.testing import copy_code_to_file, create_defs_folder_sandbox
 
 
 def asset_in_component(
@@ -186,7 +186,7 @@ def test_local_import() -> None:
         def execute_fn_to_copy(context):
             return dg.MaterializeResult(metadata={"foo": "bar"})
 
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         component_path = sandbox.scaffold_component(
             component_cls=FunctionComponent,
             defs_path="function_component",

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
@@ -4,12 +4,12 @@ from dagster.components.lib.executable_component.python_script_component import 
     PythonScriptComponent,
     ScriptSpec,
 )
-from dagster.components.testing import copy_code_to_file, temp_components_sandbox
+from dagster.components.testing import copy_code_to_file, defs_folder_sandbox
 
 
 def test_pipes_subprocess_script_hello_world() -> None:
-    with temp_components_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component(
+    with defs_folder_sandbox() as sandbox:
+        defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
@@ -26,10 +26,10 @@ def test_pipes_subprocess_script_hello_world() -> None:
                 },
             },
         )
-        execute_path = component_path / "script.py"
+        execute_path = defs_path / "script.py"
         execute_path.write_text("print('hello world')")
 
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+        with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
             defs,
         ):
@@ -50,8 +50,8 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
             with open_dagster_pipes() as context:
                 context.report_asset_materialization(metadata={"foo": "bar"})
 
-    with temp_components_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component(
+    with defs_folder_sandbox() as sandbox:
+        defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
@@ -67,10 +67,10 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
                 },
             },
         )
-        execute_path = component_path / "op_name.py"
+        execute_path = defs_path / "op_name.py"
         copy_code_to_file(code_to_copy, execute_path)
 
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+        with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
             defs,
         ):
@@ -86,8 +86,8 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
 
 
 def test_pipes_subprocess_script_with_name_override() -> None:
-    with temp_components_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component(
+    with defs_folder_sandbox() as sandbox:
+        defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
@@ -104,7 +104,7 @@ def test_pipes_subprocess_script_with_name_override() -> None:
                 },
             },
         )
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+        with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
             defs,
         ):
@@ -123,8 +123,8 @@ def test_pipes_subprocess_script_with_checks_only() -> None:
                     passed=True,
                 )
 
-    with temp_components_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component(
+    with defs_folder_sandbox() as sandbox:
+        defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
@@ -142,10 +142,10 @@ def test_pipes_subprocess_script_with_checks_only() -> None:
                 },
             },
         )
-        execute_path = component_path / "only_checks.py"
+        execute_path = defs_path / "only_checks.py"
         copy_code_to_file(code_to_copy, execute_path)
 
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+        with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
             defs,
         ):
@@ -181,8 +181,8 @@ def test_pipes_subprocess_with_args() -> None:
         def arg_list():
             return ["arg_value"]
 
-    with temp_components_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component(
+    with defs_folder_sandbox() as sandbox:
+        defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
@@ -200,12 +200,12 @@ def test_pipes_subprocess_with_args() -> None:
                 "template_vars_module": ".template_vars",
             },
         )
-        execute_path = component_path / "op_name.py"
+        execute_path = defs_path / "op_name.py"
         copy_code_to_file(op_name_contents, execute_path)
-        template_vars_path = component_path / "template_vars.py"
+        template_vars_path = defs_path / "template_vars.py"
         copy_code_to_file(template_vars_content, template_vars_path)
 
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+        with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
             defs,
         ):
@@ -230,8 +230,8 @@ def test_pipes_subprocess_with_inline_str() -> None:
             with open_dagster_pipes() as context:
                 context.report_asset_materialization(metadata={"arg": sys.argv[1]})
 
-    with temp_components_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component(
+    with defs_folder_sandbox() as sandbox:
+        defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
@@ -248,10 +248,10 @@ def test_pipes_subprocess_with_inline_str() -> None:
                 },
             },
         )
-        execute_path = component_path / "op_name.py"
+        execute_path = defs_path / "op_name.py"
         copy_code_to_file(op_name_contents, execute_path)
 
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+        with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
             defs,
         ):

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
@@ -11,7 +11,7 @@ def test_pipes_subprocess_script_hello_world() -> None:
     with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster.PythonScriptComponent",
                 "attributes": {
                     "execution": {
@@ -53,7 +53,7 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
     with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster.PythonScriptComponent",
                 "attributes": {
                     "execution": {
@@ -89,7 +89,7 @@ def test_pipes_subprocess_script_with_name_override() -> None:
     with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster.PythonScriptComponent",
                 "attributes": {
                     "execution": {
@@ -126,7 +126,7 @@ def test_pipes_subprocess_script_with_checks_only() -> None:
     with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster.PythonScriptComponent",
                 "attributes": {
                     "execution": {
@@ -184,7 +184,7 @@ def test_pipes_subprocess_with_args() -> None:
     with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster.PythonScriptComponent",
                 "attributes": {
                     "execution": {
@@ -233,7 +233,7 @@ def test_pipes_subprocess_with_inline_str() -> None:
     with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster.PythonScriptComponent",
                 "attributes": {
                     "execution": {

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
@@ -4,12 +4,12 @@ from dagster.components.lib.executable_component.python_script_component import 
     PythonScriptComponent,
     ScriptSpec,
 )
-from dagster.components.testing import copy_code_to_file, scaffold_defs_sandbox
+from dagster.components.testing import copy_code_to_file, temp_components_sandbox
 
 
 def test_pipes_subprocess_script_hello_world() -> None:
-    with scaffold_defs_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component_and_update_defs_file(
+    with temp_components_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
@@ -50,8 +50,8 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
             with open_dagster_pipes() as context:
                 context.report_asset_materialization(metadata={"foo": "bar"})
 
-    with scaffold_defs_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component_and_update_defs_file(
+    with temp_components_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
@@ -86,8 +86,8 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
 
 
 def test_pipes_subprocess_script_with_name_override() -> None:
-    with scaffold_defs_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component_and_update_defs_file(
+    with temp_components_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
@@ -123,8 +123,8 @@ def test_pipes_subprocess_script_with_checks_only() -> None:
                     passed=True,
                 )
 
-    with scaffold_defs_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component_and_update_defs_file(
+    with temp_components_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
@@ -181,8 +181,8 @@ def test_pipes_subprocess_with_args() -> None:
         def arg_list():
             return ["arg_value"]
 
-    with scaffold_defs_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component_and_update_defs_file(
+    with temp_components_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
@@ -230,8 +230,8 @@ def test_pipes_subprocess_with_inline_str() -> None:
             with open_dagster_pipes() as context:
                 context.report_asset_materialization(metadata={"arg": sys.argv[1]})
 
-    with scaffold_defs_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component_and_update_defs_file(
+    with temp_components_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
@@ -29,7 +29,10 @@ def test_pipes_subprocess_script_hello_world() -> None:
         execute_path = component_path / "script.py"
         execute_path.write_text("print('hello world')")
 
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+            component,
+            defs,
+        ):
             assert isinstance(component, dg.PythonScriptComponent)
             assert isinstance(component.execution, ScriptSpec)
             assets_def = defs.get_assets_def("asset")
@@ -67,7 +70,10 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
         execute_path = component_path / "op_name.py"
         copy_code_to_file(code_to_copy, execute_path)
 
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+            component,
+            defs,
+        ):
             assert isinstance(component, dg.PythonScriptComponent)
             assert isinstance(component.execution, ScriptSpec)
             assets_def = defs.get_assets_def("asset")
@@ -98,7 +104,10 @@ def test_pipes_subprocess_script_with_name_override() -> None:
                 },
             },
         )
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+            component,
+            defs,
+        ):
             assert defs.get_assets_def("asset").op.name == "op_name_override"
 
 
@@ -136,13 +145,14 @@ def test_pipes_subprocess_script_with_checks_only() -> None:
         execute_path = component_path / "only_checks.py"
         copy_code_to_file(code_to_copy, execute_path)
 
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+            component,
+            defs,
+        ):
             assert isinstance(component, dg.PythonScriptComponent)
             assert isinstance(component.execution, ScriptSpec)
-            asset_check_key = dg.AssetCheckKey(dg.AssetKey("asset"), "check_name")
-            asset_check_key = dg.AssetCheckKey(dg.AssetKey("asset"), "check_name")
-            # The definition is created as a checks definition, access it directly
-            check_def = defs.asset_checks[0]
+            assert defs.asset_checks
+            check_def = next(iter(defs.asset_checks))
             result = dg.materialize([check_def], selection=AssetSelection.all_asset_checks())
             assert result.success
             assert check_def.op.name == "only_checks"
@@ -194,8 +204,11 @@ def test_pipes_subprocess_with_args() -> None:
         copy_code_to_file(op_name_contents, execute_path)
         template_vars_path = component_path / "template_vars.py"
         copy_code_to_file(template_vars_content, template_vars_path)
-        
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
+
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+            component,
+            defs,
+        ):
             assert isinstance(component, dg.PythonScriptComponent)
             assert isinstance(component.execution, ScriptSpec)
             assert component.execution.args == ["arg_value"]
@@ -237,8 +250,11 @@ def test_pipes_subprocess_with_inline_str() -> None:
         )
         execute_path = component_path / "op_name.py"
         copy_code_to_file(op_name_contents, execute_path)
-        
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
+
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+            component,
+            defs,
+        ):
             assert isinstance(component, dg.PythonScriptComponent)
             assert isinstance(component.execution, ScriptSpec)
             assert component.execution.args == "arg_value"

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
@@ -4,11 +4,11 @@ from dagster.components.lib.executable_component.python_script_component import 
     PythonScriptComponent,
     ScriptSpec,
 )
-from dagster.components.testing import copy_code_to_file, defs_folder_sandbox
+from dagster.components.testing import copy_code_to_file, create_defs_folder_sandbox
 
 
 def test_pipes_subprocess_script_hello_world() -> None:
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
@@ -50,7 +50,7 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
             with open_dagster_pipes() as context:
                 context.report_asset_materialization(metadata={"foo": "bar"})
 
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
@@ -86,7 +86,7 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
 
 
 def test_pipes_subprocess_script_with_name_override() -> None:
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
@@ -123,7 +123,7 @@ def test_pipes_subprocess_script_with_checks_only() -> None:
                     passed=True,
                 )
 
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
@@ -181,7 +181,7 @@ def test_pipes_subprocess_with_args() -> None:
         def arg_list():
             return ["arg_value"]
 
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={
@@ -230,7 +230,7 @@ def test_pipes_subprocess_with_inline_str() -> None:
             with open_dagster_pipes() as context:
                 context.report_asset_materialization(metadata={"arg": sys.argv[1]})
 
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PythonScriptComponent,
             component_body={

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_pipes_subprocess.py
@@ -8,11 +8,9 @@ from dagster.components.testing import copy_code_to_file, scaffold_defs_sandbox
 
 
 def test_pipes_subprocess_script_hello_world() -> None:
-    with scaffold_defs_sandbox(component_cls=PythonScriptComponent) as sandbox:
-        execute_path = sandbox.defs_folder_path / "script.py"
-        execute_path.write_text("print('hello world')")
-
-        with sandbox.load(
+    with scaffold_defs_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component_and_update_defs_file(
+            component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
                 "attributes": {
@@ -26,8 +24,12 @@ def test_pipes_subprocess_script_hello_world() -> None:
                         }
                     ],
                 },
-            }
-        ) as (component, defs):
+            },
+        )
+        execute_path = component_path / "script.py"
+        execute_path.write_text("print('hello world')")
+
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
             assert isinstance(component, dg.PythonScriptComponent)
             assert isinstance(component.execution, ScriptSpec)
             assets_def = defs.get_assets_def("asset")
@@ -45,11 +47,9 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
             with open_dagster_pipes() as context:
                 context.report_asset_materialization(metadata={"foo": "bar"})
 
-    with scaffold_defs_sandbox(component_cls=PythonScriptComponent) as sandbox:
-        execute_path = sandbox.defs_folder_path / "op_name.py"
-        copy_code_to_file(code_to_copy, execute_path)
-
-        with sandbox.load(
+    with scaffold_defs_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component_and_update_defs_file(
+            component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
                 "attributes": {
@@ -62,8 +62,12 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
                         }
                     ],
                 },
-            }
-        ) as (component, defs):
+            },
+        )
+        execute_path = component_path / "op_name.py"
+        copy_code_to_file(code_to_copy, execute_path)
+
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
             assert isinstance(component, dg.PythonScriptComponent)
             assert isinstance(component.execution, ScriptSpec)
             assets_def = defs.get_assets_def("asset")
@@ -76,8 +80,9 @@ def test_pipes_subprocess_script_with_custom_materialize_result() -> None:
 
 
 def test_pipes_subprocess_script_with_name_override() -> None:
-    with scaffold_defs_sandbox(component_cls=PythonScriptComponent) as sandbox:
-        with sandbox.load(
+    with scaffold_defs_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component_and_update_defs_file(
+            component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
                 "attributes": {
@@ -91,8 +96,9 @@ def test_pipes_subprocess_script_with_name_override() -> None:
                         }
                     ],
                 },
-            }
-        ) as (component, defs):
+            },
+        )
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
             assert defs.get_assets_def("asset").op.name == "op_name_override"
 
 
@@ -108,17 +114,16 @@ def test_pipes_subprocess_script_with_checks_only() -> None:
                     passed=True,
                 )
 
-    with scaffold_defs_sandbox(component_cls=PythonScriptComponent) as sandbox:
-        execute_path = sandbox.defs_folder_path / "only_checks.py"
-        copy_code_to_file(code_to_copy, execute_path)
-
-        with sandbox.load(
+    with scaffold_defs_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component_and_update_defs_file(
+            component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
                 "attributes": {
                     "execution": {
                         "path": "only_checks.py",
                     },
+                    "assets": [],
                     "checks": [
                         {
                             "asset": "asset",
@@ -126,12 +131,18 @@ def test_pipes_subprocess_script_with_checks_only() -> None:
                         }
                     ],
                 },
-            }
-        ) as (component, defs):
+            },
+        )
+        execute_path = component_path / "only_checks.py"
+        copy_code_to_file(code_to_copy, execute_path)
+
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
             assert isinstance(component, dg.PythonScriptComponent)
             assert isinstance(component.execution, ScriptSpec)
             asset_check_key = dg.AssetCheckKey(dg.AssetKey("asset"), "check_name")
-            check_def = defs.get_asset_checks_def(asset_check_key)
+            asset_check_key = dg.AssetCheckKey(dg.AssetKey("asset"), "check_name")
+            # The definition is created as a checks definition, access it directly
+            check_def = defs.asset_checks[0]
             result = dg.materialize([check_def], selection=AssetSelection.all_asset_checks())
             assert result.success
             assert check_def.op.name == "only_checks"
@@ -160,12 +171,9 @@ def test_pipes_subprocess_with_args() -> None:
         def arg_list():
             return ["arg_value"]
 
-    with scaffold_defs_sandbox(component_cls=PythonScriptComponent) as sandbox:
-        execute_path = sandbox.defs_folder_path / "op_name.py"
-        copy_code_to_file(op_name_contents, execute_path)
-        template_vars_path = sandbox.defs_folder_path / "template_vars.py"
-        copy_code_to_file(template_vars_content, template_vars_path)
-        with sandbox.load(
+    with scaffold_defs_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component_and_update_defs_file(
+            component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
                 "attributes": {
@@ -180,8 +188,14 @@ def test_pipes_subprocess_with_args() -> None:
                     ],
                 },
                 "template_vars_module": ".template_vars",
-            }
-        ) as (component, defs):
+            },
+        )
+        execute_path = component_path / "op_name.py"
+        copy_code_to_file(op_name_contents, execute_path)
+        template_vars_path = component_path / "template_vars.py"
+        copy_code_to_file(template_vars_content, template_vars_path)
+        
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
             assert isinstance(component, dg.PythonScriptComponent)
             assert isinstance(component.execution, ScriptSpec)
             assert component.execution.args == ["arg_value"]
@@ -203,10 +217,9 @@ def test_pipes_subprocess_with_inline_str() -> None:
             with open_dagster_pipes() as context:
                 context.report_asset_materialization(metadata={"arg": sys.argv[1]})
 
-    with scaffold_defs_sandbox(component_cls=PythonScriptComponent) as sandbox:
-        execute_path = sandbox.defs_folder_path / "op_name.py"
-        copy_code_to_file(op_name_contents, execute_path)
-        with sandbox.load(
+    with scaffold_defs_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component_and_update_defs_file(
+            component_cls=PythonScriptComponent,
             component_body={
                 "type": "dagster.PythonScriptComponent",
                 "attributes": {
@@ -220,8 +233,12 @@ def test_pipes_subprocess_with_inline_str() -> None:
                         }
                     ],
                 },
-            }
-        ) as (component, defs):
+            },
+        )
+        execute_path = component_path / "op_name.py"
+        copy_code_to_file(op_name_contents, execute_path)
+        
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
             assert isinstance(component, dg.PythonScriptComponent)
             assert isinstance(component.execution, ScriptSpec)
             assert component.execution.args == "arg_value"

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
@@ -25,11 +25,9 @@ if __name__ == "__main__":
 
 
 def test_pipes_subprocess_script_hello_world() -> None:
-    with scaffold_defs_sandbox(component_cls=UvRunComponent) as sandbox:
-        execute_path = sandbox.defs_folder_path / "script.py"
-        execute_path.write_text(SCRIPT_CONTENT)
-
-        with sandbox.load(
+    with scaffold_defs_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component_and_update_defs_file(
+            component_cls=UvRunComponent,
             component_body={
                 "type": "dagster.UvRunComponent",
                 "attributes": {
@@ -44,8 +42,12 @@ def test_pipes_subprocess_script_hello_world() -> None:
                         }
                     ],
                 },
-            }
-        ) as (component, defs):
+            },
+        )
+        execute_path = component_path / "script.py"
+        execute_path.write_text(SCRIPT_CONTENT)
+
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
             assert isinstance(component, dg.UvRunComponent)
             assert isinstance(component.execution, ScriptSpec)
             assets_def = defs.get_assets_def("asset")

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
@@ -1,7 +1,7 @@
 import dagster as dg
 from dagster.components.lib.executable_component.script_utils import ScriptSpec
 from dagster.components.lib.executable_component.uv_run_component import UvRunComponent
-from dagster.components.testing import temp_components_sandbox
+from dagster.components.testing import defs_folder_sandbox
 
 SCRIPT_CONTENT = """# /// script
 # dependencies = [
@@ -25,8 +25,8 @@ if __name__ == "__main__":
 
 
 def test_pipes_subprocess_script_hello_world() -> None:
-    with temp_components_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component(
+    with defs_folder_sandbox() as sandbox:
+        defs_path = sandbox.scaffold_component(
             component_cls=UvRunComponent,
             component_body={
                 "type": "dagster.UvRunComponent",
@@ -44,10 +44,10 @@ def test_pipes_subprocess_script_hello_world() -> None:
                 },
             },
         )
-        execute_path = component_path / "script.py"
+        execute_path = defs_path / "script.py"
         execute_path.write_text(SCRIPT_CONTENT)
 
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+        with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
             defs,
         ):

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
@@ -47,7 +47,10 @@ def test_pipes_subprocess_script_hello_world() -> None:
         execute_path = component_path / "script.py"
         execute_path.write_text(SCRIPT_CONTENT)
 
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (component, defs):
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+            component,
+            defs,
+        ):
             assert isinstance(component, dg.UvRunComponent)
             assert isinstance(component.execution, ScriptSpec)
             assets_def = defs.get_assets_def("asset")

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
@@ -1,7 +1,7 @@
 import dagster as dg
 from dagster.components.lib.executable_component.script_utils import ScriptSpec
 from dagster.components.lib.executable_component.uv_run_component import UvRunComponent
-from dagster.components.testing import defs_folder_sandbox
+from dagster.components.testing import create_defs_folder_sandbox
 
 SCRIPT_CONTENT = """# /// script
 # dependencies = [
@@ -25,7 +25,7 @@ if __name__ == "__main__":
 
 
 def test_pipes_subprocess_script_hello_world() -> None:
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=UvRunComponent,
             component_body={

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
@@ -1,7 +1,7 @@
 import dagster as dg
 from dagster.components.lib.executable_component.script_utils import ScriptSpec
 from dagster.components.lib.executable_component.uv_run_component import UvRunComponent
-from dagster.components.testing import scaffold_defs_sandbox
+from dagster.components.testing import temp_components_sandbox
 
 SCRIPT_CONTENT = """# /// script
 # dependencies = [
@@ -25,8 +25,8 @@ if __name__ == "__main__":
 
 
 def test_pipes_subprocess_script_hello_world() -> None:
-    with scaffold_defs_sandbox() as sandbox:
-        component_path = sandbox.scaffold_component_and_update_defs_file(
+    with temp_components_sandbox() as sandbox:
+        component_path = sandbox.scaffold_component(
             component_cls=UvRunComponent,
             component_body={
                 "type": "dagster.UvRunComponent",

--- a/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/executable_component_tests/test_uv_run_component.py
@@ -28,7 +28,7 @@ def test_pipes_subprocess_script_hello_world() -> None:
     with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=UvRunComponent,
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster.UvRunComponent",
                 "attributes": {
                     "execution": {

--- a/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
+++ b/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
@@ -4,19 +4,15 @@ from dagster.components.lib.executable_component.function_component import (
     FunctionComponent,
     FunctionSpec,
 )
-from dagster.components.testing import (
-    copy_code_to_file,
-    scaffold_defs_sandbox,
-    temp_components_sandbox,
-)
+from dagster.components.testing import copy_code_to_file, defs_folder_sandbox, scaffold_defs_sandbox
 
 
 def test_temp_sandbox() -> None:
-    with temp_components_sandbox(
+    with defs_folder_sandbox(
         project_name="nested_component_project",
     ) as sandbox:
-        component_path = sandbox.scaffold_component(
-            component_path="function_component",
+        defs_path = sandbox.scaffold_component(
+            defs_path="function_component",
             component_cls=FunctionComponent,
             component_body={
                 "type": "dagster.FunctionComponent",
@@ -40,9 +36,9 @@ def test_temp_sandbox() -> None:
             def execute_fn(context) -> dg.MaterializeResult:
                 return dg.MaterializeResult()
 
-        copy_code_to_file(code_to_copy, component_path / "execute.py")
+        copy_code_to_file(code_to_copy, defs_path / "execute.py")
 
-        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+        with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
             defs,
         ):

--- a/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
+++ b/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
@@ -1,4 +1,5 @@
 import dagster as dg
+from dagster._core.definitions.asset_key import AssetKey
 from dagster.components.lib.executable_component.function_component import (
     FunctionComponent,
     FunctionSpec,
@@ -8,26 +9,17 @@ from dagster.components.testing import copy_code_to_file, scaffold_defs_sandbox
 
 def test_nested_component() -> None:
     with scaffold_defs_sandbox(
-        component_cls=FunctionComponent,
-        component_path="parent_folder/nested_component",
         project_name="nested_component_project",
     ) as sandbox:
-
-        def code_to_copy() -> None:
-            import dagster as dg
-
-            def execute_fn(context) -> dg.MaterializeResult:
-                return dg.MaterializeResult()
-
-        copy_code_to_file(code_to_copy, sandbox.defs_folder_path / "execute.py")
-
-        with sandbox.load(
+        component_path = sandbox.scaffold_component_and_update_defs_file(
+            component_path="function_component",
+            component_cls=FunctionComponent,
             component_body={
                 "type": "dagster.FunctionComponent",
                 "attributes": {
                     "execution": {
                         "name": "nested_component",
-                        "fn": ".execute.execute_fn",
+                        "fn": ".function_component.execute.execute_fn",
                     },
                     "assets": [
                         {
@@ -36,7 +28,21 @@ def test_nested_component() -> None:
                     ],
                 },
             },
-        ) as (component, defs):
+        )
+
+        def code_to_copy() -> None:
+            import dagster as dg
+
+            def execute_fn(context) -> dg.MaterializeResult:
+                return dg.MaterializeResult()
+
+        copy_code_to_file(code_to_copy, component_path / "execute.py")
+
+        with sandbox.load_component_and_build_defs_at_path(component_path=component_path) as (
+            component,
+            defs,
+        ):
             assert isinstance(component, dg.FunctionComponent)
             assert isinstance(component.execution, FunctionSpec)
             assert component.execution.name == "nested_component"
+            assert defs.resolve_all_asset_keys() == [AssetKey("asset1")]

--- a/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
+++ b/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
@@ -4,11 +4,15 @@ from dagster.components.lib.executable_component.function_component import (
     FunctionComponent,
     FunctionSpec,
 )
-from dagster.components.testing import copy_code_to_file, defs_folder_sandbox, scaffold_defs_sandbox
+from dagster.components.testing import (
+    copy_code_to_file,
+    create_defs_folder_sandbox,
+    scaffold_defs_sandbox,
+)
 
 
 def test_temp_sandbox() -> None:
-    with defs_folder_sandbox(
+    with create_defs_folder_sandbox(
         project_name="nested_component_project",
     ) as sandbox:
         defs_path = sandbox.scaffold_component(

--- a/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
+++ b/python_modules/dagster/dagster_tests/components_tests/testing_tests/test_defs_sandbox.py
@@ -18,7 +18,7 @@ def test_temp_sandbox() -> None:
         defs_path = sandbox.scaffold_component(
             defs_path="function_component",
             component_cls=FunctionComponent,
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster.FunctionComponent",
                 "attributes": {
                     "execution": {

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
@@ -48,12 +48,12 @@ def setup_airbyte_ready_project() -> Iterator[None]:
 
 @contextmanager
 def setup_airbyte_component(
-    component_body: dict[str, Any],
+    defs_yaml_contents: dict[str, Any],
 ) -> Iterator[tuple[AirbyteCloudWorkspaceComponent, Definitions]]:
     """Sets up a components project with an airbyte component based on provided params."""
     with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
-            component_cls=AirbyteCloudWorkspaceComponent, component_body=component_body
+            component_cls=AirbyteCloudWorkspaceComponent, defs_yaml_contents=defs_yaml_contents
         )
         with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
@@ -87,7 +87,7 @@ def test_basic_component_load(
             }
         ),
         setup_airbyte_component(
-            component_body=BASIC_AIRBYTE_COMPONENT_BODY,
+            defs_yaml_contents=BASIC_AIRBYTE_COMPONENT_BODY,
         ) as (
             component,
             defs,
@@ -128,7 +128,7 @@ def test_basic_component_filter(
             }
         ),
         setup_airbyte_component(
-            component_body=deep_merge_dicts(
+            defs_yaml_contents=deep_merge_dicts(
                 BASIC_AIRBYTE_COMPONENT_BODY,
                 {"attributes": {"connection_selector": connection_selector}},
             ),
@@ -189,7 +189,7 @@ class TestAirbyteTranslation(TestTranslation):
                 }
             ),
             setup_airbyte_component(
-                component_body=body,
+                defs_yaml_contents=body,
             ) as (
                 component,
                 defs,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
@@ -15,7 +15,7 @@ from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
 from dagster._utils.env import environ
 from dagster.components.core.tree import ComponentTree
-from dagster.components.testing import TestTranslation, defs_folder_sandbox
+from dagster.components.testing import TestTranslation, create_defs_folder_sandbox
 from dagster_airbyte.components.workspace_component.component import AirbyteCloudWorkspaceComponent
 from dagster_airbyte.resources import AirbyteCloudWorkspace
 from dagster_airbyte.translator import AirbyteConnection
@@ -51,7 +51,7 @@ def setup_airbyte_component(
     component_body: dict[str, Any],
 ) -> Iterator[tuple[AirbyteCloudWorkspaceComponent, Definitions]]:
     """Sets up a components project with an airbyte component based on provided params."""
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=AirbyteCloudWorkspaceComponent, component_body=component_body
         )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
@@ -15,7 +15,7 @@ from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
 from dagster._utils.env import environ
 from dagster.components.core.tree import ComponentTree
-from dagster.components.testing import TestTranslation, temp_components_sandbox
+from dagster.components.testing import TestTranslation, defs_folder_sandbox
 from dagster_airbyte.components.workspace_component.component import AirbyteCloudWorkspaceComponent
 from dagster_airbyte.resources import AirbyteCloudWorkspace
 from dagster_airbyte.translator import AirbyteConnection
@@ -51,11 +51,14 @@ def setup_airbyte_component(
     component_body: dict[str, Any],
 ) -> Iterator[tuple[AirbyteCloudWorkspaceComponent, Definitions]]:
     """Sets up a components project with an airbyte component based on provided params."""
-    with temp_components_sandbox() as defs_sandbox:
-        with defs_sandbox.scaffold_load_and_build_component_defs(
-            component_cls=AirbyteCloudWorkspaceComponent,
-            component_body=component_body,
-        ) as (component, defs):
+    with defs_folder_sandbox() as sandbox:
+        defs_path = sandbox.scaffold_component(
+            component_cls=AirbyteCloudWorkspaceComponent, component_body=component_body
+        )
+        with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
+            component,
+            defs,
+        ):
             assert isinstance(component, AirbyteCloudWorkspaceComponent)
             yield component, defs
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
@@ -51,8 +51,11 @@ def setup_airbyte_component(
     component_body: dict[str, Any],
 ) -> Iterator[tuple[AirbyteCloudWorkspaceComponent, Definitions]]:
     """Sets up a components project with an airbyte component based on provided params."""
-    with scaffold_defs_sandbox(component_cls=AirbyteCloudWorkspaceComponent) as defs_sandbox:
-        with defs_sandbox.load(component_body=component_body) as (component, defs):
+    with scaffold_defs_sandbox() as defs_sandbox:
+        with defs_sandbox.scaffold_load_and_build_defs(
+            component_cls=AirbyteCloudWorkspaceComponent,
+            component_body=component_body,
+        ) as (component, defs):
             assert isinstance(component, AirbyteCloudWorkspaceComponent)
             yield component, defs
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
@@ -15,7 +15,7 @@ from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
 from dagster._utils.env import environ
 from dagster.components.core.tree import ComponentTree
-from dagster.components.testing import TestTranslation, scaffold_defs_sandbox
+from dagster.components.testing import TestTranslation, temp_components_sandbox
 from dagster_airbyte.components.workspace_component.component import AirbyteCloudWorkspaceComponent
 from dagster_airbyte.resources import AirbyteCloudWorkspace
 from dagster_airbyte.translator import AirbyteConnection
@@ -51,8 +51,8 @@ def setup_airbyte_component(
     component_body: dict[str, Any],
 ) -> Iterator[tuple[AirbyteCloudWorkspaceComponent, Definitions]]:
     """Sets up a components project with an airbyte component based on provided params."""
-    with scaffold_defs_sandbox() as defs_sandbox:
-        with defs_sandbox.scaffold_load_and_build_defs(
+    with temp_components_sandbox() as defs_sandbox:
+        with defs_sandbox.scaffold_load_and_build_component_defs(
             component_cls=AirbyteCloudWorkspaceComponent,
             component_body=component_body,
         ) as (component, defs):

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/env.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/env.py
@@ -28,13 +28,13 @@ def get_project_specified_env_vars(dg_context: DgContext) -> Mapping[str, Sequen
     env_vars = defaultdict(list)
 
     for component_dir in dg_context.defs_path.rglob("*"):
-        component_path = component_dir / "defs.yaml"
+        defs_path = component_dir / "defs.yaml"
 
-        if component_path.exists():
-            text = component_path.read_text()
+        if defs_path.exists():
+            text = defs_path.read_text()
             try:
                 component_doc_trees = parse_yamls_with_source_position(
-                    text, filename=str(component_path)
+                    text, filename=str(defs_path)
                 )
             except ScannerError:
                 continue
@@ -42,7 +42,7 @@ def get_project_specified_env_vars(dg_context: DgContext) -> Mapping[str, Sequen
             for component_doc_tree in component_doc_trees:
                 specified_env_var_deps = get_specified_env_var_deps(component_doc_tree.value)
                 for key in specified_env_var_deps:
-                    env_vars[key].append(component_path.relative_to(dg_context.defs_path).parent)
+                    env_vars[key].append(defs_path.relative_to(dg_context.defs_path).parent)
     return env_vars
 
 

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -38,7 +38,7 @@ def dlt_init(source: str, dest: str) -> None:
 @contextmanager
 def setup_dlt_component(
     load_py_contents: Callable,
-    component_body: dict[str, Any],
+    defs_yaml_contents: dict[str, Any],
     setup_dlt_sources: Callable,
     project_name: Optional[str] = None,
 ) -> Iterator[tuple[DltLoadCollectionComponent, Definitions]]:
@@ -49,7 +49,7 @@ def setup_dlt_component(
         defs_path = defs_sandbox.scaffold_component(
             component_cls=DltLoadCollectionComponent,
             defs_path="ingest",
-            component_body=component_body,
+            defs_yaml_contents=defs_yaml_contents,
         )
         with pushd(str(defs_path)):
             setup_dlt_sources()
@@ -99,7 +99,7 @@ def test_basic_component_load() -> None:
         environ({"SOURCES__ACCESS_TOKEN": "fake"}),
         setup_dlt_component(
             load_py_contents=github_load,
-            component_body=BASIC_GITHUB_COMPONENT_BODY,
+            defs_yaml_contents=BASIC_GITHUB_COMPONENT_BODY,
             setup_dlt_sources=lambda: dlt_init("github", "snowflake"),
         ) as (
             component,
@@ -133,7 +133,7 @@ def test_component_load_abs_path_load_py() -> None:
         environ({"SOURCES__ACCESS_TOKEN": "fake"}),
         setup_dlt_component(
             load_py_contents=github_load,
-            component_body=GITHUB_COMPONENT_BODY_WITH_ABSOLUTE_PATH,
+            defs_yaml_contents=GITHUB_COMPONENT_BODY_WITH_ABSOLUTE_PATH,
             setup_dlt_sources=lambda: dlt_init("github", "snowflake"),
             project_name="foo_bar",
         ) as (
@@ -192,7 +192,7 @@ def test_component_load_multiple_pipelines() -> None:
         environ({"SOURCES__ACCESS_TOKEN": "fake"}),
         setup_dlt_component(
             load_py_contents=github_load_multiple_pipelines,
-            component_body=MULTIPLE_GITHUB_COMPONENT_BODY,
+            defs_yaml_contents=MULTIPLE_GITHUB_COMPONENT_BODY,
             setup_dlt_sources=lambda: dlt_init("github", "snowflake"),
         ) as (
             component,
@@ -224,7 +224,7 @@ class TestDltTranslation(TestTranslationBatched):
             environ({"SOURCES__ACCESS_TOKEN": "fake"}),
             setup_dlt_component(
                 load_py_contents=github_load,
-                component_body=body,
+                defs_yaml_contents=body,
                 setup_dlt_sources=lambda: dlt_init("github", "snowflake"),
             ) as (
                 component,

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -17,7 +17,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils import pushd
 from dagster._utils.env import environ
 from dagster.components.core.tree import ComponentTree
-from dagster.components.testing import TestTranslationBatched, defs_folder_sandbox
+from dagster.components.testing import TestTranslationBatched, create_defs_folder_sandbox
 from dagster_dlt import DagsterDltResource, DltLoadCollectionComponent
 from dagster_dlt.components.dlt_load_collection.component import DltLoadSpecModel
 
@@ -43,7 +43,7 @@ def setup_dlt_component(
     project_name: Optional[str] = None,
 ) -> Iterator[tuple[DltLoadCollectionComponent, Definitions]]:
     """Sets up a components project with a dlt component based on provided params."""
-    with defs_folder_sandbox(
+    with create_defs_folder_sandbox(
         project_name=project_name,
     ) as defs_sandbox:
         defs_path = defs_sandbox.scaffold_component(
@@ -259,7 +259,7 @@ def test_python_interface(dlt_pipeline: Pipeline):
 
 
 def test_scaffold_bare_component() -> None:
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(component_cls=DltLoadCollectionComponent)
         assert defs_path.exists()
         assert (defs_path / "defs.yaml").exists()
@@ -286,7 +286,7 @@ def test_scaffold_bare_component() -> None:
 )
 def test_scaffold_component_with_source_and_destination(source: str, destination: str) -> None:
     with (
-        defs_folder_sandbox() as sandbox,
+        create_defs_folder_sandbox() as sandbox,
         environ({"SOURCES__ACCESS_TOKEN": "fake"}),
     ):
         defs_path = sandbox.scaffold_component(

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -17,7 +17,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils import pushd
 from dagster._utils.env import environ
 from dagster.components.core.tree import ComponentTree
-from dagster.components.testing import TestTranslationBatched, scaffold_defs_sandbox
+from dagster.components.testing import TestTranslationBatched, temp_components_sandbox
 from dagster_dlt import DagsterDltResource, DltLoadCollectionComponent
 from dagster_dlt.components.dlt_load_collection.component import DltLoadSpecModel
 
@@ -43,10 +43,10 @@ def setup_dlt_component(
     project_name: Optional[str] = None,
 ) -> Iterator[tuple[DltLoadCollectionComponent, Definitions]]:
     """Sets up a components project with a dlt component based on provided params."""
-    with scaffold_defs_sandbox(
+    with temp_components_sandbox(
         project_name=project_name,
     ) as defs_sandbox:
-        component_path = defs_sandbox.scaffold_component_and_update_defs_file(
+        component_path = defs_sandbox.scaffold_component(
             component_cls=DltLoadCollectionComponent,
             component_path="ingest",
             component_body=component_body,
@@ -259,7 +259,7 @@ def test_python_interface(dlt_pipeline: Pipeline):
 
 
 def test_scaffold_bare_component() -> None:
-    with scaffold_defs_sandbox() as defs_sandbox:
+    with temp_components_sandbox() as defs_sandbox:
         component_path = defs_sandbox.scaffold_component(component_cls=DltLoadCollectionComponent)
         assert component_path.exists()
         assert (component_path / "defs.yaml").exists()
@@ -286,7 +286,7 @@ def test_scaffold_bare_component() -> None:
 )
 def test_scaffold_component_with_source_and_destination(source: str, destination: str) -> None:
     with (
-        scaffold_defs_sandbox() as defs_sandbox,
+        temp_components_sandbox() as defs_sandbox,
         environ({"SOURCES__ACCESS_TOKEN": "fake"}),
     ):
         component_path = defs_sandbox.scaffold_component(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -217,16 +217,17 @@ class TestFivetranTranslation(TestTranslation):
 )
 def test_scaffold_component_with_params(scaffold_params: dict):
     with create_defs_folder_sandbox() as sandbox:
-        with sandbox.scaffold_component(
+        defs_path = sandbox.scaffold_component(
             component_cls=FivetranAccountComponent,
             scaffold_params=scaffold_params,
-        ) as defs_path:
-            defs_yaml_path = defs_path / "defs.yaml"
-            assert defs_yaml_path.exists()
-            assert {
-                k: v
-                for k, v in yaml.safe_load(defs_yaml_path.read_text())["attributes"][
-                    "workspace"
-                ].items()
-                if v is not None
-            } == scaffold_params
+        )
+
+        defs_yaml_path = defs_path / "defs.yaml"
+        assert defs_yaml_path.exists()
+        assert {
+            k: v
+            for k, v in yaml.safe_load(defs_yaml_path.read_text())["attributes"][
+                "workspace"
+            ].items()
+            if v is not None
+        } == scaffold_params

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils.env import environ
 from dagster.components.core.tree import ComponentTree
-from dagster.components.testing import TestTranslation, defs_folder_sandbox
+from dagster.components.testing import TestTranslation, create_defs_folder_sandbox
 from dagster_fivetran.components.workspace_component.component import FivetranAccountComponent
 from dagster_fivetran.resources import FivetranWorkspace
 from dagster_fivetran.translator import FivetranConnector
@@ -36,7 +36,7 @@ def setup_fivetran_component(
     component_body: dict[str, Any],
 ) -> Iterator[tuple[FivetranAccountComponent, Definitions]]:
     """Sets up a components project with a fivetran component based on provided params."""
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=FivetranAccountComponent,
             component_body=component_body,
@@ -216,7 +216,7 @@ class TestFivetranTranslation(TestTranslation):
     ids=["no_params", "all_params", "just_account_id", "just_credentials"],
 )
 def test_scaffold_component_with_params(scaffold_params: dict):
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         with sandbox.scaffold_component(
             component_cls=FivetranAccountComponent,
             scaffold_params=scaffold_params,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -33,13 +33,13 @@ from dagster_fivetran_tests.conftest import (
 
 @contextmanager
 def setup_fivetran_component(
-    component_body: dict[str, Any],
+    defs_yaml_contents: dict[str, Any],
 ) -> Iterator[tuple[FivetranAccountComponent, Definitions]]:
     """Sets up a components project with a fivetran component based on provided params."""
     with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=FivetranAccountComponent,
-            component_body=component_body,
+            defs_yaml_contents=defs_yaml_contents,
         )
         with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
@@ -73,7 +73,7 @@ def test_basic_component_load(
             }
         ),
         setup_fivetran_component(
-            component_body=BASIC_FIVETRAN_COMPONENT_BODY,
+            defs_yaml_contents=BASIC_FIVETRAN_COMPONENT_BODY,
         ) as (
             component,
             defs,
@@ -128,7 +128,7 @@ def test_basic_component_filter(
             }
         ),
         setup_fivetran_component(
-            component_body=deep_merge_dicts(
+            defs_yaml_contents=deep_merge_dicts(
                 BASIC_FIVETRAN_COMPONENT_BODY,
                 {"attributes": {"connector_selector": connector_selector}},
             ),
@@ -191,7 +191,7 @@ class TestFivetranTranslation(TestTranslation):
                 }
             ),
             setup_fivetran_component(
-                component_body=body,
+                defs_yaml_contents=body,
             ) as (
                 component,
                 defs,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -36,10 +36,11 @@ def setup_fivetran_component(
     component_body: dict[str, Any],
 ) -> Iterator[tuple[FivetranAccountComponent, Definitions]]:
     """Sets up a components project with a fivetran component based on provided params."""
-    with scaffold_defs_sandbox(
-        component_cls=FivetranAccountComponent,
-    ) as defs_sandbox:
-        with defs_sandbox.load(component_body=component_body) as (component, defs):
+    with scaffold_defs_sandbox() as defs_sandbox:
+        with defs_sandbox.scaffold_load_and_build_defs(
+            component_cls=FivetranAccountComponent,
+            component_body=component_body,
+        ) as (component, defs):
             assert isinstance(component, FivetranAccountComponent)
             yield component, defs
 
@@ -211,16 +212,17 @@ class TestFivetranTranslation(TestTranslation):
     ids=["no_params", "all_params", "just_account_id", "just_credentials"],
 )
 def test_scaffold_component_with_params(scaffold_params: dict):
-    with scaffold_defs_sandbox(
-        component_cls=FivetranAccountComponent,
-        scaffold_params=scaffold_params,
-    ) as instance_folder:
-        defs_yaml_path = instance_folder.defs_folder_path / "defs.yaml"
-        assert defs_yaml_path.exists()
-        assert {
-            k: v
-            for k, v in yaml.safe_load(defs_yaml_path.read_text())["attributes"][
-                "workspace"
-            ].items()
-            if v is not None
-        } == scaffold_params
+    with scaffold_defs_sandbox() as defs_sandbox:
+        with defs_sandbox.scaffold_component(
+            component_cls=FivetranAccountComponent,
+            scaffold_params=scaffold_params,
+        ) as component_path:
+            defs_yaml_path = component_path / "defs.yaml"
+            assert defs_yaml_path.exists()
+            assert {
+                k: v
+                for k, v in yaml.safe_load(defs_yaml_path.read_text())["attributes"][
+                    "workspace"
+                ].items()
+                if v is not None
+            } == scaffold_params

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils.env import environ
 from dagster.components.core.tree import ComponentTree
-from dagster.components.testing import TestTranslation, scaffold_defs_sandbox
+from dagster.components.testing import TestTranslation, temp_components_sandbox
 from dagster_fivetran.components.workspace_component.component import FivetranAccountComponent
 from dagster_fivetran.resources import FivetranWorkspace
 from dagster_fivetran.translator import FivetranConnector
@@ -36,8 +36,8 @@ def setup_fivetran_component(
     component_body: dict[str, Any],
 ) -> Iterator[tuple[FivetranAccountComponent, Definitions]]:
     """Sets up a components project with a fivetran component based on provided params."""
-    with scaffold_defs_sandbox() as defs_sandbox:
-        with defs_sandbox.scaffold_load_and_build_defs(
+    with temp_components_sandbox() as defs_sandbox:
+        with defs_sandbox.scaffold_load_and_build_component_defs(
             component_cls=FivetranAccountComponent,
             component_body=component_body,
         ) as (component, defs):
@@ -212,7 +212,7 @@ class TestFivetranTranslation(TestTranslation):
     ids=["no_params", "all_params", "just_account_id", "just_credentials"],
 )
 def test_scaffold_component_with_params(scaffold_params: dict):
-    with scaffold_defs_sandbox() as defs_sandbox:
+    with temp_components_sandbox() as defs_sandbox:
         with defs_sandbox.scaffold_component(
             component_cls=FivetranAccountComponent,
             scaffold_params=scaffold_params,

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
@@ -11,7 +11,7 @@ from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
-from dagster.components.testing import scaffold_defs_sandbox
+from dagster.components.testing import temp_components_sandbox
 from dagster_dg_core.utils import ensure_dagster_dg_tests_import
 from dagster_powerbi import PowerBIWorkspaceComponent
 
@@ -36,8 +36,8 @@ def setup_powerbi_component(
     component_body: dict[str, Any],
 ) -> Iterator[tuple[PowerBIWorkspaceComponent, Definitions]]:
     """Sets up a components project with a powerbi component based on provided params."""
-    with scaffold_defs_sandbox() as defs_sandbox:
-        with defs_sandbox.scaffold_load_and_build_defs(
+    with temp_components_sandbox() as defs_sandbox:
+        with defs_sandbox.scaffold_load_and_build_component_defs(
             component_cls=PowerBIWorkspaceComponent,
             component_body=component_body,
         ) as (

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
@@ -11,7 +11,7 @@ from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
-from dagster.components.testing import defs_folder_sandbox
+from dagster.components.testing import create_defs_folder_sandbox
 from dagster_dg_core.utils import ensure_dagster_dg_tests_import
 from dagster_powerbi import PowerBIWorkspaceComponent
 
@@ -36,7 +36,7 @@ def setup_powerbi_component(
     component_body: dict[str, Any],
 ) -> Iterator[tuple[PowerBIWorkspaceComponent, Definitions]]:
     """Sets up a components project with a powerbi component based on provided params."""
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PowerBIWorkspaceComponent,
             component_body=component_body,

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
@@ -36,10 +36,14 @@ def setup_powerbi_component(
     component_body: dict[str, Any],
 ) -> Iterator[tuple[PowerBIWorkspaceComponent, Definitions]]:
     """Sets up a components project with a powerbi component based on provided params."""
-    with scaffold_defs_sandbox(
-        component_cls=PowerBIWorkspaceComponent,
-    ) as defs_sandbox:
-        with defs_sandbox.load(component_body=component_body) as (component, defs):
+    with scaffold_defs_sandbox() as defs_sandbox:
+        with defs_sandbox.scaffold_load_and_build_defs(
+            component_cls=PowerBIWorkspaceComponent,
+            component_body=component_body,
+        ) as (
+            component,
+            defs,
+        ):
             assert isinstance(component, PowerBIWorkspaceComponent)
             yield component, defs
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
@@ -33,13 +33,13 @@ def setup_powerbi_ready_project() -> Iterator[None]:
 
 @contextmanager
 def setup_powerbi_component(
-    component_body: dict[str, Any],
+    defs_yaml_contents: dict[str, Any],
 ) -> Iterator[tuple[PowerBIWorkspaceComponent, Definitions]]:
     """Sets up a components project with a powerbi component based on provided params."""
     with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=PowerBIWorkspaceComponent,
-            component_body=component_body,
+            defs_yaml_contents=defs_yaml_contents,
         )
         with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
@@ -67,7 +67,7 @@ def test_basic_component_load(
 ) -> None:
     with (
         setup_powerbi_component(
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster_powerbi.PowerBIWorkspaceComponent",
                 "attributes": {
                     "workspace": {
@@ -196,7 +196,7 @@ def test_translation(
         body["attributes"]["translation"] = attributes
         with (
             setup_powerbi_component(
-                component_body=body,
+                defs_yaml_contents=body,
             ) as (
                 component,
                 defs,
@@ -249,7 +249,7 @@ def test_per_content_type_translation(
     }
     with (
         setup_powerbi_component(
-            component_body=body,
+            defs_yaml_contents=body,
         ) as (
             component,
             defs,

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
@@ -11,7 +11,7 @@ from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
-from dagster.components.testing import temp_components_sandbox
+from dagster.components.testing import defs_folder_sandbox
 from dagster_dg_core.utils import ensure_dagster_dg_tests_import
 from dagster_powerbi import PowerBIWorkspaceComponent
 
@@ -36,11 +36,12 @@ def setup_powerbi_component(
     component_body: dict[str, Any],
 ) -> Iterator[tuple[PowerBIWorkspaceComponent, Definitions]]:
     """Sets up a components project with a powerbi component based on provided params."""
-    with temp_components_sandbox() as defs_sandbox:
-        with defs_sandbox.scaffold_load_and_build_component_defs(
+    with defs_folder_sandbox() as sandbox:
+        defs_path = sandbox.scaffold_component(
             component_cls=PowerBIWorkspaceComponent,
             component_body=component_body,
-        ) as (
+        )
+        with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,
             defs,
         ):

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -152,7 +152,7 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
     [Sling](https://slingdata.io/) is a Powerful Data Integration tool enabling seamless ELT
     operations as well as quality checks across files, databases, and storage systems.
 
-    dg scaffold dagster_sling.SlingReplicationCollectionComponent {component_path} to get started.
+    dg scaffold dagster_sling.SlingReplicationCollectionComponent {defs_path} to get started.
 
     This will create a defs.yaml as well as a `replication.yaml` which is a Sling-specific configuration
     file. See Sling's [documentation](https://docs.slingdata.io/concepts/replication#overview) on `replication.yaml`.

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -23,7 +23,11 @@ from dagster._core.instance_for_test import instance_for_test
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils.env import environ
 from dagster.components.resolved.core_models import AssetAttributesModel, OpSpec
-from dagster.components.testing import TestOpCustomization, TestTranslation, defs_folder_sandbox
+from dagster.components.testing import (
+    TestOpCustomization,
+    TestTranslation,
+    create_defs_folder_sandbox,
+)
 from dagster_shared import check
 from dagster_sling import SlingReplicationCollectionComponent, SlingResource
 from dagster_sling.components.sling_replication_collection.component import (
@@ -60,7 +64,7 @@ def temp_sling_component_instance(
     the proper temp path.
     """
     with (
-        defs_folder_sandbox() as sandbox,
+        create_defs_folder_sandbox() as sandbox,
         environ({"HOME": str(sandbox.defs_folder_path), "SOME_PASSWORD": "password"}),
     ):
         # Copy the entire component structure from the stub location
@@ -245,7 +249,7 @@ class TestSlingTranslation(TestTranslation):
 
 
 def test_scaffold_sling():
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(component_cls=SlingReplicationCollectionComponent)
         assert (defs_path / "defs.yaml").exists()
         assert (defs_path / "replication.yaml").exists()
@@ -267,7 +271,7 @@ def test_spec_is_available_in_scope() -> None:
 
 
 def test_asset_post_processors_deprecation_error() -> None:
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(component_cls=SlingReplicationCollectionComponent)
         with environ({"HOME": str(defs_path), "SOME_PASSWORD": "password"}):
             shutil.copytree(

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -23,7 +23,7 @@ from dagster._core.instance_for_test import instance_for_test
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils.env import environ
 from dagster.components.resolved.core_models import AssetAttributesModel, OpSpec
-from dagster.components.testing import TestOpCustomization, TestTranslation, scaffold_defs_sandbox
+from dagster.components.testing import TestOpCustomization, TestTranslation, temp_components_sandbox
 from dagster_shared import check
 from dagster_sling import SlingReplicationCollectionComponent, SlingResource
 from dagster_sling.components.sling_replication_collection.component import (
@@ -60,7 +60,7 @@ def temp_sling_component_instance(
     the proper temp path.
     """
     with (
-        scaffold_defs_sandbox() as defs_sandbox,
+        temp_components_sandbox() as defs_sandbox,
         environ({"HOME": str(defs_sandbox.defs_folder_path), "SOME_PASSWORD": "password"}),
     ):
         # Copy the entire component structure from the stub location
@@ -245,7 +245,7 @@ class TestSlingTranslation(TestTranslation):
 
 
 def test_scaffold_sling():
-    with scaffold_defs_sandbox() as defs_sandbox:
+    with temp_components_sandbox() as defs_sandbox:
         component_path = defs_sandbox.scaffold_component(
             component_cls=SlingReplicationCollectionComponent
         )
@@ -269,7 +269,7 @@ def test_spec_is_available_in_scope() -> None:
 
 
 def test_asset_post_processors_deprecation_error() -> None:
-    with scaffold_defs_sandbox() as defs_sandbox:
+    with temp_components_sandbox() as defs_sandbox:
         component_path = defs_sandbox.scaffold_component(
             component_cls=SlingReplicationCollectionComponent
         )

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
@@ -9,7 +9,7 @@ from dagster import AssetKey, Definitions
 from dagster._core.definitions.materialize import materialize
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster.components.lib.sql_component.sql_component import SqlComponent, TemplatedSqlComponent
-from dagster.components.testing import defs_folder_sandbox
+from dagster.components.testing import create_defs_folder_sandbox
 from dagster_snowflake.components.sql_component.component import SnowflakeConnectionComponent
 from dagster_snowflake.constants import SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER
 
@@ -22,7 +22,7 @@ def setup_snowflake_component_with_external_connection(
     connection_component_name: str = "sql_connection_component",
 ) -> Iterator[Definitions]:
     """Sets up a components project with a snowflake component using external connection."""
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         sandbox.scaffold_component(
             component_cls=SqlComponent,
             defs_path="sql_execution_component",
@@ -53,7 +53,7 @@ def setup_snowflake_component(
     component_body: dict,
 ) -> Iterator[tuple[TemplatedSqlComponent, Definitions]]:
     """Sets up a components project with a snowflake component based on provided params."""
-    with defs_folder_sandbox() as sandbox:
+    with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=TemplatedSqlComponent,
             component_body=component_body,

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
@@ -26,13 +26,13 @@ def setup_snowflake_component_with_external_connection(
         sandbox.scaffold_component(
             component_cls=SqlComponent,
             defs_path="sql_execution_component",
-            component_body=execution_component_body,
+            defs_yaml_contents=execution_component_body,
         )
 
         sandbox.scaffold_component(
             component_cls=SnowflakeConnectionComponent,
             defs_path=connection_component_name,
-            component_body={
+            defs_yaml_contents={
                 "type": "dagster_snowflake.SnowflakeConnectionComponent",
                 "attributes": {
                     "account": "test_account",
@@ -56,7 +56,7 @@ def setup_snowflake_component(
     with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
             component_cls=TemplatedSqlComponent,
-            component_body=component_body,
+            defs_yaml_contents=component_body,
         )
         with sandbox.load_component_and_build_defs(defs_path=defs_path) as (
             component,


### PR DESCRIPTION
## Summary

Refactor components defs sandbox utils to sit more closely on top of the new `ComponentsTree`. This simplifies the implementation a bit and makes operating on the sandbox feel more akin to operating on the defs tree itself, while enabling multi-component test cases. It also removes any real divergence between the defs sandbox behavior and a real project.

**Docs, before:**

https://docs.dagster.io/guides/build/components/creating-new-components/testing-your-component

**Docs, after:**

https://benpankow-testing-better.archive.dagster-docs.io/guides/build/components/creating-new-components/testing-your-component

## Test Plan

Existing tests.