### PR TITLE
Fix issue with PermissiveConfig dot notation #22777 

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -261,6 +261,9 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
                 if key not in model_fields(self.__class__):
                     object.__setattr__(self, key, value)
 
+'''
+This is done to support dot-access for unexpected or undeclared fields.
+'''
         self.__dict__ = ensure_env_vars_set_post_init(self.__dict__, modified_data_by_field_key)
 
     def _convert_to_config_dictionary(self) -> Mapping[str, Any]:

--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -256,6 +256,11 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
             field_key = field_info[0] if field_info else config_key
             modified_data_by_field_key[field_key] = value
 
+        if model_config(self.__class__).get("extra") == "allow":
+            for key, value in modified_data_by_field_key.items():
+                if key not in model_fields(self.__class__):
+                    object.__setattr__(self, key, value)
+
         self.__dict__ = ensure_env_vars_set_post_init(self.__dict__, modified_data_by_field_key)
 
     def _convert_to_config_dictionary(self) -> Mapping[str, Any]:

--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -261,9 +261,7 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
                 if key not in model_fields(self.__class__):
                     object.__setattr__(self, key, value)
 
-'''
-This is done to support dot-access for unexpected or undeclared fields.
-'''
+# This is done to support dot-access for unexpected or undeclared fields.
         self.__dict__ = ensure_env_vars_set_post_init(self.__dict__, modified_data_by_field_key)
 
     def _convert_to_config_dictionary(self) -> Mapping[str, Any]:

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -997,6 +997,8 @@ def test_permissive_extra_field_via_dot():
         foo: int
 
     conf = ExtraConfig(foo=10, bar="hello", baz=[1, 2, 3])
+    conf1 = ExtraConfig(foo=10, bar="hello", baz=[1, 2, 3])
+    assert conf == conf1  
     assert conf.foo == 10
     assert conf.bar == "hello"
     assert conf.baz == [1, 2, 3]

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -991,3 +991,16 @@ def test_aliases() -> None:
     d = {"test": "test"}
     result = echo_job.execute_in_process(resources={"my_resource": ConfigWithAlias(alias_name=d)})
     assert result.output_for_node("echo_config") == d
+
+def test_permissive_extra_field_via_dot():
+    class ExtraConfig(PermissiveConfig):
+        foo: int
+
+    conf = ExtraConfig(foo=10, bar="hello", baz=[1, 2, 3])
+    assert conf.foo == 10
+    assert conf.bar == "hello"
+    assert conf.baz == [1, 2, 3]
+    # confirm it’s in dict and convert_to_config_dictionary
+    expected = {"foo": 10, "bar": "hello", "baz": [1, 2, 3]}
+    assert conf.dict() == expected
+    assert conf._convert_to_config_dictionary() == expected


### PR DESCRIPTION
Fix issue with PermissiveConfig dot notation by parsing edge cases of extra fields as attributes to the config instantiation.
Co-author: @BoLiuV5
Original issue 22777 dev: @arookieds 
Linked in dev: @alangenfeld

Related Issue: #22777 
Related upstream Pydantic issue (closed without fix): [pydantic#4617](https://github.com/pydantic/pydantic/issues/4617)

## Summary & Motivation
This PR addresses an edge case in how PermissiveConfig handles extra fields passed via keyword arguments. Under the current implementation, unrecognized fields are stored in __pydantic_extra__ (or accessible via .model_extra or dict(config).get("key")), but are not accessible via dot notation (e.g., config.foo) unless explicitly declared in the model.

This leads to breakages in downstream use cases where developers expect arbitrary config keys to be accessible through attribute-style access—especially in dynamic or plugin-based systems.

While this behavior is consistent with Pydantic's design (to prevent accidental overrides of internal methods/attributes), Dagster's PermissiveConfig is explicitly meant to provide a more flexible experience. This PR adds logic to dynamically assign extra fields as instance attributes only if:

extra="allow" is set, and

The key doesn't already exist as a declared field or method.

## Related Discussion
We reviewed:

[Dagster issue #22777](https://github.com/dagster-io/dagster/issues/22777)

[Pydantic issue #4617](https://github.com/pydantic/pydantic/issues/4617), where upstream maintainers declined to adopt this behavior due to Python’s “explicit is better than implicit” principle.

Given that PermissiveConfig is a custom Dagster utility intended to be more developer-friendly, we believe this tradeoff in favor of convenience and usability is reasonable within this context.

## How I Tested These Changes
An additional test for the functionality of the dot notation was added to the existing tests in the test_pythonic_config_types.py file.
