### PR TITLE
[ui] 1/n: Insights v2 updates to LineChartWithComparison

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
@@ -36,77 +36,50 @@ import {useFormatDateTime} from '../ui/useFormatDateTime';
 
 ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Tooltip);
 
+type PeriodData = {
+  label: string;
+  data: (number | null)[];
+  timestamps: number[];
+  aggregateValue: number | null;
+  color: string;
+};
+
 export type LineChartMetrics = {
   title: string;
   color: string;
-  timestamps: number[];
   pctChange: number | null;
-  currentPeriod: {
-    label: string;
-    data: (number | null)[];
-    aggregateValue: number | null;
-    color: string;
-  };
-  prevPeriod: {
-    label: string;
-    data: (number | null)[];
-    aggregateValue: number | null;
-    color: string;
-  };
+  currentPeriod: PeriodData;
+  prevPeriod: PeriodData;
 };
 
 export const getDataset = (
   metrics: LineChartMetrics,
-  formatDatetime: (date: Date, options: Intl.DateTimeFormatOptions) => string,
-): ChartData<'line', (number | null)[], string> => {
-  const firstTimestamp = metrics.timestamps[0] ?? null;
-  const lastTimestamp = metrics.timestamps[metrics.timestamps.length - 1] ?? null;
-
-  const start = firstTimestamp
-    ? formatDatetime(new Date(firstTimestamp * 1000), {
-        month: 'short',
-        day: 'numeric',
-      })
-    : '';
-  const end = lastTimestamp
-    ? formatDatetime(new Date(lastTimestamp * 1000), {
-        month: 'short',
-        day: 'numeric',
-      })
-    : '';
-
-  const labels = metrics.timestamps.length
-    ? [start, ...Array(metrics.timestamps.length - 2).fill(''), end]
-    : [];
-
-  return {
-    labels,
-    datasets: [
-      {
-        label: metrics.currentPeriod.label,
-        data: metrics.currentPeriod.data,
-        borderColor: metrics.currentPeriod.color,
-        backgroundColor: 'transparent',
-        pointRadius: 0,
-        borderWidth: 2,
-        pointHoverRadius: 6,
-        pointHoverBorderColor: metrics.currentPeriod.color,
-      },
-      {
-        label: metrics.prevPeriod.label,
-        data: metrics.prevPeriod.data,
-        borderColor: metrics.prevPeriod.color,
-        backgroundColor: 'transparent',
-        pointRadius: 0,
-        borderWidth: 2,
-        pointHoverRadius: 6,
-        pointHoverBorderColor: metrics.prevPeriod.color,
-      },
-    ],
-  };
+): ChartData<'line', (number | null)[], string>['datasets'] => {
+  return [
+    {
+      label: metrics.currentPeriod.label,
+      data: metrics.currentPeriod.data,
+      borderColor: metrics.currentPeriod.color,
+      backgroundColor: 'transparent',
+      pointRadius: 0,
+      borderWidth: 2,
+      pointHoverRadius: 6,
+      pointHoverBorderColor: metrics.currentPeriod.color,
+    },
+    {
+      label: metrics.prevPeriod.label,
+      data: metrics.prevPeriod.data,
+      borderColor: metrics.prevPeriod.color,
+      backgroundColor: 'transparent',
+      pointRadius: 0,
+      borderWidth: 2,
+      pointHoverRadius: 6,
+      pointHoverBorderColor: metrics.prevPeriod.color,
+    },
+  ];
 };
 
