### PR TITLE
[dagster-databricks] Consolidate poll and metadata methods in BasePipesDatabricksClient

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -180,21 +180,10 @@ class PipesDatabricksClient(BasePipesDatabricksClient, TreatAsResourceParam):
         self.env = env
         super().__init__(
             client=client,
-            context_injector=check.opt_inst_param(
-                context_injector,
-                "context_injector",
-                PipesContextInjector,
-            )
-            or PipesDbfsContextInjector(client=client),
-            message_reader=check.opt_inst_param(
-                message_reader,
-                "message_reader",
-                PipesMessageReader,
-            ),
-            poll_interval_seconds=check.numeric_param(
-                poll_interval_seconds, "poll_interval_seconds"
-            ),
-            forward_termination=check.bool_param(forward_termination, "forward_termination"),
+            context_injector=context_injector,
+            message_reader=message_reader,
+            poll_interval_seconds=poll_interval_seconds,
+            forward_termination=forward_termination,
         )
 
     @classmethod
@@ -280,11 +269,12 @@ class PipesDatabricksClient(BasePipesDatabricksClient, TreatAsResourceParam):
             PipesClientCompletedInvocation: Wrapper containing results reported by the external
                 process.
         """
+        context_injector = self.context_injector or PipesDbfsContextInjector(client=self.client)
         message_reader = self.message_reader or self.get_default_message_reader(task)
         with open_pipes_session(
             context=context,
             extras=extras,
-            context_injector=self.context_injector,
+            context_injector=context_injector,
             message_reader=message_reader,
         ) as pipes_session:
             submit_task_dict = task.as_dict()
@@ -593,25 +583,10 @@ class PipesDatabricksServerlessClient(BasePipesDatabricksClient, TreatAsResource
         self.volume_path = volume_path
         super().__init__(
             client=client,
-            context_injector=check.opt_inst_param(
-                context_injector,
-                "context_injector",
-                PipesContextInjector,
-            )
-            or PipesUnityCatalogVolumesContextInjector(client=client, volume_path=self.volume_path),
-            message_reader=check.opt_inst_param(
-                message_reader,
-                "message_reader",
-                PipesMessageReader,
-            )
-            or PipesUnityCatalogVolumesMessageReader(
-                client=client,
-                volume_path=self.volume_path,
-            ),
-            poll_interval_seconds=check.numeric_param(
-                poll_interval_seconds, "poll_interval_seconds"
-            ),
-            forward_termination=check.bool_param(forward_termination, "forward_termination"),
+            context_injector=context_injector,
+            message_reader=message_reader,
+            poll_interval_seconds=poll_interval_seconds,
+            forward_termination=forward_termination,
         )
 
     @classmethod
@@ -641,11 +616,18 @@ class PipesDatabricksServerlessClient(BasePipesDatabricksClient, TreatAsResource
             PipesClientCompletedInvocation: Wrapper containing results reported by the external
                 process.
         """
