### PR TITLE
[mcp] exposes integration marketplace in list_available_integrations tool

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/mcp/server.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/mcp/server.py
@@ -1,12 +1,13 @@
 import subprocess
 from collections.abc import Sequence
+from typing import Optional
 
 from mcp.server.fastmcp import FastMCP
 
 mcp = FastMCP("dagster-dg-cli")
 
 
-def _subprocess(command: Sequence[str], cwd: str | None = None) -> str:
+def _subprocess(command: Sequence[str], cwd: Optional[str] = None) -> str:
     """Execute a subprocess command and return decoded output.
 
     Wrapper around subprocess.check_output that captures both stdout and stderr,

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/mcp/server.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/mcp/server.py
@@ -6,7 +6,7 @@ from mcp.server.fastmcp import FastMCP
 mcp = FastMCP("dagster-dg-cli")
 
 
-def _subprocess(command: Sequence[str], cwd: str) -> str:
+def _subprocess(command: Sequence[str], cwd: str | None = None) -> str:
     """Execute a subprocess command and return decoded output.
 
     Wrapper around subprocess.check_output that captures both stdout and stderr,
@@ -270,6 +270,34 @@ async def list_dagster_definitions(project_path: str) -> str:
             "dg",
             "list",
             "defs",
+            "--json",
+        ],
+        cwd=project_path,
+    )
+
+
+@mcp.tool()
+async def list_available_integrations(project_path: str) -> str:
+    """Retrieve an index of all available Dagster integrations in the marketplace.
+
+    This provides information on integrations in the marketplace that are available for
+    installation. It is a helpful resource for determine which tools are available, and provides
+    context for determining which integration may be relevant when scaffolding components.
+
+    Args:
+        project_path: Absolute filesystem path to the root directory of your Dagster project
+                     (the directory containing pyproject.toml with [tool.dg] or dg.toml).
+
+    Returns:
+        JSON-formatted metadata about all integrations available for installation, including
+        their name, description, and pypi installation url. This resource is useful for determining
+        which integrations to use when scaffolding pipelines.
+    """
+    return _subprocess(
+        [
+            "dg",
+            "docs",
+            "integrations",
             "--json",
         ],
         cwd=project_path,

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/mcp_tests/test_mcp_serve.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/mcp_tests/test_mcp_serve.py
@@ -97,3 +97,7 @@ async def test_list_dagster_integrations():
             response = await session.call_tool("list_available_integrations", {"project_path": "."})
             assert not response.isError
             assert len(response.content) == 1
+            assert isinstance(response.content, list)
+            assert dict(
+                response.content[0]
+            )  # check mcp.types.TextContent conforms to dict structure

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/mcp_tests/test_mcp_serve.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/mcp_tests/test_mcp_serve.py
@@ -87,3 +87,13 @@ async def test_scaffold_dagster_component_and_check_yaml():
                 },
             )
             assert not response.isError, response.content
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="no mcp support on 3.9")
+@pytest.mark.asyncio
+async def test_list_dagster_integrations():
+    with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner, in_workspace=False):
+        async with mcp_server() as session:
+            response = await session.call_tool("list_available_integrations", {"project_path": "."})
+            assert not response.isError
+            assert len(response.content) == 1


### PR DESCRIPTION
## Summary & Motivation

Closes ADOPT-1711.

Introduces a new tool endpoint for getting all integrations available in the marketplace. See example usage:

    > What integrations can I install?

    ⏺ I'll help you find the available integrations you can install. Let me check what integrations are available in
      the Dagster marketplace.
      ⎿  [
           {
             "id": "airlift",
         … +1362 lines (ctrl+r to expand)

    ⏺ Here are the available integrations you can install with Dagster:

      ETL & Data Movement

      - Sling - YAML configuration for data loading/replication
      - dlt - Standardized data pipeline creation
      - Embedded ELT - Framework with dlt and sling
      - Airbyte - Data sync orchestration
      - Fivetran - Connector sync orchestration
      - Census - Reverse ETL sync execution
      - Hightouch - Data activation workflows
      - Meltano - Singer specification ingestion

Originally a _resource_ was used, however, these have to explicitly be called by the end user, and Claude Code will not automatically reference a resource like it does a tool. That being said, here is an example invocation of using a resource.

See additional conversation on this here-

https://github.com/modelcontextprotocol/typescript-sdk/issues/686#issuecomment-3021782164

    > What is in the data://integrations/index resource?

    ⏺ I'll check what's available in the data://integrations/index resource using the MCP tools.

    ⏺ readMcpResource(Read resource "data://integrations/index" from server "dagster-dg-cli")
      ⎿  {
           "contents": [
             { … +504 lines (ctrl+r to expand)

    ⏺ The data://integrations/index resource contains a comprehensive JSON array of all Dagster integrations. It
      includes detailed information about each integration such as:

      - Basic info: ID, title, name, description
      - Classification: Tags indicating support level (dagster-supported, community-supported) and category (etl,
      storage, compute, bi, monitoring, alerting, ai, metadata, etc.)
      - Links: Source code repository, PyPI package, partner documentation
      - Visual: Logo filename for UI display

      The data covers integrations with cloud platforms (AWS, GCP, Azure), databases (Snowflake, BigQuery, Redshift),
      ETL tools (dbt, Airbyte, Sling), compute platforms (Databricks, Kubernetes), BI tools (Looker, Tableau, Power
      BI), monitoring services (Datadog, Prometheus), and many others.

## How I Tested These Changes

bk and local `code` usage

## Changelog

- [mcp] Adds an MCP tool (`list_available_integrations`) for retrieving all possible integrations from the marketplace
