### PR TITLE
[ai] add command to write pr summary

### DIFF
--- a/.claude/commands/write_pr_summary.md
+++ b/.claude/commands/write_pr_summary.md
@@ -1,0 +1,21 @@
+# Write PR summary
+
+Use `gt ls -s` to determine the last git ref in the stack. View all changes since that ref with `git diff`. Also view the commit messages with `git log`. Use this context, alongside any session context from what you know about the changes to write a PR summary in Markdown, of the format
+
+```md
+## Summary
+
+[brief summary of changes here, including code sample, if a new API was added, etc.]
+
+## Test Plan
+
+[very brief summary of test plan here, e.g. "New unit tests.", "New integration tests.", "Existing test suite." This can be a single sentence.]
+
+## Changelog
+
+[end user facing changelog entry, remove this section if no public-facing API was changed and no bug was fixed. Ignore minor changes.]
+```
+
+Use bullet points sparingly, and do not overuse italics/bold text. Use short sentences.
+
+Copy the md contents to the clipboard, using `pbcopy` on macos.


### PR DESCRIPTION
## Summary

Add a new `/write_pr_summary` Claude command that automatically generates PR summaries by analyzing git changes and commit history. The command uses `gt ls -s` to determine the stack position, examines diffs and commit messages, then generates a structured markdown summary with Summary, Test Plan, and Changelog sections. This PR summary was mostly generated using the command :)

```md
/write_pr_summary
```

The command automatically copies the generated summary to the clipboard for easy pasting into PR descriptions (in the `gt` cli, or in the GitHub interface).

## Test Plan

Manual testing with the new command.



