### PR TITLE
[sensor-preview] Fix bug where run_keys were not respected

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
@@ -301,6 +301,26 @@
     dict({
       'description': None,
       'minIntervalSeconds': 30,
+      'name': 'run_key_sensor',
+      'sensorState': dict({
+        'runs': list([
+        ]),
+        'runsCount': 0,
+        'status': 'STOPPED',
+        'ticks': list([
+        ]),
+      }),
+      'targets': list([
+        dict({
+          'mode': 'default',
+          'pipelineName': 'no_config_job',
+          'solidSelection': None,
+        }),
+      ]),
+    }),
+    dict({
+      'description': None,
+      'minIntervalSeconds': 30,
       'name': 'run_status',
       'sensorState': dict({
         'runs': list([

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1165,6 +1165,10 @@ def define_sensors():
         )
 
     @sensor(job_name="no_config_job")
+    def run_key_sensor(_):
+        return RunRequest(run_key="the_key")
+
+    @sensor(job_name="no_config_job")
     def always_error_sensor(_):
         raise Exception("OOPS")
 
@@ -1278,6 +1282,7 @@ def define_sensors():
 
     return [
         always_no_config_sensor_with_tags_and_metadata,
+        run_key_sensor,
         always_error_sensor,
         once_no_config_sensor,
         never_no_config_sensor,

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -271,6 +271,8 @@ def execute_preview_command(
     print_fn: PrintFn,
     instance: Optional[DagsterInstance] = None,
 ):
+    from dagster._daemon.sensor import fetch_existing_runs
+
     # We don't call _get_repo here because we need the code location.
     with (
         get_instance_for_cli() as instance,
@@ -307,14 +309,31 @@ def execute_preview_command(
             else:
                 print_fn(f"Sensor returned false for {sensor.name}, skipping")
         else:
-            print_fn(
-                "Sensor returning run requests for {num} run(s):\n\n{run_requests}".format(
-                    num=len(sensor_runtime_data.run_requests),
-                    run_requests="\n".join(
-                        dump_run_config_yaml(run_request.run_config)
-                        for run_request in sensor_runtime_data.run_requests
-                    ),
+            existing_runs = fetch_existing_runs(instance, sensor, sensor_runtime_data.run_requests)
+            skipped_run_requests = []
+            returned_run_requests = []
+
+            for run_request in sensor_runtime_data.run_requests:
+                if run_request.run_key in existing_runs:
+                    skipped_run_requests.append(run_request)
+                else:
+                    returned_run_requests.append(run_request)
+
+            if skipped_run_requests:
+                rr_string = "\n".join(
+                    dump_run_config_yaml(run_request.run_config)
+                    for run_request in skipped_run_requests
                 )
+                print_fn(
+                    f"Skipping run requests for {len(skipped_run_requests)} run(s) that already have runs matching their run_keys:\n\n{rr_string}"
+                )
+
+            rr_string = "\n".join(
+                dump_run_config_yaml(run_request.run_config)
+                for run_request in returned_run_requests
+            )
+            print_fn(
+                f"Sensor returning run requests for {len(returned_run_requests)} run(s):\n\n{rr_string}"
             )
 
 

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -1135,7 +1135,7 @@ def _submit_run_requests(
         raw_run_ids_with_requests,
         has_evaluations=len(automation_condition_evaluations) > 0,
     )
-    existing_runs_by_key = _fetch_existing_runs(
+    existing_runs_by_key = fetch_existing_runs(
         instance, remote_sensor, [request for _, request in resolved_run_ids_with_requests]
     )
     check_after_runs_num = instance.get_tick_termination_check_interval()
@@ -1274,7 +1274,7 @@ def get_elapsed(state: InstigatorState) -> Optional[float]:
     )
 
 
-def _fetch_existing_runs(
+def fetch_existing_runs(
     instance: DagsterInstance,
     remote_sensor: RemoteSensor,
     run_requests: Sequence[RunRequest],

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -157,7 +157,7 @@ def define_bar_sensors():
         run_config = {"foo": "FOO"}
         if context.last_tick_completion_time:
             run_config["since"] = context.last_tick_completion_time
-        return dg.RunRequest(run_key=None, run_config=run_config)
+        return dg.RunRequest(run_key="the_key", run_config=run_config)
 
     return {"foo_sensor": foo_sensor}
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_sensor_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_sensor_commands.py
@@ -2,6 +2,7 @@ import re
 from unittest import mock
 
 import click
+import dagster as dg
 import pytest
 from click.testing import CliRunner
 from dagster._cli.sensor import (
@@ -13,6 +14,7 @@ from dagster._cli.sensor import (
 )
 from dagster._cli.utils import validate_dagster_home_is_set, validate_repo_has_defined_sensors
 from dagster._core.remote_representation.external import RemoteRepository
+from dagster._core.storage.tags import RUN_KEY_TAG, SENSOR_NAME_TAG
 from dagster._core.test_utils import environ
 
 from dagster_tests.cli_tests.command_tests.test_cli_commands import sensor_command_contexts
@@ -115,6 +117,27 @@ def test_sensor_preview(gen_sensor_args):
 
             assert result.exit_code == 0
             assert result.output == "Sensor returning run requests for 1 run(s):\n\nfoo: FOO\n\n"
+
+            # create a run with the same run key to simulate this getting launched
+            instance._run_storage.add_run(  # noqa
+                dg.DagsterRun(
+                    job_name="baz",
+                    run_id="123",
+                    tags={RUN_KEY_TAG: "the_key", SENSOR_NAME_TAG: "foo_sensor"},
+                )
+            )
+
+            # run again, we'll skip
+            result = runner.invoke(
+                sensor_preview_command,
+                cli_args + ["foo_sensor"],
+            )
+
+            assert result.exit_code == 0
+            assert (
+                result.output
+                == "Skipping run requests for 1 run(s) that already have runs matching their run_keys:\n\nfoo: FOO\n\nSensor returning run requests for 0 run(s):\n\n\n"
+            )
 
 
 @pytest.mark.parametrize("gen_sensor_args", sensor_command_contexts())


### PR DESCRIPTION
## Summary & Motivation

This matches the behavior of regular sensors in which we filter out run requests that have a run_key matching an existing run.

These runs do not even show up in the UI, so a similar behavior here seems acceptable

## How I Tested These Changes

unit, manual

## Changelog

Fixed a bug with the sensor preview behavior that would cause run requests contianing `run_key`s that had already been submitted to show up in the preview result.
