### PR TITLE
[dagster-eval] cli util

### DIFF
--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -211,6 +211,7 @@ debugpy==1.8.14
 decopatch==1.4.10
 decorator==5.2.1
 deepdiff==7.0.1
+deepeval==3.3.9
 defusedxml==0.7.1
 deltalake==0.25.5
 deprecated==1.2.18

--- a/python_modules/automation/automation/eval/cli.py
+++ b/python_modules/automation/automation/eval/cli.py
@@ -1,0 +1,319 @@
+import hashlib
+import json
+from datetime import datetime
+from functools import cached_property
+from pathlib import Path
+from typing import Any, Optional
+
+import click
+import yaml
+from dagster_shared.record import record
+from deepeval import evaluate
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase, LLMTestCaseParams
+from rich.console import Console
+from rich.table import Table
+
+
+@record
+class Metric:
+    """A metric to evaluate."""
+
+    name: str
+    criteria: str
+    evaluation_steps: Optional[list[str]] = None
+
+    def get_hash(self) -> str:
+        """Generate a hash for this metric configuration."""
+        content = self.criteria
+        if self.evaluation_steps:
+            content += "".join(self.evaluation_steps)
+        return hashlib.sha256(content.encode()).hexdigest()[:8]
+
+    @cached_property
+    def geval(self) -> GEval:
+        return GEval(
+            name=self.name,
+            criteria=self.criteria,
+            evaluation_steps=self.evaluation_steps,
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+            ],
+        )
+
+    @property
+    def flat_name(self) -> str:
+        return self.name.lower().replace(" ", "_")
+
+    @property
+    def id(self) -> str:
+        return f"{self.flat_name}-{self.get_hash()}"
+
+
+@record
+class EvalConfig:
+    """Configuration for evaluation."""
+
+    metrics: list[Metric]
+
+
+def load_config(eval_dir: Path) -> EvalConfig:
+    """Load and validate the evaluation configuration."""
+    config_path = eval_dir / "eval.yaml"
+    if not config_path.exists():
+        raise click.UsageError(f"Configuration file {config_path} not found")
+
+    with open(config_path) as f:
+        config_data = yaml.safe_load(f)
+
+    return EvalConfig(metrics=[Metric(**metric) for metric in config_data["metrics"]])
+
+
+def load_sessions(eval_dir: Path) -> dict[str, dict[str, Any]]:
+    """Load all session files from the directory."""
+    sessions = {}
+    session_files = list(eval_dir.glob("*.json"))
+
+    # Exclude cache files
+    session_files = [f for f in session_files if not f.name.startswith("metric-")]
+
+    for session_file in session_files:
+        session_id = session_file.stem
+        with open(session_file) as f:
+            session_data = json.load(f)
+
+        # Validate required fields
+        if not isinstance(session_data, dict):
+            raise click.UsageError(
+                f"Warning: Skipping {session_file.name} - not a valid JSON object"
+            )
+
+        if (
+            "input" not in session_data
+            or "output" not in session_data
+            or "timestamp" not in session_data
+        ):
+            raise click.UsageError(
+                f"Warning: Skipping {session_file.name} - missing required fields"
+            )
+
+        sessions[session_id] = session_data
+
+    if not sessions:
+        raise click.UsageError("No valid session files found")
+
+    return sessions
+
+
+def load_results(eval_dir: Path, metric: Metric) -> dict[str, dict[str, Any]]:
+    """Load cached results for a metric."""
+    cache_file = eval_dir / f"metric-{metric.get_hash()}.json"
+
+    if not cache_file.exists():
+        return {}
+
+    with open(cache_file) as f:
+        return json.load(f)
+
+
+def save_results(eval_dir: Path, metric: Metric, cache: dict[str, dict[str, Any]]) -> None:
+    """Save cached results for a metric."""
+    cache_file = eval_dir / f"metric-{metric.get_hash()}.json"
+
+    # Write to temp file first for atomic update
+    temp_file = cache_file.with_suffix(".tmp")
+    with open(temp_file, "w") as f:
+        json.dump(cache, f, indent=2)
+
+    # Atomic rename
+    temp_file.replace(cache_file)
+
+
+def evaluate_sessions(
+    sessions: dict[str, dict[str, Any]], metric: Metric, cached_results: dict[str, dict[str, Any]]
+) -> dict[str, dict[str, Any]]:
+    """Evaluate sessions that aren't in cache."""
+    # Find uncached sessions
+    uncached_sessions = [
+        (sid, sdata) for sid, sdata in sessions.items() if sid not in cached_results
+    ]
+
+    if not uncached_sessions:
+        return cached_results
+
+    # Create test cases
+    test_cases = [
+        LLMTestCase(
+            input=str(session_data["input"]),
+            actual_output=str(session_data["output"]),
+        )
+        for _, session_data in uncached_sessions
+    ]
+
+    # Run evaluation
+    click.echo(f"Evaluating {len(test_cases)} sessions for metric '{metric.id}'...")
+    results = evaluate(test_cases=test_cases, metrics=[metric.geval])
+
+    # Update cache with new results
+    new_cache = dict(cached_results)
+    for (session_id, _), result in zip(uncached_sessions, results.test_results):
+        assert result.metrics_data
+        metric_result = result.metrics_data[0]  # We only have one metric per evaluation
+        new_cache[session_id] = {
+            "score": metric_result.score,
+            "reason": metric_result.reason,
+            "evaluated_at": datetime.now().isoformat(),
+        }
+
+    return new_cache
+
+
+def display_results(
+    sessions: dict[str, dict[str, Any]],
+    all_results: dict[str, dict[str, dict[str, Any]]],
+    metrics: list[Metric],
+    show_fields: tuple[str, ...],
+) -> None:
+    """Display evaluation results in a table."""
+    console = Console()
+
+    # Display metrics summary
+    console.print("\n[bold blue]Metrics Summary:[/bold blue]")
+    for i, metric in enumerate(metrics, 1):
+        console.print(
+            f"  {i}. [yellow]{metric.name.capitalize()}[/yellow] ([dim]{metric.get_hash()}[/dim]): {metric.criteria}"
+        )
+
+    # Sort sessions by timestamp
+    sorted_sessions = sorted(sessions.items(), key=lambda x: x[1]["timestamp"])
+
+    # Create Rich table
+    console.print()  # Add spacing before results
+    table = Table(
+        title="[bold cyan]📊 EVALUATION RESULTS[/bold cyan]",
+        show_header=True,
+        header_style="bold magenta",
+    )
+
+    # Add columns
+    table.add_column("Session ID", style="cyan", no_wrap=True)
+    table.add_column("Time", style="green", no_wrap=True)
+
+    # Add custom fields as columns
+    for field in show_fields:
+        table.add_column(field.capitalize(), style="blue")
+
+    for metric in metrics:
+        table.add_column(metric.name.capitalize(), style="yellow", justify="center")
+
+    # Add rows
+    for session_id, session_data in sorted_sessions:
+        # Parse timestamp for terse display
+        timestamp = datetime.fromisoformat(session_data["timestamp"])
+        time_str = timestamp.strftime("%m/%d %H:%M")
+
+        row_data = [session_id[:8], time_str]
+
+        # Add custom field values
+        for field in show_fields:
+            value = session_data.get(field, "")
+            # Truncate long values and convert to string
+            value_str = str(value) if value else "-"
+            if len(value_str) > 50:
+                value_str = value_str[:47] + "..."
+            row_data.append(value_str)
+
+        for metric in metrics:
+            if metric.id in all_results and session_id in all_results[metric.id]:
+                score = all_results[metric.id][session_id]["score"]
+                # Color code scores: green for high, yellow for medium, red for low
+                score_str = f"{score:.2f}"
+                if score >= 0.8:
+                    score_str = f"[bold green]{score_str}[/bold green]"
+                elif score >= 0.6:
+                    score_str = f"[bold yellow]{score_str}[/bold yellow]"
+                else:
+                    score_str = f"[bold red]{score_str}[/bold red]"
+                row_data.append(score_str)
+            else:
+                row_data.append("[dim]-[/dim]")
+
+        table.add_row(*row_data)
+
+    console.print(table)
+    console.print()  # Add spacing after results
+
+
+@click.command()
+@click.argument("directory")
+@click.option(
+    "--show",
+    "-s",
+    multiple=True,
+    help="Additional fields from session JSON to display as columns (can be specified multiple times)",
+)
+def main(directory: str, show: tuple[str, ...]) -> None:
+    """Utility for performing evaluations over ai tool sessions.
+
+    Expects a directory containing:
+    * Session files: <uuid>.json files with the following schema:
+      {
+        "input": str,        # Required: The input prompt/question
+        "output": str,       # Required: The AI's response
+        "timestamp": str,    # Required: ISO format timestamp
+        ...                  # Optional: Any additional fields (can be displayed with --show)
+      }
+
+    * Configuration file: eval.yaml with the following schema:
+      metrics:
+        - name: str                    # Display name for the metric
+          criteria: str                # Evaluation criteria description
+          evaluation_steps:            # Optional: Specific evaluation steps
+            - str
+            - str
+            ...
+
+    Example eval.yaml:
+      metrics:
+        - name: "Accuracy"
+          criteria: "How accurate is the response to the question?"
+          evaluation_steps:
+            - "Check if the response directly answers the question"
+            - "Verify factual correctness"
+        - name: "Completeness"
+          criteria: "Does the response fully address all aspects of the question?"
+    """
+    eval_dir = Path(directory)
+
+    if not eval_dir.exists():
+        raise click.UsageError(f"Directory {directory} does not exist")
+
+    # Load configuration
+    config = load_config(eval_dir)
+
+    # Load sessions
+    sessions = load_sessions(eval_dir)
+
+    # Process each metric
+    all_results = {}
+    for metric in config.metrics:
+        # Load cache
+        cached_results = load_results(eval_dir, metric)
+
+        # Evaluate uncached sessions
+        updated_results = evaluate_sessions(sessions, metric, cached_results)
+
+        # Save updated cache
+        if updated_results != cached_results:
+            save_results(eval_dir, metric, updated_results)
+
+        # Store results for display
+        all_results[metric.id] = updated_results
+
+    # Display results
+    display_results(sessions, all_results, config.metrics, show)
+
+
+if __name__ == "__main__":
+    main()

