### PR TITLE
[dagster-databricks] Implement initial DatabricksConfigs class

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/databricks_configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/databricks_configs.py
@@ -1,0 +1,108 @@
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import yaml
+from dagster import get_dagster_logger
+from dagster_shared.record import IHaveNew, record_custom
+
+logger = get_dagster_logger()
+
+
+def load_yaml(path: Path) -> Mapping[str, Any]:
+    """Load YAML file with error handling."""
+    try:
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+    except Exception as e:
+        logger.warning(f"Warning: Could not load {path}: {e}")
+        return {}
+
+
+@record_custom
+class DatabricksConfigs(IHaveNew):
+    databricks_configs_path: Path
+    tasks: list[Any]
+    job_level_parameters: Mapping[str, Any]
+
+    def __new__(
+        cls,
+        databricks_configs_path: Union[Path, str],
+    ) -> "DatabricksConfigs":
+        databricks_configs_path = Path(databricks_configs_path)
+        if not databricks_configs_path.exists():
+            raise FileNotFoundError(f"Databricks config file not found: {databricks_configs_path}")
+
+        # Load databricks config
+        databricks_config = load_yaml(databricks_configs_path)
+        bundle_dir = databricks_configs_path.parent
+
+        # Extract variables and includes
+        includes = databricks_config.get("include", [])
+
+        # Parse all included resource files
+        tasks = []
+        job_level_parameters = {}
+        for include_path in includes:
+            resource_path = bundle_dir / include_path
+            if resource_path.exists():
+                resource_tasks, resource_job_level_parameters = cls._extract_tasks_from_resource(
+                    resource_path
+                )
+                tasks.extend(resource_tasks)
+                if resource_job_level_parameters:
+                    job_level_parameters.update(resource_job_level_parameters)
+
+        if not tasks:
+            raise ValueError(f"No tasks found in databricks config: {databricks_configs_path}")
+
+        return super().__new__(
+            cls,
+            databricks_configs_path=databricks_configs_path,
+            tasks=tasks,
+            job_level_parameters=job_level_parameters,
+        )
+
+    @classmethod
+    def _extract_tasks_from_resource(
+        cls, resource_path: Path
+    ) -> tuple[list[Any], Optional[Mapping[str, Any]]]:
+        """Extract Databricks tasks from a resource YAML file."""
+        resource_config = load_yaml(resource_path)
+        tasks = []
+        job_level_parameters = {}  # Collect job-level parameters from all jobs
+
+        # Navigate to jobs section
+        resources = resource_config.get("resources", {})
+        jobs = resources.get("jobs", {})
+
+        for job_name, job_config in jobs.items():
+            # Extract job-level parameters for this job
+            job_params = cls._extract_job_level_parameters(job_config)
+            if job_params:
+                job_level_parameters[job_name] = job_params
+
+            job_tasks = job_config.get("tasks", [])
+
+            for job_task_config in job_tasks:
+                task_key = job_task_config.get("task_key", "")
+                if not task_key:
+                    continue
+
+        return tasks, job_level_parameters
+
+    @classmethod
+    def _extract_job_level_parameters(
+        cls, job_config: Mapping[str, Any]
+    ) -> Optional[Mapping[str, Any]]:
+        """Extract job-level parameters from job configuration."""
+        # Job-level parameters can be defined in several ways in Databricks bundle
+        job_parameters = None
+
+        # Check for job-level parameters in the job configuration
+        if "parameters" in job_config:
+            job_parameters = job_config["parameters"]
+        elif "job_parameters" in job_config:
+            job_parameters = job_config["job_parameters"]
+
+        return job_parameters

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/configs/databricks.yml
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/configs/databricks.yml
@@ -1,0 +1,30 @@
+# Sample Databricks bundle configuration that demonstrates new features
+# This file shows how the scaffolder extracts libraries, job parameters, and common configuration
+
+bundle:
+  name: databricks_pipeline_example
+
+variables:
+  experiment_settings: "mlflow://databricks"
+  catalog_map: "dev.catalog"
+  log_level: "INFO"
+  llm_calls: "enabled"
+  git_sha: "{{ git_sha }}"
+  output_bucket_name: "my-data-bucket"
+  orchestrator_job_run_id: "{{ run_id }}"
+  environment: "{{ env }}"
+  profiler_enabled: "false"
+
+targets:
+  dev:
+    default: true
+    variables:
+      env: "dev"
+      catalog: "dev"
+  prod:
+    variables:
+      env: "prod"
+      catalog: "prod"
+
+include:
+  - resources/jobs.yml

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/configs/resources/jobs.yml
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/configs/resources/jobs.yml
@@ -1,0 +1,48 @@
+# Example: Jobs with job-level parameters and job parameter references
+# This demonstrates how the scaffolder extracts job-level parameters and preserves references
+
+resources:
+  jobs:
+    databricks_pipeline_job:
+      name: "Databricks Pipeline Job with Job Parameters"
+
+      # Job-level parameters that will be extracted by the scaffolder and component
+      parameters:
+        environment: "{{ env }}"
+        orchestrator_job_run_id: "{{ run_id }}"
+        output_bucket_name: "{{ var.output_bucket_name }}"
+        profiler_enabled: false
+        experiment_settings: "mlflow://databricks"
+        catalog_map: "{{ env }}.catalog"
+        log_level: "INFO"
+        llm_calls: "enabled"
+        git_sha: "{{ git_sha }}"
+        batch_size: 1000
+        timeout_minutes: 30
+
+      tasks:
+        # Example 1: Notebook task with job parameter references
+        - task_key: data_processing_notebook
+          notebook_task:
+            notebook_path: "/Users/{{ workspace_user }}/ml_pipelines/data_processing"
+            base_parameters:
+              input_table: "{{ env }}.raw.customer_data"
+              output_table: "{{ env }}.processed.customer_data"
+              processing_date: "{{ ds }}"
+              # Reference job-level parameters using {{job.parameters.param_name}} syntax
+              environment: "{{job.parameters.environment}}"
+              run_id: "{{job.parameters.orchestrator_job_run_id}}"
+              output_bucket: "{{job.parameters.output_bucket_name}}"
+              profiler_enabled: "{{job.parameters.profiler_enabled}}"
+              experiment_settings: "{{job.parameters.experiment_settings}}"
+              catalog_map: "{{job.parameters.catalog_map}}"
+              log_level: "{{job.parameters.log_level}}"
+              llm_calls: "{{job.parameters.llm_calls}}"
+              git_sha: "{{job.parameters.git_sha}}"
+              batch_size: "{{job.parameters.batch_size}}"
+              timeout_minutes: "{{job.parameters.timeout_minutes}}"
+          libraries:
+            - whl: "dbfs:/FileStore/wheels/data_processing-1.0.0-py3-none-any.whl"
+            - pypi:
+                package: "pandas"
+                version: "2.0.0"

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_configs.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import pytest
+from dagster_databricks.components.databricks_asset_bundle.databricks_configs import (
+    DatabricksConfigs,
+)
+
+DATABRICKS_CONFIGS_LOCATION_PATH = Path(__file__).parent / "configs" / "databricks.yml"
+
+
+def test_load_databricks_configs():
+    # Task dataclasses are not implemented yet, no task is parsed so an exception is raised
+    with pytest.raises(ValueError, match="No tasks found in databricks config"):
+        DatabricksConfigs(databricks_configs_path=DATABRICKS_CONFIGS_LOCATION_PATH)


### PR DESCRIPTION
## Summary & Motivation

Add DatabricksConfigs class, representing the configs required for the DatabricksAssetBundleComponent. Logic inspired from the [demo in hooli](https://github.com/dagster-io/hooli-data-eng-pipelines/tree/add-hooli-ml).

The `databricks.yml` file is the main config file for the asset bundle - it references resources (includes) that define tasks and params. `databricks.yml` and resource files are parsed by `DatabricksConfigs` to extract `tasks` and `job_level_parameters`, which will be used by the component.

Tasks are not handled in this first iteration, causing the extraction process to raise an expected exception. Tasks will be implemented in subsequent PRs.

## How I Tested These Changes

BK