### PR TITLE
Use "Pythonic" instead of "legacy" language for existing integrations

### DIFF
--- a/docs/docs/integrations/libraries/dlt/dlt-pythonic.md
+++ b/docs/docs/integrations/libraries/dlt/dlt-pythonic.md
@@ -1,6 +1,6 @@
 ---
-title: Dagster & dlt (Legacy)
-sidebar_label: dlt (Legacy)
+title: Dagster & dlt (Pythonic)
+sidebar_label: dlt (Pythonic)
 description: The dltHub open-source library defines a standardized approach for creating data pipelines that load often messy data sources into well-structured data sets.
 tags: [dagster-supported, etl]
 source: https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-dlt

--- a/docs/docs/integrations/libraries/fivetran/fivetran-pythonic.md
+++ b/docs/docs/integrations/libraries/fivetran/fivetran-pythonic.md
@@ -1,6 +1,6 @@
 ---
-title: Dagster & Fivetran (Legacy)
-sidebar_label: Fivetran (Legacy)
+title: Dagster & Fivetran (Pythonic)
+sidebar_label: Fivetran (Pythonic)
 description: Orchestrate Fivetran connectors syncs with upstream or downstream dependencies.
 tags: [dagster-supported, etl]
 source: https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-fivetran

--- a/docs/docs/integrations/libraries/powerbi/powerbi-pythonic.md
+++ b/docs/docs/integrations/libraries/powerbi/powerbi-pythonic.md
@@ -1,6 +1,6 @@
 ---
-title: Dagster & Power BI (Legacy)
-sidebar_label: Power BI (Legacy)
+title: Dagster & Power BI (Pythonic)
+sidebar_label: Power BI (Pythonic)
 description: Your Power BI assets, such as semantic models, data sources, reports, and dashboards, can be represented in the Dagster asset graph, allowing you to track lineage and dependencies between Power BI assets and upstream data assets you are already modeling in Dagster. You can also use Dagster to orchestrate Power BI semantic models, allowing you to trigger refreshes of these models on a cadence or based on upstream data changes.
 tags: [dagster-supported, bi]
 source: https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-powerbi

--- a/docs/docs/integrations/libraries/sling/sling-pythonic.md
+++ b/docs/docs/integrations/libraries/sling/sling-pythonic.md
@@ -1,6 +1,6 @@
 ---
-title: Dagster & Sling (Legacy)
-sidebar_label: Sling (Legacy)
+title: Dagster & Sling (Pythonic)
+sidebar_label: Sling (Pythonic)
 description: Sling provides an easy-to-use YAML configuration layer for loading data from files, replicating data between databases, exporting custom SQL queries to cloud storage, and much more.
 tags: [dagster-supported, etl]
 source: https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-sling


### PR DESCRIPTION
## Summary & Motivation

See title. Use "Pythonic" to distinguish existing integrations from their component versions instead of "legacy", since some integrations (e.g. [Fivetran](https://docs.dagster.io/api/libraries/dagster-fivetran#legacy) already have a legacy version.

## How I Tested These Changes

Local build.

## Changelog

> Insert changelog entry or delete this section.