--- a/python_modules/automation/automation_tests/test_eval_cli.py
+++ b/python_modules/automation/automation_tests/test_eval_cli.py
@@ -1,0 +1,151 @@
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from automation.eval.cli import Metric, evaluate_sessions, load_config, load_sessions
+from dagster_shared.utils import environ
+
+
+@pytest.fixture(autouse=True, scope="session")
+def blank_openapi_key():
+    with environ({"OPENAI_API_KEY": "..."}):
+        yield
+
+
+def test_metric_hash_generation():
+    metric1 = Metric(name="Test Metric", criteria="How good is this?")
+    metric2 = Metric(name="Test Metric", criteria="How good is this?")
+    metric3 = Metric(name="Test Metric", criteria="Different criteria")
+
+    assert metric1.get_hash() == metric2.get_hash()
+    assert metric1.get_hash() != metric3.get_hash()
+
+    metric_with_steps = Metric(
+        name="Test Metric", criteria="How good is this?", evaluation_steps=["Step 1", "Step 2"]
+    )
+    assert metric_with_steps.get_hash() != metric1.get_hash()
+
+
+def test_load_config_valid():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        eval_dir = Path(tmpdir)
+        config_file = eval_dir / "eval.yaml"
+
+        # Write YAML content that load_config expects
+        yaml_content = """
+metrics:
+  - name: Accuracy
+    criteria: Is it accurate?
+  - name: Completeness
+    criteria: Is it complete?
+    evaluation_steps:
+      - Check all parts
+"""
+
+        with open(config_file, "w") as f:
+            f.write(yaml_content)
+
+        # Test that load_config properly parses and creates the config
+        config = load_config(eval_dir)
+
+        assert len(config.metrics) == 2
+        assert config.metrics[0].name == "Accuracy"
+        assert config.metrics[0].criteria == "Is it accurate?"
+        assert config.metrics[1].name == "Completeness"
+        assert config.metrics[1].evaluation_steps == ["Check all parts"]
+
+
+def test_load_config_missing_file():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        eval_dir = Path(tmpdir)
+
+        with pytest.raises(click.UsageError, match="Configuration file .* not found"):
+            load_config(eval_dir)
+
+
+def test_load_sessions_valid():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        eval_dir = Path(tmpdir)
+
+        session1 = {"input": "What is 2+2?", "output": "4", "timestamp": "2024-01-01T10:00:00"}
+        session2 = {
+            "input": "What is the capital of France?",
+            "output": "Paris",
+            "timestamp": "2024-01-01T11:00:00",
+            "extra_field": "Extra data",
+        }
+
+        with open(eval_dir / "session1.json", "w") as f:
+            json.dump(session1, f)
+        with open(eval_dir / "session2.json", "w") as f:
+            json.dump(session2, f)
+
+        sessions = load_sessions(eval_dir)
+
+        assert len(sessions) == 2
+        assert sessions["session1"]["input"] == "What is 2+2?"
+        assert sessions["session2"]["extra_field"] == "Extra data"
+
+
+def test_load_sessions_invalid_files():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        eval_dir = Path(tmpdir)
+
+        with open(eval_dir / "invalid.json", "w") as f:
+            json.dump({"missing": "required fields"}, f)
+
+        with pytest.raises(click.UsageError, match="missing required fields"):
+            load_sessions(eval_dir)
+
+
+def test_load_sessions_ignores_cache_files():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        eval_dir = Path(tmpdir)
+
+        session = {"input": "Test", "output": "Response", "timestamp": "2024-01-01T10:00:00"}
+        cache = {"session1": {"score": 0.9}}
+
+        with open(eval_dir / "session1.json", "w") as f:
+            json.dump(session, f)
+        with open(eval_dir / "metric-abc123.json", "w") as f:
+            json.dump(cache, f)
+
+        sessions = load_sessions(eval_dir)
+
+        assert len(sessions) == 1
+        assert "metric-abc123" not in sessions
+
+
+@patch("automation.eval.cli.evaluate")
+def test_evaluate_sessions_with_cache(mock_evaluate):
+    metric = Metric(name="Test", criteria="Is it good?")
+
+    sessions = {
+        "session1": {"input": "Q1", "output": "A1"},
+        "session2": {"input": "Q2", "output": "A2"},
+        "session3": {"input": "Q3", "output": "A3"},
+    }
+
+    cached_results = {
+        "session1": {"score": 0.8, "reason": "Good", "evaluated_at": "2024-01-01T10:00:00"}
+    }
+
+    mock_result = MagicMock()
+    mock_result.test_results = [
+        MagicMock(metrics_data=[MagicMock(score=0.7, reason="Okay")]),
+        MagicMock(metrics_data=[MagicMock(score=0.9, reason="Great")]),
+    ]
+    mock_evaluate.return_value = mock_result
+
+    results = evaluate_sessions(sessions, metric, cached_results)
+
+    assert len(results) == 3
+    assert results["session1"]["score"] == 0.8
+    assert results["session2"]["score"] == 0.7
+    assert results["session3"]["score"] == 0.9
+
+    mock_evaluate.assert_called_once()
+    assert len(mock_evaluate.call_args[1]["test_cases"]) == 2

