### PR TITLE
[dg] Replace `uvx -U create-dagster` with `uvx create-dagster@latest

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ Install the Python package manager [`uv`](https://docs.astral.sh/uv/getting-star
 
 Installing `uv` will install the [`uvx` command](https://docs.astral.sh/uv/guides/tools), which allows you to execute commands without having to install packages directly. You can run the `create-dagster` command using `uvx`:
 
-<CliInvocationExample contents="uvx -U create-dagster project my-project" />
+<CliInvocationExample contents="uvx create-dagster@latest project my-project" />
 
 </TabItem>
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -22,7 +22,7 @@ import ProjectCreationPrereqs from '@site/docs/partials/\_ProjectCreationPrereqs
       1. Open your terminal and scaffold a new Dagster project:
 
          ```shell
-         uvx -U create-dagster project dagster-quickstart
+         uvx create-dagster@latest project dagster-quickstart
          ```
 
       2. Respond `y` to the prompt to run `uv sync` after scaffolding

--- a/docs/docs/guides/build/external-pipelines/using-dagster-pipes/create-subprocess-asset.md
+++ b/docs/docs/guides/build/external-pipelines/using-dagster-pipes/create-subprocess-asset.md
@@ -19,7 +19,7 @@ In this part of the tutorial, you'll create a Dagster asset that, in its executi
 First we will create a new Dagster project:
 
 ```bash
-uvx -U create-dagster project external_pipeline
+uvx create-dagster@latest project external_pipeline
 ```
 
 ## Step 2: Scaffold and define the asset

--- a/docs/docs/guides/build/projects/creating-a-new-project.md
+++ b/docs/docs/guides/build/projects/creating-a-new-project.md
@@ -17,7 +17,7 @@ import ProjectCreationPrereqs from '@site/docs/partials/\_ProjectCreationPrereqs
    1. Open your terminal and scaffold a new Dagster project. You can replace `my-project` with a different project name if you wish:
 
       ```shell
-      uvx -U create-dagster project my-project
+      uvx create-dagster@latest project my-project
       ```
    
    2. Respond `y` to the prompt to run `uv sync` after scaffolding

--- a/docs/docs/guides/build/projects/multiple-projects.md
+++ b/docs/docs/guides/build/projects/multiple-projects.md
@@ -24,7 +24,7 @@ When a `dg` command runs in a workspace, it will create a subprocess for each pr
 
 ## 1. Create a new workspace and first project
 
-To scaffold a new workspace called `dagster-workspace`, run `uvx -U create-dagster workspace` and respond yes to the prompt to run `uv sync` after scaffolding:
+To scaffold a new workspace called `dagster-workspace`, run `uvx create-dagster@latest workspace` and respond yes to the prompt to run `uv sync` after scaffolding:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/workspace/1-dg-scaffold-workspace.txt" />
 
@@ -40,7 +40,7 @@ You'll need to activate this virtual environment anytime you open a new terminal
 
 :::
 
-Now we'll create a project inside our workspace called `project-1`. Run `uvx -U create-dagster project` with the path of the project:
+Now we'll create a project inside our workspace called `project-1`. Run `uvx create-dagster@latest project` with the path of the project:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/dg/workspace/3-dg-scaffold-project.txt" />
 

--- a/docs/docs/migration/airflow-to-dagster/airflow-component-tutorial.md
+++ b/docs/docs/migration/airflow-to-dagster/airflow-component-tutorial.md
@@ -16,7 +16,7 @@ The [dagster-airlift](/integrations/libraries/airlift) library provides an `Airf
 
 To begin, you'll need a Dagster project. You can use an [existing components-ready project](/guides/build/projects/moving-to-components/migrating-project) or create a new one:
 
-uvx -U create-dagster project my-project && cd my-project
+uvx create-dagster@latest project my-project && cd my-project
 
 Activate the project virtual environment:
 

--- a/docs/docs/partials/_ScaffoldProject.md
+++ b/docs/docs/partials/_ScaffoldProject.md
@@ -1,3 +1,3 @@
 ```bash
-uvx -U create-dagster project <project-name>
+uvx create-dagster@latest project <project-name>
 ```

