### PR TITLE
Issue 29914

### DIFF
--- a/python_modules/dagster/dagster/_core/loguru_bridge.py
+++ b/python_modules/dagster/dagster/_core/loguru_bridge.py
@@ -9,28 +9,35 @@ from loguru import logger
 
 
 class InterceptHandler(logging.Handler):
-    """Forwards standard logging records to Loguru."""
+    """Forwards standard Python logging records to the Loguru sink.
+    Any log emitted by the 'logging' module will be intercepted and reformatted.
+    """
 
     def emit(self, record: logging.LogRecord) -> None:
+        # Retrieve the Loguru level name corresponding to the record's level number.
         try:
             level = logger.level(record.levelname).name
         except ValueError:
             level = record.levelno
 
+        # Find the frame that originated the log call to preserve correct stack information.
         frame, depth = logging.currentframe(), 2
         while frame and frame.f_code.co_filename == logging.__file__:
             frame = frame.f_back
             depth += 1
 
+        # Forward the log to Loguru, preserving exception info and correct depth.
         logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
 
 
-# This line runs on module import, patching the root logger to use our handler.
+# This line runs once on module import, patching the root logger to use our handler.
 logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
 
 
 class LoguruConfigurator:
-    """Configures the Loguru sink with rich defaults, overridable by environment variables."""
+    """Configures the Loguru sink with rich defaults that can be overridden by environment variables.
+    Uses a singleton pattern to ensure it only runs once per process.
+    """
 
     _initialized = False
 
@@ -44,16 +51,16 @@ class LoguruConfigurator:
 
     @classmethod
     def reset(cls) -> None:
-        """Reset the initialization state, primarily for testing purposes."""
+        """Resets the initialization state, primarily for testing purposes."""
         cls._initialized = False
 
     @classmethod
     def is_initialized(cls) -> bool:
-        """Check if the LoguruConfigurator has been initialized."""
+        """Checks if the configurator has been initialized."""
         return cls._initialized
 
     def load_config(self) -> dict[str, Any]:
-        """Loads configuration from environment variables, with sensible defaults."""
+        """Loads configuration from environment variables, providing sensible defaults."""
         default_format = (
             "<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | "
             "<cyan>{name}:{function}:{line}</cyan> - <level>{message}</level>"
@@ -65,33 +72,36 @@ class LoguruConfigurator:
         }
 
     def setup_sinks(self) -> None:
-        """Sets up the final Loguru sink to stderr."""
+        """Sets up the final Loguru sink, typically to stderr for the terminal and Dagster UI."""
         if self.config.get("enabled", False):
-            logger.remove()  # only clear sinks if Loguru logging is enabled
+            logger.remove()  # Clear any existing sinks to ensure a single, consistent output.
             logger.add(
                 sys.stderr,
                 level=self.config["log_level"],
                 format=self.config["format"],
-                colorize=True,
+                colorize=True,  # Loguru automatically disables color for non-TTY outputs.
             )
 
-    # Keep backward compatibility for tests that might still use the private methods
+    # Alias private methods for backward compatibility with older tests.
     _load_config = load_config
     _setup_sinks = setup_sinks
 
 
-# Initialize the default sink configuration when the module is first imported.
+# Initialize the default sink configuration when this module is first imported.
 loguru_config = LoguruConfigurator()
 
 
 def dagster_context_sink(context: Any) -> Callable[[Any], None]:
-    """Creates a Loguru sink that forwards logs to a Dagster context-aware logger."""
+    """Creates a Loguru sink that forwards logs to a Dagster context's logger.
+    This is useful in tests or specific scenarios where logs need to be
+    channeled through a mock or real 'context.log' object.
+    """
 
     def sink(message: Any) -> None:
         record = message.record
         level = record["level"].name
         msg = record["message"]
-        extras = record["extra"] if isinstance(record.get("extra"), dict) else {}
+        extras = record.get("extra", {})
 
         level_map = {
             "TRACE": "debug",
@@ -102,17 +112,16 @@ def dagster_context_sink(context: Any) -> Callable[[Any], None]:
             "ERROR": "error",
             "CRITICAL": "critical",
         }
-
         log_method_name = level_map.get(level, "info")
 
