### PR TITLE
Make static template_vars support context argument

### DIFF
--- a/docs/sphinx/sections/api/apidocs/dagster/components.rst
+++ b/docs/sphinx/sections/api/apidocs/dagster/components.rst
@@ -19,6 +19,8 @@ Using Components
 Building Components
 -------------------
 
+.. autodecorator:: template_var
+
 .. autoclass:: Component
     :members:
 

--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -15,7 +15,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.metadata.source_code import CodeReference, LocalFileCodeReference
 from dagster._core.definitions.utils import validate_component_owner
 from dagster.components.component.component_scaffolder import DefaultComponentScaffolder
-from dagster.components.component.template_vars import get_static_template_vars
+from dagster.components.component.template_vars import get_context_free_static_template_vars
 from dagster.components.resolved.base import Resolvable
 from dagster.components.scaffold.scaffold import scaffold_with
 
@@ -259,7 +259,7 @@ class Component(ABC):
 
     @classmethod
     def get_additional_scope(cls) -> Mapping[str, Any]:
-        return get_static_template_vars(cls)
+        return get_context_free_static_template_vars(cls)
 
     @abstractmethod
     def build_defs(self, context: "ComponentLoadContext") -> Definitions: ...

--- a/python_modules/dagster/dagster/components/core/defs_module.py
+++ b/python_modules/dagster/dagster/components/core/defs_module.py
@@ -24,7 +24,10 @@ from dagster._core.definitions.module_loaders.load_defs_from_module import (
 from dagster._core.definitions.module_loaders.utils import find_objects_in_module_of_types
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster.components.component.component import Component
-from dagster.components.component.template_vars import find_inline_template_vars_in_module
+from dagster.components.component.template_vars import (
+    find_inline_template_vars_in_module,
+    get_context_aware_static_template_vars,
+)
 from dagster.components.core.context import ComponentDeclLoadContext, ComponentLoadContext
 from dagster.components.definitions import LazyDefinitions
 from dagster.components.resolved.base import Resolvable
@@ -443,9 +446,15 @@ def context_with_injected_scope(
     component_cls: type[Component],
     template_vars_module: Optional[str],
 ) -> T:
-    context = context.with_rendering_scope(
-        component_cls.get_additional_scope(),
-    )
+    # Merge backward-compatible get_additional_scope with context-aware static template vars
+
+    legacy_scope = component_cls.get_additional_scope()
+    context_aware_scope = get_context_aware_static_template_vars(component_cls, context)
+
+    # Merge scopes, with context-aware taking precedence
+    merged_scope = {**legacy_scope, **context_aware_scope}
+
+    context = context.with_rendering_scope(merged_scope)
 
     if not template_vars_module:
         return context


### PR DESCRIPTION
## Summary & Motivation

Added support for context-aware static template variables in components. This enhancement allows template variables to access the component load context, enabling more dynamic template rendering based on the current component's context.

The implementation:
- Splits static template variables into context-aware and non-context-aware variants
- Adds a new `get_context_aware_static_template_vars` function that handles template vars requiring context
- Merges legacy scope with context-aware scope in the rendering process
- Marks the `template_var` decorator as public API

## How I Tested These Changes

BK

## Changelog

* Static functions on classes decorated with `@template_var` can now optionally accept a `ComponentLoadContext` argument.
