### PR TITLE
Remove more trailing slashes from docs links in docs

### DIFF
--- a/docs/docs/guides/build/components/asset-factories-to-components.md
+++ b/docs/docs/guides/build/components/asset-factories-to-components.md
@@ -6,7 +6,7 @@ sidebar_position: 200
 
 Data engineers often need to implement multiple similar workflows in data pipelines. To keep this code maintainable, many engineers use [asset factories](/guides/build/assets/creating-asset-factories) to generate Dagster objects based on configuration instead of defining each one manually.
 
-While factories are powerful and flexible, many patterns that use them can also be expressed using [components](/guides/build/components/). In this guide, we will implement the asset factory from the [asset factory creation guide](/guides/build/assets/creating-asset-factories) into a custom component.
+While factories are powerful and flexible, many patterns that use them can also be expressed using [components](/guides/build/components). In this guide, we will implement the asset factory from the [asset factory creation guide](/guides/build/assets/creating-asset-factories) into a custom component.
 
 :::note Prerequisites
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -33,7 +33,7 @@ Dagster is a data orchestrator built for data engineers, with integrated lineage
   <Card title="Quickstart" href="/getting-started/quickstart" imagePath="./img/getting-started/icon-start.svg">
     Build your first Dagster pipeline in our Quickstart tutorial.
   </Card>
-  <Card title="Thinking in Assets" href="/guides/build/assets/" imagePath="./img/getting-started/icon-assets.svg">
+  <Card title="Thinking in Assets" href="/guides/build/assets" imagePath="./img/getting-started/icon-assets.svg">
     New to Dagster? Learn about how thinking in assets can help you manage your data better.
   </Card>
   <Card title="Dagster Plus" href="/deployment/dagster-plus" imagePath="./img/getting-started/icon-plus.svg">

--- a/docs/sphinx/sections/api/apidocs/dagster/schedules-sensors.rst
+++ b/docs/sphinx/sections/api/apidocs/dagster/schedules-sensors.rst
@@ -3,7 +3,7 @@
 Schedules and sensors
 =====================
 
-Dagster offers several ways to run data pipelines without manual intervention, including traditional scheduling and event-based triggers. `Automating your Dagster pipelines <https://docs.dagster.io/guides/automate/>`_ can boost efficiency and ensure that data is produced consistently and reliably.
+Dagster offers several ways to run data pipelines without manual intervention, including traditional scheduling and event-based triggers. `Automating your Dagster pipelines <https://docs.dagster.io/guides/automate>`_ can boost efficiency and ensure that data is produced consistently and reliably.
 
 ----
 


### PR DESCRIPTION
## Summary & Motivation

Remove a few more trailing slashes from docs links in docs.

## How I Tested These Changes

Local build.

## Changelog

> Insert changelog entry or delete this section.
