### PR TITLE
Run pyright on larger Buildkite queue

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -146,6 +146,7 @@ def build_repo_wide_pyright_steps() -> list[StepConfiguration]:
                     "make pyright",
                 )
                 .skip_if(skip_if_no_python_changes(overrides=["pyright"]))
+                # Run on a larger instance
                 .on_queue(BuildkiteQueue.DOCKER)
                 .build(),
                 add_test_image(


### PR DESCRIPTION
pyright is the slowest step in our build. I'm curious what happens if we just give it more resources.