### PR TITLE
[dg] Remove autoload_defs settings from dg project settings (ADOPT-1785)

### DIFF
--- a/examples/docs_projects/project_ask_ai_dagster/pyproject.toml
+++ b/examples/docs_projects/project_ask_ai_dagster/pyproject.toml
@@ -38,7 +38,6 @@ directory_type = "project"
 
 [tool.dg.project]
 root_module = "project_ask_ai_dagster"
-autoload_defs = true
 
 [tool.dg.project.python_environment]
 active = true

--- a/examples/docs_projects/project_atproto_dashboard/pyproject.toml
+++ b/examples/docs_projects/project_atproto_dashboard/pyproject.toml
@@ -29,7 +29,6 @@ directory_type = "project"
 
 [tool.dg.project]
 root_module = "project_atproto_dashboard"
-autoload_defs = true
 
 [tool.dg.project.python_environment]
 active = true

--- a/examples/docs_projects/project_dagster_modal_pipes/pyproject.toml
+++ b/examples/docs_projects/project_dagster_modal_pipes/pyproject.toml
@@ -30,7 +30,6 @@ directory_type = "project"
 
 [tool.dg.project]
 root_module = "project_dagster_modal_pipes"
-autoload_defs = true
 
 [tool.dg.project.python_environment]
 active = true

--- a/examples/docs_projects/project_llm_fine_tune/pyproject.toml
+++ b/examples/docs_projects/project_llm_fine_tune/pyproject.toml
@@ -25,7 +25,6 @@ directory_type = "project"
 
 [tool.dg.project]
 root_module = "project_llm_fine_tune"
-autoload_defs = true
 
 [tool.dg.project.python_environment]
 active = true

--- a/examples/docs_projects/project_prompt_eng/pyproject.toml
+++ b/examples/docs_projects/project_prompt_eng/pyproject.toml
@@ -24,7 +24,6 @@ directory_type = "project"
 
 [tool.dg.project]
 root_module = "project_prompt_eng"
-autoload_defs = true
 
 [tool.dg.project.python_environment]
 active = true

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/toml_tests/test_toml_loading.py
@@ -49,35 +49,6 @@ def test_load_python_module_from_dg_toml():
         assert origins[0].loadable_target_origin.module_name == "baaz.other_definitions"
 
 
-def test_autodefs_module_from_dg_toml():
-    with NamedTemporaryFile("w") as f:
-        f.write(
-            textwrap.dedent("""
-                [tool.dg.project]
-                root_module = "baaz"
-                autoload_defs = true
-            """).strip()
-        )
-        f.flush()
-        origins = get_origins_from_toml(f.name)
-        assert len(origins) == 1
-        assert origins[0].loadable_target_origin.autoload_defs_module_name == "baaz.defs"
-
-    with NamedTemporaryFile("w") as f:
-        f.write(
-            textwrap.dedent("""
-                [tool.dg.project]
-                root_module = "baaz"
-                autoload_defs = true
-                defs_module = "boo.bar"
-            """).strip()
-        )
-        f.flush()
-        origins = get_origins_from_toml(f.name)
-        assert len(origins) == 1
-        assert origins[0].loadable_target_origin.autoload_defs_module_name == "boo.bar"
-
-
 def test_load_empty_toml():
     assert get_origins_from_toml(dg.file_relative_path(__file__, "empty.toml")) == []
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
@@ -159,12 +159,8 @@ def _workspace_entry_for_project(
     if not dg_context.config.project:
         exit_with_error("Unexpected empty project config.")
 
-    if dg_context.config.project.autoload_defs:
-        key = "autoload_defs_module"
-        module_name = dg_context.defs_module_name
-    else:
-        key = "python_module"
-        module_name = dg_context.code_location_target_module_name
+    key = "python_module"
+    module_name = dg_context.code_location_target_module_name
 
     entry = {
         "working_directory": str(

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/warnings.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/warnings.py
@@ -8,7 +8,6 @@ from typing_extensions import TypeAlias
 from dagster_dg_core.utils import format_multiline_str
 
 DgWarningIdentifier: TypeAlias = Literal[
-    "autoload_defs_with_definitions_py",
     "cli_config_in_workspace_project",
     "deprecated_user_config_location",
     "deprecated_python_environment",

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_context.py
@@ -282,18 +282,6 @@ def test_missing_dg_registry_module_in_manifest_warning():
                 EnvRegistry.from_dg_context(context)
 
 
-def test_context_with_autoload_defs_and_definitions_py():
-    with (
-        ProxyRunner.test() as runner,
-        isolated_example_project_foo_bar(runner, in_workspace=False, uv_sync=True),
-    ):
-        # Set autoload_defs to true in pyproject.toml
-        with modify_dg_toml_config_as_dict(Path("pyproject.toml")) as toml:
-            create_toml_node(toml, ("project", "autoload_defs"), True)
-        with dg_warns("`project.autoload_defs` is enabled, but a code location load target"):
-            DgContext.for_project_environment(Path.cwd(), {})
-
-
 # ########################
 # ##### CONFIG TESTS
 # ########################
@@ -410,27 +398,6 @@ def test_invalid_config_project(config_file: ConfigFileType):
                 err_msg,
             )
 
-        # Test specifying autoload_defs and code_location_target_module
-        # errors.
-        with _reset_config_file(config_file):
-            with modify_dg_toml_config_as_dict(Path(config_file)) as toml:
-                create_toml_node(
-                    toml,
-                    ("project", "autoload_defs"),
-                    True,
-                )
-
-            full_code_location_key = _get_full_str_path(
-                config_file, "project.code_location_target_module"
-            )
-            err_msg = f"Cannot specify `{full_code_location_key}`"
-            _set_and_detect_error(
-                config_file,
-                ("project", "code_location_target_module"),
-                "foo_bar._definitions",
-                err_msg,
-            )
-
 
 @pytest.mark.parametrize("config_file", ["dg.toml", "pyproject.toml"])
 def test_deprecated_config_project(config_file: ConfigFileType):
@@ -453,13 +420,6 @@ def test_code_location_config(config_file: ConfigFileType):
         ProxyRunner.test() as runner,
         isolated_example_project_foo_bar(runner, config_file_type=config_file),
     ):
-        with modify_dg_toml_config_as_dict(Path(config_file)) as toml:
-            create_toml_node(
-                toml,
-                ("project", "autoload_defs"),
-                False,
-            )
-
         context = DgContext.for_project_environment(Path.cwd(), {})
         assert context.code_location_target_module_name == "foo_bar.definitions"
         assert context.code_location_name == "foo-bar"


### PR DESCRIPTION
## Summary & Motivation

Remove `autoload_defs` setting from dg project settings-- this was actually deprecated for removal in 1.11.0 but that never happened.

## How I Tested These Changes

Existing test suite.