### PR TITLE
Support --changed in watch docstrings command

### DIFF
--- a/python_modules/automation/automation/dagster_docs/watcher.py
+++ b/python_modules/automation/automation/dagster_docs/watcher.py
@@ -103,7 +103,7 @@ class GitignoreAwareHandler(FileSystemEventHandler):
         if event.is_directory:
             return
 
-        file_path = Path(event.src_path)
+        file_path = Path(str(event.src_path))
 
         # Only watch .py files that aren't gitignored
         if file_path.suffix == ".py" and not self._should_ignore_path(file_path):
@@ -114,7 +114,7 @@ class GitignoreAwareHandler(FileSystemEventHandler):
         if event.is_directory:
             return
         # Check if the destination is a .py file and not gitignored
-        dest_path = Path(event.dest_path)
+        dest_path = Path(str(event.dest_path))
         if dest_path.suffix == ".py" and not self._should_ignore_path(dest_path):
             self.parent_watcher._on_file_changed(dest_path)  # noqa: SLF001
 
@@ -122,7 +122,7 @@ class GitignoreAwareHandler(FileSystemEventHandler):
         """Handle file creation events (some editors recreate files)."""
         if event.is_directory:
             return
-        file_path = Path(event.src_path)
+        file_path = Path(str(event.src_path))
         if file_path.suffix == ".py" and not self._should_ignore_path(file_path):
             self.parent_watcher._on_file_changed(file_path)  # noqa: SLF001
 
@@ -149,6 +149,7 @@ class ChangedFilesWatcher:
 
     def _on_file_changed(self, file_path: Path) -> None:
         """Called when any .py file changes - triggers git refresh and watcher updates."""
+        # Debounced git status refresh to update the watcher set
         current_time = time.time()
         if current_time - self.last_git_check > self.git_refresh_debounce:
             self.last_git_check = current_time

--- a/python_modules/automation/automation/dagster_docs/watcher.py
+++ b/python_modules/automation/automation/dagster_docs/watcher.py
@@ -5,8 +5,17 @@ from pathlib import Path
 from typing import Callable
 
 import click
+import pathspec
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
+
+from automation.dagster_docs.changed_validator import (
+    ValidationConfig,
+    extract_symbols_from_file,
+    print_validation_results,
+    validate_symbols,
+)
+from automation.dagster_docs.file_discovery import git_changed_files
 
 
 class DocstringValidationHandler(FileSystemEventHandler):
@@ -61,6 +70,181 @@ class DocstringValidationHandler(FileSystemEventHandler):
         if event.is_directory:
             return
         self._handle_file_event(Path(str(event.src_path)).resolve(), "CREATED")
