### PR TITLE
[1/2] Read compressed evaluations

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -130,6 +130,10 @@ class AssetGraphView(LoadingContext):
         )
 
     @property
+    def partition_loading_context(self) -> PartitionLoadingContext:
+        return self._partition_loading_context
+
+    @property
     def instance(self) -> "DagsterInstance":
         return self._instance
 

--- a/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
@@ -7,6 +7,7 @@ from typing import (  # noqa: UP035
     Generic,
     Literal,
     NamedTuple,
+    Optional,
     TypeVar,
     Union,
 )
@@ -20,6 +21,9 @@ from dagster._core.asset_graph_view.serializable_entity_subset import (
 )
 from dagster._core.definitions.asset_key import AssetCheckKey, EntityKey, T_EntityKey
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.partitions.definition.partitions_definition import (
+    PartitionsDefinition,
+)
 from dagster._core.definitions.partitions.subset import PartitionsSubset
 from dagster._utils.cached_method import cached_method
 
@@ -56,6 +60,10 @@ class EntitySubset(Generic[T_EntityKey]):
     @property
     def key(self) -> T_EntityKey:
         return self._key
+
+    @property
+    def partitions_def(self) -> Optional[PartitionsDefinition]:
+        return self._asset_graph_view.asset_graph.get(self._key).partitions_def
 
     def convert_to_serializable_subset(self) -> SerializableEntitySubset[T_EntityKey]:
         return SerializableEntitySubset(key=self._key, value=self._value)

--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -24,6 +24,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionEvaluation,
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.partitions.context import use_partition_loading_context
 from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.instance import DynamicPartitionsStore
@@ -74,6 +75,7 @@ class AutomationTickEvaluationContext:
         self._materialize_run_tags = materialize_run_tags
         self._observe_run_tags = observe_run_tags
         self._auto_observe_asset_keys = auto_observe_asset_keys or set()
+        self._partition_loading_context = self._evaluator.asset_graph_view.partition_loading_context
 
     @property
     def cursor(self) -> AssetDaemonCursor:
@@ -165,6 +167,7 @@ class AutomationTickEvaluationContext:
                 updated_evaluations.append(result.serializable_evaluation)
         return updated_evaluations
 
+    @use_partition_loading_context
     async def async_evaluate(
         self,
     ) -> tuple[
@@ -179,6 +182,7 @@ class AutomationTickEvaluationContext:
             self._get_updated_evaluations(results),
         )
 
