### PR TITLE
store partitions subset on the run

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/base_asset_graph.py
@@ -154,10 +154,6 @@ class BaseAssetNode(BaseEntityNode[AssetKey]):
 
     @property
     @abstractmethod
-    def partitions_def(self) -> Optional[PartitionsDefinition]: ...
-
-    @property
-    @abstractmethod
     def legacy_freshness_policy(self) -> Optional[LegacyFreshnessPolicy]: ...
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/base_asset_graph.py
@@ -154,6 +154,10 @@ class BaseAssetNode(BaseEntityNode[AssetKey]):
 
     @property
     @abstractmethod
+    def partitions_def(self) -> Optional[PartitionsDefinition]: ...
+
+    @property
+    @abstractmethod
     def legacy_freshness_policy(self) -> Optional[LegacyFreshnessPolicy]: ...
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/partitions_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/partitions_subset.py
@@ -120,3 +120,10 @@ class PartitionsSubset(ABC, Generic[T_str]):
 
     def to_serializable_subset(self) -> "PartitionsSubset":
         return self
+
+
+class KeyRangesPartitionsSubset(PartitionsSubset):
+    # We will likely want to add this class in the future, but for now we will leave it as an empty
+    # class to reserve the name and make it easier to handle back-compat in the future
+
+    pass

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1331,23 +1331,23 @@ class DagsterInstance(DynamicPartitionsStore):
                     asset_key = output.properties.asset_key if output.properties else None
                     adjusted_output = output
 
-                    if asset_key is not None:
-                        asset_node = asset_graph.get(asset_key)
-                        if isinstance(asset_node.partitions_def, TimeWindowPartitionsDefinition):
-                            # maybe check that it's the same partitions definition?
-                            partitions_definition = asset_node.partitions_def
+                    if asset_key and asset_graph.has(asset_key):
+                        if partitions_definition is None:
+                            asset_node = asset_graph.get(asset_key)
+                            if isinstance(
+                                asset_node.partitions_def, TimeWindowPartitionsDefinition
+                            ):
+                                partitions_definition = asset_node.partitions_def
 
-                    if (
-                        output.properties is not None
-                        and asset_key
-                        and asset_graph.has(asset_key)
-                        and output.properties.asset_execution_type is None
-                    ):
-                        adjusted_output = output._replace(
-                            properties=output.properties._replace(
-                                asset_execution_type=asset_graph.get(asset_key).execution_type
+                        if (
+                            output.properties is not None
+                            and output.properties.asset_execution_type is None
+                        ):
+                            adjusted_output = output._replace(
+                                properties=output.properties._replace(
+                                    asset_execution_type=asset_graph.get(asset_key).execution_type
+                                )
                             )
-                        )
 
                     adjusted_outputs.append(adjusted_output)
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1399,7 +1399,7 @@ class DagsterInstance(DynamicPartitionsStore):
             end_window = partitions_definition.time_window_for_partition_key(partition_range_end)
             partitions_subset = partitions_definition.get_partition_subset_in_time_window(
                 TimeWindow(start_window.start, end_window.end)
-            )
+            ).to_serializable_subset()
 
         return DagsterRun(
             job_name=job_name,

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -34,10 +34,10 @@ from dagster._record import IHaveNew, record_custom
 from dagster._utils.tags import get_boolean_tag_value
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.partitions.subset import PartitionsSubset
     from dagster._core.definitions.schedule_definition import ScheduleDefinition
     from dagster._core.definitions.sensor_definition import SensorDefinition
     from dagster._core.remote_representation.external import RemoteSchedule, RemoteSensor
-    from dagster._core.remote_representation.external_data import PartitionsSnap
     from dagster._core.remote_representation.origin import RemoteJobOrigin
     from dagster._core.scheduler.instigation import InstigatorState
 
@@ -296,7 +296,7 @@ class DagsterRun(
             ("job_code_origin", Optional[JobPythonOrigin]),
             ("has_repository_load_data", bool),
             ("run_op_concurrency", Optional[RunOpConcurrency]),
-            ("partitions_snap", Optional["PartitionsSnap"]),
+            ("partitions_subset", Optional["PartitionsSubset"]),
         ],
     )
 ):
