### PR TITLE
Remove count tags on jobs and automations index pages

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationsTable.tsx
@@ -1,4 +1,4 @@
-import {Box, Row, Tag, Tooltip} from '@dagster-io/ui-components';
+import {Row} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
@@ -117,28 +117,7 @@ export const AutomationsTable = ({
                     onToggleAll={onToggleAll}
                     expanded={expandedKeys.includes(repoAddressAsHumanString(row.repoAddress))}
                     showLocation={duplicateRepoNames.has(row.repoAddress.name)}
-                    rightElement={
-                      <Box flex={{direction: 'row', gap: 4}}>
-                        <Tooltip
-                          content={
-                            row.sensorCount === 1 ? '1 sensor' : `${row.sensorCount} sensors`
-                          }
-                          placement="top"
-                        >
-                          <Tag icon="sensors">{row.sensorCount}</Tag>
-                        </Tooltip>
-                        <Tooltip
-                          content={
-                            row.scheduleCount === 1
-                              ? '1 schedule'
-                              : `${row.scheduleCount} schedules`
-                          }
-                          placement="top"
-                        >
-                          <Tag icon="schedule">{row.scheduleCount}</Tag>
-                        </Tooltip>
-                      </Box>
-                    }
+                    rightElement={<></>}
                   />
                 </Row>
               );

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewJobsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewJobsTable.tsx
@@ -1,4 +1,3 @@
-import {Tag, Tooltip} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import {useMemo, useRef} from 'react';
 
@@ -100,14 +99,7 @@ export const OverviewJobsTable = ({repos}: Props) => {
                     onToggleAll={onToggleAll}
                     expanded={expandedKeys.includes(repoAddressAsHumanString(row.repoAddress))}
                     showLocation={duplicateRepoNames.has(row.repoAddress.name)}
-                    rightElement={
-                      <Tooltip
-                        content={row.jobCount === 1 ? '1 job' : `${row.jobCount} jobs`}
-                        placement="top"
-                      >
-                        <Tag>{row.jobCount}</Tag>
-                      </Tooltip>
-                    }
+                    rightElement={<></>}
                   />
                 );
               }


### PR DESCRIPTION
## Summary & Motivation
Removes the count tags on the list rows to make them consistent with the Asset ones. Feels cleaner.

Before:
<img width="1194" height="892" alt="image" src="https://github.com/user-attachments/assets/6c22e967-c1d8-4a3a-9e11-1647d6594f00" />

After:
<img width="1202" height="819" alt="image" src="https://github.com/user-attachments/assets/4ce94537-a80a-483f-8d9a-ace21fd97c68" />
