### PR TITLE
Refactor: Move create_run_for_job to RunDomain

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -955,62 +955,22 @@ class DagsterInstance(DynamicPartitionsStore):
         job_code_origin: Optional[JobPythonOrigin] = None,
         repository_load_data: Optional["RepositoryLoadData"] = None,
     ) -> DagsterRun:
-        from dagster._core.definitions.job_definition import JobDefinition
-        from dagster._core.execution.api import create_execution_plan
-        from dagster._core.execution.plan.plan import ExecutionPlan
-        from dagster._core.snap import snapshot_from_execution_plan
-
-        check.inst_param(job_def, "pipeline_def", JobDefinition)
-        check.opt_inst_param(execution_plan, "execution_plan", ExecutionPlan)
-
-        # note that op_selection is required to execute the solid subset, which is the
-        # frozenset version of the previous solid_subset.
-        # op_selection is not required and will not be converted to op_selection here.
-        # i.e. this function doesn't handle solid queries.
-        # op_selection is only used to pass the user queries further down.
-        check.opt_set_param(resolved_op_selection, "resolved_op_selection", of_type=str)
-        check.opt_list_param(op_selection, "op_selection", of_type=str)
-        check.opt_set_param(asset_selection, "asset_selection", of_type=AssetKey)
-
-        # op_selection never provided
-        if asset_selection or op_selection:
-            # for cases when `create_run_for_pipeline` is directly called
-            job_def = job_def.get_subset(
-                asset_selection=asset_selection,
-                op_selection=op_selection,
-            )
-
-        if not execution_plan:
-            execution_plan = create_execution_plan(
-                job=job_def,
-                run_config=run_config,
-                instance_ref=self.get_ref() if self.is_persistent else None,
-                tags=tags,
-                repository_load_data=repository_load_data,
-            )
-
-        return self.create_run(
-            job_name=job_def.name,
+        """Delegate to run domain."""
+        return self._run_domain.create_run_for_job(
+            job_def=job_def,
+            execution_plan=execution_plan,
             run_id=run_id,
             run_config=run_config,
-            op_selection=op_selection,
-            asset_selection=asset_selection,
-            asset_check_selection=None,
-            resolved_op_selection=resolved_op_selection,
-            step_keys_to_execute=execution_plan.step_keys_to_execute,
+            resolved_op_selection=set(resolved_op_selection) if resolved_op_selection else None,
             status=DagsterRunStatus(status) if status else None,
             tags=tags,
             root_run_id=root_run_id,
             parent_run_id=parent_run_id,
-            job_snapshot=job_def.get_job_snapshot(),
-            execution_plan_snapshot=snapshot_from_execution_plan(
-                execution_plan,
-                job_def.get_job_snapshot_id(),
-            ),
-            parent_job_snapshot=job_def.get_parent_job_snapshot(),
+            op_selection=op_selection,
+            asset_selection=set(asset_selection) if asset_selection else None,
             remote_job_origin=remote_job_origin,
             job_code_origin=job_code_origin,
-            asset_graph=job_def.asset_layer.asset_graph,
+            repository_load_data=repository_load_data,
         )
 
     @cached_property

--- a/python_modules/dagster/dagster/_core/instance/runs/run_domain.py
+++ b/python_modules/dagster/dagster/_core/instance/runs/run_domain.py
@@ -51,7 +51,12 @@ if TYPE_CHECKING:
         BaseAssetGraph,
         BaseAssetNode,
     )
+    from dagster._core.definitions.job_definition import JobDefinition
+    from dagster._core.definitions.repository_definition.repository_definition import (
+        RepositoryLoadData,
+    )
     from dagster._core.definitions.utils import EntityKey
+    from dagster._core.execution.plan.plan import ExecutionPlan
     from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
     from dagster._core.instance.instance import DagsterInstance
     from dagster._core.remote_representation import CodeLocation, RemoteJob
@@ -858,3 +863,78 @@ class RunDomain:
             self._instance.report_dagster_event(
                 materialization_planned, dagster_run.run_id, logging.DEBUG
             )
