### PR TITLE
[components] move translation logic to TypeVar-ed resolver

### DIFF
--- a/python_modules/dagster/dagster/components/utils/__init__.py
+++ b/python_modules/dagster/dagster/components/utils/__init__.py
@@ -1,0 +1,94 @@
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType
+from typing import TypeVar
+
+import click
+from dagster_shared.error import DagsterError
+
+from dagster import _check as check
+from dagster.components.utils.translation import TranslatorResolvingInfo as TranslatorResolvingInfo
+
+T = TypeVar("T")
+
+
+def exit_with_error(error_message: str) -> None:
+    click.echo(click.style(error_message, fg="red"))
+    sys.exit(1)
+
+
+def format_error_message(message: str) -> str:
+    # width=10000 unwraps any hardwrapping
+    dedented = textwrap.dedent(message).strip()
+    paragraphs = [textwrap.fill(p, width=10000) for p in dedented.split("\n\n")]
+    return "\n\n".join(paragraphs)
+
+
+# Temporarily places a path at the front of sys.path, ensuring that any modules in that path are
+# importable.
+@contextmanager
+def ensure_loadable_path(path: Path) -> Iterator[None]:
+    orig_path = sys.path.copy()
+    sys.path.insert(0, str(path))
+    try:
+        yield
+    finally:
+        sys.path = orig_path
+
+
+def get_path_for_package(package_name: str) -> str:
+    spec = importlib.util.find_spec(package_name)
+    if not spec:
+        raise DagsterError(f"Cannot find package: {package_name}")
+    # file_path = spec.origin
+    submodule_search_locations = spec.submodule_search_locations
+    if not submodule_search_locations:
+        raise DagsterError(f"Package does not have any locations for submodules: {package_name}")
+    return submodule_search_locations[0]
+
+
+# ########################
+# ##### PLATFORM
+# ########################
+
+
+def is_windows() -> bool:
+    return sys.platform == "win32"
+
+
+def is_macos() -> bool:
+    return sys.platform == "darwin"
+
+
+# ########################
+# ##### VENV
+# ########################
+
+
+def get_venv_executable(venv_dir: Path, executable: str = "python") -> Path:
+    if is_windows():
+        return venv_dir / "Scripts" / f"{executable}.exe"
+    else:
+        return venv_dir / "bin" / executable
+
+
+def install_to_venv(venv_dir: Path, install_args: list[str]) -> None:
+    executable = get_venv_executable(venv_dir)
+    command = ["uv", "pip", "install", "--python", str(executable), *install_args]
+    subprocess.run(command, check=True)
+
+
+def get_path_from_module(module: ModuleType) -> Path:
+    module_path = (
+        Path(module.__file__).parent
+        if module.__file__
+        else Path(module.__path__[0])
+        if module.__path__
+        else None
+    )
+    return check.not_none(module_path, f"Module {module.__name__} has no filepath")

