### PR TITLE
[Docs] Remove trailing slash from docs links

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,6 +4,8 @@
 
 ### Links
 
+#### Use full paths instead of relative links
+
 Docusaurus doesn't always render relative links correctly, which can result in users seeing intermittent 404s when accessing those links. Use full paths instead of relative links, like this:
 
 ```
@@ -15,6 +17,12 @@ instead of this:
 ```
 For more information, see "[Defining assets](defining-assets)".
 ```
+
+#### Use non-trailing slash links to Dagster docs
+
+e.g. use `/guides/build/assets/defining-assets` instead of `/guides/build/assets/defining-assets/`. 
+
+**Context:** Links to Dagster docs with trailing slashes automatically redirect to non-trailing slash links. While that's helpful for docs links we don't control, too many redirects on our own pages can confuse search engines and cause SEO issues.
 
 ### Partials
 

--- a/docs/docs/etl-pipeline-tutorial/1-transform-data.md
+++ b/docs/docs/etl-pipeline-tutorial/1-transform-data.md
@@ -37,7 +37,7 @@ Now that we have a dbt project to work with, we need to install both the Dagster
 
 <CliInvocationExample contents="uv pip install dagster-dbt dbt-duckdb" />
 
-We still want our dbt project to be represented as assets in our graph, but we will define them in a slightly different way. In the previous step, we manually defined our assets by writing functions decorated with the <PyObject section="assets" module="dagster" object="asset" decorator />. This time ,we will use [components](/guides/build/components/), which are predefined ways to interact with common integrations or patterns. In this case, we will use the [dbt component](/guides/build/components/integrations/dbt-component-tutorial) to quickly turn our dbt project into assets.
+We still want our dbt project to be represented as assets in our graph, but we will define them in a slightly different way. In the previous step, we manually defined our assets by writing functions decorated with the <PyObject section="assets" module="dagster" object="asset" decorator />. This time ,we will use [components](/guides/build/components), which are predefined ways to interact with common integrations or patterns. In this case, we will use the [dbt component](/guides/build/components/integrations/dbt-component-tutorial) to quickly turn our dbt project into assets.
 
 The dbt component was installed when we installed the `dagster-dbt` library. This means we can now scaffold a dbt component definition with `dg scaffold defs` command:
 

--- a/docs/docs/etl-pipeline-tutorial/5-automate-your-pipeline.md
+++ b/docs/docs/etl-pipeline-tutorial/5-automate-your-pipeline.md
@@ -11,7 +11,7 @@ There are several ways to [automate assets ](/guides/automate) in Dagster. Dagst
 
 Cron-based schedules are common in data orchestration. They use time-based expressions to automatically trigger tasks at specified intervals, making them ideal for ETL pipelines that need to run consistently, such as hourly, daily, or monthly, to process and update data on a regular cadence. For our pipeline, assume that updated CSVs are uploaded at a specific time every day.
 
-While it is possible to define a standalone [schedule](/guides/automate/schedules/) object in Dagster, we can also add a schedule directly to the asset with [declarative automation](/guides/automate/declarative-automation) by including this schedule information within the <PyObject section="asset-checks" module="dagster" object="asset_check" decorator />. Now our assets will execute every day at midnight:
+While it is possible to define a standalone [schedule](/guides/automate/schedules) object in Dagster, we can also add a schedule directly to the asset with [declarative automation](/guides/automate/declarative-automation) by including this schedule information within the <PyObject section="asset-checks" module="dagster" object="asset_check" decorator />. Now our assets will execute every day at midnight:
 
 <CodeExample
   path="docs_snippets/docs_snippets/guides/tutorials/etl_tutorial/src/etl_tutorial/defs/assets.py"


### PR DESCRIPTION
## Summary & Motivation

Removes trailing slashes from docs links in docs so as not to confuse search engines and cause SEO problems.

## How I Tested These Changes

Local build.

## Changelog

> Insert changelog entry or delete this section.
