### PR TITLE
[Docs] Fix DAGSTER_HOME mount for all containers (#28284)

### DIFF
--- a/docs/docs/deployment/oss/deployment-options/docker.md
+++ b/docs/docs/deployment/oss/deployment-options/docker.md
@@ -37,6 +37,8 @@ RUN mkdir -p $DAGSTER_HOME
 
 COPY dagster.yaml workspace.yaml $DAGSTER_HOME
 
+VOLUME ["/opt/dagster/dagster_home"]
+
 WORKDIR $DAGSTER_HOME
 ```
 
@@ -58,6 +60,11 @@ RUN pip install \
     dagster \
     dagster-postgres \
     dagster-docker
+
+# Set $DAGSTER_HOME for run storage compatibility
+ENV DAGSTER_HOME=/opt/dagster/dagster_home
+
+VOLUME ["/opt/dagster/dagster_home"]
 
 # Add code location code
 WORKDIR /opt/dagster/app


### PR DESCRIPTION
## Summary & Motivation
- Added ENV DAGSTER_HOME and VOLUME to code location Dockerfile for shared run storage
- Added VOLUME to webserver/daemon Dockerfile for clarity and consistency
- Ensures run metadata and execution state can be accessed across Dagster components
## Original Issue
#28284 



@yujqiao , @garethbrickman , @neverett
