### PR TITLE
[dagster-databricks] Support serverless in DatabricksWorkspace.submit_and_poll

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
@@ -18,6 +18,7 @@ from dagster_databricks.components.databricks_asset_bundle.configs import (
     DatabricksConfig,
     ResolvedDatabricksExistingClusterConfig,
     ResolvedDatabricksNewClusterConfig,
+    ResolvedDatabricksServerlessConfig,
 )
 from dagster_databricks.components.databricks_asset_bundle.resource import DatabricksWorkspace
 from dagster_databricks.components.databricks_asset_bundle.scaffolder import (
@@ -88,15 +89,22 @@ class DatabricksAssetBundleComponent(Component, Resolvable):
     ]
     compute_config: Optional[
         Annotated[
-            Union[ResolvedDatabricksNewClusterConfig, ResolvedDatabricksExistingClusterConfig],
+            Union[
+                ResolvedDatabricksNewClusterConfig,
+                ResolvedDatabricksExistingClusterConfig,
+                ResolvedDatabricksServerlessConfig,
+            ],
             Resolver.default(
                 model_field_type=Union[
-                    ResolvedDatabricksNewClusterConfig, ResolvedDatabricksExistingClusterConfig
+                    ResolvedDatabricksNewClusterConfig,
+                    ResolvedDatabricksExistingClusterConfig,
+                    ResolvedDatabricksServerlessConfig,
                 ],
                 description=(
                     "A mapping defining a Databricks compute config. "
-                    "Allowed types are databricks_asset_bundle.configs.ResolvedDatabricksNewClusterConfig "
-                    "and databricks_asset_bundle.configs.ResolvedDatabricksExistingClusterConfig. Optional."
+                    "Allowed types are databricks_asset_bundle.configs.ResolvedDatabricksNewClusterConfig, "
+                    "databricks_asset_bundle.configs.ResolvedDatabricksExistingClusterConfig and "
+                    "databricks_asset_bundle.configs.ResolvedDatabricksServerlessConfig. Optional."
                 ),
                 examples=[
                     {
@@ -106,6 +114,9 @@ class DatabricksAssetBundleComponent(Component, Resolvable):
                     },
                     {
                         "existing_cluster_id": "existing_cluster_id",
+                    },
+                    {
+                        "is_serverless": True,
                     },
                 ],
             ),

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/configs.py
@@ -419,3 +419,7 @@ class ResolvedDatabricksNewClusterConfig(Resolvable, Model):
 
 class ResolvedDatabricksExistingClusterConfig(Resolvable, Model):
     existing_cluster_id: str
+
+
+class ResolvedDatabricksServerlessConfig(Resolvable, Model):
+    is_serverless: bool

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/resource.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/resource.py
@@ -80,7 +80,10 @@ class DatabricksWorkspace(ConfigurableResource):
 
             # Determine cluster configuration based on task type
             compute_config = {}
-            if task.needs_cluster and not component.cluster_config.is_serverless:
+            if task.needs_cluster and not (
+                hasattr(component.compute_config, "is_serverless")
+                and component.compute_config.is_serverless
+            ):
                 if isinstance(component.compute_config, ResolvedDatabricksExistingClusterConfig):
                     compute_config["existing_cluster_id"] = (
                         component.compute_config.existing_cluster_id

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/resource.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/resource.py
@@ -80,7 +80,7 @@ class DatabricksWorkspace(ConfigurableResource):
 
             # Determine cluster configuration based on task type
             compute_config = {}
-            if task.needs_cluster:
+            if task.needs_cluster and not component.cluster_config.is_serverless:
                 if isinstance(component.compute_config, ResolvedDatabricksExistingClusterConfig):
                     compute_config["existing_cluster_id"] = (
                         component.compute_config.existing_cluster_id

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/resource.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/resource.py
@@ -10,6 +10,7 @@ from pydantic import Field
 from dagster_databricks.components.databricks_asset_bundle.configs import (
     ResolvedDatabricksExistingClusterConfig,
     ResolvedDatabricksNewClusterConfig,
+    ResolvedDatabricksServerlessConfig,
 )
 
 if TYPE_CHECKING:
@@ -81,7 +82,7 @@ class DatabricksWorkspace(ConfigurableResource):
             # Determine cluster configuration based on task type
             compute_config = {}
             if task.needs_cluster and not (
-                hasattr(component.compute_config, "is_serverless")
+                isinstance(component.compute_config, ResolvedDatabricksServerlessConfig)
                 and component.compute_config.is_serverless
             ):
                 if isinstance(component.compute_config, ResolvedDatabricksExistingClusterConfig):

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/configs/serverless_custom.yml
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/configs/serverless_custom.yml
@@ -1,0 +1,1 @@
+is_serverless: True

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/configs/serverless_custom.yml
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/configs/serverless_custom.yml
@@ -1,1 +1,0 @@
-is_serverless: True

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_resource.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_resource.py
@@ -18,9 +18,13 @@ from dagster_databricks_tests.components.databricks_asset_bundle.conftest import
     [
         (False, False),
         (True, False),
-        (True, True),
+        (False, True),
     ],
-    ids=["new_cluster_compute_config", "existing_cluster_compute_config", "serverless_config"],
+    ids=[
+        "new_cluster_compute_config",
+        "existing_cluster_compute_config",
+        "serverless_compute_config",
+    ],
 )
 @mock.patch("databricks.sdk.service.jobs.SubmitTask", autospec=True)
 def test_load_component(
@@ -49,7 +53,6 @@ def test_load_component(
                         ),
                         **({"is_serverless": True} if is_serverless else {}),
                     },
-
                     "workspace": {
                         "host": TEST_DATABRICKS_WORKSPACE_HOST,
                         "token": TEST_DATABRICKS_WORKSPACE_TOKEN,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_resource.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_resource.py
@@ -20,11 +20,7 @@ from dagster_databricks_tests.components.databricks_asset_bundle.conftest import
         (True, False),
         (True, True),
     ],
-    ids=[
-        "new_cluster_compute_config",
-        "existing_cluster_compute_config",
-        "serverless_config"
-    ],
+    ids=["new_cluster_compute_config", "existing_cluster_compute_config", "serverless_config"],
 )
 @mock.patch("databricks.sdk.service.jobs.SubmitTask", autospec=True)
 def test_load_component(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_resource.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_resource.py
@@ -30,13 +30,6 @@ def test_load_component(
     databricks_config_path: str,
 ):
     with create_defs_folder_sandbox() as sandbox:
-        config_path = None
-        if use_custom_config_path:
-            if is_serverless:
-                config_path = serverless_custom_config_path
-            else:
-                config_path = custom_config_path
-
         defs_path = sandbox.scaffold_component(
             component_cls=DatabricksAssetBundleComponent,
             scaffold_params={
@@ -48,11 +41,15 @@ def test_load_component(
                 "type": "dagster_databricks.components.databricks_asset_bundle.component.DatabricksAssetBundleComponent",
                 "attributes": {
                     "databricks_config_path": databricks_config_path,
-                    **(
-                        {"compute_config": {"existing_cluster_id": "test_existing_cluster_id"}}
-                        if use_existing_cluster
-                        else {}
-                    ),
+                    "compute_config": {
+                        **(
+                            {"existing_cluster_id": "test_existing_cluster_id"}
+                            if use_existing_cluster
+                            else {}
+                        ),
+                        **({"is_serverless": True} if is_serverless else {}),
+                    },
+
                     "workspace": {
                         "host": TEST_DATABRICKS_WORKSPACE_HOST,
                         "token": TEST_DATABRICKS_WORKSPACE_TOKEN,


### PR DESCRIPTION
## Summary & Motivation

Support whether serverless compute should be used creating SubmitTask objects in submit_and_poll. If yes, cluster config must not be passed to the SubmitTask object.

## How I Tested These Changes

BK
