### PR TITLE
[RFC] Set default label for AutomationCondition to name

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -116,8 +116,8 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
     def operator_type(self) -> OperatorType:
         return "identity"
 
-    def get_label(self) -> Optional[str]:
-        return None
+    def get_label(self) -> str:
+        return self.name
 
     def get_node_snapshot(self, unique_id: str) -> AutomationConditionNodeSnapshot:
         """Returns a snapshot of this condition that can be used for serialization."""
@@ -750,8 +750,8 @@ class BuiltinAutomationCondition(AutomationCondition[T_EntityKey]):
 
     label: Optional[str] = None
 
-    def get_label(self) -> Optional[str]:
-        return self.label
+    def get_label(self) -> str:
+        return self.label or self.name
 
     @public
     def with_label(self, label: Optional[str]) -> Self:

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
@@ -137,11 +137,21 @@ def test_deserialize_definitions_with_asset_condition() -> None:
     assert isinstance(deserialized, dg.AutoMaterializePolicy)
 
 
+def test_default_label_automation_condition() -> None:
+    missing = AutomationCondition.missing()
+    assert missing.name == "missing"
+    assert missing.get_label() == "missing"
+
+    label_missing = AutomationCondition.missing().with_label("custom label")
+    assert label_missing.name == "missing"
+    assert label_missing.get_label() == "custom label"
+
+
 def test_label_automation_condition() -> None:
     not_missing = (~AutomationCondition.missing()).with_label("Not missing")
     not_in_progress = (~AutomationCondition.in_progress()).with_label("Not in progress")
     not_missing_and_not_in_progress = (not_missing & not_in_progress).with_label("Blah")
-    assert not_missing_and_not_in_progress.label == "Blah"
+    assert not_missing_and_not_in_progress.get_label() == "Blah"
     assert not_missing_and_not_in_progress.get_node_snapshot("").label == "Blah"
     assert not_missing_and_not_in_progress.children[0].get_label() == "Not missing"
     assert not_missing_and_not_in_progress.children[1].get_label() == "Not in progress"


### PR DESCRIPTION
## Summary & Motivation

Today, AutomationConditions have names and labels; names are always set and are determined by the AutomationCondition class itself; labels are customizable and are optional.

However, this leads to a few footguns. `replace()` targets AutomationConditions by label, but that means that some conditions are unexpectedly not replaceable (see https://github.com/dagster-io/dagster/issues/25439).

So here's a proposed fix: change AutomationCondition's label to be non-optional, and have it default to the name. Then if you set a label, that overrides it instead.

## How I Tested These Changes

All existing tests pass, as does typechecking, and a new test case is added demonstrating the functionality.

## Changelog

Ensure all AutomationConditions have default labels