+
+
+class GitignoreAwareHandler(FileSystemEventHandler):
+    """File handler that respects .gitignore patterns."""
+
+    def __init__(self, root_path: Path, parent_watcher: "ChangedFilesWatcher"):
+        self.root_path = root_path
+        self.parent_watcher = parent_watcher
+        self.gitignore_spec = self._load_gitignore_patterns()
+
+    def _load_gitignore_patterns(self) -> pathspec.PathSpec:
+        """Load .gitignore patterns using pathspec library."""
+        gitignore_path = self.root_path / ".gitignore"
+        if not gitignore_path.exists():
+            return pathspec.PathSpec.from_lines("gitwildmatch", [])
+
+        with open(gitignore_path) as f:
+            return pathspec.PathSpec.from_lines("gitwildmatch", f.readlines())
+
+    def _should_ignore_path(self, file_path: Path) -> bool:
+        """Check if path should be ignored based on .gitignore."""
+        # Get relative path from repo root
+        try:
+            rel_path = file_path.relative_to(self.root_path)
+            return self.gitignore_spec.match_file(str(rel_path))
+        except ValueError:
+            return True  # Outside repo, ignore
+
+    def on_modified(self, event) -> None:
+        """Handle file modification events."""
+        if event.is_directory:
+            return
+
+        file_path = Path(event.src_path)
+
+        # Only watch .py files that aren't gitignored
+        if file_path.suffix == ".py" and not self._should_ignore_path(file_path):
+            self.parent_watcher._on_file_changed(file_path)  # noqa: SLF001
+
+    def on_moved(self, event) -> None:
+        """Handle file move events (common with atomic saves)."""
+        if event.is_directory:
+            return
+        # Check if the destination is a .py file and not gitignored
+        dest_path = Path(event.dest_path)
+        if dest_path.suffix == ".py" and not self._should_ignore_path(dest_path):
+            self.parent_watcher._on_file_changed(dest_path)  # noqa: SLF001
+
+    def on_created(self, event) -> None:
+        """Handle file creation events (some editors recreate files)."""
+        if event.is_directory:
+            return
+        file_path = Path(event.src_path)
+        if file_path.suffix == ".py" and not self._should_ignore_path(file_path):
+            self.parent_watcher._on_file_changed(file_path)  # noqa: SLF001
+
+
+class ChangedFilesWatcher:
+    """Watches for file changes and dynamically manages docstring validation."""
+
+    def __init__(self, root_path: Path, config: ValidationConfig, verbose: bool = False):
+        """Initialize the changed files watcher.
+
+        Args:
+            root_path: Root path of the git repository
+            config: Validation configuration
+            verbose: Whether to print debug information
+        """
+        self.root_path = root_path
+        self.config = config
+        self.verbose = verbose
+        self.current_changed_files: set[Path] = set()
+        self.file_watchers: dict[Path, DocstringFileWatcher] = {}
+        self.observer = Observer()
+        self.git_refresh_debounce = 1.0  # Debounce git checks
+        self.last_git_check = 0
+
+    def _on_file_changed(self, file_path: Path) -> None:
+        """Called when any .py file changes - triggers git refresh and watcher updates."""
+        current_time = time.time()
+        if current_time - self.last_git_check > self.git_refresh_debounce:
+            self.last_git_check = current_time
+            self._refresh_git_status()
+
+    def _refresh_git_status(self) -> None:
+        """Check git status and update active watchers."""
+        new_changed_files = set(git_changed_files(self.root_path))
+
+        # Remove watchers for files no longer changed
+        for file_path in self.current_changed_files - new_changed_files:
+            if file_path in self.file_watchers:
+                self.file_watchers[file_path].stop_watching()
+                del self.file_watchers[file_path]
+                if self.verbose:
+                    click.echo(f"[DEBUG] Stopped watching {file_path} (no longer changed)")
+
+        # Add watchers for newly changed files
+        for file_path in new_changed_files - self.current_changed_files:
+            callback = self._create_validation_callback(file_path)
+            self.file_watchers[file_path] = DocstringFileWatcher(file_path, callback, self.verbose)
+            self.file_watchers[file_path].start_watching()
+            if self.verbose:
+                click.echo(f"[DEBUG] Started watching {file_path} (newly changed)")
+
+        # Update status message if the set changed
+        if new_changed_files != self.current_changed_files:
+            file_count = len(new_changed_files)
+            if file_count == 0:
+                click.echo("No changed files to watch")
+            else:
+                file_names = [f.name for f in new_changed_files]
+                click.echo(f"Watching {file_count} changed files: {', '.join(file_names)}")
+
+        self.current_changed_files = new_changed_files
+
+    def _create_validation_callback(self, file_path: Path) -> Callable[[], None]:
+        """Create validation callback for a specific changed file."""
+
+        def validate_file() -> None:
+            timestamp = time.strftime("%H:%M:%S")
+            click.echo(f"[{timestamp}] File changed, validating symbols in {file_path.name}...")
+
+            try:
+                # Get module path for this file
+                module_path = self.config.path_converter(file_path, self.config.root_path)
+                if module_path is None:
+                    click.echo(f"Could not determine module path for {file_path}")
+                    return
+
+                # Extract and validate symbols from this file
+                symbols = extract_symbols_from_file(file_path, module_path)
+                if not symbols:
+                    click.echo("No symbols found to validate")
+                    return
+
+                results = validate_symbols(symbols)
+                error_count, warning_count = print_validation_results(results, self.verbose)
+
+                if error_count == 0 and warning_count == 0:
+                    click.echo("✓ All docstrings are valid!")
+                elif error_count == 0:
+                    click.echo(f"✓ All docstrings are valid (with {warning_count} warnings)")
+                else:
+                    click.echo(f"✗ Found {error_count} errors, {warning_count} warnings")
+
+            except Exception as e:
+                click.echo(f"Validation error: {e}", err=True)
+                if self.verbose:
+                    import traceback
+
+                    traceback.print_exc()
+
+            click.echo("-" * 50)
+
+        return validate_file
+
+    def start_watching(self) -> None:
+        """Start watching for file changes, respecting .gitignore."""
+        handler = GitignoreAwareHandler(self.root_path, self)
+        self.observer.schedule(handler, str(self.root_path), recursive=True)
+        self.observer.start()
+
+        # Initial git status check
+        self._refresh_git_status()
+
+    def stop_watching(self) -> None:
+        """Stop watching for file changes."""
+        # Stop all individual file watchers
+        for watcher in self.file_watchers.values():
+            watcher.stop_watching()
+        self.file_watchers.clear()
+
+        # Stop the main observer
+        self.observer.stop()
+        self.observer.join()
 
 
 class DocstringFileWatcher:

