### PR TITLE
feat(docs): add context menu to navbar logo

### DIFF
--- a/docs/src/styles/custom.scss
+++ b/docs/src/styles/custom.scss
@@ -823,3 +823,27 @@ dt > a > a.hash-link {
     margin-right: max(calc(-40vw + 1650px * 0.4), -55px);
   }
 }
+
+// Context menu for the navbar logo
+.navbar-logo-menu {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  background: var(--ifm-dropdown-background-color);
+  border: 1px solid var(--ifm-dropdown-border-color);
+  border-radius: var(--ifm-dropdown-border-radius);
+  box-shadow: var(--ifm-dropdown-shadow);
+  z-index: 1000;
+}
+
+.navbar-logo-menu li a {
+  display: block;
+  padding: 0.25rem 0.75rem;
+  color: var(--ifm-font-color-base);
+  text-decoration: none;
+}
+
+.navbar-logo-menu li a:hover {
+  background: var(--ifm-dropdown-hover-background-color);
+}
+

--- a/docs/src/theme/Navbar/Logo/index.tsx
+++ b/docs/src/theme/Navbar/Logo/index.tsx
@@ -1,0 +1,47 @@
+import React, {useState, useEffect} from 'react';
+import Link from '@docusaurus/Link';
+import Logo from '@theme/Logo';
+
+export default function NavbarLogo() {
+  const [menuPosition, setMenuPosition] = useState<{x: number; y: number} | null>(null);
+
+  useEffect(() => {
+    const handleClick = () => setMenuPosition(null);
+    if (menuPosition) {
+      document.addEventListener('click', handleClick);
+    }
+    return () => {
+      document.removeEventListener('click', handleClick);
+    };
+  }, [menuPosition]);
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setMenuPosition({x: e.clientX, y: e.clientY});
+  };
+
+  return (
+    <>
+      <Logo
+        className="navbar__brand"
+        imageClassName="navbar__logo"
+        titleClassName="navbar__title text--truncate"
+        onContextMenu={handleContextMenu}
+      />
+      {menuPosition && (
+        <ul className="navbar-logo-menu" style={{position: 'fixed', top: menuPosition.y, left: menuPosition.x}}>
+          <li>
+            <Link href="/img/dagster-docs-logo.svg" download>
+              Download SVG
+            </Link>
+          </li>
+          <li>
+            <Link href="https://dagster.io" target="_blank" rel="noopener noreferrer">
+              Visit Dagster Website
+            </Link>
+          </li>
+        </ul>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add right-click context menu to docs navbar logo
- style context menu for consistent appearance

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_b_68a0d6b996148321b1c43925667fb64a