### PR TITLE
Fix redirects and 404ing links in docs

### DIFF
--- a/docs/docs/api/clis/dagster-cloud-cli/index.md
+++ b/docs/docs/api/clis/dagster-cloud-cli/index.md
@@ -2,8 +2,8 @@
 description: The dagster-cloud CLI offers command-line tools for managing and deploying Dagster+ workflows.
 sidebar_position: 4000
 title: dagster-cloud CLI
-canonicalUrl: '/deployment/dagster-plus/management/dagster-cloud-cli'
-slug: '/deployment/dagster-plus/management/dagster-cloud-cli'
+canonicalUrl: '/api/clis/dagster-cloud-cli'
+slug: '/api/clis/dagster-cloud-cli'
 ---
 
 The dagster-cloud CLI is a command-line toolkit designed to work with Dagster+.

--- a/docs/docs/deployment/dagster-plus/ci-cd/branch-deployments/multiple-deployments.md
+++ b/docs/docs/deployment/dagster-plus/ci-cd/branch-deployments/multiple-deployments.md
@@ -147,7 +147,7 @@ dagster_cloud_api:
 
 There is an organization-scoped setting `max_concurrent_branch_deployment_runs` that controls concurrency across all branch deployments. By default its value is 50.
 
-Modifying organization-scoped settings can only be done using the [dagster-cloud CLI](/deployment/dagster-plus/management/dagster-cloud-cli). The CLI must be [authenticated](/api/clis/dagster-cloud-cli/installing-and-configuring#setting-up-the-configuration-file) with a user token for a user that has the [Organization Admin role](/deployment/dagster-plus/authentication-and-access-control/rbac/user-roles-permissions#dagster-user-roles).
+Modifying organization-scoped settings can only be done using the [dagster-cloud CLI](/api/clis/dagster-cloud-cli). The CLI must be [authenticated](/api/clis/dagster-cloud-cli/installing-and-configuring#setting-up-the-configuration-file) with a user token for a user that has the [Organization Admin role](/deployment/dagster-plus/authentication-and-access-control/rbac/user-roles-permissions#dagster-user-roles).
 
 To view the organization settings in the terminal:
 

--- a/docs/docs/deployment/dagster-plus/ci-cd/branch-deployments/using-branch-deployments-with-the-cli.md
+++ b/docs/docs/deployment/dagster-plus/ci-cd/branch-deployments/using-branch-deployments-with-the-cli.md
@@ -4,7 +4,7 @@ sidebar_position: 7330
 title: Using branch deployments with the dagster-cloud CLI
 ---
 
-In this article, we'll walk you through setting up branch deployments with a general continuous integration (CI) or Git platform, using the [`dagster-cloud` CLI](/deployment/dagster-plus/management/dagster-cloud-cli).
+In this article, we'll walk you through setting up branch deployments with a general continuous integration (CI) or Git platform, using the [`dagster-cloud` CLI](/api/clis/dagster-cloud-cli).
 
 Using this approach to branch deployments may be a good fit if:
 

--- a/docs/docs/deployment/dagster-plus/ci-cd/ci-cd-in-serverless.md
+++ b/docs/docs/deployment/dagster-plus/ci-cd/ci-cd-in-serverless.md
@@ -11,7 +11,7 @@ This guide only applies to [Dagster+ Serverless deployments](/deployment/dagster
 
 :::
 
-If you're a GitHub or GitLab user, you can use our predefined workflows to seamlessly deploy and synchronize your code to Dagster+. You can also use other Git providers or a local Git repository with our [dagster-cloud CLI](/deployment/dagster-plus/management/dagster-cloud-cli) to run your own CI/CD process.
+If you're a GitHub or GitLab user, you can use our predefined workflows to seamlessly deploy and synchronize your code to Dagster+. You can also use other Git providers or a local Git repository with our [dagster-cloud CLI](/api/clis/dagster-cloud-cli) to run your own CI/CD process.
 
 :::note
 
@@ -46,7 +46,7 @@ If you're a GitLab user, with a single click our GitLab app can set up a repo co
 
 <TabItem value="Other" label="Other Git providers or local development">
 
-If you don't want to use our automated GitHub/GitLab process, we offer [the powerful `dagster-cloud` command-line interface (CLI)](/deployment/dagster-plus/management/dagster-cloud-cli) that you can use in another CI environment or locally.
+If you don't want to use our automated GitHub/GitLab process, we offer [the powerful `dagster-cloud` command-line interface (CLI)](/api/clis/dagster-cloud-cli) that you can use in another CI environment or locally.
 
 First, [create a new project](/getting-started/quickstart) with the Dagster open source CLI.
 

--- a/docs/docs/guides/build/components/building-pipelines-with-components/testing-component-definitions.md
+++ b/docs/docs/guides/build/components/building-pipelines-with-components/testing-component-definitions.md
@@ -63,4 +63,4 @@ def test_function_component_execution() -> None:
     assert dg.materialize(defs.get_assets_def("some_asset")).success
 ```
 
-See [Unit Testing Assets and Ops](https://docs.dagster.io/guides/test/unit-testing-assets-and-ops) for more information about testing definitions.
+See [Unit Testing Assets and Ops](/guides/test/unit-testing-assets-and-ops) for more information about testing definitions.

--- a/docs/docs/guides/monitor/alerts/creating-alerts.md
+++ b/docs/docs/guides/monitor/alerts/creating-alerts.md
@@ -8,7 +8,7 @@ import DagsterPlus from '@site/docs/partials/\_DagsterPlus.md';
 
 <DagsterPlus />
 
-You can create alert policies in the Dagster+ UI or with the [`dagster-cloud` CLI](/deployment/dagster-plus/management/dagster-cloud-cli).
+You can create alert policies in the Dagster+ UI or with the [`dagster-cloud` CLI](/api/clis/dagster-cloud-cli).
 
 Alert policies are configured on a per-deployment basis. This means, for example, that asset alerts configured in a prod deployment are only applicable to assets in that deployment.
 

--- a/docs/docs/guides/operate/managing-concurrency.md
+++ b/docs/docs/guides/operate/managing-concurrency.md
@@ -69,7 +69,7 @@ Without this granularity set, the default granularity is set to the `op`. This m
 
 ### Setting a default limit for concurrency pools
 
-- Dagster+: Edit the `concurrency` config in deployment settings via the [Dagster+ UI](/guides/operate/webserver) or the [`dagster-cloud` CLI](/deployment/dagster-plus/management/dagster-cloud-cli).
+- Dagster+: Edit the `concurrency` config in deployment settings via the [Dagster+ UI](/guides/operate/webserver) or the [`dagster-cloud` CLI](/api/clis/dagster-cloud-cli).
 - Dagster Open Source: Use your instance's [dagster.yaml](/deployment/oss/dagster-yaml)
 
 ```yaml

--- a/docs/docs/integrations/libraries/docker.md
+++ b/docs/docs/integrations/libraries/docker.md
@@ -22,8 +22,8 @@ partnerlink: https://www.docker.com/
 
 ## Deploying to Docker?
 
-- Deploying to Dagster+: Use with a Dagster+ Hybrid deployment, the Docker agent executes Dagster jobs on a Docker cluster. Checkout the [Dagster+ Docker Agent](https://docs.dagster.io/dagster-plus/deployment/deployment-types/hybrid/docker) guide for more information.
-- Deploying to Open Source: Visit the [Deploying Dagster to Docker](https://docs.dagster.io/guides/deploy/deployment-options/docker) guide for more information.
+- Deploying to Dagster+: Use with a Dagster+ Hybrid deployment, the Docker agent executes Dagster jobs on a Docker cluster. Checkout the [Dagster+ Docker Agent](/deployment/dagster-plus/hybrid/docker) guide for more information.
+- Deploying to Open Source: Visit the [Deploying Dagster to Docker](/deployment/oss/deployment-options/docker) guide for more information.
 
 ## About Docker
 

--- a/docs/docs/integrations/libraries/iceberg/usage.md
+++ b/docs/docs/integrations/libraries/iceberg/usage.md
@@ -149,7 +149,7 @@ By default, assets will error when you change the partition spec (e.g. if you ch
 
 ## Using the custom I/O manager
 
-The `dagster-iceberg` library leans heavily on Dagster's `DbIOManager` implementation. However, this I/O manager comes with some limitations, such as the lack of support for various [partition mappings](https://docs.dagster.io/_apidocs/partitions#partition-mapping). A custom (experimental) `DbIOManager` implementation is available that supports partition mappings as long as any time-based partition is _consecutive_ and static partitions are of string type. You can enable it as follows:
+The `dagster-iceberg` library leans heavily on Dagster's `DbIOManager` implementation. However, this I/O manager comes with some limitations, such as the lack of support for various [partition mappings](/api/dagster/partitions#partition-mapping). A custom (experimental) `DbIOManager` implementation is available that supports partition mappings as long as any time-based partition is _consecutive_ and static partitions are of string type. You can enable it as follows:
 
 <CodeExample
   path="docs_snippets/docs_snippets/integrations/iceberg/using_custom_io_manager.py"

--- a/docs/docs/integrations/libraries/kubernetes.md
+++ b/docs/docs/integrations/libraries/kubernetes.md
@@ -22,8 +22,8 @@ partnerlink: https://kubernetes.io/
 
 ## Deploying to Kubernetes?
 
-- Deploying to Dagster+: Use with a Dagster+ Hybrid deployment, the Kubernetes agent executes Dagster jobs on a Kubernetes cluster. Checkout the [Dagster+ Kubernetes Agent](https://docs.dagster.io/dagster-plus/deployment/deployment-types/hybrid/kubernetes) guide for more information.
-- Deploying to Open Source: Visit the [Deploying Dagster to Kubernetes](https://docs.dagster.io/guides/deploy/deployment-options/kubernetes) guide for more information.
+- Deploying to Dagster+: Use with a Dagster+ Hybrid deployment, the Kubernetes agent executes Dagster jobs on a Kubernetes cluster. Checkout the [Dagster+ Kubernetes Agent](/deployment/dagster-plus/hybrid/kubernetes) guide for more information.
+- Deploying to Open Source: Visit the [Deploying Dagster to Kubernetes](/deployment/oss/deployment-options/kubernetes) guide for more information.
 
 ## About Kubernetes
 

--- a/docs/docs/integrations/libraries/openai.md
+++ b/docs/docs/integrations/libraries/openai.md
@@ -58,7 +58,7 @@ The OpenAI resource can be used in assets in order to interact with the OpenAI A
   endBefore="end_example"
 />
 
-After materializing your asset, your OpenAI API usage metadata will be available in the **Events** and **Plots** tabs of your asset in the Dagster UI. If you are using [Dagster+](/deployment/dagster-plus), your usage metadata will also be available in [Dagster Insights](/guides/monitor/insights). {/* Refer to the [Viewing and materializing assets in the UI guide](https://docs.dagster.io/guides/build/assets/defining-assets#viewing-and-materializing-assets-in-the-ui) for more information. */}
+After materializing your asset, your OpenAI API usage metadata will be available in the **Events** and **Plots** tabs of your asset in the Dagster UI. If you are using [Dagster+](/deployment/dagster-plus), your usage metadata will also be available in [Dagster Insights](/guides/monitor/insights).
 
 ## Using the OpenAI resource with ops
 

--- a/docs/docs/integrations/libraries/teradata.md
+++ b/docs/docs/integrations/libraries/teradata.md
@@ -88,7 +88,7 @@ dagster-quickstart
         __init__.py
 ```
 
-Refer [here](https://docs.dagster.io/guides/build/projects/dagster-project-file-reference) to know more above this directory structure
+Refer [here](/guides/build/projects/dagster-project-file-reference) to know more above this directory structure.
 
 ## Create Sample Data
 

--- a/docs/sphinx/sections/api/apidocs/clis/dg-cli/dg-cli-reference.rst
+++ b/docs/sphinx/sections/api/apidocs/clis/dg-cli/dg-cli-reference.rst
@@ -31,7 +31,7 @@ dg CLI
 dg scaffold example
 ^^^^^^^^^^^^^^^^^^^
 
-**Note:** Before scaffolding definitions with ``dg``, you must `create a project <https://docs.dagster.io/guides/build/projects/creating-a-new-project>`_ with the `create-dagster CLI <https://docs.dagster.io/api/dg/create-dagster>`_ and activate its virtual environment.
+**Note:** Before scaffolding definitions with ``dg``, you must `create a project <https://docs.dagster.io/guides/build/projects/creating-a-new-project>`_ with the `create-dagster CLI <https://docs.dagster.io/api/clis/create-dagster>`_ and activate its virtual environment.
 
 You can use the ``dg scaffold defs`` command to scaffold a new asset underneath the ``defs`` folder. In this example, we scaffold an asset named ``my_asset.py`` and write it to the ``defs/assets`` directory:
 

--- a/docs/sphinx/sections/api/apidocs/dagster/assets.rst
+++ b/docs/sphinx/sections/api/apidocs/dagster/assets.rst
@@ -63,7 +63,7 @@ Dependencies
 Asset jobs
 ----------
 
-`Asset jobs <https://docs.dagster.io/guides/build/assets/asset-jobs>`_ enable the automation of asset materializations.  Dagster's `asset selection syntax <https://docs.dagster.io/guides/build/assets/asset-selection-syntax>`_ can be used to select assets and assign them to a job.
+`Asset jobs <https://docs.dagster.io/guides/build/jobs/asset-jobs>`_ enable the automation of asset materializations.  Dagster's `asset selection syntax <https://docs.dagster.io/guides/build/assets/asset-selection-syntax>`_ can be used to select assets and assign them to a job.
 
 .. autofunction:: define_asset_job
 
@@ -72,7 +72,7 @@ Asset jobs
 Code locations
 --------------
 
-Loading assets and asset jobs into a `code location <https://docs.dagster.io/guides/deploy/code-locations>`_ makes them available to Dagster tools like the UI, CLI, and GraphQL API.
+Loading assets and asset jobs into a `code location <https://docs.dagster.io/deployment/code-locations>`_ makes them available to Dagster tools like the UI, CLI, and GraphQL API.
 
 .. autofunction:: load_assets_from_modules
 

--- a/docs/sphinx/sections/api/apidocs/dagster/external-assets-instance-api.rst
+++ b/docs/sphinx/sections/api/apidocs/dagster/external-assets-instance-api.rst
@@ -39,4 +39,4 @@ External asset events can be recorded using :py:func:`DagsterInstance.report_run
 REST API
 --------
 
-Refer to the `External assets REST API reference <https://docs.dagster.io/api/python-api/external-assets-rest-api>`_ for information and examples on the available APIs.
+Refer to the `External assets REST API reference <https://docs.dagster.io/api/rest-apis/external-assets-rest-api>`_ for information and examples on the available APIs.

--- a/docs/sphinx/sections/api/apidocs/dagster/metadata.rst
+++ b/docs/sphinx/sections/api/apidocs/dagster/metadata.rst
@@ -72,7 +72,7 @@ Code references
 ^^^^^^^^^^^^^^^
 
 The following functions are used to attach source code references to your assets.
-For more information, refer to the `Linking to asset definition code with code references <https://docs.dagster.io/guides/dagster/code-references>`_ guide.
+For more information, refer to the `Linking to asset definition code with code references <https://docs.dagster.io/guides/build/assets/metadata-and-tags#source-code>`_ guide.
 
 
 .. autofunction:: with_source_code_references

--- a/docs/sphinx/sections/api/apidocs/dagster/pipes.rst
+++ b/docs/sphinx/sections/api/apidocs/dagster/pipes.rst
@@ -7,7 +7,7 @@ Dagster Pipes
 
 For a detailed look at the Pipes process, including how to customize it, refer to the `Dagster Pipes details and customization guide <https://docs.dagster.io/guides/build/external-pipelines/dagster-pipes-details-and-customization>`__.
 
-**Looking to write code in an external process?** Refer to the API reference for the separately-installed `dagster-pipes <https://docs.dagster.io/api/python-api/libraries/dagster-pipes>`_ library. 
+**Looking to write code in an external process?** Refer to the API reference for the separately-installed `dagster-pipes <https://docs.dagster.io/api/libraries/dagster-pipes>`_ library. 
 
 ----
 

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-dask.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-dask.rst
@@ -1,6 +1,6 @@
 Dask (dagster-dask)
 -------------------
-See also the `Dask deployment guide <https://docs.dagster.io/deployment/guides/dask>`_.
+See also the `Dask deployment guide <https://docs.dagster.io/deployment/execution/dask>`_.
 
 
 

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-dbt.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-dbt.rst
@@ -8,7 +8,7 @@ data assets that depend on specific dbt models, or to define the computation req
 the sources that your dbt models depend on.
 
 Related documentation pages: `dbt <https://docs.dagster.io/integrations/libraries/dbt>`_ and
-`dbt Cloud <https://docs.dagster.io/integrations/dbt-cloud>`_.
+`dbt Cloud <https://docs.dagster.io/integrations/libraries/dbt/dbt-cloud>`_.
 
 .. currentmodule:: dagster_dbt
 

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-k8s.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-k8s.rst
@@ -2,7 +2,7 @@
 Kubernetes (dagster-k8s)
 ========================
 
-See also the `Kubernetes deployment guide <https://docs.dagster.io/guides/deploy/deployment-options/kubernetes>`_.
+See also the `Kubernetes deployment guide <https://docs.dagster.io/deployment/oss/deployment-options/kubernetes>`_.
 
 This library contains utilities for running Dagster with Kubernetes. This includes a Python API
 allowing the webserver to launch runs as Kubernetes Jobs, as well as a Helm chart you can use as the basis

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-pipes.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-pipes.rst
@@ -7,7 +7,7 @@ The ``dagster-pipes`` library is intended for inclusion in an external process t
 
 For a detailed look at the Pipes process, including how to customize it, refer to the `Dagster Pipes details and customization guide <https://docs.dagster.io/guides/build/external-pipelines/dagster-pipes-details-and-customization>`__.
 
-**Looking to set up a Pipes client in Dagster?** Refer to the `Dagster Pipes API reference <https://docs.dagster.io/api/python-api/libraries/dagster-pipes>`_.
+**Looking to set up a Pipes client in Dagster?** Refer to the `Dagster Pipes API reference <https://docs.dagster.io/api/libraries/dagster-pipes>`_.
 
 **Note**: This library isn't included with ``dagster`` and must be `installed separately <https://pypi.org/project/dagster-pipes>`_.
 

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-snowflake-pandas.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-snowflake-pandas.rst
@@ -10,7 +10,7 @@ your data warehouse.
 
 Related Guides:
 
-* `Using Dagster with Snowflake guide <https://docs.dagster.io/integrations/snowflake>`_
+* `Using Dagster with Snowflake guides <https://docs.dagster.io/integrations/libraries/snowflake>`_
 * `Snowflake I/O manager reference <https://docs.dagster.io/integrations/libraries/snowflake/reference>`_
 
 .. currentmodule:: dagster_snowflake_pandas

--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-snowflake.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-snowflake.rst
@@ -12,7 +12,7 @@ Related Guides:
 
 * `Using Dagster with Snowflake <https://docs.dagster.io/integrations/libraries/snowflake>`_
 * `Snowflake I/O manager reference <https://docs.dagster.io/integrations/libraries/snowflake/reference>`_
-* `Transitioning data pipelines from development to production <https://docs.dagster.io/guides/deploy/dev-to-prod>`_
+* `Transitioning data pipelines from development to production <https://docs.dagster.io/guides/operate/dev-to-prod>`_
 * `Testing against production with Dagster+ Branch Deployments <https://docs.dagster.io/deployment/dagster-plus/ci-cd/branch-deployments>`_
 
 

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -589,6 +589,10 @@
       "destination": "/api/clis/dagster-cloud-cli"
     },
     {
+      "source": "/deployment/dagster-plus/management/dagster-cloud-cli",
+      "destination": "/api/clis/dagster-cloud-cli"
+    },
+    {
       "source": "/dagster-plus/developing-testing/code-locations",
       "destination": "/deployment/code-locations"
     },
@@ -3068,7 +3072,7 @@
     },
     {
       "source": "/api/python-api/external-assets-rest-api",
-      "destination": "/api/dagster/external-assets-rest-api"
+      "destination": "/api/rest-apis/external-assets-rest-api"
     },
     {
       "source": "/api/python-api/graphs",


### PR DESCRIPTION
## Summary & Motivation

Replace redirects with destination links and fix a few 404ing docs links in docs surfaced in Algolia crawler report.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
