### PR TITLE
Isolate the RemoteXXXOrigin classes in their own module to avoid circular dependencies when importing DagsterRun in isolation

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/utils.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/utils.py
@@ -3,7 +3,8 @@ import sys
 from contextlib import contextmanager
 
 from dagster import job, op, repository
-from dagster._core.remote_representation import JobHandle, ManagedGrpcPythonEnvCodeLocationOrigin
+from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
+from dagster._core.remote_representation import JobHandle
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.load_target import PythonFileTarget
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/repository_origin.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/repository_origin.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 
 import dagster._check as check
 import graphene
-from dagster._core.remote_representation import RemoteRepositoryOrigin
+from dagster._core.remote_origin import RemoteRepositoryOrigin
 
 from dagster_graphql.schema.util import ResolveInfo, non_null_list
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -20,7 +20,7 @@ from dagster._core.definitions.partitions.definition import (
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.origin import RemoteInstigatorOrigin
+from dagster._core.remote_origin import RemoteInstigatorOrigin
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_dagster_environment.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_dagster_environment.py
@@ -1,6 +1,6 @@
 import sys
 
-from dagster._core.remote_representation import ManagedGrpcPythonEnvCodeLocationOrigin
+from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._utils import file_relative_path

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -14,7 +14,7 @@ from dagster._core.execution.asset_backfill import (
 )
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.execution.job_backfill import execute_job_backfill_iteration
-from dagster._core.remote_representation.origin import RemotePartitionSetOrigin
+from dagster._core.remote_origin import RemotePartitionSetOrigin
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 from dagster import file_relative_path, repository
 from dagster._core.code_pointer import CodePointer
-from dagster._core.remote_representation import ManagedGrpcPythonEnvCodeLocationOrigin
+from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.remote_representation.external_data import RepositorySnap
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.load import location_origins_from_yaml_paths

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -5,8 +5,8 @@ from unittest import mock
 
 import pytest
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.remote_origin import RemotePartitionSetOrigin
 from dagster._core.remote_representation.external_data import partition_set_snap_name_for_job_name
-from dagster._core.remote_representation.origin import RemotePartitionSetOrigin
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import BACKFILL_ID_TAG
 from dagster._core.test_utils import create_run_for_test

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -4,7 +4,7 @@ import sys
 import time
 
 import pytest
-from dagster._core.remote_representation import InProcessCodeLocationOrigin, RemoteRepositoryOrigin
+from dagster._core.remote_origin import InProcessCodeLocationOrigin, RemoteRepositoryOrigin
 from dagster._core.remote_representation.external import CompoundID
 from dagster._core.scheduler.instigation import (
     InstigatorState,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.sensor_definition import SensorType
-from dagster._core.remote_representation import InProcessCodeLocationOrigin, RemoteRepositoryOrigin
+from dagster._core.remote_origin import InProcessCodeLocationOrigin, RemoteRepositoryOrigin
 from dagster._core.remote_representation.external import CompoundID
 from dagster._core.scheduler.instigation import (
     InstigatorState,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 from dagster import file_relative_path
-from dagster._core.remote_representation import ManagedGrpcPythonEnvCodeLocationOrigin
+from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.remote_representation.feature_flags import CodeLocationFeatureFlags
 from dagster._core.test_utils import environ
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin

--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -15,16 +15,16 @@ from dagster._core.origin import (
     JobPythonOrigin,
     RepositoryPythonOrigin,
 )
+from dagster._core.remote_origin import (
+    RemoteInstigatorOrigin,
+    RemoteJobOrigin,
+    RemoteRepositoryOrigin,
+)
 from dagster._core.remote_representation import (
     GrpcServerCodeLocationOrigin,
     InProcessCodeLocationOrigin,
     RemoteJob,
     RemoteSchedule,
-)
-from dagster._core.remote_representation.origin import (
-    RemoteInstigatorOrigin,
-    RemoteJobOrigin,
-    RemoteRepositoryOrigin,
 )
 from dagster._core.test_utils import in_process_test_workspace
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin

--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -16,16 +16,13 @@ from dagster._core.origin import (
     RepositoryPythonOrigin,
 )
 from dagster._core.remote_origin import (
+    GrpcServerCodeLocationOrigin,
+    InProcessCodeLocationOrigin,
     RemoteInstigatorOrigin,
     RemoteJobOrigin,
     RemoteRepositoryOrigin,
 )
-from dagster._core.remote_representation import (
-    GrpcServerCodeLocationOrigin,
-    InProcessCodeLocationOrigin,
-    RemoteJob,
-    RemoteSchedule,
-)
+from dagster._core.remote_representation import RemoteJob, RemoteSchedule
 from dagster._core.test_utils import in_process_test_workspace
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._serdes import create_snapshot_id
@@ -95,7 +92,7 @@ def get_test_project_recon_job(
     filename: Optional[str] = None,
 ) -> "ReOriginatedReconstructableJobForTest":
     filename = filename or "repo.py"
-    return ReOriginatedReconstructableJobForTest(  # type: ignore # ignored for update, fix me!
+    return ReOriginatedReconstructableJobForTest(
         ReconstructableRepository.for_file(
             file_relative_path(__file__, f"test_jobs/{filename}"),
             "define_demo_execution_repo",

--- a/python_modules/dagster-test/dagster_test/utils/data_factory.py
+++ b/python_modules/dagster-test/dagster_test/utils/data_factory.py
@@ -22,6 +22,7 @@ from dagster._core.events import (
     ResolvedFromDynamicStepHandle,
     StepHandle,
 )
+from dagster._core.remote_origin import RemoteJobOrigin
 from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.external_data import (
     JobDataSnap,
@@ -30,7 +31,7 @@ from dagster._core.remote_representation.external_data import (
 )
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.storage.dagster_run import RunOpConcurrency
-from dagster._grpc.types import JobPythonOrigin, RemoteJobOrigin, SerializableErrorInfo
+from dagster._grpc.types import JobPythonOrigin, SerializableErrorInfo
 from pydantic import UUID4
 
 

--- a/python_modules/dagster/dagster/_api/snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster/_api/snapshot_execution_plan.py
@@ -7,8 +7,8 @@ from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance
+from dagster._core.remote_origin import RemoteJobOrigin
 from dagster._core.remote_representation.external_data import DEFAULT_MODE_NAME
-from dagster._core.remote_representation.origin import RemoteJobOrigin
 from dagster._core.snap.execution_plan_snapshot import (
     ExecutionPlanSnapshot,
     ExecutionPlanSnapshotErrorData,

--- a/python_modules/dagster/dagster/_api/snapshot_job.py
+++ b/python_modules/dagster/dagster/_api/snapshot_job.py
@@ -5,8 +5,8 @@ from dagster._check import checked
 from dagster._core.definitions.asset_checks.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterUserCodeProcessError
+from dagster._core.remote_origin import RemoteJobOrigin
 from dagster._core.remote_representation.external_data import RemoteJobSubsetResult
-from dagster._core.remote_representation.origin import RemoteJobOrigin
 from dagster._grpc.types import JobSubsetSnapshotArgs
 from dagster._record import ImportFrom
 from dagster._serdes import deserialize_value

--- a/python_modules/dagster/dagster/_api/snapshot_repository.py
+++ b/python_modules/dagster/dagster/_api/snapshot_repository.py
@@ -14,7 +14,8 @@ if TYPE_CHECKING:
 def sync_get_streaming_external_repositories_data_grpc(
     api_client: "DagsterGrpcClient", code_location: "CodeLocation"
 ) -> Mapping[str, RepositorySnap]:
-    from dagster._core.remote_representation import CodeLocation, RemoteRepositoryOrigin
+    from dagster._core.remote_origin import RemoteRepositoryOrigin
+    from dagster._core.remote_representation import CodeLocation
 
     check.inst_param(code_location, "code_location", CodeLocation)
 
@@ -49,7 +50,8 @@ def sync_get_streaming_external_repositories_data_grpc(
 async def gen_streaming_external_repositories_data_grpc(
     api_client: "DagsterGrpcClient", code_location: "CodeLocation"
 ) -> Mapping[str, RepositorySnap]:
-    from dagster._core.remote_representation import CodeLocation, RemoteRepositoryOrigin
+    from dagster._core.remote_origin import RemoteRepositoryOrigin
+    from dagster._core.remote_representation import CodeLocation
 
     check.inst_param(code_location, "code_location", CodeLocation)
 

--- a/python_modules/dagster/dagster/_cli/proxy_server_manager.py
+++ b/python_modules/dagster/dagster/_cli/proxy_server_manager.py
@@ -10,13 +10,13 @@ from typing_extensions import Self
 import dagster._check as check
 from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.instance import DagsterInstance
+from dagster._core.remote_origin import (
+    GrpcServerCodeLocationOrigin,
+    ManagedGrpcPythonEnvCodeLocationOrigin,
+)
 from dagster._core.remote_representation.grpc_server_registry import (
     GrpcServerRegistry,
     ServerRegistryEntry,
-)
-from dagster._core.remote_representation.origin import (
-    GrpcServerCodeLocationOrigin,
-    ManagedGrpcPythonEnvCodeLocationOrigin,
 )
 from dagster._core.workspace.context import WEBSERVER_GRPC_SERVER_HEARTBEAT_TTL
 from dagster._core.workspace.load_target import WorkspaceLoadTarget

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -23,13 +23,13 @@ from dagster._core.definitions.repository_definition.valid_definitions import (
 )
 from dagster._core.instance import DagsterInstance
 from dagster._core.origin import DEFAULT_DAGSTER_ENTRY_POINT, RepositoryPythonOrigin
-from dagster._core.remote_representation.code_location import CodeLocation
-from dagster._core.remote_representation.external import RemoteJob, RemoteRepository
-from dagster._core.remote_representation.origin import (
+from dagster._core.remote_origin import (
     CodeLocationOrigin,
     GrpcServerCodeLocationOrigin,
     InProcessCodeLocationOrigin,
 )
+from dagster._core.remote_representation.code_location import CodeLocation
+from dagster._core.remote_representation.external import RemoteJob, RemoteRepository
 from dagster._core.workspace.context import WorkspaceProcessContext, WorkspaceRequestContext
 from dagster._core.workspace.load_target import (
     CompositeTarget,

--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -5,16 +5,18 @@ import threading
 import traceback
 from collections.abc import Mapping, Sequence
 from contextlib import ExitStack
-from typing import IO, Any, Optional
+from typing import IO, TYPE_CHECKING, Any, Optional
 
 from dagster_shared import seven
 
-from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
 from dagster._core.storage.compute_log_manager import ComputeIOType, ComputeLogManager
 from dagster._core.utils import coerce_valid_log_level
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.log import create_console_logger
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DagsterInstance
 
 
 class DispatchingLogHandler(logging.Handler):
@@ -92,7 +94,7 @@ class InstigationLogger(logging.Logger):
     def __init__(
         self,
         log_key: Optional[Sequence[str]] = None,
-        instance: Optional[DagsterInstance] = None,
+        instance: Optional["DagsterInstance"] = None,
         repository_name: Optional[str] = None,
         instigator_name: Optional[str] = None,
         level: int = logging.NOTSET,
@@ -166,7 +168,7 @@ class InstigationLogger(logging.Logger):
 
 
 def get_instigation_log_records(
-    instance: DagsterInstance, log_key: Sequence[str]
+    instance: "DagsterInstance", log_key: Sequence[str]
 ) -> Sequence[Mapping[str, Any]]:
     log_data = instance.compute_log_manager.get_log_data(log_key)
     raw_logs = log_data.stderr.decode("utf-8") if log_data.stderr else ""

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -53,7 +53,6 @@ from dagster._core.definitions.resource_requirement import (
     ResourceRequirement,
     ensure_requirements_satisfied,
 )
-from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY, check_valid_name
 from dagster._core.errors import (
     DagsterInvalidConfigError,
@@ -80,6 +79,7 @@ if TYPE_CHECKING:
     from dagster._core.definitions.assets.definition.assets_definition import AssetsDefinition
     from dagster._core.definitions.run_config import RunConfig
     from dagster._core.definitions.run_config_schema import RunConfigSchema
+    from dagster._core.definitions.run_request import RunRequest
     from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
     from dagster._core.execution.resources_init import InitResourceContext
     from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
@@ -1002,7 +1002,7 @@ class JobDefinition(IHasInternalInit):
         run_config: Optional[Mapping[str, Any]] = None,
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
-    ) -> RunRequest:
+    ) -> "RunRequest":
         """Creates a RunRequest object for a run that processes the given partition.
 
         Args:
@@ -1027,6 +1027,8 @@ class JobDefinition(IHasInternalInit):
         Returns:
             RunRequest: an object that requests a run to process the given partition.
         """
+        from dagster._core.definitions.run_request import RunRequest
+
         if not (self.partitions_def and self.partitioned_config):
             check.failed("Called run_request_for_partition on a non-partitioned job")
 

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -39,7 +39,7 @@ from dagster._utils.warnings import deprecation_warning, normalize_renamed_param
 if TYPE_CHECKING:
     from dagster._core.definitions.definitions_class import Definitions
     from dagster._core.definitions.repository_definition import RepositoryDefinition
-    from dagster._core.remote_representation.origin import CodeLocationOrigin
+    from dagster._core.remote_origin import CodeLocationOrigin
     from dagster._core.storage.event_log.base import EventLogRecord
 
 MAX_NUM_UNCONSUMED_EVENTS = 25

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/all.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/all.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional
 
 import dagster._check as check
 from dagster._annotations import public
@@ -13,8 +13,10 @@ from dagster._core.definitions.partitions.mapping.partition_mapping import (
 )
 from dagster._core.definitions.partitions.subset.all import AllPartitionsSubset
 from dagster._core.definitions.partitions.subset.partitions_subset import PartitionsSubset
-from dagster._core.instance import DynamicPartitionsStore
 from dagster._serdes import whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DynamicPartitionsStore
 
 
 @whitelist_for_serdes
@@ -39,7 +41,7 @@ class AllPartitionMapping(PartitionMapping, NamedTuple("_AllPartitionMapping", [
         downstream_partitions_def: Optional[PartitionsDefinition],
         upstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> UpstreamPartitionsResult:
         with partition_loading_context(current_time, dynamic_partitions_store) as ctx:
             if ctx.dynamic_partitions_store is not None and ctx.effective_dt is not None:
@@ -59,7 +61,7 @@ class AllPartitionMapping(PartitionMapping, NamedTuple("_AllPartitionMapping", [
         upstream_partitions_def: PartitionsDefinition,
         downstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> PartitionsSubset:
         with partition_loading_context(current_time, dynamic_partitions_store):
             if upstream_partitions_subset is None:

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/identity.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/identity.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional
 
 import dagster._check as check
 from dagster._annotations import public
@@ -12,8 +12,10 @@ from dagster._core.definitions.partitions.mapping.partition_mapping import (
 from dagster._core.definitions.partitions.subset.default import DefaultPartitionsSubset
 from dagster._core.definitions.partitions.subset.partitions_subset import PartitionsSubset
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._core.instance import DynamicPartitionsStore
 from dagster._serdes import whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DynamicPartitionsStore
 
 
 @whitelist_for_serdes
@@ -40,7 +42,7 @@ class IdentityPartitionMapping(PartitionMapping, NamedTuple("_IdentityPartitionM
         downstream_partitions_def: Optional[PartitionsDefinition],
         upstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> UpstreamPartitionsResult:
         with partition_loading_context(current_time, dynamic_partitions_store):
             if downstream_partitions_subset is None:
@@ -72,7 +74,7 @@ class IdentityPartitionMapping(PartitionMapping, NamedTuple("_IdentityPartitionM
         upstream_partitions_def: PartitionsDefinition,
         downstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> PartitionsSubset:
         with partition_loading_context(current_time, dynamic_partitions_store):
             if upstream_partitions_subset is None:

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/last.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/last.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional
 
 from dagster._annotations import public
 from dagster._core.definitions.partitions.context import partition_loading_context
@@ -9,8 +9,10 @@ from dagster._core.definitions.partitions.mapping.partition_mapping import (
     UpstreamPartitionsResult,
 )
 from dagster._core.definitions.partitions.subset.partitions_subset import PartitionsSubset
-from dagster._core.instance import DynamicPartitionsStore
 from dagster._serdes import whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DynamicPartitionsStore
 
 
 @whitelist_for_serdes
@@ -35,7 +37,7 @@ class LastPartitionMapping(PartitionMapping, NamedTuple("_LastPartitionMapping",
         downstream_partitions_def: Optional[PartitionsDefinition],
         upstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> UpstreamPartitionsResult:
         with partition_loading_context(current_time, dynamic_partitions_store):
             last = upstream_partitions_def.get_last_partition_key()
@@ -55,7 +57,7 @@ class LastPartitionMapping(PartitionMapping, NamedTuple("_LastPartitionMapping",
         upstream_partitions_def: PartitionsDefinition,
         downstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> PartitionsSubset:
         with partition_loading_context(current_time, dynamic_partitions_store):
             last_upstream_partition = upstream_partitions_def.get_last_partition_key()

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/multi/base.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/multi/base.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime
-from typing import NamedTuple, Optional, Union, cast
+from typing import TYPE_CHECKING, NamedTuple, Optional, Union, cast
 
 import dagster._check as check
 from dagster._core.definitions.partitions.context import partition_loading_context
@@ -18,8 +18,10 @@ from dagster._core.definitions.partitions.mapping.partition_mapping import (
 from dagster._core.definitions.partitions.subset.default import DefaultPartitionsSubset
 from dagster._core.definitions.partitions.subset.partitions_subset import PartitionsSubset
 from dagster._core.definitions.partitions.utils.multi import MultiPartitionKey
-from dagster._core.instance import DynamicPartitionsStore
 from dagster._serdes import whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DynamicPartitionsStore
 
 
 class DimensionDependency(NamedTuple):
@@ -228,7 +230,7 @@ class BaseMultiPartitionMapping(ABC):
         downstream_partitions_def: Optional[PartitionsDefinition],
         upstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> UpstreamPartitionsResult:
         with partition_loading_context(current_time, dynamic_partitions_store):
             if downstream_partitions_subset is None:
@@ -252,7 +254,7 @@ class BaseMultiPartitionMapping(ABC):
         upstream_partitions_def: PartitionsDefinition,
         downstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> PartitionsSubset:
         with partition_loading_context(current_time, dynamic_partitions_store):
             if upstream_partitions_subset is None:

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/partition_mapping.py
@@ -2,15 +2,17 @@ from abc import ABC, abstractmethod, abstractproperty
 from collections.abc import Sequence
 from datetime import datetime
 from functools import cached_property
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from dagster._annotations import public
 from dagster._core.definitions.partitions.definition.partitions_definition import (
     PartitionsDefinition,
 )
 from dagster._core.definitions.partitions.subset.partitions_subset import PartitionsSubset
-from dagster._core.instance import DynamicPartitionsStore
 from dagster._record import record
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DynamicPartitionsStore
 
 
 @record
@@ -49,7 +51,7 @@ class PartitionMapping(ABC):
         upstream_partitions_def: PartitionsDefinition,
         downstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> PartitionsSubset:
         """Returns the subset of partition keys in the downstream asset that use the data in the given
         partition key subset of the upstream asset.
@@ -81,7 +83,7 @@ class PartitionMapping(ABC):
         downstream_partitions_def: Optional[PartitionsDefinition],
         upstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> UpstreamPartitionsResult:
         """Returns a UpstreamPartitionsResult object containing the partition keys the downstream
         partitions subset was mapped to in the upstream partitions definition.

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/specific_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/specific_partitions.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from datetime import datetime
-from typing import NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional
 
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.partitions.context import partition_loading_context
@@ -10,8 +10,10 @@ from dagster._core.definitions.partitions.mapping.partition_mapping import (
     UpstreamPartitionsResult,
 )
 from dagster._core.definitions.partitions.subset.partitions_subset import PartitionsSubset
-from dagster._core.instance import DynamicPartitionsStore
 from dagster._serdes import whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DynamicPartitionsStore
 
 
 @whitelist_for_serdes
@@ -54,7 +56,7 @@ class SpecificPartitionsPartitionMapping(
         downstream_partitions_def: Optional[PartitionsDefinition],
         upstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> UpstreamPartitionsResult:
         with partition_loading_context(current_time, dynamic_partitions_store):
             return UpstreamPartitionsResult(
@@ -70,7 +72,7 @@ class SpecificPartitionsPartitionMapping(
         upstream_partitions_def: PartitionsDefinition,
         downstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> PartitionsSubset:
         with partition_loading_context(current_time, dynamic_partitions_store):
             # if any of the partition keys in this partition mapping are contained within the upstream

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/static.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/static.py
@@ -2,7 +2,7 @@ import collections.abc
 from collections import defaultdict
 from collections.abc import Collection, Mapping
 from datetime import datetime
-from typing import NamedTuple, Optional, Union, cast
+from typing import TYPE_CHECKING, NamedTuple, Optional, Union, cast
 
 import dagster._check as check
 from dagster._annotations import PublicAttr
@@ -15,9 +15,11 @@ from dagster._core.definitions.partitions.mapping.partition_mapping import (
 )
 from dagster._core.definitions.partitions.subset.partitions_subset import PartitionsSubset
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._core.instance import DynamicPartitionsStore
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.cached_method import cached_method
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DynamicPartitionsStore
 
 
 @whitelist_for_serdes
@@ -127,7 +129,7 @@ class StaticPartitionMapping(
         upstream_partitions_def: StaticPartitionsDefinition,
         downstream_partitions_def: StaticPartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> PartitionsSubset:
         with partition_loading_context(current_time, dynamic_partitions_store):
             self._check_downstream(downstream_partitions_def=downstream_partitions_def)
@@ -144,7 +146,7 @@ class StaticPartitionMapping(
         downstream_partitions_def: Optional[PartitionsDefinition],
         upstream_partitions_def: StaticPartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> UpstreamPartitionsResult:
         with partition_loading_context(current_time, dynamic_partitions_store):
             self._check_upstream(upstream_partitions_def=upstream_partitions_def)

--- a/python_modules/dagster/dagster/_core/definitions/partitions/mapping/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/mapping/time_window.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from datetime import datetime, timedelta
-from typing import NamedTuple, Optional, cast
+from typing import TYPE_CHECKING, NamedTuple, Optional, cast
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, beta_param
@@ -18,9 +18,11 @@ from dagster._core.definitions.partitions.subset.partitions_subset import Partit
 from dagster._core.definitions.partitions.subset.time_window import TimeWindowPartitionsSubset
 from dagster._core.definitions.partitions.utils.time_window import TimeWindow
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._core.instance import DynamicPartitionsStore
 from dagster._serdes import whitelist_for_serdes
 from dagster._time import add_absolute_time
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DynamicPartitionsStore
 
 
 @whitelist_for_serdes
@@ -155,7 +157,7 @@ class TimeWindowPartitionMapping(
         downstream_partitions_def: Optional[PartitionsDefinition],
         upstream_partitions_def: PartitionsDefinition,
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> UpstreamPartitionsResult:
         with partition_loading_context(current_time, dynamic_partitions_store):
             return self._map_partitions(
@@ -204,7 +206,7 @@ class TimeWindowPartitionMapping(
         upstream_partitions_def: PartitionsDefinition,
         downstream_partitions_def: Optional[PartitionsDefinition],
         current_time: Optional[datetime] = None,
-        dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
     ) -> PartitionsSubset:
         """Returns the partitions in the downstream asset that map to the given upstream partitions.
 

--- a/python_modules/dagster/dagster/_core/definitions/partitions/snap/snap.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/snap/snap.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Optional
 from typing_extensions import Self
 
 from dagster import _check as check
+from dagster._core.definitions.partitions.schedule_type import ScheduleType
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._record import IHaveNew, record, record_custom
 from dagster._serdes import whitelist_for_serdes
@@ -24,7 +25,6 @@ if TYPE_CHECKING:
         StaticPartitionsDefinition,
         TimeWindowPartitionsDefinition,
     )
-    from dagster._core.definitions.partitions.schedule_type import ScheduleType
 
 
 class PartitionsSnap(ABC):
@@ -65,7 +65,7 @@ class TimeWindowPartitionsSnap(PartitionsSnap):
     end: Optional[float] = None
     cron_schedule: Optional[str] = None
     # superseded by cron_schedule, but kept around for backcompat
-    schedule_type: Optional["ScheduleType"] = None
+    schedule_type: Optional[ScheduleType] = None
     # superseded by cron_schedule, but kept around for backcompat
     minute_offset: Optional[int] = None
     # superseded by cron_schedule, but kept around for backcompat

--- a/python_modules/dagster/dagster/_core/definitions/partitions/snap/snap.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/snap/snap.py
@@ -6,28 +6,37 @@ for that.
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from typing_extensions import Self
 
 from dagster import _check as check
-from dagster._core.definitions.partitions.definition import (
-    DynamicPartitionsDefinition,
-    MultiPartitionsDefinition,
-    PartitionsDefinition,
-    StaticPartitionsDefinition,
-    TimeWindowPartitionsDefinition,
-)
-from dagster._core.definitions.partitions.schedule_type import ScheduleType
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._record import IHaveNew, record, record_custom
 from dagster._serdes import whitelist_for_serdes
 from dagster._time import datetime_from_timestamp
 
+if TYPE_CHECKING:
+    from dagster._core.definitions.partitions.definition import (
+        DynamicPartitionsDefinition,
+        MultiPartitionsDefinition,
+        PartitionsDefinition,
+        StaticPartitionsDefinition,
+        TimeWindowPartitionsDefinition,
+    )
+    from dagster._core.definitions.partitions.schedule_type import ScheduleType
+
 
 class PartitionsSnap(ABC):
     @classmethod
-    def from_def(cls, partitions_def: PartitionsDefinition) -> "PartitionsSnap":
+    def from_def(cls, partitions_def: "PartitionsDefinition") -> "PartitionsSnap":
+        from dagster._core.definitions.partitions.definition import (
+            DynamicPartitionsDefinition,
+            MultiPartitionsDefinition,
+            StaticPartitionsDefinition,
+            TimeWindowPartitionsDefinition,
+        )
+
         if isinstance(partitions_def, TimeWindowPartitionsDefinition):
             return TimeWindowPartitionsSnap.from_def(partitions_def)
         elif isinstance(partitions_def, StaticPartitionsDefinition):
@@ -43,7 +52,7 @@ class PartitionsSnap(ABC):
             )
 
     @abstractmethod
-    def get_partitions_definition(self) -> PartitionsDefinition: ...
+    def get_partitions_definition(self) -> "PartitionsDefinition": ...
 
 
 @whitelist_for_serdes(storage_name="ExternalTimeWindowPartitionsDefinitionData")
@@ -56,7 +65,7 @@ class TimeWindowPartitionsSnap(PartitionsSnap):
     end: Optional[float] = None
     cron_schedule: Optional[str] = None
     # superseded by cron_schedule, but kept around for backcompat
-    schedule_type: Optional[ScheduleType] = None
+    schedule_type: Optional["ScheduleType"] = None
     # superseded by cron_schedule, but kept around for backcompat
     minute_offset: Optional[int] = None
     # superseded by cron_schedule, but kept around for backcompat
@@ -65,7 +74,9 @@ class TimeWindowPartitionsSnap(PartitionsSnap):
     day_offset: Optional[int] = None
 
     @classmethod
-    def from_def(cls, partitions_def: TimeWindowPartitionsDefinition) -> Self:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def from_def(cls, partitions_def: "TimeWindowPartitionsDefinition") -> Self:  # pyright: ignore[reportIncompatibleMethodOverride]
+        from dagster._core.definitions.partitions.definition import TimeWindowPartitionsDefinition
+
         check.inst_param(partitions_def, "partitions_def", TimeWindowPartitionsDefinition)
         return cls(
             cron_schedule=partitions_def.cron_schedule,
@@ -77,6 +88,8 @@ class TimeWindowPartitionsSnap(PartitionsSnap):
         )
 
     def get_partitions_definition(self):
+        from dagster._core.definitions.partitions.definition import TimeWindowPartitionsDefinition
+
         if self.cron_schedule is not None:
             return TimeWindowPartitionsDefinition(
                 cron_schedule=self.cron_schedule,
@@ -133,11 +146,15 @@ class StaticPartitionsSnap(PartitionsSnap, IHaveNew):
         )
 
     @classmethod
-    def from_def(cls, partitions_def: StaticPartitionsDefinition) -> Self:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def from_def(cls, partitions_def: "StaticPartitionsDefinition") -> Self:  # pyright: ignore[reportIncompatibleMethodOverride]
+        from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
+
         check.inst_param(partitions_def, "partitions_def", StaticPartitionsDefinition)
         return cls(partition_keys=partitions_def.get_partition_keys())
 
     def get_partitions_definition(self):
+        from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
+
         # v1.4 made `StaticPartitionsDefinition` error if given duplicate keys. This caused
         # host process errors for users who had not upgraded their user code to 1.4 and had dup
         # keys, since the host process `StaticPartitionsDefinition` would throw an error.
@@ -164,7 +181,9 @@ class MultiPartitionsSnap(PartitionsSnap):
     partition_dimensions: Sequence[PartitionDimensionSnap]
 
     @classmethod
-    def from_def(cls, partitions_def: MultiPartitionsDefinition) -> Self:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def from_def(cls, partitions_def: "MultiPartitionsDefinition") -> Self:  # pyright: ignore[reportIncompatibleMethodOverride]
+        from dagster._core.definitions.partitions.definition import MultiPartitionsDefinition
+
         check.inst_param(partitions_def, "partitions_def", MultiPartitionsDefinition)
 
         return cls(
@@ -178,6 +197,8 @@ class MultiPartitionsSnap(PartitionsSnap):
         )
 
     def get_partitions_definition(self):
+        from dagster._core.definitions.partitions.definition import MultiPartitionsDefinition
+
         return MultiPartitionsDefinition(
             {
                 partition_dimension.name: (
@@ -194,7 +215,9 @@ class DynamicPartitionsSnap(PartitionsSnap):
     name: str
 
     @classmethod
-    def from_def(cls, partitions_def: DynamicPartitionsDefinition) -> Self:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def from_def(cls, partitions_def: "DynamicPartitionsDefinition") -> Self:  # pyright: ignore[reportIncompatibleMethodOverride]
+        from dagster._core.definitions.partitions.definition import DynamicPartitionsDefinition
+
         check.inst_param(partitions_def, "partitions_def", DynamicPartitionsDefinition)
         if partitions_def.name is None:
             raise DagsterInvalidDefinitionError(
@@ -203,4 +226,6 @@ class DynamicPartitionsSnap(PartitionsSnap):
         return cls(name=partitions_def.name)
 
     def get_partitions_definition(self):
+        from dagster._core.definitions.partitions.definition import DynamicPartitionsDefinition
+
         return DynamicPartitionsDefinition(name=self.name)

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
     from dagster._core.definitions.unresolved_asset_job_definition import (
         UnresolvedAssetJobDefinition,
     )
-    from dagster._core.remote_representation.origin import CodeLocationOrigin
+    from dagster._core.remote_origin import CodeLocationOrigin
 
 
 @whitelist_for_serdes
@@ -167,7 +167,7 @@ class SensorEvaluationContext:
     ):
         from dagster._core.definitions.definitions_class import Definitions
         from dagster._core.definitions.repository_definition import RepositoryDefinition
-        from dagster._core.remote_representation.origin import CodeLocationOrigin
+        from dagster._core.remote_origin import CodeLocationOrigin
 
         self._exit_stack = ExitStack()
         self._instance_ref = check.opt_inst_param(instance_ref, "instance_ref", InstanceRef)

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -19,8 +19,8 @@ from dagster._core.execution.asset_backfill import (
 )
 from dagster._core.execution.bulk_actions import BulkActionType
 from dagster._core.instance import DynamicPartitionsStore
+from dagster._core.remote_origin import RemotePartitionSetOrigin
 from dagster._core.remote_representation.external_data import job_name_for_partition_set_snap_name
-from dagster._core.remote_representation.origin import RemotePartitionSetOrigin
 from dagster._core.storage.dagster_run import (
     CANCELABLE_RUN_STATUSES,
     NOT_FINISHED_STATUSES,

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -43,7 +43,7 @@ from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.merger import merge_dicts
 
 if TYPE_CHECKING:
-    from dagster._core.remote_representation.origin import RemotePartitionSetOrigin
+    from dagster._core.remote_origin import RemotePartitionSetOrigin
 
 # out of abundance of caution, sleep at checkpoints in case we are pinning CPU by submitting lots
 # of jobs all at once

--- a/python_modules/dagster/dagster/_core/execution/retries.py
+++ b/python_modules/dagster/dagster/_core/execution/retries.py
@@ -10,13 +10,13 @@ import dagster._check as check
 from dagster._config.field import Field
 from dagster._config.field_utils import Selector
 from dagster._core.errors import DagsterRunNotFoundError
-from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import MAX_RETRIES_TAG, RETRY_ON_ASSET_OR_OP_FAILURE_TAG
 from dagster._utils.tags import get_boolean_tag_value
 
 if TYPE_CHECKING:
     from dagster._core.events import RunFailureReason
     from dagster._core.instance import DagsterInstance
+    from dagster._core.storage.dagster_run import DagsterRun
 
 
 def get_retries_config():
@@ -81,7 +81,7 @@ class RetryState:
 
 
 def auto_reexecution_should_retry_run(
-    instance: "DagsterInstance", run: DagsterRun, run_failure_reason: Optional["RunFailureReason"]
+    instance: "DagsterInstance", run: "DagsterRun", run_failure_reason: Optional["RunFailureReason"]
 ):
     """Determines if a run will be retried by the automatic reexcution system.
     A run will retry if:
@@ -116,6 +116,7 @@ def auto_reexecution_should_retry_run(
     run itself, just that max_retries + 1 runs could be launched in total if a manual retry is timed to cause this condition (unlikely).
     """
     from dagster._core.events import RunFailureReason
+    from dagster._core.storage.dagster_run import DagsterRunStatus
 
     if run.status != DagsterRunStatus.FAILURE:
         return False

--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -90,11 +90,11 @@ if TYPE_CHECKING:
     from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
     from dagster._core.execution.stats import RunStepKeyStatsSnapshot
     from dagster._core.launcher import RunLauncher
+    from dagster._core.remote_origin import RemoteJobOrigin
     from dagster._core.remote_representation import (
         CodeLocation,
         HistoricalJob,
         RemoteJob,
-        RemoteJobOrigin,
         RemoteSensor,
     )
     from dagster._core.remote_representation.external import RemoteSchedule

--- a/python_modules/dagster/dagster/_core/instance/runs/run_domain.py
+++ b/python_modules/dagster/dagster/_core/instance/runs/run_domain.py
@@ -58,8 +58,8 @@ if TYPE_CHECKING:
     from dagster._core.execution.plan.plan import ExecutionPlan
     from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
     from dagster._core.instance.instance import DagsterInstance
+    from dagster._core.remote_origin import RemoteJobOrigin
     from dagster._core.remote_representation import CodeLocation, RemoteJob
-    from dagster._core.remote_representation.origin import RemoteJobOrigin
     from dagster._core.snap import ExecutionPlanSnapshot, JobSnap
     from dagster._core.snap.execution_plan_snapshot import (
         ExecutionStepOutputSnap,
@@ -101,7 +101,7 @@ class RunDomain:
     ) -> DagsterRun:
         """Create a run with the given parameters."""
         from dagster._core.definitions.asset_key import AssetCheckKey
-        from dagster._core.remote_representation.origin import RemoteJobOrigin
+        from dagster._core.remote_origin import RemoteJobOrigin
         from dagster._core.snap import ExecutionPlanSnapshot, JobSnap
         from dagster._utils.tags import normalize_tags
 

--- a/python_modules/dagster/dagster/_core/instance/types.py
+++ b/python_modules/dagster/dagster/_core/instance/types.py
@@ -2,9 +2,10 @@ import logging
 import sys
 import weakref
 from abc import abstractmethod
+from collections import defaultdict
 from collections.abc import Sequence
 from enum import Enum
-from typing import TYPE_CHECKING, Generic, Optional
+from typing import TYPE_CHECKING, AbstractSet, Generic, Mapping, Optional, Union  # noqa: UP035
 
 from typing_extensions import Protocol, TypeVar, runtime_checkable
 
@@ -12,10 +13,15 @@ import dagster._check as check
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.log_manager import get_log_record_metadata
 from dagster._core.types.pagination import PaginatedResults
+from dagster._record import record
 from dagster._utils.cached_method import cached_method
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.dynamic_partitions_request import (
+        AddDynamicPartitionsRequest,
+        DeleteDynamicPartitionsRequest,
+    )
     from dagster._core.instance.instance import DagsterInstance
 
 
@@ -162,3 +168,77 @@ class CachingDynamicPartitionsLoader(DynamicPartitionsStore):
     @cached_method
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
         return self._instance.has_dynamic_partition(partitions_def_name, partition_key)
+
+
+@record
+class DynamicPartitionsStoreAfterRequests(DynamicPartitionsStore):
+    """Represents the dynamic partitions that will be in the contained DynamicPartitionsStore
+    after the contained requests are satisfied.
+    """
+
+    wrapped_dynamic_partitions_store: DynamicPartitionsStore
+    added_partition_keys_by_partitions_def_name: Mapping[str, AbstractSet[str]]
+    deleted_partition_keys_by_partitions_def_name: Mapping[str, AbstractSet[str]]
+
+    @staticmethod
+    def from_requests(
+        wrapped_dynamic_partitions_store: DynamicPartitionsStore,
+        dynamic_partitions_requests: Sequence[
+            Union["AddDynamicPartitionsRequest", "DeleteDynamicPartitionsRequest"]
+        ],
+    ) -> "DynamicPartitionsStoreAfterRequests":
+        from dagster._core.definitions.dynamic_partitions_request import (
+            AddDynamicPartitionsRequest,
+            DeleteDynamicPartitionsRequest,
+        )
+
+        added_partition_keys_by_partitions_def_name: dict[str, set[str]] = defaultdict(set)
+        deleted_partition_keys_by_partitions_def_name: dict[str, set[str]] = defaultdict(set)
+
+        for req in dynamic_partitions_requests:
+            name = req.partitions_def_name
+            if isinstance(req, AddDynamicPartitionsRequest):
+                added_partition_keys_by_partitions_def_name[name].update(set(req.partition_keys))
+            elif isinstance(req, DeleteDynamicPartitionsRequest):
+                deleted_partition_keys_by_partitions_def_name[name].update(set(req.partition_keys))
+            else:
+                check.failed(f"Unexpected request type: {req}")
+
+        return DynamicPartitionsStoreAfterRequests(
+            wrapped_dynamic_partitions_store=wrapped_dynamic_partitions_store,
+            added_partition_keys_by_partitions_def_name=added_partition_keys_by_partitions_def_name,
+            deleted_partition_keys_by_partitions_def_name=deleted_partition_keys_by_partitions_def_name,
+        )
+
+    @cached_method
+    def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
+        partition_keys = set(
+            self.wrapped_dynamic_partitions_store.get_dynamic_partitions(partitions_def_name)
+        )
+        added_partition_keys = self.added_partition_keys_by_partitions_def_name.get(
+            partitions_def_name, set()
+        )
+        deleted_partition_keys = self.deleted_partition_keys_by_partitions_def_name.get(
+            partitions_def_name, set()
+        )
+        return list((partition_keys | added_partition_keys) - deleted_partition_keys)
+
+    @cached_method
+    def get_paginated_dynamic_partitions(
+        self, partitions_def_name: str, limit: int, ascending: bool, cursor: Optional[str] = None
+    ) -> PaginatedResults[str]:
+        partition_keys = self.get_dynamic_partitions(partitions_def_name)
+        return PaginatedResults.create_from_sequence(
+            seq=partition_keys, limit=limit, ascending=ascending, cursor=cursor
+        )
+
+    def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
+        return partition_key not in self.deleted_partition_keys_by_partitions_def_name.get(
+            partitions_def_name, set()
+        ) and (
+            partition_key
+            in self.added_partition_keys_by_partitions_def_name.get(partitions_def_name, set())
+            or self.wrapped_dynamic_partitions_store.has_dynamic_partition(
+                partitions_def_name, partition_key
+            )
+        )

--- a/python_modules/dagster/dagster/_core/remote_origin.py
+++ b/python_modules/dagster/dagster/_core/remote_origin.py
@@ -2,22 +2,16 @@ import os
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Final, NoReturn, Optional, cast
+from typing import TYPE_CHECKING, Any, NoReturn, Optional, cast
 
 from dagster_shared.record import IHaveNew, LegacyNamedTupleMixin, record, record_custom
 
 import dagster._check as check
 from dagster._core.errors import DagsterInvariantViolationError, DagsterUserCodeUnreachableError
 from dagster._core.instance.config import DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
+from dagster._core.origin import DEFAULT_DAGSTER_ENTRY_POINT
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._serdes import create_snapshot_id, whitelist_for_serdes
-
-DEFAULT_DAGSTER_ENTRY_POINT: Final = ["dagster"]
-
-
-def get_python_environment_entry_point(executable_path: str) -> Sequence[str]:
-    return [executable_path, "-m", "dagster"]
-
 
 if TYPE_CHECKING:
     from dagster._core.definitions.selector import (

--- a/python_modules/dagster/dagster/_core/remote_representation/__init__.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/__init__.py
@@ -6,6 +6,16 @@ It also contains classes that represent historical representations
 that have been persisted. e.g. HistoricalPipeline
 """
 
+from dagster._core.remote_origin import (
+    IN_PROCESS_NAME as IN_PROCESS_NAME,
+    CodeLocationOrigin as CodeLocationOrigin,
+    GrpcServerCodeLocationOrigin as GrpcServerCodeLocationOrigin,
+    InProcessCodeLocationOrigin as InProcessCodeLocationOrigin,
+    ManagedGrpcPythonEnvCodeLocationOrigin as ManagedGrpcPythonEnvCodeLocationOrigin,
+    RemoteInstigatorOrigin as RemoteInstigatorOrigin,
+    RemoteJobOrigin as RemoteJobOrigin,
+    RemoteRepositoryOrigin as RemoteRepositoryOrigin,
+)
 from dagster._core.remote_representation.external import (
     RemoteExecutionPlan as RemoteExecutionPlan,
     RemoteJob as RemoteJob,
@@ -40,16 +50,6 @@ from dagster._core.remote_representation.handle import (
     RepositoryHandle as RepositoryHandle,
 )
 from dagster._core.remote_representation.historical import HistoricalJob as HistoricalJob
-from dagster._core.remote_representation.origin import (
-    IN_PROCESS_NAME as IN_PROCESS_NAME,
-    CodeLocationOrigin as CodeLocationOrigin,
-    GrpcServerCodeLocationOrigin as GrpcServerCodeLocationOrigin,
-    InProcessCodeLocationOrigin as InProcessCodeLocationOrigin,
-    ManagedGrpcPythonEnvCodeLocationOrigin as ManagedGrpcPythonEnvCodeLocationOrigin,
-    RemoteInstigatorOrigin as RemoteInstigatorOrigin,
-    RemoteJobOrigin as RemoteJobOrigin,
-    RemoteRepositoryOrigin as RemoteRepositoryOrigin,
-)
 
 # ruff: isort: split
 from dagster._core.remote_representation.code_location import (

--- a/python_modules/dagster/dagster/_core/remote_representation/__init__.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/__init__.py
@@ -6,16 +6,6 @@ It also contains classes that represent historical representations
 that have been persisted. e.g. HistoricalPipeline
 """
 
-from dagster._core.remote_origin import (
-    IN_PROCESS_NAME as IN_PROCESS_NAME,
-    CodeLocationOrigin as CodeLocationOrigin,
-    GrpcServerCodeLocationOrigin as GrpcServerCodeLocationOrigin,
-    InProcessCodeLocationOrigin as InProcessCodeLocationOrigin,
-    ManagedGrpcPythonEnvCodeLocationOrigin as ManagedGrpcPythonEnvCodeLocationOrigin,
-    RemoteInstigatorOrigin as RemoteInstigatorOrigin,
-    RemoteJobOrigin as RemoteJobOrigin,
-    RemoteRepositoryOrigin as RemoteRepositoryOrigin,
-)
 from dagster._core.remote_representation.external import (
     RemoteExecutionPlan as RemoteExecutionPlan,
     RemoteJob as RemoteJob,

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -26,6 +26,11 @@ from dagster._core.execution.api import create_execution_plan
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance
 from dagster._core.origin import RepositoryPythonOrigin
+from dagster._core.remote_origin import (
+    CodeLocationOrigin,
+    GrpcServerCodeLocationOrigin,
+    InProcessCodeLocationOrigin,
+)
 from dagster._core.remote_representation import RemoteJobSubsetResult
 from dagster._core.remote_representation.external import (
     RemoteExecutionPlan,
@@ -41,11 +46,6 @@ from dagster._core.remote_representation.external_data import (
 )
 from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
 from dagster._core.remote_representation.handle import JobHandle, RepositoryHandle
-from dagster._core.remote_representation.origin import (
-    CodeLocationOrigin,
-    GrpcServerCodeLocationOrigin,
-    InProcessCodeLocationOrigin,
-)
 from dagster._core.snap.execution_plan_snapshot import snapshot_from_execution_plan
 from dagster._grpc.impl import (
     get_external_schedule_execution,

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -9,9 +9,9 @@ from typing import TYPE_CHECKING, AbstractSet, Callable, Optional, Union  # noqa
 from dagster_shared.error import DagsterError
 
 import dagster._check as check
-from dagster import AssetSelection
 from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot
 from dagster._core.definitions.asset_checks.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets.job.asset_job import IMPLICIT_ASSET_JOB_NAME
 from dagster._core.definitions.automation_condition_sensor_definition import (
     DEFAULT_AUTOMATION_CONDITION_SENSOR_NAME,

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -39,6 +39,12 @@ from dagster._core.execution.plan.handle import ResolvedFromDynamicStepHandle, S
 from dagster._core.instance import DagsterInstance
 from dagster._core.loader import LoadableBy
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
+from dagster._core.remote_origin import (
+    RemoteInstigatorOrigin,
+    RemoteJobOrigin,
+    RemotePartitionSetOrigin,
+    RemoteRepositoryOrigin,
+)
 from dagster._core.remote_representation.external_data import (
     DEFAULT_MODE_NAME,
     AssetCheckNodeSnap,
@@ -66,12 +72,6 @@ from dagster._core.remote_representation.handle import (
     RepositoryHandle,
 )
 from dagster._core.remote_representation.job_index import JobIndex
-from dagster._core.remote_representation.origin import (
-    RemoteInstigatorOrigin,
-    RemoteJobOrigin,
-    RemotePartitionSetOrigin,
-    RemoteRepositoryOrigin,
-)
 from dagster._core.remote_representation.represented import RepresentedJob
 from dagster._core.snap import ExecutionPlanSnapshot
 from dagster._core.snap.job_snapshot import JobSnap

--- a/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
@@ -8,10 +8,7 @@ from typing_extensions import TypeGuard
 import dagster._check as check
 from dagster._core.errors import DagsterUserCodeProcessError, DagsterUserCodeUnreachableError
 from dagster._core.instance import InstanceRef
-from dagster._core.remote_representation.origin import (
-    CodeLocationOrigin,
-    ManagedGrpcPythonEnvCodeLocationOrigin,
-)
+from dagster._core.remote_origin import CodeLocationOrigin, ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._time import get_current_timestamp
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info

--- a/python_modules/dagster/dagster/_core/remote_representation/handle.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/handle.py
@@ -9,7 +9,7 @@ from dagster._core.code_pointer import ModuleCodePointer
 from dagster._core.definitions.selector import JobSubsetSelector, RepositorySelector
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.origin import RepositoryPythonOrigin
-from dagster._core.remote_representation.origin import (
+from dagster._core.remote_origin import (
     CodeLocationOrigin,
     RegisteredCodeLocationOrigin,
     RemoteRepositoryOrigin,

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -21,7 +21,7 @@ from dagster._core.definitions.run_request import (
 )
 from dagster._core.definitions.selector import InstigatorSelector, RepositorySelector
 from dagster._core.definitions.sensor_definition import SensorType
-from dagster._core.remote_representation.origin import RemoteInstigatorOrigin
+from dagster._core.remote_origin import RemoteInstigatorOrigin
 from dagster._serdes import create_snapshot_id
 from dagster._time import get_current_timestamp, utc_datetime_from_naive
 from dagster._utils import xor

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -19,6 +19,7 @@ from dagster._core.definitions.partitions.subset import (
 )
 from dagster._core.loader import LoadableBy, LoadingContext
 from dagster._core.origin import JobPythonOrigin
+from dagster._core.remote_representation.origin import RemoteJobOrigin
 from dagster._core.storage.tags import (
     ASSET_EVALUATION_ID_TAG,
     AUTO_RETRY_RUN_ID_TAG,
@@ -42,7 +43,6 @@ if TYPE_CHECKING:
     from dagster._core.definitions.schedule_definition import ScheduleDefinition
     from dagster._core.definitions.sensor_definition import SensorDefinition
     from dagster._core.remote_representation.external import RemoteSchedule, RemoteSensor
-    from dagster._core.remote_representation.origin import RemoteJobOrigin
     from dagster._core.scheduler.instigation import InstigatorState
 
 
@@ -296,11 +296,11 @@ class DagsterRun(
             ("parent_run_id", Optional[str]),
             ("job_snapshot_id", Optional[str]),
             ("execution_plan_snapshot_id", Optional[str]),
-            ("remote_job_origin", Optional["RemoteJobOrigin"]),
+            ("remote_job_origin", Optional[RemoteJobOrigin]),
             ("job_code_origin", Optional[JobPythonOrigin]),
             ("has_repository_load_data", bool),
             ("run_op_concurrency", Optional[RunOpConcurrency]),
-            ("partitions_subset", Optional["PartitionsSubset"]),
+            ("partitions_subset", Optional[PartitionsSubset]),
         ],
     )
 ):

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -19,7 +19,7 @@ from dagster._core.definitions.partitions.subset import (
 )
 from dagster._core.loader import LoadableBy, LoadingContext
 from dagster._core.origin import JobPythonOrigin
-from dagster._core.remote_representation.origin import RemoteJobOrigin
+from dagster._core.remote_origin import RemoteJobOrigin
 from dagster._core.storage.tags import (
     ASSET_EVALUATION_ID_TAG,
     AUTO_RETRY_RUN_ID_TAG,
@@ -375,7 +375,7 @@ class DagsterRun(
 
         # Placing this with the other imports causes a cyclic import
         # https://github.com/dagster-io/dagster/issues/3181
-        from dagster._core.remote_representation.origin import RemoteJobOrigin
+        from dagster._core.remote_origin import RemoteJobOrigin
 
         if status == DagsterRunStatus.QUEUED:
             check.inst_param(
@@ -442,7 +442,7 @@ class DagsterRun(
         return self._replace(status=status)
 
     def with_job_origin(self, origin: "RemoteJobOrigin") -> Self:
-        from dagster._core.remote_representation.origin import RemoteJobOrigin
+        from dagster._core.remote_origin import RemoteJobOrigin
 
         check.inst_param(origin, "origin", RemoteJobOrigin)
         return self._replace(remote_job_origin=origin)

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     )
     from dagster._core.execution.stats import RunStepKeyStatsSnapshot
     from dagster._core.instance import DagsterInstance
-    from dagster._core.remote_representation.origin import RemoteJobOrigin
+    from dagster._core.remote_origin import RemoteJobOrigin
     from dagster._core.scheduler.instigation import (
         AutoMaterializeAssetEvaluationRecord,
         InstigatorState,

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -25,7 +25,7 @@ from dagster._daemon.types import DaemonHeartbeat
 from dagster._utils import PrintFn
 
 if TYPE_CHECKING:
-    from dagster._core.remote_representation.origin import RemoteJobOrigin
+    from dagster._core.remote_origin import RemoteJobOrigin
 
 
 class RunGroupInfo(TypedDict):

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -28,7 +28,7 @@ from dagster._core.events import (
     RunFailureReason,
 )
 from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
-from dagster._core.remote_representation.origin import RemoteJobOrigin
+from dagster._core.remote_origin import RemoteJobOrigin
 from dagster._core.snap import ExecutionPlanSnapshot, JobSnap, create_execution_plan_snapshot_id
 from dagster._core.storage.dagster_run import (
     DagsterRun,

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -63,11 +63,11 @@ from dagster._core.instance_for_test import (
     instance_for_test as instance_for_test,
 )
 from dagster._core.launcher import RunLauncher
+from dagster._core.remote_origin import InProcessCodeLocationOrigin
 from dagster._core.remote_representation import RemoteRepository
 from dagster._core.remote_representation.code_location import CodeLocation
 from dagster._core.remote_representation.external_data import RepositorySnap
 from dagster._core.remote_representation.handle import RepositoryHandle
-from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.run_coordinator import RunCoordinator, SubmitRunContext
 from dagster._core.secrets import SecretsLoader
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -29,6 +29,10 @@ from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.types import CachingDynamicPartitionsLoader
 from dagster._core.loader import LoadingContext
+from dagster._core.remote_origin import (
+    GrpcServerCodeLocationOrigin,
+    ManagedGrpcPythonEnvCodeLocationOrigin,
+)
 from dagster._core.remote_representation import (
     CodeLocation,
     CodeLocationOrigin,
@@ -49,10 +53,6 @@ from dagster._core.remote_representation.grpc_server_state_subscriber import (
     LocationStateSubscriber,
 )
 from dagster._core.remote_representation.handle import InstigatorHandle
-from dagster._core.remote_representation.origin import (
-    GrpcServerCodeLocationOrigin,
-    ManagedGrpcPythonEnvCodeLocationOrigin,
-)
 from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.mode import ResourceDefSnap
 from dagster._core.snap.node import GraphDefSnap, OpDefSnap

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -30,12 +30,12 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.instance.types import CachingDynamicPartitionsLoader
 from dagster._core.loader import LoadingContext
 from dagster._core.remote_origin import (
+    CodeLocationOrigin,
     GrpcServerCodeLocationOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin,
 )
 from dagster._core.remote_representation import (
     CodeLocation,
-    CodeLocationOrigin,
     GrpcServerCodeLocation,
     RemoteExecutionPlan,
     RemoteJob,

--- a/python_modules/dagster/dagster/_core/workspace/load.py
+++ b/python_modules/dagster/dagster/_core/workspace/load.py
@@ -8,7 +8,7 @@ from dagster_shared.yaml_utils import load_yaml_from_path
 import dagster._check as check
 from dagster._core.code_pointer import rebase_file
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.origin import (
+from dagster._core.remote_origin import (
     CodeLocationOrigin,
     GrpcServerCodeLocationOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin,

--- a/python_modules/dagster/dagster/_core/workspace/load_target.py
+++ b/python_modules/dagster/dagster/_core/workspace/load_target.py
@@ -5,7 +5,7 @@ from typing import Optional, Union, cast
 
 from dagster_shared.record import record
 
-from dagster._core.remote_representation.origin import (
+from dagster._core.remote_origin import (
     CodeLocationOrigin,
     GrpcServerCodeLocationOrigin,
     InProcessCodeLocationOrigin,

--- a/python_modules/dagster/dagster/_core/workspace/workspace.py
+++ b/python_modules/dagster/dagster/_core/workspace/workspace.py
@@ -8,7 +8,8 @@ from dagster._utils.error import SerializableErrorInfo
 
 if TYPE_CHECKING:
     from dagster._core.definitions.assets.graph.remote_asset_graph import RemoteWorkspaceAssetGraph
-    from dagster._core.remote_representation import CodeLocation, CodeLocationOrigin
+    from dagster._core.remote_origin import CodeLocationOrigin
+    from dagster._core.remote_representation import CodeLocation
 
 
 # For locations that are loaded asynchronously
@@ -19,7 +20,7 @@ class CodeLocationLoadStatus(Enum):
 
 @record
 class CodeLocationEntry:
-    origin: Annotated["CodeLocationOrigin", ImportFrom("dagster._core.remote_representation")]
+    origin: Annotated["CodeLocationOrigin", ImportFrom("dagster._core.remote_origin")]
     code_location: Optional[
         Annotated["CodeLocation", ImportFrom("dagster._core.remote_representation")]
     ]

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -50,9 +50,9 @@ from dagster._core.execution.submit_asset_runs import (
     submit_asset_run,
 )
 from dagster._core.instance import DagsterInstance
+from dagster._core.remote_origin import RemoteInstigatorOrigin
 from dagster._core.remote_representation import RemoteSensor
 from dagster._core.remote_representation.external import RemoteRepository
-from dagster._core.remote_representation.origin import RemoteInstigatorOrigin
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,

--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -15,7 +15,7 @@ import dagster._check as check
 from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.events import EngineEventData
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.origin import RemoteRepositoryOrigin
+from dagster._core.remote_origin import RemoteRepositoryOrigin
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.__generated__ import DagsterApiStub, dagster_api_pb2
 from dagster._grpc.server import GrpcServerProcess

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -36,6 +36,7 @@ from dagster._core.events import DagsterEvent, EngineEventData
 from dagster._core.execution.api import create_execution_plan, execute_run_iterator
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
+from dagster._core.remote_origin import CodeLocationOrigin
 from dagster._core.remote_representation.external_data import (
     JobDataSnap,
     PartitionConfigSnap,
@@ -49,7 +50,6 @@ from dagster._core.remote_representation.external_data import (
     SensorExecutionErrorSnap,
     job_name_for_partition_set_snap_name,
 )
-from dagster._core.remote_representation.origin import CodeLocationOrigin
 from dagster._core.snap.execution_plan_snapshot import snapshot_from_execution_plan
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._grpc.types import ExecuteExternalJobArgs, ExecutionPlanSnapshotArgs

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Optional
 
 import dagster._check as check
 from dagster._core.instance import InstanceRef
+from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
-from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.__generated__ import dagster_api_pb2
 from dagster._grpc.__generated__.dagster_api_pb2_grpc import DagsterApiServicer

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -40,6 +40,7 @@ from dagster._core.errors import (
 )
 from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.origin import DEFAULT_DAGSTER_ENTRY_POINT, get_python_environment_entry_point
+from dagster._core.remote_origin import RemoteRepositoryOrigin
 from dagster._core.remote_representation.external_data import (
     JobDataSnap,
     PartitionExecutionErrorSnap,
@@ -49,7 +50,6 @@ from dagster._core.remote_representation.external_data import (
     ScheduleExecutionErrorSnap,
     SensorExecutionErrorSnap,
 )
-from dagster._core.remote_representation.origin import RemoteRepositoryOrigin
 from dagster._core.snap.execution_plan_snapshot import ExecutionPlanSnapshotErrorData
 from dagster._core.types.loadable_target_origin import (
     LoadableTargetOrigin,

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -13,14 +13,10 @@ from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.execution.retries import RetryMode
 from dagster._core.instance.ref import InstanceRef
 from dagster._core.origin import JobPythonOrigin, get_python_environment_entry_point
+from dagster._core.remote_origin import CodeLocationOrigin, RemoteJobOrigin, RemoteRepositoryOrigin
 from dagster._core.remote_representation.external_data import (
     DEFAULT_MODE_NAME,
     job_name_for_partition_set_snap_name,
-)
-from dagster._core.remote_representation.origin import (
-    CodeLocationOrigin,
-    RemoteJobOrigin,
-    RemoteRepositoryOrigin,
 )
 from dagster._serdes import serialize_value, whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
-from dagster._core.remote_representation import (
+from dagster._core.remote_origin import (
     ManagedGrpcPythonEnvCodeLocationOrigin,
     RemoteRepositoryOrigin,
 )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -11,6 +11,7 @@ from dagster._api.snapshot_repository import (
 )
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.instance import DagsterInstance
+from dagster._core.remote_origin import RemoteRepositoryOrigin
 from dagster._core.remote_representation import (
     ManagedGrpcPythonEnvCodeLocationOrigin,
     RepositorySnap,
@@ -23,7 +24,6 @@ from dagster._core.remote_representation.external_data import (
     extract_serialized_job_snap_from_serialized_job_data_snap,
 )
 from dagster._core.remote_representation.handle import RepositoryHandle
-from dagster._core.remote_representation.origin import RemoteRepositoryOrigin
 from dagster._core.storage.tags import EXTERNAL_JOB_SOURCE_TAG_KEY
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._utils.env import environ

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -11,11 +11,11 @@ from dagster._api.snapshot_repository import (
 )
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_origin import RemoteRepositoryOrigin
-from dagster._core.remote_representation import (
+from dagster._core.remote_origin import (
     ManagedGrpcPythonEnvCodeLocationOrigin,
-    RepositorySnap,
+    RemoteRepositoryOrigin,
 )
+from dagster._core.remote_representation import RepositorySnap
 from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.external_data import (
     DISABLE_FAST_EXTRACT_ENV_VAR,

--- a/python_modules/dagster/dagster_tests/api_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/api_tests/utils.py
@@ -5,7 +5,8 @@ from typing import Optional
 
 import dagster as dg
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import JobHandle, ManagedGrpcPythonEnvCodeLocationOrigin
+from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
+from dagster._core.remote_representation import JobHandle
 from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -10,7 +10,7 @@ from dagster import DagsterInstance
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.data_version import CachingStaleStatusResolver
-from dagster._core.remote_representation import InProcessCodeLocationOrigin
+from dagster._core.remote_origin import InProcessCodeLocationOrigin
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceRequestContext
 from dagster._core.workspace.workspace import (

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_grpc_server_workspace.py
@@ -5,7 +5,7 @@ import pytest
 import yaml
 from dagster._check import CheckError
 from dagster._core.errors import DagsterUserCodeUnreachableError
-from dagster._core.remote_representation import GrpcServerCodeLocationOrigin
+from dagster._core.remote_origin import GrpcServerCodeLocationOrigin
 from dagster._core.test_utils import environ
 from dagster._core.workspace.load import location_origins_from_config
 from dagster._grpc.server import GrpcServerProcess

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -7,7 +7,7 @@ import pytest
 from dagster import DagsterInstance
 from dagster._config.field import resolve_to_config_type
 from dagster._config.snap import ConfigSchemaSnapshot, snap_from_config_type
-from dagster._core.remote_representation import InProcessCodeLocationOrigin
+from dagster._core.remote_origin import InProcessCodeLocationOrigin
 from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.snap.snap_to_yaml import default_values_yaml_from_type_snap
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin

--- a/python_modules/dagster/dagster_tests/core_tests/workspace_tests/test_request_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/workspace_tests/test_request_context.py
@@ -4,12 +4,12 @@ from unittest import mock
 
 import pytest
 from dagster._core.errors import DagsterCodeLocationLoadError, DagsterCodeLocationNotFoundError
+from dagster._core.remote_origin import RegisteredCodeLocationOrigin
 from dagster._core.remote_representation.code_location import CodeLocation
 from dagster._core.remote_representation.feature_flags import (
     CodeLocationFeatureFlags,
     get_feature_flags_for_location,
 )
-from dagster._core.remote_representation.origin import RegisteredCodeLocationOrigin
 from dagster._core.workspace.context import WorkspaceRequestContext
 from dagster._core.workspace.workspace import (
     CodeLocationEntry,

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -27,13 +27,13 @@ from dagster._core.definitions.sensor_definition import (
 )
 from dagster._core.events import DagsterEventType
 from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
+from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.remote_representation import (
     RemoteInstigatorOrigin,
     RemoteRepositoryOrigin,
     RemoteSensor,
 )
 from dagster._core.remote_representation.external import RemoteRepository
-from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.scheduler.instigation import (
     DynamicPartitionsRequestResult,
     InstigatorState,

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -27,12 +27,12 @@ from dagster._core.definitions.sensor_definition import (
 )
 from dagster._core.events import DagsterEventType
 from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
-from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
-from dagster._core.remote_representation import (
+from dagster._core.remote_origin import (
+    ManagedGrpcPythonEnvCodeLocationOrigin,
     RemoteInstigatorOrigin,
     RemoteRepositoryOrigin,
-    RemoteSensor,
 )
+from dagster._core.remote_representation import RemoteSensor
 from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.scheduler.instigation import (
     DynamicPartitionsRequestResult,

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -6,12 +6,12 @@ from typing import Optional, cast
 
 import dagster as dg
 import pytest
+from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.remote_representation import (
     CodeLocation,
     InProcessCodeLocationOrigin,
     RemoteRepository,
 )
-from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.test_utils import (
     InProcessTestWorkspaceLoadTarget,
     create_test_daemon_workspace_context,

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -6,12 +6,11 @@ from typing import Optional, cast
 
 import dagster as dg
 import pytest
-from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
-from dagster._core.remote_representation import (
-    CodeLocation,
+from dagster._core.remote_origin import (
     InProcessCodeLocationOrigin,
-    RemoteRepository,
+    ManagedGrpcPythonEnvCodeLocationOrigin,
 )
+from dagster._core.remote_representation import CodeLocation, RemoteRepository
 from dagster._core.test_utils import (
     InProcessTestWorkspaceLoadTarget,
     create_test_daemon_workspace_context,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -32,12 +32,8 @@ from dagster._core.execution.asset_backfill import (
 )
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
-from dagster._core.remote_representation import (
-    CodeLocation,
-    InProcessCodeLocationOrigin,
-    RemoteRepository,
-    RemoteRepositoryOrigin,
-)
+from dagster._core.remote_origin import InProcessCodeLocationOrigin, RemoteRepositoryOrigin
+from dagster._core.remote_representation import CodeLocation, RemoteRepository
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.storage.dagster_run import (
     IN_PROGRESS_RUN_STATUSES,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -9,10 +9,10 @@ import pytest
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.instance import DagsterInstance
+from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
 from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.remote_representation.handle import JobHandle, RepositoryHandle
-from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.storage.dagster_run import IN_PROGRESS_RUN_STATUSES, DagsterRunStatus
 from dagster._core.storage.tags import PRIORITY_TAG
 from dagster._core.test_utils import (

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -16,8 +16,8 @@ from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.execution.backfill import PartitionBackfill
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
+from dagster._core.remote_origin import InProcessCodeLocationOrigin
 from dagster._core.remote_representation.external import RemoteSensor
-from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorTick,

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -32,10 +32,7 @@ from dagster._core.definitions.events import AssetKeyPartitionKey, CoercibleToAs
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
-from dagster._core.remote_representation.origin import (
-    RemoteInstigatorOrigin,
-    RemoteRepositoryOrigin,
-)
+from dagster._core.remote_origin import RemoteInstigatorOrigin, RemoteRepositoryOrigin
 from dagster._core.scheduler.instigation import SensorInstigatorData, TickStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import freeze_time, wait_for_futures

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -37,7 +37,7 @@ from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._core.events import AssetMaterializationPlannedData, DagsterEventType
 from dagster._core.execution.asset_backfill import AssetBackfillData
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
-from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
+from dagster._core.remote_origin import InProcessCodeLocationOrigin
 from dagster._core.test_utils import (
     InProcessTestWorkspaceLoadTarget,
     create_test_daemon_workspace_context,

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/scenario_state.py
@@ -34,8 +34,8 @@ from dagster._core.definitions.repository_definition.valid_definitions import (
 )
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.instance import DagsterInstance
+from dagster._core.remote_origin import InProcessCodeLocationOrigin
 from dagster._core.remote_representation.external_data import RepositorySnap
-from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import (
     InProcessTestWorkspaceLoadTarget,

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -14,7 +14,7 @@ from dagster._core.definitions.assets.graph.asset_graph_differ import (
     DictDiff,
     ValueDiff,
 )
-from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
+from dagster._core.remote_origin import InProcessCodeLocationOrigin
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceRequestContext
 from dagster._core.workspace.workspace import (

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -657,7 +657,7 @@ def test_remote_job_origin_instigator_origin():
 
     legacy_env, klass, repo_klass, location_klass = build_legacy_whitelist_map()
 
-    from dagster._core.remote_representation.origin import (
+    from dagster._core.remote_origin import (
         GrpcServerCodeLocationOrigin,
         RemoteInstigatorOrigin,
         RemoteRepositoryOrigin,
@@ -906,7 +906,7 @@ def test_repo_label_tag_migration():
 
 
 def test_add_bulk_actions_columns():
-    from dagster._core.remote_representation.origin import (
+    from dagster._core.remote_origin import (
         GrpcServerCodeLocationOrigin,
         RemotePartitionSetOrigin,
         RemoteRepositoryOrigin,
@@ -1407,7 +1407,7 @@ def test_add_backfill_tags():
 
 
 def test_add_bulk_actions_job_name_column():
-    from dagster._core.remote_representation.origin import (
+    from dagster._core.remote_origin import (
         GrpcServerCodeLocationOrigin,
         RemotePartitionSetOrigin,
         RemoteRepositoryOrigin,

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_grpc_server_registry.py
@@ -9,12 +9,12 @@ import pytest
 from dagster._cli.dev import ProxyServerManager
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
-from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
-from dagster._core.remote_representation.origin import (
+from dagster._core.remote_origin import (
     ManagedGrpcPythonEnvCodeLocationOrigin,
     RegisteredCodeLocationOrigin,
 )
+from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
+from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.load_target import PythonFileTarget
 from dagster._grpc.constants import GrpcServerCommand

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
@@ -9,8 +9,7 @@ from typing import Any
 import dagster as dg
 import pytest
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_origin import GrpcServerCodeLocationOrigin
-from dagster._core.remote_representation import RemoteRepositoryOrigin
+from dagster._core.remote_origin import GrpcServerCodeLocationOrigin, RemoteRepositoryOrigin
 from dagster._grpc.client import DagsterGrpcClient
 from dagster._grpc.server import METRICS_RETRIEVAL_FUNCTIONS, DagsterApiServer, wait_for_grpc_server
 from dagster._grpc.types import SensorExecutionArgs

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
@@ -9,8 +9,8 @@ from typing import Any
 import dagster as dg
 import pytest
 from dagster._core.instance import DagsterInstance
+from dagster._core.remote_origin import GrpcServerCodeLocationOrigin
 from dagster._core.remote_representation import RemoteRepositoryOrigin
-from dagster._core.remote_representation.origin import GrpcServerCodeLocationOrigin
 from dagster._grpc.client import DagsterGrpcClient
 from dagster._grpc.server import METRICS_RETRIEVAL_FUNCTIONS, DagsterApiServer, wait_for_grpc_server
 from dagster._grpc.types import SensorExecutionArgs

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -9,13 +9,13 @@ import dagster as dg
 import pytest
 from dagster._api.list_repositories import sync_list_repositories_grpc
 from dagster._core.errors import DagsterUserCodeUnreachableError
-from dagster._core.remote_representation.external_data import SensorExecutionErrorSnap
-from dagster._core.remote_representation.origin import (
+from dagster._core.remote_origin import (
     GrpcServerCodeLocationOrigin,
     RegisteredCodeLocationOrigin,
     RemoteJobOrigin,
     RemoteRepositoryOrigin,
 )
+from dagster._core.remote_representation.external_data import SensorExecutionErrorSnap
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.test_utils import create_run_for_test, environ, new_cwd, poll_for_finished_run
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -12,6 +12,7 @@ import pytest
 from dagster import AssetExecutionContext, AssetKey, DefaultScheduleStatus, schedule
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.instance import DagsterInstance
+from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.remote_representation import (
     CodeLocation,
     GrpcServerCodeLocation,
@@ -20,7 +21,6 @@ from dagster._core.remote_representation import (
     RemoteRepositoryOrigin,
 )
 from dagster._core.remote_representation.external import RemoteRepository, RemoteSchedule
-from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -12,14 +12,13 @@ import pytest
 from dagster import AssetExecutionContext, AssetKey, DefaultScheduleStatus, schedule
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_origin import ManagedGrpcPythonEnvCodeLocationOrigin
-from dagster._core.remote_representation import (
-    CodeLocation,
-    GrpcServerCodeLocation,
+from dagster._core.remote_origin import (
     GrpcServerCodeLocationOrigin,
+    ManagedGrpcPythonEnvCodeLocationOrigin,
     RemoteInstigatorOrigin,
     RemoteRepositoryOrigin,
 )
+from dagster._core.remote_representation import CodeLocation, GrpcServerCodeLocation
 from dagster._core.remote_representation.external import RemoteRepository, RemoteSchedule
 from dagster._core.scheduler.instigation import (
     InstigatorState,

--- a/python_modules/dagster/dagster_tests/storage_tests/test_dagster_run.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_dagster_run.py
@@ -10,7 +10,7 @@ from dagster._core.origin import (
     JobPythonOrigin,
     RepositoryPythonOrigin,
 )
-from dagster._core.remote_representation.origin import (
+from dagster._core.remote_origin import (
     InProcessCodeLocationOrigin,
     RemoteJobOrigin,
     RemoteRepositoryOrigin,

--- a/python_modules/dagster/dagster_tests/storage_tests/test_job_run.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_job_run.py
@@ -10,7 +10,7 @@ from dagster._core.origin import (
     JobPythonOrigin,
     RepositoryPythonOrigin,
 )
-from dagster._core.remote_representation.origin import (
+from dagster._core.remote_origin import (
     InProcessCodeLocationOrigin,
     RemoteJobOrigin,
     RemoteRepositoryOrigin,

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -67,7 +67,7 @@ from dagster._core.execution.plan.objects import StepFailureData, StepSuccessDat
 from dagster._core.execution.stats import StepEventStatus
 from dagster._core.instance import RUNLESS_JOB_NAME, RUNLESS_RUN_ID
 from dagster._core.loader import LoadingContextForTest
-from dagster._core.remote_representation.origin import (
+from dagster._core.remote_origin import (
     InProcessCodeLocationOrigin,
     RemoteJobOrigin,
     RemoteRepositoryOrigin,

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -14,7 +14,7 @@ from dagster._core.events import DagsterEvent, DagsterEventType, JobFailureData,
 from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
 from dagster._core.instance import InstanceType
 from dagster._core.launcher.sync_in_memory_run_launcher import SyncInMemoryRunLauncher
-from dagster._core.remote_representation import (
+from dagster._core.remote_origin import (
     ManagedGrpcPythonEnvCodeLocationOrigin,
     RemoteRepositoryOrigin,
 )

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/event_stream.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/core/monitoring_job/event_stream.py
@@ -18,7 +18,7 @@ from dagster._core.events import (
     StepMaterializationData,
 )
 from dagster._core.execution.context.op_execution_context import OpExecutionContext
-from dagster._core.remote_representation.origin import RemoteJobOrigin
+from dagster._core.remote_origin import RemoteJobOrigin
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import EXTERNAL_JOB_SOURCE_TAG_KEY
 from dagster._core.utils import make_new_run_id

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
@@ -3,7 +3,7 @@ import re
 from collections.abc import Mapping
 from typing import Any
 
-from dagster._core.remote_representation.origin import RemoteJobOrigin
+from dagster._core.remote_origin import RemoteJobOrigin
 
 from dagster_aws.ecs.tasks import DagsterEcsTaskDefinitionConfig
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_utils.py
@@ -1,4 +1,4 @@
-from dagster._core.remote_representation.origin import (
+from dagster._core.remote_origin import (
     RegisteredCodeLocationOrigin,
     RemoteJobOrigin,
     RemoteRepositoryOrigin,

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/config.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/config.py
@@ -1,5 +1,5 @@
 from dagster import Field, Float, Map, Noneable, StringSource
-from dagster._core.remote_representation import IN_PROCESS_NAME
+from dagster._core.remote_origin import IN_PROCESS_NAME
 from dagster._utils.merger import merge_dicts
 from dagster_celery.executor import CELERY_CONFIG
 from dagster_k8s import DagsterK8sJobConfig

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -655,7 +655,7 @@ def test_add_backfill_tags(conn_string):
 
 
 def test_add_bulk_actions_job_name_column(conn_string):
-    from dagster._core.remote_representation.origin import (
+    from dagster._core.remote_origin import (
         GrpcServerCodeLocationOrigin,
         RemotePartitionSetOrigin,
         RemoteRepositoryOrigin,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -1057,7 +1057,7 @@ def test_add_backfill_tags(hostname, conn_string):
 
 
 def test_add_bulk_actions_job_name_column(hostname, conn_string):
-    from dagster._core.remote_representation.origin import (
+    from dagster._core.remote_origin import (
         GrpcServerCodeLocationOrigin,
         RemotePartitionSetOrigin,
         RemoteRepositoryOrigin,


### PR DESCRIPTION
## Summary & Motivation
Attempt to get a clean import of DagsterRun in isolation

## Test Plan
in a fresh repl
>> from dagster import DagsterRun
