### PR TITLE
[dagster-dg-cli] Fixes issue where not all inline documents are validated with `dg check yaml`

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_check_yaml_multi_document.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_check_yaml_multi_document.py
@@ -1,18 +1,12 @@
-"""Tests for multi-document YAML validation bug in `dg check yaml`.
+"""Tests for multi-document YAML validation in `dg check yaml`.
 
-BUG DESCRIPTION:
-The `dg check yaml` command only validates the first YAML document in multi-document
-files (documents separated by `---`). This is because the YAML parsing logic in
-dagster_dg_core.check.parse_yaml_with_source_position() only returns the first document.
+The `dg check yaml` command validates ALL YAML documents in multi-document
+files (documents separated by `---`).
 
-REPRODUCTION:
-These tests demonstrate that:
-1. Errors in the first document are caught correctly ✓
-2. Errors in subsequent documents are NOT caught (BUG) ❌
-3. Valid multi-document files work correctly ✓
-
-EXPECTED FIX:
-The YAML parsing should iterate through ALL documents in the file and validate each one.
+These tests verify that:
+1. Errors in the first document are caught correctly
+2. Errors in subsequent documents are caught correctly
+3. Valid multi-document files work correctly
 """
 
 from dagster_dg_core_tests.utils import (
@@ -23,17 +17,14 @@ from dagster_dg_core_tests.utils import (
 from dagster_test.components.test_utils.test_cases import BASIC_COMPONENT_TYPE_FILEPATH
 
 
-def test_check_yaml_multi_document_validation_bug():
-    """Test that demonstrates the bug where only the first YAML document is validated in multi-document files.
+def test_check_yaml_multi_document_validation_error_in_second_document():
+    """Test that validation errors in the second document are caught correctly.
 
     This test creates a multi-document YAML file where:
     - The first document is valid
     - The second document has a typo (arameters instead of attributes)
 
-    BUG: This test currently PASSES when it should FAIL, demonstrating that only
-    the first YAML document is being validated.
-
-    TODO: When the bug is fixed, change the assertion to expect failure.
+    The validation should fail due to the error in the second document.
     """
     multi_document_yaml_content = """type: .MyComponent
 
@@ -45,55 +36,6 @@ attributes:
 
 type: .MyComponent
 
-# BUG: This typo in the second document should cause validation to fail
-arameters:
-  a_string: "second document"  
-  an_int: 2
-"""
-
-    with (
-        ProxyRunner.test() as runner,
-        create_project_from_components(
-            runner,
-            "validation/basic_component_success",
-            local_component_defn_to_inject=BASIC_COMPONENT_TYPE_FILEPATH,
-        ) as tmpdir,
-    ):
-        # Replace the valid defs.yaml with our multi-document version containing the typo
-        defs_yaml_path = (
-            tmpdir / "src" / "foo_bar" / "defs" / "basic_component_success" / "defs.yaml"
-        )
-        defs_yaml_path.write_text(multi_document_yaml_content)
-
-        result = runner.invoke("check", "yaml")
-
-        # CURRENT BUG BEHAVIOR: This passes when it should fail
-        # The validation succeeds because only the first document is checked
-        assert_runner_result(result, exit_0=True)
-        assert "All component YAML validated successfully" in result.stdout
-
-        # Additional verification that the command output indicates success
-        assert "error" not in result.stdout.lower()
-        assert "unexpected" not in result.stdout.lower()
-
-
-def test_check_yaml_multi_document_validation_bug_expected_behavior():
-    """This test shows what SHOULD happen when the bug is fixed.
-
-    This test will FAIL until the bug is fixed, demonstrating the expected behavior.
-    When the bug is fixed, this test should pass.
-    """
-    multi_document_yaml_content = """type: .MyComponent
-
-attributes:
-  a_string: "first document"
-  an_int: 1
-
----
-
-type: .MyComponent
-
-# This typo should cause validation to fail
 arameters:
   a_string: "second document"  
   an_int: 2
@@ -114,16 +56,50 @@ arameters:
 
         result = runner.invoke("check", "yaml")
 
-        # EXPECTED BEHAVIOR: This should fail due to typo in second document
+        assert_runner_result(result, exit_0=False)
+        assert "'arameters' was unexpected" in result.stdout
+
+
+def test_check_yaml_multi_document_validation_another_error_case():
+    """Test another case of validation errors in subsequent documents."""
+    multi_document_yaml_content = """type: .MyComponent
+
+attributes:
+  a_string: "first document"
+  an_int: 1
+
+---
+
+type: .MyComponent
+
+arameters:
+  a_string: "second document"  
+  an_int: 2
+"""
+
+    with (
+        ProxyRunner.test() as runner,
+        create_project_from_components(
+            runner,
+            "validation/basic_component_success",
+            local_component_defn_to_inject=BASIC_COMPONENT_TYPE_FILEPATH,
+        ) as tmpdir,
+    ):
+        defs_yaml_path = (
+            tmpdir / "src" / "foo_bar" / "defs" / "basic_component_success" / "defs.yaml"
+        )
+        defs_yaml_path.write_text(multi_document_yaml_content)
+
+        result = runner.invoke("check", "yaml")
+
         assert_runner_result(result, exit_0=False)
         assert "'arameters' was unexpected" in result.stdout
 
 
 def test_check_yaml_multi_document_first_document_error():
-    """Test that errors in the first document are still caught (this works correctly)."""
+    """Test that errors in the first document are caught correctly."""
     multi_document_yaml_content = """type: .MyComponent
 
