### PR TITLE
only filter out the entire parent subset if it has any partitions being materialized this tick

### DIFF
--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/asset_graphs.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/asset_graphs.py
@@ -55,6 +55,26 @@ self_dependant_asset_downstream_of_regular_asset = [
     ),
 ]
 
+
+regular_asset_downstream_of_self_dependant_asset = [
+    asset_def(
+        "self_dependant",
+        partitions_def=dg.DailyPartitionsDefinition("2023-01-01"),
+        backfill_policy=BackfillPolicy.multi_run(1),
+        deps={
+            "self_dependant": dg.TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+        },
+    ),
+    asset_def(
+        "regular_asset",
+        partitions_def=dg.DailyPartitionsDefinition("2023-01-01"),
+        backfill_policy=BackfillPolicy.multi_run(2),
+        deps={
+            "self_dependant": dg.TimeWindowPartitionMapping(),
+        },
+    ),
+]
+
 self_dependant_asset_downstream_of_regular_asset_multiple_run = [
     asset_def(
         "regular_asset",


### PR DESCRIPTION
Summary:
Try to make the fix in https://github.com/dagster-io/dagster/pull/31315 even more targeted without affecting throughput as much - if a parent is actively being materialized this tick, be more careful about what child partitions get submitted, to minimize the risk of inadvertently combining them into a single run incorrectly. But if we are just reacting to parent materializations and the parent itself is not being materialized on this tick too, only remove the specific partitions that are

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
