### PR TITLE
whitelist for serdes time window partitions subclasses

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window_subclasses.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window_subclasses.py
@@ -12,7 +12,7 @@ from dagster._utils.partitions import DEFAULT_DATE_FORMAT, DEFAULT_HOURLY_FORMAT
 
 
 @public
-@whitelist_for_serdes
+@whitelist_for_serdes(kwargs_fields={"cron_schedule"})
 class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
     """A set of hourly partitions.
 
@@ -88,7 +88,7 @@ class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
 
 
 @public
-@whitelist_for_serdes
+@whitelist_for_serdes(kwargs_fields={"cron_schedule"})
 class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
     """A set of daily partitions.
 
@@ -163,7 +163,7 @@ class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
         )
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(kwargs_fields={"cron_schedule"})
 class WeeklyPartitionsDefinition(TimeWindowPartitionsDefinition):
     """Defines a set of weekly partitions.
 

--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window_subclasses.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window_subclasses.py
@@ -243,6 +243,7 @@ class WeeklyPartitionsDefinition(TimeWindowPartitionsDefinition):
 
 
 @public
+@whitelist_for_serdes(kwargs_fields={"cron_schedule"})
 class MonthlyPartitionsDefinition(TimeWindowPartitionsDefinition):
     """A set of monthly partitions.
 

--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window_subclasses.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window_subclasses.py
@@ -7,10 +7,12 @@ from dagster._core.definitions.partitions.definition.time_window import (
     TimeWindowPartitionsDefinition,
 )
 from dagster._core.definitions.partitions.schedule_type import ScheduleType
+from dagster._serdes import whitelist_for_serdes
 from dagster._utils.partitions import DEFAULT_DATE_FORMAT, DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 
 
 @public
+@whitelist_for_serdes
 class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
     """A set of hourly partitions.
 
@@ -86,6 +88,7 @@ class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
 
 
 @public
+@whitelist_for_serdes
 class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
     """A set of daily partitions.
 
@@ -160,6 +163,7 @@ class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
         )
 
 
+@whitelist_for_serdes
 class WeeklyPartitionsDefinition(TimeWindowPartitionsDefinition):
     """Defines a set of weekly partitions.
 


### PR DESCRIPTION
adding `whitelist_for_serdes` to `TimeWindowPartitionsDefinition` doesn't pass down to the subclasses, so make those serializable too. 
