### PR TITLE
[backfill] targeted fix for can run with parent logic

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1686,18 +1686,29 @@ def _should_backfill_atomic_asset_subset_unit(
                 asset_graph_subset_matched_so_far,
                 candidate_asset_graph_subset_unit,
             )
-            if cant_run_with_parent_reason is not None:
-                entity_subset_to_filter = entity_subset_to_filter.compute_difference(
-                    possibly_waiting_for_parent_subset
-                )
-                failure_subsets_with_reasons.append(
-                    (
-                        possibly_waiting_for_parent_subset.get_internal_value(),
-                        cant_run_with_parent_reason,
-                    )
-                )
-
             is_self_dependency = parent_key == asset_key
+
+            if cant_run_with_parent_reason is not None:
+                if is_self_dependency:
+                    entity_subset_to_filter = entity_subset_to_filter.compute_difference(
+                        possibly_waiting_for_parent_subset
+                    )
+                    failure_subsets_with_reasons.append(
+                        (
+                            possibly_waiting_for_parent_subset.get_internal_value(),
+                            cant_run_with_parent_reason,
+                        )
+                    )
+                else:
+                    entity_subset_to_filter = asset_graph_view.get_empty_subset(
+                        key=entity_subset_to_filter.key
+                    )
+                    failure_subsets_with_reasons.append(
+                        (
+                            entity_subset_to_filter.get_internal_value(),
+                            cant_run_with_parent_reason,
+                        )
+                    )
 
             if is_self_dependency:
                 self_dependent_node = asset_graph.get(asset_key)


### PR DESCRIPTION
## Summary & Motivation

We have some very confusing behavior at the moment, where in cases where an asset has multiple parents, it's possible for the system to determine that the entirety of a downstream asset may be able to run with one of its parents, and then when another parent is factored in and we determine that we cannot run with part of that parent, we don't accurately remove all assets from the "passed subset".

The core idea here is that we believed we could execute the given subset with its parent because all of the subset would be included in the resulting run. As soon as anything influences this fact, the core assumption breaks down and the partitions get sent to separate runs.

This is a super-targeted fix for this behavior and realistically this entire codepath should be reworked.

## How I Tested These Changes

## Changelog

NOCHANGELOG
