### PR TITLE
[3/d][components] Track component-component dependencies in ComponentTree

### DIFF
--- a/python_modules/dagster/dagster/components/core/component_tree.py
+++ b/python_modules/dagster/dagster/components/core/component_tree.py
@@ -103,6 +103,42 @@ class ComponentTreeDependencies:
             _get_canonical_component_path(defs_module_path, from_path)
         ].add(_get_canonical_component_path(defs_module_path, to_path))
 
+    def get_direct_load_dependencies_of_component(
+        self, defs_module_path: Path, component_path: ComponentPath
+    ) -> set[ComponentPath]:
+        """Returns the set of components that are directly depended on by the given component.
+
+        Args:
+            defs_module_path: The path to the defs module.
+            component_path: The path to the component to get the direct load dependencies of.
+        """
+        return set(
+            ComponentPath(
+                file_path=Path(file_path).relative_to(defs_module_path), instance_key=instance_key
+            )
+            for file_path, instance_key in self._component_load_dependency_dict[
+                _get_canonical_component_path(defs_module_path, component_path)
+            ]
+        )
+
+    def get_direct_defs_dependencies_of_component(
+        self, defs_module_path: Path, component_path: ComponentPath
+    ) -> set[ComponentPath]:
+        """Returns the set of components that are directly depended on by the given component's defs.
+
+        Args:
+            defs_module_path: The path to the defs module.
+            component_path: The path to the component to get the direct defs dependencies of.
+        """
+        return set(
+            ComponentPath(
+                file_path=Path(file_path).relative_to(defs_module_path), instance_key=instance_key
+            )
+            for file_path, instance_key in self._component_defs_dependency_dict[
+                _get_canonical_component_path(defs_module_path, component_path)
+            ]
+        )
+
 
 @record(
     checked=False,  # cant handle ModuleType

--- a/python_modules/dagster/dagster/components/core/component_tree.py
+++ b/python_modules/dagster/dagster/components/core/component_tree.py
@@ -90,55 +90,55 @@ class ComponentTreeDependencies:
     """
 
     def __init__(self):
-        self._component_load_dependency_dict = defaultdict(set)
-        self._component_defs_dependency_dict = defaultdict(set)
+        self._component_load_dependents_dict = defaultdict(set)
+        self._component_defs_dependents_dict = defaultdict(set)
 
     def mark_component_load_dependency(
         self, defs_module_path: Path, from_path: ComponentPath, to_path: ResolvableToComponentPath
     ) -> None:
-        self._component_load_dependency_dict[
-            _get_canonical_component_path(defs_module_path, from_path)
-        ].add(_get_canonical_component_path(defs_module_path, to_path))
+        self._component_load_dependents_dict[
+            _get_canonical_component_path(defs_module_path, to_path)
+        ].add(_get_canonical_component_path(defs_module_path, from_path))
 
     def mark_component_defs_dependency(
         self, defs_module_path: Path, from_path: ComponentPath, to_path: ResolvableToComponentPath
     ) -> None:
-        self._component_defs_dependency_dict[
-            _get_canonical_component_path(defs_module_path, from_path)
-        ].add(_get_canonical_component_path(defs_module_path, to_path))
+        self._component_defs_dependents_dict[
+            _get_canonical_component_path(defs_module_path, to_path)
+        ].add(_get_canonical_component_path(defs_module_path, from_path))
 
-    def get_direct_load_dependencies_of_component(
+    def get_direct_load_dependents_of_component(
         self, defs_module_path: Path, component_path: ComponentPath
     ) -> set[ComponentPath]:
-        """Returns the set of components that are directly depended on by the given component.
+        """Returns the set of components that directly depend on the given component.
 
         Args:
             defs_module_path: The path to the defs module.
-            component_path: The path to the component to get the direct load dependencies of.
+            component_path: The path to the component to get the direct load dependents of.
         """
         return set(
             ComponentPath(
                 file_path=Path(file_path).relative_to(defs_module_path), instance_key=instance_key
             )
-            for file_path, instance_key in self._component_load_dependency_dict[
+            for file_path, instance_key in self._component_load_dependents_dict[
                 _get_canonical_component_path(defs_module_path, component_path)
             ]
         )
 
-    def get_direct_defs_dependencies_of_component(
+    def get_direct_defs_dependents_of_component(
         self, defs_module_path: Path, component_path: ComponentPath
     ) -> set[ComponentPath]:
-        """Returns the set of components that are directly depended on by the given component's defs.
+        """Returns the set of components that directly depend on the given component's defs.
 
         Args:
             defs_module_path: The path to the defs module.
-            component_path: The path to the component to get the direct defs dependencies of.
+            component_path: The path to the component to get the direct defs dependents of.
         """
         return set(
             ComponentPath(
                 file_path=Path(file_path).relative_to(defs_module_path), instance_key=instance_key
             )
-            for file_path, instance_key in self._component_defs_dependency_dict[
+            for file_path, instance_key in self._component_defs_dependents_dict[
                 _get_canonical_component_path(defs_module_path, component_path)
             ]
         )

--- a/python_modules/dagster/dagster/components/core/component_tree.py
+++ b/python_modules/dagster/dagster/components/core/component_tree.py
@@ -85,6 +85,10 @@ class ComponentTreeException(Exception):
 
 
 class ComponentTreeDependencies:
+    """Stateful class which tracks the dependencies between components,
+    used when reloading a subset of the component tree.
+    """
+
     def __init__(self):
         self._component_load_dependency_dict = defaultdict(set)
         self._component_defs_dependency_dict = defaultdict(set)
@@ -352,6 +356,12 @@ class ComponentTree:
     def mark_component_load_dependency(
         self, from_path: ComponentPath, to_path: ResolvableToComponentPath
     ) -> None:
+        """Marks a dependency between the component at `from_path` and the component at `to_path`.
+
+        Args:
+            from_path: The path to the component that depends on the component at `to_path`.
+            to_path: The path to the component that the component at `from_path` depends on.
+        """
         self.component_tree_dependencies.mark_component_load_dependency(
             self.defs_module_path, from_path, to_path
         )
@@ -359,6 +369,13 @@ class ComponentTree:
     def mark_component_defs_dependency(
         self, from_path: ComponentPath, to_path: ResolvableToComponentPath
     ) -> None:
+        """Marks a dependency between the component at `from_path` on the defs of
+        the component at `to_path`.
+
+        Args:
+            from_path: The path to the component that depends on the defs of the component at `to_path`.
+            to_path: The path to the component that the component at `from_path` depends on.
+        """
         self.component_tree_dependencies.mark_component_defs_dependency(
             self.defs_module_path, from_path, to_path
         )

--- a/python_modules/dagster/dagster/components/core/component_tree.py
+++ b/python_modules/dagster/dagster/components/core/component_tree.py
@@ -84,7 +84,7 @@ class ComponentTreeException(Exception):
     pass
 
 
-class ComponentTreeDependencies:
+class ComponentTreeDependencyTracker:
     """Stateful class which tracks the dependencies between components,
     used when reloading a subset of the component tree.
     """
@@ -158,7 +158,7 @@ class ComponentTree:
     defs_module: ModuleType
     project_root: Path
     terminate_autoloading_on_keyword_files: Optional[bool] = None
-    component_tree_dependencies: ComponentTreeDependencies = ComponentTreeDependencies()
+    component_tree_dependencies: ComponentTreeDependencyTracker = ComponentTreeDependencyTracker()
 
     @contextmanager
     def augment_component_tree_exception(

--- a/python_modules/dagster/dagster/components/core/context.py
+++ b/python_modules/dagster/dagster/components/core/context.py
@@ -184,6 +184,9 @@ class ComponentDeclLoadContext:
         Returns:
             Component: The component loaded from the given path.
         """
+        self.component_tree.mark_component_load_dependency(
+            from_path=self.component_path, to_path=defs_path
+        )
         return self.component_tree.load_component_at_path(defs_path, expected_type)  # type: ignore[reportIncompatibleArgumentType]
 
     def load_structural_component_at_path(
@@ -197,6 +200,9 @@ class ComponentDeclLoadContext:
         Returns:
             Component: The component loaded from the given path.
         """
+        self.component_tree.mark_component_load_dependency(
+            from_path=self.component_path, to_path=defs_path
+        )
         return self.component_tree.load_structural_component_at_path(defs_path)
 
 
@@ -284,4 +290,7 @@ class ComponentLoadContext(ComponentDeclLoadContext):
         Returns:
             Definitions: The definitions loaded from the given path.
         """
+        self.component_tree.mark_component_defs_dependency(
+            from_path=self.component_path, to_path=defs_path
+        )
         return self.component_tree.build_defs_at_path(defs_path)

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
@@ -167,22 +167,28 @@ def test_autoload_single_file(component_tree: ComponentTree) -> None:
     defs = component_tree.build_defs()
     assert component_tree.has_built_all_defs()
 
-    assert component_tree.component_tree_dependencies.get_direct_load_dependencies_of_component(
+    assert component_tree.component_tree_dependencies.get_direct_load_dependents_of_component(
+        component_tree.defs_module_path,
+        ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None),
+    ) == {ComponentPath(file_path=Path("single_file"), instance_key=None)}
+
+    assert component_tree.component_tree_dependencies.get_direct_defs_dependents_of_component(
+        component_tree.defs_module_path,
+        ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None),
+    ) == {ComponentPath(file_path=Path("single_file"), instance_key=None)}
+
+    assert component_tree.component_tree_dependencies.get_direct_load_dependents_of_component(
         component_tree.defs_module_path,
         ComponentPath(file_path=Path("single_file"), instance_key=None),
-    ) == {ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None)}
-
-    assert component_tree.component_tree_dependencies.get_direct_defs_dependencies_of_component(
-        component_tree.defs_module_path,
-        ComponentPath(file_path=Path("single_file"), instance_key=None),
-    ) == {ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None)}
-
-    assert component_tree.component_tree_dependencies.get_direct_load_dependencies_of_component(
-        component_tree.defs_module_path,
-        ComponentPath(file_path=Path("."), instance_key=None),
     ) == {
-        ComponentPath(file_path=Path("single_file"), instance_key=None),
+        ComponentPath(file_path=Path("."), instance_key=None),
+    }
+
+    assert component_tree.component_tree_dependencies.get_direct_load_dependents_of_component(
+        component_tree.defs_module_path,
         ComponentPath(file_path=Path("__init__.py"), instance_key=None),
+    ) == {
+        ComponentPath(file_path=Path("."), instance_key=None),
     }
 
     assert {spec.key for spec in defs.resolve_all_asset_specs()} == {dg.AssetKey("an_asset")}

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
@@ -167,6 +167,24 @@ def test_autoload_single_file(component_tree: ComponentTree) -> None:
     defs = component_tree.build_defs()
     assert component_tree.has_built_all_defs()
 
+    assert component_tree.component_tree_dependencies.get_direct_load_dependencies_of_component(
+        component_tree.defs_module_path,
+        ComponentPath(file_path=Path("single_file"), instance_key=None),
+    ) == {ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None)}
+
+    assert component_tree.component_tree_dependencies.get_direct_defs_dependencies_of_component(
+        component_tree.defs_module_path,
+        ComponentPath(file_path=Path("single_file"), instance_key=None),
+    ) == {ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None)}
+
+    assert component_tree.component_tree_dependencies.get_direct_load_dependencies_of_component(
+        component_tree.defs_module_path,
+        ComponentPath(file_path=Path("."), instance_key=None),
+    ) == {
+        ComponentPath(file_path=Path("single_file"), instance_key=None),
+        ComponentPath(file_path=Path("__init__.py"), instance_key=None),
+    }
+
     assert {spec.key for spec in defs.resolve_all_asset_specs()} == {dg.AssetKey("an_asset")}
     assert (
         component_tree.to_string_representation()


### PR DESCRIPTION
## Summary

Adds a new field to `ComponentTree` which tracks component-component dependencies, which we can use down the line to power partial reloading.

```python
assert component_tree.component_tree_dependencies.get_direct_load_dependents_of_component(
    component_tree.defs_module_path,
    ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None),
) == {ComponentPath(file_path=Path("single_file"), instance_key=None)}


assert component_tree.component_tree_dependencies.get_direct_load_dependents_of_component(
    component_tree.defs_module_path,
    ComponentPath(file_path=Path("single_file"), instance_key=None),
) == {ComponentPath(file_path=Path("."), instance_key=None)}
```

## Test Plan

Unit test.