-# Typo in first document should be caught
 arameters:
   a_string: "first document"
   an_int: 1
@@ -152,14 +128,12 @@ attributes:
 
         result = runner.invoke("check", "yaml")
 
-        # This should fail correctly because the error is in the first document
         assert_runner_result(result, exit_0=False)
         assert "'arameters' was unexpected" in result.stdout
 
 
 def test_check_yaml_multi_document_comprehensive():
     """Comprehensive test showing different multi-document scenarios."""
-    # Test 1: Valid multi-document YAML should pass
     valid_multi_document = """type: .MyComponent
 
 attributes:
@@ -201,7 +175,7 @@ attributes:
         assert_runner_result(result, exit_0=True)
         assert "All component YAML validated successfully" in result.stdout
 
-        # Test with error in third document (should currently pass due to bug)
+        # Test with error in third document
         error_in_third_document = """type: .MyComponent
 
 attributes:
@@ -220,7 +194,6 @@ attributes:
 
 type: .MyComponent
 
-# BUG: This error in the third document is not caught
 arameters:
   a_string: "third"
   an_int: 3
@@ -229,7 +202,5 @@ arameters:
         defs_yaml_path.write_text(error_in_third_document)
         result = runner.invoke("check", "yaml")
 
-        # BUG: This passes when it should fail (error in third document not detected)
-        assert_runner_result(result, exit_0=True)
-        assert "All component YAML validated successfully" in result.stdout
-        assert "arameters" not in result.stdout  # Error not reported
+        assert_runner_result(result, exit_0=False)
+        assert "'arameters' was unexpected" in result.stdout

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_check_yaml_multi_document.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_check_yaml_multi_document.py
@@ -1,0 +1,235 @@
+"""Tests for multi-document YAML validation bug in `dg check yaml`.
+
+BUG DESCRIPTION:
+The `dg check yaml` command only validates the first YAML document in multi-document
+files (documents separated by `---`). This is because the YAML parsing logic in
+dagster_dg_core.check.parse_yaml_with_source_position() only returns the first document.
+
+REPRODUCTION:
+These tests demonstrate that:
+1. Errors in the first document are caught correctly ✓
+2. Errors in subsequent documents are NOT caught (BUG) ❌
+3. Valid multi-document files work correctly ✓
+
+EXPECTED FIX:
+The YAML parsing should iterate through ALL documents in the file and validate each one.
+"""
+
+from dagster_dg_core_tests.utils import (
+    ProxyRunner,
+    assert_runner_result,
+    create_project_from_components,
+)
+from dagster_test.components.test_utils.test_cases import BASIC_COMPONENT_TYPE_FILEPATH
+
+
+def test_check_yaml_multi_document_validation_bug():
+    """Test that demonstrates the bug where only the first YAML document is validated in multi-document files.
+
+    This test creates a multi-document YAML file where:
+    - The first document is valid
+    - The second document has a typo (arameters instead of attributes)
+
+    BUG: This test currently PASSES when it should FAIL, demonstrating that only
+    the first YAML document is being validated.
+
+    TODO: When the bug is fixed, change the assertion to expect failure.
+    """
+    multi_document_yaml_content = """type: .MyComponent
+
+attributes:
+  a_string: "first document"
+  an_int: 1
+
+---
+
+type: .MyComponent
+
+# BUG: This typo in the second document should cause validation to fail
+arameters:
+  a_string: "second document"  
+  an_int: 2
+"""
+
+    with (
+        ProxyRunner.test() as runner,
+        create_project_from_components(
+            runner,
+            "validation/basic_component_success",
+            local_component_defn_to_inject=BASIC_COMPONENT_TYPE_FILEPATH,
+        ) as tmpdir,
+    ):
+        # Replace the valid defs.yaml with our multi-document version containing the typo
+        defs_yaml_path = (
+            tmpdir / "src" / "foo_bar" / "defs" / "basic_component_success" / "defs.yaml"
+        )
+        defs_yaml_path.write_text(multi_document_yaml_content)
+
+        result = runner.invoke("check", "yaml")
+
+        # CURRENT BUG BEHAVIOR: This passes when it should fail
+        # The validation succeeds because only the first document is checked
+        assert_runner_result(result, exit_0=True)
+        assert "All component YAML validated successfully" in result.stdout
+
+        # Additional verification that the command output indicates success
+        assert "error" not in result.stdout.lower()
+        assert "unexpected" not in result.stdout.lower()
+
+
+def test_check_yaml_multi_document_validation_bug_expected_behavior():
+    """This test shows what SHOULD happen when the bug is fixed.
+
+    This test will FAIL until the bug is fixed, demonstrating the expected behavior.
+    When the bug is fixed, this test should pass.
+    """
+    multi_document_yaml_content = """type: .MyComponent
+
+attributes:
+  a_string: "first document"
+  an_int: 1
+
+---
+
+type: .MyComponent
+
+# This typo should cause validation to fail
+arameters:
+  a_string: "second document"  
+  an_int: 2
+"""
+
+    with (
+        ProxyRunner.test() as runner,
+        create_project_from_components(
+            runner,
+            "validation/basic_component_success",
+            local_component_defn_to_inject=BASIC_COMPONENT_TYPE_FILEPATH,
+        ) as tmpdir,
+    ):
+        defs_yaml_path = (
+            tmpdir / "src" / "foo_bar" / "defs" / "basic_component_success" / "defs.yaml"
+        )
+        defs_yaml_path.write_text(multi_document_yaml_content)
+
+        result = runner.invoke("check", "yaml")
+
+        # EXPECTED BEHAVIOR: This should fail due to typo in second document
+        assert_runner_result(result, exit_0=False)
+        assert "'arameters' was unexpected" in result.stdout
+
+
+def test_check_yaml_multi_document_first_document_error():
+    """Test that errors in the first document are still caught (this works correctly)."""
+    multi_document_yaml_content = """type: .MyComponent
+
+# Typo in first document should be caught
+arameters:
+  a_string: "first document"
+  an_int: 1
+
+---
+
+type: .MyComponent
+
+attributes:
+  a_string: "second document"
+  an_int: 2
+"""
+
+    with (
+        ProxyRunner.test() as runner,
+        create_project_from_components(
+            runner,
+            "validation/basic_component_success",
+            local_component_defn_to_inject=BASIC_COMPONENT_TYPE_FILEPATH,
+        ) as tmpdir,
+    ):
+        defs_yaml_path = (
+            tmpdir / "src" / "foo_bar" / "defs" / "basic_component_success" / "defs.yaml"
+        )
+        defs_yaml_path.write_text(multi_document_yaml_content)
+
+        result = runner.invoke("check", "yaml")
+
+        # This should fail correctly because the error is in the first document
+        assert_runner_result(result, exit_0=False)
+        assert "'arameters' was unexpected" in result.stdout
+
+
+def test_check_yaml_multi_document_comprehensive():
+    """Comprehensive test showing different multi-document scenarios."""
+    # Test 1: Valid multi-document YAML should pass
+    valid_multi_document = """type: .MyComponent
+
+attributes:
+  a_string: "first"
+  an_int: 1
+
+---
+
+type: .MyComponent
+
+attributes:
+  a_string: "second"
+  an_int: 2
+
+---
+
+type: .MyComponent
+
+attributes:
+  a_string: "third"
+  an_int: 3
+"""
+
+    with (
+        ProxyRunner.test() as runner,
+        create_project_from_components(
+            runner,
+            "validation/basic_component_success",
+            local_component_defn_to_inject=BASIC_COMPONENT_TYPE_FILEPATH,
+        ) as tmpdir,
+    ):
+        defs_yaml_path = (
+            tmpdir / "src" / "foo_bar" / "defs" / "basic_component_success" / "defs.yaml"
+        )
+
+        # Test valid multi-document
+        defs_yaml_path.write_text(valid_multi_document)
+        result = runner.invoke("check", "yaml")
+        assert_runner_result(result, exit_0=True)
+        assert "All component YAML validated successfully" in result.stdout
+
+        # Test with error in third document (should currently pass due to bug)
+        error_in_third_document = """type: .MyComponent
+
+attributes:
+  a_string: "first"
+  an_int: 1
+
+---
+
+type: .MyComponent
+
+attributes:
+  a_string: "second"
+  an_int: 2
+
+---
+
+type: .MyComponent
+
+# BUG: This error in the third document is not caught
+arameters:
+  a_string: "third"
+  an_int: 3
+"""
+
+        defs_yaml_path.write_text(error_in_third_document)
+        result = runner.invoke("check", "yaml")
+
+        # BUG: This passes when it should fail (error in third document not detected)
+        assert_runner_result(result, exit_0=True)
+        assert "All component YAML validated successfully" in result.stdout
+        assert "arameters" not in result.stdout  # Error not reported

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/check.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/check.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
 import click
 from dagster_shared.serdes.objects import EnvRegistryKey
