### PR TITLE
Add dagster-dev CLI for internal developer utilities

### DIFF
--- a/.claude/commands/ai_update_pr.md
+++ b/.claude/commands/ai_update_pr.md
@@ -52,7 +52,7 @@ Focus only on changes in the current branch, not the entire stack history. Use t
 
 ## Changelog
 
-[End user facing changelog entry, remove this section if no public-facing API was changed and no bug was fixed. Public-facing APIs are identified by the @public decorator. Ignore minor changes. If there are no user-facing changes, remove this section.]
+[End user facing changelog entry, remove this section if no public-facing API was changed and no bug was fixed. Public-facing APIs are identified by the @public decorator. Internal tools like CLIs meant for developer use should not have changelog entries. If there are no user-facing changes, remove this section.]
 ```
 
 Use bullet points sparingly, and do not overuse italics/bold text. Use short sentences.

--- a/python_modules/automation/automation/dagster_dev/CLAUDE.md
+++ b/python_modules/automation/automation/dagster_dev/CLAUDE.md
@@ -1,0 +1,36 @@
+# Dagster Dev CLI Development Guide
+
+## Command File Naming Convention
+
+**IMPORTANT**: Command files in the `commands/` directory should be named after the actual command they implement, not generic names.
+
+### Naming Rules
+
+- File names should match the command name defined in the `@click.command()` decorator
+- Use lowercase names with underscores for multi-word commands (e.g., `build_assets.py` for a `build-assets` command)
+- Avoid generic names like `example.py`, `test.py`, or `utils.py`
+
+### Examples
+
+```python
+# ✅ GOOD: greet.py
+@click.command(name="greet")
+def greet():
+    """Greet someone with a customizable message."""
+    pass
+
+# ✅ GOOD: build_assets.py
+@click.command(name="build-assets") 
+def build_assets():
+    """Build Dagster assets."""
+    pass
+
+# ❌ BAD: example.py, utils.py, helper.py
+```
+
+### Rationale
+
+- Makes it easy to find the implementation for a specific command
+- Self-documenting file structure
+- Consistent with CLI best practices
+- Helps maintain the codebase as commands grow

--- a/python_modules/automation/automation/dagster_dev/CLAUDE.md
+++ b/python_modules/automation/automation/dagster_dev/CLAUDE.md
@@ -20,7 +20,7 @@ def greet():
     pass
 
 # ✅ GOOD: build_assets.py
-@click.command(name="build-assets") 
+@click.command(name="build-assets")
 def build_assets():
     """Build Dagster assets."""
     pass

--- a/python_modules/automation/automation/dagster_dev/cli.py
+++ b/python_modules/automation/automation/dagster_dev/cli.py
@@ -1,0 +1,107 @@
+"""Main CLI entry point for dagster-dev commands."""
+
+import importlib
+import inspect
+import pkgutil
+
+import click
+
+from automation.dagster_dev import commands
+
+
+def discover_commands():
+    """Discover and load all commands from the commands directory.
+
+    Returns:
+        dict: Mapping of command name to click command function
+    """
+    discovered_commands = {}
+
+    # Iterate through all Python files in the commands directory
+    for module_info in pkgutil.iter_modules(commands.__path__, commands.__name__ + "."):
+        if module_info.name.endswith(".__init__"):
+            continue
+
+        try:
+            # Import the module
+            module = importlib.import_module(module_info.name)
+
+            # Look for click commands in the module
+            for name, obj in inspect.getmembers(module):
+                if isinstance(obj, click.Command):
+                    # Use the command name from click, or fallback to module name
+                    cmd_name = obj.name or module_info.name.split(".")[-1]
+                    discovered_commands[cmd_name] = obj
+
+        except ImportError as e:
+            # Log import errors but don't fail the entire CLI
+            click.echo(f"Warning: Could not import {module_info.name}: {e}", err=True)
+
+    return discovered_commands
+
+
+@click.group()
+@click.version_option()
+def cli():
+    """Dagster developer utilities CLI.
+
+    A collection of commands to streamline development workflows within the Dagster repository.
+    Commands are auto-discovered from the commands/ directory.
+    """
+    pass
+
+
+def create_list_command(discovered_commands):
+    """Create a dynamic list command that shows all available commands."""
+
+    @click.command(name="list")
+    def list_commands():
+        """List all available dagster-dev commands with descriptions for agent consumption."""
+        click.echo("Available dagster-dev commands:\n")
+
+        for cmd_name, cmd_obj in sorted(discovered_commands.items()):
+            # Get the short description from the command docstring
+            description = "No description available"
+            if cmd_obj.help:
+                description = cmd_obj.help.split("\n")[0].strip()
+            elif cmd_obj.short_help:
+                description = cmd_obj.short_help
+
+            click.echo(f"  {cmd_name:<20} {description}")
+
+            # Show parameters/options for agent consumption
+            if cmd_obj.params:
+                for param in cmd_obj.params:
+                    if isinstance(param, click.Option):
+                        opts = "/".join(param.opts)
+                        param_help = param.help or "No help available"
+                        click.echo(f"    {opts:<18} {param_help}")
+                    elif isinstance(param, click.Argument):
+                        param_help = f"Argument: {param.name}"
+                        click.echo(f"    {param.name:<18} {param_help}")
+
+        click.echo(f"\nTotal commands: {len(discovered_commands)}")
+        click.echo("\nUse 'dagster-dev <command> --help' for detailed help on any command.")
+
+    return list_commands
+
+
+def main():
+    """Main entry point for the dagster-dev CLI."""
+    # Discover all available commands
+    discovered_commands = discover_commands()
+
+    # Add discovered commands to the CLI group
+    for cmd_name, cmd_obj in discovered_commands.items():
+        cli.add_command(cmd_obj, name=cmd_name)
+
+    # Add the list command
+    list_cmd = create_list_command(discovered_commands)
+    cli.add_command(list_cmd)
+
+    # Run the CLI
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/python_modules/automation/automation/dagster_dev/commands/__init__.py
+++ b/python_modules/automation/automation/dagster_dev/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Commands package for dagster-dev CLI."""

--- a/python_modules/automation/automation/dagster_dev/commands/greet.py
+++ b/python_modules/automation/automation/dagster_dev/commands/greet.py
@@ -1,0 +1,24 @@
+"""Example command for dagster-dev CLI."""
+
+import click
+
+
+@click.command()
+@click.argument("name", type=str)
+@click.option("--greeting", "-g", default="Hello", help="Greeting to use")
+@click.option("--uppercase", "-u", is_flag=True, help="Convert output to uppercase")
+def greet(name, greeting, uppercase):
+    """Greet someone with a customizable message.
+
+    This is an example command that demonstrates how to create commands
+    for the dagster-dev CLI. Commands are automatically discovered and
+    added to the CLI.
+
+    NAME is the person to greet.
+    """
+    message = f"{greeting}, {name}!"
+
+    if uppercase:
+        message = message.upper()
+
+    click.echo(message)

--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -45,6 +45,7 @@ setup(
             "dagster-graphql-client = automation.graphql.python_client.cli:main",
             "dagster-docs = automation.dagster_docs:main",
             "dagster-eval = automation.eval.cli:main",
+            "dagster-dev = automation.dagster_dev.cli:main",
         ]
     },
 )


### PR DESCRIPTION
## Summary & Motivation

Introduces a new `dagster-dev` CLI tool designed for internal developer workflows and optimized for agent invocations. This replaces scattered scripts with a single, introspectable namespace that consolidates development utilities.

In AI-driven world it is very easy and natural to build one-off tools like this for human or agent use, and we should encourage it. The barrier to entry should be low. This makes it so you can vibecode a new script/command in a low-stakes way.

The CLI features automatic command discovery, making it easy for developers to add new utilities without modifying central configuration files.

Key features:

- **Auto-discovery**: Commands are automatically loaded from the `commands/` directory
- **Extensible**: New commands can be added by simply creating Python files with click commands
- **Self-documenting**: Includes a `list` command that shows all available commands with descriptions
- **Example command**: Includes a `greet` command demonstrating the pattern

```
@click.command()
@click.argument("name", type=str)
@click.option("--greeting", "-g", default="Hello", help="Greeting to use")
def greet(name, greeting, uppercase):
    """Greet someone with a customizable message."""
    pass
```

## How I Tested These Changes

New CLI functionality with example command implementation. The `greet` command can be tested with various options and arguments.