### PR TITLE
New key range subset class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/partition_key_range.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/partition_key_range.py
@@ -1,8 +1,10 @@
 from typing import NamedTuple
 
 from dagster._annotations import PublicAttr, public
+from dagster._serdes import whitelist_for_serdes
 
 
+@whitelist_for_serdes
 @public
 class PartitionKeyRange(NamedTuple):
     """Defines a range of partitions.

--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/__init__.py
@@ -4,6 +4,9 @@ from dagster._core.definitions.partitions.subset.all import (
 from dagster._core.definitions.partitions.subset.default import (
     DefaultPartitionsSubset as DefaultPartitionsSubset,
 )
+from dagster._core.definitions.partitions.subset.key_ranges import (
+    KeyRangesPartitionSubset as KeyRangesPartitionSubset,
+)
 from dagster._core.definitions.partitions.subset.partitions_subset import (
     PartitionsSubset as PartitionsSubset,
 )

--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/key_ranges.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/key_ranges.py
@@ -1,0 +1,100 @@
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING, Optional
+
+from dagster_shared.serdes.serdes import deserialize_value
+
+import dagster._check as check
+from dagster._core.definitions.partitions.definition.partitions_definition import (
+    PartitionsDefinition,
+)
+from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
+from dagster._core.definitions.partitions.subset.default import DefaultPartitionsSubset
+from dagster._core.definitions.partitions.subset.partitions_subset import PartitionsSubset
+from dagster._record import record
+from dagster._serdes import serialize_value, whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster._core.remote_representation.external_data import PartitionsSnap
+
+
+@whitelist_for_serdes
+@record
+class KeyRangesPartitionSubset(PartitionsSubset):
+    key_ranges: Sequence[PartitionKeyRange]
+    partitions_snap: "PartitionsSnap"
+
+    def get_partition_keys_not_in_subset(
+        self, partitions_def: PartitionsDefinition
+    ) -> Iterable[str]:
+        return set(partitions_def.get_partition_keys()) - set(self.get_partition_keys())
+
+    @property
+    def is_empty(self) -> bool:
+        return len(self.key_ranges) == 0
+
+    @property
+    def partitions_definition(self) -> PartitionsDefinition:
+        return self.partitions_snap.get_partitions_definition()
+
+    @property
+    def partition_key_ranges(self) -> Sequence[PartitionKeyRange]:
+        return self.key_ranges
+
+    def get_partition_key_ranges(
+        self, partitions_def: PartitionsDefinition
+    ) -> Sequence[PartitionKeyRange]:
+        return self.key_ranges
+
+    def get_partition_keys(self) -> Iterable[str]:
+        keys = []
+        for partition_key_range in self.key_ranges:
+            keys.extend(self.partitions_definition.get_partition_keys_in_range(partition_key_range))
+        return keys
+
+    def with_partition_keys(self, partition_keys: Iterable[str]) -> "PartitionsSubset[str]":
+        return DefaultPartitionsSubset({*self.get_partition_keys(), *partition_keys})
+
+    def serialize(self) -> str:
+        return serialize_value(self)
+
+    @classmethod
+    def from_serialized(
+        cls, partitions_def: PartitionsDefinition, serialized: str
+    ) -> "PartitionsSubset":
+        return deserialize_value(serialized, KeyRangesPartitionSubset)
+
+    @classmethod
+    def can_deserialize(
+        cls,
+        partitions_def: PartitionsDefinition,
+        serialized: str,
+        serialized_partitions_def_unique_id: Optional[str],
+        serialized_partitions_def_class_name: Optional[str],
+    ) -> bool:
+        return True
+
+    def __len__(self) -> int:
+        return sum(
+            [
+                len(self.partitions_definition.get_partition_keys_in_range(partition_key_range))
+                for partition_key_range in self.key_ranges
+            ]
+        )
+
+    def __contains__(self, value) -> bool:
+        return value in self.get_partition_keys()
+
+    @classmethod
+    def create_empty_subset(
+        cls, partitions_def: Optional[PartitionsDefinition] = None
+    ) -> "KeyRangesPartitionSubset":
+        from dagster._core.remote_representation.external_data import PartitionsSnap
+
+        return KeyRangesPartitionSubset(
+            key_ranges=[], partitions_snap=PartitionsSnap.from_def(check.not_none(partitions_def))
+        )
+
+    def empty_subset(
+        self,
+    ) -> "KeyRangesPartitionSubset":
+        return KeyRangesPartitionSubset(key_ranges=[], partitions_snap=self.partitions_snap)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -12,10 +12,12 @@ from dagster._core.definitions.partitions.definition import (
 from dagster._core.definitions.partitions.subset import (
     AllPartitionsSubset,
     DefaultPartitionsSubset,
+    KeyRangesPartitionSubset,
     TimeWindowPartitionsSubset,
 )
 from dagster._core.definitions.partitions.utils import PersistedTimeWindow
 from dagster._core.errors import DagsterInvalidDeserializationVersionError
+from dagster._core.remote_representation.external_data import PartitionsSnap
 from dagster._core.test_utils import freeze_time
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._time import create_datetime
@@ -272,6 +274,62 @@ def test_multi_partition_subset_to_range_conversion():
             multi_partitions_def.get_partition_keys_in_range(partition_key_range)
         )
     assert sorted(partition_keys_from_ranges) == sorted(target_partitions)
+
+
+def test_key_ranges_subset():
+    color_partition = dg.StaticPartitionsDefinition(["red", "yellow", "blue", "green", "orange"])
+
+    key_ranges_subset = KeyRangesPartitionSubset(
+        key_ranges=[
+            dg.PartitionKeyRange("red", "blue"),
+            dg.PartitionKeyRange("orange", "orange"),
+        ],
+        partitions_snap=PartitionsSnap.from_def(color_partition),
+    )
+
+    assert key_ranges_subset.get_partition_keys_not_in_subset(color_partition) == {"green"}
+    assert not key_ranges_subset.is_empty
+    assert key_ranges_subset.partitions_definition == color_partition
+
+    assert key_ranges_subset.get_partition_key_ranges(color_partition) == [
+        dg.PartitionKeyRange("red", "blue"),
+        dg.PartitionKeyRange("orange", "orange"),
+    ]
+
+    assert key_ranges_subset.get_partition_keys() == ["red", "yellow", "blue", "orange"]
+
+    assert key_ranges_subset.with_partition_keys(["green"]) == DefaultPartitionsSubset(
+        {"red", "yellow", "blue", "green", "orange"}
+    )
+
+    assert KeyRangesPartitionSubset.can_deserialize(
+        color_partition, key_ranges_subset.serialize(), None, None
+    )
+
+    assert (
+        KeyRangesPartitionSubset.from_serialized(color_partition, key_ranges_subset.serialize())
+        == key_ranges_subset
+    )
+
+    assert "yellow" in key_ranges_subset
+    assert "orange" in key_ranges_subset
+    assert "green" not in key_ranges_subset
+
+    assert len(key_ranges_subset) == 4
+
+    empty_subset = KeyRangesPartitionSubset(
+        key_ranges=[], partitions_snap=PartitionsSnap.from_def(color_partition)
+    )
+
+    assert empty_subset == key_ranges_subset.empty_subset()
+    assert empty_subset == KeyRangesPartitionSubset.create_empty_subset(color_partition)
+
+    assert len(empty_subset) == 0
+    assert empty_subset.is_empty
+    assert empty_subset.partitions_definition == color_partition
+    assert empty_subset.get_partition_keys() == []
+    assert empty_subset.get_partition_key_ranges(color_partition) == []
+    assert empty_subset.with_partition_keys(["red"]) == DefaultPartitionsSubset({"red"})
 
 
 def test_multi_partition_subset_to_range_conversion_grouping_choices():


### PR DESCRIPTION
Summary:
Allows us to store ranges of parttion keys on a run without having to list them all out and potentially use a ton of space.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
