### PR TITLE
[dbt] Fix log level

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
@@ -1,5 +1,6 @@
 import contextlib
 import copy
+import logging
 import os
 import shutil
 import signal
@@ -43,7 +44,8 @@ DAGSTER_DBT_TERMINATION_TIMEOUT_SECONDS = int(
 DEFAULT_EVENT_POSTPROCESSING_THREADPOOL_SIZE: Final[int] = 4
 
 
-logger = get_dagster_logger()
+logger = get_dagster_logger("dagster-dbt")
+logger.setLevel(logging.ERROR)
 
 
 def _get_dbt_target_path() -> Path:


### PR DESCRIPTION
## Summary & Motivation

Previously, we guaranteed that the dbt core library would always be imported, which set the overall log level to `ERROR`. This meant that we wouldn't get log messages for things like parsing the dbt project.

Recent changes have made it so we no longer require this library to be imported, meaning that these info messages started showing up in cli commands. This fixes the issue by ensuring that the dagster-dbt library logger will be set to the ERROR level

## How I Tested These Changes

## Changelog

NOCHANGELOG
