### PR TITLE
Fix reporting of failure subsets when they are filtered out by a parent

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1700,16 +1700,15 @@ def _should_backfill_atomic_asset_subset_unit(
                         )
                     )
                 else:
-                    entity_subset_to_filter = asset_graph_view.get_empty_subset(
-                        key=entity_subset_to_filter.key
-                    )
                     failure_subsets_with_reasons.append(
                         (
                             entity_subset_to_filter.get_internal_value(),
                             cant_run_with_parent_reason,
                         )
                     )
-
+                    entity_subset_to_filter = asset_graph_view.get_empty_subset(
+                        key=entity_subset_to_filter.key
+                    )
             if is_self_dependency:
                 self_dependent_node = asset_graph.get(asset_key)
                 # ensure that we don't produce more than max_partitions_per_run partitions


### PR DESCRIPTION
Summary:
Both things here are correct, they are just happening in the wrong order. This was causign the logs of why parent subsets were removed to not include the subset.

Test Plan: Run a backfill, logs are now correct

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
