### PR TITLE
Add migration for bulk_actions.body being mediumtext on mysql

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/049_cd78a5ed7029_use_mediumtext_on_bulk_actions_body_in_.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/049_cd78a5ed7029_use_mediumtext_on_bulk_actions_body_in_.py
@@ -1,0 +1,46 @@
+"""use mediumtext on bulk_actions body in mysql
+
+Revision ID: cd78a5ed7029
+Revises: b961dffeea1a
+Create Date: 2025-08-05 13:35:53.147485
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.dialects.mysql import MEDIUMTEXT
+
+
+# revision identifiers, used by Alembic.
+revision = 'cd78a5ed7029'
+down_revision = 'b961dffeea1a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    inspector = inspect(op.get_bind())
+    if "mysql" not in inspector.dialect.dialect_description:
+        return
+
+    op.alter_column(
+        table_name="bulk_actions",
+        column_name="body",
+        nullable=True,
+        type_=sa.types.Text().with_variant(MEDIUMTEXT, "mysql"),
+        existing_type=sa.types.Text(),
+    )
+
+
+def downgrade():
+    inspector = inspect(op.get_bind())
+    if "mysql" not in inspector.dialect.dialect_description:
+        return
+
+    op.alter_column(
+        table_name="bulk_actions",
+        column_name="body",
+        nullable=True,
+        type_=sa.types.Text(),
+        existing_type=sa.types.Text().with_variant(MEDIUMTEXT, "mysql"),
+    )


### PR DESCRIPTION
Text field has a length of 65,535 characters which can easily be reached if triggering a backfill with lots of partitions.

This changes the column type to mediumtext which has a character limit of 16,777,215 characters which should be ample (don't think we need to go to longtext just yet).

Sqlite and Postgres do not have a length limit on text, so this will only apply to Mysql.

## Summary & Motivation

Runs page wouldn't load without error, see https://github.com/dagster-io/dagster/issues/31540

Closes #31540

## How I Tested These Changes

I could do with some test with this, I've not really tested it and not quite sure how to.

## Changelog

Added migration to alter bulk_actions.body column from text to mediumtext for Mysql storage
