### PR TITLE
Remove unused all_none utility function

### DIFF
--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -230,13 +230,6 @@ def list_pull(alist: Iterable[object], key: str) -> Sequence[object]:
     return list(map(lambda elem: get_prop_or_key(elem, key), alist))
 
 
-def all_none(kwargs: Mapping[object, object]) -> bool:
-    for value in kwargs.values():
-        if value is not None:
-            return False
-    return True
-
-
 def check_script(path: str, return_code: int = 0) -> None:
     try:
         subprocess.check_output([sys.executable, path])


### PR DESCRIPTION
## Summary & Motivation

This PR removes the unused utility function `all_none` from `dagster._utils.__init__.py` as part of a systematic dead code cleanup effort.

### Analysis Performed
- **Usage Search**: Comprehensive codebase search found function was only defined, never called
- **Import Check**: No imports or references found anywhere in codebase
- **API Verification**: Function was not exposed in any `__all__` declarations
- **Risk Assessment**: MINIMAL - completely unused internal function

### Function Details
```python
def all_none(kwargs: Mapping[object, object]) -> bool:
    for value in kwargs.values():
        if value is not None:
            return False
    return True
```

**Location**: `python_modules/dagster/dagster/_utils/__init__.py` lines 233-237  
**Size**: 5 lines removed

## How I Tested These Changes

- **Linting**: `make ruff` passed successfully  
- **Utils Tests**: All 72 tests passed, 1 skipped (unrelated)  
- **Import Verification**: No import errors after removal  
- **Regression Check**: No functional changes detected

## Changelog

NOCHANGELOG