### PR TITLE
[ui] Fix keyboard tags in the Lineage graph settings popover

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/GraphSettings.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/GraphSettings.tsx
@@ -264,7 +264,7 @@ export const ToggleGroupsMenuItem = ({
     text={
       <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
         {expandedGroups.length === 0 ? 'Expand all groups' : 'Collapse all groups'}{' '}
-        <KeyboardTag $withinTooltip>⌥E</KeyboardTag>
+        <KeyboardTag>⌥E</KeyboardTag>
       </Box>
     }
   />
@@ -290,7 +290,7 @@ export const ToggleDirectionMenuItem = ({
     text={
       <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
         Change graph to {direction === 'vertical' ? 'horizontal' : 'vertical'} orientation{' '}
-        <KeyboardTag $withinTooltip>⌥O</KeyboardTag>
+        <KeyboardTag>⌥O</KeyboardTag>
       </Box>
     }
   />
@@ -312,7 +312,7 @@ export const ToggleHideEdgesToNodesOutsideQueryMenuItem = ({
       text={
         <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
           {hideEdgesToNodesOutsideQuery ? 'Show' : 'Hide'} neighbor assets outside of selection{' '}
-          <KeyboardTag $withinTooltip>⌥V</KeyboardTag>
+          <KeyboardTag>⌥V</KeyboardTag>
         </Box>
       }
     />


### PR DESCRIPTION
These are now within a popover, not a tooltip, so the text should be the standard color and not always white.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
