### PR TITLE
[catalog] Fix fullscreen button on catalog lineage

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -685,9 +685,6 @@ const AssetGraphExplorerWithData = ({
   const {isFullScreen, toggleFullScreen} = useFullScreen();
 
   const toggleFullScreenButton = useMemo(() => {
-    if (viewType === AssetGraphViewType.CATALOG) {
-      return null;
-    }
     return (
       <Tooltip content={isFullScreen ? 'Collapse' : 'Expand'}>
         <Button
@@ -696,7 +693,7 @@ const AssetGraphExplorerWithData = ({
         />
       </Tooltip>
     );
-  }, [viewType, toggleFullScreen, isFullScreen]);
+  }, [toggleFullScreen, isFullScreen]);
 
   const explorer = (
     <SplitPanelContainer

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGraphHeader.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGraphHeader.oss.tsx
@@ -1,8 +1,13 @@
 import {PageHeader, Subtitle1} from '@dagster-io/ui-components';
 
+import {useFullScreen} from '../app/AppTopNav/AppTopNavContext';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 
 export const AssetsGraphHeader = () => {
+  const {isFullScreen} = useFullScreen();
+  if (isFullScreen) {
+    return null;
+  }
   return (
     <PageHeader
       title={<Subtitle1>Global Asset Lineage</Subtitle1>}


### PR DESCRIPTION
## Summary & Motivation

The button was erroneously removed in https://github.com/dagster-io/dagster/pull/31018/. This adds it back. Also hide the breadcrumb in full screen mode to create more space:



 
<img width="1486" height="594" alt="Screenshot 2025-08-11 at 2 29 17 PM" src="https://github.com/user-attachments/assets/7ae1e6fc-2894-4f43-8fad-682060f384cf" />
<img width="1123" height="927" alt="Screenshot 2025-08-11 at 2 29 11 PM" src="https://github.com/user-attachments/assets/f3d6a805-250a-4ffb-babe-e4c7bd61d333" />
