### PR TITLE
[docs] add Dagster+ agent resources to ECS + k8s guides

### DIFF
--- a/docs/docs/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference.md
@@ -14,7 +14,7 @@ This reference describes the various configuration options Dagster+ currently su
 
 ## Per-agent configuration
 
-We expose `AgentMemory`, `AgentCpu` fields in the Cloud Formation templates to configure the resources that the Dagster+ agent can use.
+We expose `AgentMemory`, and `AgentCpu` fields in the Cloud Formation templates to configure the resources that the Dagster+ agent can use.
 
 ## Per-location configuration
 

--- a/docs/docs/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference.md
@@ -12,6 +12,10 @@ This guide is applicable to Dagster+.
 
 This reference describes the various configuration options Dagster+ currently supports for [Amazon ECS agents](/deployment/dagster-plus/hybrid/amazon-ecs).
 
+## Per-agent configuration
+
+We expose `AgentMemory`, `AgentCpu` fields in the Cloud Formation templates to configure the resources that the Dagster+ agent can use.
+
 ## Per-location configuration
 
 When [adding a code location](/deployment/code-locations) to Dagster+ with an Amazon ECS agent, you can use the `container_context` key on the location configuration to add additional ECS-specific configuration that will be applied to any ECS tasks associated with that code location.

--- a/docs/docs/deployment/dagster-plus/hybrid/amazon-ecs/existing-vpc.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/amazon-ecs/existing-vpc.md
@@ -61,6 +61,8 @@ After the stack is installed, you'll be prompted to configure it. In the ECS wiz
 - **Deploy VPC Subnet**: A public subnet of the existing VPC to deploy the agent into.
 - **Existing ECS Cluster**: Optionally, the name of an existing ECS cluster to deploy the agent in. Leave blank to create a new cluster
 - **Task Launch Type**: Optionally, the launch type to use for new tasks created by the agent (FARGATE or EC2). Defaults to FARGATE.
+- **AgentCPU**: The amount of AWS CPU to allocate to the agent. Defaults to 256 CPU units.
+- **AgentMemory**: The amount of memory to allocate to the agent. Defaults to 1024 MiB.
 
 The page should look similar to the following image. In this example, our organization name is `hooli` and our deployment is `prod`:
 

