### PR TITLE
Make jobs selection bar match height of other pages

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
@@ -98,7 +98,7 @@ export const JobsPageContent = () => {
 
   return (
     <>
-      <Box padding={{horizontal: 24, vertical: 8}} border="bottom">
+      <Box padding={{horizontal: 24, vertical: 12}} border="bottom">
         <JobSelectionInput items={allJobs} value={selection} onChange={setSelection} />
       </Box>
       {loading && !repoCount ? (


### PR DESCRIPTION
## Summary & Motivation
The new selection syntax bar on jobs and automations have different heights. Added some extra padding to make them match so they look nice when navigating between them and brings me peace and joy.
