### PR TITLE
Add a few flaky annotations

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_sling_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_sling_component.py
@@ -5,6 +5,7 @@ from contextlib import ExitStack
 from pathlib import Path
 from typing import Any, Optional
 
+import pytest
 from dagster_dg_core.utils import activate_venv
 
 from dagster._utils.env import environ
@@ -33,6 +34,7 @@ SNIPPETS_DIR = (
 )
 
 
+@pytest.mark.flaky(max_runs=2)
 def test_components_docs_sling_workspace(
     update_snippets: bool,
 ) -> None:

--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/test_components_docs.py
@@ -51,6 +51,7 @@ _MASK_EMPTY_WARNINGS = (r"\n +warnings.warn\(message\)\n", "")
 
 
 @pytest.mark.parametrize("package_manager", ["pip", "uv"])
+@pytest.mark.flaky(max_runs=2)
 def test_components_docs_index(
     package_manager: DgTestPackageManager, update_snippets: bool
 ) -> None:

--- a/python_modules/dagster/dagster_tests/components_tests/registry_tests/test_registry.py
+++ b/python_modules/dagster/dagster_tests/components_tests/registry_tests/test_registry.py
@@ -101,6 +101,7 @@ def _get_editable_package_root(pkg_name: str) -> str:
 # ########################
 
 
+@pytest.mark.flaky(max_runs=2)
 def test_components_from_dagster():
     common_deps: list[str] = []
     for pkg_name in [

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
@@ -230,6 +230,7 @@ _EXPECTED_PLUGIN_JSON = textwrap.dedent("""
 """).strip()
 
 
+@pytest.mark.flaky(max_runs=2)
 def test_list_registry_modules_success():
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,


### PR DESCRIPTION
I disabled universal retry of flaky tests: https://github.com/dagster-io/dagster/pull/31851

Turns out it was papering over these truly flaky tests that reliably fail on the first run and succeed on retry:

https://buildkite.com/organizations/dagster/analytics/suites/dagster/tests/0c275882-e3b8-8565-a32a-475c10c6e440 https://buildkite.com/organizations/dagster/analytics/suites/dagster/tests/b350f957-b7f6-8a53-ab27-9ab5daadf138 https://buildkite.com/organizations/dagster/analytics/suites/dagster/tests/215d7743-eed6-8916-b7a1-c8440bbe7b84 https://buildkite.com/organizations/dagster/analytics/suites/dagster/tests/0971e220-0f4b-807c-805b-8d130823ca68

Re-adding a narrow flaky annotation for now and I'll throw a card in Linear to actually address the source of these.