### PR TITLE
Prevent test_cases file from being imported by dagster module

### DIFF
--- a/python_modules/dagster/dagster/components/testing/__init__.py
+++ b/python_modules/dagster/dagster/components/testing/__init__.py
@@ -4,11 +4,6 @@ from dagster.components.testing.deprecated.utils import (
     get_module_path as get_module_path,
     scaffold_defs_sandbox as scaffold_defs_sandbox,
 )
-from dagster.components.testing.test_cases import (
-    TestOpCustomization as TestOpCustomization,
-    TestTranslation as TestTranslation,
-    TestTranslationBatched as TestTranslationBatched,
-)
 from dagster.components.testing.utils import (
     copy_code_to_file as copy_code_to_file,
     create_defs_folder_sandbox as create_defs_folder_sandbox,

--- a/python_modules/dagster/dagster_tests/general_tests/test_import.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_import.py
@@ -34,6 +34,7 @@ def test_import_cli_perf():
         "fsspec",
         "requests",
         "jinja2",
+        "pytest",
     ]
     expensive_imports = [
         f"`{lib}`"
@@ -76,6 +77,7 @@ def test_import_perf():
         "fsspec",
         "jinja2",
         "requests",
+        "pytest",
     ]
     expensive_imports = [f"`{lib}`" for lib in expensive_library if lib in import_profile]
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
@@ -15,7 +15,8 @@ from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils import alter_sys_path
 from dagster._utils.env import environ
 from dagster.components.core.component_tree import ComponentTree
-from dagster.components.testing import TestTranslation, create_defs_folder_sandbox
+from dagster.components.testing.test_cases import TestTranslation
+from dagster.components.testing.utils import create_defs_folder_sandbox
 from dagster_airbyte.components.workspace_component.component import AirbyteCloudWorkspaceComponent
 from dagster_airbyte.resources import AirbyteCloudWorkspace
 from dagster_airbyte.translator import AirbyteConnection

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -20,7 +20,7 @@ from dagster.components.core.component_tree import ComponentTree
 from dagster.components.core.load_defs import build_component_defs
 from dagster.components.resolved.core_models import AssetAttributesModel, OpSpec
 from dagster.components.resolved.errors import ResolutionException
-from dagster.components.testing import TestOpCustomization, TestTranslation
+from dagster.components.testing.test_cases import TestOpCustomization, TestTranslation
 from dagster_dbt import DbtProject, DbtProjectComponent
 from dagster_dbt.cli.app import project_app_typer_click_object
 from dagster_dbt.components.dbt_project.component import get_projects_from_dbt_component

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -17,7 +17,8 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils import pushd
 from dagster._utils.env import environ
 from dagster.components.core.component_tree import ComponentTree
-from dagster.components.testing import TestTranslationBatched, create_defs_folder_sandbox
+from dagster.components.testing.test_cases import TestTranslationBatched
+from dagster.components.testing.utils import create_defs_folder_sandbox
 from dagster_dlt import DagsterDltResource, DltLoadCollectionComponent
 from dagster_dlt.components.dlt_load_collection.component import DltLoadSpecModel
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -13,7 +13,8 @@ from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils.env import environ
 from dagster.components.core.component_tree import ComponentTree
-from dagster.components.testing import TestTranslation, create_defs_folder_sandbox
+from dagster.components.testing.test_cases import TestTranslation
+from dagster.components.testing.utils import create_defs_folder_sandbox
 from dagster_fivetran.components.workspace_component.component import FivetranAccountComponent
 from dagster_fivetran.resources import FivetranWorkspace
 from dagster_fivetran.translator import FivetranConnector

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_sling_replication_collection_component.py
@@ -23,11 +23,8 @@ from dagster._core.instance_for_test import instance_for_test
 from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._utils.env import environ
 from dagster.components.resolved.core_models import AssetAttributesModel, OpSpec
-from dagster.components.testing import (
-    TestOpCustomization,
-    TestTranslation,
-    create_defs_folder_sandbox,
-)
+from dagster.components.testing.test_cases import TestOpCustomization, TestTranslation
+from dagster.components.testing.utils import create_defs_folder_sandbox
 from dagster_shared import check
 from dagster_sling import SlingReplicationCollectionComponent, SlingResource
 from dagster_sling.components.sling_replication_collection.component import (


### PR DESCRIPTION
## Summary

This is unintentionally causing `pytest` to be imported by the core `dagster` module - this ensures `test_cases` is not imported when importing `dagster`.

## Test Plan

Update import tests to catch erroneous `pytest` imports.
