### PR TITLE
fix(docs): ensure example passes validation

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta-pythonic.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta-pythonic.py
@@ -18,7 +18,7 @@ class ShellCommand(dg.Component, dg.Resolvable):
     @classmethod
     def get_spec(cls) -> dg.ComponentTypeSpec:
         return dg.ComponentTypeSpec(
-            owners=["john.dagster@example.com"],
+            owners=["john@dagster.io"],
             tags=["shell", "script"],
         )
 

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta-pythonic.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta-pythonic.py
@@ -18,7 +18,7 @@ class ShellCommand(dg.Component, dg.Resolvable):
     @classmethod
     def get_spec(cls) -> dg.ComponentTypeSpec:
         return dg.ComponentTypeSpec(
-            owners=["John Dagster"],
+            owners=["john.dagster@example.com"],
             tags=["shell", "script"],
         )
 

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta-yaml.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta-yaml.py
@@ -13,7 +13,7 @@ class ShellCommand(dg.Component, dg.Model, dg.Resolvable):
     @classmethod
     def get_spec(cls) -> dg.ComponentTypeSpec:
         return dg.ComponentTypeSpec(
-            owners=["john.dagster@example.com"],
+            owners=["john@dagster.io"],
             tags=["shell", "script"],
         )
 

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta-yaml.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta-yaml.py
@@ -13,7 +13,7 @@ class ShellCommand(dg.Component, dg.Model, dg.Resolvable):
     @classmethod
     def get_spec(cls) -> dg.ComponentTypeSpec:
         return dg.ComponentTypeSpec(
-            owners=["John Dagster"],
+            owners=["john.dagster@example.com"],
             tags=["shell", "script"],
         )
 

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
@@ -10,7 +10,7 @@ class ShellCommand(dg.Component, dg.Resolvable):
     @classmethod
     def get_spec(cls) -> dg.ComponentTypeSpec:
         return dg.ComponentTypeSpec(
-            owners=["John Dagster"],
+            owners=["john.dagster@example.com"],
             tags=["shell", "script"],
         )
 

--- a/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
+++ b/examples/docs_snippets/docs_snippets/guides/components/shell-script-component/with-config-schema-meta.py
@@ -10,7 +10,7 @@ class ShellCommand(dg.Component, dg.Resolvable):
     @classmethod
     def get_spec(cls) -> dg.ComponentTypeSpec:
         return dg.ComponentTypeSpec(
-            owners=["john.dagster@example.com"],
+            owners=["john@dagster.io"],
             tags=["shell", "script"],
         )
 


### PR DESCRIPTION
## Summary & Motivation

[In the docs owners is a First & Last name (John Dagster)](https://docs.dagster.io/guides/build/components/creating-new-components/creating-and-registering-a-component#3-optional-add-metadata-to-your-component)
```python
dg.ComponentTypeSpec(
    owners=["John Dagster"],
    tags=["shell", "script"],
)
```
However the ComponentTypeSpec expects an email or team name
[validate_component_owner](https://github.com/dagster-io/dagster/blob/72a64f7767994cc5e3bc54088cac8baa800e4864/python_modules/dagster/dagster/_core/definitions/utils.py#L160)

```python
dg.ComponentTypeSpec(
    owners=["john@dagster.io"],
    tags=["shell", "script"],
)
```
or
```python
dg.ComponentTypeSpec(
    owners=["team: ETL_Team"],
    tags=["shell", "script"],
)
```

## How I Tested These Changes

Following the existing documentation, it hits the validation error

1. uvx create-dagster project test-project && cd test-project
2. source .venv/bin/activate
3. dg scaffold component ShellCommand
4. populate <shell_command.py>
5. dg list components

```
  File "/Users/.../Dev/test-workspace/deployments/local/.venv/lib/python3.12/site-packages/dagster/_core/definitions/utils.py", line 162, in validate_component_owner
    raise DagsterInvalidDefinitionError(
dagster._core.errors.DagsterInvalidDefinitionError: Invalid owner 'John Dagster'. Owner must be an email address or a team name prefixed with 'team:'.
```

## Changelog

> Insert changelog entry or delete this section.
https://github.com/dagster-io/dagster/commit/baf3227f4534f0823f77f61c509340fcb7073d14