### PR TITLE
[5/n] Display version info in the ui

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -58,6 +58,7 @@
   "ReportEventPartitionDefinitionQuery": "e306421344493a9986106de14bca90ec554505d6f1965991ba502725edc41c95",
   "ReportEventMutation": "80b4987cdf27ec8fac25eb6b98b996bd4fdeb4cbfff605d647da5d4bb8244cb0",
   "AssetWipeMutation": "accefb0c47b3d4a980d16965e8af565afed787a8a987a03570df876bd734dc8f",
+  "CodeLocationDefsStateQuery": "48c254f1f69e44eb1010e324b368262b96f00fdc20da873424e12ad76924c2c4",
   "CodeLocationDocsQuery": "cde585a103c0857a37a332bedf2fa15660be9b328849497fade5728947a8cbd5",
   "CodeLocationHasDocsQuery": "59aaf373b92f467a40d6c5e9580152565ff47b061d8400db05af584e099cd148",
   "RunGroupPanelQuery": "c454b4e4c3d881b2a78361c5868212f734c458291a3cb28be8ba4a63030eb004",

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefsStateComparison.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefsStateComparison.tsx
@@ -1,0 +1,152 @@
+import {Box, Colors, FontFamily, Icon, Table, Tag} from '@dagster-io/ui-components';
+import {useMemo} from 'react';
+
+import {DefsStateInfo} from '../graphql/types';
+import {TimeFromNow} from '../ui/TimeFromNow';
+
+interface Props {
+  latestDefsStateInfo: DefsStateInfo | null;
+  defsStateInfo: DefsStateInfo | null;
+}
+
+export const CodeLocationDefsStateComparison = ({latestDefsStateInfo, defsStateInfo}: Props) => {
+  const comparisonData = useMemo(() => {
+    if (!latestDefsStateInfo?.keyStateInfo || !defsStateInfo?.keyStateInfo) {
+      return [];
+    }
+
+    // Use the current defs state info as the primary source for table rows
+    const currentKeys = new Set<string>();
+    defsStateInfo.keyStateInfo.forEach((entry) => {
+      if (entry) {
+        currentKeys.add(entry.name);
+      }
+    });
+
+    // Build comparison data only for keys that exist in the current state
+    return Array.from(currentKeys)
+      .map((key) => {
+        const latestEntry = latestDefsStateInfo.keyStateInfo?.find((entry) => entry?.name === key);
+        const currentEntry = defsStateInfo.keyStateInfo?.find((entry) => entry?.name === key);
+
+        return {
+          key,
+          latestVersion: latestEntry?.info?.version || null,
+          latestTimestamp: latestEntry?.info?.createTimestamp || null,
+          currentVersion: currentEntry?.info?.version || null,
+          currentTimestamp: currentEntry?.info?.createTimestamp || null,
+        };
+      })
+      .sort((a, b) => a.key.localeCompare(b.key));
+  }, [latestDefsStateInfo, defsStateInfo]);
+
+  if (!latestDefsStateInfo?.keyStateInfo || !defsStateInfo?.keyStateInfo) {
+    return null;
+  }
+
+  const truncateVersion = (version: string | null) => {
+    if (!version) {
+      return '—';
+    }
+    return version.length > 8 ? version.substring(0, 8) : version;
+  };
+
+  const renderVersionCell = (version: string | null, timestamp: number | null) => {
+    if (!version || !timestamp) {
+      return '—';
+    }
+
+    return (
+      <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+        <span style={{fontFamily: FontFamily.monospace}}>{truncateVersion(version)}</span>
+        <Tag>
+          <TimeFromNow unixTimestamp={timestamp} />
+        </Tag>
+      </Box>
+    );
+  };
+
+  const renderStatusCell = (
+    latestVersion: string | null,
+    currentVersion: string | null,
+    key: string,
+  ) => {
+    if (!latestVersion || !currentVersion) {
+      return '—';
+    }
+
+    if (latestVersion === currentVersion) {
+      return (
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+          <Icon name="check_circle" color={Colors.accentGreen()} size={16} />
+          <span style={{color: Colors.textGreen()}}>Up to date</span>
+        </Box>
+      );
+    } else {
+      const latestEntry = latestDefsStateInfo.keyStateInfo?.find((e) => e?.name === key);
+      return (
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+          <Icon name="warning" color={Colors.accentYellow()} size={16} />
+          <span style={{color: Colors.textYellow()}}>Update available</span>
+          <Tag>
+            <TimeFromNow unixTimestamp={latestEntry?.info?.createTimestamp || 0} />
+          </Tag>
+        </Box>
+      );
+    }
+  };
+
+  return (
+    <Box>
+      <Table style={{width: '100%'}}>
+        <thead>
+          <tr>
+            <th
+              style={{
+                textAlign: 'left',
+                padding: '8px 12px',
+                borderBottom: `1px solid ${Colors.keylineDefault()}`,
+                width: '25%',
+              }}
+            >
+              Definition Key
+            </th>
+            <th
+              style={{
+                textAlign: 'left',
+                padding: '8px 12px',
+                borderBottom: `1px solid ${Colors.keylineDefault()}`,
+                width: '20%',
+              }}
+            >
+              Current State
+            </th>
+            <th
+              style={{
+                textAlign: 'left',
+                padding: '8px 12px',
+                borderBottom: `1px solid ${Colors.keylineDefault()}`,
+                width: '55%',
+              }}
+            >
+              Status
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {comparisonData.map(({key, currentVersion, currentTimestamp, latestVersion}) => (
+            <tr key={key}>
+              <td style={{padding: '8px 12px', fontFamily: FontFamily.monospace}}>{key}</td>
+              <td style={{padding: '8px 12px'}}>
+                {renderVersionCell(currentVersion, currentTimestamp)}
+              </td>
+              <td style={{padding: '8px 12px'}}>
+                {renderStatusCell(latestVersion, currentVersion, key)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefsStateComparisonSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefsStateComparisonSection.tsx
@@ -1,0 +1,55 @@
+import {Box, SpinnerWithText} from '@dagster-io/ui-components';
+
+import {useQuery} from '../apollo-client';
+import {CodeLocationDefsStateComparison} from './CodeLocationDefsStateComparison';
+import {CODE_LOCATION_DEFS_STATE_QUERY} from './CodeLocationDefsStateQuery';
+import {CodeLocationOverviewSectionHeader} from './CodeLocationOverviewSectionHeader';
+
+interface Props {
+  locationName: string;
+}
+
+export const CodeLocationDefsStateComparisonSection = ({locationName}: Props) => {
+  const {data, loading, error} = useQuery(CODE_LOCATION_DEFS_STATE_QUERY, {
+    variables: {locationName},
+    fetchPolicy: 'cache-and-network',
+  });
+
+  if (loading && !data) {
+    return (
+      <Box padding={64} flex={{direction: 'row', justifyContent: 'center'}}>
+        <SpinnerWithText label="Loading defs state comparison…" />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return null; // Silently fail if there's an error
+  }
+
+  const latestDefsStateInfo = data?.latestDefsStateInfo || null;
+  const defsStateInfo =
+    data?.workspaceLocationEntryOrError?.__typename === 'WorkspaceLocationEntry'
+      ? data.workspaceLocationEntryOrError.defsStateInfo
+      : null;
+
+  // Only show the section if we have data to compare
+  if (!latestDefsStateInfo || !defsStateInfo) {
+    return null;
+  }
+
+  // Don't show the section if there are no versions available in the current state
+  if (!defsStateInfo.keyStateInfo || defsStateInfo.keyStateInfo.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <CodeLocationOverviewSectionHeader label="Defs State Versions" />
+      <CodeLocationDefsStateComparison
+        latestDefsStateInfo={latestDefsStateInfo}
+        defsStateInfo={defsStateInfo}
+      />
+    </>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefsStateQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefsStateQuery.tsx
@@ -1,0 +1,32 @@
+import {gql} from '../apollo-client';
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
+
+export const CODE_LOCATION_DEFS_STATE_QUERY = gql`
+  query CodeLocationDefsStateQuery($locationName: String!) {
+    latestDefsStateInfo {
+      keyStateInfo {
+        name
+        info {
+          version
+          createTimestamp
+        }
+      }
+    }
+    workspaceLocationEntryOrError(name: $locationName) {
+      ... on WorkspaceLocationEntry {
+        id
+        defsStateInfo {
+          keyStateInfo {
+            name
+            info {
+              version
+              createTimestamp
+            }
+          }
+        }
+      }
+      ...PythonErrorFragment
+    }
+  }
+  ${PYTHON_ERROR_FRAGMENT}
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationOverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationOverviewRoot.tsx
@@ -18,6 +18,7 @@ import {CodeLocationTabs} from 'shared/code-location/CodeLocationTabs.oss';
 import {createGlobalStyle} from 'styled-components';
 import * as yaml from 'yaml';
 
+import {CodeLocationDefsStateComparisonSection} from './CodeLocationDefsStateComparisonSection';
 import {CodeLocationOverviewSectionHeader} from './CodeLocationOverviewSectionHeader';
 import {useCopyToClipboard} from '../app/browser';
 import {TimeFromNow} from '../ui/TimeFromNow';
@@ -162,6 +163,7 @@ export const CodeLocationOverviewRoot = (props: Props) => {
           </Table>
         </>
       ) : null}
+      <CodeLocationDefsStateComparisonSection locationName={repoAddress.location} />
       <CodeLocationAlertsSection locationName={repoAddress.location} />
       <CodeLocationOverviewSectionHeader label="Metadata" border="bottom" />
       <CodeLocationMetadataStyle />

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/types/CodeLocationDefsStateQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/types/CodeLocationDefsStateQuery.types.ts
@@ -1,0 +1,45 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type CodeLocationDefsStateQueryVariables = Types.Exact<{
+  locationName: Types.Scalars['String']['input'];
+}>;
+
+export type CodeLocationDefsStateQuery = {
+  __typename: 'Query';
+  latestDefsStateInfo: {
+    __typename: 'DefsStateInfo';
+    keyStateInfo: Array<{
+      __typename: 'DefsStateInfoEntry';
+      name: string;
+      info: {__typename: 'DefsKeyStateInfo'; version: string; createTimestamp: number};
+    }>;
+  } | null;
+  workspaceLocationEntryOrError:
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      }
+    | {
+        __typename: 'WorkspaceLocationEntry';
+        id: string;
+        defsStateInfo: {
+          __typename: 'DefsStateInfo';
+          keyStateInfo: Array<{
+            __typename: 'DefsStateInfoEntry';
+            name: string;
+            info: {__typename: 'DefsKeyStateInfo'; version: string; createTimestamp: number};
+          }>;
+        } | null;
+      }
+    | null;
+};
+
+export const CodeLocationDefsStateQueryVersion = '48c254f1f69e44eb1010e324b368262b96f00fdc20da873424e12ad76924c2c4';

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1773,6 +1773,7 @@ type WorkspaceLocationEntry {
   displayMetadata: [RepositoryMetadata!]!
   updatedTimestamp: Float!
   versionKey: String!
+  defsStateInfo: DefsStateInfo
   permissions: [Permission!]!
   featureFlags: [FeatureFlag!]!
 }
@@ -2510,6 +2511,20 @@ type DagsterLibraryVersion {
 union RepositoryOrError = PythonError | Repository | RepositoryNotFoundError
 
 union WorkspaceLocationEntryOrError = WorkspaceLocationEntry | PythonError
+
+type DefsStateInfo {
+  keyStateInfo: [DefsStateInfoEntry!]!
+}
+
+type DefsKeyStateInfo {
+  version: String!
+  createTimestamp: Float!
+}
+
+type DefsStateInfoEntry {
+  name: String!
+  info: DefsKeyStateInfo!
+}
 
 input AssetKeyInput {
   path: [String!]!
@@ -3671,6 +3686,7 @@ type Query {
     limit: Int!
     cursor: String
   ): [AssetCheckExecution!]!
+  latestDefsStateInfo: DefsStateInfo
 }
 
 union WorkspaceOrError = Workspace | PythonError

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1274,6 +1274,23 @@ export type DefinitionTag = {
   value: Scalars['String']['output'];
 };
 
+export type DefsKeyStateInfo = {
+  __typename: 'DefsKeyStateInfo';
+  createTimestamp: Scalars['Float']['output'];
+  version: Scalars['String']['output'];
+};
+
+export type DefsStateInfo = {
+  __typename: 'DefsStateInfo';
+  keyStateInfo: Array<DefsStateInfoEntry>;
+};
+
+export type DefsStateInfoEntry = {
+  __typename: 'DefsStateInfoEntry';
+  info: DefsKeyStateInfo;
+  name: Scalars['String']['output'];
+};
+
 export type DeleteDynamicPartitionsResult =
   | DeleteDynamicPartitionsSuccess
   | PythonError
@@ -4083,6 +4100,7 @@ export type Query = {
   instigationStateOrError: InstigationStateOrError;
   instigationStatesOrError: InstigationStatesOrError;
   isPipelineConfigValid: PipelineConfigValidationResult;
+  latestDefsStateInfo: Maybe<DefsStateInfo>;
   locationStatusesOrError: WorkspaceLocationStatusEntriesOrError;
   logsForRun: EventConnectionOrError;
   partitionBackfillOrError: PartitionBackfillOrError;
@@ -6086,6 +6104,7 @@ export type Workspace = {
 
 export type WorkspaceLocationEntry = {
   __typename: 'WorkspaceLocationEntry';
+  defsStateInfo: Maybe<DefsStateInfo>;
   displayMetadata: Array<RepositoryMetadata>;
   featureFlags: Array<FeatureFlag>;
   id: Scalars['ID']['output'];
@@ -8306,6 +8325,51 @@ export const buildDefinitionTag = (
     __typename: 'DefinitionTag',
     key: overrides && overrides.hasOwnProperty('key') ? overrides.key! : 'itaque',
     value: overrides && overrides.hasOwnProperty('value') ? overrides.value! : 'consequatur',
+  };
+};
+
+export const buildDefsKeyStateInfo = (
+  overrides?: Partial<DefsKeyStateInfo>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'DefsKeyStateInfo'} & DefsKeyStateInfo => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('DefsKeyStateInfo');
+  return {
+    __typename: 'DefsKeyStateInfo',
+    createTimestamp:
+      overrides && overrides.hasOwnProperty('createTimestamp') ? overrides.createTimestamp! : 2.02,
+    version: overrides && overrides.hasOwnProperty('version') ? overrides.version! : 'dolores',
+  };
+};
+
+export const buildDefsStateInfo = (
+  overrides?: Partial<DefsStateInfo>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'DefsStateInfo'} & DefsStateInfo => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('DefsStateInfo');
+  return {
+    __typename: 'DefsStateInfo',
+    keyStateInfo:
+      overrides && overrides.hasOwnProperty('keyStateInfo') ? overrides.keyStateInfo! : [],
+  };
+};
+
+export const buildDefsStateInfoEntry = (
+  overrides?: Partial<DefsStateInfoEntry>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'DefsStateInfoEntry'} & DefsStateInfoEntry => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('DefsStateInfoEntry');
+  return {
+    __typename: 'DefsStateInfoEntry',
+    info:
+      overrides && overrides.hasOwnProperty('info')
+        ? overrides.info!
+        : relationshipsToOmit.has('DefsKeyStateInfo')
+          ? ({} as DefsKeyStateInfo)
+          : buildDefsKeyStateInfo({}, relationshipsToOmit),
+    name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'voluptas',
   };
 };
 
@@ -13133,6 +13197,12 @@ export const buildQuery = (
         : relationshipsToOmit.has('InvalidSubsetError')
           ? ({} as InvalidSubsetError)
           : buildInvalidSubsetError({}, relationshipsToOmit),
+    latestDefsStateInfo:
+      overrides && overrides.hasOwnProperty('latestDefsStateInfo')
+        ? overrides.latestDefsStateInfo!
+        : relationshipsToOmit.has('DefsStateInfo')
+          ? ({} as DefsStateInfo)
+          : buildDefsStateInfo({}, relationshipsToOmit),
     locationStatusesOrError:
       overrides && overrides.hasOwnProperty('locationStatusesOrError')
         ? overrides.locationStatusesOrError!
@@ -16398,6 +16468,12 @@ export const buildWorkspaceLocationEntry = (
   relationshipsToOmit.add('WorkspaceLocationEntry');
   return {
     __typename: 'WorkspaceLocationEntry',
+    defsStateInfo:
+      overrides && overrides.hasOwnProperty('defsStateInfo')
+        ? overrides.defsStateInfo!
+        : relationshipsToOmit.has('DefsStateInfo')
+          ? ({} as DefsStateInfo)
+          : buildDefsStateInfo({}, relationshipsToOmit),
     displayMetadata:
       overrides && overrides.hasOwnProperty('displayMetadata') ? overrides.displayMetadata! : [],
     featureFlags:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -13,6 +13,7 @@ from dagster._core.remote_representation.grpc_server_state_subscriber import (
     LocationStateSubscriber,
 )
 from dagster._core.remote_representation.handle import RepositoryHandle
+from dagster._core.storage.defs_state.defs_state_info import DefsStateInfo
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.workspace import CodeLocationEntry, CodeLocationLoadStatus
 from dagster.components.core.load_defs import PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY
@@ -193,6 +194,7 @@ class GrapheneWorkspaceLocationEntry(graphene.ObjectType):
     displayMetadata = non_null_list(GrapheneRepositoryMetadata)
     updatedTimestamp = graphene.NonNull(graphene.Float)
     versionKey = graphene.NonNull(graphene.String)
+    defsStateInfo = graphene.Field(lambda: GrapheneDefsStateInfo)
 
     permissions = graphene.Field(non_null_list(GraphenePermission))
 
@@ -230,6 +232,16 @@ class GrapheneWorkspaceLocationEntry(graphene.ObjectType):
             for key, value in metadata.items()
             if value is not None
         ]
+
+    def resolve_defsStateInfo(self, graphene_info: ResolveInfo):
+        if not self._location_entry.code_location:
+            return None
+
+        defs_state_info = self._location_entry.code_location.get_defs_state_info()
+        if not defs_state_info:
+            return None
+
+        return GrapheneDefsStateInfo(defs_state_info)
 
     def resolve_updatedTimestamp(self, _) -> float:
         return self._location_entry.update_timestamp
@@ -542,6 +554,39 @@ class GrapheneWorkspaceLocationEntryOrError(graphene.Union):
         name = "WorkspaceLocationEntryOrError"
 
 
+class GrapheneDefsKeyStateInfo(graphene.ObjectType):
+    version = graphene.NonNull(graphene.String)
+    createTimestamp = graphene.NonNull(graphene.Float)
+
+    class Meta:
+        name = "DefsKeyStateInfo"
+
+
+class GrapheneDefsKeyStateInfoEntry(graphene.ObjectType):
+    name = graphene.NonNull(graphene.String)
+    info = graphene.NonNull(GrapheneDefsKeyStateInfo)
+
+    class Meta:
+        name = "DefsStateInfoEntry"
+
+
+class GrapheneDefsStateInfo(graphene.ObjectType):
+    keyStateInfo = non_null_list(GrapheneDefsKeyStateInfoEntry)
+
+    class Meta:
+        name = "DefsStateInfo"
+
+    def __init__(self, defs_state_info: DefsStateInfo):
+        super().__init__(
+            keyStateInfo=[
+                GrapheneDefsKeyStateInfoEntry(
+                    key, GrapheneDefsKeyStateInfo(info.version, info.create_timestamp)
+                )
+                for key, info in defs_state_info.info_mapping.items()
+            ]
+        )
+
+
 types = [
     GrapheneLocationStateChangeEvent,
     GrapheneLocationStateChangeEventType,
@@ -552,4 +597,7 @@ types = [
     GrapheneRepositoryLocation,
     GrapheneRepositoryOrError,
     GrapheneWorkspaceLocationEntryOrError,
+    GrapheneDefsStateInfo,
+    GrapheneDefsKeyStateInfo,
+    GrapheneDefsKeyStateInfoEntry,
 ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -119,6 +119,7 @@ from dagster_graphql.schema.backfill import (
 from dagster_graphql.schema.entity_key import GrapheneAssetKey
 from dagster_graphql.schema.env_vars import GrapheneEnvVarWithConsumersListOrError
 from dagster_graphql.schema.external import (
+    GrapheneDefsStateInfo,
     GrapheneRepositoriesOrError,
     GrapheneRepositoryConnection,
     GrapheneRepositoryOrError,
@@ -647,6 +648,11 @@ class GrapheneQuery(graphene.ObjectType):
         limit=graphene.NonNull(graphene.Int),
         cursor=graphene.String(),
         description="Retrieve the executions for a given asset check.",
+    )
+
+    latestDefsStateInfo = graphene.Field(
+        GrapheneDefsStateInfo,
+        description="Retrieve the latest available DefsStateInfo for the current workspace.",
     )
 
     @capture_error
@@ -1381,3 +1387,7 @@ class GrapheneQuery(graphene.ObjectType):
             limit=limit,
             cursor=cursor,
         )
+
+    def resolve_latestDefsStateInfo(self, graphene_info: ResolveInfo):
+        latest_info = graphene_info.context.instance.get_latest_defs_state_info()
+        return GrapheneDefsStateInfo(latest_info) if latest_info else None


### PR DESCRIPTION
## Summary & Motivation

We want to be able to visualize the state versions that are being used in a given code location alongside the latest available ones

This UI only appears in cases where you're using state-backed components, so this should not impact existing users at all.

Normal:

![Screenshot 2025-08-19 at 1.40.11 PM.png](https://app.graphite.dev/user-attachments/assets/8b846037-eb77-4704-bc80-5d34bc5db36c.png)

Out of date:
![Screenshot 2025-08-19 at 1.41.00 PM.png](https://app.graphite.dev/user-attachments/assets/ca62f4dd-97bd-4277-a69b-db19e68f78b4.png)

There are many other places where we might want to thread this information into in the future, but for now this serves as more of a useful diagnostic thing as we start experimenting with this capability.

## How I Tested These Changes

## Changelog

NOCHANGELOG