### PR TITLE
[core] pass step execution context to load_asset_value when possible

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -27,6 +27,7 @@ from dagster._core.definitions.sensor_definition import SensorDefinition
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.utils import check_valid_name
 from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.execution.context.system import StepExecutionContext
 from dagster._core.instance import DagsterInstance
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.cached_method import cached_method
@@ -350,6 +351,7 @@ class RepositoryDefinition:
         partition_key: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         resource_config: Optional[Any] = None,
+        step_context: Optional[StepExecutionContext] = None,
     ) -> object:
         """Load the contents of an asset as a Python object.
 
@@ -368,6 +370,8 @@ class RepositoryDefinition:
                 (is equivalent to setting the metadata argument in `In` or `AssetIn`).
             resource_config (Optional[Any]): A dictionary of resource configurations to be passed
                 to the :py:class:`IOManager`.
+            step_context (Optional[StepExecutionContext]): The step context to use for loading the asset.
+                Can be provided when calling load_asset_value from a Dagster step.
 
         Returns:
             The contents of an asset as a Python object.
@@ -385,6 +389,7 @@ class RepositoryDefinition:
                 partition_key=partition_key,
                 metadata=metadata,
                 resource_config=resource_config,
+                step_context=step_context,
             )
 
     @public

--- a/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
@@ -1308,4 +1308,5 @@ class OpExecutionContext(AbstractComputeExecutionContext):
             asset_key,
             python_type=python_type,
             partition_key=partition_key,
+            step_context=self._step_execution_context,
         )

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -15,6 +15,7 @@ from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.execution.build_resources import build_resources, get_mapped_resource_config
 from dagster._core.execution.context.input import build_input_context
 from dagster._core.execution.context.output import build_output_context
+from dagster._core.execution.context.system import StepExecutionContext
 from dagster._core.execution.resources_init import get_transitive_required_resource_keys
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.config import is_dagster_home_set
@@ -83,6 +84,7 @@ class AssetValueLoader:
         partition_key: Optional[str] = None,
         input_definition_metadata: Optional[dict[str, Any]] = None,
         resource_config: Optional[Mapping[str, Any]] = None,
+        step_context: Optional[StepExecutionContext] = None,
         # deprecated
         metadata: Optional[dict[str, Any]] = None,
     ) -> object:
@@ -99,6 +101,8 @@ class AssetValueLoader:
                 (is equivalent to setting the metadata argument in `In` or `AssetIn`).
             resource_config (Optional[Any]): A dictionary of resource configurations to be passed
                 to the :py:class:`IOManager`.
+            step_context (Optional[StepExecutionContext]): The step context to use for loading the asset.
+                Can be provided when calling load_asset_value from a Dagster step.
 
         Returns:
             The contents of an asset as a Python object.
@@ -168,6 +172,7 @@ class AssetValueLoader:
             definition_metadata=normalize_renamed_param(
                 input_definition_metadata, "input_definition_metadata", metadata, "metadata"
             ),
+            step_context=step_context,
         )
 
         return io_manager.load_input(input_context)


### PR DESCRIPTION
## Summary & Motivation

Resolve https://github.com/dagster-io/community-integrations/issues/184 for `AssetExecutionContext.load_asset_value` 

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
