### PR TITLE
Extract settings methods from DagsterInstance into SettingsMixin

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/CLAUDE.md
+++ b/python_modules/dagster/dagster/_core/instance/CLAUDE.md
@@ -1,0 +1,42 @@
+# DagsterInstance Architecture: Domains vs Mixins
+
+This document explains the architectural patterns used to organize the `DagsterInstance` class.
+
+## Mixins
+
+**Purpose**: Organize DagsterInstance surface area and API methods.
+
+**Implementation**: Mixins should contain trivial implementations - primarily property accessors, setting getters, and simple method delegations. They exist to keep the main `DagsterInstance` class manageable by grouping related surface area.
+
+**Examples**:
+
+- `SettingsMixin` - Contains properties and getters for various instance settings
+- Future mixins might organize other surface area like telemetry methods, debugging utilities, etc.
+
+**Key Principle**: Mixins should NOT contain complex business logic. They are organizational tools for the public API.
+
+## Domains
+
+**Purpose**: Organize the business logic of DagsterInstance into focused, cohesive modules.
+
+**Implementation**: Domains contain the meaningful business logic and complex operations. Each domain is a separate class that encapsulates a specific area of functionality.
+
+**Examples**:
+
+- `RunDomain` - Business logic for run creation, management, and lifecycle
+- `AssetDomain` - Business logic for asset operations and queries
+- `EventDomain` - Business logic for event handling and storage
+- `StorageDomain` - Business logic for storage operations
+- `SchedulingDomain` - Business logic for schedules and sensors
+- `DaemonDomain` - Business logic for daemon operations
+
+**Key Principle**: This is where complex algorithms, validation, coordination between storage systems, and other meaningful business logic should be implemented.
+
+## Usage Pattern
+
+1. **DagsterInstance** inherits from mixins to expose organized surface area
+2. **DagsterInstance** creates domain instances as cached properties (e.g., `_run_domain`, `_asset_domain`)
+3. **Mixin methods** delegate to appropriate domain methods when business logic is needed
+4. **Domain methods** contain the actual implementation logic
+
+This separation keeps the codebase organized, testable, and maintainable while preserving a clean public API on `DagsterInstance`.

--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -609,13 +609,8 @@ class DagsterInstance(SettingsMixin, DynamicPartitionsStore):
             self._compute_log_manager.register_instance(self)
         return self._compute_log_manager
 
-    def _get_settings_value(self, settings_key: str) -> Any:
-        """Get settings value from the instance settings.
-
-        This method provides a uniform interface for accessing settings,
-        allowing subclasses to customize settings behavior while maintaining
-        compatibility with the SettingsMixin.
-        """
+    def get_settings(self, settings_key: str) -> Any:
+        check.str_param(settings_key, "settings_key")
         if self._settings and settings_key in self._settings:
             return self._settings.get(settings_key)
         return {}

--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -609,6 +609,17 @@ class DagsterInstance(SettingsMixin, DynamicPartitionsStore):
             self._compute_log_manager.register_instance(self)
         return self._compute_log_manager
 
+    def _get_settings_value(self, settings_key: str) -> Any:
+        """Get settings value from the instance settings.
+
+        This method provides a uniform interface for accessing settings,
+        allowing subclasses to customize settings behavior while maintaining
+        compatibility with the SettingsMixin.
+        """
+        if self._settings and settings_key in self._settings:
+            return self._settings.get(settings_key)
+        return {}
+
     def upgrade(self, print_fn: Optional[PrintFn] = None) -> None:
         from dagster._core.storage.migration.utils import upgrading_instance
 

--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -23,12 +23,9 @@ from dagster._core.definitions.freshness import (
     FreshnessStateRecord,
 )
 from dagster._core.errors import DagsterHomeNotSetError, DagsterInvariantViolationError
