### PR TITLE
[UI] Custom `kind` icons

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -31,6 +31,7 @@ import {TimeProvider} from './time/TimeContext';
 import {AssetLiveDataProvider} from '../asset-data/AssetLiveDataProvider';
 import {AssetRunLogObserver} from '../asset-graph/AssetRunLogObserver';
 import {CodeLinkProtocolProvider} from '../code-links/CodeLinkProtocol';
+import {CustomKindIconMappingProvider} from '../graph/CustomKindIcons';
 import {DeploymentStatusProvider, DeploymentStatusType} from '../instance/DeploymentStatusProvider';
 import {InstancePageContext} from '../instance/InstancePageContext';
 import {WorkspaceProvider} from '../workspace/WorkspaceContext/WorkspaceContext';
@@ -187,22 +188,24 @@ export const AppProvider = (props: AppProviderProps) => {
               <CompatRouter>
                 <TimeProvider>
                   <CodeLinkProtocolProvider>
-                    <WorkspaceProvider>
-                      <AssetLiveDataProvider>
-                        <DeploymentStatusProvider include={statusPolling}>
-                          <CustomConfirmationProvider>
-                            <AnalyticsContext.Provider value={analytics}>
-                              <InstancePageContext.Provider value={instancePageValue}>
-                                <LayoutProvider>{props.children}</LayoutProvider>
-                              </InstancePageContext.Provider>
-                            </AnalyticsContext.Provider>
-                          </CustomConfirmationProvider>
-                          <CustomTooltipProvider />
-                          <CustomAlertProvider />
-                          <AssetRunLogObserver />
-                        </DeploymentStatusProvider>
-                      </AssetLiveDataProvider>
-                    </WorkspaceProvider>
+                    <CustomKindIconMappingProvider>
+                      <WorkspaceProvider>
+                        <AssetLiveDataProvider>
+                          <DeploymentStatusProvider include={statusPolling}>
+                            <CustomConfirmationProvider>
+                              <AnalyticsContext.Provider value={analytics}>
+                                <InstancePageContext.Provider value={instancePageValue}>
+                                  <LayoutProvider>{props.children}</LayoutProvider>
+                                </InstancePageContext.Provider>
+                              </AnalyticsContext.Provider>
+                            </CustomConfirmationProvider>
+                            <CustomTooltipProvider />
+                            <CustomAlertProvider />
+                            <AssetRunLogObserver />
+                          </DeploymentStatusProvider>
+                        </AssetLiveDataProvider>
+                      </WorkspaceProvider>
+                    </CustomKindIconMappingProvider>
                   </CodeLinkProtocolProvider>
                 </TimeProvider>
               </CompatRouter>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserSettingsDialog.tsx
@@ -16,6 +16,7 @@ import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 import {UserPreferences} from 'shared/app/UserSettingsDialog/UserPreferences.oss';
 
 import {CodeLinkProtocolSelect} from '../../code-links/CodeLinkProtocol';
+import {CustomKindIconMappingEditor} from '../../graph/CustomKindIcons';
 import {showCustomAlert} from '../CustomAlertProvider';
 import {
   getFeatureFlagDefaults,
@@ -133,6 +134,37 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
         </Tooltip>
       </Box>
       <CodeLinkProtocolSelect />
+    </Box>,
+  );
+
+  experimentalSettings.push(
+    <Box
+      padding={{vertical: 8}}
+      flex={{
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        direction: 'column',
+        gap: 8,
+      }}
+      key="custom-kind-icon-mapping"
+    >
+      <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+        Custom kind icon mapping
+        <Tooltip
+          content={
+            <>
+              Allows translating asset kinds to custom SVG icons. Provide a base64 url
+              <br />
+              &quot;data:image/svg+xml;base64,PHN2Z...c3ZnPg==&quot; or a svg url
+              <br />
+              &quot;https://example.com/icon.svg&quot;
+            </>
+          }
+        >
+          <Icon name="info" color={Colors.accentGray()} />
+        </Tooltip>
+      </Box>
+      <CustomKindIconMappingEditor />
     </Box>,
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/CustomKindIcons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/CustomKindIcons.tsx
@@ -1,0 +1,115 @@
+import {Box, Button, Icon, TextInput} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+
+export const CustomKindIconMappingStorageKey = 'CustomKindIconMapping';
+
+export type KindIconMapping = {
+  kind: string;
+  svg_url: string;
+};
+
+function isKindIconMappingArray(data: unknown): data is KindIconMapping[] {
+  if (!Array.isArray(data)) {
+    return false;
+  }
+
+  return data.every((item) => {
+    return (
+      typeof item === 'object' &&
+      item !== null &&
+      'kind' in item &&
+      typeof (item as any).kind === 'string' &&
+      'svg_url' in item &&
+      typeof (item as any).svg_url === 'string'
+    );
+  });
+}
+
+const DEFAULT_MAPPING: KindIconMapping[] = [{kind: '', svg_url: ''}];
+
+export const CustomKindIconMappingContext = React.createContext<
+  ReturnType<typeof useStateWithStorage<KindIconMapping[]>>
+>([DEFAULT_MAPPING, () => [], () => {}]);
+
+export const CustomKindIconMappingProvider = ({children}: {children: React.ReactNode}) => {
+  const state = useStateWithStorage<KindIconMapping[]>(CustomKindIconMappingStorageKey, (json) =>
+    isKindIconMappingArray(json) ? json : DEFAULT_MAPPING,
+  );
+
+  return (
+    <CustomKindIconMappingContext.Provider value={state}>
+      {children}
+    </CustomKindIconMappingContext.Provider>
+  );
+};
+
+export const CustomKindIconMappingEditor = ({}) => {
+  const [kindIconMapping, setKindIconMapping] = React.useContext(CustomKindIconMappingContext);
+
+  const onMappingEdit = (kind: string, svg_url: string, idx: number) => {
+    setKindIconMapping([
+      ...kindIconMapping.slice(0, idx),
+      {kind, svg_url},
+      ...kindIconMapping.slice(idx + 1),
+    ]);
+  };
+
+  const onRemove = (idx: number) => {
+    if (idx === 0 && kindIconMapping.length === 1) {
+      setKindIconMapping([{kind: '', svg_url: ''}]);
+    } else {
+      setKindIconMapping([...kindIconMapping.slice(0, idx), ...kindIconMapping.slice(idx + 1)]);
+    }
+  };
+
+  const addMappingEntry = () => {
+    setKindIconMapping([...kindIconMapping, {kind: '', svg_url: ''}]);
+  };
+
+  return (
+    <Box flex={{direction: 'column', gap: 12}}>
+      <Box flex={{direction: 'column', gap: 8}}>
+        {kindIconMapping.map((mapping, idx) => {
+          const {kind, svg_url} = mapping;
+          return (
+            <div
+              key={idx}
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                gap: 8,
+              }}
+            >
+              <TextInput
+                placeholder="Kind"
+                value={kind}
+                fill
+                style={{width: '100%'}}
+                onChange={(e) => onMappingEdit(e.target.value, svg_url, idx)}
+              />
+              <TextInput
+                placeholder="SVG Url"
+                value={svg_url}
+                fill
+                style={{width: '100%'}}
+                onChange={(e) => onMappingEdit(kind, e.target.value, idx)}
+              />
+              <Button
+                disabled={kindIconMapping.length === 1 && !kind.trim() && !svg_url.trim()}
+                onClick={() => onRemove(idx)}
+                icon={<Icon name="delete" />}
+              />
+            </div>
+          );
+        })}
+      </Box>
+      <Box margin={{left: 2}} flex={{direction: 'row'}}>
+        <Button onClick={addMappingEntry} icon={<Icon name="add_circle" />}>
+          Add custom kind icon
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpTags.tsx
@@ -2,6 +2,7 @@ import {Box, Colors, FontFamily, IconWrapper} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
+import {CustomKindIconMappingContext} from './CustomKindIcons';
 import csv from './kindtag-images/csv.svg';
 import dag from './kindtag-images/dag.svg';
 import dashboard from './kindtag-images/dashboard.svg';
@@ -1410,12 +1411,17 @@ export const extractIconSrc = (knownTag: KnownTag | undefined) => {
 };
 
 export const OpTags = React.memo(({tags, style, reduceColor, reduceText}: OpTagsProps) => {
+  const [customKindIconMapping, _] = React.useContext(CustomKindIconMappingContext);
+
   return (
     <OpTagsContainer style={style}>
       {tags.map((tag) => {
         const known = KNOWN_TAGS[coerceToStandardLabel(tag.label) as KnownTagType];
         const blackAndWhite = known && 'blackAndWhite' in known && known.blackAndWhite;
         const text = known?.content || tag.label;
+        const customKindIcon = customKindIconMapping.find(
+          (mapping) => coerceToStandardLabel(mapping.kind) === coerceToStandardLabel(tag.label),
+        );
 
         return (
           <Box
@@ -1428,11 +1434,11 @@ export const OpTags = React.memo(({tags, style, reduceColor, reduceText}: OpTags
               fontWeight: reduceColor ? 500 : 600,
             }}
           >
-            {known && 'icon' in known && (
+            {((known && 'icon' in known) || customKindIcon) && (
               <OpTagIconWrapper
                 role="img"
                 $size={16}
-                $img={extractIconSrc(known)}
+                $img={customKindIcon ? `"${customKindIcon.svg_url}"` : extractIconSrc(known)}
                 $color={blackAndWhite ? Colors.accentPrimary() : null}
                 $rotation={null}
                 aria-label={tag.label}


### PR DESCRIPTION
## Summary & Motivation

A WIP implementation I use after needing a custom business-specific icon in my assets. Inspired by the following use-case: 
* https://github.com/dagster-io/dagster/issues/14967.

Along with all the other icon requests:

* https://github.com/dagster-io/dagster/issues/28519
* https://github.com/dagster-io/dagster/issues/30152
* https://github.com/dagster-io/dagster/issues/31271
* https://github.com/dagster-io/dagster/issues/25918  

Interface and logic for setting custom client side asset `kind` icons by providing SVG urls (`https://example.com/icon.svg` or `data:image/svg+xml;base64,PHN2Z...c3ZnPg==`). The interface is accessible inside the User Settings panel in the main interface. Watch the below attachment for the userflow.

If this change or something like this gets implemented custom or highly specific icons can be used. Along with the possibility to use icons before they are merged using the normal PR-icon pipeline.

**_Feedback is highly appreciated regarding feasibility and implementation_** since this is my first PR in this repo.

### Video demo of proposed change
https://github.com/user-attachments/assets/f27c333c-2f08-421d-ae87-fc8c433c6b5b


## How I Tested These Changes
Tested manually using the `quickstart_etl` as a demo project:
* `dagster-webserver -p 3333 -m quickstart_etl.definitions`
* `make dev_webapp`