### PR TITLE
[docs] fixes some grammatical errors throughout the docs

### DIFF
--- a/docs/docs/etl-pipeline-tutorial/6-create-a-sensor.md
+++ b/docs/docs/etl-pipeline-tutorial/6-create-a-sensor.md
@@ -15,7 +15,7 @@ Consider using sensors in the following situations:
 
 In this step you will:
 
-- Create an asset that runs based on a event-driven workflow
+- Create an asset that runs based on an event-driven workflow
 - Create a sensor to listen for conditions to materialize the asset
 
 ## 1. Create an event-driven asset

--- a/docs/docs/examples/retrieval-augmented-generation.md
+++ b/docs/docs/examples/retrieval-augmented-generation.md
@@ -13,7 +13,7 @@ tags: [reference-architecture]
 
 ## Objective
 
-Build a retrieval-augmented generation (RAG) system that extracts data from GitHub using the GitHub API. The extracted content is stored in a vector database (Weaviate) to enable efficient semantic search. When a user submits a question through an asset at run time, relevant context is retrieved from Weaviate and passed to OpenAI to generate a response grounded in the source material.
+Build a retrieval-augmented generation (RAG) system that extracts data from GitHub using the GitHub API. The extracted content is stored in a vector database (Weaviate) to enable efficient semantic search. When a user submits a question through an asset at runtime, relevant context is retrieved from Weaviate and passed to OpenAI to generate a response grounded in the source material.
 
 ## Architecture
 

--- a/docs/docs/guides/monitor/logging/custom-logging.md
+++ b/docs/docs/guides/monitor/logging/custom-logging.md
@@ -38,7 +38,7 @@ The following example shows how to add the custom logger to your code location d
 
 ### Add the custom logger to your ops-based jobs
 
-Configuring a ops job to use the custom logger slightly differs from the asset job example. The following example shows how:
+Configuring an ops job to use the custom logger slightly differs from the asset job example. The following example shows how:
 
 <CodeExample
   path="docs_snippets/docs_snippets/guides/monitor-alert/custom-logging/ops-job-example.py"

--- a/docs/docs/guides/operate/configuration/run-configuration.md
+++ b/docs/docs/guides/operate/configuration/run-configuration.md
@@ -40,7 +40,7 @@ Here, we define a basic asset in `assets.py` and its configurable parameters in 
 </TabItem>
 <TabItem value="Using ops and jobs">
 
-Here, we define a basic op in `ops.py` and its configurable parameters in `resources.py`. `MyOpConfig` is a subclass of <PyObject section="config" module="dagster" object="Config"/> that holds a single string value representing the name of a user. This config can be accessed through the `config` parameter in the asset body:
+Here, we define a basic op in `ops.py` and its configurable parameters in `resources.py`. `MyOpConfig` is a subclass of <PyObject section="config" module="dagster" object="Config"/> that holds a single string value representing the name of a user. This config can be accessed through the `config` parameter in the op body:
 
 <CodeExample
   path="docs_snippets/docs_snippets/guides/operate/configuration/run_config/op_example/ops.py"

--- a/docs/docs/guides/operate/run-executors.md
+++ b/docs/docs/guides/operate/run-executors.md
@@ -52,16 +52,16 @@ Executing a job via <PyObject section="jobs" module="dagster" object="JobDefinit
 
 ## Example executors
 
