### PR TITLE
[ui] Support for changes to asset insights v2

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -245,7 +245,16 @@ export const AssetCatalogTableV2 = React.memo(() => {
           />
         );
       case 'insights':
-        return <AssetCatalogInsights assets={filtered} selection={assetSelection} tabs={tabs} />;
+        return (
+          <AssetCatalogInsights
+            assets={filtered}
+            selection={assetSelection}
+            tabs={tabs}
+            visibleSections={
+              new Set(['rate-cards', 'performance-metrics', 'activity-charts', 'top-assets'])
+            }
+          />
+        );
       default:
         return (
           <Table
@@ -293,19 +302,19 @@ AssetCatalogTableV2.displayName = 'AssetCatalogTableV2';
 const SORT_ITEMS = [
   {
     key: 'materialization_asc' as const,
-    text: 'Materialization (asc)',
+    text: 'Materialization (new to old)',
   },
   {
     key: 'materialization_desc' as const,
-    text: 'Materialization (desc)',
+    text: 'Materialization (old to new)',
   },
   {
     key: 'key_asc' as const,
-    text: 'Asset key (asc)',
+    text: 'Asset key (a to z)',
   },
   {
     key: 'key_desc' as const,
-    text: 'Asset key (desc)',
+    text: 'Asset key (z to a)',
   },
 ];
 const ITEMS_BY_KEY = SORT_ITEMS.reduce(

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogHorizontalTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogHorizontalTopAssetsChart.tsx
@@ -76,20 +76,23 @@ export const AssetCatalogHorizontalTopAssetsChart = React.memo(
             </div>
           </Box>
           <Box className={styles.table} margin={{vertical: 20}}>
-            {currentPageValues.map(({label, value}, i) => (
-              <React.Fragment key={i}>
-                <Body as="div" color={Colors.textLight()}>
-                  <Link to={assetDetailsPathForKey(tokenToAssetKey(label))}>
-                    <MiddleTruncate text={label} />
-                  </Link>
-                </Body>
-                <Mono color={Colors.textDefault()} className={styles.tableValue}>
-                  {numberFormatter.format(Math.round(value))}
-                </Mono>
-                {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
-                <DistributionChartRow maxValue={maxValue!} value={Math.round(value)} />
-              </React.Fragment>
-            ))}
+            {currentPageValues.map(({label, value}, i) => {
+              const assetKey = tokenToAssetKey(label.split(' / ').join('/'));
+              return (
+                <React.Fragment key={i}>
+                  <Body as="div" color={Colors.textLight()}>
+                    <Link to={assetDetailsPathForKey(assetKey)}>
+                      <MiddleTruncate text={label} />
+                    </Link>
+                  </Body>
+                  <Mono color={Colors.textDefault()} className={styles.tableValue}>
+                    {numberFormatter.format(Math.round(value))}
+                  </Mono>
+                  {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
+                  <DistributionChartRow maxValue={maxValue!} value={Math.round(value)} />
+                </React.Fragment>
+              );
+            })}
           </Box>
         </div>
         {totalPages > 1 && (


### PR DESCRIPTION
## Summary & Motivation

OSS counterpart to https://github.com/dagster-io/internal/pull/17210.

- Fix asset links on line chart dialog, which are preserving unwanted whitespace and leading to broken URLs
- Add the `visibleSections` prop that I added to `AssetCatalogInsights` to allow us to more easily show/hide sections for different use cases of the component.

Looks like I also rolled in a change to the catalog sorting button. I can back that out or leave it in.

## How I Tested These Changes

View asset insights on asset group and individual asset, verify that the page renders the correct sections.