### PR TITLE
[dagster-databricks] bump databricks sdk version to <0.60

### DIFF
--- a/python_modules/libraries/dagster-databricks/setup.py
+++ b/python_modules/libraries/dagster-databricks/setup.py
@@ -35,7 +35,7 @@ setup(
         f"dagster{pin}",
         f"dagster-pipes{pin}",
         f"dagster-pyspark{pin}",
-        "databricks-sdk>=0.41,<0.48.0",  # dbt-databricks is pinned to this version
+        "databricks-sdk>=0.41,<0.60.0",  # dbt-databricks is pinned to this version
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary & Motivation

We need changes in latest versions of Databricks sdk for our new Databricks Serverless pipes. Bumping up the pin so that we support databricks sdk 0.59.

Tests and pyright checks pass. Most changes to support newer versions of the sdk were done in #31023 3 weeks ago.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
