### PR TITLE
Disable automatic retries on feature branches

### DIFF
--- a/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
+++ b/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
@@ -241,17 +241,17 @@ class CommandStepBuilder:
         self._step["timeout_in_minutes"] = num_minutes
         return self
 
-    # def with_retry(self, num_retries):
-    #     # Only set automatic retries if we're not on a feature branch
-    #     if num_retries is not None and num_retries > 0:
-    #         try:
-    #             if not is_feature_branch():
-    #                 self._step["retry"] = {"automatic": {"limit": num_retries}}
-    #             # If we are on a feature branch, don't set automatic retries
-    #         except (AssertionError, KeyError):
-    #             # If BUILDKITE_BRANCH is not set, default to setting retries (safer fallback)
-    #             self._step["retry"] = {"automatic": {"limit": num_retries}}
-    #     return self
+    def with_retry(self, num_retries):
+        # Only set automatic retries if we're not on a feature branch
+        if num_retries is not None and num_retries > 0:
+            try:
+                if not is_feature_branch():
+                    self._step["retry"] = {"automatic": {"limit": num_retries}}
+                # If we are on a feature branch, don't set automatic retries
+            except (AssertionError, KeyError):
+                # If BUILDKITE_BRANCH is not set, default to setting retries (safer fallback)
+                self._step["retry"] = {"automatic": {"limit": num_retries}}
+        return self
 
     def on_queue(self, queue: BuildkiteQueue):
         self._step["agents"]["queue"] = queue.value  # type: ignore

--- a/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
+++ b/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
@@ -251,8 +251,14 @@ class CommandStepBuilder:
         return self
 
     def with_retry(self, num_retries):
+        # Always include manual retry configuration to match constructor behavior
+        retry_config: dict[str, object] = {"manual": {"permit_on_passed": True}}
+
+        # Add automatic retry only when appropriate
         if num_retries is not None and num_retries > 0 and self._should_enable_automatic_retry():
-            self._step["retry"] = {"automatic": {"limit": num_retries}}
+            retry_config["automatic"] = {"limit": num_retries}
+
+        self._step["retry"] = retry_config
         return self
 
     def on_queue(self, queue: BuildkiteQueue):

--- a/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
+++ b/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
@@ -242,7 +242,15 @@ class CommandStepBuilder:
         return self
 
     def with_retry(self, num_retries):
-        self._step["retry"] = {"automatic": {"limit": num_retries}}
+        # Only set automatic retries if we're not on a feature branch
+        if num_retries is not None and num_retries > 0:
+            try:
+                if not is_feature_branch():
+                    self._step["retry"] = {"automatic": {"limit": num_retries}}
+                # If we are on a feature branch, don't set automatic retries
+            except (AssertionError, KeyError):
+                # If BUILDKITE_BRANCH is not set, default to setting retries (safer fallback)
+                self._step["retry"] = {"automatic": {"limit": num_retries}}
         return self
 
     def on_queue(self, queue: BuildkiteQueue):

--- a/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
+++ b/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
@@ -241,17 +241,17 @@ class CommandStepBuilder:
         self._step["timeout_in_minutes"] = num_minutes
         return self
 
-    def with_retry(self, num_retries):
-        # Only set automatic retries if we're not on a feature branch
-        if num_retries is not None and num_retries > 0:
-            try:
-                if not is_feature_branch():
-                    self._step["retry"] = {"automatic": {"limit": num_retries}}
-                # If we are on a feature branch, don't set automatic retries
-            except (AssertionError, KeyError):
-                # If BUILDKITE_BRANCH is not set, default to setting retries (safer fallback)
-                self._step["retry"] = {"automatic": {"limit": num_retries}}
-        return self
+    # def with_retry(self, num_retries):
+    #     # Only set automatic retries if we're not on a feature branch
+    #     if num_retries is not None and num_retries > 0:
+    #         try:
+    #             if not is_feature_branch():
+    #                 self._step["retry"] = {"automatic": {"limit": num_retries}}
+    #             # If we are on a feature branch, don't set automatic retries
+    #         except (AssertionError, KeyError):
+    #             # If BUILDKITE_BRANCH is not set, default to setting retries (safer fallback)
+    #             self._step["retry"] = {"automatic": {"limit": num_retries}}
+    #     return self
 
     def on_queue(self, queue: BuildkiteQueue):
         self._step["agents"]["queue"] = queue.value  # type: ignore

--- a/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
+++ b/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
@@ -90,7 +90,7 @@ class CommandStepBuilder:
         self._secrets = {}
         self._kubernetes_secrets = []
         self._docker_settings = None
-        
+
         # Determine retry behavior: if not explicitly set, only retry on master/release branches
         if retry_automatically is None:
             try:
@@ -98,7 +98,7 @@ class CommandStepBuilder:
             except (AssertionError, KeyError):
                 # If BUILDKITE_BRANCH is not set, default to retry (safer fallback)
                 retry_automatically = True
-        
+
         retry: dict[str, Any] = {
             "manual": {"permit_on_passed": True},
         }

--- a/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
@@ -5,6 +5,7 @@ from dagster._core.asset_graph_view.serializable_entity_subset import Serializab
 
 
 def test_union():
+    raise Exception("fail me")
     a_true = SerializableEntitySubset(key=dg.AssetKey("a"), value=True)
     a_false = SerializableEntitySubset(key=dg.AssetKey("a"), value=False)
 

--- a/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
+++ b/python_modules/dagster/dagster_tests/core_tests/asset_graph_view_tests/test_serializable_entity_subset.py
@@ -5,7 +5,6 @@ from dagster._core.asset_graph_view.serializable_entity_subset import Serializab
 
 
 def test_union():
-    raise Exception("fail me")
     a_true = SerializableEntitySubset(key=dg.AssetKey("a"), value=True)
     a_false = SerializableEntitySubset(key=dg.AssetKey("a"), value=False)
 


### PR DESCRIPTION
## Summary & Motivation

This change modifies the Buildkite command step builder to disable automatic retries on feature branches while maintaining them on master and release branches. The retry_automatically parameter now defaults to None and uses branch detection logic to determine the appropriate retry behavior.

The reason why is that retries delay the time to failure on feature branches which is not want you want. You want to accelerate the time-to-failure, so that the developer can fix it quickly.

Feature branches will not retry automatically, but master/release branches will continue to retry as before.

## How I Tested These Changes

Existing test suite covers the command step builder functionality.  
  
Injected failure [here](https://buildkite.com/dagster/dagster-dagster/builds/131630/steps/canvas) and saw no retry.

## Changelog

Updated Buildkite CI configuration to disable automatic retries on feature branches while maintaining them on master/release branches.