### PR TITLE
[dg] Update "dg cli configuration" docs page (DOC-1247)

### DIFF
--- a/docs/docs/api/clis/dg-cli/dg-cli-configuration.mdx
+++ b/docs/docs/api/clis/dg-cli/dg-cli-configuration.mdx
@@ -41,7 +41,7 @@ workspace.
 
 There are three kinds of `dg` configuration files: user, project, and workspace.
 
-- [User configuration files](#user-configuration-file) are optional and contain only application-level settings. They are located in a platform-specific location, `~/.dg.toml` (Unix) or `%APPDATA%/dg/dg.toml` (Windows).
+- [User configuration files](#user-configuration-file) are optional and contain only application-level settings. They are located in a platform-specific location, `~/.config/dg.toml` (Unix) or `%APPDATA%/dg/dg.toml` (Windows).
 - [Project configuration files](#project-configuration-file) are required to mark a directory as a `dg` project. They are located in the root of a `dg` project and contain project-specific settings. They may also contain application-level settings if the project is not inside a workspace.
 - [Workspace configuration files](#workspace-configuration-file) are required to mark a directory as a `dg` workspace. They are located in the root of a `dg` workspace and contain workspace-specific settings. They may also contain application-level settings. When projects are inside a workspace, the application-level settings of the workspace apply to all contained projects as well.
 
@@ -49,7 +49,7 @@ When `dg` is launched, it will attempt to discover all three configuration files
 
 ### User configuration file
 
-A user configuration file can be placed at `~/.dg.toml` (Unix) or
+A user configuration file can be placed at `~/.config/dg.toml` (Unix) or
 `%APPDATA%/dg/dg.toml` (Windows).
 
 Below is an example of a user configuration file. The `cli` section contains

--- a/examples/docs_snippets/docs_snippets/guides/dg/configuring-dg/project-config.toml
+++ b/examples/docs_snippets/docs_snippets/guides/dg/configuring-dg/project-config.toml
@@ -27,6 +27,21 @@ code_location_target_module = "my_project.definitions"
 # the root module name).
 code_location_name = "my-project"
 
+# (list[string], optional) List of module names or name-matching patterns to include in the dg
+# registry. Defaults to `<root_module>.components`. Patterns can include `*` to match entire
+# segments of the module name. * does NOT match partial segments. Example:
+#
+# - foo.*.bar matches foo.baz.bar and foo.qux.bar
+# - foo.*bar is invalid because * does not constitute an entire segment
+#
+# When a new component scaffolded with `dg scaffold component <module>.MyComponent`, this setting
+# will be created if it does not already exist and the module will be added to the list.
+# 
+# Defaults to [].
+registry_modules = [
+  "my_project.alternate_components.*",
+]
+
 [tool.dg.cli]
 
 # Application-level settings can be set here. See "User configuration file"

--- a/examples/docs_snippets/docs_snippets/guides/dg/configuring-dg/project-config.toml
+++ b/examples/docs_snippets/docs_snippets/guides/dg/configuring-dg/project-config.toml
@@ -34,7 +34,7 @@ code_location_name = "my-project"
 # - foo.*.bar matches foo.baz.bar and foo.qux.bar
 # - foo.*bar is invalid because * does not constitute an entire segment
 #
-# When a new component scaffolded with `dg scaffold component <module>.MyComponent`, this setting
+# When a new component is scaffolded with `dg scaffold component <module>.MyComponent`, this setting
 # will be created if it does not already exist and the module will be added to the list.
 # 
 # Defaults to [].

--- a/examples/docs_snippets/docs_snippets/guides/dg/configuring-dg/user-config.toml
+++ b/examples/docs_snippets/docs_snippets/guides/dg/configuring-dg/user-config.toml
@@ -1,18 +1,20 @@
 [cli]
-# (bool, optional) Specifies whether the `dg` cache is disabled.
-#
-# Defaults to `false`.
-disable_cache = false
-
-# (string, optional) Specifies the directory where the `dg` cache is stored.
-#
-# Defaults to a platform-specific cache directory.
-cache_dir = "/path/to/my-cache"
 
 # (bool, optional) Specifies whether to use verbose output.
 # 
 # Defaults to `false`.
 verbose = false
+
+# (list[str], optional) Specifies a list of warning IDs to suppress. Full list of warning IDs can be
+# found here: https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/warnings.py
+suppress_warnings = [
+    "cli_config_in_workspace_project",
+    "deprecated_user_config_location",
+    "deprecated_python_environment",
+    "deprecated_dagster_dg_library_entry_point",
+    "missing_dg_plugin_module_in_manifest",
+    "project_and_activated_venv_mismatch",
+]
 
 # Telemetry-related settings.
 [cli.telemetry]


### PR DESCRIPTION
## Summary & Motivation

Update the "dg cli configuration" page, removing old settings and adding new ones, also fixing error for user config file path.

## How I Tested These Changes

Existing test suite.