### PR TITLE
"last materialized" -> "last successfully materialized" in asset health report card

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
@@ -288,7 +288,7 @@ const Criteria = React.memo(
 
           return (
             <Body>
-              Last materialized{' '}
+              Last successfully materialized{' '}
               <TimeFromNow unixTimestamp={Number(metadata.lastMaterializedTimestamp)} />
             </Body>
           );


### PR DESCRIPTION
From dogfooding, we want to change the wording to “Last successfully materialized”

![Screenshot 2025-08-14 at 12.03.00 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ZRXX3vnjVUaPJfH2BEFH/1ff254bd-a9c6-4d06-8457-93d4492888e9.png)