-| Name                                                                                            | Description                                                                                                           |
-| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| <PyObject section="execution" module="dagster" object="in_process_executor" />                  | Execution plan executes serially within the run worker itself.                                                        |
-| <PyObject section="execution" module="dagster" object="multiprocess_executor" />                | Executes each step within its own spawned process. Has a configurable level of parallelism.                           |
-| <PyObject section="libraries" module="dagster_dask" object="dask_executor" />                   | Executes each step within a Dask task.                                                                                |
-| <PyObject section="libraries" module="dagster_celery" object="celery_executor" />               | Executes each step within a Celery task.                                                                              |
-| <PyObject section="libraries" module="dagster_docker" object="docker_executor" />               | Executes each step within an ephemeral Kubernetes pod.                                                                |
-| <PyObject section="libraries" module="dagster_k8s" object="k8s_job_executor" />                 | Executes each step within an ephemeral Kubernetes pod.                                                                |
-| <PyObject section="libraries" module="dagster_celery_k8s" object="celery_k8s_job_executor" />   | Executes each step within a ephemeral Kubernetes pod, using Celery as a control plane for prioritization and queuing. |
-| <PyObject section="libraries" module="dagster_celery_docker" object="celery_docker_executor" /> | Executes each step within a Docker container, using Celery as a control plane for prioritization and queueing.        |
+| Name                                                                                            | Description                                                                                                            |
+| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| <PyObject section="execution" module="dagster" object="in_process_executor" />                  | Execution plan executes serially within the run worker itself.                                                         |
+| <PyObject section="execution" module="dagster" object="multiprocess_executor" />                | Executes each step within its own spawned process. Has a configurable level of parallelism.                            |
+| <PyObject section="libraries" module="dagster_dask" object="dask_executor" />                   | Executes each step within a Dask task.                                                                                 |
+| <PyObject section="libraries" module="dagster_celery" object="celery_executor" />               | Executes each step within a Celery task.                                                                               |
+| <PyObject section="libraries" module="dagster_docker" object="docker_executor" />               | Executes each step within an ephemeral Kubernetes pod.                                                                 |
+| <PyObject section="libraries" module="dagster_k8s" object="k8s_job_executor" />                 | Executes each step within an ephemeral Kubernetes pod.                                                                 |
+| <PyObject section="libraries" module="dagster_celery_k8s" object="celery_k8s_job_executor" />   | Executes each step within an ephemeral Kubernetes pod, using Celery as a control plane for prioritization and queuing. |
+| <PyObject section="libraries" module="dagster_celery_docker" object="celery_docker_executor" /> | Executes each step within a Docker container, using Celery as a control plane for prioritization and queueing.         |
 
 ## Custom executors
 

--- a/docs/docs/integrations/guides/multi-asset-integration.md
+++ b/docs/docs/integrations/guides/multi-asset-integration.md
@@ -16,7 +16,7 @@ This guide assumes basic familiarity with Dagster and Python decorators.
 
 ## Step 1: Input
 
-For this guide, let's imagine a tool that replicates data between two databases. It's configured using a `replication.yaml` configuration file, in which a user is able to define source and destination databases, along with the tables that they would like to replicate between these systems.
+For this guide, let's imagine a tool that replicates data between two databases. It's configured using a `replication.yaml` configuration file, in which a user can define source and destination databases, along with the tables that they would like to replicate between these systems.
 
 ```yml
 connections:


### PR DESCRIPTION
## Summary & Motivation

1. Article Usage (a/an/the):
  - docs/docs/guides/monitor/logging/custom-logging.md:41: "Configuring a ops job" → "Configuring an ops job"
  - docs/docs/etl-pipeline-tutorial/6-create-a-sensor.md:18: "based on a event-driven workflow" → "based on an event-driven workflow"
  - docs/docs/guides/operate/run-executors.md:63: "within a ephemeral Kubernetes pod" → "within an ephemeral Kubernetes pod"
2. Subject-Verb Agreement & Consistency:
  - docs/docs/guides/operate/configuration/run-configuration.md:43: Fixed inconsistent terminology - "accessed through the config parameter in the asset body" → "accessed through the config parameter
in the op body" (when discussing ops, not assets)
3. Sentence Structure & Clarity:
  - docs/docs/examples/retrieval-augmented-generation.md:16: "run time" → "runtime" for consistency
  - docs/docs/integrations/guides/multi-asset-integration.md:19: "a user is able to define" → "a user can define" (simplified and more concise)

## How I Tested These Changes

## Changelog

NOCHANGELOG
