### PR TITLE
[7/n] Update get_defs_state_key functionality

### DIFF
--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
@@ -167,24 +167,24 @@ def test_autoload_single_file(component_tree: ComponentTree) -> None:
     defs = component_tree.build_defs()
     assert component_tree.has_built_all_defs()
 
-    assert component_tree.component_tree_dependencies.get_direct_load_dependents_of_component(
+    assert component_tree.component_tree_state_tracker.get_direct_load_dependents_of_component(
         component_tree.defs_module_path,
         ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None),
     ) == {ComponentPath(file_path=Path("single_file"), instance_key=None)}
 
-    assert component_tree.component_tree_dependencies.get_direct_defs_dependents_of_component(
+    assert component_tree.component_tree_state_tracker.get_direct_defs_dependents_of_component(
         component_tree.defs_module_path,
         ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None),
     ) == {ComponentPath(file_path=Path("single_file"), instance_key=None)}
 
-    assert component_tree.component_tree_dependencies.get_direct_load_dependents_of_component(
+    assert component_tree.component_tree_state_tracker.get_direct_load_dependents_of_component(
         component_tree.defs_module_path,
         ComponentPath(file_path=Path("single_file"), instance_key=None),
     ) == {
         ComponentPath(file_path=Path("."), instance_key=None),
     }
 
-    assert component_tree.component_tree_dependencies.get_direct_load_dependents_of_component(
+    assert component_tree.component_tree_state_tracker.get_direct_load_dependents_of_component(
         component_tree.defs_module_path,
         ComponentPath(file_path=Path("__init__.py"), instance_key=None),
     ) == {

--- a/python_modules/dagster/dagster_tests/components_tests/state_backed_component_tests/test_state_backed_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/state_backed_component_tests/test_state_backed_component.py
@@ -1,16 +1,24 @@
 import asyncio
 import json
 import random
+import shutil
 from pathlib import Path
 from typing import Optional
 
 import dagster as dg
+import pytest
 from dagster._core.instance_for_test import instance_for_test
 from dagster.components.component.state_backed_component import StateBackedComponent
+from dagster.components.core.component_tree import ComponentTreeException
 from dagster.components.testing.utils import create_defs_folder_sandbox
 
 
 class MyStateBackedComponent(StateBackedComponent, dg.Model, dg.Resolvable):
+    defs_state_key: Optional[str] = None
+
+    def get_defs_state_key(self) -> str:
+        return self.defs_state_key or super().get_defs_state_key()
+
     def build_defs_from_state(
         self, context: dg.ComponentLoadContext, state_path: Optional[Path]
     ) -> dg.Definitions:
@@ -21,7 +29,10 @@ class MyStateBackedComponent(StateBackedComponent, dg.Model, dg.Resolvable):
                 state = json.load(f)
             value = state["value"]
 
-        @dg.asset(metadata={"state_value": value})
+        @dg.asset(
+            name=f"the_asset_{context.component_path.file_path.stem}",
+            metadata={"state_value": value},
+        )
         def the_asset():
             return dg.MaterializeResult(metadata={"foo": value})
 
@@ -36,7 +47,7 @@ class MyStateBackedComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         def refresh_state_op():
             asyncio.run(self.refresh_state())
 
-        @dg.job
+        @dg.job(name=f"state_refresh_job_{context.component_path.file_path.stem}")
         def state_refresh_job():
             refresh_state_op()
 
@@ -56,6 +67,7 @@ def test_simple_state_backed_component() -> None:
             defs_yaml_contents={
                 "type": "dagster_tests.components_tests.state_backed_component_tests.test_state_backed_component.MyStateBackedComponent",
             },
+            defs_path="foo",
         )
 
         # initial load, no state written, so use "initial"
@@ -70,7 +82,7 @@ def test_simple_state_backed_component() -> None:
             # materialize the asset, the random number should be preserved
             result = dg.materialize([defs.get_assets_def(spec.key)], instance=instance)
             assert result.success
-            mats = result.asset_materializations_for_node("the_asset")
+            mats = result.asset_materializations_for_node("the_asset_foo")
             assert len(mats) == 1
             assert mats[0].metadata["foo"] == dg.TextMetadataValue(original_metadata_value)
 
@@ -82,7 +94,7 @@ def test_simple_state_backed_component() -> None:
             assert spec.metadata["state_value"] == original_metadata_value
 
             # now execute the job to refresh the state
-            refresh_job = defs.get_job_def("state_refresh_job")
+            refresh_job = defs.get_job_def("state_refresh_job_foo")
             refresh_job.execute_in_process(instance=instance)
 
         # now we reload the definitions, state should be updated to something random
@@ -91,3 +103,43 @@ def test_simple_state_backed_component() -> None:
             spec = specs[0]
             new_metadata_value = spec.metadata["state_value"]
             assert new_metadata_value != original_metadata_value
+
+
+def test_multiple_components() -> None:
+    with instance_for_test(), create_defs_folder_sandbox() as sandbox:
+        sandbox.scaffold_component(
+            component_cls=MyStateBackedComponent,
+            defs_yaml_contents={
+                "type": "dagster_tests.components_tests.state_backed_component_tests.test_state_backed_component.MyStateBackedComponent",
+            },
+            defs_path="first",
+        )
+
+        second_component_path = sandbox.scaffold_component(
+            component_cls=MyStateBackedComponent,
+            defs_yaml_contents={
+                "type": "dagster_tests.components_tests.state_backed_component_tests.test_state_backed_component.MyStateBackedComponent",
+            },
+            defs_path="second",
+        )
+
+        with pytest.raises(
+            ComponentTreeException,
+            match="MyStateBackedComponent",
+        ):
+            with sandbox.build_all_defs():
+                pass
+
+        # now update the defs_state_key
+        shutil.rmtree(second_component_path)
+        sandbox.scaffold_component(
+            component_cls=MyStateBackedComponent,
+            defs_yaml_contents={
+                "type": "dagster_tests.components_tests.state_backed_component_tests.test_state_backed_component.MyStateBackedComponent",
+                "attributes": {"defs_state_key": "MyStateBackedComponent_but_different"},
+            },
+            defs_path="second",
+        )
+
+        with sandbox.build_all_defs() as defs:
+            assert len(defs.get_all_asset_specs()) == 2

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
@@ -13,10 +13,8 @@ from dagster.components.core.decl import (
     PythonFileDecl,
 )
 from dagster.components.core.defs_module import ComponentPath, PythonFileComponent
-from dagster_shared.record import record
 
 
-@record(checked=False)
 class MockComponentTree(ComponentTree):
     def set_root_decl(self, root_decl: ComponentDecl):
         setattr(self, "_root_decl", root_decl)

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/state_versions/test_state_versions_grpc.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/state_versions/test_state_versions_grpc.py
@@ -59,13 +59,13 @@ def setup_test_environment(project_dir, instance):
         p.write_text("hi")
         defs_state_storage.upload_state_from_path(
             path=p,
-            key="the_component",
+            key="SampleStateBackedComponent",
             version="abcde-12345",
         )
 
     original_state_versions = defs_state_storage.get_latest_defs_state_info()
     assert original_state_versions and len(original_state_versions.info_mapping) == 1
-    assert original_state_versions.get_version("the_component") == "abcde-12345"
+    assert original_state_versions.get_version("SampleStateBackedComponent") == "abcde-12345"
 
     # add some new state with a different value, should NOT use this
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -73,7 +73,7 @@ def setup_test_environment(project_dir, instance):
         p.write_text("blah")
         defs_state_storage.upload_state_from_path(
             path=p,
-            key="the_component",
+            key="SampleStateBackedComponent",
             version="fghij-67890",
         )
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/sample_state_backed_component.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/sample_state_backed_component.py
@@ -7,6 +7,13 @@ from dagster.components.component.state_backed_component import StateBackedCompo
 
 class SampleStateBackedComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     fail_write: bool = False
+    defs_state_key_id: Optional[str] = None
+
+    def get_defs_state_key(self) -> str:
+        default_key = super().get_defs_state_key()
+        if self.defs_state_key_id is None:
+            return default_key
+        return f"{default_key}[{self.defs_state_key_id}]"
 
     def build_defs_from_state(
         self, context: dg.ComponentLoadContext, state_path: Optional[Path]

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/defs_state_info.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/defs_state_info.py
@@ -41,11 +41,13 @@ class DefsStateInfo:
 
     @staticmethod
     def from_dict(val: dict[str, Any]) -> "DefsStateInfo":
+        """Used for converting from the user-facing dict representation."""
         return DefsStateInfo(
             info_mapping={key: DefsKeyStateInfo.from_dict(info) for key, info in val.items()}
         )
 
     def to_dict(self) -> dict[str, Any]:
+        """Used for converting to the user-facing dict representation."""
         return {key: info.to_dict() for key, info in self.info_mapping.items()}
 
     def get_version(self, key: str) -> Optional[str]:


### PR DESCRIPTION
## Summary & Motivation

We want this to be based on something more stable than the path to the component. This uses the class name, which feels like a fairly-straightforward option.

This PR adds in error-checking functionality, providing a useful error if/when multiple components are detected with the same defs state key.

Also fixes an issue w/ the ComponentTreeDependencyTracker where a single instance was shared across all ComponentTrees (and renames it to be more general)

## How I Tested These Changes

## Changelog

NOCHANGELOG
