### PR TITLE
Document nux option in dagster.yaml

### DIFF
--- a/docs/docs/deployment/oss/dagster-yaml.md
+++ b/docs/docs/deployment/oss/dagster-yaml.md
@@ -118,6 +118,9 @@ run_launcher:
 telemetry:
   enabled: true
 
+nux:
+  enabled: true
+
 run_monitoring:
   enabled: true
   poll_interval_seconds: 60
@@ -256,6 +259,15 @@ Controls whether Dagster collects anonymized usage statistics.
 
 ```yaml
 telemetry:
+  enabled: false
+```
+
+### `nux`
+
+Controls whether Dagster displays the new-user experience (NUX) to the first user who connects to this Dagster instance.
+
+```yaml
+nux:
   enabled: false
 ```
 


### PR DESCRIPTION
## Summary & Motivation
As of https://github.com/dagster-io/dagster/releases/tag/1.1.13, the `dagster.yaml` file accepts a new option called `nux` to control the behavior of the new-user experience. This PR updates the `dagster.yaml` reference documentation to include the new `nux` option.