+        context_injector = self.context_injector or PipesUnityCatalogVolumesContextInjector(
+            client=self.client, volume_path=self.volume_path
+        )
+        message_reader = self.message_reader or PipesUnityCatalogVolumesMessageReader(
+            client=self.client,
+            volume_path=self.volume_path,
+        )
         with open_pipes_session(
             context=context,
             extras=extras,
-            context_injector=self.context_injector,
-            message_reader=self.message_reader,
+            context_injector=context_injector,
+            message_reader=message_reader,
         ) as pipes_session:
             submit_task_dict = task.as_dict()
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -180,11 +180,12 @@ class PipesDatabricksClient(BasePipesDatabricksClient, TreatAsResourceParam):
         self.env = env
         super().__init__(
             client=client,
-            context_injector= check.opt_inst_param(
+            context_injector=check.opt_inst_param(
                 context_injector,
                 "context_injector",
                 PipesContextInjector,
-            ) or PipesDbfsContextInjector(client=client),
+            )
+            or PipesDbfsContextInjector(client=client),
             message_reader=check.opt_inst_param(
                 message_reader,
                 "message_reader",
@@ -592,18 +593,18 @@ class PipesDatabricksServerlessClient(BasePipesDatabricksClient, TreatAsResource
         self.volume_path = volume_path
         super().__init__(
             client=client,
-            context_injector= check.opt_inst_param(
+            context_injector=check.opt_inst_param(
                 context_injector,
                 "context_injector",
                 PipesContextInjector,
-            ) or PipesUnityCatalogVolumesContextInjector(
-                client=client, volume_path=self.volume_path
-            ),
+            )
+            or PipesUnityCatalogVolumesContextInjector(client=client, volume_path=self.volume_path),
             message_reader=check.opt_inst_param(
                 message_reader,
                 "message_reader",
                 PipesMessageReader,
-            ) or PipesUnityCatalogVolumesMessageReader(
+            )
+            or PipesUnityCatalogVolumesMessageReader(
                 client=client,
                 volume_path=self.volume_path,
             ),

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -36,6 +36,87 @@ from pydantic import Field
 
 _CONTEXT_FILENAME = "context.json"
 
+
+# #########################
+# ##### Base Class
+# #########################
+
+
+class BasePipesDatabricksClient(PipesClient):
+    def run(
+        self,
+        *,
+        context: Union[OpExecutionContext, AssetExecutionContext],
+        extras: Optional[PipesExtras] = None,
+        **kwargs,
+    ):
+        raise NotImplementedError()
+
+    def _poll_til_success(
+        self, context: Union[OpExecutionContext, AssetExecutionContext], run_id: int
+    ) -> None:
+        # poll the Databricks run until it reaches RunResultState.SUCCESS, raising otherwise
+
+        last_observed_state = None
+        while True:
+            run_state = self._get_run_state(run_id)
+            if run_state.life_cycle_state != last_observed_state:
+                context.log.info(
+                    f"[pipes] Databricks run {run_id} observed state transition to {run_state.life_cycle_state}"
+                )
+            last_observed_state = run_state.life_cycle_state
+
+            if run_state.life_cycle_state in (
+                jobs.RunLifeCycleState.TERMINATED,
+                jobs.RunLifeCycleState.SKIPPED,
+            ):
+                if run_state.result_state == jobs.RunResultState.SUCCESS:
+                    break
+                else:
+                    raise DagsterPipesExecutionError(
+                        f"Error running Databricks job: {run_state.state_message}"
+                    )
+            elif run_state.life_cycle_state == jobs.RunLifeCycleState.INTERNAL_ERROR:
+                raise DagsterPipesExecutionError(
+                    f"Error running Databricks job: {run_state.state_message}"
+                )
+
+            time.sleep(self.poll_interval_seconds)
+
+    def _poll_til_terminating(self, run_id: int) -> None:
+        # Wait to see the job enters a state that indicates the underlying task is no longer executing
+        # TERMINATING: "The task of this run has completed, and the cluster and execution context are being cleaned up."
+        while True:
+            run_state = self._get_run_state(run_id)
+            if run_state.life_cycle_state in (
+                jobs.RunLifeCycleState.TERMINATING,
+                jobs.RunLifeCycleState.TERMINATED,
+                jobs.RunLifeCycleState.SKIPPED,
+                jobs.RunLifeCycleState.INTERNAL_ERROR,
+            ):
+                return
+
+            time.sleep(self.poll_interval_seconds)
+
+    def _get_run_state(self, run_id: int) -> jobs.RunState:
+        run = self.client.jobs.get_run(run_id)
+        if run.state is None:
+            check.failed("Databricks job run state is None")
+        return run.state
+
+    def _extract_dagster_metadata(self, run_id: int) -> RawMetadataMapping:
+        metadata: RawMetadataMapping = {}
+
+        run = self.client.jobs.get_run(run_id)
+
+        metadata["Databricks Job Run ID"] = str(run_id)
+
+        if run_page_url := run.run_page_url:
+            metadata["Databricks Job Run URL"] = run_page_url
+
+        return metadata
+
+
 # #########################
 # ##### Databricks
 # #########################
@@ -246,70 +327,6 @@ class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
 
     def get_task_fields_which_support_cli_parameters(self) -> set[str]:
         return {"spark_python_task", "python_wheel_task"}
-
-    def _poll_til_success(
-        self, context: Union[OpExecutionContext, AssetExecutionContext], run_id: int
-    ) -> None:
-        # poll the Databricks run until it reaches RunResultState.SUCCESS, raising otherwise
-
-        last_observed_state = None
-        while True:
-            run_state = self._get_run_state(run_id)
-            if run_state.life_cycle_state != last_observed_state:
-                context.log.info(
-                    f"[pipes] Databricks run {run_id} observed state transition to {run_state.life_cycle_state}"
-                )
-            last_observed_state = run_state.life_cycle_state
-
-            if run_state.life_cycle_state in (
-                jobs.RunLifeCycleState.TERMINATED,
-                jobs.RunLifeCycleState.SKIPPED,
-            ):
-                if run_state.result_state == jobs.RunResultState.SUCCESS:
-                    break
-                else:
-                    raise DagsterPipesExecutionError(
-                        f"Error running Databricks job: {run_state.state_message}"
-                    )
-            elif run_state.life_cycle_state == jobs.RunLifeCycleState.INTERNAL_ERROR:
-                raise DagsterPipesExecutionError(
-                    f"Error running Databricks job: {run_state.state_message}"
-                )
-
-            time.sleep(self.poll_interval_seconds)
-
-    def _poll_til_terminating(self, run_id: int) -> None:
-        # Wait to see the job enters a state that indicates the underlying task is no longer executing
-        # TERMINATING: "The task of this run has completed, and the cluster and execution context are being cleaned up."
-        while True:
-            run_state = self._get_run_state(run_id)
-            if run_state.life_cycle_state in (
-                jobs.RunLifeCycleState.TERMINATING,
-                jobs.RunLifeCycleState.TERMINATED,
-                jobs.RunLifeCycleState.SKIPPED,
-                jobs.RunLifeCycleState.INTERNAL_ERROR,
-            ):
-                return
-
-            time.sleep(self.poll_interval_seconds)
-
-    def _get_run_state(self, run_id: int) -> jobs.RunState:
-        run = self.client.jobs.get_run(run_id)
-        if run.state is None:
-            check.failed("Databricks job run state is None")
-        return run.state
-
-    def _extract_dagster_metadata(self, run_id: int) -> RawMetadataMapping:
-        metadata: RawMetadataMapping = {}
-
-        run = self.client.jobs.get_run(run_id)
-
-        metadata["Databricks Job Run ID"] = str(run_id)
-
-        if run_page_url := run.run_page_url:
-            metadata["Databricks Job Run URL"] = run_page_url
-
-        return metadata
 
 
 @contextmanager
@@ -632,70 +649,6 @@ class PipesDatabricksServerlessClient(PipesClient, TreatAsResourceParam):
         return PipesClientCompletedInvocation(
             pipes_session, metadata=self._extract_dagster_metadata(run_id)
         )
-
-    def _poll_til_success(
-        self, context: Union[OpExecutionContext, AssetExecutionContext], run_id: int
-    ) -> None:
-        # poll the Databricks run until it reaches RunResultState.SUCCESS, raising otherwise
-
-        last_observed_state = None
-        while True:
-            run_state = self._get_run_state(run_id)
-            if run_state.life_cycle_state != last_observed_state:
-                context.log.info(
-                    f"[pipes] Databricks run {run_id} observed state transition to {run_state.life_cycle_state}"
-                )
-            last_observed_state = run_state.life_cycle_state
-
-            if run_state.life_cycle_state in (
-                jobs.RunLifeCycleState.TERMINATED,
-                jobs.RunLifeCycleState.SKIPPED,
-            ):
-                if run_state.result_state == jobs.RunResultState.SUCCESS:
-                    break
-                else:
-                    raise DagsterPipesExecutionError(
-                        f"Error running Databricks job: {run_state.state_message}"
-                    )
-            elif run_state.life_cycle_state == jobs.RunLifeCycleState.INTERNAL_ERROR:
-                raise DagsterPipesExecutionError(
-                    f"Error running Databricks job: {run_state.state_message}"
-                )
-
-            time.sleep(self.poll_interval_seconds)
-
-    def _poll_til_terminating(self, run_id: int) -> None:
-        # Wait to see the job enters a state that indicates the underlying task is no longer executing
-        # TERMINATING: "The task of this run has completed, and the cluster and execution context are being cleaned up."
-        while True:
-            run_state = self._get_run_state(run_id)
-            if run_state.life_cycle_state in (
-                jobs.RunLifeCycleState.TERMINATING,
-                jobs.RunLifeCycleState.TERMINATED,
-                jobs.RunLifeCycleState.SKIPPED,
-                jobs.RunLifeCycleState.INTERNAL_ERROR,
-            ):
-                return
-
-            time.sleep(self.poll_interval_seconds)
-
-    def _get_run_state(self, run_id: int) -> jobs.RunState:
-        run = self.client.jobs.get_run(run_id)
-        if run.state is None:
-            check.failed("Databricks job run state is None")
-        return run.state
-
-    def _extract_dagster_metadata(self, run_id: int) -> RawMetadataMapping:
-        metadata: RawMetadataMapping = {}
-
-        run = self.client.jobs.get_run(run_id)
-
-        metadata["Databricks Job Run ID"] = str(run_id)
-
-        if run_page_url := run.run_page_url:
-            metadata["Databricks Job Run URL"] = run_page_url
-
-        return metadata
 
 
 @contextmanager

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -122,7 +122,7 @@ class BasePipesDatabricksClient(PipesClient):
 # #########################
 
 
-class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
+class PipesDatabricksClient(BasePipesDatabricksClient, TreatAsResourceParam):
     """Pipes client for databricks.
 
     Args:
@@ -538,7 +538,7 @@ class PipesDbfsLogReader(PipesChunkedLogReader):
 # ####################################
 
 
-class PipesDatabricksServerlessClient(PipesClient, TreatAsResourceParam):
+class PipesDatabricksServerlessClient(BasePipesDatabricksClient, TreatAsResourceParam):
     """Pipes client for Databricks Serverless.
 
     Args:


### PR DESCRIPTION
## Summary & Motivation

PipesDatabricksClient and PipesDatabricksServerless share the same code for poll and metadata methods - consolidate duplicated methods in one base class

## How I Tested These Changes

Unit test (manual run)

## Changelog

> Insert changelog entry or delete this section.
