### PR TITLE
[ui] Update contributing.md and modify dagster-ui package scripts

### DIFF
--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -108,11 +108,9 @@ make dev_webapp
 
 During development, you might find these commands useful. Run them from `js_modules/dagster-ui`:
 
-- `yarn ts`: Typescript typechecking
-- `yarn lint`: Linting with autofix
-- `yarn jest`: An interactive Jest test runner that runs only affected tests by default
-
-To run all of them together, run `yarn test`.
+- `make ts`: Typescript typechecking
+- `make lint`: Linting with autofix
+- `make jest`: Test runner that runs the full suite of tests
 
 ## Developing documentation
 

--- a/js_modules/dagster-ui/package.json
+++ b/js_modules/dagster-ui/package.json
@@ -10,7 +10,8 @@
     "lint": "yarn workspace @dagster-io/app-oss lint && yarn workspace @dagster-io/ui-core lint && yarn workspace @dagster-io/ui-components lint",
     "remove-cloud-resolutions": "rm -rf ./packages/ui-core/src/tsconfig.json",
     "start": "yarn remove-cloud-resolutions && yarn workspace @dagster-io/app-oss start",
-    "ts": "yarn workspace @dagster-io/app-oss ts && yarn workspace @dagster-io/ui-components ts",
+    "ts": "yarn workspace @dagster-io/app-oss ts && yarn workspace @dagster-io/ui-core ts && yarn workspace @dagster-io/ui-components ts",
+    "jest": "yarn workspace @dagster-io/ui-core jest-all-silent && yarn workspace @dagster-io/ui-components jest-all-silent",
     "postinstall": "patch-package"
   },
   "workspaces": {

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -11300,31 +11300,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001517, caniuse-lite@npm:^1.0.30001565":
-  version: 1.0.30001606
-  resolution: "caniuse-lite@npm:1.0.30001606"
-  checksum: 10/55ee377f9b5e09d290d2a60d339aa1fbab949d3086cfd0546d2896bc57f4df693cf69e9a0c828cb9622df039403927c66ec2d6a7ff4b7580f38846314bdb4800
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001579":
-  version: 1.0.30001617
-  resolution: "caniuse-lite@npm:1.0.30001617"
-  checksum: 10/eac442b9ad12801086be19f6dc17056827fe398f1c05983357e2531c8183ee890ffc8fb973d54519ad7114a2fd47de8f33ec66d98565b995fef1c6ba02b5bc5b
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001629":
-  version: 1.0.30001636
-  resolution: "caniuse-lite@npm:1.0.30001636"
-  checksum: 10/9e6c5ab4c20df31df36720dda77cf6a781549ac2ad844bc0a416b327a793da21486358a1f85fdd6c39e22d336f70aac3b0e232f5f228cdff0ceb6e3e1c5e98fd
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001646":
-  version: 1.0.30001653
-  resolution: "caniuse-lite@npm:1.0.30001653"
-  checksum: 10/cd9b1c0fe03249e593789a11a9ef14f987b385e60441748945916b19e74e7bc5c82c40d4836496a647586651898741aed1598ae0792114a9f0d7d7fdb2b7deb0
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001517, caniuse-lite@npm:^1.0.30001565, caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001629, caniuse-lite@npm:^1.0.30001646":
+  version: 1.0.30001734
+  resolution: "caniuse-lite@npm:1.0.30001734"
+  checksum: 10/330daaab3991b3e6c8536547df73b40de3885b1335a598e402e232820e3ca8d7f531298f0276b6a340b503b6c3df1ba253843091efe7de198fc6a151bcf7fd6b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

Fix comments in contributing.md regarding OSS contributions to UI, which recommend `yarn` commands that don't really do what they say they will (and one of which doesn't exist at all).

- Updated to use `make` commends for these, since that's what is recommended elsewhere in the doc and would be fine for this too
- Added `jest` to the list of scripts in `package.json`, since it wasn't there at all
- Added `ui-core` to the `ts` script, which for some reason was missing. (Since we never run `yarn ts` from here ourselves, I guess we never noticed, but it missed a TS error for our contributor on https://github.com/dagster-io/dagster/pull/31706.)

Also updated caniuse, because it was shouting at me.

## How I Tested These Changes

Run `yarn ts` and `yarn jest` from dagster-ui, just to sanity check them.

## Changelog

[docs] Update recommended command-line scripts for UI contributions.
