### PR TITLE
Run test_docs_component_type_success in isolated dir

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/docs.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/docs.py
@@ -143,7 +143,14 @@ def build_docs_command(
 
         with yaspin(text="Building docs", color="blue") as spinner:
             spinner.start()
-            subprocess.check_output(["yarn", "build"])
+            try:
+                subprocess.check_output(["yarn", "build"], stderr=subprocess.STDOUT, text=True)
+            except subprocess.CalledProcessError as e:
+                spinner.fail("✗")
+                click.echo(f"Error building docs (exit code {e.returncode}):")
+                click.echo(f"Command: {' '.join(e.cmd)}")
+                click.echo(f"Output:\n{e.output}")
+                raise
             spinner.ok("✓")
 
         Path(output_dir).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
I suspect this is failing on Buildkite because of how we mount /tmp to the running container although I don't quite know why that matters. Potentially collision between multiple tests running using the same /tmp/.venv?

https://buildkite.com/dagster/dagster-dagster/builds/132825#0198c330-fb36-4ec7-a6f6-ddd4f5f708ba/474-540

Regardless, I'd like to see if this works. The test has always succeeded locally but reliably fails remotely (it's just been muted for a while).