### PR TITLE
[ui] Lint against non-null assertions

### DIFF
--- a/js_modules/dagster-ui/packages/eslint-config/index.js
+++ b/js_modules/dagster-ui/packages/eslint-config/index.js
@@ -157,7 +157,7 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/array-type': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
-    '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'error',
     '@typescript-eslint/prefer-interface': 'off',
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-empty-object-type': ['error', {allowInterfaces: 'with-single-extends'}],

--- a/js_modules/dagster-ui/packages/ui-core/src/app/BaseFallthroughRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/BaseFallthroughRoot.tsx
@@ -53,6 +53,7 @@ const FinalRedirectOrLoadingRoot = () => {
           to={workspacePath(
             repoWithAssetGroup.repository.name,
             repoWithAssetGroup.repositoryLocation.name,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             `/asset-groups/${repoWithAssetGroup.repository.assetGroups[0]!.groupName}`,
           )}
         />

--- a/js_modules/dagster-ui/packages/ui-core/src/app/CustomAlertProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/CustomAlertProvider.tsx
@@ -54,6 +54,7 @@ export const CustomAlertProvider = () => {
 
   const onCopy = React.useCallback(
     (e: React.MouseEvent) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const copyElement = copySelector ? body.current!.querySelector(copySelector) : body.current;
       const copyText =
         copyElement instanceof HTMLElement ? copyElement.innerText : copyElement?.textContent;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
@@ -81,6 +81,7 @@ export function applyRemoveSession(data: IStorageData, key: string) {
   delete next.sessions[key];
   if (next.current === key) {
     const remaining = Object.keys(next.sessions);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     next.current = remaining[idx] || remaining[idx - 1] || remaining[0]!;
   }
   return next;
@@ -91,6 +92,7 @@ export function applyChangesToSession(
   key: string,
   changes: IExecutionSessionChanges,
 ) {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const saved = data.sessions[key]!;
   if (changes.runConfigYaml && changes.runConfigYaml !== saved.runConfigYaml && saved.runId) {
     changes.configChangedSinceRun = true;
@@ -156,6 +158,7 @@ const buildValidator =
     }
 
     if (!data.sessions[data.current]) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       data.current = Object.keys(data.sessions)[0]!;
     }
 
@@ -217,6 +220,7 @@ export const useInvalidateConfigsForRepo = () => {
           const data: IStorageData | undefined = getJSONForKey(key);
           if (data) {
             const withBase = Object.keys(data.sessions).filter(
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               (sessionKey) => data.sessions[sessionKey]!.base !== null,
             );
             if (withBase.length) {
@@ -258,9 +262,11 @@ export const useInitialDataForMode = (
       return {
         base: {
           type: 'preset',
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           presetName: presetsForMode[0]!.name,
           tags: null,
         },
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         runConfigYaml: presetsForMode[0]!.runConfigYaml,
       };
     }
@@ -269,6 +275,7 @@ export const useInitialDataForMode = (
       return {
         base: {
           type: 'op-job-partition-set',
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           partitionsSetName: partitionSetsForMode[0]!.name,
           partitionName: null,
           tags: null,

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -75,6 +75,7 @@ export const getFeatureFlagsWithDefaults = (): FeatureFlagMap => {
  */
 export const featureEnabled = (flag: FeatureFlag): boolean => {
   if (flag in currentFeatureFlags) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return currentFeatureFlags[flag]!;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/GraphQueryImpl.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/GraphQueryImpl.ts
@@ -43,6 +43,7 @@ export class GraphTraverser<T extends GraphQueryItem> {
      * A --> B --> C
      */
     while (queue.length) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const [item, depth] = queue.shift()!;
       results[item.name] = item;
       if (depth < maxDepth) {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Permissions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Permissions.tsx
@@ -223,6 +223,7 @@ export const usePermissionsForLocation = (
   const {unscopedPermissions, locationPermissions, loading} = React.useContext(PermissionsContext);
   let permissionsForLocation = unscopedPermissions;
   if (locationName && locationPermissions.hasOwnProperty(locationName)) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     permissionsForLocation = locationPermissions[locationName]!;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/QueryRefresh.tsx
@@ -212,6 +212,7 @@ export function useMergedRefresh(
   return useMemo(() => {
     const refetch: ObservableQuery['refetch'] = async () => {
       const [ar] = await Promise.all(args.map((s) => s?.refetch()));
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return ar!;
     };
     return {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -197,6 +197,7 @@ export const indexedDBAsyncMemoize = <R, U extends (...args: any[]) => Promise<R
         });
       }
       try {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const result = await hashToPromise[hashKey]!;
         resolve(result);
       } catch (e) {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/ExecutionSessionStorage.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/ExecutionSessionStorage.test.tsx
@@ -22,6 +22,7 @@ describe('ExecutionSessionStorage', () => {
     return (
       <>
         <div>Current: {data.current}</div>
+        {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
         <div>{`YAML: "${data.sessions[data.current]!.runConfigYaml}"`}</div>
       </>
     );
@@ -60,6 +61,7 @@ describe('ExecutionSessionStorage', () => {
       return (
         <>
           <div>Current: {data.current}</div>
+          {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
           <div>{`YAML: "${data.sessions[data.current]!.runConfigYaml}"`}</div>
         </>
       );

--- a/js_modules/dagster-ui/packages/ui-core/src/app/analytics.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/analytics.tsx
@@ -14,6 +14,7 @@ export interface GenericAnalytics {
   track: (eventName: string, properties?: Record<string, any>) => void;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 export const AnalyticsContext = createContext<GenericAnalytics>(undefined!);
 
 const PAGEVIEW_DELAY = 300;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/TimezoneSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/TimezoneSelect.tsx
@@ -18,6 +18,7 @@ const extractOffset = (targetDate: Date, timeZone: string) => {
     timeZoneName: 'longOffset',
   });
   const [_, gmtOffset] = formatted.split(', ');
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const stripped = gmtOffset!.replace(/^GMT/, '').replace(/:/, '');
 
   // Already GMT.

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/browserTimezone.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/browserTimezone.ts
@@ -21,6 +21,7 @@ export const timezoneAbbreviation = memoize((timeZone: string) => {
     timeZoneName: 'short',
   });
   const [_, abbreviation] = dateString.split(', ');
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return abbreviation!;
 });
 export const automaticLabel = memoize(() => `Automatic (${browserTimezoneAbbreviation()})`);

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
@@ -98,6 +98,7 @@ describe('AssetLiveDataProvider', () => {
 
     // Initially an empty object
     expect(resultFn).toHaveBeenCalledTimes(0);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(hookResult.mock.calls[0]!.value).toEqual(undefined);
 
     act(() => {
@@ -106,6 +107,7 @@ describe('AssetLiveDataProvider', () => {
 
     expect(resultFn).toHaveBeenCalled();
     await waitFor(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(hookResult.mock.calls[1]!.value).not.toEqual({});
     });
 
@@ -163,6 +165,7 @@ describe('AssetLiveDataProvider', () => {
 
     // Initially an empty object
     expect(resultFn).toHaveBeenCalledTimes(0);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(hookResult.mock.calls[0]!.value).toEqual(undefined);
 
     act(() => {
@@ -183,6 +186,7 @@ describe('AssetLiveDataProvider', () => {
 
     // Initially an empty object
     expect(resultFn2).not.toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(hookResult2.mock.calls[0]!.value).toEqual(undefined);
     act(() => {
       jest.runOnlyPendingTimers();
@@ -363,6 +367,7 @@ describe('AssetLiveDataProvider', () => {
       expect(resultFn).toHaveBeenCalled();
     });
     await waitFor(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(hookResult.mock.calls[1]!.value).not.toEqual({});
     });
     expect(resultFn2).not.toHaveBeenCalled();
@@ -431,6 +436,7 @@ describe('AssetLiveDataProvider', () => {
 
     // Initially an empty object
     expect(resultFn).toHaveBeenCalledTimes(0);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(hookResult.mock.calls[0]!.value).toEqual(undefined);
 
     act(() => {
@@ -497,7 +503,9 @@ describe('AssetLiveDataProvider', () => {
     // Initially an empty object
     expect(resultFn).toHaveBeenCalledTimes(0);
     expect(resultFn2).toHaveBeenCalledTimes(0);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(hookResult.mock.calls[0]!.value).toEqual(undefined);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(hookResult2.mock.calls[0]!.value).toEqual(undefined);
 
     act(() => {
@@ -507,7 +515,9 @@ describe('AssetLiveDataProvider', () => {
     expect(resultFn).toHaveBeenCalled();
     expect(resultFn2).toHaveBeenCalled();
     await waitFor(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(hookResult.mock.calls[1]!.value).not.toEqual({});
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(hookResult2.mock.calls[1]!.value).not.toEqual({});
     });
   });
@@ -592,6 +602,7 @@ describe('AssetLiveDataProvider', () => {
 
     // Initially an empty object
     expect(resultFn).toHaveBeenCalledTimes(0);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(hookResult.mock.calls[0]!.value).toEqual(undefined);
 
     act(() => {
@@ -600,6 +611,7 @@ describe('AssetLiveDataProvider', () => {
 
     expect(resultFn).toHaveBeenCalled();
     await waitFor(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(hookResult.mock.calls[1][0]!).toEqual({
         ['key1']: expect.any(Object),
         ['key2']: expect.any(Object),

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/_useAssetLiveDataProviderChangeSignal.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/_useAssetLiveDataProviderChangeSignal.oss.tsx
@@ -49,6 +49,7 @@ export const useAssetLiveDataProviderChangeSignal = () => {
       ];
       const assetKeyTokens = new Set(assetKeyTokensArray);
       const dataForObservedKeys = assetKeyTokensArray
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         .map((key) => AssetBaseData.manager.getCacheEntry(key)!)
         .filter((n) => n);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -184,9 +184,11 @@ const AssetGraphExplorerWithData = ({
     Object.values(assetGraphData.nodes).forEach((node) => {
       const groupId = groupIdForNode(node);
       groupedAssets[groupId] = groupedAssets[groupId] || [];
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       groupedAssets[groupId]!.push(node);
     });
     const counts: Record<string, number> = {};
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     Object.keys(groupedAssets).forEach((key) => (counts[key] = groupedAssets[key]!.length));
     return {allGroups: Object.keys(groupedAssets), allGroupCounts: counts, groupedAssets};
   }, [assetGraphData]);
@@ -226,10 +228,12 @@ const AssetGraphExplorerWithData = ({
   const viewportEl = React.useRef<SVGViewportRef>();
 
   const selectedTokens =
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     explorerPath.opNames[explorerPath.opNames.length - 1]!.split(',').filter(Boolean);
   const selectedGraphNodes = Object.values(assetGraphData.nodes).filter((node) =>
     selectedTokens.includes(tokenForAssetKey(node.definition.assetKey)),
   );
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const lastSelectedNode = selectedGraphNodes[selectedGraphNodes.length - 1]!;
 
   const selectedDefinitions = selectedGraphNodes.map((a) => a.definition);
@@ -274,12 +278,14 @@ const AssetGraphExplorerWithData = ({
           }
         }
 
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const existing = explorerPath.opNames[0]!.split(',');
         nextOpsNameSelection = (
           existing.includes(token) ? without(existing, token) : uniq([...existing, ...tokensToAdd])
         ).join(',');
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const nextCenter = layout?.nodes[nextOpsNameSelection[nextOpsNameSelection.length - 1]!];
       if (nextCenter) {
         viewportEl.current?.zoomToSVGCoords(nextCenter.bounds.x, nextCenter.bounds.y, true);
@@ -387,6 +393,7 @@ const AssetGraphExplorerWithData = ({
       const assets = groupedAssets[groupId] || [];
       const childNodeTokens = assets.map((n) => tokenForAssetKey(n.assetKey));
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const existing = explorerPath.opNames[0]!.split(',');
 
       const nextOpsNameSelection = childNodeTokens.every((token) => existing.includes(token))
@@ -589,6 +596,7 @@ const AssetGraphExplorerWithData = ({
           {Object.values(layout.nodes)
             .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
             .map(({id, bounds}) => {
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               const graphNode = assetGraphData.nodes[id]!;
               const path = JSON.parse(id);
               if (scale < GROUPS_ONLY_SCALE) {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -96,6 +96,7 @@ export const AssetNode = React.memo(({definition, selected, onChangeAssetSelecti
 }, isEqual);
 
 export const AssetNameRow = ({definition}: {definition: AssetNodeFragment}) => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const displayName = definition.assetKey.path[definition.assetKey.path.length - 1]!;
 
   return (
@@ -226,6 +227,7 @@ export const AssetNodeMinimalWithHealth = ({
   const {liveData: healthData} = useAssetHealthData(assetKey);
   const health = healthData?.assetHealth;
 
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const displayName = assetKey.path[assetKey.path.length - 1]!;
   const isChanged = definition.changedReasons.length;
   const isStale = isAssetStale(liveData);
@@ -302,6 +304,7 @@ export const AssetNodeMinimalOld = ({
   const {liveData} = useAssetLiveData(assetKey);
 
   const {border, background} = buildAssetNodeStatusContent({assetKey, definition, liveData});
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const displayName = assetKey.path[assetKey.path.length - 1]!;
 
   const isChanged = definition.changedReasons.length;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode2025.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode2025.tsx
@@ -241,6 +241,7 @@ export const AssetNodeAutomationRowWithData = ({
           </Tooltip>
         ) : null}
         {hasAutomationCondition ? (
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           <Tooltip content={automationData.automationCondition!.label!} placement="top">
             <AutomationConditionEvaluationLink
               definition={definition}
@@ -304,6 +305,7 @@ const AssetNodeStatusRow = ({
 
 const SingleOwnerOrTooltip = ({owners}: {owners: AssetNodeFragment['owners']}) => {
   if (owners.length === 1) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const owner = owners[0]!;
     return (
       <div className={styles.UserDisplayWrapNoPadding}>
@@ -365,6 +367,7 @@ export const AutomationConditionEvaluationLink = ({
         <EvaluationDetailDialog
           isOpen={isOpen}
           onClose={() => setOpen(false)}
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           evaluationID={automationData.lastAutoMaterializationEvaluationRecord!.evaluationId}
           assetKeyPath={definition.assetKey.path}
         />

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetRunLogObserver.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetRunLogObserver.tsx
@@ -18,7 +18,9 @@ function removeCallback(runId: string, callback: ObservedRunCallback) {
   if (!ObservedRuns[runId]) {
     console.log('[ObserveRuns]: Attempted to release runId that has already been released.');
   }
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   ObservedRuns[runId] = ObservedRuns[runId]!.filter((w) => w !== callback);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   if (ObservedRuns[runId]!.length === 0) {
     delete ObservedRuns[runId];
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ComputeGraphData.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ComputeGraphData.ts
@@ -62,18 +62,24 @@ const removeEdgesToHiddenAssets = (graphData: GraphData, allNodes: WorkspaceAsse
   const notSourceAsset = (id: string) => !!allNodesById[id];
 
   for (const node of Object.keys(graphData.upstream)) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     for (const edge of Object.keys(graphData.upstream[node]!)) {
       if (!graphData.nodes[edge] && notSourceAsset(node)) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         delete graphData.upstream[node]![edge];
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         delete graphData.downstream[edge]![node];
       }
     }
   }
 
   for (const node of Object.keys(graphData.downstream)) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     for (const edge of Object.keys(graphData.downstream[node]!)) {
       if (!graphData.nodes[edge] && notSourceAsset(node)) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         delete graphData.upstream[edge]![node];
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         delete graphData.downstream[node]![edge];
       }
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ForeignNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ForeignNode.tsx
@@ -6,6 +6,7 @@ import {ASSET_LINK_NAME_MAX_LENGTH} from './layout';
 import {withMiddleTruncation} from '../app/Util';
 
 export const AssetNodeLink = memo(({assetKey}: {assetKey: {path: string[]}}) => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const label = assetKey.path[assetKey.path.length - 1]!;
   return (
     <AssetNodeLinkContainer>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -134,6 +134,7 @@ export const graphHasCycles = (graphData: GraphData) => {
   };
   let hasCycles = false;
   while (nodes.size !== 0 && !hasCycles) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     hasCycles = search([], nodes.values().next().value!);
   }
   return hasCycles;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
@@ -149,7 +149,9 @@ export const PartnerTags = () => {
     function SetCacheEntry() {
       const assetKey = buildAssetKey({path: [liveData.stepKey]});
       const key = tokenForAssetKey(assetKey);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const entry = {[key]: liveData!};
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const {staleStatus, staleCauses} = liveData!;
       const staleEntry = {
         [key]: buildAssetNode({

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/SidebarAssetInfo.stories.tsx
@@ -236,6 +236,7 @@ const TestContainer = ({
     mocks={
       mocks || [
         buildEventsMock({reported: false}),
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         buildPartitionHealthMock(MockAssetKey.path[0]!),
         buildSidebarQueryMock(),
       ]
@@ -260,6 +261,7 @@ export const AssetWithReportedMaterialization = () => {
     <TestContainer
       mocks={[
         buildEventsMock({reported: true}),
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         buildPartitionHealthMock(MockAssetKey.path[0]!),
         buildSidebarQueryMock(),
       ]}
@@ -274,6 +276,7 @@ export const AssetWithPolicies = () => {
     <TestContainer
       mocks={[
         buildEventsMock({reported: false}),
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         buildPartitionHealthMock(MockAssetKey.path[0]!),
         buildSidebarQueryMock({
           freshnessPolicy: buildFreshnessPolicy({

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
@@ -45,7 +45,9 @@ describe('AssetNode', () => {
       function SetCacheEntry() {
         if (scenario.liveData) {
           const key = tokenForAssetKey(definitionCopy.assetKey);
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const entry = {[key]: scenario.liveData!};
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const {staleStatus, staleCauses} = scenario.liveData!;
           const staleEntry = {
             [key]: buildAssetNode({
@@ -73,6 +75,7 @@ describe('AssetNode', () => {
 
       await waitFor(() => {
         const assetKey = definitionCopy.assetKey;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const displayName = assetKey.path[assetKey.path.length - 1]!;
         expect(
           screen.getByText(

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/useAssetGraphData.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/useAssetGraphData.test.tsx
@@ -81,10 +81,15 @@ describe('calculateGraphDistances', () => {
     const TWO_GRAPHS = cloneDeep(TEST_GRAPH);
 
     // Break the test graph in two at E
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     TWO_GRAPHS.find((item) => item.name === 'E')!.outputs = [];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     TWO_GRAPHS.find((item) => item.name === 'D')!.outputs = [];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     TWO_GRAPHS.find((item) => item.name === 'F')!.inputs = [];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     TWO_GRAPHS.find((item) => item.name === 'G')!.inputs = [];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     TWO_GRAPHS.find((item) => item.name === 'H')!.inputs = [
       {dependsOn: [{solid: {name: 'F'}}, {solid: {name: 'G'}}]},
     ];

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/assetKeyTokensInRange.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/assetKeyTokensInRange.ts
@@ -13,9 +13,11 @@ const graphDirectionOf = ({
 }) => {
   const stack = [from];
   while (stack.length) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const node = stack.pop()!;
 
     const downstream = [...Object.keys(graph.downstream[node.id] || {})]
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       .map((n) => graph.nodes[n]!)
       .filter(Boolean);
     if (downstream.some((d) => d.id === to.id)) {
@@ -42,6 +44,7 @@ export const assetKeyTokensInRange = (
   }
 
   const downstream = [...Object.keys(graph.downstream[from.id] || {})]
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     .map((n) => graph.nodes[n]!)
     .filter(Boolean);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -248,6 +248,7 @@ export const layoutAssetGraphImpl = (
     if (!isGroupId(id)) {
       nodes[id] = {id, bounds};
     } else if (!expandedGroupsSet.has(id)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const group = groups[id]!;
       group.bounds = bounds;
     }
@@ -262,6 +263,7 @@ export const layoutAssetGraphImpl = (
       const nodeLayout = nodes[node.id];
       if (nodeLayout && node.definition.groupName) {
         const groupId = groupIdForNode(node);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const group = groups[groupId]!;
         group.bounds =
           group.bounds.width === 0

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -120,7 +120,9 @@ export const AssetGraphExplorerSidebar = React.memo(
           )
           .sort((a, b) =>
             COLLATOR.compare(
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               getDisplayName(graphData.nodes[a]!),
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               getDisplayName(graphData.nodes[b]!),
             ),
           ),
@@ -158,9 +160,11 @@ export const AssetGraphExplorerSidebar = React.memo(
           locationName: codeLocation,
           groups: {},
         };
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         if (!codeLocationNodes[codeLocation]!.groups[groupId]!) {
           groupsCount += 1;
         }
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         codeLocationNodes[codeLocation]!.groups[groupId] = codeLocationNodes[codeLocation]!.groups[
           groupId
         ] || {
@@ -169,6 +173,7 @@ export const AssetGraphExplorerSidebar = React.memo(
           repositoryName,
           repositoryLocationName: locationName,
         };
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         codeLocationNodes[codeLocation]!.groups[groupId]!.assets.push(node);
       });
       const codeLocationsCount = Object.keys(codeLocationNodes).length;
@@ -318,6 +323,7 @@ export const AssetGraphExplorerSidebar = React.memo(
             values={React.useMemo(() => {
               return allAssetKeys.map((key) => ({
                 value: JSON.stringify(key.path),
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 label: key.path[key.path.length - 1]!,
               }));
             }, [allAssetKeys])}
@@ -346,6 +352,7 @@ export const AssetGraphExplorerSidebar = React.memo(
                   indexOfLastSelectedNodeRef.current = nextIndex;
                   e.preventDefault();
                   const nextNode =
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     renderedNodes[(nextIndex + renderedNodes.length) % renderedNodes.length]!;
                   setSelectedNode(nextNode);
                   selectNode(e, nextNode.id);
@@ -369,6 +376,7 @@ export const AssetGraphExplorerSidebar = React.memo(
             >
               <Inner $totalHeight={totalHeight}>
                 {items.map(({index, key, size, start}) => {
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                   const node = renderedNodes[index]!;
                   const isCodelocationNode = 'locationName' in node;
                   const isGroupNode = 'groupNode' in node;
@@ -381,6 +389,7 @@ export const AssetGraphExplorerSidebar = React.memo(
                         <AssetSidebarNode
                           isOpen={openNodes.has(nodePathKey(node))}
                           fullAssetGraphData={fullAssetGraphData}
+                          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                           node={row!}
                           level={node.level}
                           isLastSelected={lastSelectedNode?.id === node.id}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
@@ -30,6 +30,7 @@ export function nodePathKey(node: {path: string; id: string} | {id: string}) {
 }
 
 export function getDisplayName(node: {assetKey: AssetKeyInput}) {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return node.assetKey.path[node.assetKey.path.length - 1]!;
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -205,6 +205,7 @@ export const calculateGraphDistances = (items: GraphQueryItem[], assetKey: Asset
     upstreamDepth += 1;
 
     candidates.forEach((candidate) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       map[candidate]!.inputs.flatMap((i) =>
         i.dependsOn.forEach((d) => {
           if (!candidates.has(d.solid.name)) {
@@ -224,6 +225,7 @@ export const calculateGraphDistances = (items: GraphQueryItem[], assetKey: Asset
     downstreamDepth += 1;
 
     candidates.forEach((candidate) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       map[candidate]!.outputs.flatMap((i) =>
         i.dependedBy.forEach((d) => {
           if (!candidates.has(d.solid.name)) {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/AntlrAssetSelectionVisitor.oss.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/AntlrAssetSelectionVisitor.oss.ts
@@ -260,6 +260,7 @@ export class AntlrAssetSelectionVisitor
     }
     return new Set(
       matchingAssetKeys
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         .map((key) => this.allAssetsByKey.get(tokenForAssetKey(key))!)
         .filter(Boolean),
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/useAssetSelectionFiltering.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/useAssetSelectionFiltering.test.tsx
@@ -298,6 +298,7 @@ describe('useAssetSelectionFiltering', () => {
 
     await waitFor(() => {
       expect(result.current.filtered).toHaveLength(1);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(result.current.filtered[0]!.key.path).toEqual(['asset1']);
     });
   });
@@ -346,6 +347,7 @@ describe('useAssetSelectionFiltering', () => {
       }),
     );
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const callArgs = mockUseAssetGraphData.mock.calls[0]!;
     const config = callArgs[1];
     expect(config.hideNodesMatching).toBeDefined();

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/syntaxUpgrader.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/syntaxUpgrader.ts
@@ -26,7 +26,9 @@ class SyntaxUpgradingVisitor
   defaultResult() {}
 
   visitUnmatchedValue(ctx: UnmatchedValueContext) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const originalStart = ctx.value().start!.startIndex;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const originalEnd = ctx.value().stop!.stopIndex;
 
     const currentStart = originalStart + this.offset;
@@ -49,6 +51,7 @@ class SyntaxUpgradingVisitor
 
   visitCommaToken(ctx: CommaTokenContext) {
     const start = ctx.start.startIndex + this.offset;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const end = ctx.stop!.stopIndex + this.offset;
 
     // Remove any spaces around the comma and replace with ' or '

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionFiltering.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionFiltering.tsx
@@ -74,6 +74,7 @@ export const useAssetSelectionFiltering = <
     return (
       graphAssetKeys
         .map((key) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           return assetsByKey.get(tokenForAssetKey(key))!;
         })
         .filter(Boolean)

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
@@ -65,6 +65,7 @@ export const AssetEventList = ({
       >
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, key, size, start}) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const group = groups[index]!;
             return (
               <AssetListRow

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupSuggest.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupSuggest.tsx
@@ -64,6 +64,7 @@ export const AssetGroupSuggest = ({
         ) : undefined,
       }}
       inputValueRenderer={() =>
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         value.length === 1 ? value[0]!.groupName : value.length > 1 ? `${value.length} groups` : ``
       }
       itemPredicate={(query, partition) =>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationGraphs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMaterializationGraphs.tsx
@@ -65,6 +65,7 @@ export const AssetMaterializationGraphs = (props: {
                 <AssetValueGraph
                   label={label}
                   width="100%"
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                   data={graphDataByMetadataLabel[label]!}
                   xHover={xHover}
                   onHoverX={(x) => x !== xHover && setXHover(x)}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -47,6 +47,7 @@ const AssetNodeLineageGraphInner = ({
     Object.values(assetGraphData.nodes).forEach((node) => {
       const groupId = groupIdForNode(node);
       groupedAssets[groupId] = groupedAssets[groupId] || [];
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       groupedAssets[groupId]!.push(node);
     });
     return {allGroups: Object.keys(groupedAssets), groupedAssets};
@@ -149,6 +150,7 @@ const AssetNodeLineageGraphInner = ({
               .map((group) => (
                 <foreignObject {...group.bounds} key={group.id}>
                   <ExpandedGroupNode
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     group={{...group, assets: groupedAssets[group.id]!}}
                     minimal={scale < MINIMAL_SCALE}
                     setHighlighted={setHighlighted}
@@ -164,6 +166,7 @@ const AssetNodeLineageGraphInner = ({
 
                 const contextMenuProps = {
                   graphData: assetGraphData,
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                   node: graphNode!,
                 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionList.tsx
@@ -22,6 +22,7 @@ export const AssetPartitionList = ({
 
   const rowVirtualizer = useVirtualizer({
     count: partitions.length,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     getItemKey: (idx) => partitions[idx]!,
     getScrollElement: () => parentRef.current,
     estimateSize: () => 36,
@@ -58,6 +59,7 @@ export const AssetPartitionList = ({
     >
       <Inner $totalHeight={totalHeight}>
         {items.map(({index, key, size, start}) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const dimensionKey = partitions[index]!;
           const state = statusForPartition(dimensionKey);
           return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionStatus.tsx
@@ -56,9 +56,12 @@ export const assetPartitionStatusesToStyle = (status: AssetPartitionStatus[]): C
     return {background: Colors.backgroundLight()};
   }
   if (status.length === 1) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return {background: assetPartitionStatusToColor(status[0]!)};
   }
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const a = assetPartitionStatusToColor(status[0]!);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const b = assetPartitionStatusToColor(status[1]!);
 
   return {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
@@ -74,6 +74,7 @@ export const AssetPartitions = ({
   dataRefreshHint,
   isLoadingDefinition,
 }: Props) => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const assetHealth = usePartitionHealthData([assetKey], dataRefreshHint)[0]!;
   const [selections, setSelections] = usePartitionDimensionSelections({
     knownDimensionNames: assetPartitionDimensions,
@@ -123,6 +124,7 @@ export const AssetPartitions = ({
     params,
     setParams,
     dimensionCount: selections.length,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     defaultKeyInDimension: (dimensionIdx) => dimensionKeysInSelection(dimensionIdx)[0]!,
   });
 
@@ -137,9 +139,11 @@ export const AssetPartitions = ({
       assetHealth.rangesForSingleDimension(
         idx,
         idx === 1 && focusedDimensionKeys[0]
-          ? [selectionRangeWithSingleKey(focusedDimensionKeys[0], selections[0]!.dimension)]
+          ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            [selectionRangeWithSingleKey(focusedDimensionKeys[0], selections[0]!.dimension)]
           : timeDimensionIdx !== -1 && idx !== timeDimensionIdx
-            ? selections[timeDimensionIdx]!.selectedRanges
+            ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              selections[timeDimensionIdx]!.selectedRanges
             : undefined,
       ),
     );
@@ -156,12 +160,15 @@ export const AssetPartitions = ({
     }
     // Special case: If you have cleared the time selection in the top bar, we
     // clear all dimension columns, (even though you still have a dimension 2 selection)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     if (timeDimensionIdx !== -1 && selections[timeDimensionIdx]!.selectedRanges.length === 0) {
       return [];
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const {dimension, selectedRanges} = selections[idx]!;
     const allKeys = dimension.partitionKeys;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const sortType = getSort(sortTypes, idx, selections[idx]!.dimension.type);
 
     const filterResultsBySearch = (keys: string[]) => {
@@ -181,6 +188,7 @@ export const AssetPartitions = ({
     // Get the health ranges, and then explode them into a `matching` set of keys
     // that have the requested statuses.
     const healthRangesInSelection = rangesClippedToSelection(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       rangesForEachDimension[idx]!,
       selectedRanges,
     );
@@ -236,9 +244,13 @@ export const AssetPartitions = ({
       {timeDimensionIdx !== -1 && (
         <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
           <DimensionRangeWizard
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             dimensionType={selections[timeDimensionIdx]!.dimension.type}
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             partitionKeys={selections[timeDimensionIdx]!.dimension.partitionKeys}
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             health={{ranges: rangesForEachDimension[timeDimensionIdx]!}}
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             selected={selections[timeDimensionIdx]!.selectedKeys}
             setSelected={(selectedKeys) =>
               setSelections(
@@ -386,6 +398,7 @@ export const AssetPartitions = ({
                     }
                     const dimensionKeyIdx = selection.dimension.partitionKeys.indexOf(dimensionKey);
                     return partitionStatusAtIndex(
+                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       rangesForEachDimension[idx]!,
                       dimensionKeyIdx,
                     ).filter((s) => statusFilters.includes(s));
@@ -432,5 +445,6 @@ function getSort(sortTypes: Array<SortType>, idx: number, definitionType: Partit
     ? definitionType === PartitionDefinitionType.TIME_WINDOW
       ? SortType.REVERSE_CREATION
       : SortType.CREATION
-    : sortTypes[idx]!;
+    : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      sortTypes[idx]!;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
@@ -151,13 +151,16 @@ const EventPopover = React.memo(
             return {
               content: <Body>In progress</Body>,
               icon: <Icon name="run_started" color={Colors.accentBlue()} />,
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               runId: event.latestRun!.id,
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               timestamp: Number(event.latestRun!.startTime) * 1000,
             };
           }
           return {
             content: <Body>Queued</Body>,
             icon: <Icon name="run_queued" color={Colors.accentBlue()} />,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             runId: event.latestRun!.id,
             timestamp: null,
           };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetValueGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetValueGraph.tsx
@@ -176,6 +176,7 @@ export const AssetValueGraph = (props: {
         props.onHoverX(null);
         return;
       }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       props.onHoverX(props.data.values[itemIdx]!.x);
     },
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -72,7 +72,9 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
   >(GET_EVALUATIONS_SPECIFIC_PARTITION_QUERY, {
     variables: {
       assetKey,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       evaluationId: selectedEvaluationId!,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       partition: selectedPartition!,
     },
     skip: skipSpecificPartitionQuery,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRequestedPartitionsLink.tsx
@@ -242,6 +242,7 @@ const VirtualizedPartitionList = ({partitionKeys, runsByPartitionKey}: Virtualiz
     <Container ref={container} style={{padding: '8px 24px'}}>
       <Inner $totalHeight={totalHeight}>
         {items.map(({index, key, size, start}) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const partitionKey = partitionKeys[index]!;
           const runForPartition = runsByPartitionKey ? runsByPartitionKey[partitionKey] : null;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSubsetList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSubsetList.tsx
@@ -114,6 +114,7 @@ export const PartitionSubsetList = ({
             <Menu>
               <Inner $totalHeight={totalHeight}>
                 {virtualItems.map(({index, key, size, start}) => {
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                   const partitionKey = filteredKeys[index]!;
                   return (
                     <Row $height={size} $start={start} key={key}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationTable.tsx
@@ -228,6 +228,7 @@ const NewPolicyEvaluationTable = ({
                 onClick={(e) => {
                   e?.stopPropagation();
                   pushHistory({
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     assetKeyPath: assetKey!.path,
                     assetCheckName: checkName,
                     evaluationID: lastEvaluationForEntityKey.evaluationId,
@@ -308,6 +309,7 @@ const NewPolicyEvaluationTable = ({
                 </td>
               ) : (
                 <td>
+                  {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
                   <PolicyEvaluationStatusTag status={status!} />
                 </td>
               )}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/QueryfulEvaluationDetailTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/QueryfulEvaluationDetailTable.tsx
@@ -44,6 +44,7 @@ export const QueryfulEvaluationDetailTable = ({
     variables: {
       assetKey: {path: assetKeyPath},
       evaluationId: evaluation.evaluationId,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       partition: selectedPartition!,
     },
     skip: !selectedPartition || !evaluation.isLegacy,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/VirtualizedAssetPartitionListForDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/VirtualizedAssetPartitionListForDialog.tsx
@@ -37,6 +37,7 @@ export function VirtualizedAssetPartitionListForDialog<A>({
       COMMON_COLLATOR.compare(a, b),
     );
     partitionNames.forEach((partitionName) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const assetKeys = assetKeysByPartition[partitionName]!;
       const expanded = expandedPartitions.has(partitionName);
       rows.push({type: 'partition-name', partitionName, expanded, assetCount: assetKeys.length});
@@ -74,6 +75,7 @@ export function VirtualizedAssetPartitionListForDialog<A>({
     <Container ref={container} style={{padding: '8px 24px'}}>
       <Inner $totalHeight={totalHeight}>
         {items.map(({index, key, size, start}) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const row = allRows[index]!;
           return (
             <Row $height={size} $start={start} key={key}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysPartitionLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/WaitingOnAssetKeysPartitionLink.tsx
@@ -23,6 +23,7 @@ export const WaitingOnAssetKeysPartitionLink = ({assetKeysByPartition}: Props) =
     return Object.fromEntries(
       filteredPartitionNames.map((partitionName) => [
         partitionName,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         [...assetKeysByPartition[partitionName]!].sort(sortAssetKeys),
       ]),
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/flattenEvaluations.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/flattenEvaluations.tsx
@@ -72,12 +72,14 @@ export const flattenEvaluations = ({evaluationNodes, rootUniqueId, expandedRecor
     if (evaluation.childUniqueIds && expandedRecords.has(evaluation.uniqueId)) {
       const parentCounter = counter;
       evaluation.childUniqueIds.forEach((childId) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const child = recordsById[childId]!;
         append(child, parentCounter, depth + 1);
       });
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   append(recordsById[rootUniqueId]!, null, 0);
 
   return all;
@@ -255,6 +257,7 @@ export const defaultExpanded = ({
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const rootEvaluation = recordsById[rootUniqueId]!;
   expand(rootEvaluation, rootEvaluation.entityKey);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/BackfillPreviewDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/BackfillPreviewDialog.tsx
@@ -80,6 +80,7 @@ export const BackfillPreviewDialog = ({
         <BackfillPreviewTableHeader />
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, size, start}) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const {assetKey, partitionDefinition, backfillPolicy} = assets[index]!;
             const token = tokenForAssetKey(assetKey);
             const partitions = partitionsByAssetToken[token];

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/CalculateUnsyncedDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/CalculateUnsyncedDialog.tsx
@@ -119,6 +119,7 @@ export const CalculateUnsyncedDialog = React.memo(
             <Container ref={containerRef} style={{maxHeight: '400px'}}>
               <Inner $totalHeight={totalHeight}>
                 {items.map(({index, key, size, start}) => {
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                   const item = unsynced[index]!;
                   return (
                     <Row

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -99,7 +99,8 @@ export const LaunchAssetChoosePartitionsDialog = (
   const displayName =
     props.assets.length > 1
       ? `${props.assets.length} assets`
-      : displayNameForAssetKey(props.assets[0]!.assetKey);
+      : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        displayNameForAssetKey(props.assets[0]!.assetKey);
 
   const title = `Launch runs to materialize ${displayName}`;
 
@@ -182,6 +183,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
 
   const displayedPartitionDefinition = displayedBaseAsset?.partitionDefinition;
 
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const knownDimensions = partitionedAssets[0]!.partitionDefinition?.dimensionTypes || [];
   const [missingFailedOnly, setMissingFailedOnly] = useState(false);
 
@@ -271,6 +273,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
     }
 
     const config = await fetchTagsAndConfigForAssetJob(client, {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       partitionName: keysFiltered[0]!,
       repositoryLocationName: repoAddress.location,
       repositoryName: repoAddress.name,
@@ -288,10 +291,12 @@ const LaunchAssetChoosePartitionsDialogBody = ({
       allTags = allTags.filter((t) => !t.key.startsWith(DagsterTag.Partition));
       allTags.push({
         key: DagsterTag.AssetPartitionRangeStart,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         value: keysFiltered[0]!,
       });
       allTags.push({
         key: DagsterTag.AssetPartitionRangeEnd,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         value: keysFiltered[keysFiltered.length - 1]!,
       });
     }
@@ -631,7 +636,8 @@ const UpstreamUnavailableWarning = ({
 
   const upstreamUnavailableSpans =
     selections.length === 1
-      ? assembleIntoSpans(selections[0]!.selectedKeys, upstreamUnavailable).filter(
+      ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        assembleIntoSpans(selections[0]!.selectedKeys, upstreamUnavailable).filter(
           (s) => s.status === true,
         )
       : [];
@@ -644,6 +650,7 @@ const UpstreamUnavailableWarning = ({
     if (selections.length > 1) {
       throw new Error('Assertion failed, this feature is only available for 1 dimensional assets');
     }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const selection = selections[0]!;
     setSelections([
       {...selection, selectedKeys: reject(selection.selectedKeys, upstreamUnavailable)},
@@ -657,6 +664,7 @@ const UpstreamUnavailableWarning = ({
       description={
         <>
           {upstreamUnavailableSpans
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             .map((span) => stringForSpan(span, selections[0]!.selectedKeys))
             .join(', ')}
           {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -708,6 +708,7 @@ function getAnchorAssetForPartitionMappedBackfill(assets: LaunchAssetExecutionAs
   if (
     first &&
     !partitionedRoots.every((r) =>
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       partitionDefinitionsEqual(first.partitionDefinition!, r.partitionDefinition!),
     )
   ) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/MultipartitioningSupport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/MultipartitioningSupport.tsx
@@ -45,6 +45,7 @@ export function mergedAssetHealth(assetHealth: PartitionHealthData[]): Partition
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const dimensions = assetHealth[0]!.dimensions;
 
   if (!assetHealth.every((h) => h.dimensions.length === dimensions.length)) {
@@ -63,6 +64,7 @@ export function mergedAssetHealth(assetHealth: PartitionHealthData[]): Partition
       uniq(assetHealth.map((health) => health.stateForKeyIdx(dimensionKeyIdxs))),
     rangesForSingleDimension: (dimensionIdx, otherDimensionSelectedRanges?) =>
       mergedRanges(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         dimensions[dimensionIdx]!.partitionKeys,
         assetHealth.map((health) =>
           health.rangesForSingleDimension(dimensionIdx, otherDimensionSelectedRanges),
@@ -91,6 +93,7 @@ export function mergedAssetHealth(assetHealth: PartitionHealthData[]): Partition
  */
 export function mergedRanges(allKeys: string[], rangeSets: Range[][]): Range[] {
   if (rangeSets.length === 1) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return rangeSets[0]!;
   }
 
@@ -168,11 +171,14 @@ export function assembleRangesFromTransitions(
     if (!isEqual(last?.value, value)) {
       if (last) {
         const clippedLastEndIdx = Math.min(idx - 1, allKeys.length - 1);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         last.end = {idx: clippedLastEndIdx, key: allKeys[clippedLastEndIdx]!};
       }
       const clippedEndIdx = Math.min(idx, allKeys.length - 1);
       result.push({
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         start: {idx, key: allKeys[idx]!},
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         end: {idx: clippedEndIdx, key: allKeys[clippedEndIdx]!},
         value,
       });
@@ -213,9 +219,11 @@ export function explodePartitionKeysInSelectionMatching(
   let keyNotFound = false;
 
   if (selections.length === 1) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     for (const range of selections[0]!.selectedRanges) {
       for (let idx = range.start.idx; idx <= range.end.idx; idx++) {
         if (shouldIncludeKey([idx])) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const value = selections[0]!.dimension.partitionKeys[idx];
           if (value === undefined) {
             keyNotFound = true;
@@ -229,16 +237,20 @@ export function explodePartitionKeysInSelectionMatching(
   }
 
   if (selections.length === 2) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     for (const range1 of selections[0]!.selectedRanges) {
       for (let idx1 = range1.start.idx; idx1 <= range1.end.idx; idx1++) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const key1 = selections[0]!.dimension.partitionKeys[idx1];
         if (key1 === undefined) {
           keyNotFound = true;
           break;
         }
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         for (const range2 of selections[1]!.selectedRanges) {
           for (let idx2 = range2.start.idx; idx2 <= range2.end.idx; idx2++) {
             if (shouldIncludeKey([idx1, idx2])) {
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               const key2 = selections[1]!.dimension.partitionKeys[idx2];
               if (key2 === undefined) {
                 keyNotFound = true;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
@@ -123,10 +123,13 @@ export const RecentUpdatesTimeline = ({assetKey, events, loading}: Props) => {
         hasFailedMaterializations: false,
         hasMaterializations: false,
       };
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       bucketsArr[bucketIndex]!.events.push(e);
       if (e.__typename === 'FailedToMaterializeEvent') {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         bucketsArr[bucketIndex]!.hasFailedMaterializations = true;
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         bucketsArr[bucketIndex]!.hasMaterializations = true;
       }
     });
@@ -381,9 +384,11 @@ function getTimelineBounds(sortedMaterializations: {timestamp: string}[]): [numb
   }
 
   const endTimestamp = parseInt(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     sortedMaterializations[sortedMaterializations.length - 1]!.timestamp,
   );
   const startTimestamp = Math.min(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     parseInt(sortedMaterializations[0]!.timestamp),
     endTimestamp - 100,
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
@@ -32,7 +32,7 @@ export const SimpleStakeholderAssetStatus = ({
   if ((liveData.inProgressRunIds || []).length > 0) {
     return (
       <Caption>
-        Materializing in{' '}
+        {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
         <AssetRunLink assetKey={assetNode.assetKey} runId={liveData.inProgressRunIds[0]!} />
       </Caption>
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/Stale.tsx
@@ -209,6 +209,7 @@ const StaleCausesPopoverSummary = ({
         </Subtitle2>
       </Box>
       {Object.entries(grouped).map(([label, causes], idx) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const isSelf = isEqual(assetKey.path, causes[0]!.key.path);
         return (
           <Box key={label}>
@@ -217,6 +218,7 @@ const StaleCausesPopoverSummary = ({
               border={idx === 0 ? 'bottom' : 'top-and-bottom'}
             >
               <CaptionSubtitle>
+                {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
                 {getCollapsedHeaderLabel(isSelf, causes[0]!.category, causes.length)}
               </CaptionSubtitle>
             </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/VirtualizedSimpleAssetKeyList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/VirtualizedSimpleAssetKeyList.tsx
@@ -30,6 +30,7 @@ export const VirtualizedSimpleAssetKeyList = ({
     <div style={{...style, overflowY: 'auto'}} ref={parentRef}>
       <Inner $totalHeight={totalHeight}>
         {items.map(({index, key, size, start}) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const assetKey = assetKeys[index]!;
           return (
             <Row key={key} $height={size} $start={start}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -681,6 +681,7 @@ export function buildExpectedLaunchSingleRunMutation(
           run: buildRun({
             runId: 'RUN_ID',
             id: 'RUN_ID',
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             pipelineName: executionParams['selector']['pipelineName']!,
           }),
         },

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetTables.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetTables.test.tsx
@@ -29,6 +29,7 @@ const workspaceMocks = buildWorkspaceMocks([
       repositories: [
         buildRepository({
           assetNodes: AssetCatalogTableMockAssets.filter((asset) => asset.definition).map(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             (asset) => asset.definition!,
           ),
         }),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/usePartitionHealthData.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/usePartitionHealthData.test.tsx
@@ -35,7 +35,9 @@ function selectionWithSlice(
     selectedKeys: dim.partitionKeys.slice(start, end + 1),
     selectedRanges: [
       {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         start: {idx: start, key: dim.partitionKeys[start]!},
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         end: {idx: end, key: dim.partitionKeys[end]!},
       },
     ],
@@ -616,6 +618,7 @@ describe('usePartitionHealthData utilities', () => {
       const one = buildPartitionHealthData(ONE_DIMENSIONAL_ASSET, {path: ['asset']});
 
       expect(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         keyCountByStateInSelection(one, [selectionWithSlice(one.dimensions[0]!, 0, 5)]),
       ).toEqual({
         ...emptyAssetPartitionStatusCounts(),
@@ -625,6 +628,7 @@ describe('usePartitionHealthData utilities', () => {
       });
 
       expect(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         keyCountByStateInSelection(one, [selectionWithSlice(one.dimensions[0]!, 0, 2)]),
       ).toEqual({
         ...emptyAssetPartitionStatusCounts(),
@@ -637,7 +641,9 @@ describe('usePartitionHealthData utilities', () => {
 
       expect(
         keyCountByStateInSelection(two, [
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           selectionWithSlice(two.dimensions[0]!, 0, 5),
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           selectionWithSlice(two.dimensions[1]!, 0, 4),
         ]),
       ).toEqual({
@@ -649,7 +655,9 @@ describe('usePartitionHealthData utilities', () => {
 
       expect(
         keyCountByStateInSelection(two, [
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           selectionWithSlice(two.dimensions[0]!, 0, 3),
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           selectionWithSlice(two.dimensions[1]!, 0, 3),
         ]),
       ).toEqual({
@@ -660,7 +668,9 @@ describe('usePartitionHealthData utilities', () => {
 
       expect(
         keyCountByStateInSelection(two, [
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           selectionWithSlice(two.dimensions[0]!, 0, 5),
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           selectionWithSlice(two.dimensions[1]!, 4, 4),
         ]),
       ).toEqual({
@@ -674,7 +684,9 @@ describe('usePartitionHealthData utilities', () => {
 
       expect(
         keyCountByStateInSelection(twoEmpty, [
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           selectionWithSlice(twoEmpty.dimensions[0]!, 0, 5),
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           selectionWithSlice(twoEmpty.dimensions[1]!, 0, 4),
         ]),
       ).toEqual({

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useSelectionHealthData.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useSelectionHealthData.test.tsx
@@ -336,6 +336,7 @@ describe('useSelectionHealthData', () => {
       ];
       const assetKeys = assets.map((asset) => asset.key);
       // Only provide health data for one asset
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const partialHealthData = createMockHealthData([assetKeys[0]!]);
 
       mockedUseAssetSelectionFiltering.mockReturnValue({

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckOverview.tsx
@@ -46,7 +46,9 @@ export const AssetCheckOverview = ({
       executions
         .filter((e) => e.evaluation)
         .map((e) => ({
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           metadataEntries: e.evaluation!.metadataEntries,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           timestamp: `${Math.round(e.evaluation!.timestamp * 1000)}`,
         }))
         .map((e) => ({latest: e, all: [e], timestamp: e.timestamp})),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckStatusTag.tsx
@@ -242,10 +242,12 @@ export const AssetCheckErrorsTag = ({
 
   if (checks.length === 1) {
     const actions: TagAction[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const execution = checks[0]!.executionForLatestMaterialization;
 
     actions.push({
       label: 'View details',
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       to: assetDetailsPathForAssetCheck({assetKey, name: checks[0]!.name}),
     });
     if (execution) {
@@ -265,6 +267,7 @@ export const AssetCheckErrorsTag = ({
         childrenMiddleTruncate={checks.length === 1}
       >
         <Tag icon={tagIcon} intent={tagIntent}>
+          {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
           <MiddleTruncate text={checks[0]!.name} />
         </Tag>
       </TagActionsPopover>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetChecks.tsx
@@ -183,6 +183,7 @@ export const AssetChecks = ({
               <Container ref={containerRef}>
                 <Inner $totalHeight={totalHeight}>
                   {items.map(({index, size, start}) => {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     const check = filteredChecks[index]!;
                     return (
                       <CheckRow

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/VirtualizedAssetCheckTable.tsx
@@ -41,6 +41,7 @@ export const VirtualizedAssetCheckTable = ({assetNode, rows}: Props) => {
         <VirtualizedAssetCheckHeader />
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, key, size, start}) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const row: AssetCheckTableFragment = rows[index]!;
             return (
               <VirtualizedAssetCheckRow

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogV2VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogV2VirtualizedTable.tsx
@@ -99,6 +99,7 @@ export const AssetCatalogV2VirtualizedTable = React.memo(
             }}
           >
             {items.map(({index, key}) => {
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               const item = rowItems[index]!;
 
               const wrapper = (content: React.ReactNode) => (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsGroupedView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsGroupedView.tsx
@@ -247,6 +247,7 @@ const List = ({rows}: {rows: React.ReactNode[]}) => {
           }}
         >
           {rowItems.map(({index, key}) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const row = rows[index]!;
             return (
               <div key={key} ref={rowVirtualizer.measureElement} data-index={index}>
@@ -350,6 +351,7 @@ const SelectionListItem = React.memo(
       <AssetSelectionSummaryListItem
         index={index}
         assets={item.assets
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           .map((assetKey: string) => assetsByAssetKey.get(assetKey)!)
           .filter(Boolean)}
         icon={<Icon name={item.icon as IconName} size={16} />}
@@ -374,6 +376,7 @@ export const SelectionTile = React.memo(
       <AssetSelectionSummaryTile
         icon={<Icon name={item.icon as IconName} size={24} />}
         label={item.name}
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         assets={item.assets.map((assetKey: any) => assetsByAssetKey.get(assetKey)!).filter(Boolean)}
         link={item.link}
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/ListGridViews.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/ListGridViews.tsx
@@ -193,6 +193,7 @@ export const List = ({rows}: {rows: React.ReactNode[]}) => {
     <Container ref={scrollWrapperRef} style={{maxHeight: '600px', overflowY: 'auto'}}>
       <Inner $totalHeight={totalHeight}>
         {rowItems.map(({index, key, size, start}) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const row = rows[index]!;
           return (
             <Row key={key} $height={size} $start={start}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/SelectedAssetsPopoverContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/SelectedAssetsPopoverContent.tsx
@@ -57,6 +57,7 @@ export const SelectedAssetsPopoverContent = ({checkedDisplayKeys, groupedByStatu
             }}
           >
             {items.map(({index, key}) => {
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               const item = selectedAssets[index]!;
               const {iconName, iconColor} = STATUS_INFO[item.status];
               return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/useSelectionHealthData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/useSelectionHealthData.tsx
@@ -59,6 +59,7 @@ export const SelectionHealthDataProvider = ({children}: {children: React.ReactNo
       if (!registries[selection]) {
         registries[selection] = new SelectionRegistry();
       }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const registry = registries[selection]!;
       const unwatch = registry.watchSelection(setHealthData, setFilterData);
       forceRerender();
@@ -76,8 +77,11 @@ export const SelectionHealthDataProvider = ({children}: {children: React.ReactNo
         <SelectionHealthDataObserver
           key={selection}
           selection={selection}
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           registry={registries[selection]!}
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           filterListeners={registries[selection]!.getFilterListeners()}
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           healthListeners={registries[selection]!.getHealthListeners()}
         />
       ))}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/util.tsx
@@ -42,6 +42,7 @@ export function getGroupedAssets(assets: AssetTableFragment[]) {
                 label: owner.team,
                 link: linkToAssetTableWithAssetOwnerFilter(owner),
               };
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               acc.owners[owner.team]!.assets.push(asset);
               break;
             case 'UserAssetOwner':
@@ -50,6 +51,7 @@ export function getGroupedAssets(assets: AssetTableFragment[]) {
                 label: owner.email,
                 link: linkToAssetTableWithAssetOwnerFilter(owner),
               };
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               acc.owners[owner.email]!.assets.push(asset);
               break;
             default:
@@ -63,6 +65,7 @@ export function getGroupedAssets(assets: AssetTableFragment[]) {
           label: groupName,
           link: linkToAssetTableWithCrossCodeLocationGroupFilter(groupName),
         };
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         acc.groupName[groupName]!.assets.push(asset);
       }
       if (repository) {
@@ -72,6 +75,7 @@ export function getGroupedAssets(assets: AssetTableFragment[]) {
           label: name,
           link: linkToCodeLocationInCatalog(repository.name, repository.location.name),
         };
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         acc.repository[name]!.assets.push(asset);
       }
       if (tags) {
@@ -82,6 +86,7 @@ export function getGroupedAssets(assets: AssetTableFragment[]) {
             label: stringValue,
             link: linkToAssetTableWithTagFilter(tag),
           };
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           acc.tags[stringValue]!.assets.push(asset);
         });
       }
@@ -92,6 +97,7 @@ export function getGroupedAssets(assets: AssetTableFragment[]) {
             label: kind,
             link: linkToAssetTableWithKindFilter(kind),
           };
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           acc.kinds[kind]!.assets.push(asset);
         });
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogHorizontalTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogHorizontalTopAssetsChart.tsx
@@ -45,6 +45,7 @@ export const AssetCatalogHorizontalTopAssetsChart = React.memo(
       return datasets.labels
         .map((label, i) => ({
           label,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           value: datasets.data[i]!,
         }))
         .filter(({value}) => value !== 0)
@@ -85,6 +86,7 @@ export const AssetCatalogHorizontalTopAssetsChart = React.memo(
                 <Mono color={Colors.textDefault()} className={styles.tableValue}>
                   {numberFormatter.format(Math.round(value))}
                 </Mono>
+                {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
                 <DistributionChartRow maxValue={maxValue!} value={Math.round(value)} />
               </React.Fragment>
             ))}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogInsightsLineChart.tsx
@@ -59,13 +59,15 @@ const getDataset = (
   formatDatetime: (date: Date, options: Intl.DateTimeFormatOptions) => string,
 ): ChartData<'line', (number | null)[], string> => {
   const start = metrics.timestamps.length
-    ? formatDatetime(new Date(metrics.timestamps[0]! * 1000), {
+    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      formatDatetime(new Date(metrics.timestamps[0]! * 1000), {
         month: 'short',
         day: 'numeric',
       })
     : '';
   const end = metrics.timestamps.length
-    ? formatDatetime(new Date(metrics.timestamps[metrics.timestamps.length - 1]! * 1000), {
+    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      formatDatetime(new Date(metrics.timestamps[metrics.timestamps.length - 1]! * 1000), {
         month: 'short',
         day: 'numeric',
       })
@@ -128,9 +130,12 @@ export const AssetCatalogInsightsLineChart = React.memo(
       useCallback(
         ({context}: {context: Context}) => {
           const {tooltip} = context;
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const currentPeriodDataPoint = tooltip.dataPoints[0]!;
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const prevPeriodDataPoint = tooltip.dataPoints[1]!;
           const date = formatDatetime(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             new Date(metrics.timestamps[currentPeriodDataPoint.dataIndex]! * 1000),
             {
               month: 'short',
@@ -286,6 +291,7 @@ export const AssetCatalogInsightsLineChart = React.memo(
             }
           }
 
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const before = metrics.timestamps[index]!;
           const after = before - timeSliceSeconds;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogTopAssetsChart.tsx
@@ -56,6 +56,7 @@ export const AssetCatalogTopAssetsChart = React.memo(
       return datasets.labels
         .map((label, i) => ({
           label,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           value: datasets.data[i]!,
         }))
         .filter(({value}) => value !== 0)

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AssetNodeOverview.tsx
@@ -133,6 +133,7 @@ export const AssetNodeOverview = ({
               <SimpleStakeholderAssetStatus
                 liveData={liveData}
                 partition={liveDataPartition}
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 assetNode={assetNode ?? cachedAssetNode!}
               />
             ) : (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AutomationDetailsSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AutomationDetailsSection.tsx
@@ -34,6 +34,7 @@ export const AutomationDetailsSection = ({
           isJob
           showIcon
           pipelineName={jobName}
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           pipelineHrefContext={repoAddress!}
         />
       )),
@@ -42,6 +43,7 @@ export const AutomationDetailsSection = ({
       label: 'Sensors',
       children: assetNode ? (
         sensors.length > 0 ? (
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           <ScheduleOrSensorTag repoAddress={repoAddress!} sensors={sensors} showSwitch={false} />
         ) : null
       ) : (
@@ -53,6 +55,7 @@ export const AutomationDetailsSection = ({
       children: assetNode ? (
         schedules.length > 0 && (
           <ScheduleOrSensorTag
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             repoAddress={repoAddress!}
             schedules={schedules}
             showSwitch={false}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/ComputeDetailsSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/ComputeDetailsSection.tsx
@@ -34,6 +34,7 @@ export const ComputeDetailsSection = ({
         <Tag>
           <UnderlyingOpsOrGraph
             assetNode={assetNode}
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             repoAddress={repoAddress!}
             hideIfRedundant={false}
           />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/DefinitionSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/DefinitionSection.tsx
@@ -60,6 +60,7 @@ export const DefinitionSection = ({
         <Tag icon="asset_group">
           <Link
             to={workspacePathFromAddress(
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               repoAddress!,
               `/asset-groups/${cachedOrLiveAssetNode.groupName}`,
             )}
@@ -73,8 +74,10 @@ export const DefinitionSection = ({
         <Box flex={{direction: 'column'}}>
           <AssetDefinedInMultipleReposNotice
             assetKey={cachedOrLiveAssetNode.assetKey}
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             loadedFromRepo={repoAddress!}
           />
+          {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
           <RepositoryLink repoAddress={repoAddress!} />
           {location && (
             <Caption color={Colors.textLighter()}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAllAssets.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAllAssets.tsx
@@ -192,6 +192,7 @@ class FetchManager {
     }
 
     if (didChange) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this._subscribers.forEach((callback) => callback(this._assetsOrError!));
     }
     if (this._subscribers.size) {
@@ -339,6 +340,7 @@ const getAssets = weakMapMemoize((allAssetNodes: WorkspaceAssetFragment[]) => {
       materializableAsset || observableAsset || nonGeneratedAsset || assetWithRepo || anyAsset;
 
     softwareDefinedAssets.push(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       combineAssetDefinitions(assetToReturn!, softwareDefinedAssetsByAssetKey[key]!),
     );
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionHealthData.tsx
@@ -97,8 +97,10 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
   const isRangeDataInverted =
     __dims.length === 2 &&
     assetPartitionStatuses.__typename === 'MultiPartitionStatuses' &&
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     assetPartitionStatuses.primaryDimensionName !== __dims[0]!.name;
 
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const dimensions = isRangeDataInverted ? [__dims[1]!, __dims[0]!] : __dims;
   const ranges = addKeyIndexesToMaterializedRanges(dimensions, assetPartitionStatuses);
 
@@ -111,6 +113,7 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
       warnUnlessTest('[stateForKey] called with zero dimension keys');
       return AssetPartitionStatus.MISSING;
     }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return stateForKeyIdx(dimensionKeys.map((key, idx) => __dims[idx]!.partitionKeys.indexOf(key)));
   };
 
@@ -128,6 +131,7 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
       return AssetPartitionStatus.MISSING;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const d0Range = ranges.find((r) => r.start.idx <= dIndexes[0]! && r.end.idx >= dIndexes[0]!);
 
     if (!d0Range) {
@@ -137,8 +141,10 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
       return d0Range.value[0] ?? AssetPartitionStatus.MISSING; // 1D case
     }
     const d1Range = d0Range.subranges.find(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       (r) => r.start.idx <= dIndexes[1]! && r.end.idx >= dIndexes[1]!,
     );
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return d1Range ? d1Range.value[0]! : AssetPartitionStatus.MISSING;
   };
 
@@ -182,10 +188,12 @@ export function buildPartitionHealthData(data: PartitionHealthQuery, loadKey: As
       return removeSubrangesAndJoin(clipped);
     } else {
       const [d0, d1] = dimensions;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const allKeys = d1!.partitionKeys;
       const d0KeyCount = otherDimensionSelectedRanges
         ? keyCountInRanges(otherDimensionSelectedRanges)
-        : d0!.partitionKeys.length;
+        : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          d0!.partitionKeys.length;
       if (d0KeyCount === 0) {
         return [];
       }
@@ -361,10 +369,12 @@ export function keyCountByStateInSelection(
 
   const rangesInSelection = rangesClippedToSelection(
     assetHealth?.ranges || [],
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     selections[0]!.selectedRanges,
   );
 
   const secondDimensionKeyCount =
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     selections.length > 1 ? keyCountInRanges(selections[1]!.selectedRanges) : 1;
 
   const sumWithStatus = (status: AssetPartitionStatus) => {
@@ -374,6 +384,7 @@ export function keyCountByStateInSelection(
         (b.end.idx - b.start.idx + 1) *
           (b.subranges
             ? keyCountInRanges(
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 rangesClippedToSelection(b.subranges, selections[1]!.selectedRanges).filter((b) =>
                   b.value.includes(status),
                 ),
@@ -417,6 +428,7 @@ function addKeyIndexesToMaterializedRanges(
     return result;
   }
   if (partitions.__typename === 'DefaultPartitionStatuses') {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const dim = dimensions[0]!;
     const materializedPartitionKeys = new Set(partitions.materializedPartitions);
     const materializingPartitionKeys = new Set(partitions.materializingPartitions);
@@ -443,7 +455,9 @@ function addKeyIndexesToMaterializedRanges(
   for (const range of partitions.ranges) {
     if (range.__typename === 'TimePartitionRangeStatus') {
       result.push({
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         start: {key: range.startKey, idx: dimensions[0]!.partitionKeys.indexOf(range.startKey)},
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         end: {key: range.endKey, idx: dimensions[0]!.partitionKeys.indexOf(range.endKey)},
         value: [rangeStatusToState(range.status)],
       });
@@ -453,7 +467,9 @@ function addKeyIndexesToMaterializedRanges(
         return result;
       }
       const [dim0, dim1] = dimensions;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const subranges: Range[] = addKeyIndexesToMaterializedRanges([dim1!], range.secondaryDim);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const value = partitionStatusGivenRanges(subranges, dim1!.partitionKeys.length);
       if (isEqual(value, [AssetPartitionStatus.MISSING])) {
         continue; // should not happen, just for Typescript correctness
@@ -463,10 +479,12 @@ function addKeyIndexesToMaterializedRanges(
         subranges,
         start: {
           key: range.primaryDimStartKey,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           idx: dim0!.partitionKeys.indexOf(range.primaryDimStartKey),
         },
         end: {
           key: range.primaryDimEndKey,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           idx: dim0!.partitionKeys.indexOf(range.primaryDimEndKey),
         },
       });
@@ -487,7 +505,9 @@ export function rangesForKeys(keys: string[], allKeys: string[]): Range[] {
   if (keys.length === allKeys.length) {
     return [
       {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         start: {key: allKeys[0]!, idx: 0},
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         end: {key: allKeys[allKeys.length - 1]!, idx: allKeys.length - 1},
         value: [AssetPartitionStatus.MATERIALIZED],
       },
@@ -502,11 +522,15 @@ export function rangesForKeys(keys: string[], allKeys: string[]): Range[] {
   const ranges: Range[] = [];
 
   for (const idx of keysIdxs) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     if (ranges.length && idx === ranges[ranges.length - 1]!.end.idx + 1) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       ranges[ranges.length - 1]!.end = {idx, key: allKeys[idx]!};
     } else {
       ranges.push({
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         start: {idx, key: allKeys[idx]!},
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         end: {idx, key: allKeys[idx]!},
         value: [AssetPartitionStatus.MATERIALIZED],
       });

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationsTable.tsx
@@ -104,7 +104,9 @@ export const AutomationsTable = ({
         {flagUseNewObserveUIs ? null : <VirtualizedAutomationHeader checkbox={headerCheckbox} />}
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, key, size, start}) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const row: RowType = flattened[index]!;
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const type = row!.type;
             if (type === 'header') {
               return (

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/VirtualizedAutomationScheduleRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/VirtualizedAutomationScheduleRow.tsx
@@ -184,6 +184,7 @@ export const VirtualizedAutomationScheduleRow = forwardRef(
                     >
                       Next tick:&nbsp;
                       <TimestampDisplay
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         timestamp={scheduleData.scheduleState.nextTick.timestamp!}
                         timezone={scheduleData.executionTimezone}
                         timeFormat={{showSeconds: false, showTimezone: true}}

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/__tests__/AutomationStateChangeDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/__tests__/AutomationStateChangeDialog.test.tsx
@@ -396,9 +396,13 @@ describe('AutomationStateChangeDialog', () => {
       expect(screen.getByText(/could not start 2 automations/i)).toBeVisible();
       const errorItems = screen.getAllByRole('listitem');
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(errorItems[0]!.textContent).toMatch(/louisiana/i);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(errorItems[0]!.textContent).toMatch(/lol u cannot/i);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(errorItems[1]!.textContent).toMatch(/colorado/i);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(errorItems[1]!.textContent).toMatch(/lol u cannot/i);
     });
   });
@@ -600,9 +604,13 @@ describe('AutomationStateChangeDialog', () => {
       expect(screen.getByText(/could not stop 2 automations/i)).toBeVisible();
       const errorItems = screen.getAllByRole('listitem');
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(errorItems[0]!.textContent).toMatch(/oregon/i);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(errorItems[0]!.textContent).toMatch(/lol u cannot/i);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(errorItems[1]!.textContent).toMatch(/hawaii/i);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(errorItems[1]!.textContent).toMatch(/lol u cannot/i);
     });
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLinkProtocol.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLinkProtocol.tsx
@@ -21,6 +21,7 @@ const POPULAR_PROTOCOLS: {[name: string]: string} = {
   '': 'Custom',
 };
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const DEFAULT_PROTOCOL = {protocol: Object.keys(POPULAR_PROTOCOLS)[0]!, custom: false};
 
 export type ProtocolData = {

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationAssetsList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationAssetsList.tsx
@@ -120,6 +120,7 @@ export const CodeLocationAssetsList = ({repoAddress}: Props) => {
         </HeaderRow>
         <Inner $totalHeight={totalHeight}>
           {virtualItems.map(({index, key, size, start}) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const item = flattened[index]!;
             if (item.type === 'group') {
               return (

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationSearchableList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationSearchableList.tsx
@@ -64,6 +64,7 @@ export const CodeLocationSearchableList = <T,>(props: Props<T>) => {
           {virtualItems.length > 0 ? (
             <Inner $totalHeight={totalHeight}>
               {virtualItems.map(({index, key, size, start}) => {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 const item = filteredItems[index]!;
                 return (
                   <Row key={key} $height={size} $start={start}>

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/DynamicStepSupport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/DynamicStepSupport.tsx
@@ -23,9 +23,11 @@ export function invocationsOfPlannedDynamicStep(plannedStepKey: string, runtimeS
 }
 
 export function dynamicKeyWithoutIndex(stepKey: string) {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return stepKey.split('[')[0]!;
 }
 
 export function replacePlannedIndex(stepKey: string, stepKeyWithIndex: string) {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return stepKey.replace('[?]', stepKeyWithIndex.match(/(\[.*\])/)![1]!);
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChart.tsx
@@ -136,6 +136,7 @@ export const GanttChart = (props: GanttChartProps) => {
       cachedLayout.current = buildLayout(layoutParams);
       cachedLayoutParams.current = layoutParams;
     }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return cachedLayout.current!;
   }, [layoutParams]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChartLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChartLayout.ts
@@ -105,6 +105,7 @@ export const buildLayout = (params: BuildLayoutParams) => {
       if (isDynamicStep(box.node.name) && !isDynamicStep(highestYParent.node.name)) {
         continue;
       }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const onTargetY = boxesByY[`${highestYParent.y}`]!;
       const taken = onTargetY.find((r) => r.x === box.x);
       if (taken) {
@@ -120,8 +121,10 @@ export const buildLayout = (params: BuildLayoutParams) => {
         continue;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       boxesByY[`${box.y}`] = boxesByY[`${box.y}`]!.filter((b) => b !== box);
       box.y = highestYParent.y;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       boxesByY[`${box.y}`]!.push(box);
 
       changed = true;
@@ -135,13 +138,16 @@ export const buildLayout = (params: BuildLayoutParams) => {
     // resulting tree rather than placed randomly before their mutual dependents.
     let bottomY = 0;
     for (const y of Object.keys(boxesByY)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const row = boxesByY[y]!;
       if (!row.length) {
         continue;
       }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       let x = row[0]!.root
         ? LEFT_INSET
-        : parents[row[0]!.node.name]![0]!.x + FLAT_INSET_FROM_PARENT;
+        : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          parents[row[0]!.node.name]![0]!.x + FLAT_INSET_FROM_PARENT;
       for (const box of row) {
         box.x = x;
         box.y = bottomY;
@@ -238,6 +244,7 @@ const addChildren = (boxes: GanttChartBox[], box: GanttChartBox, params: BuildLa
         boxes.push(depBox);
         added.push(depBox);
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         depBox = boxes[depBoxIdx]!;
         ensureSubtreeAfterParentInArray(boxes, box, depBox);
       }
@@ -318,6 +325,7 @@ const cloneLayout = ({boxes, markers}: GanttChartLayout): GanttChartLayout => {
   }
 
   boxes.forEach((box, ii) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     nextBoxes[ii]!.children = box.children.map((c) => map.get(c));
   });
 
@@ -336,6 +344,7 @@ const positionAndSplitBoxes = (
   // Apply X values + widths to boxes, and break apart retries into their own boxes by looking
   // at the transitions recorded for each step.
   for (let ii = boxes.length - 1; ii >= 0; ii--) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const box = boxes[ii]!;
     const meta = metadata.steps[box.node.name];
     if (!meta) {
@@ -360,8 +369,10 @@ const positionAndSplitBoxes = (
 
     // Move the children (used to draw outbound lines) to the last box
     for (let jj = 0; jj < runBoxes.length - 1; jj++) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       runBoxes[jj]!.children = [runBoxes[jj + 1]!];
     }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     runBoxes[runBoxes.length - 1]!.children = box.children;
 
     Object.assign(box, runBoxes[0]);
@@ -503,6 +514,7 @@ export const interestingQueriesFor = (metadata: IRunMetadataDict, layout: GanttC
   const results: {name: string; value: string}[] = [];
 
   const errorsQuery = Object.keys(metadata.steps)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     .filter((k) => metadata.steps[k]!.state === IStepState.FAILED)
     .map((k) => `+${k}`)
     .join(', ');
@@ -514,8 +526,11 @@ export const interestingQueriesFor = (metadata: IRunMetadataDict, layout: GanttC
     .filter((k) => metadata.steps[k]?.end && metadata.steps[k]?.start)
     .sort(
       (a, b) =>
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         metadata.steps[b]!.end! -
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         metadata.steps[b]!.start! -
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         (metadata.steps[a]!.end! - metadata.steps[a]!.start!),
     )
     .slice(0, 5)

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChartTimescale.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChartTimescale.tsx
@@ -139,11 +139,14 @@ export const GanttChartTimescale = React.memo(
               key="highlight-duration"
               className="tick duration"
               style={{
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 left: (highlightedMs[0]! - startMs) * pxPerMs + 2,
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 width: (highlightedMs[1]! - highlightedMs[0]!) * pxPerMs - 2,
                 transform,
               }}
             >
+              {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
               {formatElapsedTimeWithoutMsec(highlightedMs[1]! - highlightedMs[0]!)}
             </div>
           )}

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttStatusPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttStatusPanel.tsx
@@ -44,6 +44,7 @@ export const GanttStatusPanel = React.memo(
       const succeeded = [];
       const notExecuted = [];
       for (const key of keys) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const state = metadata.steps[key]!.state;
         switch (state) {
           case IStepState.PREPARING:

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/ZoomSlider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/ZoomSlider.tsx
@@ -13,6 +13,7 @@ export const ZoomSlider = React.memo((props: {value: number; onChange: (v: numbe
       $fillColor={Colors.accentGray()}
       className="bp5-slider bp5-slider-unlabeled"
       onMouseDown={(e: React.MouseEvent) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const rect = e.currentTarget.closest('.bp5-slider')!.getBoundingClientRect();
 
         let initialX: number;

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/__tests__/GanttChartLayout.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/__tests__/GanttChartLayout.test.ts
@@ -32,6 +32,7 @@ describe('toGraphQueryItems', () => {
       x: 16,
       y: 0,
     });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(result.boxes[0]!.children.length).toEqual(1);
     expect(result.boxes[1]).toMatchObject({
       key: 'depends_on_yesterday',

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/toGraphQueryItems.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/toGraphQueryItems.tsx
@@ -72,6 +72,7 @@ export const toGraphQueryItems = (
       for (const input of step.inputs) {
         // Add the input to our node in the result set
         const nodeInput: GraphQueryItem['inputs'][0] = {dependsOn: []};
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         nodeTable[key]!.inputs.push(nodeInput);
 
         // For each upstream step in the plan, map it to upstream nodes in the runtime graph
@@ -97,9 +98,11 @@ export const toGraphQueryItems = (
               continue;
             }
             nodeInput.dependsOn.push({solid: {name: upstreamKey}});
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             let upstreamOutput: GraphQueryItem['outputs'][0] = nodeTable[upstreamKey]!.outputs[0]!;
             if (!upstreamOutput) {
               upstreamOutput = {dependedBy: []};
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               nodeTable[upstreamKey]!.outputs.push(upstreamOutput);
             }
             upstreamOutput.dependedBy.push({

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpEdges.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpEdges.tsx
@@ -20,11 +20,13 @@ type Path = {
 const buildSVGPaths = weakMapMemoize((edges: OpLayoutEdge[], nodes: {[name: string]: OpLayout}) =>
   edges
     .map(({from, to}) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const source = nodes[from.opName]!;
       const sourceOutput =
         source.outputs[from.edgeName] ||
         Object.values(source.outputs).find((o) => o.collapsed.includes(from.edgeName));
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const target = nodes[to.opName]!;
       const targetInput =
         target.inputs[to.edgeName] ||

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpGraph.tsx
@@ -105,6 +105,7 @@ const OpGraphContents = React.memo((props: OpGraphContentsProps) => {
       ))}
       <foreignObject width={layout.width} height={layout.height} style={{pointerEvents: 'none'}}>
         {ops
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           .filter((op) => !isNodeOffscreen(layout.nodes[op.name]!.bounds, viewportRect))
           .map((op) => (
             <OpNode
@@ -116,6 +117,7 @@ const OpGraphContents = React.memo((props: OpGraphContentsProps) => {
               onDoubleClick={() => onDoubleClickOp({name: op.name})}
               onEnterComposite={() => onEnterSubgraph({name: op.name})}
               onHighlightEdges={setHighlighted}
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               layout={layout.nodes[op.name]!}
               selected={selectedOp === op}
               focused={focusOps.includes(op)}
@@ -141,6 +143,7 @@ export class OpGraph extends React.Component<OpGraphProps> {
   viewportEl: React.RefObject<SVGViewportRef> = React.createRef();
 
   argToOpLayout = (arg: OpNameOrPath) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const lastName = 'name' in arg ? arg.name : arg.path[arg.path.length - 1]!;
     return this.props.layout.nodes[lastName];
   };
@@ -160,16 +163,20 @@ export class OpGraph extends React.Component<OpGraphProps> {
   };
 
   unfocus = (e: React.MouseEvent<any>) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.viewportEl.current!.autocenter(true);
     e.stopPropagation();
   };
 
   componentDidUpdate(prevProps: OpGraphProps) {
     if (prevProps.parentOp !== this.props.parentOp) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.viewportEl.current!.cancelAnimations();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.viewportEl.current!.autocenter();
     }
     if (prevProps.layout !== this.props.layout) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.viewportEl.current!.autocenter();
     }
     if (prevProps.selectedOp !== this.props.selectedOp && this.props.selectedOp) {

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpIOBox.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpIOBox.tsx
@@ -173,6 +173,7 @@ export function metadataForCompositeParentIO(
   return {
     edges,
     title,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     jumpTargetOp: edges.length === 1 ? edges[0]!.a : null,
   };
 }
@@ -187,9 +188,11 @@ export function metadataForIO(
   let jumpTargetOp: string | null = null;
 
   if (invocation && item.__typename === 'InputDefinition') {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const others = invocation.inputs.find((i) => i.definition.name === item.name)!.dependsOn;
     if (others.length) {
       title += `\n\nFrom:\n` + others.map(titleOfIO).join('\n');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       jumpTargetOp = others.length === 1 ? others[0]!.solid.name : null;
       edges.push(...others.map((o) => ({a: o.solid.name, b: invocation.name})));
     }
@@ -206,6 +209,7 @@ export function metadataForIO(
     const others = output.dependedBy;
     if (others.length) {
       title += '\n\nUsed By:\n' + others.map((o) => titleOfIO(o)).join('\n');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       jumpTargetOp = others.length === 1 ? others[0]!.solid.name : null;
       edges.push(...others.map((o) => ({a: o.solid.name, b: invocation.name})));
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpNode.tsx
@@ -202,6 +202,7 @@ const OpNodeAssociatedAssets = ({nodes}: {nodes: {assetKey: AssetKey}[]}) => {
   return (
     <div className="assets">
       <Icon name="asset" size={16} />
+      {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
       {withMiddleTruncation(displayNameForAssetKey(nodes[0]!.assetKey), {
         maxLength: 48 - more.length,
       })}

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/ParentOpNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/ParentOpNode.tsx
@@ -128,6 +128,7 @@ export const ParentOpNode = (props: ParentOpNodeProps) => {
       })}
       {op.definition.inputDefinitions.map((input, idx) => {
         const metadata = metadataForCompositeParentIO(op.definition, input);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const invocationInput = op.inputs.find((i) => i.definition.name === input.name)!;
         return (
           <Fragment key={idx}>
@@ -139,7 +140,9 @@ export const ParentOpNode = (props: ParentOpNodeProps) => {
                 labelAttachment="top"
                 label={titleOfIO(dependsOn)}
                 minified={minified}
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 layout={parentLayout.dependsOn[titleOfIO(dependsOn)]!}
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 target={parentLayout.inputs[input.name]!.port}
                 onDoubleClickLabel={() => props.onClickOp({path: ['..', dependsOn.solid.name]})}
               />
@@ -149,6 +152,7 @@ export const ParentOpNode = (props: ParentOpNodeProps) => {
       })}
       {op.definition.outputDefinitions.map((output, idx) => {
         const metadata = metadataForCompositeParentIO(op.definition, output);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const invocationOutput = op.outputs.find((i) => i.definition.name === output.name)!;
         return (
           <Fragment key={idx}>
@@ -160,7 +164,9 @@ export const ParentOpNode = (props: ParentOpNodeProps) => {
                 labelAttachment="bottom"
                 label={titleOfIO(dependedBy)}
                 minified={minified}
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 layout={parentLayout.dependedBy[titleOfIO(dependedBy)]!}
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 target={parentLayout.outputs[output.name]!.port}
                 onDoubleClickLabel={() => props.onClickOp({path: ['..', dependedBy.solid.name]})}
               />

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGComponents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGComponents.tsx
@@ -46,6 +46,7 @@ export class SVGMonospaceText extends React.PureComponent<
 
     if (allowTwoLines) {
       const parts = text.split('_');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       while (parts.length && line1.length + parts[0]!.length <= lineChars) {
         line1 += parts.shift() + (parts.length > 0 ? '_' : '');
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/__fixtures__/OpGraph.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/__fixtures__/OpGraph.fixtures.ts
@@ -18,6 +18,7 @@ function buildEdge(descriptor: string): Edge {
     throw new Error(`Cannot parse ${descriptor}`);
   }
   const [_, fromOp, fromIO, toOp, toIO] = match;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return {fromOp: fromOp!, fromIO: fromIO!, toOp: toOp!, toIO: toIO!};
 }
 
@@ -103,6 +104,7 @@ export function buildTaggedDAG() {
   const ops = buildBasicDAG();
 
   ['ipynb', 'sql', 'verylongtypename', 'story'].forEach((kind, idx) =>
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     ops[idx]!.definition.metadata.push({
       key: 'kind',
       value: kind,
@@ -115,6 +117,7 @@ export function buildTaggedDAG() {
 
 export function buildCompositeDAG() {
   const ops = buildBasicDAG();
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const composite = ops.find((s) => s.name === 'C')!;
 
   const edges = [buildEdge(`CA:out=>CB:in`)];
@@ -130,10 +133,13 @@ export function buildCompositeDAG() {
     inputMappings: [
       {
         __typename: 'InputMapping',
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         definition: composite.definition.inputDefinitions[0]!,
         mappedInput: {
           __typename: 'Input',
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           solid: childOps[0]!,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           definition: childOps[0]!.definition.inputDefinitions[0]!,
         },
       },
@@ -141,10 +147,13 @@ export function buildCompositeDAG() {
     outputMappings: [
       {
         __typename: 'OutputMapping',
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         definition: composite.definition.outputDefinitions[0]!,
         mappedOutput: {
           __typename: 'Output',
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           solid: childOps[1]!,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           definition: childOps[1]!.definition.outputDefinitions[0]!,
         },
       },
@@ -172,21 +181,29 @@ export function buildCompositeCollapsedIODAG() {
     ...composite.definition,
     __typename: 'CompositeSolidDefinition',
     id: 'composite-solid-id',
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     inputMappings: childOps[0]!.definition.inputDefinitions.map((inputDef, idx) => ({
       __typename: 'InputMapping',
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       definition: composite.definition.inputDefinitions[idx]!,
       mappedInput: {
         __typename: 'Input',
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         solid: childOps[0]!,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         definition: inputDef!,
       },
     })),
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     outputMappings: childOps[1]!.definition.outputDefinitions.map((outputDef, idx) => ({
       __typename: 'OutputMapping',
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       definition: composite.definition.outputDefinitions[idx]!,
       mappedOutput: {
         __typename: 'Output',
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         solid: childOps[1]!,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         definition: outputDef!,
       },
     })),

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/layout.ts
@@ -215,7 +215,9 @@ export function layoutOpGraph(pipelineOps: ILayoutOp[], opts: LayoutOpGraphOptio
     const conn = edges.find((c) => c.from.opName === e.v && c.to.opName === e.w);
     const points = g.edge(e).points;
     if (conn && points.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       conn.from.point = points[0]!;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       conn.to.point = points[points.length - 1]!;
     }
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/makeSVGPortable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/makeSVGPortable.tsx
@@ -59,6 +59,7 @@ async function makeAttributeValuePortable(attrValue: string) {
   if (attrValue.startsWith('url(')) {
     const match = attrValue.match(/url\(['"]?(http[^'"]+)['"]?\)/);
     if (match) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const url = match[1]!;
       const data = await convertURLToBase64Data(url);
       attrValue = attrValue.replace(url, data);

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useQueryPersistedState.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useQueryPersistedState.test.tsx
@@ -568,6 +568,7 @@ describe('useQueryPersistedState', () => {
     );
 
     act(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       push!('/page?');
     });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useDebugChanged.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useDebugChanged.tsx
@@ -41,8 +41,10 @@ export const useDebugChanged = <T,>(objects: T[]): void => {
       if (obj !== previousObjects[index]) {
         changes.push({
           index,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           previous: previousObjects[index]!,
           current: obj,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           differences: getDifferences(previousObjects[index]!, obj!),
         });
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useSelectionReducer.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useSelectionReducer.ts
@@ -45,6 +45,7 @@ const reducer = (state: State, action: Action): State => {
       }
 
       const [start, end] = [indexOfLast, indexOfChecked].sort();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       allIds.slice(start, end! + 1).forEach((id) => {
         if (checked) {
           copy.add(id);

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
@@ -22,6 +22,7 @@ export const ThrottledMemoBatchingContext = createContext<{enqueue: (update: () 
           setTimeout(() => {
             unstable_batchedUpdates(() => {
               while (queue.length) {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 queue.shift()!();
               }
               isScheduled = false;

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsBarChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsBarChart.tsx
@@ -82,6 +82,7 @@ export const InsightsBarChart = (props: Props) => {
   // Don't show the y axis while loading datapoints, to avoid jumping renders.
   const showYAxis = values.length > 0;
 
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const barColorRGB = rgbColors[barColor]!;
   const keylineDefaultRGB = rgbColors[Colors.keylineDefault()];
   const textLighterRGB = rgbColors[Colors.textLighter()];

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsLineChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsLineChart.tsx
@@ -94,6 +94,7 @@ export const InsightsLineChart = (props: Props) => {
     return {
       labels: timestamps,
       datasets: dataEntries.map(([key, {label, lineColor, values}]) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const rgbLineColor = rgbColors[lineColor]!;
         return {
           label,

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/__stories__/InsightsLineChart.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/__stories__/InsightsLineChart.stories.tsx
@@ -36,6 +36,7 @@ export const Default = () => {
         return [
           key,
           {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             lineColor: orderedColors[ii % numLines]!,
             type: 'asset-group' as const,
             label: key,

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrencyKeyInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceConcurrencyKeyInfo.tsx
@@ -294,6 +294,7 @@ const EditConcurrencyLimitDialog = ({
   const save = async () => {
     setIsSubmitting(true);
     await setConcurrencyLimit({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       variables: {concurrencyKey, limit: parseInt(limitInput!.trim())},
     });
     setIsSubmitting(false);

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/StepSummaryForRun.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/StepSummaryForRun.tsx
@@ -53,6 +53,7 @@ export const StepSummaryForRun = (props: Props) => {
 
   if (failedStatuses.has(status)) {
     if (stepCount === 1) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const step = relevantSteps[0]!;
       const query = step.endTime
         ? qs.stringify({focusedTime: Math.floor(step.endTime * 1000)}, {addQueryPrefix: true})
@@ -72,6 +73,7 @@ export const StepSummaryForRun = (props: Props) => {
 
   if (inProgressStatuses.has(status)) {
     if (stepCount === 1) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const step = relevantSteps[0]!;
       const query = step.endTime
         ? qs.stringify({focusedTime: Math.floor(step.endTime * 1000)}, {addQueryPrefix: true})

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/VirtualizedInstanceConcurrencyTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/VirtualizedInstanceConcurrencyTable.tsx
@@ -34,6 +34,7 @@ export const ConcurrencyTable = ({concurrencyKeys}: {concurrencyKeys: string[]})
         <ConcurrencyHeader />
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, key, size, start}) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const concurrencyKey = concurrencyKeys[index]!;
             return (
               <ConcurrencyRow

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillAssetPartitionsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillAssetPartitionsTable.tsx
@@ -77,6 +77,7 @@ export const BackfillAssetPartitionsTable = ({
         {items.map(({index, key, size, start}) => (
           <VirtualizedBackfillPartitionsRow
             key={key}
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             asset={assetStatuses[index]!}
             backfill={backfill}
             height={size}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/ExecutionTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/ExecutionTimeline.tsx
@@ -77,6 +77,7 @@ export const ExecutionTimeline = (props: Props) => {
               {items.map(({index, key, size, start}) => (
                 <ExecutionTimelineRow
                   key={key}
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                   run={runs[index]!}
                   top={start}
                   height={size}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/TargetPartitionsDisplay.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/TargetPartitionsDisplay.tsx
@@ -60,6 +60,7 @@ export const TargetPartitionsDisplay = ({
 
   if (ranges) {
     if (ranges.length === 1) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const {start, end} = ranges[0]!;
       return (
         <div>

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/LiveTickTimeline2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/LiveTickTimeline2.tsx
@@ -79,6 +79,7 @@ export const LiveTickTimeline = <T extends HistoryTickFragment | AssetDaemonTick
 
   const ticksToDisplay = useMemo(() => {
     return ticksReversed.map((tick, i) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const startX = getX(1000 * tick.timestamp!, viewport.width, minX, fullRange);
       const endTimestamp = isStuckStartedTick(tick, ticksReversed.length - i - 1)
         ? tick.timestamp
@@ -208,6 +209,7 @@ const TickTooltip = memo(
       }
     }, [tick, tickResultType]);
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const startTime = dayjs(1000 * tick.timestamp!);
     const endTime = dayjs(tick.endTimestamp ? 1000 * tick.endTimestamp : Date.now());
     const elapsedTime = startTime.to(endTime, true);

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
@@ -229,6 +229,7 @@ export function TickDetailSummary({
                 onClick={() => {
                   showCustomAlert({
                     title: 'Tick error',
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     body: <PythonErrorInfo error={tick.error!} />,
                   });
                 }}

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickMaterializationsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickMaterializationsTable.tsx
@@ -101,6 +101,7 @@ export const TickMaterializationsTable = ({
         </HeaderRow>
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, key, size, start}) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const assetKey = filteredAssetKeys[index]!;
             return (
               <AssetDetailRow
@@ -109,6 +110,7 @@ export const TickMaterializationsTable = ({
                 $start={start}
                 assetKey={assetKey}
                 partitionKeys={assetKeyToPartitionsMap[tokenForAssetKey(assetKey)]}
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 evaluationId={tick.autoMaterializeAssetEvaluationId!}
               />
             );

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -855,6 +855,7 @@ const deletePropertyPath = (obj: any, path: string) => {
   // the second to last nested object. This is so we can call `delete` using
   // this object and the last part of the path.
   for (let i = 0; i < parts.length - 1; i++) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     obj = obj[parts[i]!];
     if (typeof obj === 'undefined') {
       return;

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadStoredSessionsContainer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadStoredSessionsContainer.tsx
@@ -40,6 +40,7 @@ export const LaunchpadStoredSessionsContainer = (props: Props) => {
     onSave((data) => applyCreateSession(data, initialDataForMode));
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const currentSession = data.sessions[data.current]!;
 
   const onSaveSession = useSetStateUpdateCallback<IExecutionSessionChanges>(

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTabs.tsx
@@ -111,6 +111,7 @@ export const LaunchpadTabs = (props: LaunchpadTabsProps) => {
       await confirm({
         title: 'Remove tab?',
         description: `The configuration for ${
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           keyToRemove && sessions[keyToRemove] ? `"${sessions[keyToRemove]!.name}"` : 'this tab'
         } will be discarded.`,
       });
@@ -141,6 +142,7 @@ export const LaunchpadTabs = (props: LaunchpadTabsProps) => {
             canRemove={sessionCount > 1}
             key={key}
             active={key === data.current}
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             title={sessions[key]!.name || 'Unnamed'}
             onClick={() => onApply(applySelectSession, key)}
             onChange={(name) => onApply(applyChangesToSession, key, {name})}

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/RunPreview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/RunPreview.tsx
@@ -77,8 +77,11 @@ const RemoveExtraConfigButton = ({
     // these in `knownKeyExtraPaths` just so we can display them with an extra description.
     if (parts.length === 2) {
       const [type, name] = parts;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const target = knownKeyExtraPaths[type!] || [];
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       target.push(name!);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       knownKeyExtraPaths[type!] = target;
     } else {
       otherPaths.push(path);
@@ -383,12 +386,15 @@ export const RunPreview = (props: RunPreviewProps) => {
         return (
           <Tooltip
             position="bottom"
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             content={stateToHint[state]!.title}
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             intent={stateToHint[state]!.intent}
             key={item.name}
           >
             <Tag
               key={item.name}
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               intent={stateToHint[state]!.intent}
               onClick={() => {
                 const first = pathErrors.find(isValidationError);
@@ -691,5 +697,6 @@ function pathExistsInObject(path: string[], object: any): boolean {
     return true;
   }
   const [first, ...rest] = path;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return pathExistsInObject(rest, object[first!]);
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/scaffoldType.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/scaffoldType.ts
@@ -8,6 +8,7 @@ export const scaffoldType = (
   configTypeKey: string,
   typeLookup: {[key: string]: AllConfigTypesForEditorFragment},
 ): any => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const type = typeLookup[configTypeKey]!;
 
   switch (type.__typename) {
@@ -34,6 +35,7 @@ export const scaffoldType = (
     case 'NullableConfigType':
       // If a type is nullable we include it in the scaffolded config anyway
       // by using the inner type
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const innerType = type.typeParamKeys[0]!;
       return scaffoldType(innerType, typeLookup);
     case 'EnumConfigType':

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThreadManager.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThreadManager.tsx
@@ -73,6 +73,7 @@ export class LiveDataThreadManager<T> {
       this.threads[threadID] = _thread;
     }
     this.listeners[key] = this.listeners[key] || new Set();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.listeners[key]!.add(listener);
     if (this.cache[key]) {
       listener(key, this.cache[key]);

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/__tests__/TableMetadataEntryComponent.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/__tests__/TableMetadataEntryComponent.test.tsx
@@ -25,7 +25,9 @@ describe('TableMetadataEntryComponent', () => {
     const rows = await screen.findAllByRole('row');
     expect(rows).toHaveLength(2);
     const [headerRow, dataRow] = rows;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(headerRow!).toHaveTextContent(/foobar/i);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(dataRow!).toHaveTextContent(/12/i);
   });
 
@@ -47,12 +49,17 @@ describe('TableMetadataEntryComponent', () => {
     const [headerRow, dataRow, invalidRow] = rows;
 
     // Display parseable rows as expected
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(headerRow!).toHaveTextContent(/foobar/i);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(dataRow!).toHaveTextContent(/12/i);
 
     // Display unparseable text in a single stretched cell
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(invalidRow!.childNodes).toHaveLength(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(invalidRow!).toHaveTextContent(/could not parse/i);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(invalidRow!).toHaveTextContent(/{"foo": NaN, "bar": …/i);
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNavItem.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNavItem.tsx
@@ -35,6 +35,7 @@ export const LeftNavItem = React.forwardRef(
 
     useQuery<InstigationStatesQuery, InstigationStatesQueryVariables>(INSTIGATION_STATES_QUERY, {
       variables: {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         repositoryID: repositoryId!,
       },
       skip: !repositoryId,
@@ -75,6 +76,7 @@ export const LeftNavItem = React.forwardRef(
 
         if (scheduleCount) {
           if (scheduleCount === 1) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const schedule = schedules[0]!;
             const {cronSchedule, executionTimezone} = schedule;
             return (
@@ -92,7 +94,8 @@ export const LeftNavItem = React.forwardRef(
 
         return sensorCount === 1 ? (
           <div>
-            Sensor: <strong>{sensors[0]!.name}</strong>
+            {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
+            <strong>{sensors[0]!.name}</strong>
           </div>
         ) : (
           `${sensorCount} sensors`
@@ -118,9 +121,11 @@ export const LeftNavItem = React.forwardRef(
         }
 
         const path = scheduleCount
-          ? `/schedules/${schedules[0]!.name}`
+          ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            `/schedules/${schedules[0]!.name}`
           : sensorCount
-            ? `/sensors/${sensors[0]!.name}`
+            ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              `/sensors/${sensors[0]!.name}`
             : null;
 
         return path ? <Link to={workspacePathFromAddress(repoAddress, path)}>{icon}</Link> : null;

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/PipelineNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/PipelineNav.tsx
@@ -24,6 +24,7 @@ export const PipelineNav = (props: Props) => {
     '/locations/:repoPath/pipeline_or_job/:selector/:tab?',
   ]);
 
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const explorerPath = explorerPathFromString(match!.params.selector);
   const {pipelineName, snapshotId} = explorerPath;
 
@@ -71,6 +72,7 @@ export const PipelineNav = (props: Props) => {
             isJob={isJob}
             explorerPath={explorerPath}
             permissions={permissions}
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             matchingTab={match!.params.tab}
             tabs={tabs}
           />

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/RepoNavItem.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/RepoNavItem.tsx
@@ -41,9 +41,11 @@ export const RepoNavItem = (props: Props) => {
       return <span style={{color: Colors.textLighter()}}>No definitions</span>;
     }
     if (allRepos.length === 1) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return <SingleRepoSummary repo={allRepos[0]!} onlyRepo />;
     }
     if (selected.length === 1) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const selectedRepo = selected[0]!;
       return <SingleRepoSummary repo={selectedRepo} onlyRepo={false} />;
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/ScheduleOrSensorTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/ScheduleOrSensorTag.tsx
@@ -67,6 +67,7 @@ export const ScheduleOrSensorTag = ({
   if (scheduleCount) {
     return (
       <MatchingSchedule
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         schedule={schedules[0]!}
         repoAddress={repoAddress}
         showSwitch={showSwitch}
@@ -76,6 +77,7 @@ export const ScheduleOrSensorTag = ({
 
   if (sensorCount) {
     return (
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       <MatchingSensor sensor={sensors[0]!} repoAddress={repoAddress} showSwitch={showSwitch} />
     );
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__stories__/RepoNavItem.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__stories__/RepoNavItem.stories.tsx
@@ -159,6 +159,7 @@ export const ManyRepos = () => {
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const ONE_REPO = [OPTIONS[0]!];
 
 export const OneRepo = () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
@@ -219,6 +219,7 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
 
       const toastContent = () => {
         if (addedEntries.length === 1) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const entryId = addedEntries[0]!;
           const locationName = currEntriesById[entryId]?.name;
           // The entry should be in the entry map, but guard against errors just in case.
@@ -263,7 +264,8 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
             {currentlyLoading.length === 1 ? (
               <span>
-                Updating <strong>{currentlyLoading[0]!.name}</strong>
+                {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
+                <strong>{currentlyLoading[0]!.name}</strong>
               </span>
             ) : (
               <span>Updating {currentlyLoading.length} code locations</span>

--- a/js_modules/dagster-ui/packages/ui-core/src/ops/OpsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ops/OpsRoot.tsx
@@ -186,6 +186,7 @@ export const OpsRootWithData = (props: OpsRootWithDataProps) => {
   React.useEffect(() => {
     // If the user has typed in a search that brings us to a single result, autoselect it
     if (sorted.length === 1 && (!selected || sorted[0] !== selected)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       onClickOp(sorted[0]!.definition.name);
     }
 
@@ -279,6 +280,7 @@ const OpList = (props: OpListProps) => {
     <Container ref={containerRef}>
       <Inner $totalHeight={totalHeight}>
         {virtualItems.map(({index, size, start}) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const solid = items[index]!;
           return (
             <Row key={solid.definition.name} $height={size} $start={start}>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -127,6 +127,7 @@ export const OverviewAssetsRoot = ({Header, TabButton}: Props) => {
           <VirtualHeaderRow />
           <Inner $totalHeight={totalHeight}>
             {items.map(({index, key, size, start}) => {
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               const group = groupedAssets[index]!;
               return <VirtualRow key={key} start={start} height={size} group={group} />;
             })}

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewJobsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewJobsTable.tsx
@@ -85,7 +85,9 @@ export const OverviewJobsTable = ({repos}: Props) => {
             }}
           >
             {items.map(({index, key}) => {
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               const row: RowType = flattened[index]!;
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               const type = row!.type;
 
               if (type === 'header') {

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesTable.tsx
@@ -78,7 +78,9 @@ export const OverviewResourcesTable = ({repos}: Props) => {
         <VirtualizedResourceHeader />
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, key, size, start}) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const row: RowType = flattened[index]!;
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const type = row!.type;
             return type === 'header' ? (
               <RepoRow

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/groupRunsByAutomation.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/groupRunsByAutomation.tsx
@@ -24,6 +24,7 @@ export const groupRunsByAutomation = (jobRows: TimelineRow[]): TimelineRow[] => 
         };
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       byAutomation[key]!.runs.push(run);
     });
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
@@ -87,6 +87,7 @@ export const BackfillPartitionSelector = ({
   ]);
 
   const selected = React.useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return range.filter((r) => stateFilters.includes(runStatusData[r]!));
   }, [range, stateFilters, runStatusData]);
 
@@ -172,6 +173,7 @@ export const BackfillPartitionSelector = ({
   const counts = countsByState(
     range.map((key) => ({
       partitionKey: key,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       state: runStatusData[key]!,
     })),
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizards.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizards.tsx
@@ -55,6 +55,7 @@ export const DimensionRangeWizards = ({
             health={{
               ranges: displayedHealth.rangesForSingleDimension(
                 idx,
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 selections.length === 2 ? selections[1 - idx]!.selectedRanges : undefined,
               ),
             }}

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/JobBackfillsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/JobBackfillsTable.tsx
@@ -84,6 +84,7 @@ export const JobBackfillsTable = ({
             if (cursor) {
               setCursorStack((current) => [...current, cursor]);
             }
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const nextCursor = backfills && backfills[backfills.length - 1]!.id;
             if (!nextCursor) {
               return;

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
@@ -144,12 +144,14 @@ export function usePartitionDurations(partitions: PartitionRuns[]) {
         return;
       }
       const sortedRuns = p.runs.sort((a, b) => a.startTime || 0 - (b.startTime || 0));
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const lastRun = sortedRuns[sortedRuns.length - 1]!;
       stepDurationData[p.name] = {};
       runDurationData[p.name] =
         lastRun?.endTime && lastRun?.startTime ? lastRun.endTime - lastRun.startTime : undefined;
 
       lastRun.stepStats.forEach((s) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         stepDurationData[p.name]![s.stepKey] = [
           s.endTime && s.startTime ? s.endTime - s.startTime : undefined,
         ];

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatus.tsx
@@ -273,7 +273,9 @@ export const PartitionStatus = React.memo(
                   left: 0,
                   width: indexToPct(
                     Math.min(
+                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       partitionNames.indexOf(selected[selected.length - 1]!),
+                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       partitionNames.indexOf(selected[0]!),
                     ),
                   ),
@@ -284,13 +286,17 @@ export const PartitionStatus = React.memo(
                 style={{
                   left: `min(calc(100% - 3px), ${indexToPct(
                     Math.min(
+                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       partitionNames.indexOf(selected[0]!),
+                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       partitionNames.indexOf(selected[selected.length - 1]!),
                     ),
                   )})`,
                   width: indexToPct(
                     Math.abs(
+                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       partitionNames.indexOf(selected[selected.length - 1]!) -
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         partitionNames.indexOf(selected[0]!),
                     ) + 1,
                   ),
@@ -305,7 +311,9 @@ export const PartitionStatus = React.memo(
                     partitionNames.length -
                       1 -
                       Math.max(
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         partitionNames.indexOf(selected[selected.length - 1]!),
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         partitionNames.indexOf(selected[0]!),
                       ),
                   ),
@@ -354,7 +362,8 @@ function useColorSegments(
       ? opRunStatusToColorRanges(partitionNames, splitPartitions, _statusForKey)
       : _ranges && splitPartitions
         ? splitColorSegments(partitionNames, assetHealthToColorSegments(_ranges))
-        : assetHealthToColorSegments(_ranges!);
+        : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          assetHealthToColorSegments(_ranges!);
   }, [splitPartitions, partitionNames, _ranges, _statusForKey]);
 }
 
@@ -366,7 +375,9 @@ function splitColorSegments(partitionNames: string[], segments: ColorSegment[]):
   for (const segment of segments) {
     for (let idx = segment.start.idx; idx <= segment.end.idx; idx++) {
       result.push({
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         start: {idx, key: partitionNames[idx]!},
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         end: {idx, key: partitionNames[idx]!},
         label: segment.label,
         style: segment.style,

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStepStatus.tsx
@@ -142,6 +142,7 @@ export const PartitionPerAssetStatus = React.memo(
             name: box.node.name,
             unix: 0,
             color: assetPartitionStatusToSquareColor(
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               partitionStatusAtIndex(rangesByAssetKey[box.node.name]!, partitionKeyIdx),
             ),
           })),
@@ -520,6 +521,7 @@ const PartitionSquare = React.memo(
             <MenuLink
               icon="open_in_new"
               text="Show logs from last run"
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               to={linkToRunEvent(runs[runs.length - 1]!, {stepKey: step ? step.name : null})}
             />
             <MenuItem

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/SpanRepresentation.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/SpanRepresentation.tsx
@@ -23,6 +23,7 @@ export function stringForSpan(
   {startIdx, endIdx}: {startIdx: number; endIdx: number},
   all: string[],
 ) {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return startIdx === endIdx ? all[startIdx]! : `[${all[startIdx]!}...${all[endIdx]!}]`;
 }
 
@@ -36,7 +37,9 @@ export function allPartitionsRange({
   partitionKeys: string[];
 }): PartitionDimensionSelectionRange {
   return {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     start: {idx: 0, key: partitionKeys[0]!},
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     end: {idx: partitionKeys.length - 1, key: partitionKeys[partitionKeys.length - 1]!},
   };
 }
@@ -59,7 +62,9 @@ export function spanTextToSelectionsOrError(
     const rangeMatch = /^\[(.*)\.\.\.(.*)\]$/g.exec(term);
     if (rangeMatch) {
       const [, start, end] = rangeMatch;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const allStartIdx = allPartitionKeys.indexOf(start!);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const allEndIdx = allPartitionKeys.indexOf(end!);
       if (allStartIdx === -1 || allEndIdx === -1) {
         return new Error(`Could not find partitions for provided range: ${start}...${end}`);
@@ -68,7 +73,9 @@ export function spanTextToSelectionsOrError(
         allPartitionKeys.slice(allStartIdx, allEndIdx + 1),
       );
       result.selectedRanges.push({
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         start: {idx: allStartIdx, key: allPartitionKeys[allStartIdx]!},
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         end: {idx: allEndIdx, key: allPartitionKeys[allEndIdx]!},
       });
     } else if (term.includes('*')) {
@@ -78,7 +85,9 @@ export function spanTextToSelectionsOrError(
       const close = (end: number) => {
         result.selectedKeys = result.selectedKeys.concat(allPartitionKeys.slice(start, end + 1));
         result.selectedRanges.push({
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           start: {idx: start, key: allPartitionKeys[start]!},
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           end: {idx: end, key: allPartitionKeys[end]!},
         });
         start = -1;
@@ -86,6 +95,7 @@ export function spanTextToSelectionsOrError(
 
       // todo bengotow: Was this change correct??
       allPartitionKeys.forEach((key, idx) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const match = key.startsWith(prefix!) && key.endsWith(suffix!);
         if (match && start === -1) {
           start = idx;

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/OrdinalOrSingleRangePartitionSelector.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/OrdinalOrSingleRangePartitionSelector.test.tsx
@@ -25,6 +25,7 @@ const Wrapper = ({
   return (
     <>
       <OrdinalOrSingleRangePartitionSelector
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         dimension={assetHealth.dimensions[0]!}
         health={assetHealth}
         selection={selection}

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/useMatrixData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/useMatrixData.tsx
@@ -81,6 +81,7 @@ function buildMatrixData(
         return blankState;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const lastRun = partition.runs[partition.runs.length - 1]!;
       const lastRunStepStatus = lastRun.stepStats.find((stats) =>
         isStepKeyForNode(node.name, stats.stepKey),
@@ -93,6 +94,7 @@ function buildMatrixData(
       ) {
         let idx = partition.runs.length - 2;
         while (idx >= 0 && !previousRunStatus) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const currRun = partition.runs[idx]!;
           const currRunStatus = currRun.stepStats.find((stats) =>
             isStepKeyForNode(node.name, stats.stepKey),
@@ -129,7 +131,9 @@ function buildMatrixData(
   const partitionsWithARun = partitionColumns.filter((p) => p.runs.length > 0).length;
 
   const stepRows = layout.boxes.map((box, idx) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const totalFailures = partitionColumns.filter((p) => p.steps[idx]!.color.includes('FAILURE'));
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const finalFailures = partitionColumns.filter((p) => p.steps[idx]!.color.endsWith('FAILURE'));
     return {
       x: box.x,
@@ -145,6 +149,7 @@ function buildMatrixData(
 
   if (options?.showFailuresAndGapsOnly) {
     for (let ii = stepRows.length - 1; ii >= 0; ii--) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       if (stepRows[ii]!.finalFailurePercent === 0) {
         stepRows.splice(ii, 1);
         partitionColumns.forEach((p) => p.steps.splice(ii, 1));
@@ -152,7 +157,9 @@ function buildMatrixData(
     }
     for (let ii = partitionColumns.length - 1; ii >= 0; ii--) {
       if (
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         partitionColumns[ii]!.runs.length === 0 ||
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         partitionColumns[ii]!.steps.every((step) => step.color.includes('SUCCESS'))
       ) {
         partitionColumns.splice(ii, 1);

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
@@ -232,6 +232,7 @@ function assemblePartitions(data: DataState, partitionTagName: string) {
       runsLoaded: idx >= data.loadingCursorIdx,
       runs: [],
     };
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     results.push(byName[name]!);
   });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/CompositeSupport.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/CompositeSupport.ts
@@ -156,6 +156,7 @@ export function explodeCompositesInHandleGraph(handles: GraphExplorerSolidHandle
     if (idx === -1) {
       break;
     }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     results.splice(idx, 1, ...explodeComposite(handles, results[idx]!));
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/Description.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/Description.tsx
@@ -24,10 +24,12 @@ function removeLeadingSpaces(input: string) {
   }
 
   const lines = input.split('\n');
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   if (!lines.every((l) => l.substr(0, leadingSpaces[1]!.length).trim() === '')) {
     return input;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return lines.map((l) => l.substr(leadingSpaces[1]!.length)).join('\n');
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphExplorer.tsx
@@ -111,6 +111,7 @@ export const GraphExplorer = (props: GraphExplorerProps) => {
 
     window.requestAnimationFrame(() => {
       handleAdjustPath((opNames) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const last = 'name' in arg ? arg.name : arg.path[arg.path.length - 1]!;
         opNames[opNames.length - 1] = last;
         opNames.push('');

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/JobTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/JobTabs.tsx
@@ -34,6 +34,7 @@ export const JobTabs = (props: Props) => {
   }, [matchingTab, tabs]);
 
   return (
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     <Tabs size="large" selectedTabId={selectedTab!.id}>
       {tabs
         .filter((tab) => !tab.isHidden)

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOverviewRoot.tsx
@@ -77,6 +77,7 @@ export const PipelineOverviewRoot = (props: Props) => {
             ...explorerPath,
             opNames: [tokenForAssetKey(node.assetKey)],
             opsQuery: '',
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             pipelineName: node.jobName!,
           })}`,
         ),

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelinePathUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelinePathUtils.tsx
@@ -43,6 +43,7 @@ function tryDecodeURIComponent(str: string) {
 
 export function explorerPathFromString(path: string): ExplorerPath {
   const rootAndOps = path.split('/');
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const root = rootAndOps[0]!;
   const opNames = rootAndOps.length === 1 ? [''] : rootAndOps.slice(1);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOp.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOp.tsx
@@ -122,13 +122,16 @@ export const SidebarOp = ({
       </Box>
     );
   }
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const pools = solidContainer!.solidHandle!.solid.definition.pools;
   return (
     <>
       <SidebarOpInvocation
         key={`${handleID}-inv`}
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         solid={solidContainer!.solidHandle!.solid}
         onEnterSubgraph={
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           solidContainer!.solidHandle!.solid.definition.__typename === 'CompositeSolidDefinition'
             ? onEnterSubgraph
             : undefined
@@ -149,6 +152,7 @@ export const SidebarOp = ({
         <SidebarOpExecutionGraphs
           key={`${handleID}-graphs`}
           handleID={handleID}
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           solidName={solidContainer!.solidHandle!.solid.name}
           pipelineName={explorerPath.pipelineName}
           repoAddress={repoAddress}
@@ -157,6 +161,7 @@ export const SidebarOp = ({
       <SidebarOpDefinition
         key={`${handleID}-def`}
         showingSubgraph={showingSubgraph}
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         definition={solidContainer!.solidHandle!.solid.definition}
         getInvocations={getInvocations}
         onClickInvocation={({handleID}) => onClickOp({path: handleID.split('.')})}

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOpDefinition.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOpDefinition.tsx
@@ -142,6 +142,7 @@ export const SidebarOpDefinition = (props: SidebarOpDefinitionProps) => {
                 <TypeWithTooltip type={inputDef.type} />
               </TypeWrapper>
               <Description description={inputDef.description} />
+              {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
               <OpEdges title="Mapped to:" items={inputMappings[inputDef.name]!} />
             </SectionItemContainer>
           ))}
@@ -158,6 +159,7 @@ export const SidebarOpDefinition = (props: SidebarOpDefinitionProps) => {
               <TypeWrapper>
                 <TypeWithTooltip type={outputDef.type} />
               </TypeWrapper>
+              {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
               <OpEdges title="Mapped from:" items={outputMappings[outputDef.name]!} />
               <Description description={outputDef.description} />
             </SectionItemContainer>

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOpExecutionGraphs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOpExecutionGraphs.tsx
@@ -60,6 +60,7 @@ export const SidebarOpExecutionGraphs = ({
           .map((s) => ({
             x: Number(s.startTime) * 1000,
             xNumeric: Number(s.startTime) * 1000,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             y: s.endTime! - s.startTime!,
           }))
       : [];

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
@@ -312,10 +312,12 @@ const ResourceConfig = (props: {
               resourceDetails.configFields.map((field) => {
                 const defaultValue = field.defaultValueAsJson;
                 const type = configuredValues.hasOwnProperty(field.name)
-                  ? configuredValues[field.name]!.type
+                  ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    configuredValues[field.name]!.type
                   : null;
                 const actualValue = configuredValues.hasOwnProperty(field.name)
-                  ? configuredValues[field.name]!.value
+                  ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    configuredValues[field.name]!.value
                   : defaultValue;
 
                 const isDefault = type === 'VALUE' && defaultValue === actualValue;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
@@ -94,6 +94,7 @@ export function useAdjustChildVisibilityToFill(moreLabelFn: (count: number) => s
     }
 
     const tagsEls = children.slice(0, -1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const moreEl = children.pop()!;
 
     const apply = () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
@@ -148,7 +148,9 @@ export class HourlyDataCache<T> {
     if (!this.cache.has(hour)) {
       this.cache.set(hour, []);
     }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.cache.get(hour)!.push({start, end, data});
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.cache.set(hour, this.mergeIntervals(this.cache.get(hour)!));
   }
 
@@ -160,6 +162,7 @@ export class HourlyDataCache<T> {
   getHourData(s: number): T[] {
     const hour = Math.floor(s / ONE_HOUR_S);
     if (this.cache.has(hour)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return this.cache.get(hour)!.flatMap((interval) => interval.data);
     }
     return [];
@@ -174,7 +177,9 @@ export class HourlyDataCache<T> {
     const hour = Math.floor(s / ONE_HOUR_S);
     if (
       this.cache.has(hour) &&
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.cache.get(hour)!.length === 1 &&
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.cache.get(hour)![0]!.end - this.cache.get(hour)![0]!.start === ONE_HOUR_S
     ) {
       return [];
@@ -186,6 +191,7 @@ export class HourlyDataCache<T> {
     let currentStart = hourStart;
 
     if (this.cache.has(hour)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       for (const {start: cachedStart, end: cachedEnd} of this.cache.get(hour)!) {
         if (cachedStart > currentStart) {
           missingIntervals.push([currentStart, cachedStart]);
@@ -216,6 +222,7 @@ export class HourlyDataCache<T> {
     }
 
     if (this.cache.has(startHour)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const intervals = this.cache.get(startHour)!;
       let currentStart = start;
 
@@ -246,9 +253,11 @@ export class HourlyDataCache<T> {
     }
 
     intervals.sort((a, b) => a.start - b.start);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const mergedIntervals: Array<TimeWindow<T>> = [intervals[0]!];
 
     for (const current of intervals.slice(1)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const lastMerged = mergedIntervals[mergedIntervals.length - 1]!;
 
       if (current.start <= lastMerged.end) {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsFilterInput.tsx
@@ -91,6 +91,7 @@ export const LogsFilterInput = (props: Props) => {
 
       const [token, value] = queryString.split(':');
       if (token && token in perProvider) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const {fuse, all} = perProvider[token]!;
         const results = value
           ? fuse.search(value).map((result) => `${token}:${result.item}`)

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsProvider.tsx
@@ -173,6 +173,7 @@ const useLogsProviderWithSubscription = (runId: string) => {
       const queuedLogs = [...queue.current];
       queue.current = [];
       const queuedMessages = queuedLogs.flatMap((log) => log.messages);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const lastLog = queuedLogs[queuedLogs.length - 1]!;
       const hasMore = lastLog.hasMorePastEvents;
       const cursor = lastLog.cursor;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTable.tsx
@@ -104,6 +104,7 @@ export const LogsScrollingTable = (props: Props) => {
     return (
       <Inner $totalHeight={totalHeight}>
         {items.map(({index, key, size, start}) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const node = filteredNodes[index]!;
           const textMatch = textMatchNodes.includes(node);
           const focusedTimeMatch = Number(node.timestamp) === filter.focusedTime;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaDialog.tsx
@@ -197,6 +197,7 @@ const QueuedRunCriteriaDialogContent = ({run}: ContentProps) => {
               </Box>
             </td>
             <td>
+              {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
               {(poolOpGranularityRunLimited ? rootConcurrencyKeys : allPools)!.map((pool) => (
                 <PoolTag key={pool} pool={pool} />
               ))}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/ReexecutionDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/ReexecutionDialog.tsx
@@ -258,6 +258,7 @@ export const ReexecutionDialog = (props: ReexecutionDialogProps) => {
                 ) : (
                   <>
                     One or more of these runs is part of backfill{' '}
+                    {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
                     <Link to={getBackfillPath(selectedRunBackfillIds[0]!, 'runs')}>
                       {selectedRunBackfillIds[0]}
                     </Link>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionButtons.tsx
@@ -155,6 +155,7 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
         <StepSelectionDescription selection={currentRunSelection} />
       </div>
     ),
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     onClick: () => reexecuteWithSelection(currentRunSelection!),
   };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunConfigDialog.tsx
@@ -114,6 +114,7 @@ function OpenInLaunchpadButton({
 }) {
   const openInNewTab = useOpenInNewTab();
   const pipelineName = request.jobName ?? jobName;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const [_, onSave] = useExecutionSessionStorage(repoAddress, pipelineName!);
 
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunMetadataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunMetadataProvider.tsx
@@ -373,7 +373,9 @@ export function extractMetadataFromLogs(
     // as a tiny dot on the chart.
     if (step.transitions.length === 1 && step.state === IStepState.SKIPPED) {
       step.attempts.push({
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         start: step.transitions[0]!.time,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         end: step.transitions[0]!.time,
         exitState: IStepState.SKIPPED,
       });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
@@ -99,6 +99,7 @@ export const RunTimeline = (props: Props) => {
           const {repoAddress} = row;
           const repoKey = repoAddressAsURLString(repoAddress);
           accum[repoKey] = accum[repoKey] || [];
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           accum[repoKey]!.push(row);
           return accum;
         },
@@ -159,6 +160,7 @@ export const RunTimeline = (props: Props) => {
 
   const expandedRepos = repoOrder.filter((repoKey) => expandedKeys.includes(repoKey));
   const expandedJobCount = expandedRepos.reduce(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     (accum, repoKey) => accum + buckets[repoKey]!.length,
     0,
   );
@@ -187,7 +189,9 @@ export const RunTimeline = (props: Props) => {
           <Container ref={parentRef}>
             <Inner $totalHeight={totalHeight}>
               {items.map(({index, key, size, start}) => {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 const row: RowType = flattened[index]!;
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 const type = row!.type;
                 if (type === 'header') {
                   const repoKey = repoAddressAsURLString(row.repoAddress);
@@ -200,6 +204,7 @@ export const RunTimeline = (props: Props) => {
                       top={start}
                       repoAddress={row.repoAddress}
                       isDuplicateRepoName={!!(repoName && duplicateRepoNames.has(repoName))}
+                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       rows={buckets[repoKey]!}
                       onToggle={onToggle}
                       onToggleAll={onToggleAll}
@@ -649,6 +654,7 @@ const RunTimelineRow = ({
           const runCount = runs.length;
           return (
             <RunChunk
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               key={batch.runs[0]!.id}
               $background={mergeStatusToBackground(batch.runs)}
               $multiple={runCount > 1}
@@ -838,6 +844,7 @@ export const RunHoverContent = (props: RunHoverContentProps) => {
         <Container ref={parentRef}>
           <Inner $totalHeight={totalHeight}>
             {items.map(({index, key, size, start}) => {
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               const run = batch.runs[index]!;
               return (
                 <Row key={key} $height={size} $start={start}>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
@@ -144,6 +144,7 @@ export const RunsFeedRow = ({
       <RowCell style={{flexDirection: 'row', alignItems: 'flex-start'}}>
         {entry.__typename === 'Run' ? (
           <RunTargetLink
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             run={{...entry, pipelineName: entry.jobName!, stepKeysToExecute: []}}
             repoAddress={repoAddress}
             extraTags={

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -159,8 +159,10 @@ export function runsFilterForSearchTokens(search: TokenizingFieldValue[]) {
     } else if (item.token === 'tag') {
       const [key, value = ''] = item.value.split('=');
       if (obj.tags) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         obj.tags.push({key: key!, value});
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         obj.tags = [{key: key!, value}];
       }
     }
@@ -433,6 +435,7 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
       <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
         <Icon name="id" />
         <TruncatedTextWithFullTextOnHover text={value.value} />
+        {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
         {value.value!}
       </Box>
     ),
@@ -488,6 +491,7 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
       <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
         <Icon name="partition" />
         <TruncatedTextWithFullTextOnHover text={value.value} />
+        {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
         {value.value!}
       </Box>
     ),
@@ -508,6 +512,7 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
       } else if (value.type === DagsterTag.ScheduleName) {
         icon = <Icon name="schedule" />;
       } else if (value.type === DagsterTag.User) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return <UserDisplay email={value.value!} isFilter />;
       } else if (value.type === DagsterTag.Automaterialize) {
         icon = <Icon name="automation_condition" />;
@@ -516,6 +521,7 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
       return (
         <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
           {icon}
+          {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
           <TruncatedTextWithFullTextOnHover text={labelValue!} />
         </Box>
       );
@@ -524,6 +530,7 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
       if (x.type === DagsterTag.Automaterialize) {
         return 'Automation condition';
       }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return x.value!;
     },
     state: useMemo(() => {
@@ -636,6 +643,7 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
         })
         .map((token) => {
           const [key, value] = token.value.split('=');
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           return tagSuggestionValueObject(key!, value!).value;
         });
     }, [tokens]),
@@ -772,6 +780,7 @@ function tagToFilterValue(key: string, value: string) {
 export const tagValueToFilterObject = memoize((value: string) => ({
   key: value,
   type: value.split('=')[0] as DagsterTag,
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   value: value.split('=')[1]!,
 }));
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__stories__/RunTimeline.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__stories__/RunTimeline.stories.tsx
@@ -54,6 +54,7 @@ export const RowWithOverlappingRuns = () => {
         type: 'job',
         path: `/${rowKey}`,
         repoAddress,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         runs: [{...first!}, {...first!}, {...second!}, {...second!}, {...second!}, third!],
       },
     ];

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__stories__/TerminationDialog.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__stories__/TerminationDialog.stories.tsx
@@ -29,8 +29,11 @@ ForceTerminationCheckbox.args = {
     console.log('Close!');
   },
   selectedRuns: {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     [runIDs[0]!]: true,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     [runIDs[1]!]: false,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     [runIDs[2]!]: true,
   },
 };
@@ -42,8 +45,11 @@ ForceTerminationNoCheckbox.args = {
     console.log('Close!');
   },
   selectedRuns: {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     [runIDs[0]!]: false,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     [runIDs[1]!]: false,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     [runIDs[2]!]: false,
   },
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/AssetCheckTagCollection.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/AssetCheckTagCollection.test.tsx
@@ -12,6 +12,7 @@ describe('AssetKeyTagCollection', () => {
   };
 
   it('renders individual tag if there is just one key', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const key = makeKeys(1)[0]!;
     render(
       <MemoryRouter>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/AssetKeyTagCollection.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/AssetKeyTagCollection.test.tsx
@@ -13,6 +13,7 @@ describe('AssetKeyTagCollection', () => {
   };
 
   it('renders individual tag if there is just one key', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const key = makeKeys(1)[0]!;
     render(
       <MemoryRouter>
@@ -36,6 +37,7 @@ describe('AssetKeyTagCollection', () => {
     });
 
     expect(screen.queryByText('5 assets')).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(screen.queryByText(displayNameForAssetKey(keys[0]!))).toBeNull();
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunFilterInput.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunFilterInput.test.tsx
@@ -190,6 +190,7 @@ describe('<RunFilterInput  />', () => {
     expect(onChange).toHaveBeenCalledWith([
       {
         token: 'created_date_after',
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         value: '' + todayRange[0]! / 1000,
       },
     ]);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/batchRunsForTimeline.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/batchRunsForTimeline.test.tsx
@@ -22,6 +22,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(70);
@@ -42,6 +43,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(50);
@@ -64,6 +66,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(90);
@@ -87,6 +90,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(90);
@@ -108,6 +112,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(100);
@@ -128,6 +133,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(70);
@@ -152,7 +158,9 @@ describe('batchRunsForTimeline', () => {
       expect(batched.length).toBe(2);
 
       // Batch A contains the earlier run due to sorting.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batchA = batched[0]!;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batchB = batched[1]!;
 
       expect(batchA.startTime).toBe(10);
@@ -182,8 +190,11 @@ describe('batchRunsForTimeline', () => {
       const batched = getBatch(runs);
       expect(batched.length).toBe(3);
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batchA = batched[0]!;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batchB = batched[1]!;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batchC = batched[2]!;
 
       expect(batchA.startTime).toBe(10);
@@ -211,6 +222,7 @@ describe('batchRunsForTimeline', () => {
       const tinyRun = {startTime: 10, endTime: 11};
       const batched = getBatch([tinyRun]);
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(11);
@@ -224,6 +236,7 @@ describe('batchRunsForTimeline', () => {
       const tinyRunB = {startTime: 10, endTime: 12};
       const batched = getBatch([tinyRunA, tinyRunB]);
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(12);
@@ -257,6 +270,7 @@ describe('batchRunsForTimeline', () => {
 
       const batched = getBatch(runs);
       expect(batched.length).toBe(1);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batch = batched[0]!;
       expect(batch.startTime).toBe(10);
       expect(batch.endTime).toBe(70);
@@ -280,7 +294,9 @@ describe('batchRunsForTimeline', () => {
       const batched = getBatch(runs);
       expect(batched.length).toBe(2);
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batchA = batched[0]!;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const batchB = batched[1]!;
 
       expect(batchA.startTime).toBe(10);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/fetchPaginatedBucketData.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/fetchPaginatedBucketData.test.tsx
@@ -50,6 +50,7 @@ describe('fetchPaginatedBucketData', () => {
     });
 
     expect(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       setQueryDataMock.mock.calls[0][0]!({data: [{id: 1}], hasMore: false, cursor: undefined}),
     ).toEqual({
       called: true,
@@ -130,6 +131,7 @@ describe('fetchPaginatedBucketData', () => {
 
     const calls = setQueryDataMock.mock.calls;
     expect(calls.length).toEqual(2);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(calls[calls.length - 1]![0]({})).toEqual({
       loading: false,
       called: true,
@@ -157,6 +159,7 @@ describe('fetchPaginatedBucketData', () => {
     const data = [{id: 1}];
     const calls = setQueryDataMock.mock.calls;
     expect(calls.length).toEqual(2);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(calls[calls.length - 1]![0]({data})).toEqual({
       data,
       loading: false,
@@ -184,6 +187,7 @@ describe('fetchPaginatedBucketData', () => {
 
     const calls = setQueryDataMock.mock.calls;
     expect(calls.length).toEqual(2);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(calls[calls.length - 1]![0]({data})).toEqual({
       data,
       loading: false,

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useQueryPersistedLogFilter.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useQueryPersistedLogFilter.test.tsx
@@ -151,6 +151,7 @@ describe('decodeRunPageFilters', () => {
         render(<Test />);
         const mockFn = useQueryPersistedState as jest.MockedFunction<typeof useQueryPersistedState>;
         expect(mockFn).toHaveBeenCalled();
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const args = mockFn.mock.calls[0]![0];
         expect(args).toMatchObject({
           defaults: {
@@ -164,6 +165,7 @@ describe('decodeRunPageFilters', () => {
         render(<Test />);
         const mockFn = useQueryPersistedState as jest.MockedFunction<typeof useQueryPersistedState>;
         expect(mockFn).toHaveBeenCalled();
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const args = mockFn.mock.calls[0]![0];
         expect(args).toMatchObject({
           defaults: {
@@ -177,6 +179,7 @@ describe('decodeRunPageFilters', () => {
         render(<Test />);
         const mockFn = useQueryPersistedState as jest.MockedFunction<typeof useQueryPersistedState>;
         expect(mockFn).toHaveBeenCalled();
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const args = mockFn.mock.calls[0]![0];
         expect(args).toMatchObject({
           defaults: {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useRunsForTimeline.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useRunsForTimeline.test.tsx
@@ -246,7 +246,9 @@ describe('useRunsForTimeline', () => {
         {
           id: `1-0`,
           status: RunStatus.SUCCESS,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           startTime: buckets[0]![0] * 1000,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           endTime: buckets[0]![1] * 1000,
           automation: null,
           externalJobSource: null,
@@ -375,6 +377,7 @@ describe('useRunsForTimeline', () => {
     // Verify the initial data
     expect(result.current.jobs).toHaveLength(2);
     expect(result.current.loading).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(result.current.jobs[0]!.runs).toHaveLength(1);
 
     // Rerender hook with extended interval
@@ -397,6 +400,7 @@ describe('useRunsForTimeline', () => {
     const buckets = getHourlyBuckets(interval[0], interval[1]);
     expect(buckets).toHaveLength(1);
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const bucket = buckets[0]!;
     const updatedBefore = bucket[1];
     const updatedAfter = bucket[0];
@@ -500,21 +504,28 @@ describe('useRunsForTimeline', () => {
       expect(result.current.jobs).toHaveLength(2);
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(result.current.jobs[0]!.runs).toHaveLength(2);
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(result.current.jobs[0]!.runs[0]).toEqual({
       id: '1-1',
       status: 'SUCCESS',
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       startTime: buckets[0]![0] * 1000,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       endTime: buckets[0]![1] * 1000,
       automation: null,
       externalJobSource: null,
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(result.current.jobs[0]!.runs[1]).toEqual({
       id: '1-2',
       status: 'SUCCESS',
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       startTime: buckets[0]![0] * 1000,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       endTime: buckets[0]![1] * 1000,
       automation: null,
       externalJobSource: null,
@@ -716,6 +727,7 @@ describe('useRunsForTimeline', () => {
     const buckets = getHourlyBuckets(interval[0], interval[1]);
     expect(buckets).toHaveLength(1);
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const bucket = buckets[0]!;
     const updatedBefore = bucket[1];
     const updatedAfter = bucket[0];

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/mergeStatusToBackground.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/mergeStatusToBackground.tsx
@@ -49,6 +49,7 @@ export const mergeStatusToBackground = (runs: TimelineRun[]) => {
 
   if (statusArr.length === 1) {
     const [element] = statusArr;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return statusToColor(element!);
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useComputeLogFileKeyForSelection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useComputeLogFileKeyForSelection.tsx
@@ -42,13 +42,16 @@ export function useComputeLogFileKeyForSelection({
         return selectionStepKeys.every(
           (stepKey) =>
             metadata.logCaptureSteps &&
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             metadata.logCaptureSteps[logFileKey]!.stepKeys.includes(stepKey),
         );
       });
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       setComputeLogFileKey(selectedLogKey || logFileKeys[0]!);
     } else if (!stepKeys.includes(computeLogFileKey)) {
       const matching = matchingComputeLogKeyFromStepKey(
         metadata.logCaptureSteps,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         selectionStepKeys.length === 1 ? selectionStepKeys[0]! : stepKeys[0]!,
       );
       if (matching) {
@@ -57,6 +60,7 @@ export function useComputeLogFileKeyForSelection({
     } else if (selectionStepKeys.length === 1 && computeLogFileKey !== selectionStepKeys[0]) {
       const matching = matchingComputeLogKeyFromStepKey(
         metadata.logCaptureSteps,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         selectionStepKeys[0]!,
       );
       if (matching) {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useCursorAccumulatedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useCursorAccumulatedQuery.tsx
@@ -73,6 +73,7 @@ class AccumulatingDataFetcher<DataType, CursorType, ErrorType> {
       }
       res();
     });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const result = await this.fetchPromise!;
     this.fetchPromise = undefined;
     return result;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -86,7 +86,9 @@ export const useRunsForTimeline = ({
       setCompletedRuns(
         runs.filter(
           (run) =>
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             (run.startTime! <= endSec && run.updateTime! >= endSec) ||
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             (run.updateTime! >= startSec && run.updateTime! <= endSec),
         ),
       );
@@ -201,6 +203,7 @@ export const useRunsForTimeline = ({
         const runs: RunTimelineFragment[] = data.completed.results;
 
         const hasMoreData = runs.length === batchLimit;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const nextCursor = hasMoreData ? runs[runs.length - 1]!.id : undefined;
 
         const accumulatedData = dataToCommitToCacheByBucket.get(bucket) ?? [];
@@ -272,6 +275,7 @@ export const useRunsForTimeline = ({
           }
           const runs = data.ongoing.results;
           const hasMoreData = runs.length === batchLimit;
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const nextCursor = hasMoreData ? runs[runs.length - 1]!.id : undefined;
           return {
             data: runs,
@@ -375,6 +379,7 @@ export const useRunsForTimeline = ({
       const runJobKey = makeJobKey(repoAddress, run.pipelineName);
 
       map[runJobKey] = map[runJobKey] || {};
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       map[runJobKey]![run.id] = {
         id: run.id,
         status: run.status,
@@ -479,6 +484,7 @@ export const useRunsForTimeline = ({
           for (const schedule of schedules) {
             if (schedule.scheduleState.status === InstigationStatus.RUNNING) {
               schedule.futureTicks.results.forEach(({timestamp}) => {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 const startTime = timestamp! * 1000;
                 if (
                   startTime > now &&
@@ -542,6 +548,7 @@ export const useRunsForTimeline = ({
     }
     allKeys.forEach((key) => {
       if (!addedJobKeys.has(key)) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         jobs.push(jobsWithCompletedRunsAndOngoingRuns[key]!);
       }
     });
@@ -567,6 +574,7 @@ export const useRunsForTimeline = ({
       {} as {[jobKey: string]: number},
     );
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return unsortedJobs.sort((a, b) => earliest[a.key]! - earliest[b.key]!);
   }, [unsortedJobs]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
@@ -97,6 +97,7 @@ export const ScheduleDetails = (props: {
               <td>Next tick</td>
               <td>
                 <TimestampDisplay
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                   timestamp={futureTicks.results[0].timestamp!}
                   timezone={executionTimezone}
                   timeFormat={TIME_FORMAT}

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/SchedulerInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/SchedulerInfo.tsx
@@ -15,6 +15,7 @@ export const SchedulerInfo = ({daemonHealth, ...boxProps}: Props) => {
       (daemon) => daemon.daemonType === 'SCHEDULER',
     );
     if (schedulerHealths.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const schedulerHealth = schedulerHealths[0]!;
       healthy = schedulerHealth.required && schedulerHealth.healthy;
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/SchedulesNextTicks.tsx
@@ -85,13 +85,16 @@ export const SchedulesNextTicks = memo(({repos}: Props) => {
     const minMaxTimestamp = Math.min(
       ...futureTickSchedules.map(
         (schedule) =>
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           schedule.futureTicks.results[schedule.futureTicks.results.length - 1]!.timestamp!,
       ),
     );
 
     futureTickSchedules.forEach((schedule) => {
       schedule.futureTicks.results.forEach((tick) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         if (tick.timestamp! <= minMaxTimestamp) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           nextTicks.push({schedule, timestamp: tick.timestamp!, repoAddress});
         }
       });
@@ -335,7 +338,8 @@ const NextTickDialog = ({
   const [selectedRunRequest, setSelectedRunRequest] =
     useState<ScheduleFutureTickRunRequestFragment | null>(
       evaluationResult && evaluationResult.runRequests && evaluationResult.runRequests.length === 1
-        ? evaluationResult.runRequests[0]!
+        ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          evaluationResult.runRequests[0]!
         : null,
     );
 
@@ -348,6 +352,7 @@ const NextTickDialog = ({
       evaluationResult.runRequests &&
       evaluationResult.runRequests.length === 1
     ) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       setSelectedRunRequest(evaluationResult.runRequests[0]!);
     }
   }, [evaluationResult]);

--- a/js_modules/dagster-ui/packages/ui-core/src/search/BuildAssetSearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/BuildAssetSearchResults.tsx
@@ -84,6 +84,7 @@ export function buildAssetCountBySection(assets: AssetDefinitionMetadata[]): Ass
   assets
     .filter((asset) => asset.definition)
     .forEach((asset) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const assetDefinition = asset.definition!;
       assetDefinition.owners.forEach((owner) => {
         const ownerKey = JSON.stringify(owner);
@@ -183,6 +184,7 @@ export function buildAssetCountBySection(assets: AssetDefinitionMetadata[]): Ass
   const countPerCodeLocation = assetCountByCodeLocation
     .entries()
     .map(([key, count]) => ({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       repoAddress: repoAddressFromPath(key)!,
       assetCount: count,
     }))

--- a/js_modules/dagster-ui/packages/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
@@ -183,7 +183,9 @@ describe('useIndexedDBCachedQuery', () => {
             expect(mockFn1).toHaveBeenCalledTimes(1);
             expect(mockFn2).not.toHaveBeenCalled();
 
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect(result1!.data).toEqual(result2!.data);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect(result1!.loading).toEqual(result2!.loading);
           });
         });

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -162,13 +162,17 @@ const secondaryDataToSearchResults = (
     key: node.key,
     label: displayNameForAssetKey(node.key),
     description: `Asset in ${buildRepoPathForHuman(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       node.definition!.repository.name,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       node.definition!.repository.location.name,
     )}`,
     node,
     href: assetDetailsPathForKey(node.key),
     type: SearchResultType.Asset,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     tags: node.definition!.tags,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     kinds: node.definition!.kinds,
   }));
 

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/BaseSelectionVisitor.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/BaseSelectionVisitor.ts
@@ -135,6 +135,7 @@ export class BaseSelectionVisitor
   }
 
   public visitPostAttributeValueWhitespace(ctx: PostAttributeValueWhitespaceContext) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const attributeValue = ctx.parent!.getChild(2) as ParserRuleContext;
     if (this.cursorIndex === (attributeValue?.stop?.stopIndex ?? 0) + 1) {
       this.forceVisit(attributeValue);

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteProvider.tsx
@@ -235,6 +235,7 @@ export const createProvider = <
     const displayText = `${attribute as string}:`;
     const icon: IconName = attributeToIcon[attribute];
     let label = (attribute as string).replace(/_/g, ' ');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     label = label[0]!.toUpperCase() + label.slice(1);
     return {
       text,
@@ -290,6 +291,7 @@ export const createProvider = <
     text: string;
     options?: {includeParenthesis?: boolean};
   }) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const functionName = func[0]!.toUpperCase() + func.slice(1);
     const rightLabel = options?.includeParenthesis ? `${func}()` : func;
     let icon: IconName;
@@ -319,6 +321,7 @@ export const createProvider = <
     const attribute = primaryAttributeKey as string;
     const text = `${attribute}:"*${query}*"`;
     let displayAttribute = attribute.replace(/_/g, ' ');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     displayAttribute = displayAttribute[0]!.toUpperCase() + displayAttribute.slice(1);
     const displayText = (
       <Box flex={{direction: 'row', alignItems: 'center', gap: 2}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteVisitor.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionAutoCompleteVisitor.ts
@@ -161,6 +161,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
   public visitFunctionName(ctx: FunctionNameContext) {
     if (this.nodeIncludesCursor(ctx)) {
       this.startReplacementIndex = ctx.start.startIndex;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.stopReplacementIndex = ctx.stop!.stopIndex + 1;
       this.addFunctionResults(ctx.text);
     }
@@ -178,6 +179,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
   }
 
   public visitAttributeValue(ctx: AttributeValueContext) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const stopIndex = ctx.stop!.stopIndex;
     if (
       this.cursorIndex >= stopIndex &&
@@ -187,12 +189,15 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
       this.addAfterExpressionResults(ctx);
       return;
     }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.startReplacementIndex = ctx.start!.startIndex;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.stopReplacementIndex = ctx.stop!.stopIndex + 1;
 
     const parentContext = ctx.parent;
     if (parentContext instanceof AttributeExpressionContext) {
       this.startReplacementIndex = parentContext.colonToken().start.startIndex + 1;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.stopReplacementIndex = parentContext.postAttributeValueWhitespace().start!.startIndex;
     }
 
@@ -234,15 +239,18 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
 
   public visitAttributeName(ctx: AttributeNameContext) {
     this.startReplacementIndex = ctx.start.startIndex;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.stopReplacementIndex = ctx.stop!.stopIndex + 2;
     this.addAttributeResults(ctx.text);
   }
 
   public visitOrToken(ctx: OrTokenContext) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     if (this.cursorIndex > ctx.stop!.stopIndex) {
       // Let whitespace token handle
     } else {
       this.startReplacementIndex = ctx.start.startIndex;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.stopReplacementIndex = ctx.stop!.stopIndex + 1;
       this.list.push(
         this.createOperatorSuggestion({text: 'or', type: 'or', displayText: 'or'}),
@@ -252,10 +260,12 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
   }
 
   public visitAndToken(ctx: AndTokenContext) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     if (this.cursorIndex > ctx.stop!.stopIndex) {
       // Let whitespace token handle
     } else {
       this.startReplacementIndex = ctx.start.startIndex;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.stopReplacementIndex = ctx.stop!.stopIndex + 1;
       this.list.push(
         this.createOperatorSuggestion({text: 'and', type: 'and', displayText: 'and'}),
@@ -267,6 +277,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
   public visitUnmatchedValue(ctx: UnmatchedValueContext) {
     if (this.nodeIncludesCursor(ctx)) {
       this.startReplacementIndex = ctx.start.startIndex;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.stopReplacementIndex = ctx.stop!.stopIndex + 1;
       this.addUnmatchedValueResults(ctx.text);
     }
@@ -278,6 +289,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
     const value = getValueNodeValue(ctx.value());
     if (this.nodeIncludesCursor(ctx.value())) {
       this.startReplacementIndex = ctx.value().start.startIndex;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.stopReplacementIndex = ctx.value().stop!.stopIndex + 1;
       this.addUnmatchedValueResults(value, DEFAULT_TEXT_CALLBACK, {
         excludePlus: true,
@@ -339,6 +351,7 @@ export class SelectionAutoCompleteVisitor extends BaseSelectionVisitor {
 
   public visitPostDigitsWhitespace(ctx: PostDigitsWhitespaceContext) {
     this.startReplacementIndex = ctx.start.startIndex;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.stopReplacementIndex = ctx.stop!.stopIndex;
     this.list.push(
       this.createOperatorSuggestion({

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputAutoCompleteResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputAutoCompleteResults.tsx
@@ -59,6 +59,7 @@ export const SelectionInputAutoCompleteResults = React.memo(
           <Container ref={menuRef} style={{maxHeight: '300px', overflowY: 'auto'}}>
             <Inner $totalHeight={totalHeight}>
               {items.map(({index, key, size, start}) => {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 const result = results!.list[index]!;
                 return (
                   <Row key={key} $height={size} $start={start}>

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputHighlighter.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputHighlighter.ts
@@ -76,6 +76,7 @@ export class SyntaxHighlightingVisitor
     ctx: IncompleteAttributeExpressionMissingKeyContext,
   ) {
     const start = ctx.start.startIndex;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     let end = ctx.stop!.stopIndex;
     if (ctx.postExpressionWhitespace()) {
       end = ctx.postExpressionWhitespace().start.startIndex;
@@ -86,6 +87,7 @@ export class SyntaxHighlightingVisitor
 
   visitAttributeExpression(ctx: AttributeExpressionContext) {
     const start = ctx.start.startIndex;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     let end = ctx.stop!.stopIndex;
     if (ctx.postAttributeValueWhitespace()) {
       end = ctx.postAttributeValueWhitespace().start.startIndex;

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputParser.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputParser.ts
@@ -62,6 +62,7 @@ export const parseInput = memoize((input: string): ParseResult => {
       const currentErrors = errorListener.getErrors();
 
       if (currentErrors.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const error = currentErrors[0]!;
         const errorCharPos = error.from;
         const errorIndex = currentPosition + errorCharPos;

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/createSelectionLinter.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/createSelectionLinter.ts
@@ -95,6 +95,7 @@ class InvalidAttributeVisitor
 
     while (low <= high) {
       const mid = Math.floor((low + high) / 2);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const error = this.sortedLintErrors[mid]!;
 
       if (error.to < from) {
@@ -113,6 +114,7 @@ class InvalidAttributeVisitor
     const attributeName = ctx.IDENTIFIER().text;
     if (!this.supportedAttributes.includes(attributeName)) {
       const from = ctx.start.startIndex;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const to = ctx.stop!.stopIndex + 1;
 
       if (!this.hasOverlap(from, to)) {

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -175,6 +175,7 @@ export const SensorDetails = ({
             <tr>
               <td>Next tick</td>
               <td>
+                {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
                 <TimestampDisplay timestamp={sensor.nextTick.timestamp!} timeFormat={TIME_FORMAT} />
               </td>
             </tr>

--- a/js_modules/dagster-ui/packages/ui-core/src/setupTests.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/setupTests.ts
@@ -49,6 +49,7 @@ class MockBroadcastChannel {
       this.name = name;
       this.listeners = [];
     }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return MockBroadcastChannel._instancesByName[name]!;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/testing/mocking.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/testing/mocking.ts
@@ -71,11 +71,13 @@ export function buildMutationMock<
 }
 
 export function getMockResultFn<T>(mock: MockedResponse<T>) {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const result = mock.result!;
   let mockFn;
   if (typeof result === 'function') {
     mockFn = jest.fn(result);
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     mockFn = jest.fn(() => result!);
   }
   mock.result = mockFn;
@@ -90,17 +92,21 @@ export function mergeMockQueries<T extends Record<string, any>>(
   defaultData: MockedResponse<T>,
   ...queries: Array<MockedResponse<T>>
 ): MockedResponse<T> {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   let mergedResult = resultData(queries[0]!.result, queries[0]!.request.variables);
   for (let i = 1; i < queries.length; i++) {
     mergedResult = deepmerge(
       mergedResult,
       removeDefaultValues(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         resultData(defaultData.result!),
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         resultData(queries[i]!.result!, queries[i]?.request.variables),
       ),
     );
   }
   return {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     ...queries[0]!,
     result: mergedResult,
   };
@@ -108,8 +114,10 @@ export function mergeMockQueries<T extends Record<string, any>>(
 
 function resultData<T>(result: MockedResponse<T>['result'], variables: Record<string, any> = {}) {
   if (result instanceof Function) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return result(variables)!;
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return result!;
   }
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateScheduleDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateScheduleDialog.tsx
@@ -141,6 +141,7 @@ const EvaluateSchedule = ({repoAddress, name, onClose, jobName}: Props) => {
           ...repositorySelector,
           scheduleName: name,
         },
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         timestamp: selectedTimestampRef.current!.ts,
       },
     });
@@ -241,6 +242,7 @@ const EvaluateSchedule = ({repoAddress, name, onClose, jobName}: Props) => {
         <EvaluateScheduleResult
           repoAddress={repoAddress}
           name={name}
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           timestamp={selectedTimestampRef.current!.ts}
           jobName={jobName}
           scheduleExecutionData={scheduleExecutionData}

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/InstigationEventLogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/InstigationEventLogTable.tsx
@@ -69,6 +69,7 @@ export const InstigationEventLogTable = ({events}: {events: InstigationEventLogF
       <Container ref={parentRef} style={{position: 'relative'}}>
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, key, size, start}) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const event = events[index]!;
             return (
               <Row key={key} $start={start} $height={size}>

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/DryRunRequestTable.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/DryRunRequestTable.test.tsx
@@ -35,6 +35,7 @@ describe('RunRequestTableTest', () => {
     render(<TestComponent />);
 
     runRequests.forEach((req) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(screen.getByTestId(req.runKey!)).toBeVisible();
     });
   });
@@ -42,6 +43,7 @@ describe('RunRequestTableTest', () => {
   it('renders preview button and opens dialog on click', async () => {
     render(<TestComponent />);
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const previewButton = screen.getByTestId(`preview-${runRequests[0]!.runKey || ''}`);
     expect(previewButton).toBeVisible();
     previewButton.click();

--- a/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/TypeListContainer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/TypeListContainer.tsx
@@ -39,6 +39,7 @@ export const TypeListContainer = ({explorerPath, repoAddress}: ITypeListContaine
   const queryResult = useQuery<TypeListContainerQuery, TypeListContainerQueryVariables>(
     TYPE_LIST_CONTAINER_QUERY,
     {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       variables: {pipelineSelector: pipelineSelector!},
       skip: !pipelineSelector,
     },

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/__tests__/FilterDropdown.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/__tests__/FilterDropdown.test.tsx
@@ -70,7 +70,9 @@ describe('FilterDropdown', () => {
     await userEvent.type(searchInput, 'type');
     await waitFor(() => expect(screen.getByText('Type 1')).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText('Type 2')).toBeInTheDocument());
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await waitFor(() => expect(mockFilters[0]!.getResults).toHaveBeenCalledWith('type'));
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await waitFor(() => expect(mockFilters[1]!.getResults).toHaveBeenCalledWith('type'));
   });
 
@@ -172,6 +174,7 @@ describe('FilterDropdown Accessibility', () => {
     await userEvent.keyboard(enterKey);
 
     await waitFor(() => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(mockFilters[1]!.onSelect).toHaveBeenCalled();
     });
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useTimeRangeFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useTimeRangeFilter.tsx
@@ -231,6 +231,7 @@ export function ActiveFilterState({
       if (!state[0]) {
         return (
           <>
+            {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
             before <FilterTagHighlightedText>{L_FORMAT.format(state[1]!)}</FilterTagHighlightedText>
           </>
         );
@@ -238,6 +239,7 @@ export function ActiveFilterState({
       if (!state[1]) {
         return (
           <>
+            {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
             after <FilterTagHighlightedText>{L_FORMAT.format(state[0]!)}</FilterTagHighlightedText>
           </>
         );
@@ -245,15 +247,17 @@ export function ActiveFilterState({
       if (state[1] - state[0] === (24 * 60 * 60 - 1) * 1000) {
         return (
           <>
-            on
-            <FilterTagHighlightedText>{L_FORMAT.format(state[0]!)}</FilterTagHighlightedText>
+            {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
+            on <FilterTagHighlightedText>{L_FORMAT.format(state[0]!)}</FilterTagHighlightedText>
           </>
         );
       }
       return (
         <>
+          {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
           from <FilterTagHighlightedText>{L_FORMAT.format(state[0]!)}</FilterTagHighlightedText>
           {' through '}
+          {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
           <FilterTagHighlightedText>{L_FORMAT.format(state[1]!)}</FilterTagHighlightedText>
         </>
       );
@@ -341,6 +345,7 @@ export function CustomTimeRangeFilterDialog({
           intent="primary"
           disabled={!startDate || !endDate}
           onClick={() => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             filter.setState([startDate!.valueOf(), endDate!.valueOf()]);
             setIsOpen(false);
           }}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/GraphQueryInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/GraphQueryInput.tsx
@@ -93,12 +93,15 @@ export const placeholderTextForItems = (base: string, items: GraphQueryItem[]) =
 
   if (seed === 0) {
     const example = ranked.sort((a, b) => b.outcount - a.outcount)[0];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     placeholder = `${placeholder} (ex: ${key(example!.name)}${traversal('down')})`;
   } else if (seed === 1) {
     const example = ranked.sort((a, b) => b.outcount - a.outcount)[0];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     placeholder = `${placeholder} (ex: ${key(example!.name)}${traversal('down', 1)})`;
   } else if (seed === 2) {
     const example = ranked.sort((a, b) => b.incount - a.incount)[0];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     placeholder = `${placeholder} (ex: ${traversal('up', 2)}${key(example!.name)})`;
   }
   return placeholder;
@@ -158,6 +161,7 @@ const buildSuggestions = (
       : [];
 
   // No need to show a match if our string exactly matches the one suggestion.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   if (matching.length === 1 && matching[0]!.name.toLowerCase() === lastElementLower) {
     return [];
   }
@@ -184,6 +188,7 @@ export const GraphQueryInput = React.memo(
 
     const [, prefix, lastElementName, suffix] = lastClause || [];
     const suggestions = React.useMemo(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       () => buildSuggestions(lastElementName!, props.items, suffix!),
       [lastElementName, props.items, suffix],
     );
@@ -207,6 +212,7 @@ export const GraphQueryInput = React.memo(
       if (!suggestions[nextIdx]) {
         return;
       }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const nextText = suggestions[nextIdx]!.name;
 
       if (nextIdx !== active.idx || nextText !== active.text) {
@@ -241,6 +247,7 @@ export const GraphQueryInput = React.memo(
         e.preventDefault();
         let idx = (active ? active.idx : -1) + shift;
         idx = Math.max(0, Math.min(idx, suggestions.length - 1));
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         setActive({text: suggestions[idx]!.name, idx});
       }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/SectionedLeftNav.tsx
@@ -209,6 +209,7 @@ export const SectionedLeftNav = ({visibleRepos}: Props) => {
     count: flattened.length,
     getScrollElement: () => parentRef.current,
     estimateSize: (index: number) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const item = flattened[index]!;
       switch (item.type) {
         case 'code-location':
@@ -239,7 +240,9 @@ export const SectionedLeftNav = ({visibleRepos}: Props) => {
     <Container ref={parentRef}>
       <Inner $totalHeight={totalHeight}>
         {items.map(({index, key, size, start}) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const row: RowType = flattened[index]!;
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const type = row!.type;
 
           if (type === 'code-location') {

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedItemListForDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedItemListForDialog.tsx
@@ -33,6 +33,7 @@ export function VirtualizedItemListForDialog<A>({
     <Container ref={container} style={{padding}}>
       <Inner $totalHeight={totalHeight}>
         {virtualItems.map(({index, key, size, start}) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const assetKey = items[index]!;
           return (
             <Row

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/__tests__/autolinking.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/__tests__/autolinking.test.tsx
@@ -58,6 +58,7 @@ describe('autolinking', () => {
       'https://www.google.com/maps/place/Nashville,+TN/@36.1865271,-86.9503948,11z/data=!3m1!4b1!4m6!3m5!1s0x8864ec3213eb903d:0x7d3fb9d0a1e9daa0!8m2!3d36.1626638!4d-86.7816016!16zL20vMDVqYm4?entry=ttu',
     ]);
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(rendered.container.textContent!.trim()).toEqual(message.trim());
   });
 
@@ -76,6 +77,7 @@ describe('autolinking', () => {
       'https://dataproc.googleapis.com/',
     ]);
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(rendered.container.textContent!.trim()).toEqual(LongMessage.trim());
   });
 
@@ -95,6 +97,7 @@ describe('autolinking', () => {
         'https://dataproc.googleapis.com/',
       ]);
     });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(rendered.container.textContent!.trim()).toEqual(LongMessage.trim());
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/colorForString.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/colorForString.tsx
@@ -11,5 +11,6 @@ export const colorForString = (colors: string[]) =>
           return a & a;
         }, 0),
       ) % colors.length;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return colors[index]!;
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/formatDuration.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/formatDuration.ts
@@ -109,6 +109,7 @@ export function formatDuration(
     let violatingUnitIndex = -1;
 
     for (let i = 0; i < UNITS.length; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const [unitMs, singular] = UNITS[i]!;
       const value = roundFn(remainingMs / unitMs);
       const threshold = maxValueBeforeNextUnit[singular];
@@ -120,6 +121,7 @@ export function formatDuration(
 
     if (violatingUnitIndex !== -1) {
       if (violatingUnitIndex > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const nextLargerUnit = UNITS[violatingUnitIndex - 1]!;
         if (nextLargerUnit) {
           const [unitMs, singular, plural] = nextLargerUnit;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/usePersistedExpansionStateWithDefault.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/usePersistedExpansionStateWithDefault.tsx
@@ -35,6 +35,7 @@ export const usePersistedExpansionStateWithDefault = (
 
   const isExpanded = useCallback(
     (key: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return key in expandedKeys ? expandedKeys[key]! : defaultValue;
     },
     [expandedKeys, defaultValue],

--- a/js_modules/dagster-ui/packages/ui-core/src/util/DeferredCallbackRegistry.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/DeferredCallbackRegistry.ts
@@ -11,6 +11,7 @@ export class DeferredCallbackRegistry<TCallbacks extends Record<string, (...args
 
     // Execute all queued callbacks
     while (this.queue.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const callbacks = this.queue.shift()!;
 
       fn(callbacks);
@@ -36,6 +37,7 @@ export class DeferredCallbackRegistry<TCallbacks extends Record<string, (...args
         if (!this.listeners[key]) {
           this.listeners[key] = new Set();
         }
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.listeners[key]!.add(wrapped as unknown as TCallbacks[typeof key]);
         this.listeners[key] = new Set(this.listeners[key]);
         addedCallbacks.push({key, callback: wrapped});

--- a/js_modules/dagster-ui/packages/ui-core/src/util/generateObjectHash.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/generateObjectHash.ts
@@ -37,12 +37,14 @@ export function generateObjectHashStream(
   hash.append(encoder.encode(isRootArray ? '[' : '{'));
 
   while (stack.length > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const currentFrame = stack[stack.length - 1]!;
 
     if (currentFrame.index >= currentFrame.keys.length) {
       stack.pop();
       hash.append(encoder.encode(currentFrame.isArray ? ']' : '}'));
       if (stack.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const parentFrame = stack[stack.length - 1]!;
         parentFrame.isFirst = false;
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/util/hashObject.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/hashObject.ts
@@ -71,6 +71,7 @@ export const hashObject = weakMapMemoize((obj: any): string => {
 
   // Process the object iteratively
   while (stack.length > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const current = stack[stack.length - 1]!;
 
     // Start processing a new item
@@ -140,6 +141,7 @@ export const hashObject = weakMapMemoize((obj: any): string => {
           current.state = 2;
         }
       } else if (current.type === TYPE_OBJECT) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const keys = current.keys!;
 
         if (current.index > 0) {
@@ -147,6 +149,7 @@ export const hashObject = weakMapMemoize((obj: any): string => {
         }
 
         if (current.index < keys.length) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const key = keys[current.index++]!;
           hashChunk(key);
           hashChunk(smallBuffer[4]); // ':'

--- a/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/weakMapMemoize.ts
@@ -139,6 +139,7 @@ export function weakMapMemoize<T extends AnyFunction>(fn: T, options?: WeakMapMe
         nextCacheNode = currentCache.map.get(arg);
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       currentCache = nextCacheNode!;
     }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/GuessJobLocationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/GuessJobLocationRoot.tsx
@@ -26,6 +26,7 @@ export const GuessJobLocationRoot = () => {
   const entireMatch = useRouteMatch('/guess/(/?.*)');
   const location = useLocation();
 
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const toAppend = (entireMatch!.params as any)[0];
   const {search} = location;
 
@@ -57,6 +58,7 @@ export const GuessJobLocationRoot = () => {
   }
 
   if (reposWithMatch.length === 1) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const match = reposWithMatch[0]!;
     const repoAddress = optionToRepoAddress(match);
     const isJob = isThisThingAJob(match, pipelineName);

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
@@ -93,6 +93,7 @@ export const RepositoryLocationsList = ({
       <VirtualizedCodeLocationHeader />
       <Inner $totalHeight={totalHeight}>
         {items.map(({index, key, size, start}) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const row: CodeLocationRowType = codeLocations[index]!;
           if (row.type === 'location') {
             const repoAddressString = repoAddressAsHumanString({

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -326,6 +326,7 @@ export function useLiveDataOrLatestMaterializationDebounced(
   }, [type, path]);
 
   if (type === 'asset') {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return liveDataByNode[tokenForAssetKey({path})]!;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
@@ -51,10 +51,12 @@ export const VirtualizedAssetTable = (props: Props) => {
     }
     return Object.entries(groups).map(([displayKey, assets]) => {
       const path = [...prefixPath, ...JSON.parse(displayKey)];
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const isFolder = assets.length > 1 || path.join('/') !== assets[0]!.key.path.join('/');
       return isFolder
         ? {type: 'folder', path, displayKey, assets}
-        : {type: 'asset', path, displayKey, asset: assets[0]!};
+        : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          {type: 'asset', path, displayKey, asset: assets[0]!};
     });
   }, [prefixPath, groups, isLoading]);
 
@@ -75,6 +77,7 @@ export const VirtualizedAssetTable = (props: Props) => {
         <VirtualizedAssetCatalogHeader headerCheckbox={headerCheckbox} view={view} />
         <Inner $totalHeight={totalHeight}>
           {items.map(({index, key, size, start}) => {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const row: Row = rows[index]!;
             if (row.type === 'shimmer') {
               return (

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
@@ -188,6 +188,7 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
                   >
                     Next tick:&nbsp;
                     <TimestampDisplay
+                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       timestamp={scheduleData.scheduleState.nextTick.timestamp!}
                       timezone={scheduleData.executionTimezone}
                       timeFormat={{showSeconds: false, showTimezone: true}}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceContext.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceContext.test.tsx
@@ -50,12 +50,14 @@ jest.mock('../../../util/idb-lru-cache', () => {
 const mockLoadFromServerQueue: (() => void)[] = [];
 function drainMockLoadFromServerQueue() {
   while (mockLoadFromServerQueue.length) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     mockLoadFromServerQueue.shift()!();
   }
 }
 const mockHandleStatusUpdateQueue: (() => void)[] = [];
 function drainMockHandleStatusUpdateQueue() {
   while (mockHandleStatusUpdateQueue.length) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     mockHandleStatusUpdateQueue.shift()!();
   }
 }
@@ -187,6 +189,7 @@ describe('WorkspaceContext', () => {
     const mockCbs = mocks.map(getMockResultFn);
 
     // Include code location status mock a second time since we call runOnlyPendingTimersAsync twice
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const {result} = renderWithMocks([...mocks, mocks[0]!]);
 
     expect(result.current.allRepos).toEqual([]);
@@ -262,30 +265,37 @@ describe('WorkspaceContext', () => {
 
     caches.codeLocationStatusQuery.has.mockResolvedValue(true);
     caches.codeLocationStatusQuery.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[0]! as any).result.data, version: CodeLocationStatusQueryVersion},
     });
     caches.location1.has.mockResolvedValue(true);
     caches.location1.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[1]! as any).result.data, version: LocationWorkspaceQueryVersion},
     });
     caches.location2.has.mockResolvedValue(true);
     caches.location2.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[2]! as any).result.data, version: LocationWorkspaceQueryVersion},
     });
     caches.location3.has.mockResolvedValue(true);
     caches.location3.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[3]! as any).result.data, version: LocationWorkspaceQueryVersion},
     });
     caches.location1Assets.has.mockResolvedValue(true);
     caches.location1Assets.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[4]! as any).result.data, version: LocationWorkspaceAssetsQueryVersion},
     });
     caches.location2Assets.has.mockResolvedValue(true);
     caches.location2Assets.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[5]! as any).result.data, version: LocationWorkspaceAssetsQueryVersion},
     });
     caches.location3Assets.has.mockResolvedValue(true);
     caches.location3Assets.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[6]! as any).result.data, version: LocationWorkspaceAssetsQueryVersion},
     });
 
@@ -350,34 +360,42 @@ describe('WorkspaceContext', () => {
 
     caches.codeLocationStatusQuery.has.mockResolvedValue(true);
     caches.codeLocationStatusQuery.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[0]! as any).result.data, version: CodeLocationStatusQueryVersion},
     });
     caches.location1.has.mockResolvedValue(true);
     caches.location1.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[1]! as any).result.data, version: LocationWorkspaceQueryVersion},
     });
     caches.location2.has.mockResolvedValue(true);
     caches.location2.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[2]! as any).result.data, version: LocationWorkspaceQueryVersion},
     });
     caches.location3.has.mockResolvedValue(true);
     caches.location3.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[3]! as any).result.data, version: LocationWorkspaceQueryVersion},
     });
     caches.location1Assets.has.mockResolvedValue(true);
     caches.location1Assets.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[4]! as any).result.data, version: LocationWorkspaceAssetsQueryVersion},
     });
     caches.location2Assets.has.mockResolvedValue(true);
     caches.location2Assets.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[5]! as any).result.data, version: LocationWorkspaceAssetsQueryVersion},
     });
     caches.location3Assets.has.mockResolvedValue(true);
     caches.location3Assets.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[6]! as any).result.data, version: LocationWorkspaceAssetsQueryVersion},
     });
     const mockCbs = updatedMocks.map(getMockResultFn);
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const {result} = renderWithMocks([...updatedMocks, updatedMocks[0]!]);
 
     await act(async () => {
@@ -443,30 +461,37 @@ describe('WorkspaceContext', () => {
 
     caches.codeLocationStatusQuery.has.mockResolvedValue(true);
     caches.codeLocationStatusQuery.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[0]! as any).result.data, version: CodeLocationStatusQueryVersion},
     });
     caches.location1.has.mockResolvedValue(true);
     caches.location1.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[1]! as any).result.data, version: LocationWorkspaceQueryVersion},
     });
     caches.location2.has.mockResolvedValue(true);
     caches.location2.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[2]! as any).result.data, version: LocationWorkspaceQueryVersion},
     });
     caches.location3.has.mockResolvedValue(true);
     caches.location3.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[3]! as any).result.data, version: LocationWorkspaceQueryVersion},
     });
     caches.location1Assets.has.mockResolvedValue(true);
     caches.location1Assets.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[4]! as any).result.data, version: LocationWorkspaceAssetsQueryVersion},
     });
     caches.location2Assets.has.mockResolvedValue(true);
     caches.location2Assets.get.mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value: {data: (mocks[5]! as any).result.data, version: LocationWorkspaceAssetsQueryVersion},
     });
     const mockCbs = updatedMocks.map(getMockResultFn);
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const {result} = renderWithMocks([...updatedMocks, updatedMocks[0]!]);
 
     await act(async () => {
@@ -536,6 +561,7 @@ describe('WorkspaceContext', () => {
     location2.locationOrLoadError = error;
 
     const mocks = buildWorkspaceMocks([location1, location2, location3], {delay: 10});
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     mocks[0]!.maxUsageCount = 999;
     const mockCbs = mocks.map(getMockResultFn);
 
@@ -594,6 +620,7 @@ describe('WorkspaceContext', () => {
     caches.codeLocationStatusQuery.has.mockResolvedValue(false);
 
     const mocks = buildWorkspaceMocks([], {delay: 10});
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     mocks[0]!.maxUsageCount = 9999;
 
     const {result} = renderWithMocks(mocks);
@@ -630,6 +657,7 @@ describe('WorkspaceContext', () => {
     });
     const mockCbs = mocks.map(getMockResultFn);
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const {result} = renderWithMocks([...mocks, mocks[0]!]);
 
     expect(result.current.allRepos).toEqual([]);

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/useFlattenedGroupedAssetList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/useFlattenedGroupedAssetList.tsx
@@ -34,6 +34,7 @@ export const useFlattenedGroupedAssetList = ({repoAddress, assets}: Config) => {
       if (!groups[groupName]) {
         groups[groupName] = [];
       }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       groups[groupName]!.push(asset);
     }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/useRepositoryForRun.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/useRepositoryForRun.ts
@@ -103,6 +103,7 @@ export const useRepositoryForRunWithoutSnapshot = (
   }
   const jobNameMatches = jobNameMatchesForRun(options, run);
   if (jobNameMatches && jobNameMatches.length) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return {match: jobNameMatches[0]!, type: 'pipeline-name-only'};
   }
   return null;


### PR DESCRIPTION
## Summary & Motivation

Begin linting against TypeScript non-null assertions. We've had a couple of bugs lately that were introduced by these (ex. https://github.com/dagster-io/internal/pull/17122), where we should have been more appropriately handling null/undefined cases.

I can't take the time to fix these right now, so I added disable directives to them. Going forward, we should a) avoid using these operators, and b) clean them up when we come across the override directives.

I used Claude to do most of the work on this.

## How I Tested These Changes

yarn lint