### PR TITLE
Add unsafe_ruff make target for applying ruff unsafe fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ check_ruff:
 	ruff check .
 	ruff format --check .
 
+unsafe_ruff:
+	-ruff check --fix --unsafe-fixes .
+	ruff format .
+
 check_prettier:
 #NOTE: excludes symlinked md files
 	prettier `git ls-files \


### PR DESCRIPTION
## Summary & Motivation

Add a new `unsafe_ruff` make target that runs ruff with the `--unsafe-fixes` flag enabled. This allows developers to apply potentially unsafe but helpful ruff fixes when needed.

The new target runs:
- `ruff check --fix --unsafe-fixes .` - Apply all available fixes including unsafe ones
- `ruff format .` - Format code

## How I Tested These Changes

Verified the make target works correctly and applies unsafe fixes as expected.