### PR TITLE
Prefer passing in a workspace scoped asset graph when creating runs

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -48,10 +48,7 @@ def do_launch(
         check.str_param(execution_metadata.root_run_id, "root_run_id")
         check.str_param(execution_metadata.parent_run_id, "parent_run_id")
     remote_job = get_remote_job_or_raise(graphene_info, execution_params.selector)
-    code_location = graphene_info.context.get_code_location(execution_params.selector.location_name)
-    dagster_run = create_valid_pipeline_run(
-        graphene_info.context, remote_job, execution_params, code_location
-    )
+    dagster_run = create_valid_pipeline_run(graphene_info.context, remote_job, execution_params)
 
     return graphene_info.context.instance.submit_run(
         dagster_run.run_id,
@@ -112,6 +109,7 @@ def launch_reexecution_from_parent_run(
 
     run = instance.create_reexecuted_run(
         parent_run=cast("DagsterRun", parent_run),
+        request_context=graphene_info.context,
         code_location=repo_location,
         remote_job=external_pipeline,
         strategy=ReexecutionStrategy(strategy),

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -5,7 +5,6 @@ import dagster._check as check
 from dagster._core.errors import DagsterRunNotFoundError
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.code_location import CodeLocation
 from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import RESUME_RETRY_TAG
@@ -63,7 +62,6 @@ def create_valid_pipeline_run(
     graphql_context: BaseWorkspaceRequestContext,
     remote_job: RemoteJob,
     execution_params: ExecutionParams,
-    code_location: CodeLocation,
 ) -> DagsterRun:
     ensure_valid_config(remote_job, execution_params.run_config)
 
@@ -114,9 +112,7 @@ def create_valid_pipeline_run(
         status=DagsterRunStatus.NOT_STARTED,
         remote_job_origin=remote_job.get_remote_origin(),
         job_code_origin=remote_job.get_python_origin(),
-        asset_graph=code_location.get_repository(
-            remote_job.repository_handle.repository_name
-        ).asset_graph,
+        asset_graph=graphql_context.asset_graph,
     )
 
     return dagster_run

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -3717,7 +3717,7 @@ class TestPersistentInstanceAssetInProgress(ExecutingGraphQLContextTestMatrix):
 
             for i in range(2):
                 queued_runs.append(
-                    create_valid_pipeline_run(graphql_context, job, execution_params, code_location)
+                    create_valid_pipeline_run(graphql_context, job, execution_params)
                 )
 
             in_progress_run_id = queued_runs[0].run_id

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -908,6 +908,7 @@ def execute_backfill_command(
 
             for partition_data in partition_execution_data.partition_data:
                 dagster_run = create_backfill_run(
+                    workspace,
                     instance,
                     code_location,
                     remote_job,

--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/remote_asset_graph.py
@@ -48,6 +48,7 @@ from dagster._record import ImportFrom, record
 from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
+    from dagster._core.remote_origin import RemoteRepositoryOrigin
     from dagster._core.remote_representation.external_data import AssetCheckNodeSnap, AssetNodeSnap
 
 
@@ -65,6 +66,11 @@ class RemoteAssetCheckNode:
 class RemoteAssetNode(BaseAssetNode, ABC):
     @abstractmethod
     def resolve_to_singular_repo_scoped_node(self) -> "RemoteRepositoryAssetNode": ...
+
+    @abstractmethod
+    def resolve_to_repo_scoped_node(
+        self, repository_origin: "RemoteRepositoryOrigin"
+    ) -> Optional["RemoteRepositoryAssetNode"]: ...
 
     @property
     def execution_set_asset_keys(self) -> AbstractSet[AssetKey]:
@@ -156,6 +162,16 @@ class RemoteRepositoryAssetNode(RemoteAssetNode):
         # we create sets of these objects in the context of asset graphs but don't want to
         # enforce that all recursively contained types are hashable so use object hash instead
         return object.__hash__(self)
+
+    def resolve_to_repo_scoped_node(
+        self, repository_origin: "RemoteRepositoryOrigin"
+    ) -> Optional["RemoteRepositoryAssetNode"]:
+        return (
+            self
+            if self.repository_handle.get_remote_origin().get_selector()
+            == repository_origin.get_selector()
+            else None
+        )
 
     def resolve_to_singular_repo_scoped_node(self) -> "RemoteRepositoryAssetNode":
         return self
@@ -334,6 +350,18 @@ class RemoteWorkspaceAssetNode(RemoteAssetNode):
     @property
     def backfill_policy(self) -> Optional[BackfillPolicy]:
         return self._materializable_node_snap.backfill_policy if self.is_materializable else None
+
+    def resolve_to_repo_scoped_node(
+        self, repository_origin: "RemoteRepositoryOrigin"
+    ) -> Optional["RemoteRepositoryAssetNode"]:
+        return next(
+            iter(
+                info.asset_node
+                for info in self.repo_scoped_asset_infos
+                if info.asset_node.repository_handle.get_remote_origin() == repository_origin
+            ),
+            None,
+        )
 
     ##### REMOTE-SPECIFIC INTERFACE
     @cached_method
@@ -657,6 +685,16 @@ class RemoteWorkspaceAssetGraph(RemoteAssetGraph[RemoteWorkspaceAssetNode]):
             return self.get(key).resolve_to_singular_repo_scoped_node().repository_handle
         else:
             return self.remote_asset_check_nodes_by_key[key].handle
+
+    def get_repo_scoped_node(
+        self, key: EntityKey, repository_origin: "RemoteRepositoryOrigin"
+    ) -> Optional[Union[RemoteRepositoryAssetNode, RemoteAssetCheckNode]]:
+        if isinstance(key, AssetKey):
+            if not self.has(key):
+                return None
+            return self.get(key).resolve_to_repo_scoped_node(repository_origin)
+        else:
+            raise Exception("Key must be an asset key for get_repo_scoped_node")
 
     def split_entity_keys_by_repository(
         self, keys: AbstractSet[EntityKey]

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -422,6 +422,7 @@ def submit_backfill_runs(
         code_location = workspace.get_code_location(location_name)
 
         dagster_run = create_backfill_run(
+            workspace,
             instance,
             code_location,
             remote_job,
@@ -459,6 +460,7 @@ def submit_backfill_runs(
 
 
 def create_backfill_run(
+    request_context: BaseWorkspaceRequestContext,
     instance: DagsterInstance,
     code_location: CodeLocation,
     remote_job: RemoteJob,
@@ -504,6 +506,7 @@ def create_backfill_run(
             return None
         return instance.create_reexecuted_run(
             parent_run=last_run,
+            request_context=request_context,
             code_location=code_location,
             remote_job=remote_job,
             strategy=ReexecutionStrategy.FROM_FAILURE,

--- a/python_modules/dagster/dagster/_core/instance/methods/run_methods.py
+++ b/python_modules/dagster/dagster/_core/instance/methods/run_methods.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from dagster._core.storage.dagster_run import DagsterRunStatsSnapshot
     from dagster._core.storage.event_log import EventLogStorage
     from dagster._core.storage.runs import RunStorage
+    from dagster._core.workspace.context import BaseWorkspaceRequestContext
 
 
 class RunMethods:
@@ -189,6 +190,7 @@ class RunMethods:
     def create_reexecuted_run(
         self,
         *,
+        request_context: "BaseWorkspaceRequestContext",
         parent_run: DagsterRun,
         code_location: "CodeLocation",
         remote_job: "RemoteJob",
@@ -198,6 +200,7 @@ class RunMethods:
         use_parent_run_tags: bool = False,
     ) -> DagsterRun:
         return self.run_domain.create_reexecuted_run(
+            request_context=request_context,
             parent_run=parent_run,
             code_location=code_location,
             remote_job=remote_job,

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -208,6 +208,7 @@ def retry_run(
     tags = {RETRY_NUMBER_TAG: str(len(run_group_list))}
     new_run = instance.create_reexecuted_run(
         parent_run=failed_run,
+        request_context=workspace,
         code_location=code_location,
         remote_job=remote_job,
         strategy=strategy,

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -374,7 +374,9 @@ def test_create_run_without_asset_execution_type_on_snapshot():
         ) as f:
             ep_snapshot = deserialize_value(f.read())
 
-        asset_graph = mock_workspace_from_repos([noop_asset_defs.get_repository_def()]).asset_graph
+        workspace = mock_workspace_from_repos([noop_asset_defs.get_repository_def()])
+
+        asset_graph = workspace.asset_graph
 
         run = create_run_for_test(
             instance=instance,
@@ -382,6 +384,19 @@ def test_create_run_without_asset_execution_type_on_snapshot():
             execution_plan_snapshot=ep_snapshot,
             job_snapshot=noop_asset_job.get_job_snapshot(),
             tags={ASSET_PARTITION_RANGE_START_TAG: "bar", ASSET_PARTITION_RANGE_END_TAG: "foo"},
+            remote_job_origin=(
+                next(
+                    iter(
+                        check.not_none(
+                            next(iter(workspace.code_location_entries.values())).code_location
+                        )
+                        .get_repositories()
+                        .values()
+                    )
+                )
+                .get_full_job(noop_asset_job.name)
+                .get_remote_origin()
+            ),
             asset_graph=asset_graph,
         )
 

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
@@ -284,6 +284,7 @@ def test_create_reexecuted_run_from_failure(
         code_location=code_location,
         remote_job=remote_job,
         strategy=ReexecutionStrategy.FROM_FAILURE,
+        request_context=workspace,
     )
 
     assert run.tags[RESUME_RETRY_TAG] == "true"
@@ -298,7 +299,7 @@ def test_create_reexecuted_run_from_failure(
 
 
 def test_create_reexecuted_run_from_failure_all_steps_succeeded(
-    instance: dg.DagsterInstance, code_location, remote_job, success_run
+    instance: dg.DagsterInstance, workspace, code_location, remote_job, success_run
 ):
     failed_after_finish_run = success_run._replace(status=DagsterRunStatus.FAILURE)
 
@@ -307,6 +308,7 @@ def test_create_reexecuted_run_from_failure_all_steps_succeeded(
     ):
         instance.create_reexecuted_run(
             parent_run=failed_after_finish_run,
+            request_context=workspace,
             code_location=code_location,
             remote_job=remote_job,
             strategy=ReexecutionStrategy.FROM_FAILURE,
@@ -315,12 +317,14 @@ def test_create_reexecuted_run_from_failure_all_steps_succeeded(
 
 def test_create_reexecuted_run_from_failure_tags(
     instance: dg.DagsterInstance,
+    workspace,
     code_location,
     remote_job,
     failed_run,
 ):
     run = instance.create_reexecuted_run(
         parent_run=failed_run,
+        request_context=workspace,
         code_location=code_location,
         remote_job=remote_job,
         strategy=ReexecutionStrategy.FROM_FAILURE,
@@ -331,6 +335,7 @@ def test_create_reexecuted_run_from_failure_tags(
 
     run = instance.create_reexecuted_run(
         parent_run=failed_run,
+        request_context=workspace,
         code_location=code_location,
         remote_job=remote_job,
         strategy=ReexecutionStrategy.FROM_FAILURE,
@@ -342,6 +347,7 @@ def test_create_reexecuted_run_from_failure_tags(
 
     run = instance.create_reexecuted_run(
         parent_run=failed_run,
+        request_context=workspace,
         code_location=code_location,
         remote_job=remote_job,
         strategy=ReexecutionStrategy.FROM_FAILURE,
@@ -359,6 +365,7 @@ def test_create_reexecuted_run_all_steps(
 ):
     run = instance.create_reexecuted_run(
         parent_run=failed_run,
+        request_context=workspace,
         code_location=code_location,
         remote_job=remote_job,
         strategy=ReexecutionStrategy.ALL_STEPS,
@@ -415,6 +422,7 @@ def test_create_reexecuted_run_from_multi_asset_failure(
     }
     run = instance.create_reexecuted_run(
         parent_run=failed_run,
+        request_context=workspace,
         code_location=code_location,
         remote_job=remote_job,
         strategy=ReexecutionStrategy.FROM_ASSET_FAILURE,
@@ -450,6 +458,7 @@ def test_create_reexecuted_run_from_multi_asset_check_failure(
     }
     run = instance.create_reexecuted_run(
         parent_run=failed_run,
+        request_context=workspace,
         code_location=code_location,
         remote_job=remote_job,
         strategy=ReexecutionStrategy.FROM_ASSET_FAILURE,
@@ -491,6 +500,7 @@ def test_create_reexecuted_run_from_multi_asset_failure_after_all_assets_materia
     ):
         instance.create_reexecuted_run(
             parent_run=failed_run,
+            request_context=workspace,
             code_location=code_location,
             remote_job=remote_job,
             strategy=ReexecutionStrategy.FROM_ASSET_FAILURE,
@@ -517,6 +527,7 @@ def test_create_reexecuted_run_from_multi_asset_check_failure_blocking_check(
     }
     run = instance.create_reexecuted_run(
         parent_run=failed_run,
+        request_context=workspace,
         code_location=code_location,
         remote_job=remote_job,
         strategy=ReexecutionStrategy.FROM_ASSET_FAILURE,
@@ -558,6 +569,7 @@ def test_create_reexecuted_run_from_multi_asset_check_failure_unsubsettable(
     }
     run = instance.create_reexecuted_run(
         parent_run=failed_run,
+        request_context=workspace,
         code_location=code_location,
         remote_job=remote_job,
         strategy=ReexecutionStrategy.FROM_ASSET_FAILURE,

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -17,7 +17,7 @@ from dagster._core.test_utils import (
     create_test_daemon_workspace_context,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._core.workspace.context import WorkspaceProcessContext
+from dagster._core.workspace.context import BaseWorkspaceRequestContext, WorkspaceProcessContext
 
 
 @pytest.fixture(name="instance_module_scoped", scope="module")
@@ -62,15 +62,18 @@ def workspace_fixture(instance_module_scoped) -> Iterator[WorkspaceProcessContex
         yield workspace_context
 
 
+@pytest.fixture(scope="module")
+def workspace_request_context(workspace_context) -> Iterator[BaseWorkspaceRequestContext]:
+    yield workspace_context.create_request_context()
+
+
 @pytest.fixture(name="code_location", scope="module")
 def code_location_fixture(
-    workspace_context: WorkspaceProcessContext,
+    workspace_request_context: BaseWorkspaceRequestContext,
 ) -> CodeLocation:
     return cast(
         "CodeLocation",
-        next(
-            iter(workspace_context.create_request_context().get_code_location_entries().values())
-        ).code_location,
+        next(iter(workspace_request_context.get_code_location_entries().values())).code_location,
     )
 
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -63,7 +63,7 @@ from dagster._core.test_utils import (
     wait_for_futures,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._core.workspace.context import WorkspaceProcessContext
+from dagster._core.workspace.context import BaseWorkspaceRequestContext, WorkspaceProcessContext
 from dagster._core.workspace.load_target import ModuleTarget
 from dagster._daemon import get_default_daemon_logger
 from dagster._daemon.auto_run_reexecution.auto_run_reexecution import (
@@ -3924,6 +3924,7 @@ def test_asset_backfill_retries_make_downstreams_runnable(
 def test_run_retry_not_part_of_completed_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
+    workspace_request_context: BaseWorkspaceRequestContext,
     code_location: CodeLocation,
     remote_repo: RemoteRepository,
 ):
@@ -3932,7 +3933,7 @@ def test_run_retry_not_part_of_completed_backfill(
     asset_selection = [dg.AssetKey("foo"), dg.AssetKey("a1"), dg.AssetKey("bar")]
     instance.add_backfill(
         PartitionBackfill.from_asset_partitions(
-            asset_graph=workspace_context.create_request_context().asset_graph,
+            asset_graph=workspace_request_context.asset_graph,
             backfill_id=backfill_id,
             tags={"custom_tag_key": "custom_tag_value"},
             backfill_timestamp=get_current_timestamp(),
@@ -3983,6 +3984,7 @@ def test_run_retry_not_part_of_completed_backfill(
     remote_job = code_location.get_job(selector)
     retried_run = instance.create_reexecuted_run(
         parent_run=run_to_retry,
+        request_context=workspace_request_context,
         code_location=code_location,
         remote_job=remote_job,
         strategy=ReexecutionStrategy.ALL_STEPS,


### PR DESCRIPTION
## Summary & Motivation
This asset graph sometimes has better caching behavior than the repository scoped asset graph.

## How I Tested These Changes
Existing test coverage (ensure both types of asset graphs are covered)
