### PR TITLE
Install dbt-core in kitchen-sink tests

### DIFF
--- a/python_modules/libraries/dagster-dbt/kitchen-sink/setup.py
+++ b/python_modules/libraries/dagster-dbt/kitchen-sink/setup.py
@@ -22,6 +22,7 @@ setup(
         f"dagster{pin}",
         f"dagster-webserver{pin}",
         "dagster-dbt",
+        "dbt-core>=1.4.0",
     ],
     extras_require={"test": ["pytest"]},
 )


### PR DESCRIPTION
Our dbt-live tests have been failing since we removed our dependency on dbt-core. But they just don't run that frequently so we didn't catch this until I ran a few NO_SKIP builds (frequency is something I'm choosing to ignore for now - defering to the folks working more closely on this stuff on how often they want them to run).

Anyway, I think this should fix them:

https://buildkite.com/organizations/dagster/analytics/suites/dagster-steps/tests/6881a1be-c8be-89aa-9d9d-d9e3272e2055

```
ERROR dagster_dbt_cloud_kitchen_sink_tests/test_dagster_assets.py - dagster_shared.check.functions.CheckError: Expected non-None value: project must be passed if dbt-core is not installed
```