### PR TITLE
Remove automatic flaky retries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ markers = [
 ]
 
 timeout = 240
-addopts = "-ra --force-flaky --max-runs=2 --no-success-flaky-report"
+addopts = "-ra"
 
 # ########################
 # ##### RUFF


### PR DESCRIPTION
After letting this bake for quite a while, I'm not actually convinced it's providing much value:

https://github.com/dagster-io/dagster/pull/30261

Let's go back to just running each test once and more aggressively applying our own flakiness annotations when appropriate.

In particular, https://buildkite.com/organizations/dagster/analytics/suites/dagster/tests/41011484-ec45-8168-98bb-ce4a568ef784 is a weird one (which I'm looking into separately),but the way this retries on flakes does odd things with our test muting.