### PR TITLE
Remove __all__ from subpackage init files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ yarn build-api-docs          # Build API docs after .rst changes
 - Follow Google-style docstrings
 - **ALWAYS use `@record` from `dagster_shared.record` for data structures, result objects, and immutable classes**
 - Only use `@dataclass` when mutability is specifically required
+- **NEVER use `__all__` in subpackage `__init__.py` files** - only use `__all__` in top-level package `__init__.py` files to define public APIs
 
 ## Code Quality Requirements
 

--- a/python_modules/dagster/dagster/_core/instance/scheduling/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/scheduling/__init__.py
@@ -1,3 +1,0 @@
-from dagster._core.instance.scheduling.scheduling_domain import SchedulingDomain
-
-__all__ = ["SchedulingDomain"]


### PR DESCRIPTION
## Summary & Motivation

Remove `__all__` declaration from `dagster/_core/instance/scheduling/__init__.py` subpackage. This follows the established coding convention that `__all__` should only be used in top-level package `__init__.py` files to define public APIs, not in subpackages.

The change also updates the development documentation in `CLAUDE.md` to explicitly document this convention for future contributors.

## How I Tested These Changes

Existing test suite.