--- a/docs/docs/deployment/dagster-plus/hybrid/amazon-ecs/new-vpc.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/amazon-ecs/new-vpc.md
@@ -72,6 +72,8 @@ After the stack is installed, you'll be prompted to configure it. In the ECS wiz
 - **Dagster+ Deployment**: Enter the name of the Dagster+ deployment you want to use. Leave this field empty if the agent will only serve Branch deployments.
 - **Enable Branch Deployments**: Whether to have this agent serve your ephemeral [Branch deployments](/deployment/dagster-plus/ci-cd/branch-deployments). Only a single agent should have this setting enabled.
 - **Agent Token**: Paste the agent token you generated in [Step 1](#step-1-generate-a-dagster-agent-token).
+- **AgentCPU**: The amount of AWS CPU to allocate to the agent. Defaults to 256 CPU units.
+- **AgentMemory**: The amount of memory to allocate to the agent. Defaults to 1024 MiB.
 
 The page should look similar to the following image. In this example, our organization name is `hooli` and our deployment is `prod`:
 

--- a/docs/docs/deployment/dagster-plus/hybrid/index.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/index.md
@@ -44,10 +44,10 @@ If you're not sure which agent to use, we recommend the [Dagster+ Kubernetes age
 
 The Dagster+ agent acts as a message relay and executor that picks up messages from Dagster+ and launches or queries your user code.
 
-#### Infrastructure Management
+#### Infrastructure management
 
 - Launches and manages code servers for each code location
--Launches run workers (new containers/processes) when runs need to be executed
+- Launches run workers (new containers/processes) when runs need to be executed
 - Acts as the run launcher, spinning up isolated tasks/pods/processes for each run
 
 #### Communication
@@ -78,8 +78,8 @@ You can do the following to make your Dagster+ Hybrid deployment more secure:
 - [Disable log forwarding](/deployment/dagster-plus/management/customizing-agent-settings#disabling-compute-logs)
 - [Manage tokens](/deployment/dagster-plus/management/tokens/agent-tokens)
 
-### Recommended Compute Resources for New Dagster+ Deployment
+### Recommended compute resources for new Dagster+ deployment
 
 - Agent: 256 CPU, 1024 memory
-- Code Server: 256 CPU, 1024 memory
+- Code server: 256 CPU, 1024 memory
 - Runs: 4 vCPU cores, 8-16 GB of RAM depending on the workload

--- a/docs/docs/deployment/dagster-plus/hybrid/index.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/index.md
@@ -40,6 +40,21 @@ If you're not sure which agent to use, we recommend the [Dagster+ Kubernetes age
 
 ## What you'll see in your environment
 
+### Agent
+
+The Dagster+ agent acts as a message relay and executor that picks up messages from Dagster+ and launches or queries your user code.
+
+#### Infrastructure Management
+
+- Launches and manages code servers for each code location
+-Launches run workers (new containers/processes) when runs need to be executed
+- Acts as the run launcher, spinning up isolated tasks/pods/processes for each run
+
+#### Communication
+
+- Receives messages and instructions from Dagster+ about what work needs to be done
+- Sends metadata back to Dagster+ about launched runs and code server status
+
 ### Code location servers
 
 Dagster+ runs your Dagster projects through code locations. To add a code location, see the [code locations documentation](/deployment/code-locations).
@@ -62,3 +77,9 @@ You can do the following to make your Dagster+ Hybrid deployment more secure:
 
 - [Disable log forwarding](/deployment/dagster-plus/management/customizing-agent-settings#disabling-compute-logs)
 - [Manage tokens](/deployment/dagster-plus/management/tokens/agent-tokens)
+
+### Recommended Compute Resources for New Dagster+ Deployment
+
+- Agent: 256 CPU, 1024 memory
+- Code Server: 256 CPU, 1024 memory
+- Runs: 4 vCPU cores, 8-16 GB of RAM depending on the workload

--- a/docs/docs/deployment/dagster-plus/hybrid/kubernetes/configuration.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/kubernetes/configuration.md
@@ -18,6 +18,23 @@ helm show values dagster-plus/dagster-plus-agent
 
 You can also view the chart values on [ArtifactHub](https://artifacthub.io/packages/helm/dagster-cloud/dagster-cloud-agent?modal=values).
 
+## Agent configuration
+
+The [`dagsterCloudAgent`](https://artifacthub.io/packages/helm/dagster-cloud/dagster-cloud-agent?modal=values) value of the helm chart provides the ability to add configuration to the Dagster+ agent.
+
+The following `values.yaml` example file shows how to configure the resources for a Dagster+ agent:
+
+```yaml
+dagsterCloudAgent:
+  resources:
+    requests:
+      cpu: "1000m"
+      memory: "2Gi"
+    limits:
+      cpu: "2000m"
+      memory: "4Gi"
+```
+
 ## Per-deployment configuration
 
 The [`workspace`](https://artifacthub.io/packages/helm/dagster-cloud/dagster-cloud-agent?modal=values) value of the Helm chart provides the ability to add configuration for all jobs that are spun up by the agent, across all repositories. To add secrets or mounted volumes to all Kubernetes Pods, you can specify your desired configuration under this value.

--- a/docs/docs/deployment/dagster-plus/hybrid/kubernetes/configuration.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/kubernetes/configuration.md
@@ -20,7 +20,7 @@ You can also view the chart values on [ArtifactHub](https://artifacthub.io/packa
 
 ## Agent configuration
 
-The [`dagsterCloudAgent`](https://artifacthub.io/packages/helm/dagster-cloud/dagster-cloud-agent?modal=values) value of the helm chart provides the ability to add configuration to the Dagster+ agent.
+The [`dagsterCloudAgent`](https://artifacthub.io/packages/helm/dagster-cloud/dagster-cloud-agent?modal=values) value of the Helm chart provides the ability to add configuration to the Dagster+ agent.
 
 The following `values.yaml` example file shows how to configure the resources for a Dagster+ agent:
 


### PR DESCRIPTION
## Summary & Motivation

Adds sections on how to configure and what decent default values are for the Dagster+ agent CPU and memory usage. Adds documentation on how to the k8s and ECS agents. These concepts are not applicable to the Docker agent or the local agent.

## How I Tested These Changes

`yarn start`
