### PR TITLE
Extend @public annotation to support classes

### DIFF
--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -37,18 +37,31 @@ _PUBLIC_ATTR_NAME: Final[str] = "_is_public"
 
 
 def public(obj: T_Annotatable) -> T_Annotatable:
-    """Mark a method on a public class as public. This distinguishes the method from "internal"
+    """Mark a method or class as public. For methods, this distinguishes them from "internal"
     methods, which are methods that are public in the Python sense of being non-underscored, but
     not intended for user access. Only `public` methods of a class are rendered in the docs.
+    When applied to a class, only that specific class is marked public, not its superclasses or subclasses.
     """
-    target = _get_annotation_target(obj)
-    setattr(target, _PUBLIC_ATTR_NAME, True)
+    if inspect.isclass(obj):
+        # For classes, we need to use type.__setattr__ instead of object.__setattr__
+        # This ensures the attribute is set directly on the class's __dict__
+        type.__setattr__(obj, _PUBLIC_ATTR_NAME, True)
+    else:
+        target = _get_annotation_target(obj)
+        setattr(target, _PUBLIC_ATTR_NAME, True)
     return obj
 
 
 def is_public(obj: Annotatable) -> bool:
-    target = _get_annotation_target(obj)
-    return hasattr(target, _PUBLIC_ATTR_NAME) and getattr(target, _PUBLIC_ATTR_NAME)
+    """Check if a method or class is marked as public. For classes, this only checks
+    the specific class, not its superclasses or subclasses.
+    """
+    if inspect.isclass(obj):
+        # Only consider the attribute if it is set directly on the class, not inherited
+        return _PUBLIC_ATTR_NAME in getattr(obj, "__dict__", {}) and getattr(obj, _PUBLIC_ATTR_NAME)
+    else:
+        target = _get_annotation_target(obj)
+        return hasattr(target, _PUBLIC_ATTR_NAME) and getattr(target, _PUBLIC_ATTR_NAME)
 
 
 # Use `PublicAttr` to annotate public attributes on `NamedTuple`:

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -1,7 +1,7 @@
 import inspect
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Annotated, Any, Callable, Final, Optional, TypeVar, Union, overload
+from typing import Annotated, Any, Callable, Final, Optional, TypeVar, Union, cast, overload
 
 from typing_extensions import TypeAlias
 
@@ -46,10 +46,11 @@ def public(obj: T_Annotatable) -> T_Annotatable:
         # For classes, we need to use type.__setattr__ instead of object.__setattr__
         # This ensures the attribute is set directly on the class's __dict__
         type.__setattr__(obj, _PUBLIC_ATTR_NAME, True)
+        return cast("T_Annotatable", obj)
     else:
         target = _get_annotation_target(obj)
         setattr(target, _PUBLIC_ATTR_NAME, True)
-    return obj
+        return obj
 
 
 def is_public(obj: Annotatable) -> bool:

--- a/python_modules/dagster/dagster_tests/utils_tests/test_annotations.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_annotations.py
@@ -1223,3 +1223,37 @@ def test_hidden_annotations() -> None:
         match="vanilla_func got an unexpected keyword argument 'hidden_param'",
     ):
         vanilla_func(hidden_param="foo")
+
+
+def test_classes() -> None:
+    @public
+    class Public:
+        def bar(self):
+            pass
+
+    assert is_public(Public)
+
+    class NotPublic:
+        def bar(self):
+            pass
+
+    assert is_public(Public)
+    assert not is_public(NotPublic)
+
+    @public
+    class DerivedFromNotPublic(NotPublic):
+        def bar(self):
+            pass
+
+    assert is_public(Public)
+    assert not is_public(NotPublic)
+    assert is_public(DerivedFromNotPublic)
+
+    class DerivedFromPublic(Public):
+        def bar(self):
+            pass
+
+    assert is_public(Public)
+    assert not is_public(NotPublic)
+    assert is_public(DerivedFromNotPublic)
+    assert not is_public(DerivedFromPublic)


### PR DESCRIPTION
## Summary & Motivation

Enhanced the `@public` decorator to support class annotations in addition to methods. Previously, the decorator only worked for methods, but now it can be applied to entire classes to mark them as public. The implementation ensures that the public status is only applied to the specific class being decorated, not to its superclasses or subclasses.

This is to setup a system that maintains the invariant that all @public classes and functions are in our public docblocks and that all things in our .rst file are marked public. We are going to programmaticaly enforce this so to make this easier for tools and developers alike.

## How I Tested These Changes

Added comprehensive tests that verify:
- Classes can be marked as public using the decorator
- Public status is correctly detected with `is_public()`
- Inheritance doesn't affect the public status (parent classes remain non-public when child classes are marked public and vice versa)
- The existing method annotation functionality continues to work as expected

