### PR TITLE
[ui] Additional export to support billing charts

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
@@ -53,7 +53,7 @@ export type LineChartMetrics = {
   };
 };
 
-const getDataset = (
+export const getDataset = (
   metrics: LineChartMetrics,
   formatDatetime: (date: Date, options: Intl.DateTimeFormatOptions) => string,
 ): ChartData<'line', (number | null)[], string> => {


### PR DESCRIPTION
## Summary & Motivation

This is a tiny PR exposing a utility we use for LineCharts so that I can reuse it within the billing charts. On the billing page we have a Line chart, but it has a custom timeframe (the billing period), different tooltips, etc. so this is the only part that it reuses.

https://linear.app/dagster-labs/issue/OPER-2230/billing-page-design-updates-for-self-managed-upsells