### PR TITLE
Shorten previous period to prev period in insights charts

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogRateCard.tsx
@@ -116,7 +116,7 @@ export function AssetCatalogRateCard({
           prevValue !== null &&
           value !== null && (
             <>
-              <div className={styles.rateCardPrev}>{prevValueString + ' previous period'}</div>
+              <div className={styles.rateCardPrev}>{prevValueString + ' prev period'}</div>
               <Box
                 className={styles.rateCardDeltaRow}
                 flex={{direction: 'row', alignItems: 'center', gap: 4}}

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
@@ -371,7 +371,7 @@ const InnerLineChartWithComparison = <T,>(props: Props<T>) => {
             {metrics.prevPeriod.aggregateValue
               ? numberFormatterWithMaxFractionDigits(2).format(prevPeriodDisplayValueAndUnit.value)
               : 0}
-            <span> previous period</span>
+            <span> prev period</span>
           </Box>
           <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
             {metrics.pctChange && metrics.pctChange > 0 ? (


### PR DESCRIPTION
## Summary & Motivation
Shortens the sub label to Prev period instead of Previous period to make the chart cards stack better on mobile

<img width="629" height="329" alt="image" src="https://github.com/user-attachments/assets/12207773-6cd9-47d6-8918-cfec38017611" />