--- a/python_modules/dagster/dagster/components/utils/translation.py
+++ b/python_modules/dagster/dagster/components/utils/translation.py
@@ -125,19 +125,6 @@ def _build_translation_fn(
     return resolve_translation
 
 
-ResolvedTranslationFn: TypeAlias = Optional[
-    Annotated[
-        TranslationFn[T],
-        Resolver(
-            _build_translation_fn(
-                template_vars_for_translation_fn=lambda data: {"data": data},
-            ),
-            model_field_type=Union[str, AssetAttributesModel],
-        ),
-    ]
-]
-
-
 class TranslatorResolver(Resolver, Generic[T]):
     """Resolver which builds a TranslationFn from input AssetAttributesModel, injecting
     the provided template vars into the resolution process.
@@ -163,3 +150,13 @@ class TranslatorResolver(Resolver, Generic[T]):
             ),
             model_field_type=Union[str, AssetAttributesModel],
         )
+
+
+# Common case of a TranslationFn that takes a single underlying entity and passes it through
+# as a template var called "data".
+ResolvedTranslationFn: TypeAlias = Optional[
+    Annotated[
+        TranslationFn[T],
+        TranslatorResolver[T](lambda data: {"data": data}),
+    ]
+]

--- a/python_modules/dagster/dagster/components/utils/translation.py
+++ b/python_modules/dagster/dagster/components/utils/translation.py
@@ -149,6 +149,7 @@ class TranslatorResolver(Resolver, Generic[T]):
                 template_vars_for_translation_fn=template_vars_for_translation_fn
             ),
             model_field_type=Union[str, AssetAttributesModel],
+            inject_before_resolve=False,
         )
 
 

--- a/python_modules/dagster/dagster/components/utils/translation.py
+++ b/python_modules/dagster/dagster/components/utils/translation.py
@@ -129,20 +129,30 @@ class TranslationFnResolver(Resolver, Generic[T]):
     """Resolver which builds a TranslationFn from input AssetAttributesModel, injecting
     the provided template vars into the resolution process.
 
+    This is useful to expose nested fields within the input data as template vars.
+
     Example:
-    ```python
+    .. code-block:: python
 
-    class MyApiData(BaseModel):
-        name: str
+        class MyApiData(BaseModel):
+            name: str
 
-    class MyApiComponent(Component, Resolvable):
-        translation: Annotated[
-            TranslationFn[MyApiData],
-            TranslationFnResolver[MyApiData](
-                template_vars_for_resolving_translation_fn=lambda data: {"name": data.name}
-            ),
-        ]
-    ```
+        class MyApiComponent(Component, Resolvable):
+            translation: Annotated[
+                TranslationFn[MyApiData],
+                TranslationFnResolver[MyApiData](
+                    template_vars_for_resolving_translation_fn=lambda data: {"name": data.name}
+                ),
+            ]
+
+    .. code-block:: yaml
+
+        type: my_module.MyApiComponent
+
+        attributes:
+            translation:
+                key: {{ name }}
+
     """
 
     def __init__(

--- a/python_modules/dagster/dagster/components/utils/translation.py
+++ b/python_modules/dagster/dagster/components/utils/translation.py
@@ -103,7 +103,7 @@ TranslationFn: TypeAlias = Callable[[AssetSpec, T], AssetSpec]
 
 
 def _build_translation_fn(
-    template_vars_for_resolving_translation_fn: Callable[[T], Mapping[str, Any]],
+    template_vars_for_translation_fn: Callable[[T], Mapping[str, Any]],
 ) -> Callable[[ResolutionContext, T], TranslationFn[T]]:
     def resolve_translation(
         context: ResolutionContext,
@@ -117,7 +117,7 @@ def _build_translation_fn(
         return lambda base_asset_spec, data: info.get_asset_spec(
             base_asset_spec,
             {
-                **(template_vars_for_resolving_translation_fn(data)),
+                **(template_vars_for_translation_fn(data)),
                 "spec": base_asset_spec,
             },
         )
@@ -141,7 +141,7 @@ class TranslationFnResolver(Resolver, Generic[T]):
             translation: Annotated[
                 TranslationFn[MyApiData],
                 TranslationFnResolver[MyApiData](
-                    template_vars_for_resolving_translation_fn=lambda data: {"name": data.name}
+                    template_vars_for_translation_fn=lambda data: {"name": data.name}
                 ),
             ]
 
@@ -155,12 +155,10 @@ class TranslationFnResolver(Resolver, Generic[T]):
 
     """
 
-    def __init__(
-        self, template_vars_for_resolving_translation_fn: Callable[[T], Mapping[str, Any]]
-    ):
+    def __init__(self, template_vars_for_translation_fn: Callable[[T], Mapping[str, Any]]):
         super().__init__(
             _build_translation_fn(
-                template_vars_for_resolving_translation_fn=template_vars_for_resolving_translation_fn
+                template_vars_for_translation_fn=template_vars_for_translation_fn
             ),
             model_field_type=Union[str, AssetAttributesModel],
             inject_before_resolve=False,

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_spec_processing.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_spec_processing.py
@@ -142,7 +142,6 @@ def test_load_attributes(python, expected) -> None:
 def test_prefixing():
     prefix = ["sweet_prefix"]
     translated = TranslatorResolvingInfo(
-        obj_name="",
         resolution_context=ResolutionContext.default(),
         asset_attributes=dg.AssetAttributesModel(
             key_prefix=prefix,
@@ -155,7 +154,6 @@ def test_prefixing():
 def test_key_set():
     spec = dg.AssetSpec("a")
     translated = TranslatorResolvingInfo(
-        obj_name="",
         resolution_context=ResolutionContext.default(),
         asset_attributes=dg.AssetAttributesModel(
             key="{{ spec.key.to_user_string() + '_key' }}",
@@ -169,7 +167,6 @@ def test_key_and_prefix():
     prefix = ["sweet_prefix"]
     spec = dg.AssetSpec("a")
     translated = TranslatorResolvingInfo(
-        obj_name="",
         resolution_context=ResolutionContext.default(),
         asset_attributes=dg.AssetAttributesModel(
             key="{{ spec.key.to_user_string() + '_key' }}",

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/components/workspace_component/component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/components/workspace_component/component.py
@@ -6,7 +6,7 @@ import dagster as dg
 import pydantic
 from dagster._core.definitions.job_definition import default_job_io_manager
 from dagster.components.resolved.base import resolve_fields
-from dagster.components.utils.translation import TranslationFn, TranslatorResolver
+from dagster.components.utils.translation import TranslationFn, TranslationFnResolver
 from dagster_shared import check
 
 from dagster_airbyte.asset_defs import build_airbyte_assets_definitions
@@ -98,7 +98,9 @@ class AirbyteCloudWorkspaceComponent(dg.Component, dg.Model, dg.Resolvable):
     translation: Optional[
         Annotated[
             TranslationFn[AirbyteConnectionTableProps],
-            TranslatorResolver(template_vars_for_translation_fn=lambda data: {"props": data}),
+            TranslationFnResolver(
+                template_vars_for_resolving_translation_fn=lambda data: {"props": data}
+            ),
         ]
     ] = pydantic.Field(
         None,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/components/workspace_component/component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/components/workspace_component/component.py
@@ -98,9 +98,7 @@ class AirbyteCloudWorkspaceComponent(dg.Component, dg.Model, dg.Resolvable):
     translation: Optional[
         Annotated[
             TranslationFn[AirbyteConnectionTableProps],
-            TranslationFnResolver(
-                template_vars_for_resolving_translation_fn=lambda data: {"props": data}
-            ),
+            TranslationFnResolver(template_vars_for_translation_fn=lambda data: {"props": data}),
         ]
     ] = pydantic.Field(
         None,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -15,7 +15,7 @@ from dagster.components.core.tree import ComponentTree
 from dagster.components.resolved.core_models import OpSpec, ResolutionContext
 from dagster.components.resolved.model import Resolver
 from dagster.components.scaffold.scaffold import scaffold_with
-from dagster.components.utils.translation import TranslationFn, TranslatorResolver
+from dagster.components.utils.translation import TranslationFn, TranslationFnResolver
 
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.asset_utils import DBT_DEFAULT_EXCLUDE, DBT_DEFAULT_SELECT, get_node
@@ -129,7 +129,9 @@ class DbtProjectComponent(Component, Resolvable):
     ] = None
     translation: Annotated[
         Optional[TranslationFn[Mapping[str, Any]]],
-        TranslatorResolver(lambda data: {"node": data}),
+        TranslationFnResolver(
+            template_vars_for_resolving_translation_fn=lambda data: {"node": data}
+        ),
     ] = None
     select: Annotated[
         str,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -129,9 +129,7 @@ class DbtProjectComponent(Component, Resolvable):
     ] = None
     translation: Annotated[
         Optional[TranslationFn[Mapping[str, Any]]],
-        TranslationFnResolver(
-            template_vars_for_resolving_translation_fn=lambda data: {"node": data}
-        ),
+        TranslationFnResolver(template_vars_for_translation_fn=lambda data: {"node": data}),
     ] = None
     select: Annotated[
         str,

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
@@ -9,7 +9,7 @@ from dagster import AssetKey, AssetSpec, Component, ComponentLoadContext, Resolv
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster.components.resolved.context import ResolutionContext
 from dagster.components.scaffold.scaffold import scaffold_with
-from dagster.components.utils.translation import TranslationFn, TranslatorResolver
+from dagster.components.utils.translation import TranslationFn, TranslationFnResolver
 from dlt import Pipeline
 from dlt.extract.source import DltSource
 
@@ -76,7 +76,7 @@ class DltLoadSpecModel(Resolvable):
     translation: Optional[
         Annotated[
             TranslationFn[DltResourceTranslatorData],
-            TranslatorResolver[DltResourceTranslatorData](
+            TranslationFnResolver[DltResourceTranslatorData](
                 lambda data: {"resource": data.resource, "pipeline": data.pipeline}
             ),
         ]

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/components/workspace_component/component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/components/workspace_component/component.py
@@ -97,9 +97,7 @@ class FivetranAccountComponent(dg.Component, dg.Model, dg.Resolvable):
     translation: Optional[
         Annotated[
             TranslationFn[FivetranConnectorTableProps],
-            TranslationFnResolver(
-                template_vars_for_resolving_translation_fn=lambda data: {"props": data}
-            ),
+            TranslationFnResolver(template_vars_for_translation_fn=lambda data: {"props": data}),
         ]
     ] = pydantic.Field(
         None,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/components/workspace_component/component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/components/workspace_component/component.py
@@ -6,7 +6,7 @@ import dagster as dg
 import pydantic
 from dagster._core.definitions.job_definition import default_job_io_manager
 from dagster.components.resolved.base import resolve_fields
-from dagster.components.utils.translation import TranslationFn, TranslatorResolver
+from dagster.components.utils.translation import TranslationFn, TranslationFnResolver
 from dagster_shared import check
 
 from dagster_fivetran.asset_defs import build_fivetran_assets_definitions
@@ -97,7 +97,9 @@ class FivetranAccountComponent(dg.Component, dg.Model, dg.Resolvable):
     translation: Optional[
         Annotated[
             TranslationFn[FivetranConnectorTableProps],
-            TranslatorResolver(lambda data: {"props": data}),
+            TranslationFnResolver(
+                template_vars_for_resolving_translation_fn=lambda data: {"props": data}
+            ),
         ]
     ] = pydantic.Field(
         None,

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/components/power_bi_workspace/component.py
@@ -68,7 +68,6 @@ TranslationFn: TypeAlias = Callable[[AssetSpec, PowerBITranslatorData], AssetSpe
 
 def resolve_translation(context: ResolutionContext, model):
     info = TranslatorResolvingInfo(
-        "data",
         asset_attributes=model,
         resolution_context=context,
         model_key="translation",
@@ -125,7 +124,6 @@ def resolve_multilayer_translation(context: ResolutionContext, model):
     per-content-type transforms with the global transforms.
     """
     info = TranslatorResolvingInfo(
-        "data",
         asset_attributes=model,
         resolution_context=context,
         model_key="translation",

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -52,7 +52,7 @@ class SlingReplicationSpecModel(Resolvable):
         Annotated[
             TranslationFn[Mapping[str, Any]],
             TranslationFnResolver(
-                template_vars_for_resolving_translation_fn=lambda data: {"stream_definition": data}
+                template_vars_for_translation_fn=lambda data: {"stream_definition": data}
             ),
         ]
     ] = None

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -20,7 +20,7 @@ from dagster.components.core.context import ComponentLoadContext
 from dagster.components.resolved.context import ResolutionContext
 from dagster.components.resolved.core_models import AssetPostProcessor, OpSpec
 from dagster.components.scaffold.scaffold import scaffold_with
-from dagster.components.utils.translation import TranslationFn, TranslatorResolver
+from dagster.components.utils.translation import TranslationFn, TranslationFnResolver
 from dagster_shared.utils.warnings import deprecation_warning
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypeAlias
@@ -51,7 +51,9 @@ class SlingReplicationSpecModel(Resolvable):
     translation: Optional[
         Annotated[
             TranslationFn[Mapping[str, Any]],
-            TranslatorResolver(lambda data: {"stream_definition": data}),
+            TranslationFnResolver(
+                template_vars_for_resolving_translation_fn=lambda data: {"stream_definition": data}
+            ),
         ]
     ] = None
     include_metadata: list[SlingMetadataAddons] = field(default_factory=list)

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -20,7 +20,7 @@ from dagster.components.core.context import ComponentLoadContext
 from dagster.components.resolved.context import ResolutionContext
 from dagster.components.resolved.core_models import AssetPostProcessor, OpSpec
 from dagster.components.scaffold.scaffold import scaffold_with
-from dagster.components.utils.translation import TranslationFn, TranslatorResolvable
+from dagster.components.utils.translation import TranslationFn, TranslatorResolver
 from dagster_shared.utils.warnings import deprecation_warning
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypeAlias
@@ -45,14 +45,16 @@ class ProxyDagsterSlingTranslator(DagsterSlingTranslator):
 
 
 @dataclass
-class SlingReplicationSpecModel(TranslatorResolvable[Mapping[str, Any]]):
+class SlingReplicationSpecModel(Resolvable):
     path: str
     op: Optional[OpSpec] = None
+    translation: Optional[
+        Annotated[
+            TranslationFn[Mapping[str, Any]],
+            TranslatorResolver(lambda data: {"stream_definition": data}),
+        ]
+    ] = None
     include_metadata: list[SlingMetadataAddons] = field(default_factory=list)
-
-    @classmethod
-    def get_template_vars_for_translation(cls, data: Mapping[str, Any]) -> Mapping[str, Any]:
-        return {"stream_definition": data}
 
     @cached_property
     def translator(self):


### PR DESCRIPTION
## Summary

Refactored translator logic in our various components by moving shared translation functionality to a new `TranslatorResolver` class to standardize translation function resolution across component types.

Simple translation, which passes along the underlying entity as a template var called `data`, can be accomplished with the following:

```python
class MyComponent(Component, Resolvable):
    translation: ResolvedTranslationFn[DataType]
```

For cases where the user wants to customize the mapping of underlying entity -> template vars, they can use `TranslatorResolver`:

```python
class MyComplexDataType(BaseModel):
  name: str
  id: int

class MyComponent(Component, Resolvable):
    translation: Annotated[
        TranslationFn[MyComplexDataType],
        TranslationFnResolver[MyComplexDataType](
            template_vars_for_resolving_translation_fn=lambda data: {"name": data.name, "id": data.id}
        ),
    ]
```

## Test Plan

Existing test suites for components.
