### PR TITLE
Skip test_build_docs_success_in_published_package

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_docs_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_docs_commands.py
@@ -135,6 +135,9 @@ def test_build_docs_success():
         assert (venv_path / "built_docs" / "index.html").exists()
 
 
+@pytest.mark.skip(
+    "While we figure out why this is failing remotely: https://buildkite.com/organizations/dagster/analytics/suites/dagster/tests/41011484-ec45-8168-98bb-ce4a568ef784"
+)
 def test_build_docs_success_in_published_package():
     # Tests that the logic to copy the docs webapp to the dagster-dg-cli Python package works
     with (


### PR DESCRIPTION
This has been failing for some time now. Since ~July 22.

It's muted in Buildkite and backlogged linear but hasn't been fixed yet.

It does look like it succeeds locally so my suspicion is something Buildkite related. In recent days, I've noticed it falling through our soft mute in Buildkite more frequently (presumably us getting rate limited? Or some weird interaction with its auto-retry https://github.com/dagster-io/dagster/pull/31851)? I'm going to hard skip and see if I can figure out why it's actually failing.