### PR TITLE
Make docstring docstrings for consistency

### DIFF
--- a/python_modules/automation/DAGSTER_DOCS_CLI.md
+++ b/python_modules/automation/DAGSTER_DOCS_CLI.md
@@ -106,14 +106,14 @@ Checks that top-level package exports have public decorators and entries in .rst
 
 Monitors files for changes and performs real-time validation.
 
-#### `watch docstring`
+#### `watch docstrings`
 
 ```bash
 # Watch a specific symbol
-dagster-docs watch docstring --symbol dagster.asset --verbose
+dagster-docs watch docstrings --symbol dagster.asset --verbose
 
 # Watch changed files
-dagster-docs watch docstring --changed
+dagster-docs watch docstrings --changed
 ```
 
 **Options** (exactly one required):
@@ -137,7 +137,7 @@ dagster-docs check docstrings --changed
 dagster-docs ls symbols --package dagster._core
 
 # Watch a symbol for changes
-dagster-docs watch docstring --symbol dagster.asset --verbose
+dagster-docs watch docstrings --symbol dagster.asset --verbose
 ```
 
 ## Development Notes

--- a/python_modules/automation/automation/docs_cli/commands/watch.py
+++ b/python_modules/automation/automation/docs_cli/commands/watch.py
@@ -152,7 +152,7 @@ def watch():
 @click.option("--changed", is_flag=True, help="Watches the files currently changed in git")
 @click.option("--symbol", help="Targets a particular symbol")
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
-def docstring(changed: bool, symbol: Optional[str], verbose: bool):
+def docstrings(changed: bool, symbol: Optional[str], verbose: bool):
     """Watch docstring files for changes and validate them."""
     # Validate that exactly one option is provided
     if not changed and not symbol:

--- a/python_modules/automation/automation_tests/docs_cli_tests/test_watch_commands.py
+++ b/python_modules/automation/automation_tests/docs_cli_tests/test_watch_commands.py
@@ -18,11 +18,11 @@ class TestWatchCommands:
 
         assert result.exit_code == 0
         assert "Watch files for changes" in result.output
-        assert "docstring" in result.output
+        assert "docstrings" in result.output
 
-    def test_watch_docstring_help_command(self):
-        """Test that watch docstring help works."""
-        result = self.runner.invoke(watch, ["docstring", "--help"])
+    def test_watch_docstrings_help_command(self):
+        """Test that watch docstrings help works."""
+        result = self.runner.invoke(watch, ["docstrings", "--help"])
 
         assert result.exit_code == 0
         assert "Watch docstring files for changes and validate them" in result.output
@@ -30,26 +30,26 @@ class TestWatchCommands:
         assert "--changed" in result.output
         assert "--verbose" in result.output
 
-    def test_watch_docstring_no_options_fails(self):
-        """Test that watch docstring without options fails."""
-        result = self.runner.invoke(watch, ["docstring"])
+    def test_watch_docstrings_no_options_fails(self):
+        """Test that watch docstrings without options fails."""
+        result = self.runner.invoke(watch, ["docstrings"])
 
         # Should fail with exit code 1
         assert result.exit_code == 1
         assert "Error: One of --changed or --symbol must be provided" in result.output
 
-    def test_watch_docstring_multiple_options_fails(self):
-        """Test that watch docstring with multiple options fails."""
-        result = self.runner.invoke(watch, ["docstring", "--symbol", "dagster.asset", "--changed"])
+    def test_watch_docstrings_multiple_options_fails(self):
+        """Test that watch docstrings with multiple options fails."""
+        result = self.runner.invoke(watch, ["docstrings", "--symbol", "dagster.asset", "--changed"])
 
         # Should fail with exit code 1
         assert result.exit_code == 1
         assert "Error: Cannot use both --changed and --symbol together" in result.output
 
-    def test_watch_docstring_changed_not_implemented(self):
-        """Test that watch docstring --changed raises NotImplementedError."""
+    def test_watch_docstrings_changed_not_implemented(self):
+        """Test that watch docstrings --changed raises NotImplementedError."""
         with pytest.raises(NotImplementedError) as excinfo:
-            self.runner.invoke(watch, ["docstring", "--changed"], catch_exceptions=False)
+            self.runner.invoke(watch, ["docstrings", "--changed"], catch_exceptions=False)
 
         assert "Watching changed files functionality not yet fully implemented" in str(
             excinfo.value


### PR DESCRIPTION
## Summary & Motivation

Renamed the `docstring` command to `docstrings` in the Dagster docs CLI to better reflect that it operates on multiple docstrings. Updated all references to this command in documentation, code, and tests to maintain consistency.

## How I Tested These Changes

Ran the test suite for the docs CLI to ensure all tests pass with the renamed command. Verified that the command help text and error messages correctly reflect the new command name.
