### PR TITLE
Allow for partial ComponentTreeReloading

### DIFF
--- a/python_modules/dagster/dagster_tests/components_tests/component_tree_tests/test_component_tree_reloading.py
+++ b/python_modules/dagster/dagster_tests/components_tests/component_tree_tests/test_component_tree_reloading.py
@@ -1,0 +1,98 @@
+import dagster as dg
+import pytest
+from dagster.components.core.component_tree import ComponentTreeException
+from dagster.components.testing import create_defs_folder_sandbox
+
+
+class SingletonComponent(dg.Component):
+    """Forthright and by the book."""
+
+    def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
+        # this should only ever be called once
+        sentinel_path = context.component_path.file_path / "sentinel.txt"
+        assert not sentinel_path.exists()
+        sentinel_path.touch()
+
+        return dg.Definitions(assets=[dg.AssetSpec("singleton")])
+
+
+class DuplicitousComponent(dg.Component):
+    """Extremely sneaky."""
+
+    def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
+        # keeps track of how many times this has been called
+        postfix = 0
+        while True:
+            sentinel_path = context.component_path.file_path / str(postfix)
+            if not sentinel_path.exists():
+                sentinel_path.touch()
+                assert sentinel_path.exists()
+                break
+            postfix += 1
+
+        return dg.Definitions(assets=[dg.AssetSpec(f"dup_{postfix}")])
+
+
+def test_reload_component_tree_cached() -> None:
+    with create_defs_folder_sandbox() as sandbox:
+        singleton_path = sandbox.scaffold_component(
+            component_cls=SingletonComponent,
+            defs_yaml_contents={
+                "type": "dagster_tests.components_tests.component_tree_tests.test_component_tree_reloading.SingletonComponent",
+            },
+        )
+
+        duplicitous_path = sandbox.scaffold_component(
+            component_cls=DuplicitousComponent,
+            defs_yaml_contents={
+                "type": "dagster_tests.components_tests.component_tree_tests.test_component_tree_reloading.DuplicitousComponent",
+            },
+        )
+
+        with sandbox.build_component_tree() as tree:
+            defs1 = tree.build_defs()
+            assert len(defs1.get_all_asset_specs()) == 2
+            keys = {spec.key for spec in defs1.get_all_asset_specs()}
+            assert keys == {dg.AssetKey("singleton"), dg.AssetKey("dup_0")}
+
+            # should be cached, will not trip the singleton assertion
+            defs2 = tree.build_defs()
+            assert defs1 is defs2
+
+            # ... and so on
+            defs3 = tree.build_defs()
+            assert defs1 is defs3
+
+            # now invalidate duplicitous
+            tree.state_tracker.invalidate_cache_key(
+                defs_module_path=tree.defs_module_path,
+                component_path=duplicitous_path,
+            )
+
+            defs4 = tree.build_defs()
+            assert defs1 is not defs4
+            keys = {spec.key for spec in defs4.get_all_asset_specs()}
+            # now have dup_1 instead of dup0
+            assert keys == {dg.AssetKey("singleton"), dg.AssetKey("dup_1")}
+
+            # invalidate duplicitous again
+            tree.state_tracker.invalidate_cache_key(
+                defs_module_path=tree.defs_module_path,
+                component_path=duplicitous_path,
+            )
+
+            defs5 = tree.build_defs()
+            assert defs1 is not defs5
+            keys = {spec.key for spec in defs5.get_all_asset_specs()}
+            # now have dup_2 instead of dup0
+            assert keys == {dg.AssetKey("singleton"), dg.AssetKey("dup_2")}
+
+            # now invalidate singleton
+            tree.state_tracker.invalidate_cache_key(
+                defs_module_path=tree.defs_module_path,
+                component_path=singleton_path,
+            )
+
+            # should raise an exception because we end up calling singleton again
+            with pytest.raises(ComponentTreeException):
+                tree.build_defs()

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
@@ -167,24 +167,24 @@ def test_autoload_single_file(component_tree: ComponentTree) -> None:
     defs = component_tree.build_defs()
     assert component_tree.has_built_all_defs()
 
-    assert component_tree.component_tree_state_tracker.get_direct_load_dependents_of_component(
+    assert component_tree.state_tracker.get_direct_load_dependents_of_component(
         component_tree.defs_module_path,
         ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None),
     ) == {ComponentPath(file_path=Path("single_file"), instance_key=None)}
 
-    assert component_tree.component_tree_state_tracker.get_direct_defs_dependents_of_component(
+    assert component_tree.state_tracker.get_direct_defs_dependents_of_component(
         component_tree.defs_module_path,
         ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None),
     ) == {ComponentPath(file_path=Path("single_file"), instance_key=None)}
 
-    assert component_tree.component_tree_state_tracker.get_direct_load_dependents_of_component(
+    assert component_tree.state_tracker.get_direct_load_dependents_of_component(
         component_tree.defs_module_path,
         ComponentPath(file_path=Path("single_file"), instance_key=None),
     ) == {
         ComponentPath(file_path=Path("."), instance_key=None),
     }
 
-    assert component_tree.component_tree_state_tracker.get_direct_load_dependents_of_component(
+    assert component_tree.state_tracker.get_direct_load_dependents_of_component(
         component_tree.defs_module_path,
         ComponentPath(file_path=Path("__init__.py"), instance_key=None),
     ) == {


### PR DESCRIPTION
## Summary & Motivation

**NOTE:** this implementation is pretty jank, and mostly a proof of concept / addition of a test case prior to the next PR in the stack, which formalizes this caching concept a bit more. Arguably, I should just merge these prs together, but I do a bunch of other refactoring in the upstack PR as well, so I didn't want the core logical bit to be tied into that. 

this reworks https://github.com/dagster-io/dagster/pull/31482 to have a more explicit concept of a "cache key" that is wired through any cached methods / properties. Each path has an associated cache key, allowing us to update this cache key out of band when certain events happen.

In this pr, the cache key will only ever get invalidated manually, but upstack, we'll add functionality to invalidate the cache key when the state of a state-backed component is updated. this will make it possible to do a partial reload of only the impacted components.

## How I Tested These Changes

## Changelog

NOCHANGELOG
