### PR TITLE
Improve ai_update_pr command to focus on current branch changes only

### DIFF
--- a/.claude/commands/ai_update_pr.md
+++ b/.claude/commands/ai_update_pr.md
@@ -1,6 +1,6 @@
 # AI Update PR summary
 
-Use `gt ls -s` to determine the last git ref in the stack. View all changes since that ref with `git diff`. Also view the commit messages with `git log`. Use this context, alongside any session context from what you know about the changes to write a PR summary in Markdown, of the format
+Use `gt ls -s` to determine the last git ref in the stack. View changes for ONLY the current branch with `git diff <previous_branch>..HEAD` where <previous_branch> is the branch immediately below the current branch in the stack. Also view the commit messages for the current branch only with `git log --oneline <previous_branch>..HEAD`. Focus only on changes in the current branch, not the entire stack history. Use this context, alongside any session context from what you know about the changes to write a PR summary in Markdown, of the format
 
 ```md
 ## Summary & Motivation


### PR DESCRIPTION
## Summary & Motivation

This change improves the  command by making its git diff analysis more precise. The updated instructions now specify that the command should analyze only the current branch's changes using `git diff <previous_branch>..HEAD` rather than examining the entire stack history.

The change ensures that PR summaries focus on the specific changes introduced in each branch, avoiding confusion from unrelated changes in the broader stack context.

## How I Tested These Changes

Ran it on this branch