### PR TITLE
fix issue where an asset was declared a stub if it was a stub in any code location

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/useShowStubAssets.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/useShowStubAssets.tsx
@@ -5,7 +5,7 @@ const SHOW_STUB_ASSETS_STORAGE_KEY = 'showStubAssets';
 export const useShowStubAssets = () => {
   const [showStubAssets, setShowStubAssets] = useStateWithStorage(
     SHOW_STUB_ASSETS_STORAGE_KEY,
-    (value: any) => (typeof value === 'boolean' ? value : true),
+    (value: any) => (typeof value === 'boolean' ? value : false),
   );
 
   return {showStubAssets, setShowStubAssets};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAllAssets.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAllAssets.tsx
@@ -408,7 +408,6 @@ const MERGE_BOOLEAN_KEYS = [
   'isExecutable',
   'isObservable',
   'isMaterializable',
-  'isAutoCreatedStub',
 ] as const;
 
 const combineAssetDefinitions = weakMapMemoize(


### PR DESCRIPTION
## Summary & Motivation
Unlike these other properties, an asset should only be called a stub if it is a stub in the actual asset definition that we picked.

## How I Tested These Changes
Load an asset job with the 'filter stubs' toggle on when it defined in another code location as a stub, the toggle no longer excludes it.
