### PR TITLE
Add a crosshair to the line charts

### DIFF
--- a/js_modules/dagster-ui/package.json
+++ b/js_modules/dagster-ui/package.json
@@ -19,6 +19,8 @@
     ]
   },
   "dependencies": {
+    "@types/chartjs-plugin-crosshair": "^1.1.5",
+    "chartjs-plugin-crosshair": "^2.0.0",
     "graphql.macro": "^1.4.2",
     "patch-package": "^8.0.0",
     "postinstall-postinstall": "^2.1.0"

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
@@ -320,13 +320,16 @@ const InnerLineChartWithComparison = <T,>(props: Props<T>) => {
 
         const after = before - timeSliceSeconds;
 
-        // Open the dialog for any clicked index, including when value is 0
-        openMetricDialog?.({
-          after,
-          before,
-          metric: metricName,
-          unit: unitType,
-        });
+        // Only open the dialog if data exists for the clicked index
+        // in the current period
+        if (metrics.currentPeriod.data[index] && openMetricDialog) {
+          openMetricDialog({
+            after,
+            before,
+            metric: metricName,
+            unit: unitType,
+          });
+        }
       }
     }
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
@@ -16,9 +16,11 @@ import {
   ChartOptions,
   LineElement,
   LinearScale,
+  Plugin,
   PointElement,
   Tooltip,
 } from 'chart.js';
+import CrosshairPlugin from 'chartjs-plugin-crosshair';
 import React, {memo, useCallback, useMemo, useRef} from 'react';
 import {Line} from 'react-chartjs-2';
 
@@ -211,6 +213,23 @@ const InnerLineChartWithComparison = <T,>(props: Props<T>) => {
     () => ({
       plugins: {
         legend: {display: false},
+        crosshair: {
+          enabled: true,
+          zoom: {
+            enabled: false,
+          },
+          sync: {
+            enabled: true,
+          },
+          line: {
+            color: rgbColors[Colors.borderDefault()],
+            width: 1,
+            dashPattern: [3, 3],
+          },
+          snap: {
+            enabled: true,
+          },
+        },
         tooltip: {
           enabled: false,
           position: 'nearest',
@@ -301,16 +320,13 @@ const InnerLineChartWithComparison = <T,>(props: Props<T>) => {
 
         const after = before - timeSliceSeconds;
 
-        // Only open the dialog if data exists for the clicked index
-        // in the current period
-        if (metrics.currentPeriod.data[index] && openMetricDialog) {
-          openMetricDialog({
-            after,
-            before,
-            metric: metricName,
-            unit: unitType,
-          });
-        }
+        // Open the dialog for any clicked index, including when value is 0
+        openMetricDialog?.({
+          after,
+          before,
+          metric: metricName,
+          unit: unitType,
+        });
       }
     }
   };
@@ -371,6 +387,7 @@ const InnerLineChartWithComparison = <T,>(props: Props<T>) => {
             data={getDataset(metrics, formatDatetime)}
             options={options}
             onClick={onClick}
+            plugins={[CrosshairPlugin as Plugin<'line'>]}
             updateMode="none"
           />
         </div>

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -3592,6 +3592,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dagster-io/dagster-ui-workspace@workspace:."
   dependencies:
+    "@types/chartjs-plugin-crosshair": "npm:^1.1.5"
+    chartjs-plugin-crosshair: "npm:^2.0.0"
     graphql.macro: "npm:^1.4.2"
     patch-package: "npm:^8.0.0"
     postinstall-postinstall: "npm:^2.1.0"
@@ -8039,6 +8041,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/chart.js@npm:<3":
+  version: 2.9.41
+  resolution: "@types/chart.js@npm:2.9.41"
+  dependencies:
+    moment: "npm:^2.10.2"
+  checksum: 10/302b251633bb469410c0a8bd3e9b30fdc08c14f9d92998095ae3849a1c3069f61e70df530e6598e6416b3abd13d15dd4eb4c45914300a679ce4c8dee21847301
+  languageName: node
+  linkType: hard
+
+"@types/chartjs-plugin-crosshair@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "@types/chartjs-plugin-crosshair@npm:1.1.5"
+  dependencies:
+    "@types/chart.js": "npm:<3"
+  checksum: 10/fb6d45aabbafbdbc84bff266be9563abfdc7061f140cdcbecdc752f045aaff1ba53436b6456b123c6ee2f56aad336a0e4e45494b1b4483c483039824b60c70a2
+  languageName: node
+  linkType: hard
+
 "@types/codemirror@npm:^5.60.5":
   version: 5.60.8
   resolution: "@types/codemirror@npm:5.60.8"
@@ -11500,6 +11520,15 @@ __metadata:
   peerDependencies:
     chart.js: ">=2.8.0"
   checksum: 10/13b1a76988471cd3931ba39501daba221983bd45d12751a4c99e6a1c2622945c69248d6ce4142b26454249060db1b306f084ff541b142c6d1e2afa7996bc0f87
+  languageName: node
+  linkType: hard
+
+"chartjs-plugin-crosshair@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "chartjs-plugin-crosshair@npm:2.0.0"
+  peerDependencies:
+    chart.js: ^4.0.1
+  checksum: 10/f07105c2995c80d7a011a9e97765b97f1fbb1db7eab514381d0a50df665239fdc86219b920299e5363347a7857cbfef957499548df27ab756531415461b77d72
   languageName: node
   linkType: hard
 
@@ -20164,7 +20193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:^2.26.0":
+"moment@npm:^2.10.2, moment@npm:^2.26.0":
   version: 2.30.1
   resolution: "moment@npm:2.30.1"
   checksum: 10/ae42d876d4ec831ef66110bdc302c0657c664991e45cf2afffc4b0f6cd6d251dde11375c982a5c0564ccc0fa593fc564576ddceb8c8845e87c15f58aa6baca69


### PR DESCRIPTION
## Summary & Motivation
Adds a crosshair to the line charts in Insights.
I used the chartJS crosshair plugin to add these and style them. 

### New UX
https://github.com/user-attachments/assets/8d8f3971-3fd4-45da-88ef-7ebaa9014e7a


When a user hovers over an insight chart it now

## How I Tested These Changes
Loaded up Dagster+ locally 