### PR TITLE
Fix a lineage issue when self-dependant assets are launched in the same run as non-self-dependant assets

### DIFF
--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/asset_graphs.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/legacy_tests/scenarios/asset_graphs.py
@@ -55,6 +55,23 @@ self_dependant_asset_downstream_of_regular_asset = [
     ),
 ]
 
+self_dependant_asset_downstream_of_regular_asset_multiple_run = [
+    asset_def(
+        "regular_asset",
+        partitions_def=dg.DailyPartitionsDefinition("2023-01-01"),
+        backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=1),
+    ),
+    asset_def(
+        "self_dependant",
+        partitions_def=dg.DailyPartitionsDefinition("2023-01-01"),
+        deps={
+            "self_dependant": dg.TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            "regular_asset": dg.TimeWindowPartitionMapping(),
+        },
+        backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=1),
+    ),
+]
+
 self_dependant_asset_with_grouped_run_backfill_policy = [
     asset_def(
         "self_dependant",


### PR DESCRIPTION
 Fix a lineage issue when self-dependant assets are launched in the same run as non-self-dependant assets
    
 Summary:
    follow-on fix to https://github.com/dagster-io/dagster/pull/31315, making sure that we still capture the case where there are two parents and one of them is yourself.
    
 Test Plan: New test case that was failing before

