### PR TITLE
Disable retries for deterministic, reproducable tests

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -83,7 +83,10 @@ def build_dagster_steps() -> list[StepConfiguration]:
 
 def build_repo_wide_ruff_steps() -> list[CommandStepConfiguration]:
     return [
-        add_test_image(CommandStepBuilder(":zap: ruff"), AvailablePythonVersion.get_default())
+        add_test_image(
+            CommandStepBuilder(":zap: ruff", retry_automatically=False),
+            AvailablePythonVersion.get_default(),
+        )
         .run(
             "pip install -e python_modules/dagster[ruff] -e python_modules/dagster-pipes -e python_modules/libraries/dagster-shared",
             "make check_ruff",
@@ -96,7 +99,7 @@ def build_repo_wide_ruff_steps() -> list[CommandStepConfiguration]:
 def build_repo_wide_prettier_steps() -> list[CommandStepConfiguration]:
     return [
         add_test_image(
-            CommandStepBuilder(":prettier: prettier"),
+            CommandStepBuilder(":prettier: prettier", retry_automatically=False),
             AvailablePythonVersion.get_default(),
         )
         .run(
@@ -130,7 +133,7 @@ def build_repo_wide_pyright_steps() -> list[StepConfiguration]:
             name=":pyright: pyright",
             steps=[
                 add_test_image(
-                    CommandStepBuilder(":pyright: make pyright"),
+                    CommandStepBuilder(":pyright: make pyright", retry_automatically=False),
                     AvailablePythonVersion.get_default(),
                 )
                 .run(
@@ -144,7 +147,9 @@ def build_repo_wide_pyright_steps() -> list[StepConfiguration]:
                 .skip_if(skip_if_no_python_changes(overrides=["pyright"]))
                 .build(),
                 add_test_image(
-                    CommandStepBuilder(":pyright: make rebuild_pyright_pins"),
+                    CommandStepBuilder(
+                        ":pyright: make rebuild_pyright_pins", retry_automatically=False
+                    ),
                     AvailablePythonVersion.get_default(),
                 )
                 .run(

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
@@ -43,7 +43,7 @@ def build_build_docs_step():
 def build_docstring_validation_step() -> GroupLeafStepConfiguration:
     return (
         add_test_image(
-            CommandStepBuilder(":memo: docstring validation"),
+            CommandStepBuilder(":memo: docstring validation", retry_automatically=False),
             AvailablePythonVersion.get_default(),
         )
         .run(

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -634,6 +634,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: list[PackageSpec] = [
         # test suite also installs a ton of packages in the same environment, which is liable to
         # cause dependency collisions.
         unsupported_python_versions=AvailablePythonVersion.get_all_except_default(),
+        retries=0,
     ),
     PackageSpec("python_modules/dagster-webserver", pytest_extra_cmds=ui_extra_cmds),
     PackageSpec(


### PR DESCRIPTION
## Summary & Motivation

These tests don't fail non-deterministically except getting a node interrupted or something, which in practice don't see too much AFAIK.

BK will fail faster, which in this case is good as it reduces dev feedback loops

## How I Tested These Changes

Injected ruff error. Pushed [build](https://buildkite.com/dagster/dagster-dagster/builds/130036/steps/canvas?sid=0198656b-4df7-4444-877a-0746e077dd7f). Saw no retries