### PR TITLE
[ui] Don’t show triangle on single asset lineage sidebar repo

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
@@ -41,7 +41,7 @@ export const AssetSidebarNode = (props: AssetSidebarNodeProps) => {
 
   const elementRef = React.useRef<HTMLDivElement | null>(null);
 
-  const showArrow = !isAssetNode;
+  const showArrow = !isAssetNode && !('openAlways' in node && node.openAlways);
 
   return (
     <Box ref={elementRef} padding={{left: 8, right: 12}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -180,7 +180,12 @@ export const AssetGraphExplorerSidebar = React.memo(
       Object.entries(codeLocationNodes)
         .sort(([_1, a], [_2, b]) => COLLATOR.compare(a.locationName, b.locationName))
         .forEach(([locationName, locationNode]) => {
-          folderNodes.push({locationName, id: locationName, level: 1});
+          folderNodes.push({
+            locationName,
+            id: locationName,
+            level: 1,
+            openAlways: codeLocationsCount === 1,
+          });
           if (openNodes.has(locationName) || codeLocationsCount === 1) {
             Object.entries(locationNode.groups)
               .sort(([_1, a], [_2, b]) => COLLATOR.compare(a.groupName, b.groupName))
@@ -378,9 +383,9 @@ export const AssetGraphExplorerSidebar = React.memo(
                 {items.map(({index, key, size, start}) => {
                   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                   const node = renderedNodes[index]!;
-                  const isCodelocationNode = 'locationName' in node;
+                  const isCodeLocationNode = 'locationName' in node;
                   const isGroupNode = 'groupNode' in node;
-                  const row = !isCodelocationNode && !isGroupNode ? graphData.nodes[node.id] : node;
+                  const row = !isCodeLocationNode && !isGroupNode ? graphData.nodes[node.id] : node;
                   const isSelected =
                     selectedNode?.id === node.id || selectedNodes.includes(row as GraphNode);
                   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/util.tsx
@@ -9,6 +9,7 @@ import {GraphNode} from '../Utils';
 export type FolderNodeGroupType = {
   id: string;
   level: number;
+  openAlways?: boolean;
   groupNode: {
     groupName: string;
     assets: GraphNode[];


### PR DESCRIPTION
## Summary & Motivation

If there is only one code location, but more than one asset group, the asset graph sidebar forces the code location open all the time. This PR hides the disclosure triangle in this case rather than it just being broken.

Sidenote: We don't have stories for this component and this behavior is tricky - to repro this I had to adjust the toys repo, couldn't see it in elementl prod or dogfood/hooli. It's also interesting that if there is just one code location and one asset group we get rid of all the hierarchy and just show the assets, but we don't get rid of this code location row if there's just one code location.  Will come back and add stories in a follow-up.

<img width="358" height="442" alt="image" src="https://github.com/user-attachments/assets/e10a7848-d8f5-4a74-ac65-e495d468c47d" />
