### PR TITLE
[job] update resource checks in _copy

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -1122,7 +1122,9 @@ class JobDefinition(IHasInternalInit):
             asset_layer=self.asset_layer,
             input_values=self.input_values,
             partitions_def=self._original_partitions_def_argument,
-            _was_explicitly_provided_resources=None,
+            _was_explicitly_provided_resources=(
+                "resource_defs" in kwargs or self._was_provided_resources
+            ),
         )
         resolved_kwargs = {**base_kwargs, **kwargs}  # base kwargs overwritten for conflicts
         job_def = JobDefinition.dagster_internal_init(**resolved_kwargs)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -317,13 +317,17 @@ def test_kitchen_sink_on_create_helper_and_definitions():
     def an_op():
         pass
 
+    @dg.op(required_resource_keys={"a_resource_key"})
+    def other_op():
+        pass
+
     @dg.job
     def a_job():
         an_op()
 
     @dg.job
     def sensor_target():
-        an_op()
+        other_op()
 
     @dg.job
     def schedule_target():


### PR DESCRIPTION
update how `_was_explicitly_provided_resources` is handled in `_copy` to prevent things like metadata updates from causing an incorrect resource validation 

## How I Tested These Changes

updated test