--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -23,12 +23,16 @@ setup(
         "pandas",
         "pathspec",
         "pytablereader",
+        "pydantic",
+        "pyyaml",
         "requests",
+        "rich",
         "twine>=1.15.0",
         "sphinx",
         "virtualenv>=20.27.0",
         "urllib3",
         "watchdog",
+        "deepeval",
     ],
     extras_require={
         "buildkite": [
@@ -40,6 +44,7 @@ setup(
             "dagster-image = automation.docker.cli:main",
             "dagster-graphql-client = automation.graphql.python_client.cli:main",
             "dagster-docs = automation.dagster_docs:main",
+            "dagster-eval = automation.eval.cli:main",
         ]
     },
 )

--- a/python_modules/libraries/dagster-dg-cli/tox.ini
+++ b/python_modules/libraries/dagster-dg-cli/tox.ini
@@ -23,6 +23,7 @@ deps =
   -e ../../../python_modules/libraries/dagster-shared
   -e ../../../python_modules/libraries/dagster-cloud-cli
   -e ../../../python_modules/libraries/create-dagster
+  -e ../../../python_modules/automation
   plus: -e ../../../python_modules/libraries/dagster-aws
   plus: -e ../../../python_modules/libraries/dagster-k8s
   plus: -e ../../../python_modules/libraries/dagster-docker


