### PR TITLE
[dg] guard relative pathing on check

### DIFF
--- a/python_modules/dagster/dagster/components/list/list.py
+++ b/python_modules/dagster/dagster/components/list/list.py
@@ -287,6 +287,7 @@ def _get_source(
                 str(Path(ref.source).relative_to(dg_context.root_path))
                 for ref in code_ref_metadata.code_references
                 if isinstance(ref, LocalFileCodeReference)
+                and Path(ref.source).is_relative_to(dg_context.root_path)
             ),
             None,
         )


### PR DESCRIPTION
dont blow up if the path is not in the dg project, just omit it 

## How I Tested These Changes

ran in `hooli` where local refs to dbt files that were not in the dg project 