### PR TITLE
[dg] unhide mcp cli group

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/mcp_server.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/mcp_server.py
@@ -29,13 +29,6 @@ def serve_command():
             "Please upgrade your Python version and reinstall `dagster-dg-cli`.",
         )
 
-    try:
-        import mcp.server.fastmcp
-    except ImportError:
-        raise ImportError(
-            "dagster-dg-cli must be installed with the mcp extra to use `dg mcp` commands."
-        )
-
     from dagster_dg_cli.mcp.server import mcp
 
     mcp.run(transport="stdio")

--- a/python_modules/libraries/dagster-dg-cli/setup.py
+++ b/python_modules/libraries/dagster-dg-cli/setup.py
@@ -37,16 +37,12 @@ setup(
     install_requires=[
         f"dagster-dg-core{pin}",
         f"dagster{pin}",
+        "mcp; python_version>='3.10'",  # mcp not available for 3.9
     ],
     entry_points={
         "console_scripts": [
             "dg = dagster_dg_cli.cli:main",
         ]
-    },
-    extras_require={
-        "mcp": [
-            "mcp",
-        ],
     },
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-dg-cli/tox.ini
+++ b/python_modules/libraries/dagster-dg-cli/tox.ini
@@ -26,7 +26,6 @@ deps =
   plus: -e ../../../python_modules/libraries/dagster-aws
   plus: -e ../../../python_modules/libraries/dagster-k8s
   plus: -e ../../../python_modules/libraries/dagster-docker
-  mcp: -e .[mcp]
   -e .
 allowlist_externals =
   /bin/bash


### PR DESCRIPTION
adjust requires and imports accordingly 

## How I Tested These Changes

existing coverage

## Changelog

[dg] A MCP server is available to expose `dg` CLI capabilities to MCP clients. See the `dg mcp` CLI group for details.
