### PR TITLE
Process target subset before using it to compute root assets

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -196,6 +196,18 @@ class AssetGraphView(LoadingContext):
         )
 
     @use_partition_loading_context
+    def get_latest_asset_graph_subset_from_serialized_asset_graph_subset(
+        self, asset_graph_subset: AssetGraphSubset
+    ) -> AssetGraphSubset:
+        # Ensures that all the passed in subsets are valid and up to date with the latest partitions
+        # that are actually in the asset graph
+        entity_subsets = [
+            self.get_entity_subset_from_asset_graph_subset(asset_graph_subset, asset_key)
+            for asset_key in asset_graph_subset.asset_keys
+        ]
+        return AssetGraphSubset.from_entity_subsets(entity_subsets)
+
+    @use_partition_loading_context
     def get_entity_subset_from_asset_graph_subset(
         self, asset_graph_subset: AssetGraphSubset, key: AssetKey
     ) -> EntitySubset[AssetKey]:

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -205,34 +205,40 @@ class AssetBackfillData(NamedTuple):
         return self.replace_requested_subset(submitted_partitions)
 
     def get_target_root_asset_graph_subset(
-        self, instance_queryer: CachingInstanceQueryer
+        self, asset_graph_view: AssetGraphView
     ) -> AssetGraphSubset:
+        target_subset = (
+            asset_graph_view.get_latest_asset_graph_subset_from_serialized_asset_graph_subset(
+                self.target_subset
+            )
+        )
+
         def _get_self_and_downstream_targeted_subset(
             initial_subset: AssetGraphSubset,
         ) -> AssetGraphSubset:
             self_and_downstream = initial_subset
             for asset_key in initial_subset.asset_keys:
                 self_and_downstream = self_and_downstream | (
-                    instance_queryer.asset_graph.bfs_filter_subsets(
-                        lambda asset_key, _: asset_key in self.target_subset,
+                    asset_graph_view.asset_graph.bfs_filter_subsets(
+                        lambda asset_key, _: asset_key in target_subset,
                         initial_subset.filter_asset_keys({asset_key}),
                     )
-                    & self.target_subset
+                    & target_subset
                 )
             return self_and_downstream
 
         assets_with_no_parents_in_target_subset = {
             asset_key
-            for asset_key in self.target_subset.asset_keys
+            for asset_key in target_subset.asset_keys
             if all(
-                parent not in self.target_subset.asset_keys
-                for parent in instance_queryer.asset_graph.get(asset_key).parent_keys
+                parent not in target_subset.asset_keys
+                for parent in asset_graph_view.asset_graph.get(asset_key).parent_keys
                 - {asset_key}  # Do not include an asset as its own parent
             )
         }
 
         # The partitions that do not have any parents in the target subset
-        root_subset = self.target_subset.filter_asset_keys(assets_with_no_parents_in_target_subset)
+        root_subset = target_subset.filter_asset_keys(assets_with_no_parents_in_target_subset)
 
         # Partitions in root_subset and their downstreams within the target subset
         root_and_downstream_partitions = _get_self_and_downstream_targeted_subset(root_subset)
@@ -242,19 +248,19 @@ class AssetBackfillData(NamedTuple):
         previous_root_and_downstream_partitions = None
 
         while (
-            root_and_downstream_partitions != self.target_subset
+            root_and_downstream_partitions != target_subset
             and root_and_downstream_partitions
             != previous_root_and_downstream_partitions  # Check against previous iteration result to exit if no new partitions are targeted
         ):
             # Find the asset graph subset is not yet targeted by the backfill
-            unreachable_targets = self.target_subset - root_and_downstream_partitions
+            unreachable_targets = target_subset - root_and_downstream_partitions
 
             # Find the root assets of the unreachable targets. Any targeted partition in these
             # assets becomes part of the root subset
             unreachable_target_root_subset = unreachable_targets.filter_asset_keys(
                 KeysAssetSelection(selected_keys=list(unreachable_targets.asset_keys))
                 .sources()
-                .resolve(instance_queryer.asset_graph)
+                .resolve(asset_graph_view.asset_graph)
             )
             root_subset = root_subset | unreachable_target_root_subset
 
@@ -272,7 +278,7 @@ class AssetBackfillData(NamedTuple):
             raise DagsterInvariantViolationError(
                 "Unable to determine root partitions for backfill. The following asset partitions"
                 " are not targeted:"
-                f" \n\n{list((self.target_subset - root_and_downstream_partitions).iterate_asset_partitions())} \n\n"
+                f" \n\n{list((target_subset - root_and_downstream_partitions).iterate_asset_partitions())} \n\n"
                 " This is likely a system error. Please report this issue to the Dagster team."
             )
 
@@ -1486,7 +1492,7 @@ def _execute_asset_backfill_iteration_inner(
         logger.info(
             "Not all root assets (assets in backfill that do not have parents in the backill) have been requested, finding root assets."
         )
-        target_roots = asset_backfill_data.get_target_root_asset_graph_subset(instance_queryer)
+        target_roots = asset_backfill_data.get_target_root_asset_graph_subset(asset_graph_view)
         candidate_asset_graph_subset = target_roots
         logger.info(
             f"Root assets that have not yet been requested:\n{_asset_graph_subset_to_str(target_roots, asset_graph)}"

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
@@ -115,6 +115,18 @@ def test_partitions_definition_valid_subset():
         assert subset.included_time_windows == old_partitions_subset.included_time_windows
         assert subset.partitions_def == current_partitions_def
 
+        new_asset_graph_subset = (
+            asset_graph_view.get_latest_asset_graph_subset_from_serialized_asset_graph_subset(
+                old_asset_graph_subset
+            )
+        )
+
+        assert (
+            new_asset_graph_subset != old_asset_graph_subset
+        )  # because the partitions defs are different
+
+        assert new_asset_graph_subset.partitions_subsets_by_asset_key[asset0.key] == subset
+
 
 @pytest.mark.parametrize(
     "invalid_asset_graph_subset, error_match",

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_asset_backfill.py
@@ -2510,7 +2510,9 @@ def test_connected_assets_disconnected_partitions():
         ],
     )
 
-    target_root_subset = asset_backfill_data.get_target_root_asset_graph_subset(instance_queryer)
+    target_root_subset = asset_backfill_data.get_target_root_asset_graph_subset(
+        _get_asset_graph_view(instance, asset_graph, backfill_start_datetime)
+    )
     assert set(target_root_subset.iterate_asset_partitions()) == {
         AssetKeyPartitionKey(asset_key=dg.AssetKey(["foo"]), partition_key="2023-10-05"),
         AssetKeyPartitionKey(asset_key=dg.AssetKey(["foo"]), partition_key="2023-10-03"),


### PR DESCRIPTION
Summary:
This is really only an issue when dry running old backfills (or if you get incredibly unlucky and a partitions def changes right before the very first tick), but ensure that the serialized asset graph subset will pass equality checks when you compre it with a fresh one generated from the asset graph view.

Test Plan:
Dry run of old backfill now passes  that was failing before