+    @use_partition_loading_context
     def evaluate(
         self,
     ) -> tuple[

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -26,6 +26,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionSnapshot,
     OperatorType,
     get_serializable_candidate_subset,
+    get_serializable_true_subset,
 )
 from dagster._core.definitions.partitions.subset import (
     AllPartitionsSubset,
@@ -861,10 +862,8 @@ class AutomationResult(Generic[T_EntityKey]):
         if not self.condition.requires_cursor:
             return None
         return AutomationConditionNodeCursor(
-            true_subset=self.get_serializable_subset(),
-            candidate_subset=get_serializable_candidate_subset(
-                self._context.candidate_subset.convert_to_serializable_subset()
-            ),
+            true_subset=get_serializable_true_subset(self.true_subset),
+            candidate_subset=get_serializable_candidate_subset(self._context.candidate_subset),
             subsets_with_metadata=self._subsets_with_metadata,
             metadata=self._metadata,
             extra_state=self._extra_state,
@@ -874,10 +873,8 @@ class AutomationResult(Generic[T_EntityKey]):
     def serializable_evaluation(self) -> AutomationConditionEvaluation:
         return AutomationConditionEvaluation(
             condition_snapshot=self.condition.get_node_snapshot(self.condition_unique_id),
-            true_subset=self.get_serializable_subset(),
-            candidate_subset=get_serializable_candidate_subset(
-                self._context.candidate_subset.convert_to_serializable_subset()
-            ),
+            true_subset=get_serializable_true_subset(self.true_subset),
+            candidate_subset=get_serializable_candidate_subset(self._context.candidate_subset),
             subsets_with_metadata=self._subsets_with_metadata,
             metadata=self._metadata,
             start_timestamp=self._start_timestamp,

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -36,7 +36,6 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionEvaluationWithRunIds,
 )
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.partitions.context import partition_loading_context
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
@@ -467,16 +466,35 @@ class AssetDaemon(DagsterDaemon):
         if get_auto_materialize_paused(instance) and not use_auto_materialize_sensors:
             return
 
-        now = get_current_timestamp()
+        with workspace_process_context.create_request_context() as workspace_request_context:
+            self._run_iteration_impl_with_request_context(
+                workspace_process_context,
+                workspace_request_context,
+                instance,
+                threadpool_executor,
+                amp_tick_futures,
+                use_auto_materialize_sensors,
+                debug_crash_flags,
+            )
 
-        workspace = workspace_process_context.create_request_context()
+    def _run_iteration_impl_with_request_context(
+        self,
+        workspace_process_context: IWorkspaceProcessContext,
+        workspace_request_context: BaseWorkspaceRequestContext,
+        instance: DagsterInstance,
+        threadpool_executor: Optional[ThreadPoolExecutor],
+        amp_tick_futures: dict[Optional[str], Future],
+        use_auto_materialize_sensors: bool,
+        debug_crash_flags: SingleInstigatorDebugCrashFlags,
+    ):
+        now = get_current_timestamp()
 
         sensors_and_repos: Sequence[tuple[Optional[RemoteSensor], Optional[RemoteRepository]]] = []
 
         if use_auto_materialize_sensors:
             current_workspace = {
                 location_entry.origin.location_name: location_entry
-                for location_entry in workspace.get_code_location_entries().values()
+                for location_entry in workspace_request_context.get_code_location_entries().values()
             }
 
             eligible_sensors_and_repos = []
@@ -502,7 +520,7 @@ class AssetDaemon(DagsterDaemon):
                 if not get_has_migrated_to_sensors(instance):
                     # Do a one-time migration to create the cursors for each sensor, based on the
                     # existing cursor for the legacy AMP tick
-                    asset_graph = workspace.asset_graph
+                    asset_graph = workspace_request_context.asset_graph
                     pre_sensor_cursor = _get_pre_sensor_auto_materialize_cursor(
                         instance, asset_graph
                     )
@@ -597,7 +615,7 @@ class AssetDaemon(DagsterDaemon):
                 future = threadpool_executor.submit(
                     self._process_auto_materialize_tick,
                     workspace_process_context,
-                    workspace,
+                    workspace_request_context,
                     repo,
                     sensor,
                     debug_crash_flags,
@@ -606,7 +624,7 @@ class AssetDaemon(DagsterDaemon):
             else:
                 self._process_auto_materialize_tick(
                     workspace_process_context,
-                    workspace,
+                    workspace_request_context,
                     repo,
                     sensor,
                     debug_crash_flags,
@@ -903,18 +921,13 @@ class AssetDaemon(DagsterDaemon):
                     )
                 )
 
-            with (
-                AutoMaterializeLaunchContext(
-                    tick,
-                    sensor,
-                    instance,
-                    self._logger,
-                    tick_retention_settings,
-                ) as tick_context,
-                partition_loading_context(
-                    dynamic_partitions_store=workspace.dynamic_partitions_loader
-                ),
-            ):
+            with AutoMaterializeLaunchContext(
+                tick,
+                sensor,
+                instance,
+                self._logger,
+                tick_retention_settings,
+            ) as tick_context:
                 await self._evaluate_auto_materialize_tick(
                     tick_context,
                     tick,

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
@@ -4,6 +4,7 @@ import operator
 import dagster as dg
 import pytest
 from dagster import AutoMaterializePolicy, AutomationCondition
+from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.declarative_automation.operators import (
@@ -13,6 +14,8 @@ from dagster._core.definitions.declarative_automation.operators import (
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     HistoricalAllPartitionsSubsetSentinel,
 )
+from dagster._core.definitions.partitions.context import partition_loading_context
+from dagster._core.definitions.partitions.subset.key_ranges import KeyRangesPartitionsSubset
 from dagster._core.remote_representation.external_data import RepositorySnap
 from dagster_shared.check import CheckError
 
@@ -368,3 +371,46 @@ def test_use_historical_all_partitions_subset_sentinel() -> None:
         .serializable_evaluation.candidate_subset,
         HistoricalAllPartitionsSubsetSentinel,
     )
+
+
+@pytest.mark.skip(reason="PUSH-SAFETY: do not compress until the read path is released")
+def test_use_key_ranges_partitions_subset() -> None:
+    @dg.asset(
+        partitions_def=dg.DynamicPartitionsDefinition(name="some_def"),
+        # using this weird condition to make a predictable non-AllPartitionsSubset candidate subset
+        automation_condition=dg.AutomationCondition.missing() & dg.AutomationCondition.missing(),
+    )
+    def A(): ...
+
+    defs = dg.Definitions(assets=[A])
+    instance = dg.DagsterInstance.ephemeral()
+    instance.add_dynamic_partitions("some_def", ["a", "b", "c", "d", "e"])
+    for partition in ["a", "c", "e"]:
+        instance.report_runless_asset_event(
+            dg.AssetMaterialization(asset_key=dg.AssetKey("A"), partition=partition)
+        )
+
+    current_time = datetime.datetime(2024, 8, 16, 4, 35)
+    result = dg.evaluate_automation_conditions(
+        defs=defs, instance=instance, evaluation_time=current_time
+    )
+    assert result.total_requested == 2
+
+    with partition_loading_context(effective_dt=current_time, dynamic_partitions_store=instance):
+        # outer AND condition
+        serializable_evaluation = result.results[0].serializable_evaluation
+        assert isinstance(serializable_evaluation.true_subset.value, KeyRangesPartitionsSubset)
+        assert serializable_evaluation.true_subset.value.get_partition_keys() == ["b", "d"]
+
+        assert isinstance(
+            serializable_evaluation.candidate_subset, HistoricalAllPartitionsSubsetSentinel
+        )
+
+        # inner missing condition (second operand)
+        serializable_evaluation = result.results[0].child_results[1].serializable_evaluation
+        assert isinstance(serializable_evaluation.true_subset.value, KeyRangesPartitionsSubset)
+        assert serializable_evaluation.true_subset.value.get_partition_keys() == ["b", "d"]
+
+        assert isinstance(serializable_evaluation.candidate_subset, SerializableEntitySubset)
+        assert isinstance(serializable_evaluation.candidate_subset.value, KeyRangesPartitionsSubset)
+        assert serializable_evaluation.candidate_subset.value.get_partition_keys() == ["b", "d"]

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/dynamic_partitions_on_missing.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/dynamic_partitions_on_missing.py
@@ -1,0 +1,11 @@
+import dagster as dg
+
+
+@dg.asset(
+    partitions_def=dg.DynamicPartitionsDefinition(name="dynamic"),
+    automation_condition=dg.AutomationCondition.on_missing(),
+)
+def A(): ...
+
+
+defs = dg.Definitions(assets=[A])

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -836,3 +836,49 @@ def test_observable_source_asset_is_not_backfilled() -> None:
             assert len(runs) == 0
             backfills = _get_backfills_for_latest_ticks(context)
             assert len(backfills) == 0
+
+
+def test_dynamic_partitions() -> None:
+    with (
+        get_grpc_workspace_request_context("dynamic_partitions_on_missing") as context,
+        get_threadpool_executor() as executor,
+    ):
+        time = datetime.datetime(2024, 8, 16, 1, 35)
+        with freeze_time(time):
+            _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
+            runs = _get_runs_for_latest_ticks(context)
+            assert len(runs) == 0
+
+        context.instance.add_dynamic_partitions("dynamic", ["a", "b", "c"])
+        context.instance.report_runless_asset_event(dg.AssetMaterialization("A", partition="a"))
+        context.instance.report_runless_asset_event(dg.AssetMaterialization("A", partition="b"))
+
+        time += datetime.timedelta(hours=1)
+        with freeze_time(time):
+            _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
+            runs = _get_runs_for_latest_ticks(context)
+            assert len(runs) == 1
+            assert runs[0].asset_selection == {dg.AssetKey("A")}
+            assert runs[0].tags["dagster/partition"] == "c"
+
+        time += datetime.timedelta(minutes=1)
+        with freeze_time(time):
+            _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
+            runs = _get_runs_for_latest_ticks(context)
+            assert len(runs) == 0
+
+        # add new partition
+        time += datetime.timedelta(minutes=1)
+        context.instance.add_dynamic_partitions("dynamic", ["d"])
+        with freeze_time(time):
+            _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
+            runs = _get_runs_for_latest_ticks(context)
+            assert len(runs) == 1
+
+        # delete a partition that we just added, should not cause errors
+        time += datetime.timedelta(minutes=1)
+        context.instance.delete_dynamic_partition("dynamic", "d")
+        with freeze_time(time):
+            _execute_ticks(context, executor)  # pyright: ignore[reportArgumentType]
+            runs = _get_runs_for_latest_ticks(context)
+            assert len(runs) == 0


### PR DESCRIPTION
## Summary & Motivation

uses a more compact format for storing the true/candidate subsets for DynamicPartitionsDefinitions.

while theoretically this is a lossy way to compress these subsets, in practice it would be hard for this to actually impact operation. 

## How I Tested These Changes

## Changelog

NOCHANGELOG
