### PR TITLE
Add redirects for old docs URLs

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -646,7 +646,7 @@
     },
     {
       "source": "/integrations/airlift/reference",
-      "destination": "/migration/airflow-to-dagster/migration-reference"
+      "destination": "/migration/airflow-to-dagster/airlift-v1/migration-reference"
     },
     {
       "source": "/integrations/libraries/airlift/federation-tutorial/observe",
@@ -2913,6 +2913,78 @@
     {
       "source": "/dagster-cloud/insights",
       "destination": "/guides/monitor/insights"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/branch-deployments",
+      "destination": "/deployment/dagster-plus/ci-cd/branch-deployments"
+    },
+    {
+      "source": "/dagster-cloud/account/managing-users/managing-teams",
+      "destination": "/deployment/dagster-plus/authentication-and-access-control/rbac/teams"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/alerts/microsoft-teams",
+      "destination": "/guides/monitor/alerts/configuring-an-alert-notification-service"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/alerts/pagerduty",
+      "destination": "/guides/monitor/alerts/configuring-an-alert-notification-service"
+    },
+    {
+      "source": "/dagster-cloud/account/managing-users/managing-user-roles-permissions",
+      "destination": "/deployment/dagster-plus/authentication-and-access-control/rbac/user-roles-permissions"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/alerts/email",
+      "destination": "/guides/monitor/alerts/configuring-an-alert-notification-service"
+    },
+    {
+      "source": "/dagster-cloud/account/authentication/utilizing-scim-provisioning",
+      "destination": "/deployment/dagster-plus/authentication-and-access-control/scim"
+    },
+    {
+      "source": "/dagster-cloud/deployment/agents/amazon-ecs/configuration-reference",
+      "destination": "/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference"
+    },
+    {
+      "source": "/dagster-cloud/deployment/agents/running-multiple-agents",
+      "destination": "/deployment/dagster-plus/hybrid/multiple"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments-with-github",
+      "destination": "/deployment/dagster-plus/ci-cd/branch-deployments/setting-up-branch-deployments"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/alerts/slack",
+      "destination": "/guides/monitor/alerts/configuring-an-alert-notification-service"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/branch-deployments/using-branch-deployments-with-gitlab",
+      "destination": "/deployment/dagster-plus/ci-cd/branch-deployments/setting-up-branch-deployments"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/setting-up-alerts",
+      "destination": "/guides/monitor/alerts/configuring-an-alert-notification-service"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/alerts/managing-alerts-cli",
+      "destination": "/guides/monitor/alerts/creating-alerts"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/alerts",
+      "destination": "/guides/monitor/alerts"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/alerts/managing-alerts-in-ui",
+      "destination": "/guides/monitor/alerts/creating-alerts"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/managing-deployments",
+      "destination": "/deployment/dagster-plus/full-deployments"
+    },
+    {
+      "source": "/dagster-cloud/managing-deployments/environment-variables-and-secrets",
+      "destination": "/deployment/dagster-plus/management/environment-variables"
     },
     {
       "source": "/concepts/dagster-pipes/pyspark",


### PR DESCRIPTION
## Summary & Motivation

Addresses https://app.asana.com/1/355940007332123/project/1209571247235207/task/1210929065885816

We were still missing some redirects from very old docs URLs from a previous iteration of the docs site -- this PR adds redirects for them.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
