### PR TITLE
Add get_records_for_run method to DagsterInstance for proper Datadog tracing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,3 +128,5 @@ yarn build-api-docs          # Build API docs after .rst changes
 - **Reason**: GT is the source of truth for stack metadata and relationships
 - **Primary command**: `gt log` provides comprehensive PR numbers, statuses, and branch relationships
 - **Impact**: Single command reveals entire stack structure vs. manual discovery
+
+- Do not automatically do git commit --amend on user's behalf since you lose track of what the agent has done

--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -47,7 +47,11 @@ if TYPE_CHECKING:
     from dagster._core.storage.daemon_cursor import DaemonCursorStorage
     from dagster._core.storage.dagster_run import JobBucket, RunRecord, TagBucket
     from dagster._core.storage.event_log import EventLogStorage
-    from dagster._core.storage.event_log.base import AssetRecord, EventRecordsResult
+    from dagster._core.storage.event_log.base import (
+        AssetRecord,
+        EventLogConnection,
+        EventRecordsResult,
+    )
     from dagster._core.storage.partition_status_cache import AssetPartitionStatus
     from dagster._core.storage.root import LocalArtifactStorage
     from dagster._core.storage.runs import RunStorage
@@ -558,6 +562,23 @@ class DagsterInstance(
         return self._event_storage.fetch_run_status_changes(
             records_filter, limit, cursor, ascending
         )
+
+    @traced
+    def get_records_for_run(
+        self,
+        run_id: str,
+        cursor: Optional[str] = None,
+        of_type: Optional[Union["DagsterEventType", set["DagsterEventType"]]] = None,
+        limit: Optional[int] = None,
+        ascending: bool = True,
+    ) -> "EventLogConnection":
+        """Get event records for run.
+
+        NOTE: This method is duplicated here (vs only being in EventMethods) because
+        some Datadog tracing spans specifically expect to find this method on the
+        DagsterInstance class for proper trace attribution.
+        """
+        return EventMethods.get_records_for_run(self, run_id, cursor, of_type, limit, ascending)
 
     # Storage/Partition Domain
     # ------------------------


### PR DESCRIPTION
## Summary & Motivation

This change adds the `get_records_for_run` method directly to the `DagsterInstance` class to ensure proper Datadog tracing span attribution. The method was previously only available in `EventMethods`, but Datadog tracing spans specifically expect to find this method on the `DagsterInstance` class itself.

The method is marked as `@traced`, and delegates to the existing implementation in `EventMethods.get_records_for_run`. This duplication is necessary for maintaining proper observability tooling integration while preserving the clean architecture introduced in the recent instance refactoring work.

## How I Tested These Changes

BK