-        # Fallback if context or log method is missing
-        if not context or not hasattr(context, "log"):
+        if not (context and hasattr(context, "log")):
             return
 
         log_method = getattr(context.log, log_method_name, None)
         if not callable(log_method):
             return
-
+        # Introspect the log method to see if it accepts **kwargs.
+        # This makes the sink robust against different logger implementations.
         try:
             sig = inspect.signature(log_method)
             if any(p.kind == p.VAR_KEYWORD for p in sig.parameters.values()):
@@ -120,7 +129,7 @@ def dagster_context_sink(context: Any) -> Callable[[Any], None]:
             else:
                 log_method(msg)
         except Exception:
-            # best-effort fallback
+            # Fallback to a simple call if inspection fails.
             log_method(msg)
 
     return sink
@@ -128,8 +137,7 @@ def dagster_context_sink(context: Any) -> Callable[[Any], None]:
 
 def with_loguru_logger(fn: Callable) -> Callable:
     """Decorator that patches 'context.log' methods to redirect to 'loguru.logger'.
-    This ensures that calls like 'context.log.info()' within an asset are also
-    formatted by Loguru, providing a completely unified logging experience.
+    This provides a completely unified logging experience and is async-aware.
     """
 
     @wraps(fn)
@@ -137,44 +145,62 @@ def with_loguru_logger(fn: Callable) -> Callable:
         context = kwargs.get("context", None)
         if context is None and args and hasattr(args[0], "log"):
             context = args[0]
-
         if not (context and hasattr(context, "log")):
             return fn(*args, **kwargs)
 
-        # Save original context.log methods to restore them later.
         original_log_methods = {
             name: getattr(context.log, name)
             for name in ["debug", "info", "warning", "error", "critical"]
+            if hasattr(context.log, name)  # This check makes it robust against simple mocks.
         }
 
-        # Create proxy functions that forward calls to loguru.logger AND call the original method.
-        def make_proxy(level: str, original_method: Callable):
-            def proxy_fn(msg: str, *p_args, **p_kwargs) -> None:
-                logger.opt(depth=1).log(level, msg)
-
-                try:
-                    original_method(msg, *p_args, **p_kwargs)
-                except TypeError:
-                    original_method(msg, *p_args)
+        def make_proxy(level: str) -> Callable:
+            def proxy_fn(msg: str, *p_args: Any, **p_kwargs: Any) -> None:
+                logger.bind(**p_kwargs).opt(depth=1).log(level, msg.format(*p_args))
 
             return proxy_fn
 
-        # Replace context.log methods with our proxies.
-        for name, lvl in {
-            "debug": "DEBUG",
-            "info": "INFO",
-            "warning": "WARNING",
-            "error": "ERROR",
-            "critical": "CRITICAL",
-        }.items():
-            original = original_log_methods[name]
-            setattr(context.log, name, make_proxy(lvl, original))
+        for name in original_log_methods:
+            lvl = name.upper()
+            setattr(context.log, name, make_proxy(lvl))
 
         try:
             return fn(*args, **kwargs)
         finally:
-            # Restore the original context.log methods after execution.
             for name, orig in original_log_methods.items():
                 setattr(context.log, name, orig)
 
-    return wrapper
+    if inspect.iscoroutinefunction(fn):
+
+        @wraps(fn)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            context = kwargs.get("context", None)
+            if context is None and args and hasattr(args[0], "log"):
+                context = args[0]
+            if not (context and hasattr(context, "log")):
+                return await fn(*args, **kwargs)
+
+            original_log_methods = {
+                name: getattr(context.log, name)
+                for name in ["debug", "info", "warning", "error", "critical"]
+                if hasattr(context.log, name)
+            }
+
+            def make_proxy(level: str) -> Callable:
+                def proxy_fn(msg: str, *p_args: Any, **p_kwargs: Any) -> None:
+                    logger.bind(**p_kwargs).opt(depth=1).log(level, msg.format(*p_args))
+
+                return proxy_fn
+
+            for name in original_log_methods:
+                lvl = name.upper()
+                setattr(context.log, name, make_proxy(lvl))
+            try:
+                return await fn(*args, **kwargs)
+            finally:
+                for name, orig in original_log_methods.items():
+                    setattr(context.log, name, orig)
+
+        return async_wrapper
+    else:
+        return wrapper

