### PR TITLE
Bump perf timeout

### DIFF
--- a/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
+++ b/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
@@ -61,11 +61,11 @@ perf_scenarios = [
         n_runs=2, randomize_runs=True, max_execution_time_seconds=5
     ),
     all_daily_partitioned_500_assets.build_scenario(
-        partition_keys_to_backfill=["2020-01-01", "2020-01-02"], max_execution_time_seconds=40
+        partition_keys_to_backfill=["2020-01-01", "2020-01-02"], max_execution_time_seconds=45
     ),
     all_daily_partitioned_500_assets.build_scenario(
         partition_keys_to_backfill=[f"2020-01-{i + 1:02}" for i in range(20)],
-        max_execution_time_seconds=40,
+        max_execution_time_seconds=45,
     ),
     all_hourly_partitioned_100_assets.build_scenario(
         partition_keys_to_backfill=["2020-01-01-00:00", "2020-01-02-00:00"],


### PR DESCRIPTION
We just saw a build fail because these were all taking ~42s and we assert they they take less than 40s:

https://buildkite.com/dagster/dagster-dagster/builds/130982#01988aad-29f2-4c1e-9283-ba1467eaaa07

It looks like these run about 39s on averge though so it's not clear to me if we actually introduced a change of just got unlucky:

https://buildkite.com/organizations/dagster/analytics/suites/dagster/tests/b53d1bfe-31c6-8b82-88d5-db0a9431bac0?period=7days

Anyway, putting up a small lift to the ceiling and perhaps it's worth looking into whether these have regressed beyond what we're comfortable with.