### PR TITLE
[dagster-databricks] Support databricks serverless with pipes client

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -1412,6 +1412,37 @@ class PipesDbfsMessageWriter(PipesBlobStoreMessageWriter):
             return {}
 
 
+# #################################################################
+# ##### IO - Unity Catalog Volumes (Databricks Serverless)
+# #################################################################
+
+
+class PipesUnityCatalogVolumesContextLoader(PipesContextLoader):
+    """Context loader that reads context from a JSON file on Unity Catalog Volumes."""
+
+    @contextmanager
+    def load_context(self, params: PipesParams) -> Iterator[PipesContextData]:
+        path = _assert_env_param_type(params, "path", str, self.__class__)
+        with open(path) as f:
+            yield json.load(f)
+
+
+class PipesUnityCatalogVolumesMessageWriter(PipesBlobStoreMessageWriter):
+    """Message writer that writes messages by periodically writing message chunks
+    to a directory on Unity Catalog Volumes.
+    """
+
+    def make_channel(
+        self,
+        params: PipesParams,
+    ) -> "PipesBufferedFilesystemMessageWriterChannel":
+        path = _assert_env_param_type(params, "path", str, self.__class__)
+        return PipesBufferedFilesystemMessageWriterChannel(
+            path=path,
+            interval=self.interval,
+        )
+
+
 # ########################
 # ##### CONTEXT
 # ########################

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -1412,9 +1412,9 @@ class PipesDbfsMessageWriter(PipesBlobStoreMessageWriter):
             return {}
 
 
-# #################################################################
-# ##### IO - Unity Catalog Volumes (Databricks Serverless)
-# #################################################################
+# #########################################
+# ##### IO - Databricks Serverless
+# #########################################
 
 
 class PipesUnityCatalogVolumesContextLoader(PipesContextLoader):
@@ -1441,6 +1441,27 @@ class PipesUnityCatalogVolumesMessageWriter(PipesBlobStoreMessageWriter):
             path=path,
             interval=self.interval,
         )
+
+
+DAGSTER_PIPES_CONTEXT_WIDGET_KEY = DAGSTER_PIPES_CONTEXT_ENV_VAR
+DAGSTER_PIPES_MESSAGES_WIDGET_KEY = DAGSTER_PIPES_MESSAGES_ENV_VAR
+
+
+class PipesDatabricksNotebookWidgetsParamsLoader(PipesParamsLoader):
+    """Params loader that extracts params from widgets (base params) in a Databricks Notebook."""
+
+    def __init__(self, widgets: Any):
+        self.widgets = widgets
+
+    def is_dagster_pipes_process(self) -> bool:
+        # use the presence of the pipes context to discern if we are in a pipes process
+        return self.widgets.get(DAGSTER_PIPES_CONTEXT_WIDGET_KEY) is not None
+
+    def load_context_params(self) -> PipesParams:
+        return decode_param(self.widgets.get(DAGSTER_PIPES_CONTEXT_WIDGET_KEY))
+
+    def load_messages_params(self) -> PipesParams:
+        return decode_param(self.widgets.get(DAGSTER_PIPES_MESSAGES_WIDGET_KEY))
 
 
 # ########################

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/_test_utils.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/_test_utils.py
@@ -11,7 +11,6 @@ import dagster._check as check
 import pytest
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import files
-from databricks.sdk.service.workspace import ImportFormat, Language
 
 from dagster_databricks.pipes import dbfs_tempdir
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/_test_utils.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/_test_utils.py
@@ -1,7 +1,6 @@
 import base64
 import inspect
 import os
-import io
 import subprocess
 import textwrap
 from collections.abc import Iterator
@@ -12,9 +11,9 @@ import dagster._check as check
 import pytest
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import files
-from databricks.sdk.service.workspace import Language, ImportFormat
+from databricks.sdk.service.workspace import ImportFormat, Language
 
-from dagster_databricks.pipes import dbfs_tempdir, volumes_tempdir
+from dagster_databricks.pipes import dbfs_tempdir
 
 DAGSTER_PIPES_WHL_FILENAME = "dagster_pipes-1!0+dev-py3-none-any.whl"
 
@@ -54,6 +53,7 @@ def databricks_client() -> WorkspaceClient:
         host=os.environ["DATABRICKS_HOST"],
         token=os.environ["DATABRICKS_TOKEN"],
     )