--- a/examples/docs_snippets/docs_snippets/guides/components/adding-attributes-to-assets/1-scaffold-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/adding-attributes-to-assets/1-scaffold-project.txt
@@ -1,4 +1,4 @@
-uvx -U create-dagster project my-project \
+uvx create-dagster@latest project my-project \
     && cd my-project/src \
     && dg scaffold defs dagster.asset team_a/subproject/a.py \
     && dg scaffold defs dagster.asset team_a/b.py \

--- a/examples/docs_snippets/docs_snippets/guides/components/adding-attributes-to-assets/generated/1-scaffold-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/adding-attributes-to-assets/generated/1-scaffold-project.txt
@@ -1,4 +1,4 @@
-uvx -U create-dagster project my-project \
+uvx create-dagster@latest project my-project \
     && cd my-project/src \
     && dg scaffold defs dagster.asset team_a/subproject/a.py \
     && dg scaffold defs dagster.asset team_a/b.py \

--- a/examples/docs_snippets/docs_snippets/guides/components/index/2-a-uv-scaffold.txt
+++ b/examples/docs_snippets/docs_snippets/guides/components/index/2-a-uv-scaffold.txt
@@ -1,1 +1,1 @@
-uvx -U create-dagster project jaffle-platform
+uvx create-dagster@latest project jaffle-platform

--- a/examples/docs_snippets/docs_snippets/guides/dg/scaffolding-project/1-scaffolding-project.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/scaffolding-project/1-scaffolding-project.txt
@@ -1,4 +1,4 @@
-uvx -U create-dagster project my-project
+uvx create-dagster@latest project my-project
 
 Creating a Dagster project at /.../my-project.
 Scaffolded files for Dagster project at /.../my-project.

--- a/examples/docs_snippets/docs_snippets/guides/dg/using-env/1-dg-init.txt
+++ b/examples/docs_snippets/docs_snippets/guides/dg/using-env/1-dg-init.txt
@@ -1,1 +1,1 @@
-uvx -U create-dagster project ingestion
+uvx create-dagster@latest project ingestion

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_component_docs_adding_attributes_to_assets.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_component_docs_adding_attributes_to_assets.py
@@ -59,7 +59,7 @@ def test_components_docs_adding_attributes_to_assets(
             snippet_replace_regex=[
                 ("--uv-sync --use-editable-dagster ", ""),
                 (".*&& source my-project/.venv/bin/activate.*\n", ""),
-                ("create-dagster", "uvx -U create-dagster"),
+                ("create-dagster", "uvx create-dagster@latest"),
             ],
             ignore_output=True,
         )

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -110,7 +110,7 @@ def test_components_docs_index(
                 ],
                 input_str="y\n",
                 ignore_output=True,
-                print_cmd="uvx -U create-dagster project jaffle-platform",
+                print_cmd="uvx create-dagster@latest project jaffle-platform",
             )
             context.run_command_and_snippet_output(
                 cmd="cd jaffle-platform && source .venv/bin/activate",

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_scaffolding_project.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_scaffolding_project.py
@@ -37,7 +37,7 @@ def test_dg_docs_scaffolding_project(update_snippets: bool) -> None:
                 MASK_EDITABLE_DAGSTER,
                 MASK_USING_ENVIRONMENT,
                 make_project_scaffold_mask("my-project"),
-                ("create-dagster", "uvx -U create-dagster"),
+                ("create-dagster", "uvx create-dagster@latest"),
             ],
             print_cmd="create-dagster project my-project",
             input_str="y\n",

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_using_env.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_using_env.py
@@ -238,7 +238,7 @@ def test_component_docs_using_env(
                     # we simulate the input we don't get the newline we get in terminal so we
                     # slide it in here.
                     (r"Running `uv sync`\.\.\.", "\nRunning `uv sync`..."),
-                    ("create-dagster", "uvx -U create-dagster"),
+                    ("create-dagster", "uvx create-dagster@latest"),
                 ],
                 input_str="y\n",
                 ignore_output=True,


### PR DESCRIPTION
## Summary & Motivation

At some point in the last 2 months, `uvx -U` stopped working:

```
$ uvx -U create-dagster project my-project
warning: Tools cannot be upgraded via `uvx`; use `uv tool upgrade --all` to upgrade all installed tools, or `uvx package@latest` to run the latest version of a tool.
```

Update our docs to use `uvx create-dagster@latest` instead.

## How I Tested These Changes

Existing test suite, manually.