### PR TITLE
Add coding convention for internal subpackages without __init__.py files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ yarn build-api-docs          # Build API docs after .rst changes
 - **ALWAYS use `@record` from `dagster_shared.record` for data structures, result objects, and immutable classes**
 - Only use `@dataclass` when mutability is specifically required
 - **NEVER use `__all__` in subpackage `__init__.py` files** - only use `__all__` in top-level package `__init__.py` files to define public APIs
+- **DO NOT create `__init__.py` files for internal subpackages** - use absolute imports instead since we use absolute imports throughout the codebase
 
 ## Code Quality Requirements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,6 +300,8 @@ ban-relative-imports = "all"
 "**/scripts/**" = ["INP001"]
 "python_modules/dagster/dagster/_core/storage/alembic/env.py" = ["INP001"]
 "python_modules/libraries/dagster-airlift/kitchen-sink/**" = ["INP001"]
+# Internal subpackages that use absolute imports and don't need __init__.py
+"python_modules/dagster/dagster/_core/instance/mixins/**" = ["INP001"]
 # There is an __init__.py.tmpl
 "python_modules/dagster/dagster/_generate/templates/REPO_NAME_PLACEHOLDER/REPO_NAME_PLACEHOLDER/assets.py" = ["INP001"]
 


### PR DESCRIPTION
## Summary & Motivation

This PR codifies a coding convention for internal subpackage organization in the Dagster codebase. It establishes that internal subpackages should not have `__init__.py` files and should use absolute imports instead.

The changes include:
- Added explicit guidance in `CLAUDE.md` stating "DO NOT create `__init__.py` files for internal subpackages - use absolute imports instead since we use absolute imports throughout the codebase"
- Updated `pyproject.toml` ruff configuration to ignore INP001 linting errors for the `mixins` directory, as it's an internal subpackage that intentionally doesn't have an `__init__.py` file

This convention aligns with the existing codebase patterns and prevents unnecessary `__init__.py` files in internal organizational directories.

## How I Tested These Changes

Verified that ruff linting passes with the new configuration and that the coding conventions are clearly documented.