--- a/python_modules/automation/automation_tests/dagster_docs_tests/test_watch_commands.py
+++ b/python_modules/automation/automation_tests/dagster_docs_tests/test_watch_commands.py
@@ -1,6 +1,5 @@
 """Tests for dagster-docs watch commands."""
 
-import pytest
 from automation.dagster_docs.commands.watch import watch
 from click.testing import CliRunner
 
@@ -46,14 +45,13 @@ class TestWatchCommands:
         assert result.exit_code == 1
         assert "Error: Cannot use both --changed and --symbol together" in result.output
 
-    def test_watch_docstrings_changed_not_implemented(self):
-        """Test that watch docstrings --changed raises NotImplementedError."""
-        with pytest.raises(NotImplementedError) as excinfo:
-            self.runner.invoke(watch, ["docstrings", "--changed"], catch_exceptions=False)
+    def test_watch_docstrings_changed_option_available(self):
+        """Test that watch docstrings --changed option is available in help."""
+        result = self.runner.invoke(watch, ["docstrings", "--help"])
 
-        assert "Watching changed files functionality not yet fully implemented" in str(
-            excinfo.value
-        )
+        assert result.exit_code == 0
+        assert "--changed" in result.output
+        assert "Watches the files currently changed in git" in result.output
 
     # Note: We don't test --symbol functionality since it would actually start watching
     # and would be difficult to test in a unit test environment. The integration

--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -21,6 +21,7 @@ setup(
         "click",
         "packaging>=20.9",
         "pandas",
+        "pathspec",
         "pytablereader",
         "requests",
         "twine>=1.15.0",


### PR DESCRIPTION
## Summary & Motivation

Implemented the `--changed` flag functionality for the `watch docstrings` command, which allows monitoring files that have been modified in git. This feature automatically validates docstrings in Python files as they change, making it easier to maintain documentation quality during development.

This will be a nice default dev loop as you don't have to copy and paste symbol names around.

The implementation includes:
- A new `ChangedFilesWatcher` class that monitors git-modified files
- Git integration to detect changed files
- Support for .gitignore patterns to avoid watching irrelevant files
- Automatic refreshing of the watch list when files change status

## How I Tested These Changes

dagster-docs watch docstrings --changed
