### PR TITLE
Raise an exception at backfill submission time when it targets partitions whose parents do not yet exist

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -241,7 +241,6 @@ def create_and_launch_partition_backfill(
         assert_valid_asset_partition_backfill(
             graphene_info,
             backfill,
-            dynamic_partitions_store,
             backfill_datetime,
         )
     elif partitions_by_assets is not None:
@@ -278,7 +277,6 @@ def create_and_launch_partition_backfill(
         assert_valid_asset_partition_backfill(
             graphene_info,
             backfill,
-            dynamic_partitions_store,
             backfill_datetime,
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -19,11 +19,14 @@ from typing import (
 )
 
 import dagster._check as check
+from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.definitions.asset_checks.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.assets.graph.remote_asset_graph import RemoteWorkspaceAssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.selector import GraphSelector, JobSubsetSelector
+from dagster._core.definitions.temporal_context import TemporalContext
+from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.backfill import PartitionBackfill
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 from dagster._utils.error import serializable_error_info_from_exc_info
@@ -174,7 +177,6 @@ def assert_valid_job_partition_backfill(
 def assert_valid_asset_partition_backfill(
     graphene_info: "ResolveInfo",
     backfill: PartitionBackfill,
-    dynamic_partitions_store: CachingInstanceQueryer,
     backfill_datetime: datetime,
 ) -> None:
     from dagster_graphql.schema.errors import GraphenePartitionKeysNotFoundError
@@ -182,25 +184,50 @@ def assert_valid_asset_partition_backfill(
     asset_graph = graphene_info.context.asset_graph
     asset_backfill_data = backfill.asset_backfill_data
 
+    asset_graph_view = AssetGraphView(
+        temporal_context=TemporalContext(
+            effective_dt=backfill_datetime,
+            last_event_id=None,
+        ),
+        instance=graphene_info.context.instance,
+        asset_graph=asset_graph,
+    )
+
     if not asset_backfill_data:
         return
 
-    partition_subset_by_asset_key = (
-        asset_backfill_data.target_subset.partitions_subsets_by_asset_key
-    )
+    for asset_key in asset_backfill_data.target_subset.asset_keys:
+        entity_subset = asset_graph_view.get_entity_subset_from_asset_graph_subset(
+            asset_backfill_data.target_subset, asset_key
+        )
 
-    for asset_key, partition_subset in partition_subset_by_asset_key.items():
         partitions_def = asset_graph.get(asset_key).partitions_def
 
         if not partitions_def:
             continue
 
-        invalid_subset = partition_subset - partitions_def.subset_with_all_partitions()
+        invalid_subset = (
+            entity_subset.get_internal_subset_value() - partitions_def.subset_with_all_partitions()
+        )
 
         if not invalid_subset.is_empty:
             raise UserFacingGraphQLError(
                 GraphenePartitionKeysNotFoundError(set(invalid_subset.get_partition_keys()))
             )
+
+        for parent_key in asset_graph.get(asset_key).parent_keys:
+            _parent_subset, required_but_nonexistent_subset = (
+                asset_graph_view.compute_parent_subset_and_required_but_nonexistent_subset(
+                    parent_key,
+                    entity_subset,
+                )
+            )
+
+            if not required_but_nonexistent_subset.is_empty:
+                raise DagsterInvariantViolationError(
+                    f"Targeted partition subset {entity_subset}"
+                    f" depends on non-existent partitions: {required_but_nonexistent_subset}"
+                )
 
 
 def _noop(_) -> None:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -173,6 +173,19 @@ def get_repo_with_non_partitioned_asset() -> RepositoryDefinition:
     return Definitions(assets=[asset1, asset2]).get_repository_def()
 
 
+def get_repo_with_missing_upstream_partition() -> RepositoryDefinition:
+    upstream_partitions_def = StaticPartitionsDefinition(["a", "b"])
+    downstream_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
+
+    @asset(partitions_def=downstream_partitions_def)
+    def child(parent): ...
+
+    @asset(partitions_def=upstream_partitions_def)
+    def parent(): ...
+
+    return Definitions(assets=[child, parent]).get_repository_def()
+
+
 def get_repo_with_root_assets_different_partitions() -> RepositoryDefinition:
     return Definitions(assets=root_assets_different_partitions_same_downstream).get_repository_def()
 
@@ -597,6 +610,32 @@ def test_launch_asset_backfill_with_nonexistent_partition_key():
             )
             assert (
                 "Partition keys `['nonexistent1', 'nonexistent2']` could not be found"
+                in launch_backfill_result.data["launchPartitionBackfill"]["message"]
+            )
+
+
+def test_launch_asset_backfill_with_nonexistent_upstream_partition_key():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_missing_upstream_partition", instance
+        ) as context:
+            # launchPartitionBackfill
+            launch_backfill_result = execute_dagster_graphql(
+                context,
+                LAUNCH_PARTITION_BACKFILL_MUTATION,
+                variables={
+                    "backfillParams": {
+                        "partitionNames": ["a", "b", "c"],
+                        "assetSelection": [{"path": ["child"]}],
+                    }
+                },
+            )
+            assert (
+                launch_backfill_result.data["launchPartitionBackfill"]["__typename"]
+                == "PythonError"
+            )
+            assert (
+                "depends on non-existent partitions: EntitySubset<AssetKey(['parent'])>(DefaultPartitionsSubset(subset={'c'}"
                 in launch_backfill_result.data["launchPartitionBackfill"]["message"]
             )
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1682,7 +1682,7 @@ def _should_backfill_atomic_asset_subset_unit(
         if not required_but_nonexistent_subset.is_empty:
             raise DagsterInvariantViolationError(
                 f"Asset partition subset {entity_subset_to_filter}"
-                f" depends on invalid partitions {required_but_nonexistent_subset}"
+                f" depends on non-existent partitions {required_but_nonexistent_subset}"
             )
 
         parent_materialized_subset = asset_graph_view.get_entity_subset_from_asset_graph_subset(

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_asset_backfill.py
@@ -2148,7 +2148,9 @@ def test_asset_backfill_throw_error_on_invalid_upstreams():
     )
 
     instance = DagsterInstance.ephemeral()
-    with pytest.raises(dg.DagsterInvariantViolationError, match="depends on invalid partitions"):
+    with pytest.raises(
+        dg.DagsterInvariantViolationError, match="depends on non-existent partitions"
+    ):
         run_backfill_to_completion(asset_graph, assets_by_repo_name, backfill_data, [], instance)
 
 


### PR DESCRIPTION
## Summary & Motivation
These backfills are likely to fail when the backfill actually runs - catch them earlier instead.

You could imagine making this check more conservative (e.g. only complaining if the parent asset key in question is also in the target subset). If we do that though, we should probably make the corresponding check in the actual asset backfill execution logic more conservative as well.

## Changelog
Backfills will now raise an error at submission time if the backfill targets an asset with a required parent partition that does not exist (for example, an asset with an hourly partition that depends on an asset with daily partition will error if it attempts to backill the hourly asset for the current day, before the daily partition exists yet). Previously, the error would not be raised until the backfill actually started.