### PR TITLE
Fix broken docs build because of lack of claude sdk include

### DIFF
--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -1,2 +1,3 @@
   sphinx>=8,<9
   sphinx_toolbox
+  claude_code_sdk


### PR DESCRIPTION
## Summary & Motivation

Fixes broken API docs build by adding new requirement to sphinx requirements file.

## How I Tested These Changes

Local build.

## Changelog

> Insert changelog entry or delete this section.
