### PR TITLE
[dg] Add component descriptions to `dg scaffold defs --help` output (ADOPT-1800)

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/defs.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/defs.py
@@ -105,6 +105,7 @@ class ScaffoldDefsGroup(DgClickGroup):
             name=key.to_typename(),
             context_settings={"help_option_names": ["-h", "--help"]},
             aliases=aliases,
+            help=obj.description or obj.summary,
         )
         @click.argument("defs_path", type=str)
         @click.pass_context

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_custom_help_format.py
@@ -186,6 +186,10 @@ def test_dynamic_subcommand_help_message():
                 textwrap.dedent("""
                 Usage: dg scaffold defs [GLOBAL OPTIONS] dagster_test.components.SimplePipesScriptComponent [OPTIONS] DEFS_PATH
 
+                A simple asset that runs a Python script with the Pipes subprocess client.                                             
+                                                                                                                                        
+                Because it is a pipes asset, no value is returned.
+
                 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
                 │ *    defs_path      TEXT  [required]                                                                                 │
                 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+import re
 import subprocess
 import textwrap
 from pathlib import Path
@@ -35,14 +36,18 @@ def test_scaffold_defs_dynamic_subcommand_generation() -> None:
 
         normalized_output = standardize_box_characters(result.output)
         # These are wrapped in a table so it's hard to check exact output.
+        # The " +\w" at the end is used to ensure that a help message is generated for the
+        # component.
         for line in [
-            "╭─ Commands",
-            "│ dagster_test.components.AllMetadataEmptyComponent",
-            "│ dagster_test.components.ComplexAssetComponent",
-            "│ dagster_test.components.SimpleAssetComponent",
-            "│ dagster_test.components.SimplePipesScriptComponent",
+            r"╭─ Commands",
+            r"│ dagster_test.components.AllMetadataEmptyComponent +\w",
+            r"│ dagster_test.components.ComplexAssetComponent +\w",
+            r"│ dagster_test.components.SimpleAssetComponent +\w",
+            r"│ dagster_test.components.SimplePipesScriptComponent +\w",
         ]:
-            assert standardize_box_characters(line) in normalized_output
+            assert re.search(standardize_box_characters(line), normalized_output), (
+                f"Expected line not found: {line}"
+            )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary & Motivation

Before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YRZmeX8NtwrdWNuUQ4Fv/fcd0d62b-50b3-491b-bf96-6de5462fb963.png)

After:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YRZmeX8NtwrdWNuUQ4Fv/c1bb59b6-1473-4dff-a745-ac6561242786.png)

## How I Tested These Changes

Modified unit tests.

## Changelog

`dg scaffold defs --help` now shows descriptions for subcommands.
