### PR TITLE
[components testing] Rearrange testing module

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -693,9 +693,8 @@ from dagster.components.scaffold.scaffold import (
     ScaffoldRequest as ScaffoldRequest,
     scaffold_with as scaffold_with,
 )
-from dagster.components.testing import (
+from dagster.components.testing.utils import (
     component_defs as component_defs,
-    defs_from_component_yaml_path as defs_from_component_yaml_path,
     get_all_components_defs_within_project as get_all_components_defs_within_project,
     get_component_defs_within_project as get_component_defs_within_project,
 )

--- a/python_modules/dagster/dagster/components/testing/__init__.py
+++ b/python_modules/dagster/dagster/components/testing/__init__.py
@@ -1,0 +1,16 @@
+from dagster.components.testing.deprecated.utils import (
+    scaffold_defs_sandbox as scaffold_defs_sandbox,
+)
+from dagster.components.testing.test_cases import (
+    TestOpCustomization as TestOpCustomization,
+    TestTranslation as TestTranslation,
+    TestTranslationBatched as TestTranslationBatched,
+)
+from dagster.components.testing.utils import (
+    copy_code_to_file as copy_code_to_file,
+    get_all_components_defs_from_defs_path as get_all_components_defs_from_defs_path,
+    get_module_path as get_module_path,
+    get_original_module_name as get_original_module_name,
+    random_importable_name as random_importable_name,
+    temp_components_sandbox as temp_components_sandbox,
+)

--- a/python_modules/dagster/dagster/components/testing/__init__.py
+++ b/python_modules/dagster/dagster/components/testing/__init__.py
@@ -8,9 +8,9 @@ from dagster.components.testing.test_cases import (
 )
 from dagster.components.testing.utils import (
     copy_code_to_file as copy_code_to_file,
+    create_defs_folder_sandbox as create_defs_folder_sandbox,
     get_all_components_defs_from_defs_path as get_all_components_defs_from_defs_path,
     get_module_path as get_module_path,
     get_original_module_name as get_original_module_name,
     random_importable_name as random_importable_name,
-    temp_components_sandbox as temp_components_sandbox,
 )

--- a/python_modules/dagster/dagster/components/testing/deprecated/utils.py
+++ b/python_modules/dagster/dagster/components/testing/deprecated/utils.py
@@ -80,7 +80,7 @@ class DefsPathSandbox:
 
     @contextmanager
     def load_all(self) -> Iterator[list[tuple[Component, Definitions]]]:
-        from dagster.components.testing import (
+        from dagster.components.testing.utils import (
             get_all_components_defs_from_defs_path,
             get_module_path,
         )
@@ -177,7 +177,7 @@ def scaffold_defs_sandbox(
                 assert isinstance(component, MyComponent)
                 assert defs.get_asset_def("different_asset_key").key == AssetKey("different_asset_key")
     """
-    from dagster.components.testing import get_original_module_name, random_importable_name
+    from dagster.components.testing.utils import get_original_module_name, random_importable_name
 
     project_name = project_name or random_importable_name()
     component_path = component_path or random_importable_name()

--- a/python_modules/dagster/dagster/components/testing/test_cases.py
+++ b/python_modules/dagster/dagster/components/testing/test_cases.py
@@ -1,0 +1,194 @@
+from typing import Callable
+
+from dagster_shared.merger import deep_merge_dicts
+
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
+from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
+
+"""Testing utilities for components."""
+
+from typing import Any, NamedTuple, Optional
+
+# Unfortunate hack - we only use this util in pytest tests, we just drop in a no-op
+# implementation if pytest is not installed.
+try:
+    import pytest  # type: ignore
+except ImportError:
+
+    class pytest:
+        @staticmethod
+        def fixture(*args, **kwargs) -> Callable:
+            def wrapper(fn):
+                return fn
+
+            return wrapper
+
+
+class TranslationTestCase(NamedTuple):
+    name: str
+    attributes: dict[str, Any]
+    assertion: Callable[[AssetSpec], bool]
+    key_modifier: Optional[Callable[[AssetKey], AssetKey]] = None
+
+
+test_cases = [
+    TranslationTestCase(
+        name="group_name",
+        attributes={"group_name": "group"},
+        assertion=lambda asset_spec: asset_spec.group_name == "group",
+    ),
+    TranslationTestCase(
+        name="owners",
+        attributes={"owners": ["team:analytics"]},
+        assertion=lambda asset_spec: asset_spec.owners == ["team:analytics"],
+    ),
+    TranslationTestCase(
+        name="tags",
+        attributes={"tags": {"foo": "bar"}},
+        assertion=lambda asset_spec: asset_spec.tags.get("foo") == "bar",
+    ),
+    TranslationTestCase(
+        name="kinds",
+        attributes={"kinds": ["snowflake", "dbt"]},
+        assertion=lambda asset_spec: "snowflake" in asset_spec.kinds and "dbt" in asset_spec.kinds,
+    ),
+    TranslationTestCase(
+        name="tags-and-kinds",
+        attributes={"tags": {"foo": "bar"}, "kinds": ["snowflake", "dbt"]},
+        assertion=lambda asset_spec: "snowflake" in asset_spec.kinds
+        and "dbt" in asset_spec.kinds
+        and asset_spec.tags.get("foo") == "bar",
+    ),
+    TranslationTestCase(
+        name="code-version",
+        attributes={"code_version": "1"},
+        assertion=lambda asset_spec: asset_spec.code_version == "1",
+    ),
+    TranslationTestCase(
+        name="description",
+        attributes={"description": "some description"},
+        assertion=lambda asset_spec: asset_spec.description == "some description",
+    ),
+    TranslationTestCase(
+        name="metadata",
+        attributes={"metadata": {"foo": "bar"}},
+        assertion=lambda asset_spec: asset_spec.metadata.get("foo") == "bar",
+    ),
+    TranslationTestCase(
+        name="deps",
+        attributes={"deps": ["nonexistent"]},
+        assertion=lambda asset_spec: len(asset_spec.deps) == 1
+        and asset_spec.deps[0].asset_key == AssetKey("nonexistent"),
+    ),
+    TranslationTestCase(
+        name="automation_condition",
+        attributes={"automation_condition": "{{ automation_condition.eager() }}"},
+        assertion=lambda asset_spec: asset_spec.automation_condition is not None,
+    ),
+    TranslationTestCase(
+        name="key",
+        attributes={"key": "{{ spec.key.to_user_string() + '_suffix' }}"},
+        assertion=lambda asset_spec: asset_spec.key.path[-1].endswith("_suffix"),
+        key_modifier=lambda key: AssetKey(path=list(key.path[:-1]) + [f"{key.path[-1]}_suffix"]),
+    ),
+    TranslationTestCase(
+        name="key_prefix",
+        attributes={"key_prefix": "cool_prefix"},
+        assertion=lambda asset_spec: asset_spec.key.has_prefix(["cool_prefix"]),
+        key_modifier=lambda key: AssetKey(path=["cool_prefix"] + list(key.path)),
+    ),
+    TranslationTestCase(
+        name="partitions_defs",
+        attributes={"partitions_def": {"type": "static", "partition_keys": ["foo", "bar"]}},
+        assertion=lambda asset_spec: isinstance(
+            asset_spec.partitions_def, StaticPartitionsDefinition
+        ),
+    ),
+]
+
+
+class TestTranslation:
+    """Pytest test class for testing translation of asset attributes. You can subclass
+    this class and implement a test_translation function using the various fixtures in
+    order to comprehensively test asset translation options for your component.
+    """
+
+    @pytest.fixture(params=test_cases, ids=[case.name for case in test_cases])
+    def translation_test_case(self, request):
+        return request.param
+
+    @pytest.fixture
+    def attributes(self, translation_test_case: TranslationTestCase):
+        return translation_test_case.attributes
+
+    @pytest.fixture
+    def assertion(self, translation_test_case: TranslationTestCase):
+        return translation_test_case.assertion
+
+    @pytest.fixture
+    def key_modifier(self, translation_test_case: TranslationTestCase):
+        return translation_test_case.key_modifier
+
+
+class TestTranslationBatched(TestTranslation):
+    """This version of the TestTranslation class is used to test the translation of
+    asset attributes, applying all customizations in parallel to speed up tests for
+    components which might be expensive to construct.
+    """
+
+    @pytest.fixture()
+    def translation_test_case(self, request):
+        deep_merge_all_attributes = {}
+        for case in test_cases:
+            deep_merge_all_attributes = deep_merge_dicts(deep_merge_all_attributes, case.attributes)
+        merged_assertion = lambda asset_spec: all(case.assertion(asset_spec) for case in test_cases)
+
+        # successively apply key modifiers
+        def _merged_key_modifier(key):
+            for case in test_cases:
+                if case.key_modifier:
+                    key = case.key_modifier(key)
+            return key
+
+        return TranslationTestCase(
+            name="merged",
+            attributes=deep_merge_all_attributes,
+            assertion=merged_assertion,
+            key_modifier=_merged_key_modifier,
+        )
+
+
+class TestOpCustomization:
+    """Pytest test class for testing customization of op spec. You can subclass
+    this class and implement a test_op_customization function using the various fixtures in
+    order to comprehensively test op spec customization options for your component.
+    """
+
+    @pytest.fixture(
+        params=[
+            (
+                {"name": "my_op"},
+                lambda op: op.name == "my_op",
+            ),
+            (
+                {"tags": {"foo": "bar"}},
+                lambda op: op.tags.get("foo") == "bar",
+            ),
+            (
+                {"backfill_policy": {"type": "single_run"}},
+                lambda op: op.backfill_policy.max_partitions_per_run is None,
+            ),
+        ],
+        ids=["name", "tags", "backfill_policy"],
+    )
+    def translation_test_case(self, request):
+        return request.param
+
+    @pytest.fixture
+    def attributes(self, translation_test_case):
+        return translation_test_case[0]
+
+    @pytest.fixture
+    def assertion(self, translation_test_case):
+        return translation_test_case[1]

--- a/python_modules/dagster/dagster/components/testing/utils.py
+++ b/python_modules/dagster/dagster/components/testing/utils.py
@@ -11,11 +11,7 @@ from typing import Callable
 
 import yaml
 from dagster_shared import check
-from dagster_shared.merger import deep_merge_dicts
 
-from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
-from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
 from dagster.components.component_scaffolding import scaffold_object
 from dagster.components.core.tree import ComponentTree
 from dagster.components.scaffold.scaffold import ScaffoldFormatOptions
@@ -26,32 +22,13 @@ import tempfile
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, NamedTuple, Optional, Union
+from typing import Any, Optional, Union
 
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils import alter_sys_path
 from dagster.components.component.component import Component
 from dagster.components.core.context import ComponentLoadContext
-from dagster.components.core.defs_module import (
-    CompositeYamlComponent,
-    get_component,
-    load_yaml_component_from_path,
-)
-from dagster.components.deprecated.testing import scaffold_defs_sandbox as scaffold_defs_sandbox
-
-# Unfortunate hack - we only use this util in pytest tests, we just drop in a no-op
-# implementation if pytest is not installed.
-try:
-    import pytest  # type: ignore
-except ImportError:
-
-    class pytest:
-        @staticmethod
-        def fixture(*args, **kwargs) -> Callable:
-            def wrapper(fn):
-                return fn
-
-            return wrapper
+from dagster.components.core.defs_module import CompositeYamlComponent, get_component
 
 
 def component_defs(
@@ -87,17 +64,6 @@ def component_defs(
     """
     context = context or ComponentTree.for_test().load_context
     return component.build_defs(context).with_resources(resources)
-
-
-def defs_from_component_yaml_path(
-    *,
-    component_yaml: Path,
-    context: Optional[ComponentLoadContext] = None,
-    resources: Optional[dict[str, Any]] = None,
-):
-    context = context or ComponentTree.for_test().load_context
-    component = load_yaml_component_from_path(context=context, component_def_path=component_yaml)
-    return component_defs(component=component, resources=resources, context=context)
 
 
 def get_original_module_name(cls):
@@ -481,172 +447,3 @@ def copy_code_to_file(fn: Callable, file_path: Path) -> None:
     source_code_text = "\n".join(source_code_text.split("\n")[1:])
     dedented_source_code_text = textwrap.dedent(source_code_text)
     file_path.write_text(dedented_source_code_text)
-
-
-class TranslationTestCase(NamedTuple):
-    name: str
-    attributes: dict[str, Any]
-    assertion: Callable[[AssetSpec], bool]
-    key_modifier: Optional[Callable[[AssetKey], AssetKey]] = None
-
-
-test_cases = [
-    TranslationTestCase(
-        name="group_name",
-        attributes={"group_name": "group"},
-        assertion=lambda asset_spec: asset_spec.group_name == "group",
-    ),
-    TranslationTestCase(
-        name="owners",
-        attributes={"owners": ["team:analytics"]},
-        assertion=lambda asset_spec: asset_spec.owners == ["team:analytics"],
-    ),
-    TranslationTestCase(
-        name="tags",
-        attributes={"tags": {"foo": "bar"}},
-        assertion=lambda asset_spec: asset_spec.tags.get("foo") == "bar",
-    ),
-    TranslationTestCase(
-        name="kinds",
-        attributes={"kinds": ["snowflake", "dbt"]},
-        assertion=lambda asset_spec: "snowflake" in asset_spec.kinds and "dbt" in asset_spec.kinds,
-    ),
-    TranslationTestCase(
-        name="tags-and-kinds",
-        attributes={"tags": {"foo": "bar"}, "kinds": ["snowflake", "dbt"]},
-        assertion=lambda asset_spec: "snowflake" in asset_spec.kinds
-        and "dbt" in asset_spec.kinds
-        and asset_spec.tags.get("foo") == "bar",
-    ),
-    TranslationTestCase(
-        name="code-version",
-        attributes={"code_version": "1"},
-        assertion=lambda asset_spec: asset_spec.code_version == "1",
-    ),
-    TranslationTestCase(
-        name="description",
-        attributes={"description": "some description"},
-        assertion=lambda asset_spec: asset_spec.description == "some description",
-    ),
-    TranslationTestCase(
-        name="metadata",
-        attributes={"metadata": {"foo": "bar"}},
-        assertion=lambda asset_spec: asset_spec.metadata.get("foo") == "bar",
-    ),
-    TranslationTestCase(
-        name="deps",
-        attributes={"deps": ["nonexistent"]},
-        assertion=lambda asset_spec: len(asset_spec.deps) == 1
-        and asset_spec.deps[0].asset_key == AssetKey("nonexistent"),
-    ),
-    TranslationTestCase(
-        name="automation_condition",
-        attributes={"automation_condition": "{{ automation_condition.eager() }}"},
-        assertion=lambda asset_spec: asset_spec.automation_condition is not None,
-    ),
-    TranslationTestCase(
-        name="key",
-        attributes={"key": "{{ spec.key.to_user_string() + '_suffix' }}"},
-        assertion=lambda asset_spec: asset_spec.key.path[-1].endswith("_suffix"),
-        key_modifier=lambda key: AssetKey(path=list(key.path[:-1]) + [f"{key.path[-1]}_suffix"]),
-    ),
-    TranslationTestCase(
-        name="key_prefix",
-        attributes={"key_prefix": "cool_prefix"},
-        assertion=lambda asset_spec: asset_spec.key.has_prefix(["cool_prefix"]),
-        key_modifier=lambda key: AssetKey(path=["cool_prefix"] + list(key.path)),
-    ),
-    TranslationTestCase(
-        name="partitions_defs",
-        attributes={"partitions_def": {"type": "static", "partition_keys": ["foo", "bar"]}},
-        assertion=lambda asset_spec: isinstance(
-            asset_spec.partitions_def, StaticPartitionsDefinition
-        ),
-    ),
-]
-
-
-class TestTranslation:
-    """Pytest test class for testing translation of asset attributes. You can subclass
-    this class and implement a test_translation function using the various fixtures in
-    order to comprehensively test asset translation options for your component.
-    """
-
-    @pytest.fixture(params=test_cases, ids=[case.name for case in test_cases])
-    def translation_test_case(self, request):
-        return request.param
-
-    @pytest.fixture
-    def attributes(self, translation_test_case: TranslationTestCase):
-        return translation_test_case.attributes
-
-    @pytest.fixture
-    def assertion(self, translation_test_case: TranslationTestCase):
-        return translation_test_case.assertion
-
-    @pytest.fixture
-    def key_modifier(self, translation_test_case: TranslationTestCase):
-        return translation_test_case.key_modifier
-
-
-class TestTranslationBatched(TestTranslation):
-    """This version of the TestTranslation class is used to test the translation of
-    asset attributes, applying all customizations in parallel to speed up tests for
-    components which might be expensive to construct.
-    """
-
-    @pytest.fixture()
-    def translation_test_case(self, request):
-        deep_merge_all_attributes = {}
-        for case in test_cases:
-            deep_merge_all_attributes = deep_merge_dicts(deep_merge_all_attributes, case.attributes)
-        merged_assertion = lambda asset_spec: all(case.assertion(asset_spec) for case in test_cases)
-
-        # successively apply key modifiers
-        def _merged_key_modifier(key):
-            for case in test_cases:
-                if case.key_modifier:
-                    key = case.key_modifier(key)
-            return key
-
-        return TranslationTestCase(
-            name="merged",
-            attributes=deep_merge_all_attributes,
-            assertion=merged_assertion,
-            key_modifier=_merged_key_modifier,
-        )
-
-
-class TestOpCustomization:
-    """Pytest test class for testing customization of op spec. You can subclass
-    this class and implement a test_op_customization function using the various fixtures in
-    order to comprehensively test op spec customization options for your component.
-    """
-
-    @pytest.fixture(
-        params=[
-            (
-                {"name": "my_op"},
-                lambda op: op.name == "my_op",
-            ),
-            (
-                {"tags": {"foo": "bar"}},
-                lambda op: op.tags.get("foo") == "bar",
-            ),
-            (
-                {"backfill_policy": {"type": "single_run"}},
-                lambda op: op.backfill_policy.max_partitions_per_run is None,
-            ),
-        ],
-        ids=["name", "tags", "backfill_policy"],
-    )
-    def translation_test_case(self, request):
-        return request.param
-
-    @pytest.fixture
-    def attributes(self, translation_test_case):
-        return translation_test_case[0]
-
-    @pytest.fixture
-    def assertion(self, translation_test_case):
-        return translation_test_case[1]


### PR DESCRIPTION
## Summary

🧹 moves testing utils and prebuilt test suites into separate folders in a new module, along with deprecated/old sandbox