### PR TITLE
[ui] Remove the “Hide non-matches” option in the Run logs view

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsProvider.tsx
@@ -35,7 +35,6 @@ export type LogFilter = {
   levels: {[key: string]: boolean};
   focusedTime: number;
   sinceTime: number;
-  hideNonMatches: boolean;
 };
 
 export interface LogsProviderLogs {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTable.tsx
@@ -31,7 +31,7 @@ export const LogsScrollingTable = (props: Props) => {
   const parentRef = useRef<HTMLDivElement>(null);
   const pinToBottom = useRef(true);
 
-  const {filteredNodes, textMatchNodes} = filterLogs(logs, filter, filterStepKeys);
+  const filteredNodes = filterLogs(logs, filter, filterStepKeys);
 
   const virtualizer = useVirtualizer({
     count: filteredNodes.length,
@@ -106,9 +106,7 @@ export const LogsScrollingTable = (props: Props) => {
         {items.map(({index, key, size, start}) => {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const node = filteredNodes[index]!;
-          const textMatch = textMatchNodes.includes(node);
-          const focusedTimeMatch = Number(node.timestamp) === filter.focusedTime;
-          const highlighted = textMatch || focusedTimeMatch;
+          const highlighted = Number(node.timestamp) === filter.focusedTime;
 
           const row =
             node.__typename === 'LogMessageEvent' ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   Button,
   ButtonGroup,
-  Checkbox,
   ExternalAnchorButton,
   Icon,
   IconName,
@@ -11,7 +10,6 @@ import {
   Tooltip,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
-import styled from 'styled-components';
 
 import {FilterOption, LogFilterSelect} from './LogFilterSelect';
 import {LogLevel} from './LogLevel';
@@ -254,7 +252,6 @@ const StructuredLogToolbar = ({
   const [_, setStoredLogLevels] = useStateWithStorage(EnabledRunLogLevelsKey, validateLogLevels);
 
   const selectedStep = filter.logQuery.find((v) => v.token === 'step')?.value || null;
-  const filterText = filter.logQuery.reduce((accum, value) => accum + value.value, '');
 
   // Reset the query string if the filter is updated, allowing external behavior
   // (e.g. clicking a Gantt step) to set the input.
@@ -337,31 +334,12 @@ const StructuredLogToolbar = ({
         suggestionProviders={getRunFilterProviders(steps)}
         onChange={onChange}
       />
-      {filterText ? (
-        <NonMatchCheckbox
-          checked={filter.hideNonMatches}
-          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-            onSetFilter({...filter, hideNonMatches: event.currentTarget.checked})
-          }
-          label="Hide non-matches"
-        />
-      ) : null}
-      <Box flex={{direction: 'row', alignItems: 'center', gap: 8}} margin={{left: 12}}>
-        <LogFilterSelect
-          options={filterOptions as Record<LogLevel, FilterOption>}
-          onSetFilter={onChangeFilter}
-        />
-      </Box>
+      <LogFilterSelect
+        options={filterOptions as Record<LogLevel, FilterOption>}
+        onSetFilter={onChangeFilter}
+      />
       {selectedStep && <OptionsDivider />}
       <div style={{minWidth: 15, flex: 1}} />
     </>
   );
 };
-
-const NonMatchCheckbox = styled(Checkbox)`
-  &&& {
-    margin: 0 4px 0 12px;
-  }
-
-  white-space: nowrap;
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/StepLogsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/StepLogsDialog.tsx
@@ -121,7 +121,6 @@ export const StepLogsDialogContent = ({
   const firstLogForStepTime = firstLogForStep ? Number(firstLogForStep.timestamp) : 0;
 
   const [filter, setFilter] = useState<LogFilter>({
-    hideNonMatches: false,
     focusedTime: firstLogForStepTime,
     levels: Object.fromEntries(DefaultLogLevels.map((l) => [l, true])),
     logQuery: stepKeys.map((stepKey) => ({token: 'step', value: stepKey})),

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useQueryPersistedLogFilter.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useQueryPersistedLogFilter.test.tsx
@@ -17,7 +17,6 @@ describe('encodeRunPageFilters', () => {
   it('serializes log levels,', () => {
     expect(
       encodeRunPageFilters({
-        hideNonMatches: true,
         focusedTime: 1611430148147,
         logQuery: [
           {token: 'step', value: 'bar'},
@@ -28,7 +27,6 @@ describe('encodeRunPageFilters', () => {
       }),
     ).toEqual({
       focusedTime: '1611430148147',
-      hideNonMatches: 'true',
       levels: 'critical|error',
       logs: 'step:bar|query:foo*',
     });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/filterLogs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/filterLogs.tsx
@@ -6,7 +6,7 @@ import {flattenOneLevel} from '../util/flattenOneLevel';
 import {weakMapMemoize} from '../util/weakMapMemoize';
 
 export function filterLogs(logs: LogsProviderLogs, filter: LogFilter, filterStepKeys: string[]) {
-  const filteredNodes = flattenOneLevel(logs.allNodeChunks).filter((node) => {
+  let filteredNodes = flattenOneLevel(logs.allNodeChunks).filter((node) => {
     // These events are used to determine which assets a run will materialize and are not intended
     // to be displayed in the Dagster UI. Pagination is offset based, so we remove these logs client-side.
     if (
@@ -26,33 +26,29 @@ export function filterLogs(logs: LogsProviderLogs, filter: LogFilter, filterStep
   });
 
   const hasTextFilter = !!(filter.logQuery[0] && filter.logQuery[0].value !== '');
+  if (hasTextFilter) {
+    filteredNodes = filteredNodes.filter((node) => {
+      const nodeTexts = [node.message.toLowerCase(), ...metadataEntryKeyValueStrings(node)];
+      return (
+        filter.logQuery.length > 0 &&
+        filter.logQuery.every((f) => {
+          if (f.token === 'query') {
+            return node.stepKey && filterStepKeys.includes(node.stepKey);
+          }
+          if (f.token === 'step') {
+            return node.stepKey && node.stepKey === f.value;
+          }
+          if (f.token === 'type') {
+            return node.eventType && f.value === eventTypeToDisplayType(node.eventType);
+          }
+          const valueLower = f.value.toLowerCase();
+          return nodeTexts.some((text) => text.toLowerCase().includes(valueLower));
+        })
+      );
+    });
+  }
 
-  const textMatchNodes = hasTextFilter
-    ? filteredNodes.filter((node) => {
-        const nodeTexts = [node.message.toLowerCase(), ...metadataEntryKeyValueStrings(node)];
-        return (
-          filter.logQuery.length > 0 &&
-          filter.logQuery.every((f) => {
-            if (f.token === 'query') {
-              return node.stepKey && filterStepKeys.includes(node.stepKey);
-            }
-            if (f.token === 'step') {
-              return node.stepKey && node.stepKey === f.value;
-            }
-            if (f.token === 'type') {
-              return node.eventType && f.value === eventTypeToDisplayType(node.eventType);
-            }
-            const valueLower = f.value.toLowerCase();
-            return nodeTexts.some((text) => text.toLowerCase().includes(valueLower));
-          })
-        );
-      })
-    : [];
-
-  return {
-    filteredNodes: hasTextFilter && filter.hideNonMatches ? textMatchNodes : filteredNodes,
-    textMatchNodes,
-  };
+  return filteredNodes;
 }
 
 // Given an array of metadata entries, returns searchable text in the format:

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useQueryPersistedLogFilter.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useQueryPersistedLogFilter.ts
@@ -21,7 +21,6 @@ export const DefaultQuerystring: {[key: string]: string} = {
   steps: '*',
   logs: '',
   levels: levelsToQuery(DefaultLogLevels),
-  hideNonMatches: 'true',
   focusedTime: '',
 };
 
@@ -44,12 +43,10 @@ export const DefaultQuerystring: {[key: string]: string} = {
 export const decodeRunPageFilters = (qs: qs.ParsedQs) => {
   const logsQuery = typeof qs['logs'] === 'string' ? qs['logs'] : '';
   const focusedTimeQuery = typeof qs['focusedTime'] === 'string' ? qs['focusedTime'] : '';
-  const hideNonMatchesQuery = typeof qs['hideNonMatches'] === 'string' ? qs['hideNonMatches'] : '';
   const levelsQuery = typeof qs['levels'] === 'string' ? qs['levels'] : '';
 
   const logValues = logsQuery.split(DELIMITER);
   const focusedTime = focusedTimeQuery && !logsQuery ? Number(focusedTimeQuery) : null;
-  const hideNonMatches = hideNonMatchesQuery === 'true';
 
   const providers = getRunFilterProviders();
   const logQuery = logValues.map((token) => tokenizedValueFromString(token, providers));
@@ -59,7 +56,6 @@ export const decodeRunPageFilters = (qs: qs.ParsedQs) => {
   return {
     sinceTime: 0,
     focusedTime,
-    hideNonMatches,
     logQuery,
     levels: levelsValues
       .map((level) => level.toUpperCase())
@@ -80,7 +76,6 @@ export function encodeRunPageFilters(filter: LogFilter) {
   );
 
   return {
-    hideNonMatches: filter.hideNonMatches ? 'true' : 'false',
     focusedTime: String(filter.focusedTime || ''),
     logs: logQueryTokenStrings.join(DELIMITER),
     levels: levelsToQuery(Object.keys(filter.levels).filter((key) => !!filter.levels[key])),


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

- Verified that clicking steps and typing in the filter box directly filters down the logs
- Verified that opening a URL with the hideNonMatches query param just ignores the param and doesn't do anything odd

New appearance of toolbar:

<img width="1002" height="384" alt="image" src="https://github.com/user-attachments/assets/719eef10-6adb-48bc-8b13-24f9be0d8729" />

https://linear.app/dagster-labs/issue/FE-929/remove-confusing-hide-non-matches-checkbox