### PR TITLE
[ui] Prevent hidden chart tooltips from blocking clicks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/renderChartTooltip.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/renderChartTooltip.tsx
@@ -86,7 +86,12 @@ const PopoverWrapper = ({
       <PopoverPortal forceMount>
         <PopoverContent
           forceMount
-          style={{zIndex: 1, outline: 'none', opacity: tooltip.opacity}}
+          style={{
+            zIndex: 1,
+            outline: 'none',
+            opacity: tooltip.opacity,
+            display: tooltip.opacity === 0 ? 'none' : 'initial',
+          }}
           {...popoverContentProps}
         >
           {children}


### PR DESCRIPTION
## Summary & Motivation

This is an interesting one we noticed during testing of the Billing page. When the chart tooltip is closed, it remains where it was in the DOM and blocks clicks on elements beneath it. Adding `display:none` changes the radix popover container size to 0px and fixes the issue.

This could have an impact if we had tooltip animations on the opacity, but it appears we do not.

<img width="1171" height="680" alt="image" src="https://github.com/user-attachments/assets/546fff4a-e0e3-40fb-ae01-20f111bfd466" />

