### PR TITLE
Implement check docstrings --all

### DIFF
--- a/python_modules/automation/automation/dagster_docs/exclude_lists.py
+++ b/python_modules/automation/automation/dagster_docs/exclude_lists.py
@@ -411,3 +411,62 @@ EXCLUDE_MODULES_FROM_PUBLIC_SCAN = set()
 
 # RST files to exclude from symbol extraction
 EXCLUDE_RST_FILES = set()
+
+
+# Docstring validation exclude lists
+
+# Symbols that currently have missing or empty docstrings
+EXCLUDE_MISSING_DOCSTRINGS = {
+    "dagster.AssetCheckExecutionContext",
+    "dagster.AssetExecutionContext",
+    "dagster.BoolSource",
+    "dagster.IntSource",
+    "dagster.StringSource",
+    "dagster_dask.dask_resource",
+    "dagster_databricks.databricks_client",
+    "dagster_datahub.datahub_kafka_emitter",
+    "dagster_datahub.datahub_rest_emitter",
+    "dagster_gcp.bigquery_resource",
+    "dagster_gcp.configurable_dataproc_op",
+    "dagster_gcp.dataproc_op",
+    "dagster_gcp.dataproc_resource",
+    "dagster_gcp.gcs_resource",
+    "dagster_gcp.import_df_to_bq",
+    "dagster_gcp.import_file_to_bq",
+    "dagster_gcp.import_gcs_paths_to_bq",
+    "dagster_github.github_resource",
+    "dagster_mlflow.end_mlflow_on_run_finished",
+    "dagster_prometheus.prometheus_resource",
+    "dagster_spark.spark_resource",
+    "dagster_twilio.twilio_resource",
+}
+# Total: 22 symbols
+
+# Symbols that currently have docstring validation errors
+EXCLUDE_DOCSTRING_ERRORS = {
+    "dagster.ExecuteInProcessResult",
+    "dagster.scaffold_with",
+    "dagster_dask.dask_executor",
+    "dagster_fivetran.fivetran_resync_op",
+}
+# Total: 4 symbols
+
+# Symbols that currently have docstring validation warnings
+EXCLUDE_DOCSTRING_WARNINGS = {
+    "dagster.Component",
+    "dagster.ComponentLoadContext",
+    "dagster.ConfigSchema",
+    "dagster.DagsterInstance",
+    "dagster.GraphDefinition.execute_in_process",
+    "dagster.JobDefinition.execute_in_process",
+    "dagster.ReexecutionOptions",
+    "dagster.definitions",
+    "dagster.execute_job",
+    "dagster_celery_k8s.celery_k8s_job_executor",
+    "dagster_docker.docker_container_op",
+    "dagster_docker.docker_executor",
+    "dagster_gcp.gcs_pickle_io_manager",
+    "dagster_k8s.k8s_job_executor",
+    "dagster_k8s.k8s_job_op",
+}
+# Total: 15 symbols

--- a/python_modules/automation/automation_tests/dagster_docs_tests/test_integration.py
+++ b/python_modules/automation/automation_tests/dagster_docs_tests/test_integration.py
@@ -78,14 +78,20 @@ class TestRealDagsterSymbols:
 
         # Should complete successfully (exit code 0 or 1 for validation errors)
         assert result.exit_code in [0, 1]
-        assert f"Validating docstring for: {symbol}" in result.output
 
-        # Should show some result (valid or invalid)
+        # Should either validate the symbol or show it's excluded
+        assert (
+            f"Validating docstring for: {symbol}" in result.output
+            or f"Symbol '{symbol}' is in the exclude list" in result.output
+        )
+
+        # Should show some result (valid or invalid or excluded)
         assert (
             "✓" in result.output
             or "✗" in result.output
             or "ERROR" in result.output
             or "WARNING" in result.output
+            or "excluded" in result.output
         )
 
     def test_check_docstrings_dagster_package(self):

--- a/python_modules/dagster/dagster/components/core/context.py
+++ b/python_modules/dagster/dagster/components/core/context.py
@@ -294,3 +294,17 @@ class ComponentLoadContext(ComponentDeclLoadContext):
             from_path=self.component_path, to_path=defs_path
         )
         return self.component_tree.build_defs_at_path(defs_path)
+
+    def for_path(self, path: Path) -> "Self":
+        """Creates a new context for the given path.
+
+        Args:
+            path: The filesystem path to create a new context for.
+
+        Returns:
+            ComponentLoadContext: A new context for the given path.
+        """
+        from dagster.components.core.defs_module import ComponentPath
+
+        component_path = ComponentPath(file_path=path)
+        return self.for_component_path(component_path)


### PR DESCRIPTION
## Summary & Motivation

This PR enhances the docstring validation system by implementing the ability to validate docstrings across all public Dagster packages. The implementation adds:

1. A new `_validate_all_packages()` function that processes all public modules
2. Support for exclude lists to manage symbols with known docstring issues
3. Three new exclude lists for different types of docstring problems:
   - `EXCLUDE_MISSING_DOCSTRINGS` for symbols with missing docstrings
   - `EXCLUDE_DOCSTRING_ERRORS` for symbols with validation errors
   - `EXCLUDE_DOCSTRING_WARNINGS` for symbols with validation warnings
4. An `--ignore-exclude-lists` flag to bypass these exclusions when needed

The PR also includes minor formatting improvements to the component example code.

## How I Tested These Changes

I ran the new docstring validation command with various options to verify it correctly:
- Processes all public packages
- Respects the exclude lists
- Properly counts and reports errors, warnings, and excluded symbols
- Handles the `--ignore-exclude-lists` flag correctly

## Changelog

Add comprehensive docstring validation across all public Dagster packages with support for exclude lists to manage known issues.