### PR TITLE
Raise an exception in `dagster definitions validate` on time window partition mappings with missing upstream partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/time_window.py
@@ -198,6 +198,18 @@ class TimeWindowPartitionMapping(
                 f"Timezones {upstream_partitions_def.timezone} and {downstream_partitions_def.timezone} don't match"
             )
 
+        with partition_loading_context():
+            full_partition_mapping_result = self.get_upstream_mapped_partitions_result_for_partitions(
+                downstream_partitions_subset=downstream_partitions_def.subset_with_all_partitions(),
+                downstream_partitions_def=downstream_partitions_def,
+                upstream_partitions_def=upstream_partitions_def,
+            )
+            if not full_partition_mapping_result.required_but_nonexistent_subset.is_empty:
+                raise DagsterInvalidDefinitionError(
+                    f"Upstream partitions definition is missing expected partitions: {full_partition_mapping_result.required_but_nonexistent_subset}. "
+                    "To allow missing partitions in a TimeWindowPartitionMapping, set allow_nonexistent_upstream_partitions to True."
+                )
+
     def get_downstream_partitions_for_partitions(
         self,
         upstream_partitions_subset: PartitionsSubset,


### PR DESCRIPTION
## Summary & Motivation
Lets you catch errors like this during CI instead of when a backfill or DA tries to execute them.

## How I Tested These Changes
New test case

## Changelog
`dagster definitions validate` will now raise an exception if two assets have a TimeWindowPartitionMapping that is missing partitions in the upstream asset, if `allow_nonexistent_upstream_partitions` is set to the default value of False. Previously, invalid partition mappings like this would only be caught at runtime.