### PR TITLE
AutomationCondition.replace should target name as well as label

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -305,14 +305,14 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
     ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
-        If ``old`` is a string, then conditions with a label matching
+        If ``old`` is a string, then conditions with a label or name matching
         that string will be replaced.
 
         Args:
             old (Union[AutomationCondition, str]): The condition to replace.
             new (AutomationCondition): The condition to replace with.
         """
-        return new if old in [self, self.get_label()] else self
+        return new if old in [self, self.name, self.get_label()] else self
 
     @public
     @staticmethod

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -81,7 +81,7 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
-        If ``old`` is a string, then conditions with a label matching
+        If ``old`` is a string, then conditions with a label or name matching
         that string will be replaced.
 
         Args:
@@ -90,7 +90,7 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         """
         return (
             new
-            if old in [self, self.get_label()]
+            if old in [self, self.name, self.get_label()]
             else copy(self, operands=[child.replace(old, new) for child in self.operands])
         )
 
@@ -188,7 +188,7 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
-        If ``old`` is a string, then conditions with a label matching
+        If ``old`` is a string, then conditions with a label or name matching
         that string will be replaced.
 
         Args:
@@ -197,7 +197,7 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         """
         return (
             new
-            if old in [self, self.get_label()]
+            if old in [self, self.name, self.get_label()]
             else copy(self, operands=[child.replace(old, new) for child in self.operands])
         )
 
@@ -283,7 +283,7 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
-        If ``old`` is a string, then conditions with a label matching
+        If ``old`` is a string, then conditions with a label or name matching
         that string will be replaced.
 
         Args:
@@ -292,7 +292,7 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         """
         return (
             new
-            if old in [self, self.get_label()]
+            if old in [self, self.name, self.get_label()]
             else copy(self, operand=self.operand.replace(old, new))
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -76,7 +76,7 @@ class EntityMatchesCondition(
     ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
-        If ``old`` is a string, then conditions with a label matching
+        If ``old`` is a string, then conditions with a label or name matching
         that string will be replaced.
 
         Args:
@@ -85,7 +85,7 @@ class EntityMatchesCondition(
         """
         return (
             new
-            if old in [self, self.get_label()]
+            if old in [self, self.name, self.get_label()]
             else copy(self, operand=self.operand.replace(old, new))
         )
 
@@ -176,7 +176,7 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
-        If ``old`` is a string, then conditions with a label matching
+        If ``old`` is a string, then conditions with a label or name matching
         that string will be replaced.
 
         Args:
@@ -185,7 +185,7 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         """
         return (
             new
-            if old in [self, self.get_label()]
+            if old in [self, self.name, self.get_label()]
             else copy(self, operand=self.operand.replace(old, new))
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -143,7 +143,7 @@ class SinceCondition(BuiltinAutomationCondition[T_EntityKey]):
     ) -> Union[Self, T_AutomationCondition]:
         """Replaces all instances of ``old`` across any sub-conditions with ``new``.
 
-        If ``old`` is a string, then conditions with a label matching
+        If ``old`` is a string, then conditions with a label or name matching
         that string will be replaced.
 
         Args:
@@ -152,7 +152,7 @@ class SinceCondition(BuiltinAutomationCondition[T_EntityKey]):
         """
         return (
             new
-            if old in [self, self.get_label()]
+            if old in [self, self.name, self.get_label()]
             else copy(
                 self,
                 trigger_condition=self.trigger_condition.replace(old, new),

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
@@ -206,6 +206,14 @@ def test_replace_automation_conditions() -> None:
     )
 
 
+def test_replace_automation_condition_by_names() -> None:
+    a = AutomationCondition.in_latest_time_window()
+    b = AutomationCondition.missing()
+    c = AutomationCondition.any_deps_match(AutomationCondition.in_progress())
+
+    assert (a & b).replace("missing", c) == a & c
+
+
 def test_replace_automation_condition_since() -> None:
     a = AutomationCondition.in_latest_time_window().with_label("in_latest_time_window")
     b = AutomationCondition.any_deps_match(AutomationCondition.in_progress())


### PR DESCRIPTION
## Summary & Motivation

Many AutomationConditions don't have labels, since they just define the name in the class. But it's still natural to target those conditions using replace(), for use cases like https://docs.dagster.io/guides/automate/declarative-automation/customizing-automation-conditions/customizing-eager-condition

This allows you to target conditions by name as well as by label.

## How I Tested These Changes

Unit test

## Changelog

Fixed issue causing `AutomationCondition.replace` to not update built-in sub-conditions that did not have an explicit label.