-from dagster_shared.yaml_utils import parse_yaml_with_source_position
+from dagster_shared.yaml_utils import parse_yamls_with_source_position
 from dagster_shared.yaml_utils.source_position import (
     LineCol,
     SourcePosition,
@@ -98,7 +98,9 @@ def check_yaml(
         if yaml_path:
             text = yaml_path.read_text()
             try:
-                component_doc_tree = parse_yaml_with_source_position(text, filename=str(yaml_path))
+                component_doc_trees = parse_yamls_with_source_position(
+                    text, filename=str(yaml_path)
+                )
             except ScannerError as se:
                 validation_errors.append(
                     ErrorInput(
@@ -113,52 +115,54 @@ def check_yaml(
                 )
                 continue
 
-            if validate_requirements:
-                specified_env_var_deps = get_specified_env_var_deps(component_doc_tree.value)
-                used_env_vars = get_used_env_vars(component_doc_tree.value)
-                all_specified_env_var_deps.update(specified_env_var_deps)
+            # Validate each YAML document in multi-document files
+            for component_doc_tree in component_doc_trees:
+                if validate_requirements:
+                    specified_env_var_deps = get_specified_env_var_deps(component_doc_tree.value)
+                    used_env_vars = get_used_env_vars(component_doc_tree.value)
+                    all_specified_env_var_deps.update(specified_env_var_deps)
 
-                if used_env_vars - specified_env_var_deps:
-                    msg = (
-                        "Component uses environment variables that are not specified in the component file: "
-                        + ", ".join(sorted(used_env_vars - specified_env_var_deps))
-                    )
-
-                    validation_errors.append(
-                        ErrorInput(
-                            None,
-                            ValidationError(
-                                msg,
-                                path=["requirements", "env"],
-                            ),
-                            component_doc_tree,
+                    if used_env_vars - specified_env_var_deps:
+                        msg = (
+                            "Component uses environment variables that are not specified in the component file: "
+                            + ", ".join(sorted(used_env_vars - specified_env_var_deps))
                         )
-                    )
 
-            # First, validate the top-level structure of the component file
-            # (type and params keys) before we try to validate the params themselves.
-            top_level_errs = list(
-                top_level_component_validator.iter_errors(component_doc_tree.value)
-            )
-            for err in top_level_errs:
-                validation_errors.append(ErrorInput(None, err, component_doc_tree))
-            if top_level_errs:
-                continue
+                        validation_errors.append(
+                            ErrorInput(
+                                None,
+                                ValidationError(
+                                    msg,
+                                    path=["requirements", "env"],
+                                ),
+                                component_doc_tree,
+                            )
+                        )
 
-            raw_key = component_doc_tree.value.get("type")
-            component_instance_module = dg_context.get_component_instance_module_name(
-                component_dir.name
-            )
-            qualified_key = (
-                f"{component_instance_module}{raw_key}" if raw_key.startswith(".") else raw_key
-            )
-            key = EnvRegistryKey.from_typename(qualified_key)
-            component_contents_by_key[key] = component_doc_tree
+                # First, validate the top-level structure of the component file
+                # (type and params keys) before we try to validate the params themselves.
+                top_level_errs = list(
+                    top_level_component_validator.iter_errors(component_doc_tree.value)
+                )
+                for err in top_level_errs:
+                    validation_errors.append(ErrorInput(None, err, component_doc_tree))
+                if top_level_errs:
+                    continue
 
-            # Add every module referenced to be explicitly fetched. If we don't do this, only
-            # modules that are explicitly declared as registry modules will work.
-            # `from_dg_context()` on the registry ensures that modules aren't double-fetched.
-            modules_to_fetch.add(key.namespace)
+                raw_key = component_doc_tree.value.get("type")
+                component_instance_module = dg_context.get_component_instance_module_name(
+                    component_dir.name
+                )
+                qualified_key = (
+                    f"{component_instance_module}{raw_key}" if raw_key.startswith(".") else raw_key
+                )
+                key = EnvRegistryKey.from_typename(qualified_key)
+                component_contents_by_key[key] = component_doc_tree
+
+                # Add every module referenced to be explicitly fetched. If we don't do this, only
+                # modules that are explicitly declared as registry modules will work.
+                # `from_dg_context()` on the registry ensures that modules aren't double-fetched.
+                modules_to_fetch.add(key.namespace)
 
     # Fetch the local component types, if we need any local components
     component_registry = EnvRegistry.from_dg_context(


### PR DESCRIPTION

## Summary & Motivation

- **Adds failing test suite for bug in inline YAML validation failure**
- **Fixes \`dg check yaml\` to check all inline documents**

Previously, typos or schema validation errors were not being caught when multiple documents are provided in a single `defs.yaml` file (delineated with `---`).

This PR introduces a test to catch that scenario, and also implements a fix.

## How I Tested These Changes

## Changelog

- [dagster-dg-cli] Fixed bug where not all inline definitions were validated by `dg check yaml`
