### PR TITLE
[dagster-databricks] Support existing cluster ID in DatabricksWorkspace.submit_and_poll

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
@@ -94,13 +94,19 @@ class DatabricksAssetBundleComponent(Component, Resolvable):
                     ResolvedDatabricksNewClusterConfig, ResolvedDatabricksExistingClusterConfig
                 ],
                 description=(
-                    "A mapping defining a databricks_asset_bundle.configs.ResolvedDatabricksNewClusterConfig. Optional."
+                    "A mapping defining a Databricks compute config. "
+                    "Allowed types are databricks_asset_bundle.configs.ResolvedDatabricksNewClusterConfig "
+                    "and databricks_asset_bundle.configs.ResolvedDatabricksExistingClusterConfig. "
+                    "Optional."
                 ),
                 examples=[
                     {
                         "spark_version": "test_spark_version",
                         "node_type_id": "node_type_id",
                         "num_workers": 1,
+                    },
+                    {
+                        "existing_cluster_id": "existing_cluster_id",
                     },
                 ],
             ),

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
@@ -3,7 +3,7 @@ import re
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Optional, Union
 
 from dagster import AssetExecutionContext, AssetSpec, MetadataValue, Resolvable, multi_asset
 from dagster._core.definitions.definitions_class import Definitions
@@ -16,6 +16,7 @@ from dagster.components.scaffold.scaffold import scaffold_with
 from dagster_databricks.components.databricks_asset_bundle.configs import (
     DatabricksBaseTask,
     DatabricksConfig,
+    ResolvedDatabricksExistingClusterConfig,
     ResolvedDatabricksNewClusterConfig,
 )
 from dagster_databricks.components.databricks_asset_bundle.resource import DatabricksWorkspace
