### PR TITLE
[ui] Fix missing loading bar on the RunsFeedTable

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunsBanners.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunsBanners.tsx
@@ -13,15 +13,16 @@ import {useCanSeeConfig} from '../instance/useCanSeeConfig';
 export const QueuedRunsBanners = () => {
   const canSeeConfig = useCanSeeConfig();
 
+  if (!canSeeConfig) {
+    return null;
+  }
   return (
     <Box flex={{direction: 'column', gap: 8}} style={{minWidth: '100%'}} border="bottom">
-      {canSeeConfig && (
-        <Alert
-          intent="info"
-          title={<Link to="/config#run_coordinator">View queue configuration</Link>}
-        />
-      )}
-      {canSeeConfig && <QueueDaemonAlert />}
+      <Alert
+        intent="info"
+        title={<Link to="/config#run_coordinator">View queue configuration</Link>}
+      />
+      <QueueDaemonAlert />
     </Box>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTable.tsx
@@ -176,20 +176,14 @@ export const RunsFeedTable = ({
 
     if (entries.length === 0 && !loading) {
       const anyFilter = !!Object.keys(filter || {}).length;
-      if (emptyState) {
-        return (
-          <div style={{overflow: 'hidden'}}>
-            <IndeterminateLoadingBar $loading={loading} />
-            {header}
-            <div style={{minHeight: 82}}>{emptyState()}</div>
-          </div>
-        );
-      }
-
       return (
         <div style={{overflow: 'hidden'}}>
           {header}
-          <RunTableEmptyState anyFilter={anyFilter} />
+          {emptyState ? (
+            <div style={{minHeight: 82}}>{emptyState()}</div>
+          ) : (
+            <RunTableEmptyState anyFilter={anyFilter} />
+          )}
         </div>
       );
     }
@@ -212,7 +206,6 @@ export const RunsFeedTable = ({
           onClose={() => setDialog(null)}
         />
 
-        <IndeterminateLoadingBar $loading={loading} />
         <Container ref={parentRef} style={scroll ? {overflow: 'auto'} : {overflow: 'visible'}}>
           {header}
           {entries.length === 0 && loading && (
@@ -251,11 +244,14 @@ export const RunsFeedTable = ({
 
   return (
     <Box
-      flex={{direction: 'column', gap: 8}}
+      flex={{direction: 'column'}}
       padding={{vertical: 12}}
       style={scroll ? {height: '100%', minHeight: 0} : {}}
     >
-      {actionBar}
+      <Box flex={{direction: 'column', gap: 8}} padding={{bottom: 12}}>
+        {actionBar}
+      </Box>
+      <IndeterminateLoadingBar $loading={loading} />
       {content()}
     </Box>
   );


### PR DESCRIPTION
It looks like the Runs feed table has not been showing it’s indeterminate loading bar, and Daniel flagged that it was confusing when switching tabs, since there’s a delay before the rows reflect the new tab.

This is happening because the IndeterminateLoadingBar is rendered inside the `overflow:hidden` portion of the run feed table. Both code paths inside `content()` render the loading bar, so I moved it up one layer so that it is rendered in the same place but outside the overflow: hidden container.

Sidenote: The loading bar has a height of 2px even when it's not animating, which does create a bit of visual space in the design that isn't there otherwise. Propose we consider making it 2px transparent and not 2px gray, but I'll post in the design channel.
 
After:

<img width="1754" height="397" alt="image" src="https://github.com/user-attachments/assets/f6dfc651-cf00-4085-b422-8cb261b8ab4a" />