-from dagster._core.instance.config import (
-    DAGSTER_CONFIG_YAML_FILENAME,
-    DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT,
-    ConcurrencyConfig,
-)
+from dagster._core.instance.config import DAGSTER_CONFIG_YAML_FILENAME
 from dagster._core.instance.ref import InstanceRef
+from dagster._core.instance.settings_mixin import SettingsMixin
 from dagster._core.instance.types import (
     DynamicPartitionsStore,
     InstanceType,
@@ -141,7 +138,7 @@ DagsterInstanceOverrides: TypeAlias = Mapping[str, Any]
 
 
 @public
-class DagsterInstance(DynamicPartitionsStore):
+class DagsterInstance(SettingsMixin, DynamicPartitionsStore):
     """Core abstraction for managing Dagster's access to storage and other resources.
 
     Use DagsterInstance.get() to grab the current DagsterInstance which will load based on
@@ -283,15 +280,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
         self._subscribers: dict[str, list[Callable]] = defaultdict(list)
 
-        run_monitoring_enabled = self.run_monitoring_settings.get("enabled", False)
-        self._run_monitoring_enabled = run_monitoring_enabled
-        if self.run_monitoring_enabled and self.run_monitoring_max_resume_run_attempts:
-            check.invariant(
-                self.run_launcher.supports_resume_run,
-                "The configured run launcher does not support resuming runs. Set"
-                " max_resume_run_attempts to 0 to use run monitoring. Any runs with a failed"
-                " run worker will be marked as failed, but will not be resumed.",
-            )
+        self._initialize_run_monitoring()
 
         # Used for batched event handling
         self._event_buffer: dict[str, list[EventLogEntry]] = defaultdict(list)
@@ -590,19 +579,6 @@ class DagsterInstance(DynamicPartitionsStore):
             self._run_coordinator.register_instance(self)
         return self._run_coordinator
 
-    def get_concurrency_config(self) -> ConcurrencyConfig:
-        from dagster._core.run_coordinator.queued_run_coordinator import QueuedRunCoordinator
-
-        if isinstance(self.run_coordinator, QueuedRunCoordinator):
-            run_coordinator_run_queue_config = self.run_coordinator.get_run_queue_config()
-        else:
-            run_coordinator_run_queue_config = None
-
-        concurrency_settings = self.get_settings("concurrency")
-        return ConcurrencyConfig.from_concurrency_settings(
-            concurrency_settings, run_coordinator_run_queue_config
-        )
-
     @property
     def run_launcher(self) -> "RunLauncher":
         # Lazily load in case the launcher requires dependencies that are not available everywhere
@@ -632,172 +608,6 @@ class DagsterInstance(DynamicPartitionsStore):
             self._compute_log_manager = cast("ComputeLogManager", compute_log_manager)
             self._compute_log_manager.register_instance(self)
         return self._compute_log_manager
-
-    def get_settings(self, settings_key: str) -> Any:
-        check.str_param(settings_key, "settings_key")
-        if self._settings and settings_key in self._settings:
-            return self._settings.get(settings_key)
-        return {}
-
-    def get_backfill_settings(self) -> Mapping[str, Any]:
-        return self.get_settings("backfills")
-
-    def get_scheduler_settings(self) -> Mapping[str, Any]:
-        return self.get_settings("schedules")
-
-    def get_sensor_settings(self) -> Mapping[str, Any]:
-        return self.get_settings("sensors")
-
-    def get_auto_materialize_settings(self) -> Mapping[str, Any]:
-        return self.get_settings("auto_materialize")
-
-    @property
-    def telemetry_enabled(self) -> bool:
-        if self.is_ephemeral:
-            return False
-
-        dagster_telemetry_enabled_default = True
-
-        telemetry_settings = self.get_settings("telemetry")
-
-        if not telemetry_settings:
-            return dagster_telemetry_enabled_default
-
-        if "enabled" in telemetry_settings:
-            return telemetry_settings["enabled"]
-        else:
-            return dagster_telemetry_enabled_default
-
-    @property
-    def nux_enabled(self) -> bool:
-        if self.is_ephemeral:
-            return False
-
-        nux_enabled_by_default = True
-
-        nux_settings = self.get_settings("nux")
-        if not nux_settings:
-            return nux_enabled_by_default
-
-        if "enabled" in nux_settings:
-            return nux_settings["enabled"]
-        else:
-            return nux_enabled_by_default
-
-    # run monitoring
-
-    @property
-    def run_monitoring_enabled(self) -> bool:
-        return self._run_monitoring_enabled
-
-    @property
-    def run_monitoring_settings(self) -> Any:
-        return self.get_settings("run_monitoring")
-
-    @property
-    def run_monitoring_start_timeout_seconds(self) -> int:
-        return self.run_monitoring_settings.get("start_timeout_seconds", 180)
-
-    @property
-    def run_monitoring_cancel_timeout_seconds(self) -> int:
-        return self.run_monitoring_settings.get("cancel_timeout_seconds", 180)
-
-    @property
-    def run_monitoring_max_runtime_seconds(self) -> int:
-        return self.run_monitoring_settings.get("max_runtime_seconds", 0)
-
-    @property
-    def code_server_settings(self) -> Any:
-        return self.get_settings("code_servers")
-
-    @property
-    def code_server_process_startup_timeout(self) -> int:
-        return self.code_server_settings.get(
-            "local_startup_timeout", DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
-        )
-
-    @property
-    def code_server_reload_timeout(self) -> int:
-        return self.code_server_settings.get(
-            "reload_timeout", DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
-        )
-
-    @property
-    def wait_for_local_code_server_processes_on_shutdown(self) -> bool:
-        return self.code_server_settings.get("wait_for_local_processes_on_shutdown", False)
-
-    @property
-    def run_monitoring_max_resume_run_attempts(self) -> int:
-        return self.run_monitoring_settings.get("max_resume_run_attempts", 0)
-
-    @property
-    def run_monitoring_poll_interval_seconds(self) -> int:
-        return self.run_monitoring_settings.get("poll_interval_seconds", 120)
-
-    @property
-    def cancellation_thread_poll_interval_seconds(self) -> int:
-        return self.get_settings("run_monitoring").get(
-            "cancellation_thread_poll_interval_seconds", 10
-        )
-
-    @property
-    def run_retries_enabled(self) -> bool:
-        return self.get_settings("run_retries").get("enabled", False)
-
-    @property
-    def run_retries_max_retries(self) -> int:
-        return self.get_settings("run_retries").get("max_retries", 0)
-
-    @property
-    def run_retries_retry_on_asset_or_op_failure(self) -> bool:
-        return self.get_settings("run_retries").get("retry_on_asset_or_op_failure", True)
-
-    @property
-    def auto_materialize_enabled(self) -> bool:
-        return self.get_settings("auto_materialize").get("enabled", True)
-
-    @property
-    def freshness_enabled(self) -> bool:
-        return self.get_settings("freshness").get("enabled", False)
-
-    @property
-    def auto_materialize_minimum_interval_seconds(self) -> int:
-        return self.get_settings("auto_materialize").get("minimum_interval_seconds")
-
-    @property
-    def auto_materialize_run_tags(self) -> dict[str, str]:
-        return self.get_settings("auto_materialize").get("run_tags", {})
-
-    @property
-    def auto_materialize_respect_materialization_data_versions(self) -> bool:
-        return self.get_settings("auto_materialize").get(
-            "respect_materialization_data_versions", False
-        )
-
-    @property
-    def auto_materialize_max_tick_retries(self) -> int:
-        return self.get_settings("auto_materialize").get("max_tick_retries", 3)
-
-    @property
-    def auto_materialize_use_sensors(self) -> bool:
-        return self.get_settings("auto_materialize").get("use_sensors", True)
-
-    @property
-    def global_op_concurrency_default_limit(self) -> Optional[int]:
-        return self.get_concurrency_config().pool_config.default_pool_limit
-
-    # python logs
-
-    @property
-    def managed_python_loggers(self) -> Sequence[str]:
-        python_log_settings = self.get_settings("python_logs") or {}
-        loggers: Sequence[str] = python_log_settings.get("managed_python_loggers", [])
-        return loggers
-
-    @property
-    def python_log_level(self) -> Optional[str]:
-        python_log_settings = self.get_settings("python_logs") or {}
-        return python_log_settings.get("python_log_level")
 
     def upgrade(self, print_fn: Optional[PrintFn] = None) -> None:
         from dagster._core.storage.migration.utils import upgrading_instance
@@ -1705,7 +1515,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
     def _get_yaml_python_handlers(self) -> Sequence[logging.Handler]:
         if self._settings:
-            logging_config = self.get_settings("python_logs").get("dagster_handler_config", {})
+            logging_config = self.get_python_log_dagster_handler_config()
 
             if logging_config:
                 beta_warning("Handling yaml-defined logging configuration")

--- a/python_modules/dagster/dagster/_core/instance/settings_mixin.py
+++ b/python_modules/dagster/dagster/_core/instance/settings_mixin.py
@@ -1,0 +1,241 @@
+"""Settings mixin for DagsterInstance."""
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Optional
+
+import dagster._check as check
+from dagster._core.instance.config import (
+    DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT,
+    ConcurrencyConfig,
+)
+
+if TYPE_CHECKING:
+    from dagster._core.launcher import RunLauncher
+    from dagster._core.run_coordinator import RunCoordinator
+
+
+class SettingsMixin:
+    """Mixin class providing settings capabilities for DagsterInstance.
+
+    This class extracts all settings-related methods and properties from
+    DagsterInstance to improve code organization and maintainability.
+    """
+
+    # These attributes are provided by DagsterInstance
+    _settings: Any  # Any type to allow custom settings objects - internal repo depends on this
+    _run_monitoring_enabled: bool
+
+    @property
+    def is_ephemeral(self) -> bool:
+        """Property that should be implemented by the concrete class."""
+        raise NotImplementedError
+
+    @property
+    def run_launcher(self) -> "RunLauncher":
+        """Property that should be implemented by the concrete class."""
+        raise NotImplementedError
+
+    @property
+    def run_coordinator(self) -> "RunCoordinator":
+        """Property that should be implemented by the concrete class."""
+        raise NotImplementedError
+
+    def get_settings(self, settings_key: str) -> Any:
+        check.str_param(settings_key, "settings_key")
+        if self._settings and settings_key in self._settings:
+            return self._settings.get(settings_key)
+        return {}
+
+    def get_backfill_settings(self) -> Mapping[str, Any]:
+        return self.get_settings("backfills")
+
+    def get_scheduler_settings(self) -> Mapping[str, Any]:
+        return self.get_settings("schedules")
+
+    def get_sensor_settings(self) -> Mapping[str, Any]:
+        return self.get_settings("sensors")
+
+    def get_auto_materialize_settings(self) -> Mapping[str, Any]:
+        return self.get_settings("auto_materialize")
+
+    @property
+    def telemetry_enabled(self) -> bool:
+        if self.is_ephemeral:
+            return False
+
+        dagster_telemetry_enabled_default = True
+
+        telemetry_settings = self.get_settings("telemetry")
+
+        if not telemetry_settings:
+            return dagster_telemetry_enabled_default
+
+        if "enabled" in telemetry_settings:
+            return telemetry_settings["enabled"]
+        else:
+            return dagster_telemetry_enabled_default
+
+    @property
+    def nux_enabled(self) -> bool:
+        if self.is_ephemeral:
+            return False
+
+        nux_enabled_by_default = True
+
+        nux_settings = self.get_settings("nux")
+        if not nux_settings:
+            return nux_enabled_by_default
+
+        if "enabled" in nux_settings:
+            return nux_settings["enabled"]
+        else:
+            return nux_enabled_by_default
+
+    # run monitoring
+
+    @property
+    def run_monitoring_enabled(self) -> bool:
+        return self._run_monitoring_enabled
+
+    @property
+    def run_monitoring_settings(self) -> Any:
+        return self.get_settings("run_monitoring")
+
+    @property
+    def run_monitoring_start_timeout_seconds(self) -> int:
+        return self.run_monitoring_settings.get("start_timeout_seconds", 180)
+
+    @property
+    def run_monitoring_cancel_timeout_seconds(self) -> int:
+        return self.run_monitoring_settings.get("cancel_timeout_seconds", 180)
+
+    @property
+    def run_monitoring_max_runtime_seconds(self) -> int:
+        return self.run_monitoring_settings.get("max_runtime_seconds", 0)
+
+    @property
+    def code_server_settings(self) -> Any:
+        return self.get_settings("code_servers")
+
+    @property
+    def code_server_process_startup_timeout(self) -> int:
+        return self.code_server_settings.get(
+            "local_startup_timeout", DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
+        )
+
+    @property
+    def code_server_reload_timeout(self) -> int:
+        return self.code_server_settings.get(
+            "reload_timeout", DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
+        )
+
+    @property
+    def wait_for_local_code_server_processes_on_shutdown(self) -> bool:
+        return self.code_server_settings.get("wait_for_local_processes_on_shutdown", False)
+
+    @property
+    def run_monitoring_max_resume_run_attempts(self) -> int:
+        return self.run_monitoring_settings.get("max_resume_run_attempts", 0)
+
+    @property
+    def run_monitoring_poll_interval_seconds(self) -> int:
+        return self.run_monitoring_settings.get("poll_interval_seconds", 120)
+
+    @property
+    def cancellation_thread_poll_interval_seconds(self) -> int:
+        return self.get_settings("run_monitoring").get(
+            "cancellation_thread_poll_interval_seconds", 10
+        )
+
+    @property
+    def run_retries_enabled(self) -> bool:
+        return self.get_settings("run_retries").get("enabled", False)
+
+    @property
+    def run_retries_max_retries(self) -> int:
+        return self.get_settings("run_retries").get("max_retries", 0)
+
+    @property
+    def run_retries_retry_on_asset_or_op_failure(self) -> bool:
+        return self.get_settings("run_retries").get("retry_on_asset_or_op_failure", True)
+
+    @property
+    def auto_materialize_enabled(self) -> bool:
+        return self.get_settings("auto_materialize").get("enabled", True)
+
+    @property
+    def freshness_enabled(self) -> bool:
+        return self.get_settings("freshness").get("enabled", False)
+
+    @property
+    def auto_materialize_minimum_interval_seconds(self) -> int:
+        return self.get_settings("auto_materialize").get("minimum_interval_seconds")
+
+    @property
+    def auto_materialize_run_tags(self) -> dict[str, str]:
+        return self.get_settings("auto_materialize").get("run_tags", {})
+
+    @property
+    def auto_materialize_respect_materialization_data_versions(self) -> bool:
+        return self.get_settings("auto_materialize").get(
+            "respect_materialization_data_versions", False
+        )
+
+    @property
+    def auto_materialize_max_tick_retries(self) -> int:
+        return self.get_settings("auto_materialize").get("max_tick_retries", 3)
+
+    @property
+    def auto_materialize_use_sensors(self) -> bool:
+        return self.get_settings("auto_materialize").get("use_sensors", True)
+
+    @property
+    def global_op_concurrency_default_limit(self) -> Optional[int]:
+        return self.get_concurrency_config().pool_config.default_pool_limit
+
+    # python logs
+
+    @property
+    def managed_python_loggers(self) -> Sequence[str]:
+        python_log_settings = self.get_settings("python_logs") or {}
+        loggers: Sequence[str] = python_log_settings.get("managed_python_loggers", [])
+        return loggers
+
+    @property
+    def python_log_level(self) -> Optional[str]:
+        python_log_settings = self.get_settings("python_logs") or {}
+        return python_log_settings.get("python_log_level")
+
+    def _initialize_run_monitoring(self) -> None:
+        """Initialize run monitoring settings and validate configuration."""
+        import dagster._check as check
+
+        run_monitoring_enabled = self.run_monitoring_settings.get("enabled", False)
+        self._run_monitoring_enabled = run_monitoring_enabled
+        if self.run_monitoring_enabled and self.run_monitoring_max_resume_run_attempts:
+            check.invariant(
+                self.run_launcher.supports_resume_run,
+                "The configured run launcher does not support resuming runs. Set"
+                " max_resume_run_attempts to 0 to use run monitoring. Any runs with a failed"
+                " run worker will be marked as failed, but will not be resumed.",
+            )
+
+    def get_python_log_dagster_handler_config(self) -> dict:
+        """Extract dagster handler config from python_logs settings."""
+        if self._settings:
+            return self.get_settings("python_logs").get("dagster_handler_config", {})
+        return {}
+
+    def get_concurrency_config(self) -> ConcurrencyConfig:
+        """Get concurrency configuration from settings."""
+        from dagster._core.run_coordinator.queued_run_coordinator import QueuedRunCoordinator
+
+        if isinstance(self.run_coordinator, QueuedRunCoordinator):
+            run_coordinator_run_queue_config = self.run_coordinator.get_run_queue_config()
+        else:
+            run_coordinator_run_queue_config = None
+
+        concurrency_settings = self.get_settings("concurrency")
+        return ConcurrencyConfig.from_concurrency_settings(
+            concurrency_settings, run_coordinator_run_queue_config
+        )

--- a/python_modules/dagster/dagster/_core/instance/settings_mixin.py
+++ b/python_modules/dagster/dagster/_core/instance/settings_mixin.py
@@ -39,13 +39,9 @@ class SettingsMixin:
         """Property that should be implemented by the concrete class."""
         raise NotImplementedError
 
-    def _get_settings_value(self, settings_key: str) -> Any:
+    def get_settings(self, settings_key: str) -> Any:
         """Abstract method to get settings value - implemented by DagsterInstance."""
         raise NotImplementedError
-
-    def get_settings(self, settings_key: str) -> Any:
-        check.str_param(settings_key, "settings_key")
-        return self._get_settings_value(settings_key)
 
     def get_backfill_settings(self) -> Mapping[str, Any]:
         return self.get_settings("backfills")
@@ -209,8 +205,6 @@ class SettingsMixin:
 
     def _initialize_run_monitoring(self) -> None:
         """Initialize run monitoring settings and validate configuration."""
-        import dagster._check as check
-
         run_monitoring_enabled = self.run_monitoring_settings.get("enabled", False)
         self._run_monitoring_enabled = run_monitoring_enabled
         if self.run_monitoring_enabled and self.run_monitoring_max_resume_run_attempts:


### PR DESCRIPTION
## Summary & Motivation

This PR extracts settings-related functionality from the `DagsterInstance` class into a separate `SettingsMixin` class to improve code organization and maintainability. The refactoring moves over 150 lines of settings methods and properties from the main `DagsterInstance` class into the mixin.

The main changes include:
- Created new `SettingsMixin` class containing all settings-related methods and properties
- Updated `DagsterInstance` to inherit from `SettingsMixin` and `DynamicPartitionsStore`
- Moved settings methods like `get_settings()`, `get_backfill_settings()`, run monitoring properties, and logging configuration methods to the mixin
- Added `_initialize_run_monitoring()` method to handle run monitoring setup
- Cleaned up imports by removing unused config imports from instance.py

## How I Tested These Changes

Existing test suite covers the functionality since this is purely a refactoring with no behavioral changes.