### PR TITLE
Extract domain properties into DomainsMixin class

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/domains_mixin.py
+++ b/python_modules/dagster/dagster/_core/instance/domains_mixin.py
@@ -1,10 +1,11 @@
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from dagster._core.instance.assets.asset_domain import AssetDomain
     from dagster._core.instance.daemon.daemon_domain import DaemonDomain
     from dagster._core.instance.events.event_domain import EventDomain
+    from dagster._core.instance.instance import DagsterInstance
     from dagster._core.instance.run_launcher.run_launcher_domain import RunLauncherDomain
     from dagster._core.instance.runs.run_domain import RunDomain
     from dagster._core.instance.scheduling.scheduling_domain import SchedulingDomain
@@ -18,40 +19,40 @@ class DomainsMixin:
     def run_domain(self) -> "RunDomain":
         from dagster._core.instance.runs.run_domain import RunDomain
 
-        return RunDomain(self)
+        return RunDomain(cast("DagsterInstance", self))
 
     @cached_property
     def asset_domain(self) -> "AssetDomain":
         from dagster._core.instance.assets.asset_domain import AssetDomain
 
-        return AssetDomain(self)
+        return AssetDomain(cast("DagsterInstance", self))
 
     @cached_property
     def event_domain(self) -> "EventDomain":
         from dagster._core.instance.events.event_domain import EventDomain
 
-        return EventDomain(self)
+        return EventDomain(cast("DagsterInstance", self))
 
     @cached_property
     def scheduling_domain(self) -> "SchedulingDomain":
         from dagster._core.instance.scheduling.scheduling_domain import SchedulingDomain
 
-        return SchedulingDomain(self)
+        return SchedulingDomain(cast("DagsterInstance", self))
 
     @cached_property
     def storage_domain(self) -> "StorageDomain":
         from dagster._core.instance.storage.storage_domain import StorageDomain
 
-        return StorageDomain(self)
+        return StorageDomain(cast("DagsterInstance", self))
 
     @cached_property
     def run_launcher_domain(self) -> "RunLauncherDomain":
         from dagster._core.instance.run_launcher.run_launcher_domain import RunLauncherDomain
 
-        return RunLauncherDomain(self)
+        return RunLauncherDomain(cast("DagsterInstance", self))
 
     @cached_property
     def daemon_domain(self) -> "DaemonDomain":
         from dagster._core.instance.daemon.daemon_domain import DaemonDomain
 
-        return DaemonDomain(self)
+        return DaemonDomain(cast("DagsterInstance", self))

--- a/python_modules/dagster/dagster/_core/instance/domains_mixin.py
+++ b/python_modules/dagster/dagster/_core/instance/domains_mixin.py
@@ -1,0 +1,57 @@
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dagster._core.instance.assets.asset_domain import AssetDomain
+    from dagster._core.instance.daemon.daemon_domain import DaemonDomain
+    from dagster._core.instance.events.event_domain import EventDomain
+    from dagster._core.instance.run_launcher.run_launcher_domain import RunLauncherDomain
+    from dagster._core.instance.runs.run_domain import RunDomain
+    from dagster._core.instance.scheduling.scheduling_domain import SchedulingDomain
+    from dagster._core.instance.storage.storage_domain import StorageDomain
+
+
+class DomainsMixin:
+    """Mixin providing domain properties for DagsterInstance."""
+
+    @cached_property
+    def run_domain(self) -> "RunDomain":
+        from dagster._core.instance.runs.run_domain import RunDomain
+
+        return RunDomain(self)
+
+    @cached_property
+    def asset_domain(self) -> "AssetDomain":
+        from dagster._core.instance.assets.asset_domain import AssetDomain
+
+        return AssetDomain(self)
+
+    @cached_property
+    def event_domain(self) -> "EventDomain":
+        from dagster._core.instance.events.event_domain import EventDomain
+
+        return EventDomain(self)
+
+    @cached_property
+    def scheduling_domain(self) -> "SchedulingDomain":
+        from dagster._core.instance.scheduling.scheduling_domain import SchedulingDomain
+
+        return SchedulingDomain(self)
+
+    @cached_property
+    def storage_domain(self) -> "StorageDomain":
+        from dagster._core.instance.storage.storage_domain import StorageDomain
+
+        return StorageDomain(self)
+
+    @cached_property
+    def run_launcher_domain(self) -> "RunLauncherDomain":
+        from dagster._core.instance.run_launcher.run_launcher_domain import RunLauncherDomain
+
+        return RunLauncherDomain(self)
+
+    @cached_property
+    def daemon_domain(self) -> "DaemonDomain":
+        from dagster._core.instance.daemon.daemon_domain import DaemonDomain
+
+        return DaemonDomain(self)


### PR DESCRIPTION
## Summary & Motivation

This PR extracts domain properties from DagsterInstance into a reusable DomainsMixin class and converts private domain properties to public ones.

**Key Changes:**
- Created `DomainsMixin` class that defines all domain properties as public `@cached_property` methods
- Updated `DagsterInstance` to inherit from `DomainsMixin` instead of defining domain properties directly
- Converted all domain property access from private (`_run_domain`, `_asset_domain`, etc.) to public (`run_domain`, `asset_domain`, etc.) throughout the DagsterInstance class
- Used `cast("DagsterInstance", self)` pattern in mixin to maintain type safety

This refactoring consolidates the domain architecture pattern and makes domain properties consistently accessible as public APIs.

## How I Tested These Changes

Existing test suite covers all domain functionality.

## Changelog

This is an internal refactoring with no public-facing API changes.