### PR TITLE
Improve @public API validation with dynamic imports and canonical module paths

### DIFF
--- a/python_modules/automation/automation/docstring_lint/exclude_lists.py
+++ b/python_modules/automation/automation/docstring_lint/exclude_lists.py
@@ -39,8 +39,15 @@ EXCLUDE_MISSING_RST = {
     # Library resources
     "dagster_openai.resources.with_usage_metadata",
     "dagster_openai.resources.OpenAIResource",
-    "dagster_sling.resources.SlingMode",
+    "dagster_sling.SlingMode",
     "dagster_sling.resources.SlingConnectionResource",
+    # New public APIs missing RST documentation
+    "dagster.build_defs_for_component",
+    "dagster.ComponentTypeSpec",
+    "dagster.scaffold_with",
+    "dagster.ScaffoldRequest",
+    "dagster.Scaffolder",
+    "dagster.SqlComponent",
     # Library components
     "dagster_snowflake.components.sql_component.component.SnowflakeConnectionComponentBase",
 }

--- a/python_modules/automation/automation/docstring_lint/exclude_lists.py
+++ b/python_modules/automation/automation/docstring_lint/exclude_lists.py
@@ -370,8 +370,6 @@ EXCLUDE_MISSING_PUBLIC = {
     "dagster.reconstructable",
     "dagster.AssetExecutionContext",
     "dagster.OpExecutionContext",
-    "dagster.AssetCheckExecutionContext",
-    "dagster.TypeCheckContext",
     "dagster.materialize",
     "dagster.materialize_to_memory",
     "dagster.execute_job",

--- a/python_modules/dagster/dagster/_core/execution/context/asset_check_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/asset_check_execution_context.py
@@ -22,6 +22,7 @@ from dagster._core.storage.dagster_run import DagsterRun
 from dagster._utils.forked_pdb import ForkedPdb
 
 
+@public
 class AssetCheckExecutionContext:
     def __init__(self, op_execution_context: OpExecutionContext) -> None:
         self._op_execution_context = check.inst_param(

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -1311,6 +1311,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             return self.op.output_dict.keys()
 
 
+@public
 class TypeCheckContext:
     """The ``context`` object available to a type check function on a DagsterType."""
 


### PR DESCRIPTION
## Summary & Motivation

Added @public to a couple decorators in order to debug the process.



1. Adding proper `@public` decorators to `AssetCheckExecutionContext` and `TypeCheckContext` classes
2. Enhancing the public symbol detection to use the exported module path as the canonical path
3. Implementing a more reliable method to check if symbols are exported using dynamic imports instead of regex parsing
4. Adding a cache for package discovery to improve performance
5. Removing `AssetCheckExecutionContext` and `TypeCheckContext` from the exclude list since they're now properly marked as public

These changes make our public API documentation more accurate by correctly identifying where symbols are exported from, which is important for users of our API.

## How I Tested These Changes

BK