### PR TITLE
[components] Error if attributes are passed to a component without a model

### DIFF
--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -17,11 +17,18 @@ from dagster._core.definitions.utils import validate_component_owner
 from dagster.components.component.component_scaffolder import DefaultComponentScaffolder
 from dagster.components.component.template_vars import get_static_template_vars
 from dagster.components.resolved.base import Resolvable
+from dagster.components.resolved.model import Model
 from dagster.components.scaffold.scaffold import scaffold_with
 
 if TYPE_CHECKING:
     from dagster.components.core.context import ComponentLoadContext
     from dagster.components.core.decl import ComponentDecl
+
+
+class _Empty(Model):
+    """Represents a model that should explicitly have no fields set."""
+
+    pass
 
 
 @public
@@ -255,7 +262,7 @@ class Component(ABC):
         if cls_from_get_schema:
             return cls_from_get_schema
 
-        return None
+        return _Empty
 
     @classmethod
     def get_additional_scope(cls) -> Mapping[str, Any]:

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_unresolvable_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_unresolvable_component.py
@@ -1,0 +1,27 @@
+import dagster as dg
+import pytest
+from dagster.components.core.tree import ComponentTreeException
+from dagster.components.testing.utils import create_defs_folder_sandbox
+
+
+class UnresolvableComponent(dg.Component, dg.Model):
+    """This component class does not subclass Resolvable."""
+
+    some_field: str
+
+    def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions: ...
+
+
+def test_unresolvable_component():
+    with create_defs_folder_sandbox() as sandbox:
+        defs_path = sandbox.scaffold_component(
+            UnresolvableComponent,
+            defs_yaml_contents={
+                "type": "dagster_tests.components_tests.unit_tests.test_unresolvable_component.UnresolvableComponent",
+                # this component is not resolvable and so cannot have attributes
+                "attributes": {"some_field": "foo"},
+            },
+        )
+        with pytest.raises(ComponentTreeException):
+            with sandbox.load_component_and_build_defs(defs_path=defs_path) as (component, defs):
+                ...


### PR DESCRIPTION
## Summary & Motivation

Ran into this in the wild, and was very confused. The net result is that before this change, we would silently drop the `attributes` dictionary and then error when constructing the component class. Now we can error in the yaml itself.

## How I Tested These Changes

## Changelog

Fixed an issue that could cause confusing errors when attempting to supply `attributes` configuration to `Component` subclasses that did not inherit from `Resolvable`.
