### PR TITLE
Remove yaml-based erorrs

### DIFF
--- a/python_modules/automation/automation_tests/dagster_docs_tests/test_known_valid_symbols.py
+++ b/python_modules/automation/automation_tests/dagster_docs_tests/test_known_valid_symbols.py
@@ -29,11 +29,6 @@ SYMBOL_EXCLUDE_LIST = {
     "dagster.config_mapping",  # Module resolution error
     "dagster.configured",  # Module resolution error
     "dagster.scaffold_with",  # Module resolution error
-    # Components with YAML code snippets that should use .. code-block:: yaml instead
-    "dagster.Component",  # Contains literal YAML with "attributes:" that gets flagged as section header
-    "dagster.DefsFolderComponent",  # Contains literal YAML with "attributes:" that gets flagged as section header
-    "dagster.PythonScriptComponent",  # Contains literal YAML with "attributes:" that gets flagged as section header
-    "dagster.UvRunComponent",  # Contains literal YAML with "attributes:" that gets flagged as section header
     # Invalid section headers that need to be fixed
     "dagster.ExecuteInProcessResult",  # Invalid section header: "This object is returned by:" should be restructured
     "dagster.asset_check",  # Invalid section header: "Example with a DataFrame Output:" should be "Examples:"

--- a/python_modules/dagster/dagster/components/lib/executable_component/python_script_component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/python_script_component.py
@@ -27,14 +27,14 @@ class PythonScriptComponent(ExecutableComponent):
     Accepts a path to a Python script which will be executed in a dagster-pipes subprocess using your installed `python` executable.
 
     Examples:
-    ```yaml
-    type: dagster.PythonScriptComponent
-    attributes:
-      execution:
-        path: update_table.py
-      assets:
-        - key: my_table
-    ```
+        .. code-block:: yaml
+
+            type: dagster.PythonScriptComponent
+            attributes:
+              execution:
+                path: update_table.py
+              assets:
+                - key: my_table
     """
 
     execution: ScriptSpec

--- a/python_modules/dagster/dagster/components/lib/executable_component/uv_run_component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/uv_run_component.py
@@ -27,14 +27,14 @@ class UvRunComponent(ExecutableComponent):
     Accepts a path to a Python script which will be executed in a dagster-pipes subprocess using the `uv run` command.
 
     Example:
-    ```yaml
-    type: dagster.UvRunComponent
-    attributes:
-      execution:
-        path: update_table.py
-      assets:
-        - key: my_table
-    ```
+        .. code-block:: yaml
+
+            type: dagster.UvRunComponent
+            attributes:
+              execution:
+                path: update_table.py
+              assets:
+                - key: my_table
     """
 
     execution: ScriptSpec


### PR DESCRIPTION
## Summary & Motivation

Now that we skip code-blocks for section header checks we can remove from exclude list

Updated the YAML code snippets in component documentation to use proper reStructuredText syntax. Changed the format from triple backticks (```yaml) to the proper Sphinx directive (.. code-block:: yaml) in PythonScriptComponent and UvRunComponent classes. Also removed the corresponding entries from the test_known_valid_symbols.py exclusion list since they no longer need to be excluded.

## How I Tested These Changes

Verified that the documentation renders correctly with the new format and confirmed that the tests pass without the exclusions in the test file.