--- a/python_modules/dagster/dagster/_core/loguru_bridge.py
+++ b/python_modules/dagster/dagster/_core/loguru_bridge.py
@@ -107,7 +107,7 @@ def dagster_context_sink(context: Any) -> Callable[[Any], None]:
 
         log_method = getattr(context.log, log_method_name, None)
 
-        # Context veya log metodu yoksa fallback
+        # Fallback if context or log method is missing  
         if not context or not hasattr(context, "log") or not callable(log_method):
             return
 

--- a/python_modules/dagster/dagster/_core/loguru_bridge.py
+++ b/python_modules/dagster/dagster/_core/loguru_bridge.py
@@ -1,0 +1,144 @@
+import logging
+import os
+import sys
+from functools import wraps
+from typing import Any, Callable
+
+from loguru import logger
+
+
+class InterceptHandler(logging.Handler):
+    """Forwards standard logging records to Loguru."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        frame, depth = logging.currentframe(), 2
+        while frame and frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+
+        logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+
+
+# This line runs on module import, patching the root logger to use our handler.
+logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
+
+
+class LoguruConfigurator:
+    """Configures the Loguru sink with rich defaults, overridable by environment variables."""
+
+    _initialized = False
+
+    def __init__(self, enable_terminal_sink: bool = True):
+        if LoguruConfigurator._initialized:
+            return
+        self.config = self._load_config()
+        if enable_terminal_sink:
+            self._setup_sinks()
+        LoguruConfigurator._initialized = True
+
+    def _load_config(self) -> dict[str, Any]:
+        """Loads configuration from environment variables, with sensible defaults."""
+        default_format = (
+            "<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | "
+            "<cyan>{name}:{function}:{line}</cyan> - <level>{message}</level>"
+        )
+        return {
+            "enabled": os.getenv("DAGSTER_LOGURU_ENABLED", "true").lower() in ("true", "1", "yes"),
+            "log_level": os.getenv("DAGSTER_LOGURU_LOG_LEVEL", "DEBUG"),
+            "format": os.getenv("DAGSTER_LOGURU_FORMAT", default_format),
+        }
+
+    def _setup_sinks(self) -> None:
+        """Sets up the final Loguru sink to stderr."""
+        if not self.config.get("enabled", False):
+            return
+        logger.remove()
+        logger.add(
+            sys.stderr,
+            level=self.config["log_level"],
+            format=self.config["format"],
+            colorize=True,
+        )
+
+
+# Initialize the default sink configuration when the module is first imported.
+loguru_config = LoguruConfigurator()
+
+
+def dagster_context_sink(context: Any) -> Callable[[Any], None]:
+    """Creates a Loguru sink that forwards formatted messages to the Dagster log manager.
+    Useful for capturing 'logger' calls and displaying them in the Dagster UI.
+    """
+
+    def sink(message: Any) -> None:
+        record = message.record
+        level = record["level"].name
+        msg = record["message"]
+
+        level_map = {
+            "TRACE": "debug",
+            "DEBUG": "debug",
+            "INFO": "info",
+            "SUCCESS": "info",
+            "WARNING": "warning",
+            "ERROR": "error",
+            "CRITICAL": "critical",
+        }
+        log_method_name = level_map.get(level, "info")
+        log_method = getattr(context.log, log_method_name, context.log.info)
+        log_method(msg)
+
+    return sink
+
+
+def with_loguru_logger(fn: Callable) -> Callable:
+    """Decorator that patches 'context.log' methods to redirect to 'loguru.logger'.
+    This ensures that calls like 'context.log.info()' within an asset are also
+    formatted by Loguru, providing a completely unified logging experience.
+    """
+
+    @wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        context = kwargs.get("context", None)
+        if context is None and args and hasattr(args[0], "log"):
+            context = args[0]
+
+        if not (context and hasattr(context, "log")):
+            return fn(*args, **kwargs)
+
+        # Save original context.log methods to restore them later.
+        original_log_methods = {
+            name: getattr(context.log, name)
+            for name in ["debug", "info", "warning", "error", "critical"]
+        }
+
+        # Create proxy functions that forward calls to loguru.logger.
+        def make_proxy(level: str) -> Callable[[str], None]:
+            def proxy_fn(msg: str) -> None:
+                logger.opt(depth=1).log(level, msg)
+
+            return proxy_fn
+
+        # Replace context.log methods with our proxies.
+        for name, lvl in {
+            "debug": "DEBUG",
+            "info": "INFO",
+            "warning": "WARNING",
+            "error": "ERROR",
+            "critical": "CRITICAL",
+        }.items():
+            setattr(context.log, name, make_proxy(lvl))
+
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            # Restore the original context.log methods after execution.
+            for name, orig in original_log_methods.items():
+                setattr(context.log, name, orig)
+
+    return wrapper

--- a/python_modules/dagster/dagster/_core/loguru_bridge.py
+++ b/python_modules/dagster/dagster/_core/loguru_bridge.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 
 from loguru import logger
 
+
 class InterceptHandler(logging.Handler):
     """Forwards standard logging records to Loguru."""
 
@@ -90,7 +91,7 @@ def dagster_context_sink(context: Any) -> Callable[[Any], None]:
         record = message.record
         level = record["level"].name
         msg = record["message"]
-        extras = record["extra"] or {}
+        extras = record["extra"] if isinstance(record.get("extra"), dict) else {}
 
         level_map = {
             "TRACE": "debug",

--- a/python_modules/dagster/dagster/_core/loguru_bridge.py
+++ b/python_modules/dagster/dagster/_core/loguru_bridge.py
@@ -7,7 +7,6 @@ from typing import Any, Callable
 
 from loguru import logger
 
-
 class InterceptHandler(logging.Handler):
     """Forwards standard logging records to Loguru."""
 
@@ -148,12 +147,14 @@ def with_loguru_logger(fn: Callable) -> Callable:
         }
 
         # Create proxy functions that forward calls to loguru.logger AND call the original method.
-        def make_proxy(level: str, original_method: Callable) -> Callable[[str], None]:
+        def make_proxy(level: str, original_method: Callable):
             def proxy_fn(msg: str, *p_args, **p_kwargs) -> None:
-                # Forward to loguru.logger
                 logger.opt(depth=1).log(level, msg)
-                # Also call the original method to maintain original behavior
-                original_method(msg, *p_args, **p_kwargs)
+
+                try:
+                    original_method(msg, *p_args, **p_kwargs)
+                except TypeError:
+                    original_method(msg, *p_args)
 
             return proxy_fn
 

--- a/python_modules/dagster/dagster_tests/logging_tests/test_bridge.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_bridge.py
@@ -1,0 +1,367 @@
+import logging
+import os
+import sys
+import threading
+import time
+
+import pytest
+from dagster._core.loguru_bridge import (
+    InterceptHandler,
+    LoguruConfigurator,
+    dagster_context_sink,
+    with_loguru_logger,
+)
+from loguru import logger
+
+root_dir = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+sys.path.insert(0, root_dir)
+sys.path.insert(0, os.path.join(root_dir, "python_modules"))
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass  # dotenv is optional
+
+
+class MockLogHandler:
+    """A mock log handler that prints (for capfd tests) and stores log messages."""
+
+    def __init__(self):
+        self.history = []
+
+    def debug(self, msg):
+        print(f"[dagster.debug] {msg}")  # noqa: T201
+        self.history.append({"level": "debug", "message": msg})
+
+    def info(self, msg):
+        print(f"[dagster.info] {msg}")  # noqa: T201
+        self.history.append({"level": "info", "message": msg})
+
+    def warning(self, msg):
+        print(f"[dagster.warning] {msg}")  # noqa: T201
+        self.history.append({"level": "warning", "message": msg})
+
+    def error(self, msg):
+        print(f"[dagster.error] {msg}")  # noqa: T201
+        self.history.append({"level": "error", "message": msg})
+
+    def critical(self, msg):
+        print(f"[dagster.critical] {msg}")  # noqa: T201
+        self.history.append({"level": "critical", "message": msg})
+
+
+class MockDagsterContext:
+    """Simulates Dagster's context.log interface using the MockLogHandler."""
+
+    def __init__(self):
+        self.log = MockLogHandler()
+
+
+class DagsterOperations:
+    """A collection of mock operations to test the decorator."""
+
+    def __init__(self, context):
+        self._context = context
+
+    @with_loguru_logger
+    def successful_op(self, context=None):
+        logger.info("Operation completed successfully!")
+        return True
+
+    @with_loguru_logger
+    def failing_op(self, context=None):
+        logger.error("Operation failed!")
+        raise ValueError("Operation failed")
+
+    @with_loguru_logger
+    def complex_op(self, context=None):
+        logger.debug("Starting complex...")
+        logger.info("Processing...")
+        logger.warning("High usage")
+        logger.success("Done")
+
+
+class DagsterTestContext:
+    """Helper class to bundle a mock context and operations for tests."""
+
+    def __init__(self):
+        self.context = MockDagsterContext()
+        self.test_ops = DagsterOperations(self.context)
+
+
+# --- Step 4: Pytest Fixtures ---
+
+
+@pytest.fixture
+def setup_logger():
+    """Fixture to setup and cleanup a standard logger for each test."""
+    logger.remove()
+
+    def test_formatter(record):
+        level_name = record["level"].name.lower()
+        if level_name == "success":
+            level_name = "info"
+        return f"[dagster.{level_name}] {record['message']}\n"
+
+    handler_id = logger.add(
+        lambda msg: print(test_formatter(msg.record), end=""),  # noqa: T201
+        level="TRACE",
+    )
+    yield
+    try:
+        logger.remove(handler_id)
+    except ValueError:
+        pass
+
+
+# --- Step 5: The Full Suite of Tests, Corrected and Ruff-Compliant ---
+
+
+def test_dagster_context_sink_basic_logging(capfd, setup_logger):
+    context = MockDagsterContext()
+    sink = dagster_context_sink(context)
+    logger.remove()
+    logger.add(sink, level="DEBUG")
+    logger.debug("Debug message")
+    captured = capfd.readouterr()
+    assert "[dagster.debug] Debug message" in captured.out
+
+
+def test_dagster_context_sink_with_structured_logging(capfd, setup_logger):
+    context = MockDagsterContext()
+    sink = dagster_context_sink(context)
+    logger.remove()
+    logger.add(sink, level="DEBUG")
+    logger.bind(user="test").info("User login attempt")
+    captured = capfd.readouterr()
+    assert "[dagster.info] User login attempt" in captured.out
+
+
+def test_dagster_context_sink_different_log_levels(capfd, setup_logger):
+    context = MockDagsterContext()
+    sink = dagster_context_sink(context)
+    logger.remove()
+    logger.add(sink, level="TRACE")
+    logger.critical("Critical message")
+    captured = capfd.readouterr()
+    assert "[dagster.critical] Critical message" in captured.out
+
+
+def test_with_loguru_logger_decorator_success(capfd, setup_logger):
+    context = MockDagsterContext()
+    DagsterOperations(context).successful_op()
+    captured = capfd.readouterr()
+    assert "[dagster.info] Operation completed successfully!" in captured.out
+
+
+def test_with_loguru_logger_decorator_failure(capfd, setup_logger):
+    context = MockDagsterContext()
+    with pytest.raises(ValueError):
+        DagsterOperations(context).failing_op()
+    captured = capfd.readouterr()
+    assert "[dagster.error] Operation failed!" in captured.out
+
+
+def test_with_loguru_logger_decorator_complex(capfd, setup_logger):
+    context = MockDagsterContext()
+    DagsterOperations(context).complex_op()
+    captured = capfd.readouterr()
+    assert "[dagster.debug] Starting complex..." in captured.out
+    assert "[dagster.info] Processing..." in captured.out
+    assert "[dagster.warning] High usage" in captured.out
+    assert "[dagster.info] Done" in captured.out
+
+
+def test_mixed_logging_systems(capfd, setup_logger):
+    context = MockDagsterContext()
+
+    @with_loguru_logger
+    def op(context=None):
+        context.log.info("Direct Dagster")
+        logger.info("Loguru log")
+
+    op(context=context)
+    captured = capfd.readouterr()
+    assert "[dagster.info] Direct Dagster" in captured.out
+    assert "[dagster.info] Loguru log" in captured.out
+
+
+def test_nested_operations_logging(capfd, setup_logger):
+    test_ctx = DagsterTestContext()
+
+    @with_loguru_logger
+    def op(context=None):
+        logger.info("Outer start")
+        test_ctx.test_ops.complex_op()
+        logger.info("Outer end")
+
+    op(context=test_ctx.context)
+    captured = capfd.readouterr()
+    assert "[dagster.info] Outer start" in captured.out
+    assert "[dagster.debug] Starting complex..." in captured.out
+    assert "[dagster.info] Outer end" in captured.out
+
+
+def test_exception_handling_with_logging(capfd, setup_logger):
+    context = MockDagsterContext()
+
+    @with_loguru_logger
+    def op(context=None):
+        try:
+            raise ValueError("E")
+        except ValueError as e:
+            logger.error(f"Caught: {e}")
+            context.log.error("Also caught")
+
+    op(context=context)
+    captured = capfd.readouterr()
+    assert "[dagster.error] Caught: E" in captured.out
+    assert "[dagster.error] Also caught" in captured.out
+
+
+def test_structured_logging_with_context(capfd, setup_logger):
+    context = MockDagsterContext()
+
+    @with_loguru_logger
+    def op(context=None):
+        logger.bind(id=1).info("Structured")
+
+    op(context=context)
+    captured = capfd.readouterr()
+    assert "[dagster.info] Structured" in captured.out
+
+
+def test_log_level_inheritance(capfd):
+    logger.remove()
+    logger.add(sys.stdout, level="INFO", format="{message}")
+    logger.debug("Hidden")
+    logger.info("Visible")
+    captured = capfd.readouterr()
+    assert "Hidden" not in captured.out
+    assert "Visible" in captured.out
+
+
+def test_concurrent_operations_logging():
+    log_messages = []
+    logger.remove()
+    logger.add(log_messages.append, level="INFO")
+
+    @with_loguru_logger
+    def op(op_id, context=None):
+        logger.info(f"Run {op_id}")
+
+    threads = [threading.Thread(target=op, args=(i, MockDagsterContext())) for i in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    full_log = "".join(log_messages)
+    assert "Run 0" in full_log and "Run 1" in full_log and "Run 2" in full_log
+
+
+def test_log_formatting_consistency(capfd, setup_logger):
+    @with_loguru_logger
+    def op(context=None):
+        logger.info("Hello {}", "World")
+
+    op(context=MockDagsterContext())
+    captured = capfd.readouterr()
+    assert "[dagster.info] Hello World" in captured.out
+
+
+def test_error_context_preservation(capfd, setup_logger):
+    context = MockDagsterContext()
+
+    @with_loguru_logger
+    def op(context=None):
+        try:
+            raise RuntimeError("E")
+        except RuntimeError:
+            logger.exception("Caught")
+
+    op(context=context)
+    captured = capfd.readouterr()
+    assert "[dagster.error] Caught" in captured.out
+
+
+def test_loguru_configurator_initialization(monkeypatch):
+    monkeypatch.setenv("DAGSTER_LOGURU_ENABLED", "false")
+    LoguruConfigurator._initialized = False  # noqa: SLF001
+    configurator = LoguruConfigurator(enable_terminal_sink=False)
+    assert not configurator.config["enabled"]
+
+
+def test_dagster_handler_logging():
+    log_messages = []
+    logger.remove()
+    logger.add(log_messages.append, level="DEBUG", format="{message}")
+
+    test_logger = logging.getLogger("isolated_test_logger")
+    test_logger.setLevel(logging.DEBUG)
+    test_logger.propagate = False
+
+    test_logger.addHandler(InterceptHandler())
+
+    test_logger.warning("From isolated python logging")
+
+    assert any("From isolated python logging" in msg for msg in log_messages)
+
+
+def test_loguru_bridge_integration_with_dagster_context(capfd, setup_logger):
+    context = MockDagsterContext()
+
+    @with_loguru_logger
+    def op(context=None):
+        logger.info("Integrated")
+
+    op(context=context)
+    captured = capfd.readouterr()
+    assert "[dagster.info] Integrated" in captured.out
+
+
+def test_loguru_bridge_performance():
+    context = MockDagsterContext()
+    sink = dagster_context_sink(context)
+    logger.remove()
+    logger.add(sink, level="INFO")
+    start = time.time()
+    for _ in range(100):
+        logger.info("Perf msg")
+    duration = time.time() - start
+    assert duration < 1.0
+
+
+def test_loguru_bridge_with_stdout_integration(capfd, setup_logger):
+    @with_loguru_logger
+    def op(context=None):
+        print("to stdout")  # noqa: T201
+        logger.info("to loguru")
+        print("to stderr", file=sys.stderr)  # noqa: T201
+
+    op(context=MockDagsterContext())
+    captured = capfd.readouterr()
+    assert "to stdout" in captured.out
+    assert "[dagster.info] to loguru" in captured.out
+    assert "to stderr" in captured.err
+
+
+def test_direct_loguru_usage(capfd, setup_logger):
+    logger.info("Direct usage")
+    captured = capfd.readouterr()
+    assert "[dagster.info] Direct usage" in captured.out
+
+
+def test_context_log_with_loguru_decorator(capfd, setup_logger):
+    context = MockDagsterContext()
+
+    @with_loguru_logger
+    def op(context=None):
+        context.log.info("From context.log")
+
+    op(context=context)
+    captured = capfd.readouterr()
+    assert "[dagster.info] From context.log" in captured.out

--- a/python_modules/dagster/dagster_tests/logging_tests/test_bridge.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_bridge.py
@@ -330,7 +330,7 @@ def test_loguru_bridge_performance():
     logger.add(sink, level="INFO")
     start = time.time()
     for _ in range(100):
-        logger.info("Perf msg")
+        logger.info("Perf message")
     duration = time.time() - start
     assert duration < 1.0
 

--- a/python_modules/dagster/dagster_tests/logging_tests/test_bridge.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_bridge.py
@@ -577,6 +577,7 @@ def test_intercept_handler_forwards(capfd):
     finally:
         logger.remove(handler_id)
 
+
 def test_with_loguru_logger_restores_on_exception():
     ctx = MockDagsterContext()
 


### PR DESCRIPTION
## 🧩 Summary & Motivation

This PR introduces a robust logging bridge between Dagster’s internal logging system ('context.log') and the Loguru logging framework.  
While working on **Issue #29914**, we were investigating inconsistencies and limitations in how logs appeared across Dagster’s UI and terminal output.

During this process, we traced the behavior of 'context.log' to 'log_manager.py', which ultimately led to the idea of placing a dedicated 'loguru_bridge.py' module in 'dagster/_core/'.  
This placement ensures the bridge lives as close as possible to Dagster's logging heart, making it efficient and context-aware.

The goal: bring cleaner, consistent, colored logs—without modifying user code or Dagster internals.  
The solution seamlessly connects 'context.log', Loguru, and third-party 'logging' messages.

---

## 🧪 How We Tested These Changes

- ✅ Verified colored Loguru output from 'context.log.*' inside Dagster assets using the new decorator.
- ✅ Confirmed that logs appear identically in:
  - Dagster Cloud UI ('stderr')
  - Terminal logs (including Docker containers)
- ✅ Ensured no duplicate messages, recursion, or lost output.
- ✅ Tested fallback behavior when context is missing (no crash).
- ✅ Used both Loguru and native logging calls in parallel to confirm interception.

---

## 🔗 Interactive Preview

You can explore the full story, reasoning, and code in this Google Colab-compatible notebook:

👉 **[Open Colab: Dagster + Loguru Integration Walkthrough](https://colab.research.google.com/drive/1rmhbHY9R_P-9CgbGvhXQAHaPsbUpjPov?usp=sharing)** 

---

## 🧾 Changelog

```markdown
- Added 'loguru_bridge.py' to handle Loguru integration with Dagster’s 'context.log'
- Implemented 'InterceptHandler' to route standard logging to Loguru
- Introduced 'with_loguru_logger' decorator to forward context logs to Loguru dynamically

