### PR TITLE
Add PR stack operations guide to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,3 +108,18 @@ yarn build-api-docs          # Build API docs after .rst changes
 ## Make Command Guidelines
 
 - Whenever there is an instruction to run a make command, ALWAYS cd to $DAGSTER_GIT_REPO_DIR, as the Makefile is at the root of the repository
+
+## PR Stack Operations
+
+### Finding GitHub Usernames Efficiently
+
+- **Best method**: `gh search commits "FirstName" --author="Full Name" --repo=dagster-io/dagster`
+- **Why effective**: Co-authored commits reveal exact GitHub username format
+- **Alternative**: Check recent PRs or issues for the person's contributions
+
+### Stack Operations Always Use GT
+
+- **Key rule**: When someone mentions "stacking" or "stack", always use `gt` commands first
+- **Reason**: GT is the source of truth for stack metadata and relationships
+- **Primary command**: `gt log` provides comprehensive PR numbers, statuses, and branch relationships
+- **Impact**: Single command reveals entire stack structure vs. manual discovery


### PR DESCRIPTION
## Summary & Motivation

I used Claude to find PRs and automatically publish them and owen as a reviewer. Added some CLAUDE instructions help out.

Added documentation about PR stack operations to CLAUDE.md, including:
- Techniques for efficiently finding GitHub usernames using `gh search commits`
- Guidelines for using `gt` commands when working with PR stacks
- Explanation of why `gt log` is the preferred command for understanding stack structure

## How I Tested These Changes

Use while assigned a bunch of PRs for owen to review
