### PR TITLE
[dagster-dg] disables env validation as default behavior for check yaml

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/check.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/check.py
@@ -28,10 +28,8 @@ def check_group():
     "--watch", is_flag=True, help="Watch for changes to the component files and re-validate them."
 )
 @click.option(
-    "--validate-requirements",
-    "--no-validate-requirements",
-    is_flag=True,
-    default=True,
+    "--validate-requirements/--no-validate-requirements",
+    default=False,
     help="Validate environment variables in requirements for all components in the given module.",
 )
 @dg_global_options

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_check_yaml_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_check_yaml_command.py
@@ -86,7 +86,11 @@ def test_check_yaml(test_case: ComponentValidationTestCase) -> None:
         ) as tmpdir,
     ):
         with pushd(tmpdir):
-            result = runner.invoke("check", "yaml")
+            # Enable validation for ENV_VAR_TEST_CASES since default is now False
+            cmd_args = ["check", "yaml"]
+            if test_case in ENV_VAR_TEST_CASES:
+                cmd_args.append("--validate-requirements")
+            result = runner.invoke(*cmd_args)
             if test_case.should_error:
                 assert_runner_result(result, exit_0=False)
                 assert test_case.check_error_msg
@@ -102,9 +106,7 @@ def test_check_yaml(test_case: ComponentValidationTestCase) -> None:
     ids=[str(case.component_path) for case in ENV_VAR_TEST_CASES],
 )
 def test_check_yaml_no_env_var_validation(test_case: ComponentValidationTestCase) -> None:
-    """Tests that the check CLI does not validate env vars when the
-    --no-validate-requirements flag is provided.
-    """
+    """Tests that the check CLI does not validate env vars when the --no-validate-requirements flag is provided (default)."""
     with (
         ProxyRunner.test() as runner,
         create_project_from_components(
@@ -114,9 +116,12 @@ def test_check_yaml_no_env_var_validation(test_case: ComponentValidationTestCase
         ) as tmpdir,
     ):
         with pushd(tmpdir):
-            result = runner.invoke("check", "yaml", "--no-validate-requirements")
+            # Test both default behavior (no validation) and explicit --no-validate-requirements
+            result_default = runner.invoke("check", "yaml")
+            assert_runner_result(result_default)
 
-            assert_runner_result(result)
+            result_explicit = runner.invoke("check", "yaml", "--no-validate-requirements")
+            assert_runner_result(result_explicit)
 
 
 def test_check_yaml_succeeds_non_default_defs_module() -> None:


### PR DESCRIPTION
## Summary & Motivation

Disables the validation of `requirements.env` variable usage as default behavior when running `dg check yaml`.

When defining many inline (via `---`) component definitions with `reuirements.env` being required, this requirement caused a significant increase in lines of YAML. I believe the original intention was for this to be optional, but please correct me if I'm wrong.

## How I Tested These Changes

## Changelog

- [dagster-dg-cli] Made the validation of `requirements.env` opt-in for `dg check yaml`