-type MetricDialogData<T> = {
+export type MetricDialogData<T> = {
   after: number;
   before: number;
   metric: T;
@@ -118,7 +91,9 @@ interface Props<T> {
   loading: boolean;
   unitType: ReportingUnitType;
   openMetricDialog?: (data: MetricDialogData<T>) => void;
+  showPreviousAggregate?: boolean;
   metricName: T;
+  tickLabels: string[];
   height?: number;
   width?: number;
 }
@@ -137,8 +112,19 @@ export const LineChartWithComparison = <T,>(props: Props<T>) => {
   );
 };
 
-export const InnerLineChartWithComparison = <T,>(props: Omit<Props<T>, 'loading'>) => {
-  const {metrics, unitType, openMetricDialog, metricName, height = 160, width} = props;
+export const InnerLineChartWithComparison = <T,>(props: Props<T>) => {
+  const {
+    metrics,
+    loading,
+    unitType,
+    openMetricDialog,
+    metricName,
+    showPreviousAggregate,
+    tickLabels,
+    height = 160,
+    width,
+  } = props;
+
   const formatDatetime = useFormatDateTime();
   const rgbColors = useRGBColorsForTheme();
 
@@ -153,7 +139,7 @@ export const InnerLineChartWithComparison = <T,>(props: Omit<Props<T>, 'loading'
           return <div />;
         }
 
-        const timestamp = metrics.timestamps[currentPeriodDataPoint.dataIndex];
+        const timestamp = metrics.currentPeriod.timestamps[currentPeriodDataPoint.dataIndex];
         if (!timestamp) {
           return <div />;
         }
@@ -321,15 +307,15 @@ export const InnerLineChartWithComparison = <T,>(props: Omit<Props<T>, 'loading'
       if (element) {
         const index = element.index;
         let timeSliceSeconds = 60 * 60; // Default to 1 hour
-        if (metrics.timestamps.length >= 2) {
-          const timeSliceStart = metrics.timestamps[0];
-          const timeSliceEnd = metrics.timestamps[1];
+        if (metrics.currentPeriod.timestamps.length >= 2) {
+          const timeSliceStart = metrics.currentPeriod.timestamps[0];
+          const timeSliceEnd = metrics.currentPeriod.timestamps[1];
           if (timeSliceStart && timeSliceEnd) {
             timeSliceSeconds = timeSliceEnd - timeSliceStart;
           }
         }
 
-        const before = metrics.timestamps[index];
+        const before = metrics.currentPeriod.timestamps[index];
         if (typeof before !== 'number') {
           return;
         }
@@ -367,37 +353,47 @@ export const InnerLineChartWithComparison = <T,>(props: Omit<Props<T>, 'loading'
   return (
     <>
       <Box flex={{direction: 'column', justifyContent: 'space-between'}}>
-        <div className={styles.chartCount}>
-          {metrics.currentPeriod.aggregateValue
-            ? numberFormatterWithMaxFractionDigits(2).format(currentPeriodDisplayValueAndUnit.value)
-            : 0}
-          <Body color={Colors.textDefault()}>{currentPeriodDisplayValueAndUnit.unit}</Body>
-        </div>
-        <Box
-          className={styles.chartChange}
-          flex={{direction: 'row', gap: 4, justifyContent: 'space-between'}}
-        >
-          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-            {metrics.prevPeriod.aggregateValue
-              ? numberFormatterWithMaxFractionDigits(2).format(prevPeriodDisplayValueAndUnit.value)
+        {loading ? (
+          <div className={styles.chartCount}>&mdash;</div>
+        ) : (
+          <div className={styles.chartCount}>
+            {metrics.currentPeriod.aggregateValue
+              ? numberFormatterWithMaxFractionDigits(2).format(
+                  currentPeriodDisplayValueAndUnit.value,
+                )
               : 0}
-            <span> prev period</span>
+            <Body color={Colors.textDefault()}>{currentPeriodDisplayValueAndUnit.unit}</Body>
+          </div>
+        )}
+        {showPreviousAggregate ? (
+          <Box
+            className={styles.chartChange}
+            flex={{direction: 'row', gap: 4, justifyContent: 'space-between'}}
+          >
+            <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+              {metrics.prevPeriod.aggregateValue
+                ? numberFormatterWithMaxFractionDigits(2).format(
+                    prevPeriodDisplayValueAndUnit.value,
+                  )
+                : 0}
+              <span> prev period</span>
+            </Box>
+            <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+              {metrics.pctChange && metrics.pctChange > 0 ? (
+                <Icon name="trending_up" size={16} color={Colors.textLighter()} />
+              ) : metrics.pctChange && metrics.pctChange < 0 ? (
+                <Icon name="trending_down" size={16} color={Colors.textLighter()} />
+              ) : null}
+              {percentFormatter.format(Math.abs(metrics.pctChange ?? 0))}
+            </Box>
           </Box>
-          <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-            {metrics.pctChange && metrics.pctChange > 0 ? (
-              <Icon name="trending_up" size={16} color={Colors.textLighter()} />
-            ) : metrics.pctChange && metrics.pctChange < 0 ? (
-              <Icon name="trending_down" size={16} color={Colors.textLighter()} />
-            ) : null}
-            {percentFormatter.format(Math.abs(metrics.pctChange ?? 0))}
-          </Box>
-        </Box>
+        ) : null}
       </Box>
       <div className={styles.chartWrapper}>
         <div className={styles.chartGraph} style={{height}}>
           <Line
             ref={chartRef}
-            data={getDataset(metrics, formatDatetime)}
+            data={{labels: tickLabels, datasets: getDataset(metrics)}}
             options={options}
             onClick={onClick}
             plugins={[CrosshairPlugin as Plugin<'line'>]}


### PR DESCRIPTION
## Summary & Motivation

Corresponds to internal https://github.com/dagster-io/internal/pull/17622.

- Move label generation out of OSS and into internal. Right now it makes significant assumptions about the labels to be generated, in particular that the "end" label should match the last timestamp in the data provided. This is no longer correct for "This month" and "This week".
- Give the option of hiding the "previous aggregate" section of the line chart header, which no longer really makes sense for "This month" and "This week" data.

## How I Tested These Changes

Proxy as Elementl, verify changes.