### PR TITLE
Remove dagster-pandera polars pin (ADOPT-1779)

### DIFF
--- a/python_modules/libraries/dagster-pandera/setup.py
+++ b/python_modules/libraries/dagster-pandera/setup.py
@@ -40,9 +40,9 @@ setup(
         "pandera>=0.24.0",
     ],
     extras_require={
-        "polars": ["polars>=1,<=1.32.0"],
+        "polars": ["polars>=1"],
         "test": [
-            "polars>=1,<=1.32.0",
+            "polars>=1",
             "pytest",
         ],
     },


### PR DESCRIPTION
## Summary & Motivation

The pin was added for a version (1.32.1) that has now been yanked.

## How I Tested These Changes

Existing test suite.