### PR DESCRIPTION
Adds a cli utility for running evaluations over a directory of "session" json files. The goal of this tool is to provide a lightweight way to iterate on: 
* An ai flow, where you can accumulate sessions over time and see how evaluation results change. The expected workflow here is running in the same directory as it accumulates new session files. 
* The evaluation definition it self. Only new or modified metric definitions in `eval.yaml` will result in new evaluations performed.

`deepeval` was chosen here as it was the best tool i found from my time searching for doing LLM-as-a-judge evals via `GEval`.


## How I Tested These Changes
added test
run it on `dg scaffold branch --record` output 

sample:
`eval.yaml`: 
```
metrics:
  - name: "Requirement Fulfillment"
    criteria: "Assess requirement fulfillment: data sources/destinations, pipeline flow, technologies, scenario coverage"
```
output:
```
(py312) ~/code/demo-gen:main$ dagster-eval ./summaries/ -s demo_directory

Metrics Summary:
  1. Requirement fulfillment (dc21147b): Assess requirement fulfillment: data sources/destinations, pipeline flow, technologies, scenario coverage

                                           📊 EVALUATION RESULTS
┏━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Session ID ┃ Time        ┃ Demo_directory                                     ┃ Requirement fulfillment ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 0940d480   │ 07/30 09:54 │ my-demos/api-s3-redshift-demo                      │          0.96           │
│ e26546d3   │ 07/30 10:53 │ my-demos/api-to-redshift-demo                      │          0.00           │
│ 07b7b9a0   │ 07/30 13:53 │ user-exports/thomasganka-20250731/my-demos/info... │          0.80           │
│ 0f969624   │ 07/31 00:45 │ user-exports/izzy-20250731/shared-demos/finance... │          0.00           │
│ 7860ad50   │ 07/31 13:39 │ user-exports/thomasganka-20250805/my-demos/info... │          0.54           │
│ edc04680   │ 07/31 13:54 │ user-exports/thomasganka-20250805/my-demos/info... │          0.00           │
│ b20bbca5   │ 08/04 09:22 │ user-exports/thomasganka-20250805/my-demos/info... │          0.95           │
│ 294783ea   │ 08/06 09:25 │ user-exports/christian-20250806/my-demos/erp-cr... │          0.91           │
│ 6ea994cc   │ 08/06 13:41 │ my-demos/test-new-flow                             │          0.99           │
│ 8d93559a   │ 08/06 14:57 │ my-demos/test-new-flow                             │          1.00           │
│ c4c08b40   │ 08/06 15:03 │ my-demos/new-flow-test                             │          0.00           │
│ 3ba3083e   │ 08/06 15:04 │ my-demos/new-flow-test2                            │          0.00           │
└────────────┴─────────────┴────────────────────────────────────────────────────┴─────────────────────────┘
```
