### PR TITLE
[dagster-eval] cost and help text

### DIFF
--- a/python_modules/automation/automation_tests/test_eval_cli.py
+++ b/python_modules/automation/automation_tests/test_eval_cli.py
@@ -140,7 +140,7 @@ def test_evaluate_sessions_with_cache(mock_evaluate):
     ]
     mock_evaluate.return_value = mock_result
 
-    results = evaluate_sessions(sessions, metric, cached_results)
+    results = evaluate_sessions(sessions, metric, cached_results, [])
 
     assert len(results) == 3
     assert results["session1"]["score"] == 0.8


### PR DESCRIPTION
get the help text to output without weird wrapping and add cost logging

## How I Tested These Changes

`dagster-eval --help`
`dagster-eval` with new metric