### PR TITLE
[eslint-config] Updates for v1.0.20

### DIFF
--- a/js_modules/dagster-ui/packages/eslint-config/CHANGES.md
+++ b/js_modules/dagster-ui/packages/eslint-config/CHANGES.md
@@ -1,3 +1,8 @@
+## 1.0.20 (August 19, 2025)
+
+- Disallow TypeScript non-null assertions.
+- Guard against importing `dayjs` extensions directly from `dayjs`, to ensure that our configurations are used.
+
 ## 1.0.19 (January 7, 2025)
 
 - Added custom rule to autocorrect `shared` paths to avoid internal build failures.

--- a/js_modules/dagster-ui/packages/eslint-config/package.json
+++ b/js_modules/dagster-ui/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dagster-io/eslint-config",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Shared eslint configuration for @dagster-io",
   "license": "Apache-2.0",
   "main": "index.js",


### PR DESCRIPTION
## Summary & Motivation

The internal app is a couple versions behind on our eslint-config. Update the package to get recent changes available to install there.

## How I Tested These Changes

None, but we've been using this configuration in OSS.