### PR TITLE
Always depend on tzdata, not just on Windows

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -99,7 +99,7 @@ setup(
         "tabulate",
         "tomli<3",
         "tqdm<5",
-        'tzdata; platform_system=="Windows"',
+        "tzdata",
         "structlog",
         "sqlalchemy>=1.0,<3",
         "toposort>=1.0",


### PR DESCRIPTION
## Summary & Motivation
The python:slim packages seem to have upgraded to a new version of debian in the last 24 hours that doesn't have all the same timezone strings that the previous version did, which means that declaring timezones like US/Central can start failing without having this dependency installed. Add it as an explicit dependency to mitigate that (before, we were only adding it on Wdinows).


## How I Tested These Changes
BK

## Changelog
Added `tzdata` as a dependency to `dagster`, to ensure that declaring timezones like `US/Central` work in all environments.