+
+    def create_run_for_job(
+        self,
+        job_def: "JobDefinition",
+        execution_plan: Optional["ExecutionPlan"] = None,
+        run_id: Optional[str] = None,
+        run_config: Optional[Mapping[str, object]] = None,
+        resolved_op_selection: Optional[Set[str]] = None,
+        status: Optional[DagsterRunStatus] = None,
+        tags: Optional[Mapping[str, str]] = None,
+        root_run_id: Optional[str] = None,
+        parent_run_id: Optional[str] = None,
+        op_selection: Optional[Sequence[str]] = None,
+        asset_selection: Optional[Set[AssetKey]] = None,
+        remote_job_origin: Optional["RemoteJobOrigin"] = None,
+        job_code_origin: Optional[JobPythonOrigin] = None,
+        repository_load_data: Optional["RepositoryLoadData"] = None,
+    ) -> DagsterRun:
+        """Create run for job - moved from DagsterInstance.create_run_for_job()."""
+        from dagster._core.definitions.job_definition import JobDefinition
+        from dagster._core.execution.api import create_execution_plan
+        from dagster._core.execution.plan.plan import ExecutionPlan
+        from dagster._core.snap import snapshot_from_execution_plan
+
+        check.inst_param(job_def, "pipeline_def", JobDefinition)
+        check.opt_inst_param(execution_plan, "execution_plan", ExecutionPlan)
+        # note that op_selection is required to execute the solid subset, which is the
+        # frozenset version of the previous solid_subset.
+        # op_selection is not required and will not be converted to op_selection here.
+        # i.e. this function doesn't handle solid queries.
+        # op_selection is only used to pass the user queries further down.
+        check.opt_set_param(resolved_op_selection, "resolved_op_selection", of_type=str)
+        check.opt_list_param(op_selection, "op_selection", of_type=str)
+        check.opt_set_param(asset_selection, "asset_selection", of_type=AssetKey)
+
+        # op_selection never provided
+        if asset_selection or op_selection:
+            # for cases when `create_run_for_pipeline` is directly called
+            job_def = job_def.get_subset(
+                asset_selection=asset_selection,
+                op_selection=op_selection,
+            )
+
+        if not execution_plan:
+            execution_plan = create_execution_plan(
+                job=job_def,
+                run_config=run_config,
+                instance_ref=self._instance.get_ref() if self._instance.is_persistent else None,
+                tags=tags,
+                repository_load_data=repository_load_data,
+            )
+
+        return self.create_run(
+            job_name=job_def.name,
+            run_id=run_id,
+            run_config=run_config,
+            op_selection=op_selection,
+            asset_selection=asset_selection,
+            asset_check_selection=None,
+            resolved_op_selection=resolved_op_selection,
+            step_keys_to_execute=execution_plan.step_keys_to_execute,
+            status=status,
+            tags=tags,
+            root_run_id=root_run_id,
+            parent_run_id=parent_run_id,
+            job_snapshot=job_def.get_job_snapshot(),
+            execution_plan_snapshot=snapshot_from_execution_plan(
+                execution_plan,
+                job_def.get_job_snapshot_id(),
+            ),
+            parent_job_snapshot=job_def.get_parent_job_snapshot(),
+            remote_job_origin=remote_job_origin,
+            job_code_origin=job_code_origin,
+            asset_graph=job_def.asset_layer.asset_graph,
+        )


### PR DESCRIPTION
## Summary & Motivation

This PR continues the DagsterInstance refactoring effort by moving the `create_run_for_job` method from `DagsterInstance` to `RunDomain`. This is part of the ongoing decomposition of the monolithic DagsterInstance class to improve maintainability and separation of concerns.

The change extracts ~60 lines of job run creation logic from DagsterInstance into the dedicated RunDomain, where it logically belongs alongside other run lifecycle operations. The DagsterInstance method now simply delegates to the RunDomain implementation.

```python
# Before: DagsterInstance.create_run_for_job (60+ lines of logic)
def create_run_for_job(self, job_def, ...):
    # Complex implementation with execution plan creation, job snapshots, etc.

# After: Simple delegation
def create_run_for_job(self, job_def, ...):
    """Delegate to run domain."""
    return self._run_domain.create_run_for_job(...)
```

## How I Tested These Changes

Existing test suite covers all functionality. The refactoring maintains identical behavior through delegation pattern.