### PR TITLE
Adds .gitignore and README.md to standalone `create-dagster` projects

### DIFF
--- a/python_modules/libraries/create-dagster/create_dagster/scaffold.py
+++ b/python_modules/libraries/create-dagster/create_dagster/scaffold.py
@@ -121,13 +121,20 @@ def scaffold_project(
         else None
     )
 
+    project_excludes = None
+    if dg_context.is_in_workspace:
+        project_excludes = [
+            ".gitignore",
+            "README.md.jinja",
+        ]
+
     scaffold_subtree(
         path=path,
         name_placeholder="PROJECT_NAME_PLACEHOLDER",
         project_template_path=Path(
             os.path.join(os.path.dirname(__file__), "templates", "PROJECT_NAME_PLACEHOLDER")
         ),
-        excludes=None,
+        excludes=project_excludes,
         **get_dependencies_template_params(
             use_editable_dagster,
             scaffold_project_options,

--- a/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/.gitignore
+++ b/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/.gitignore
@@ -1,6 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[cod]
+*.py[codz]
 *$py.class
 
 # C extensions
@@ -46,7 +46,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
-*.py,cover
+*.py.cover
 .hypothesis/
 .pytest_cache/
 cover/
@@ -94,20 +94,35 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
+#poetry.toml
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
 #pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/#use-with-ide
-.pdm.toml
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
@@ -121,6 +136,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/
@@ -159,15 +175,29 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-# ruff
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
 .ruff_cache/
 
-# uv
-uv.lock
+# PyPI configuration file
+.pypirc
 
-# DuckDB
-*.duckdb
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
 
-# Dagster
-.dagster/
-dagster_home/
+# Streamlit
+.streamlit/secrets.toml

--- a/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/.gitignore
+++ b/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/.gitignore
@@ -1,0 +1,173 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# ruff
+.ruff_cache/
+
+# uv
+uv.lock
+
+# DuckDB
+*.duckdb
+
+# Dagster
+.dagster/
+dagster_home/

--- a/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/README.md.jinja
+++ b/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/README.md.jinja
@@ -1,30 +1,56 @@
 # {{ project_name }}
 
-Welcome to your new Dagster project!
-
 ## Getting started
 
-First, install the dependencies of your newly created Dagster project.
+### Installing dependencies
 
-```bash
-uv venv
-```
+**Option 1: uv**
 
-```bash
-source .venv/bin/activate
-```
+Ensure [`uv`](https://docs.astral.sh/uv/) is installed following their [official documentation](https://docs.astral.sh/uv/getting-started/installation/).
+
+Create a virtual environment, and install the required dependencies using _sync_:
 
 ```bash
 uv sync
 ```
 
-Then, start the Dagster UI web server:
+Then, activate the virtual environment:
+
+| OS | Command |
+| --- | --- |
+| MacOS | ```source .venv/bin/activate``` |
+| Windows | ```.venv\Scripts\activate``` |
+
+**Option 2: pip**
+
+Install the python dependencies with [pip](https://pypi.org/project/pip/):
+
+```bash
+python3 -m venv .venv
+```
+
+Then active the virtual environment:
+
+| OS | Command |
+| --- | --- |
+| MacOS | ```source .venv/bin/activate``` |
+| Windows | ```.venv\Scripts\activate``` |
+
+Install the required dependencies:
+
+```bash
+pip install -e ".[dev]"
+```
+
+### Running Dagster
+
+Start the Dagster UI web server:
 
 ```bash
 dg dev
 ```
 
-Open http://localhost:3000 with your browser to see the project.
+Open http://localhost:3000 in your browser to see the project.
 
 ## Learn more
 

--- a/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/README.md.jinja
+++ b/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/README.md.jinja
@@ -1,0 +1,35 @@
+# {{ project_name }}
+
+Welcome to your new Dagster project!
+
+## Getting started
+
+First, install the dependencies of your newly created Dagster project.
+
+```bash
+uv venv
+```
+
+```bash
+source .venv/bin/activate
+```
+
+```bash
+uv sync
+```
+
+Then, start the Dagster UI web server:
+
+```bash
+dg dev
+```
+
+Open http://localhost:3000 with your browser to see the project.
+
+## Learn more
+
+To learn more about this template and Dagster in general:
+
+- [Dagster Documentation](https://docs.dagster.io/)
+- [Dagster University](https://courses.dagster.io/)
+- [Dagster Slack Community](https://dagster.io/slack)

--- a/python_modules/libraries/create-dagster/create_dagster_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/create-dagster/create_dagster_tests/test_scaffold_commands.py
@@ -164,6 +164,13 @@ def test_scaffold_project_success(
         assert Path("foo-bar/src/foo_bar/defs").exists()
         assert Path("foo-bar/tests").exists()
         assert Path("foo-bar/pyproject.toml").exists()
+        # Standalone projects should have README.md and .gitignore
+        assert Path("foo-bar/README.md").exists()
+        assert Path("foo-bar/.gitignore").exists()
+
+        # Verify README.md contains the project name
+        readme_content = Path("foo-bar/README.md").read_text()
+        assert "foo_bar" in readme_content
 
         # this indicates user opts to create venv and uv.lock
         if not use_preexisting_venv and (
@@ -197,6 +204,9 @@ def test_scaffold_project_inside_workspace_success(monkeypatch) -> None:
         assert Path("projects/foo-bar/src/foo_bar/defs").exists()
         assert Path("projects/foo-bar/tests").exists()
         assert Path("projects/foo-bar/pyproject.toml").exists()
+        # Workspace projects should NOT have README.md and .gitignore
+        assert not Path("projects/foo-bar/README.md").exists()
+        assert not Path("projects/foo-bar/.gitignore").exists()
 
         # Check project TOML content
         toml = tomlkit.parse(Path("projects/foo-bar/pyproject.toml").read_text())
@@ -231,6 +241,10 @@ def test_scaffold_project_inside_workspace_success(monkeypatch) -> None:
         )
         assert_runner_result(result)
 
+        # Verify the second workspace project also doesn't have README.md and .gitignore
+        assert not Path("other_projects/baz/README.md").exists()
+        assert not Path("other_projects/baz/.gitignore").exists()
+
         # Check workspace TOML content
         raw_toml = Path("dg.toml").read_text()
         toml = tomlkit.parse(raw_toml)
@@ -259,6 +273,9 @@ def test_scaffold_project_inside_workspace_applies_scaffold_project_options(monk
             "--uv-sync",
         )
         assert_runner_result(result)
+        # Workspace projects should NOT have README.md and .gitignore
+        assert not Path("projects/foo-bar/README.md").exists()
+        assert not Path("projects/foo-bar/.gitignore").exists()
         # Check that use_editable_dagster was applied
         toml = tomlkit.parse(Path("projects/foo-bar/pyproject.toml").read_text())
         assert has_toml_node(toml, ("tool", "uv", "sources", "dagster"))
@@ -291,6 +308,9 @@ def test_scaffold_project_editable_dagster_success(
         assert_runner_result(result)
         assert Path("projects/foo-bar").exists()
         assert Path("projects/foo-bar/pyproject.toml").exists()
+        # Workspace projects should NOT have README.md and .gitignore
+        assert not Path("projects/foo-bar/README.md").exists()
+        assert not Path("projects/foo-bar/.gitignore").exists()
         with open("projects/foo-bar/pyproject.toml") as f:
             toml = tomlkit.parse(f.read())
             validate_pyproject_toml_with_editable(toml, option, dagster_git_repo_dir)


### PR DESCRIPTION
## Summary & Motivation

When not in a workspace, automatically include the following files in the scaffolded project:

* README.md
* .gitignore

## How I Tested These Changes

Manually testing:

Verify standalone project:

    create-dagster project my-standalone-project --no-uv-sync --use-editable-dagster ~/src/dagster

    ls -la my-standalone-project/

    head -n 5 my-standalone-project/README.md

    wc -l my-standalone-project/.gitignore

Verify workspace project:

    create-dagster workspace my-workspace --no-uv-sync --use-editable-dagster ~/src/dagster

    cd my-workspace

    create-dagster project projects/workspace-project --no-uv-sync

    ls -la projects/workspace-project/

Unit testing.

## Changelog

- [create-dagster] Adds .gitignore and README.md to standalone projects