+
 
 @pytest.fixture
 def databricks_notebook_folder_path() -> str:
@@ -116,7 +116,7 @@ def temp_notebook_script(
     else:
         check.failed("Unreachable")
 
-    content_b64 = base64.b64encode(source.encode('utf-8'))
+    content_b64 = base64.b64encode(source.encode("utf-8"))
     notebook_path = os.path.join(notebook_folder_path, "notebook")
     try:
         # Upload to workspace
@@ -125,7 +125,7 @@ def temp_notebook_script(
             content=content_b64,
             language=Language.PYTHON,
             format=ImportFormat.SOURCE,
-            overwrite=True
+            overwrite=True,
         )
         yield notebook_path
     finally:

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -705,7 +705,7 @@ def volumes_tempdir(files_client: files.FilesAPI, volume_path: str) -> Iterator[
     try:
         yield tempdir
     finally:
-        # delete_volume_directory_recursive(files_client, tempdir)
+        delete_volume_directory_recursive(files_client, tempdir)
         pass
 
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -701,7 +701,7 @@ class PipesDatabricksServerlessClient(PipesClient, TreatAsResourceParam):
 def volumes_tempdir(files_client: files.FilesAPI, volume_path: str) -> Iterator[str]:
     dirname = "".join(random.choices(string.ascii_letters, k=30))
     tempdir = f"{volume_path}/tmp/{dirname}"
-    files_client.create_directory(tempdir)
+    files_client.create_directory(tempdir)  # pyright: ignore
     try:
         yield tempdir
     finally:
@@ -717,7 +717,7 @@ def delete_volume_directory_recursive(volumes_client: files.FilesAPI, directory_
         directory_path: Path to directory
     """
     # List all contents in the directory
-    contents = list(volumes_client.list_directory_contents(directory_path))
+    contents = list(volumes_client.list_directory_contents(directory_path))  # pyright: ignore
 
     # Delete each item recursively
     for item in contents:
@@ -730,7 +730,7 @@ def delete_volume_directory_recursive(volumes_client: files.FilesAPI, directory_
             volumes_client.delete(item_path)
 
     # Finally delete the empty directory
-    volumes_client.delete_directory(directory_path)
+    volumes_client.delete_directory(directory_path)  # pyright: ignore
 
 
 class PipesUnityCatalogVolumesContextInjector(PipesContextInjector):
@@ -817,7 +817,7 @@ class PipesUnityCatalogVolumesMessageReader(PipesBlobStoreMessageReader):
         """Check if the messages directory exists and is readable."""
         try:
             # The API returns an error if there is no directory at the specified path
-            self.files_client.list_directory_contents(params["path"])
+            self.files_client.list_directory_contents(params["path"])  # pyright: ignore
             return True
         except Exception:
             return False

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -1,4 +1,5 @@
 import base64
+import io
 import json
 import os
 import random
@@ -32,6 +33,12 @@ from dagster_pipes import PipesBlobStoreMessageWriter, PipesContextData, PipesEx
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import files, jobs
 from pydantic import Field
+
+_CONTEXT_FILENAME = "context.json"
+
+# #########################
+# ##### Databricks
+# #########################
 
 
 class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
@@ -305,9 +312,6 @@ class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
         return metadata
 
 
-_CONTEXT_FILENAME = "context.json"
-
-
 @contextmanager
 def dbfs_tempdir(dbfs_client: files.DbfsAPI) -> Iterator[str]:
     dirname = "".join(random.choices(string.ascii_letters, k=30))
@@ -510,3 +514,334 @@ class PipesDbfsLogReader(PipesChunkedLogReader):
                 self.log_path = f"dbfs:{match.path}"
 
         return self.log_path
+
+
+# ####################################
+# ##### Databricks Serverless
+# ####################################
+
+
+class PipesDatabricksServerlessClient(PipesClient, TreatAsResourceParam):
+    """Pipes client for Databricks Serverless.
+
+    Args:
+        client (WorkspaceClient): A databricks `WorkspaceClient` object.
+        context_injector (Optional[PipesContextInjector]): A context injector to use to inject
+            context into the k8s container process. Defaults to :py:class:`PipesUnityCatalogVolumesContextInjector`.
+        message_reader (Optional[PipesMessageReader]): A message reader to use to read messages
+            from the Databricks Serverless job. Defaults to :py:class:`PipesUnityCatalogVolumesMessageReader`.
+        poll_interval_seconds (float): How long to sleep between checking the status of the job run.
+            Defaults to 5.
+        forward_termination (bool): Whether to cancel the Databricks Serverless job if the orchestration process
+            is interrupted or canceled. Defaults to True.
+    """
+
+    def __init__(
+        self,
+        client: WorkspaceClient,
+        volume_path: str,
+        context_injector: Optional[PipesContextInjector] = None,
+        message_reader: Optional[PipesMessageReader] = None,
+        poll_interval_seconds: float = 5,
+        forward_termination: bool = True,
+    ):
+        self.client = client
+        self.volume_path = volume_path
+        self.context_injector = check.opt_inst_param(
+            context_injector,
+            "context_injector",
+            PipesContextInjector,
+        ) or PipesUnityCatalogVolumesContextInjector(
+            client=self.client, volume_path=self.volume_path
+        )
+        self.message_reader = check.opt_inst_param(
+            message_reader,
+            "message_reader",
+            PipesMessageReader,
+        ) or PipesUnityCatalogVolumesMessageReader(
+            client=self.client,
+            volume_path=self.volume_path,
+        )
+        self.poll_interval_seconds = check.numeric_param(
+            poll_interval_seconds, "poll_interval_seconds"
+        )
+        self.forward_termination = check.bool_param(forward_termination, "forward_termination")
+
+    @classmethod
+    def _is_dagster_maintained(cls) -> bool:
+        return True
+
+    def run(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        *,
+        context: Union[OpExecutionContext, AssetExecutionContext],
+        extras: Optional[PipesExtras] = None,
+        task: jobs.SubmitTask,
+        submit_args: Optional[Mapping[str, Any]] = None,
+    ) -> PipesClientCompletedInvocation:
+        """Synchronously execute a Databricks job with the pipes protocol.
+
+        Args:
+            task (databricks.sdk.service.jobs.SubmitTask): Specification of the Databricks Serverless
+                task to run. Fields `task_key`, `environment_key` and `notebook_task` must be provided.
+            context (Union[OpExecutionContext, AssetExecutionContext]): The context from the executing op or asset.
+            extras (Optional[PipesExtras]): An optional dict of extra parameters to pass to the
+                subprocess.
+            submit_args (Optional[Mapping[str, Any]]): Additional keyword arguments that will be
+                forwarded as-is to `WorkspaceClient.jobs.submit`.
+
+        Returns:
+            PipesClientCompletedInvocation: Wrapper containing results reported by the external
+                process.
+        """
+        with open_pipes_session(
+            context=context,
+            extras=extras,
+            context_injector=self.context_injector,
+            message_reader=self.message_reader,
+        ) as pipes_session:
+            submit_task_dict = task.as_dict()
+
+            submit_task_dict["tags"] = {
+                **submit_task_dict.get("tags", {}),
+                **pipes_session.default_remote_invocation_info,
+            }
+
+            existing_params = submit_task_dict["notebook_task"].get("base_parameters", {})
+
+            # merge the existing parameters with the CLI arguments
+            existing_params = {**existing_params, **pipes_session.get_bootstrap_env_vars()}
+
+            submit_task_dict["notebook_task"]["base_parameters"] = existing_params
+
+            task = jobs.SubmitTask.from_dict(submit_task_dict)
+            run_id = self.client.jobs.submit(
+                tasks=[task],
+                **(submit_args or {}),
+            ).bind()["run_id"]
+
+            try:
+                self._poll_til_success(context, run_id)
+            except DagsterExecutionInterruptedError:
+                if self.forward_termination:
+                    context.log.info("[pipes] execution interrupted, canceling Databricks job.")
+                    self.client.jobs.cancel_run(run_id)
+                    self._poll_til_terminating(run_id)
+
+        return PipesClientCompletedInvocation(
+            pipes_session, metadata=self._extract_dagster_metadata(run_id)
+        )
+
+    def _poll_til_success(
+        self, context: Union[OpExecutionContext, AssetExecutionContext], run_id: int
+    ) -> None:
+        # poll the Databricks run until it reaches RunResultState.SUCCESS, raising otherwise
+
+        last_observed_state = None
+        while True:
+            run_state = self._get_run_state(run_id)
+            if run_state.life_cycle_state != last_observed_state:
+                context.log.info(
+                    f"[pipes] Databricks run {run_id} observed state transition to {run_state.life_cycle_state}"
+                )
+            last_observed_state = run_state.life_cycle_state
+
+            if run_state.life_cycle_state in (
+                jobs.RunLifeCycleState.TERMINATED,
+                jobs.RunLifeCycleState.SKIPPED,
+            ):
+                if run_state.result_state == jobs.RunResultState.SUCCESS:
+                    break
+                else:
+                    raise DagsterPipesExecutionError(
+                        f"Error running Databricks job: {run_state.state_message}"
+                    )
+            elif run_state.life_cycle_state == jobs.RunLifeCycleState.INTERNAL_ERROR:
+                raise DagsterPipesExecutionError(
+                    f"Error running Databricks job: {run_state.state_message}"
+                )
+
+            time.sleep(self.poll_interval_seconds)
+
+    def _poll_til_terminating(self, run_id: int) -> None:
+        # Wait to see the job enters a state that indicates the underlying task is no longer executing
+        # TERMINATING: "The task of this run has completed, and the cluster and execution context are being cleaned up."
+        while True:
+            run_state = self._get_run_state(run_id)
+            if run_state.life_cycle_state in (
+                jobs.RunLifeCycleState.TERMINATING,
+                jobs.RunLifeCycleState.TERMINATED,
+                jobs.RunLifeCycleState.SKIPPED,
+                jobs.RunLifeCycleState.INTERNAL_ERROR,
+            ):
+                return
+
+            time.sleep(self.poll_interval_seconds)
+
+    def _get_run_state(self, run_id: int) -> jobs.RunState:
+        run = self.client.jobs.get_run(run_id)
+        if run.state is None:
+            check.failed("Databricks job run state is None")
+        return run.state
+
+    def _extract_dagster_metadata(self, run_id: int) -> RawMetadataMapping:
+        metadata: RawMetadataMapping = {}
+
+        run = self.client.jobs.get_run(run_id)
+
+        metadata["Databricks Job Run ID"] = str(run_id)
+
+        if run_page_url := run.run_page_url:
+            metadata["Databricks Job Run URL"] = run_page_url
+
+        return metadata
+
+
+@contextmanager
+def volumes_tempdir(files_client: files.FilesAPI, volume_path: str) -> Iterator[str]:
+    dirname = "".join(random.choices(string.ascii_letters, k=30))
+    tempdir = f"{volume_path}/tmp/{dirname}"
+    files_client.create_directory(tempdir)
+    try:
+        yield tempdir
+    finally:
+        # delete_volume_directory_recursive(files_client, tempdir)
+        pass
+
+
+def delete_volume_directory_recursive(volumes_client: files.FilesAPI, directory_path: str) -> None:
+    """Recursively delete a directory and all its contents in Unity Catalog Volumes.
+
+    Args:
+        volumes_client: The Files API client
+        directory_path: Path to directory
+    """
+    # List all contents in the directory
+    contents = list(volumes_client.list_directory_contents(directory_path))
+
+    # Delete each item recursively
+    for item in contents:
+        item_path = f"{directory_path.rstrip('/')}/{item.name}"
+
+        if item.is_directory:
+            # Recursively delete subdirectory
+            delete_volume_directory_recursive(volumes_client, item_path)
+        else:
+            volumes_client.delete(item_path)
+
+    # Finally delete the empty directory
+    volumes_client.delete_directory(directory_path)
+
+
+class PipesUnityCatalogVolumesContextInjector(PipesContextInjector):
+    """A context injector that injects context into a Databricks Serverless job
+     by writing a JSON file to Unity Catalog Volumes.
+
+    Args:
+        client (WorkspaceClient): A databricks `WorkspaceClient` object.
+    """
+
+    def __init__(self, *, client: WorkspaceClient, volume_path: str):
+        super().__init__()
+        self.files_client = files.FilesAPI(client.api_client)
+        self.volume_path = volume_path
+
+    @contextmanager
+    def inject_context(self, context: "PipesContextData") -> Iterator[PipesParams]:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Inject context to external environment by writing it to an automatically-generated
+        Unity Catalog Volumes temporary file as JSON and exposing the path to the file.
+
+        Args:
+            context (PipesContextData): The context data to inject.
+
+        Yields:
+            PipesParams: A dict of parameters that can be used by the external process to locate and
+                load the injected context data.
+        """
+        with volumes_tempdir(self.files_client, self.volume_path) as tempdir:
+            path = os.path.join(tempdir, _CONTEXT_FILENAME)
+
+            contents = io.BytesIO(json.dumps(context).encode("utf-8"))
+            self.files_client.upload(path, contents=contents, overwrite=True)
+            yield {"path": path}
+
+    def no_messages_debug_text(self) -> str:
+        return (
+            "Attempted to inject context via a temporary file in Unity Catalog Volumes. Expected"
+            " PipesUnityCatalogVolumesContextLoader to be explicitly passed to open_dagster_pipes in the external"
+            " process."
+        )
+
+
+class PipesUnityCatalogVolumesMessageReader(PipesBlobStoreMessageReader):
+    """Message reader that reads messages by periodically reading message chunks from an
+    automatically-generated temporary directory in Unity Catalog Volumes.
+
+    Args:
+        interval (float): interval in seconds between attempts to download a chunk
+        client (WorkspaceClient): A databricks `WorkspaceClient` object.
+        include_stdio_in_messages (bool): Whether to send stdout/stderr to Dagster via Pipes messages. Defaults to True.
+    """
+
+    def __init__(
+        self,
+        *,
+        interval: float = 10,
+        client: WorkspaceClient,
+        volume_path: str,
+        include_stdio_in_messages: bool = True,
+    ):
+        self.include_stdio_in_messages = check.bool_param(
+            include_stdio_in_messages, "include_stdio_in_messages"
+        )
+
+        super().__init__(
+            interval=interval,
+        )
+        self.files_client = files.FilesAPI(client.api_client)
+        self.volume_path = volume_path
+
+    @contextmanager
+    def get_params(self) -> Iterator[PipesParams]:
+        with ExitStack() as stack:
+            params: PipesParams = {}
+            params["path"] = stack.enter_context(
+                volumes_tempdir(self.files_client, self.volume_path)
+            )
+            params[PipesBlobStoreMessageWriter.INCLUDE_STDIO_IN_MESSAGES_KEY] = (
+                self.include_stdio_in_messages
+            )
+            yield params
+
+    def messages_are_readable(self, params: PipesParams) -> bool:
+        """Check if the messages directory exists and is readable."""
+        try:
+            # The API returns an error if there is no directory at the specified path
+            self.files_client.list_directory_contents(params["path"])
+            return True
+        except Exception:
+            return False
+
+    def download_messages_chunk(self, index: int, params: PipesParams) -> Optional[str]:
+        """Download a specific message chunk from Unity Catalog Volume."""
+        message_path = f"{params['path']}/{index}.json"
+
+        try:
+            download_response = self.files_client.download(message_path)
+            response_contents = check.not_none(
+                download_response.contents, "Read message with null data."
+            )
+            # Databricks sdk returns a BinaryIO object
+            return response_contents.read().decode("utf-8")
+        # An error here is an expected result, since an IOError will be thrown if the next message
+        # chunk doesn't yet exist. Swallowing the error here is equivalent to doing a no-op on a
+        # status check showing a non-existent file.
+        except OSError:
+            return None
+
+    def no_messages_debug_text(self) -> str:
+        return (
+            "Attempted to read messages from a temporary directory in Unity Catalog Volumes. Expected"
+            " PipesUnityCatalogVolumesMessageWriter to be explicitly passed to open_dagster_pipes in the external"
+            " process."
+        )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_serverless_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_serverless_pipes.py
@@ -1,5 +1,4 @@
 import os
-from contextlib import ExitStack
 from typing import Any
 
 import pytest

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_serverless_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_serverless_pipes.py
@@ -1,0 +1,128 @@
+import os
+from contextlib import ExitStack
+from typing import Any
+
+import pytest
+from dagster import AssetExecutionContext, asset, materialize
+from dagster._core.errors import DagsterPipesExecutionError
+from dagster_databricks._test_utils import (
+    databricks_client,  # noqa: F401
+    databricks_notebook_folder_path, # noqa: F401
+    temp_notebook_script,
+)
+from dagster_databricks.pipes import PipesDatabricksServerlessClient
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service import jobs
+
+IS_BUILDKITE = os.getenv("BUILDKITE") is not None
+IS_WORKSPACE = os.getenv("DATABRICKS_HOST") is not None
+
+TEST_VOLUME_PATH = "/Volumes/workspace/default/databricks_serverless_pipes_test"
+
+def script_fn():
+    import sys
+
+    from dagster_pipes import (
+        PipesDatabricksNotebookWidgetsParamsLoader,
+        PipesUnityCatalogVolumesContextLoader,
+        PipesUnityCatalogVolumesMessageWriter,
+        open_dagster_pipes,
+    )
+
+    mock_widgets = {}
+
+    with open_dagster_pipes(
+        params_loader=PipesDatabricksNotebookWidgetsParamsLoader(mock_widgets),
+        context_loader=PipesUnityCatalogVolumesContextLoader(),
+        message_writer=PipesUnityCatalogVolumesMessageWriter(),
+    ) as context:
+        multiplier = context.get_extra("multiplier")
+        value = 2 * multiplier
+        print("hello from databricks stdout")  # noqa: T201
+        print("hello from databricks stderr", file=sys.stderr)  # noqa: T201
+        context.log.info(f"{context.asset_key}: {2} * {multiplier} = {value}")
+        context.report_asset_materialization(
+            metadata={"value": value},
+        )
+
+
+TASK_KEY = "DAGSTER_SERVERLESS_PIPES_TASK"
+
+
+def make_submit_task_dict(
+    notebook_path: str,
+) -> dict[str, Any]:
+    submit_spec = {
+        "task_key": TASK_KEY,
+        "notebook_task": {
+            "notebook_path": notebook_path,
+            "source": jobs.Source.WORKSPACE,
+        },
+    }
+    return submit_spec
+
+
+def make_submit_task(
+    notebook_path: str,
+) -> jobs.SubmitTask:
+    return jobs.SubmitTask.from_dict(
+        make_submit_task_dict(
+            notebook_path=notebook_path,
+        )
+    )
+
+
+@pytest.mark.skipif(IS_BUILDKITE, reason="Not configured to run on BK yet.")
+@pytest.mark.skipif(not IS_WORKSPACE, reason="No DB workspace credentials found.")
+def test_pipes_client(
+    databricks_client: WorkspaceClient,  # noqa: F811
+    databricks_notebook_folder_path: str,  # noqa: F811
+):
+    @asset
+    def number_x(context: AssetExecutionContext, pipes_client: PipesDatabricksServerlessClient):
+        with ExitStack() as stack:
+            script_path = stack.enter_context(
+                temp_notebook_script(databricks_client, databricks_notebook_folder_path, script_fn=script_fn)
+            )
+            task = make_submit_task(script_path)
+            return pipes_client.run(
+                task=task,
+                context=context,
+                extras={"multiplier": 2, "storage_root": "fake"},
+            ).get_results()
+
+    result = materialize(
+        [number_x],
+        resources={
+            "pipes_client": PipesDatabricksServerlessClient(
+                client=databricks_client, volume_path=TEST_VOLUME_PATH
+            )
+        },
+        raise_on_error=False,
+    )
+    assert result.success
+    mats = result.asset_materializations_for_node(number_x.op.name)
+    assert mats[0].metadata["value"].value == 4
+
+    # check Databricks metadata automatically added to materialization
+    assert "Databricks Job Run ID" in mats[0].metadata
+    assert "Databricks Job Run URL" in mats[0].metadata
+
+
+@pytest.mark.skipif(IS_BUILDKITE, reason="Not configured to run on BK yet.")
+@pytest.mark.skipif(not IS_WORKSPACE, reason="No DB workspace credentials found.")
+def test_nonexistent_entry_point(databricks_client: WorkspaceClient):  # noqa: F811
+    @asset
+    def fake(context: AssetExecutionContext, pipes_client: PipesDatabricksServerlessClient):
+        task = make_submit_task("/fake/fake")
+        return pipes_client.run(task=task, context=context).get_results()
+
+    with pytest.raises(DagsterPipesExecutionError, match=r"Unable to access the notebook"):
+        materialize(
+            [fake],
+            resources={
+                "pipes_client": PipesDatabricksServerlessClient(
+                    client=databricks_client, volume_path=TEST_VOLUME_PATH
+                )
+            },
+        )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_serverless_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_serverless_pipes.py
@@ -7,7 +7,7 @@ from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.errors import DagsterPipesExecutionError
 from dagster_databricks._test_utils import (
     databricks_client,  # noqa: F401
-    databricks_notebook_folder_path, # noqa: F401
+    databricks_notebook_folder_path,  # noqa: F401
     temp_notebook_script,
 )
 from dagster_databricks.pipes import PipesDatabricksServerlessClient
@@ -18,6 +18,7 @@ IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 IS_WORKSPACE = os.getenv("DATABRICKS_HOST") is not None
 
 TEST_VOLUME_PATH = "/Volumes/workspace/default/databricks_serverless_pipes_test"
+
 
 def script_fn():
     import sys
@@ -82,7 +83,9 @@ def test_pipes_client(
     def number_x(context: AssetExecutionContext, pipes_client: PipesDatabricksServerlessClient):
         with ExitStack() as stack:
             script_path = stack.enter_context(
-                temp_notebook_script(databricks_client, databricks_notebook_folder_path, script_fn=script_fn)
+                temp_notebook_script(
+                    databricks_client, databricks_notebook_folder_path, script_fn=script_fn
+                )
             )
             task = make_submit_task(script_path)
             return pipes_client.run(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_serverless_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_serverless_pipes.py
@@ -31,7 +31,7 @@ def script_fn():
     with open_dagster_pipes(
         context_loader=PipesUnityCatalogVolumesContextLoader(),
         message_writer=PipesUnityCatalogVolumesMessageWriter(),
-        params_loader=PipesDatabricksNotebookWidgetsParamsLoader(dbutils.widgets),  # noqa
+        params_loader=PipesDatabricksNotebookWidgetsParamsLoader(dbutils.widgets),  # noqa  # pyright: ignore
     ) as context:
         multiplier = context.get_extra("multiplier")
         value = 2 * multiplier


### PR DESCRIPTION
## Summary & Motivation

Fixes #27558.

This PR adds a new `PipesDatabricksServerlessClient` with other required classes to support Databricks Serverless.

How to use in Dagster code:

```python
import os

from dagster_databricks.pipes import PipesDatabricksServerlessClient
import dagster as dg
from databricks.sdk import WorkspaceClient
from databricks.sdk.service import jobs

pipes_databricks_resource = PipesDatabricksServerlessClient(
    client=WorkspaceClient(
        host=os.environ["DATABRICKS_HOST"],
        token=os.environ["DATABRICKS_TOKEN"],
    ),
    # A volume used to read and write for the pipes process
    volume_path="/Volumes/catalog/schema/volume",
)


@dg.asset
def databricks_asset(
    context: dg.AssetExecutionContext, pipes_databricks: PipesDatabricksServerlessClient
):
    task = jobs.SubmitTask.from_dict(
        {
            "task_key": "serverless_pipes_task",
            "notebook_task": {
                "notebook_path": "/path/to/my/notebook", 
                "source": jobs.Source.WORKSPACE,
            },
        }
    )

    extras = {"some_parameter": 100}

    return pipes_databricks.run(
        task=task,
        context=context,
        extras=extras,
    ).get_materialize_result()


@dg.definitions
def resources():
    return dg.Definitions(
        assets=[databricks_asset],
        resources={"pipes_databricks": pipes_databricks_resource}
    )
```

How to use in Databricks notebooks:

```python
from dagster_pipes import (
    PipesDatabricksNotebookWidgetsParamsLoader,
    PipesUnityCatalogVolumesContextLoader,
    PipesUnityCatalogVolumesMessageWriter,
    open_dagster_pipes,
)

with open_dagster_pipes(
    context_loader=PipesUnityCatalogVolumesContextLoader(),
    message_writer=PipesUnityCatalogVolumesMessageWriter(),
    params_loader=PipesDatabricksNotebookWidgetsParamsLoader(dbutils.widgets),
) as pipes:
    # Access the `extras` dict passed when launching the job from Dagster.
    some_parameter_value = pipes.get_extra("some_parameter")

    # Stream log message back to Dagster
    pipes.log.info(f"Using some_parameter value: {some_parameter_value}")

    # ... your code that computes and persists the asset

    # Stream asset materialization metadata and data version back to Dagster.
    # This should be called after you've computed and stored the asset value. We
    # omit the asset key here because there is only one asset in scope, but for
    # multi-assets you can pass an `asset_key` parameter.
    pipes.report_asset_materialization(
        metadata={
            "some_metric": {"raw_value": some_parameter_value + 1, "type": "int"}
        },
        data_version="alpha",
    )
```

## How I Tested These Changes

Local + manual unit test (not configured yet for BK)

## Changelog

[dagster-databricks] `PipesDatabricksServerlessClient` is added to support Databricks Serverless jobs with Dagster pipes.
