### PR TITLE
[docs] Update redirect for `dagster-instance`

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1416,7 +1416,7 @@
     },
     {
       "source": "/deployment/dagster-instance",
-      "destination": "/deployment/oss/instance-configuration"
+      "destination": "/deployment/oss/oss-instance-configuration"
     },
     {
       "source": "/deployment/dagster-daemon",


### PR DESCRIPTION
## Summary & Motivation
Redirect: https://docs.dagster.io/deployment/dagster-instance should go to https://docs.dagster.io/deployment/oss/oss-instance-configuration. Updating existing redirect

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
