### PR TITLE
Skip `AssetPartitionEventsQuery` when partitions are loading

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useRecentAssetEvents.tsx
@@ -130,7 +130,11 @@ export function useLatestAssetPartitionMaterializations(
   limit: number,
 ) {
   const {partitionKeys, loading} = useLatestAssetPartitions(assetKey, limit);
-  return useAssetPartitionMaterializations(assetKey, [...partitionKeys].reverse(), loading);
+  return useAssetPartitionMaterializations(
+    assetKey,
+    useMemo(() => [...partitionKeys].reverse(), [partitionKeys]),
+    loading,
+  );
 }
 
 export type RecentAssetEvents = ReturnType<typeof useRecentAssetEvents>;


### PR DESCRIPTION
## Summary & Motivation

Skip the query because an empty list of partitions is interpreted as all partitions.