@@ -322,6 +322,7 @@ class DagsterRun(
         job_code_origin (Optional[JobPythonOrigin]): The origin of the job code.
         has_repository_load_data (bool): Whether the run has repository load data.
         run_op_concurrency (Optional[RunOpConcurrency]): The op concurrency information for the run.
+        partitions_subset (Optional[PartitionsSubset]): The subset of partitions to execute.
     """
 
     def __new__(
@@ -344,9 +345,11 @@ class DagsterRun(
         job_code_origin: Optional[JobPythonOrigin] = None,
         has_repository_load_data: Optional[bool] = None,
         run_op_concurrency: Optional[RunOpConcurrency] = None,
-        partitions_snap: Optional["PartitionsSnap"] = None,
+        partitions_subset: Optional["PartitionsSubset"] = None,
     ):
-        from dagster._core.remote_representation.external_data import TimeWindowPartitionsSnap
+        from dagster._core.definitions.partitions.subset.time_window import (
+            TimeWindowPartitionsSubset,
+        )
 
         check.invariant(
             (root_run_id is not None and parent_run_id is not None)
@@ -417,10 +420,10 @@ class DagsterRun(
             run_op_concurrency=check.opt_inst_param(
                 run_op_concurrency, "run_op_concurrency", RunOpConcurrency
             ),
-            # Only support storing time window partitions definitions on the run for now, other partitions
-            # definitions types are too big
-            partitions_snap=check.opt_inst_param(
-                partitions_snap, "partitions_snap", TimeWindowPartitionsSnap
+            # Only support storing time window partitions subsets on the run for now, other
+            # partitions subsets are too big
+            partitions_subset=check.opt_inst_param(
+                partitions_subset, "partitions_subset", TimeWindowPartitionsSubset
             ),
         )
 

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from dagster._core.definitions.schedule_definition import ScheduleDefinition
     from dagster._core.definitions.sensor_definition import SensorDefinition
     from dagster._core.remote_representation.external import RemoteSchedule, RemoteSensor
+    from dagster._core.remote_representation.external_data import PartitionsSnap
     from dagster._core.remote_representation.origin import RemoteJobOrigin
     from dagster._core.scheduler.instigation import InstigatorState
 
@@ -295,6 +296,7 @@ class DagsterRun(
             ("job_code_origin", Optional[JobPythonOrigin]),
             ("has_repository_load_data", bool),
             ("run_op_concurrency", Optional[RunOpConcurrency]),
+            ("partitions_snap", Optional["PartitionsSnap"]),
         ],
     )
 ):
@@ -342,7 +344,10 @@ class DagsterRun(
         job_code_origin: Optional[JobPythonOrigin] = None,
         has_repository_load_data: Optional[bool] = None,
         run_op_concurrency: Optional[RunOpConcurrency] = None,
+        partitions_snap: Optional["PartitionsSnap"] = None,
     ):
+        from dagster._core.remote_representation.external_data import TimeWindowPartitionsSnap
+
         check.invariant(
             (root_run_id is not None and parent_run_id is not None)
             or (root_run_id is None and parent_run_id is None),
@@ -411,6 +416,11 @@ class DagsterRun(
             ),
             run_op_concurrency=check.opt_inst_param(
                 run_op_concurrency, "run_op_concurrency", RunOpConcurrency
+            ),
+            # Only support storing time window partitions definitions on the run for now, other partitions
+            # definitions types are too big
+            partitions_snap=check.opt_inst_param(
+                partitions_snap, "partitions_snap", TimeWindowPartitionsSnap
             ),
         )
 

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import re
@@ -277,11 +278,21 @@ def noop_asset():
     pass
 
 
+@dg.asset(partitions_def=dg.WeeklyPartitionsDefinition(start_date=datetime.datetime(2025, 1, 1)))
+def noop_time_window_asset():
+    pass
+
+
 noop_asset_defs = dg.Definitions(
-    assets=[noop_asset], jobs=[dg.define_asset_job("noop_asset_job", [noop_asset])]
+    assets=[noop_asset, noop_time_window_asset],
+    jobs=[
+        dg.define_asset_job("noop_asset_job", [noop_asset]),
+        dg.define_asset_job("noop_time_window_asset_job", [noop_time_window_asset]),
+    ],
 )
 
 noop_asset_job = noop_asset_defs.resolve_job_def("noop_asset_job")
+noop_time_window_asset_job = noop_asset_defs.resolve_job_def("noop_time_window_asset_job")
 
 
 def test_create_job_snapshot():
@@ -419,6 +430,54 @@ def test_create_run_with_asset_partitions():
             tags={ASSET_PARTITION_RANGE_START_TAG: "bar", ASSET_PARTITION_RANGE_END_TAG: "foo"},
             asset_graph=noop_asset_job.asset_layer.asset_graph,
         )
+
+
+def test_create_run_with_partitioned_asset_stores_partitions_definition():
+    with dg.instance_for_test() as instance:
+        execution_plan = create_execution_plan(noop_time_window_asset_job)
+
+        ep_snapshot = snapshot_from_execution_plan(
+            execution_plan, noop_time_window_asset_job.get_job_snapshot_id()
+        )
+
+        run = create_run_for_test(
+            instance=instance,
+            job_name="foo",
+            execution_plan_snapshot=ep_snapshot,
+            job_snapshot=noop_time_window_asset_job.get_job_snapshot(),
+            tags={
+                ASSET_PARTITION_RANGE_START_TAG: "2025-1-1",
+                ASSET_PARTITION_RANGE_END_TAG: "2025-1-4",
+            },
+            asset_graph=noop_time_window_asset_job.asset_layer.asset_graph,
+        )
+        assert run.partitions_snap is not None
+        assert (
+            run.partitions_snap.get_partitions_definition()
+            == noop_time_window_asset_job.asset_layer.asset_graph.get(
+                dg.AssetKey("noop_time_window_asset")
+            ).partitions_def
+        )
+
+        # assets with non-time window partitions do not store the partitions definition on the run
+        execution_plan = create_execution_plan(noop_asset_job)
+
+        ep_snapshot = snapshot_from_execution_plan(
+            execution_plan, noop_asset_job.get_job_snapshot_id()
+        )
+
+        run = create_run_for_test(
+            instance=instance,
+            job_name="foo",
+            execution_plan_snapshot=ep_snapshot,
+            job_snapshot=noop_asset_job.get_job_snapshot(),
+            tags={
+                ASSET_PARTITION_RANGE_START_TAG: "foo",
+                ASSET_PARTITION_RANGE_END_TAG: "bar",
+            },
+            asset_graph=noop_asset_job.asset_layer.asset_graph,
+        )
+        assert run.partitions_snap is None
 
 
 def test_get_required_daemon_types():


### PR DESCRIPTION
Store the `PartitionsSubset` on `DagsterRun` if the partitions def for the run is a timewindow partitions def. This allows us to get the partitions materialized by a ranged-run without needing the asset graph

enables https://github.com/dagster-io/internal/pull/17284