### PR TITLE
Remove runTimeFragment type from job action menu

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/JobMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/JobMenu.tsx
@@ -8,14 +8,13 @@ import {useMaterializationAction} from '../assets/LaunchAssetExecutionButton';
 import {EXECUTION_PLAN_TO_GRAPH_FRAGMENT} from '../gantt/toGraphQueryItems';
 import {ReexecutionStrategy} from '../graphql/types';
 import {canRunAllSteps, canRunFromFailure} from '../runs/RunActionButtons';
-import {RunTimeFragment} from '../runs/types/RunUtils.types';
 import {useJobReexecution} from '../runs/useJobReExecution';
 import {MenuLink} from '../ui/MenuLink';
 import {RepoAddress} from '../workspace/types';
 import {workspacePipelinePath} from '../workspace/workspacePath';
 
 interface Props {
-  job: {isJob: boolean; name: string; runs: RunTimeFragment[]};
+  job: {isJob: boolean; name: string; runs: {id: string}[]};
   repoAddress: RepoAddress;
   isAssetJob: boolean | 'loading';
 }


### PR DESCRIPTION
## Summary & Motivation
Removes the runTimeFragment type from the job action menu to make the component more reusable. This change allows us to add the action menu to the Failed Jobs list on the new Dagster+ Homepage.