### PR TITLE
pipe through dbt project in various places

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -291,12 +291,14 @@ def build_dbt_asset_selection(
         select=dbt_assets_select,
         exclude=dbt_assets_exclude,
         selector=dbt_assets_selector,
+        project=dbt_project,
     ) & DbtManifestAssetSelection.build(
         manifest=manifest,
         dagster_dbt_translator=dagster_dbt_translator,
         select=dbt_select,
         exclude=dbt_exclude or DBT_DEFAULT_EXCLUDE,
         selector=dbt_selector or DBT_DEFAULT_SELECTOR,
+        project=dbt_project,
     )
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
@@ -114,7 +114,7 @@ class DbtManifestAssetSelection(AssetSelection):
             is_dbt_asset = dbt_resource_props["resource_type"] in ASSET_RESOURCE_TYPES
             if is_dbt_asset and not is_non_asset_node(dbt_resource_props):
                 asset_key = self.dagster_dbt_translator.get_asset_spec(
-                    self.manifest, unique_id, None
+                    self.manifest, unique_id, self.project
                 ).key
                 keys.add(asset_key)
 
@@ -132,13 +132,13 @@ class DbtManifestAssetSelection(AssetSelection):
             exclude=self.exclude,
             selector=self.selector,
             manifest_json=self.manifest,
-            project=None,
+            project=self.project,
         ):
             asset_check_key = get_asset_check_key_for_test(
                 self.manifest,
                 self.dagster_dbt_translator,
                 test_unique_id=unique_id,
-                project=None,
+                project=self.project,
             )
 
             if asset_check_key:


### PR DESCRIPTION
## Summary

We don't pipe through the dbt project in these helper methods, which breaks `build_schedule_from_dbt_selection` for dbt component assets.