### PR TITLE
[RFC] Update BaseFallthroughRoot to handle no-job schedules and automations

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/BaseFallthroughRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/BaseFallthroughRoot.tsx
@@ -42,26 +42,31 @@ const FinalRedirectOrLoadingRoot = () => {
     return <Redirect to="/locations" />;
   }
 
+  // If there are visible jobs, redirect to overview
   const reposWithVisibleJobs = allRepos.filter((r) => getVisibleJobs(r).length > 0);
-
-  // If we have no repos with jobs, see if we have an asset group and route to it.
-  if (reposWithVisibleJobs.length === 0) {
-    const repoWithAssetGroup = allRepos.find((r) => r.repository.assetGroups.length);
-    if (repoWithAssetGroup) {
-      return (
-        <Redirect
-          to={workspacePath(
-            repoWithAssetGroup.repository.name,
-            repoWithAssetGroup.repositoryLocation.name,
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            `/asset-groups/${repoWithAssetGroup.repository.assetGroups[0]!.groupName}`,
-          )}
-        />
-      );
-    }
-  }
   if (reposWithVisibleJobs.length > 0) {
     return <Redirect to="/overview" />;
+  }
+
+  // If there are jobs but they are all hidden, route to the overview timeline grouped by automation.
+  const hasAnyJobs = allRepos.some((r) => r.repository.pipelines.length > 0);
+  if (hasAnyJobs) {
+    return <Redirect to="/overview/activity/timeline?groupBy=automation" />;
+   }
+
+  // If we have no repos with jobs, see if we have an asset group and route to it.
+  const repoWithAssetGroup = allRepos.find((r) => r.repository.assetGroups.length);
+  if (repoWithAssetGroup) {
+    return (
+      <Redirect
+        to={workspacePath(
+          repoWithAssetGroup.repository.name,
+          repoWithAssetGroup.repositoryLocation.name,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          `/asset-groups/${repoWithAssetGroup.repository.assetGroups[0]!.groupName}`,
+        )}
+      />
+    );
   }
 
   // Ben note: We only reach here if reposWithVisibleJobs === 0 AND there is no asset group.


### PR DESCRIPTION


## Summary & Motivation

Right now, if you have no jobs, but have schedules or automation conditions to materialize assets, the default dagster landing page redirects to the first asset group. But it sounds like this is (and will be) increasingly common, since schedules can target assets directly in modern Dagster versions, rather than needing to target jobs.

This proposes to redirect to `/overview` in cases where there are "hidden" jobs (which appear to represent automation conditions and schedules), and to group by automation in that link, since that grouping is more valuable than just showing the "ad hoc materializations" under group-by-jobs.

## How I Tested These Changes

_(Full disclosure: I've tested about 50% of these entries right now. Before merging I'll test 100% of them, but wanted to put the RFC up to make sure this isn't completely wrong before doing that)_

| Pipeline | Before  | After |
| ------------- | ------------- | ------------- |
| `uvx create-dagster`  | `/locations`  | `/locations`  |
| `uvx create-dagster` + asset  | `/locations`  | `/locations`  |
| `uvx create-dagster` + asset + asset group  | `/asset-groups/`  | `/asset-groups/`  |
| `uvx create-dagster` + asset + asset group + job  | `/overview`  | `/overview`  |
| `uvx create-dagster` + asset + asset group + automation condition | `/asset-groups/`  | `/overview/activity/timeline?groupBy=automation`  |
| `uvx create-dagster` + asset + asset group + schedule | `/asset-groups/`  | `/overview/activity/timeline?groupBy=automation`  |

## Changelog

Changed root URL to display the Overview/Timeline view for pipelines with schedules/automations, but no jobs
