### PR TITLE
handle nested jobs in with_definition_metadata_update

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -933,6 +933,10 @@ class ScheduleDefinition(IHasInternalInit):
         """Mapping[str, str]: The metadata for this schedule."""
         return self._metadata
 
+    @property
+    def has_job(self) -> bool:
+        return self._target.has_job_def
+
     @public
     @property
     def job(self) -> Union[JobDefinition, UnresolvedAssetJobDefinition]:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -348,7 +348,12 @@ def test_kitchen_sink_on_create_helper_and_definitions():
     repo = dg.create_repository_using_definitions_args(
         name="foobar",
         assets=[an_asset, another_asset],
-        jobs=[a_job, another_asset_job],
+        jobs=[
+            a_job,
+            another_asset_job,
+            sensor_target,
+            schedule_target,
+        ],
         schedules=[a_schedule],
         sensors=[a_sensor],
         resources={"a_resource_key": "the resource"},
@@ -382,7 +387,12 @@ def test_kitchen_sink_on_create_helper_and_definitions():
     # test the kitchen sink since we have created it
     defs = dg.Definitions(
         assets=[an_asset, another_asset],
-        jobs=[a_job, another_asset_job],
+        jobs=[
+            a_job,
+            another_asset_job,
+            sensor_target,
+            schedule_target,
+        ],
         schedules=[a_schedule],
         sensors=[a_sensor],
         resources={"a_resource_key": "the resource"},


### PR DESCRIPTION
we were de-syncing nested jobs as part of the update, fix by updating them and ensuring we re-use the same object if the job is additionally passed directly to `Definitions` 

## How I Tested These Changes

updated test

## Changelog

[bugfix] incorrect duplicate definitions are no longer created when including jobs for schedules & sensors when loading from a `defs` folder 