@@ -87,9 +88,11 @@ class DatabricksAssetBundleComponent(Component, Resolvable):
     ]
     compute_config: Optional[
         Annotated[
-            ResolvedDatabricksNewClusterConfig,
+            Union[ResolvedDatabricksNewClusterConfig, ResolvedDatabricksExistingClusterConfig],
             Resolver.default(
-                model_field_type=ResolvedDatabricksNewClusterConfig,
+                model_field_type=Union[
+                    ResolvedDatabricksNewClusterConfig, ResolvedDatabricksExistingClusterConfig
+                ],
                 description=(
                     "A mapping defining a databricks_asset_bundle.configs.ResolvedDatabricksNewClusterConfig. Optional."
                 ),

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
@@ -97,7 +97,6 @@ class DatabricksAssetBundleComponent(Component, Resolvable):
                     "A mapping defining a Databricks compute config. "
                     "Allowed types are databricks_asset_bundle.configs.ResolvedDatabricksNewClusterConfig "
                     "and databricks_asset_bundle.configs.ResolvedDatabricksExistingClusterConfig. "
-                    "Optional."
                 ),
                 examples=[
                     {

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
@@ -96,7 +96,7 @@ class DatabricksAssetBundleComponent(Component, Resolvable):
                 description=(
                     "A mapping defining a Databricks compute config. "
                     "Allowed types are databricks_asset_bundle.configs.ResolvedDatabricksNewClusterConfig "
-                    "and databricks_asset_bundle.configs.ResolvedDatabricksExistingClusterConfig. "
+                    "and databricks_asset_bundle.configs.ResolvedDatabricksExistingClusterConfig. Optional."
                 ),
                 examples=[
                     {

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/configs.py
@@ -415,3 +415,4 @@ class ResolvedDatabricksNewClusterConfig(Resolvable, Model):
     spark_version: str = "13.3.x-scala2.12"
     node_type_id: str = "i3.xlarge"
     num_workers: int = 1
+    existing_cluster_id: Optional[str] = None

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/configs.py
@@ -415,4 +415,7 @@ class ResolvedDatabricksNewClusterConfig(Resolvable, Model):
     spark_version: str = "13.3.x-scala2.12"
     node_type_id: str = "i3.xlarge"
     num_workers: int = 1
-    existing_cluster_id: Optional[str] = None
+
+
+class ResolvedDatabricksExistingClusterConfig(Resolvable, Model):
+    existing_cluster_id: str

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/resource.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/resource.py
@@ -74,17 +74,18 @@ class DatabricksWorkspace(ConfigurableResource):
             context.log.info(f"Task {task_key} depends on: {task_dependencies}")
 
             # Determine cluster configuration based on task type
-            compute_config = (
-                {
-                    "new_cluster": compute.ClusterSpec(
-                        spark_version=component.compute_config.spark_version,  # pyright: ignore
-                        node_type_id=component.compute_config.node_type_id,  # pyright: ignore
-                        num_workers=component.compute_config.num_workers,  # pyright: ignore
+            compute_config = {}
+            if task.needs_cluster:
+                if component.compute_config.existing_cluster_id:
+                    cluster_config["existing_cluster_id"] = (
+                        component.compute_config.existing_cluster_id
                     )
-                }
-                if task.needs_cluster
-                else {}
-            )
+                else:
+                    cluster_config["new_cluster"] = compute.ClusterSpec(
+                        spark_version=component.compute_config.spark_version,
+                        node_type_id=component.compute_config.node_type_id,
+                        num_workers=component.compute_config.num_workers,
+                    )
 
             submit_task_params = {
                 **submit_task_params,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/resource.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/resource.py
@@ -7,6 +7,11 @@ from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import compute, jobs
 from pydantic import Field
 
+from dagster_databricks.components.databricks_asset_bundle.configs import (
+    ResolvedDatabricksExistingClusterConfig,
+    ResolvedDatabricksNewClusterConfig,
+)
+
 if TYPE_CHECKING:
     from dagster_databricks.components.databricks_asset_bundle.component import (
         DatabricksAssetBundleComponent,
@@ -76,11 +81,11 @@ class DatabricksWorkspace(ConfigurableResource):
             # Determine cluster configuration based on task type
             compute_config = {}
             if task.needs_cluster:
-                if hasattr(component.compute_config, "existing_cluster_id"):
+                if isinstance(component.compute_config, ResolvedDatabricksExistingClusterConfig):
                     compute_config["existing_cluster_id"] = (
                         component.compute_config.existing_cluster_id
                     )
-                else:
+                elif isinstance(component.compute_config, ResolvedDatabricksNewClusterConfig):
                     compute_config["new_cluster"] = compute.ClusterSpec(
                         spark_version=component.compute_config.spark_version,
                         node_type_id=component.compute_config.node_type_id,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/resource.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/resource.py
@@ -76,12 +76,12 @@ class DatabricksWorkspace(ConfigurableResource):
             # Determine cluster configuration based on task type
             compute_config = {}
             if task.needs_cluster:
-                if component.compute_config.existing_cluster_id:
-                    cluster_config["existing_cluster_id"] = (
+                if hasattr(component.compute_config, "existing_cluster_id"):
+                    compute_config["existing_cluster_id"] = (
                         component.compute_config.existing_cluster_id
                     )
                 else:
-                    cluster_config["new_cluster"] = compute.ClusterSpec(
+                    compute_config["new_cluster"] = compute.ClusterSpec(
                         spark_version=component.compute_config.spark_version,
                         node_type_id=component.compute_config.node_type_id,
                         num_workers=component.compute_config.num_workers,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/conftest.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/conftest.py
@@ -17,3 +17,11 @@ def databricks_config_path() -> Iterator[str]:
         shutil.copytree(DATABRICKS_CONFIG_LOCATION_PATH.parent.parent, temp_dir, dirs_exist_ok=True)
         databricks_config_path = f"{temp_dir}/configs/databricks.yml"
         yield databricks_config_path
+
+
+@pytest.fixture(scope="module")
+def custom_config_path() -> Iterator[str]:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        shutil.copytree(CUSTOM_CONFIG_LOCATION_PATH.parent.parent, temp_dir, dirs_exist_ok=True)
+        custom_config_path = f"{temp_dir}/configs/custom.yml"
+        yield custom_config_path

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/conftest.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/conftest.py
@@ -17,11 +17,3 @@ def databricks_config_path() -> Iterator[str]:
         shutil.copytree(DATABRICKS_CONFIG_LOCATION_PATH.parent.parent, temp_dir, dirs_exist_ok=True)
         databricks_config_path = f"{temp_dir}/configs/databricks.yml"
         yield databricks_config_path
-
-
-@pytest.fixture(scope="module")
-def custom_config_path() -> Iterator[str]:
-    with tempfile.TemporaryDirectory() as temp_dir:
-        shutil.copytree(CUSTOM_CONFIG_LOCATION_PATH.parent.parent, temp_dir, dirs_exist_ok=True)
-        custom_config_path = f"{temp_dir}/configs/custom.yml"
-        yield custom_config_path

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_resource.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_resource.py
@@ -42,7 +42,7 @@ def test_load_component(
                 "type": "dagster_databricks.components.databricks_asset_bundle.component.DatabricksAssetBundleComponent",
                 "attributes": {
                     "databricks_config_path": databricks_config_path,
-                    "cluster_config": {"existing_cluster_id": "test"}
+                    "cluster_config": {"existing_cluster_id": "test_existing_cluster_id"}
                     if use_existing_cluster
                     else None,
                     "workspace": {

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_resource.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_resource.py
@@ -20,8 +20,8 @@ from dagster_databricks_tests.components.databricks_asset_bundle.conftest import
         True,
     ],
     ids=[
-        "no_custom_config",
-        "custom_config",
+        "no_cluster_config",
+        "existing_cluster_config",
     ],
 )
 @mock.patch("databricks.sdk.service.jobs.SubmitTask", autospec=True)

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_resource.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_resource.py
@@ -20,8 +20,8 @@ from dagster_databricks_tests.components.databricks_asset_bundle.conftest import
         True,
     ],
     ids=[
-        "no_cluster_config",
-        "existing_cluster_config",
+        "new_cluster_compute_config",
+        "existing_cluster_compute_config",
     ],
 )
 @mock.patch("databricks.sdk.service.jobs.SubmitTask", autospec=True)
@@ -42,9 +42,11 @@ def test_load_component(
                 "type": "dagster_databricks.components.databricks_asset_bundle.component.DatabricksAssetBundleComponent",
                 "attributes": {
                     "databricks_config_path": databricks_config_path,
-                    "cluster_config": {"existing_cluster_id": "test_existing_cluster_id"}
-                    if use_existing_cluster
-                    else None,
+                    **(
+                        {"compute_config": {"existing_cluster_id": "test_existing_cluster_id"}}
+                        if use_existing_cluster
+                        else {}
+                    ),
                     "workspace": {
                         "host": TEST_DATABRICKS_WORKSPACE_HOST,
                         "token": TEST_DATABRICKS_WORKSPACE_TOKEN,


### PR DESCRIPTION
## Summary & Motivation

Support existing cluster ID when creating SubmitTask objects in submit_and_poll. Users can pass an existing cluster ID in their custom config file to avoid creating a new cluster when submitting their task via Dagster. 

## How I Tested These Changes

BK
