### PR TITLE
[ui] Insights v2 update line chart dialog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogHorizontalTopAssetsChart.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogHorizontalTopAssetsChart.module.css
@@ -1,19 +1,13 @@
 .container {
-  background-color: var(--color-background-default);
-  color: var(--color-text-default);
+  height: 100%;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  padding: 16px 24px;
-  height: 460px;
 }
 
-.table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 14px;
-  display: grid;
-  grid-template-columns: minmax(0, 3fr) minmax(0, 1fr) minmax(0, 1fr);
-  gap: 12px;
+.listContainer {
+  flex: 1;
+  overflow: hidden;
 }
 
 .tableValue {
@@ -23,4 +17,54 @@
 .distributionRow {
   background-color: var(--color-accent-blue);
   height: 20px;
+}
+
+.headerGrid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr;
+  padding: 0px 20px 8px 24px;
+}
+
+.headerGrid.hasCurrentData,
+.headerGrid.hasPreviousData {
+  grid-template-columns: 1fr 88px;
+}
+
+.headerGrid.change.change {
+  grid-template-columns: 1fr repeat(3, 88px);
+}
+
+.sortButton.sortButton {
+  font-size: 12px;
+  text-align: right;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  justify-content: flex-end;
+}
+
+.sortButton:first-child {
+  text-align: left;
+  justify-content: flex-start;
+}
+
+.sortButton.active {
+  color: var(--color-text-default);
+}
+
+.rightGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 88px);
+  gap: 12px;
+}
+
+.rightGrid.hasCurrentData,
+.rightGrid.hasPreviousData {
+  grid-template-columns: 88px;
+}
+
+.rightGrid.change.change {
+  grid-template-columns: repeat(3, 88px);
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogHorizontalTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogHorizontalTopAssetsChart.tsx
@@ -1,148 +1,267 @@
 import {
-  Body,
-  BodySmall,
   Box,
-  Button,
   Colors,
+  Container,
   Icon,
+  Inner,
+  ListItem,
   MiddleTruncate,
   Mono,
-  Spinner,
+  Row,
+  UnstyledButton,
 } from '@dagster-io/ui-components';
-import React, {useMemo, useState} from 'react';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import clsx from 'clsx';
+import React, {useMemo, useRef, useState} from 'react';
 import {Link} from 'react-router-dom';
 
 import styles from './AssetCatalogHorizontalTopAssetsChart.module.css';
+import {COMMON_COLLATOR} from '../../app/commonCollator';
 import {tokenToAssetKey} from '../../asset-graph/Utils';
+import {formatMetric} from '../../insights/formatMetric';
+import {ReportingUnitType} from '../../insights/types';
 import {numberFormatter} from '../../ui/formatters';
 import {assetDetailsPathForKey} from '../assetDetailsPathForKey';
 
-const PAGE_SIZE = 10;
+type SortBy = 'name' | 'current' | 'previous' | 'change';
+type SortDir = 'asc' | 'desc';
 
-const DistributionChartRow = ({maxValue, value}: {maxValue: number; value: number}) => {
-  const percentage = Math.round((value / maxValue) * 100);
-
-  return (
-    <Box flex={{direction: 'row'}}>
-      <div className={styles.distributionRow} style={{width: `${percentage}%`}} />
-    </Box>
-  );
+const getInitialSortBy = (currentData: MaybeData, previousData: MaybeData) => {
+  if (currentData && previousData) {
+    return 'change';
+  }
+  if (currentData) {
+    return 'current';
+  }
+  if (previousData) {
+    return 'previous';
+  }
+  return 'name';
 };
 
+const calculateChange = (current: number, previous: number) => {
+  if (previous === 0) {
+    return current === 0 ? 0 : 1;
+  }
+  return (current - previous) / previous;
+};
+
+const getChangeColor = (change: number) => {
+  if (change === 0) {
+    return Colors.textLight();
+  }
+  return change > 0 ? Colors.textGreen() : Colors.textRed();
+};
+
+type MaybeData = null | {labels: string[]; data: number[]};
+
+interface Props {
+  currentData: MaybeData;
+  previousData: MaybeData;
+  unitType: ReportingUnitType;
+}
+
 export const AssetCatalogHorizontalTopAssetsChart = React.memo(
-  ({
-    datasets,
-    unitType,
-    loading,
-  }: {
-    datasets: {labels: string[]; data: number[]};
-    unitType: string;
-    loading: boolean;
-  }) => {
-    const [page, setPage] = useState(0);
+  ({currentData, previousData, unitType}: Props) => {
+    const [sortBy, setSortBy] = useState<{by: SortBy; dir: SortDir}>(() => ({
+      by: getInitialSortBy(currentData, previousData),
+      dir: 'desc',
+    }));
 
-    const values = useMemo(() => {
-      return datasets.labels
-        .map((label, i) => ({
-          label,
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          value: datasets.data[i]!,
-        }))
-        .filter(({value}) => value !== 0)
-        .sort((a, b) => b.value - a.value);
-    }, [datasets.data, datasets.labels]);
+    const containerRef = useRef<HTMLDivElement>(null);
 
-    // Compute the max value from all values for consistent X axis scaling
-    const maxValue = useMemo(() => {
-      return values.length > 0 ? Math.max(...values.map(({value}) => value)) : undefined;
-    }, [values]);
+    const valueMap = useMemo(() => {
+      const currentMap = currentData
+        ? Object.fromEntries(
+            currentData.labels.map((label, ii) => [label, currentData.data[ii] ?? 0]),
+          )
+        : null;
+      const previousMap = previousData
+        ? Object.fromEntries(
+            previousData.labels.map((label, ii) => [label, previousData.data[ii] ?? 0]),
+          )
+        : null;
+      return {
+        current: currentMap,
+        previous: previousMap,
+      };
+    }, [currentData, previousData]);
 
-    const totalPages = Math.ceil(values.length / PAGE_SIZE);
+    const count = useMemo(() => {
+      const set = new Set([
+        ...(valueMap?.current ? Object.keys(valueMap.current) : []),
+        ...(valueMap?.previous ? Object.keys(valueMap.previous) : []),
+      ]);
+      return set.size;
+    }, [valueMap]);
 
-    const currentPageValues = useMemo(
-      () => values.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
-      [page, values],
-    );
+    const sorted = useMemo(() => {
+      const currentKeys = valueMap.current ? Object.keys(valueMap.current) : [];
+      const previousKeys = valueMap.previous ? Object.keys(valueMap.previous) : [];
+      const allKeys = Array.from(new Set([...currentKeys, ...previousKeys]));
+      return allKeys.sort((a, b) => {
+        if (sortBy.by === 'name') {
+          return sortBy.dir === 'desc'
+            ? COMMON_COLLATOR.compare(b, a)
+            : COMMON_COLLATOR.compare(a, b);
+        }
+
+        const currentA = valueMap.current?.[a] ?? 0;
+        const currentB = valueMap.current?.[b] ?? 0;
+        const previousA = valueMap.previous?.[a] ?? 0;
+        const previousB = valueMap.previous?.[b] ?? 0;
+        switch (sortBy.by) {
+          case 'current':
+            return sortBy.dir === 'desc' ? currentB - currentA : currentA - currentB;
+          case 'previous':
+            return sortBy.dir === 'desc' ? previousB - previousA : previousA - previousB;
+          case 'change': {
+            const changeA = calculateChange(currentA, previousA);
+            const changeB = calculateChange(currentB, previousB);
+            return sortBy.dir === 'desc' ? changeB - changeA : changeA - changeB;
+          }
+        }
+      });
+    }, [valueMap, sortBy]);
+
+    const onSort = (by: SortBy) => {
+      setSortBy((current) => {
+        if (current.by === by) {
+          return {by, dir: current.dir === 'asc' ? 'desc' : 'asc'};
+        }
+        return {by, dir: by === 'name' ? 'asc' : 'desc'};
+      });
+      containerRef.current?.scrollTo({top: 0});
+    };
+
+    const rowVirtualizer = useVirtualizer({
+      count,
+      getScrollElement: () => containerRef.current,
+      estimateSize: () => 42,
+      overscan: 20,
+    });
+
+    const items = rowVirtualizer.getVirtualItems();
+    const totalHeight = rowVirtualizer.getTotalSize();
+    const icon = sortBy.dir === 'asc' ? 'expand_less' : 'expand_more';
 
     return (
       <div className={styles.container}>
-        {loading ? <Spinner purpose="body-text" /> : null}
-        <div>
-          <Box style={{color: Colors.textLighter()}} border="bottom" padding={{vertical: 8}}>
-            <div className={styles.table}>
-              <BodySmall>Asset</BodySmall>
-              <BodySmall style={{textAlign: 'right'}}>{unitType}</BodySmall>
-              <BodySmall>Distribution</BodySmall>
-            </div>
-          </Box>
-          <Box className={styles.table} margin={{vertical: 20}}>
-            {currentPageValues.map(({label, value}, i) => {
-              const assetKey = tokenToAssetKey(label.split(' / ').join('/'));
-              return (
-                <React.Fragment key={i}>
-                  <Body as="div" color={Colors.textLight()}>
-                    <Link to={assetDetailsPathForKey(assetKey)}>
-                      <MiddleTruncate text={label} />
-                    </Link>
-                  </Body>
-                  <Mono color={Colors.textDefault()} className={styles.tableValue}>
-                    {numberFormatter.format(Math.round(value))}
-                  </Mono>
-                  {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
-                  <DistributionChartRow maxValue={maxValue!} value={Math.round(value)} />
-                </React.Fragment>
-              );
-            })}
-          </Box>
-        </div>
-        {totalPages > 1 && (
-          <Box
-            flex={{
-              alignItems: 'flex-end',
-              grow: 1,
-              direction: 'row',
-            }}
+        <Box style={{color: Colors.textLighter()}} border="bottom" padding={{top: 8}}>
+          <div
+            className={clsx(
+              styles.headerGrid,
+              currentData ? styles.hasCurrentData : null,
+              previousData ? styles.hasPreviousData : null,
+              currentData && previousData ? styles.change : null,
+            )}
           >
-            <Box
-              flex={{
-                direction: 'row',
-                grow: 1,
-                alignItems: 'flex-end',
-                justifyContent: 'stretch',
-              }}
-              border="top"
-              padding={{top: 12, horizontal: 8}}
+            <UnstyledButton
+              onClick={() => onSort('name')}
+              className={clsx(styles.sortButton, sortBy.by === 'name' && styles.active)}
             >
-              <Box
-                flex={{
-                  direction: 'row',
-                  gap: 12,
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                }}
-                style={{width: '100%'}}
+              <span>Asset</span>
+              <Icon name={sortBy.by === 'name' ? icon : 'expand'} />
+            </UnstyledButton>
+            {currentData ? (
+              <UnstyledButton
+                onClick={() => onSort('current')}
+                className={clsx(styles.sortButton, sortBy.by === 'current' && styles.active)}
               >
-                <BodySmall>
-                  {page + 1} of {totalPages}
-                </BodySmall>
-                <Box flex={{direction: 'row', gap: 4}}>
-                  <Button
-                    outlined
-                    onClick={() => setPage(page - 1)}
-                    disabled={page === 0}
-                    icon={<Icon name="arrow_back" />}
-                  />
-                  <Button
-                    outlined
-                    onClick={() => setPage(page + 1)}
-                    disabled={page === totalPages - 1}
-                    icon={<Icon name="arrow_forward" />}
-                  />
-                </Box>
-              </Box>
-            </Box>
-          </Box>
-        )}
+                <span>This period</span>
+                <Icon name={sortBy.by === 'current' ? icon : 'expand'} />
+              </UnstyledButton>
+            ) : null}
+            {previousData ? (
+              <UnstyledButton
+                onClick={() => onSort('previous')}
+                className={clsx(styles.sortButton, sortBy.by === 'previous' && styles.active)}
+              >
+                <span>Prev period</span>
+                <Icon name={sortBy.by === 'previous' ? icon : 'expand'} />
+              </UnstyledButton>
+            ) : null}
+            {currentData && previousData ? (
+              <UnstyledButton
+                onClick={() => onSort('change')}
+                className={clsx(styles.sortButton, sortBy.by === 'change' && styles.active)}
+              >
+                <span>Change</span>
+                <Icon name={sortBy.by === 'change' ? icon : 'expand'} />
+              </UnstyledButton>
+            ) : null}
+          </div>
+        </Box>
+        <div className={styles.listContainer}>
+          <Container ref={containerRef}>
+            <Inner $totalHeight={totalHeight}>
+              {items.map(({index, key, size, start}) => {
+                const itemLabel = sorted[index];
+                if (!itemLabel) {
+                  return null;
+                }
+
+                const current = valueMap.current?.[itemLabel] ?? 0;
+                const previous = valueMap.previous?.[itemLabel] ?? 0;
+
+                const assetKey = tokenToAssetKey(itemLabel.split(' / ').join('/'));
+                const change = calculateChange(current, previous);
+
+                const currentFormatted =
+                  unitType === ReportingUnitType.TIME_MS
+                    ? formatMetric(current, unitType)
+                    : numberFormatter.format(current);
+                const previousFormatted =
+                  unitType === ReportingUnitType.TIME_MS
+                    ? formatMetric(previous, unitType)
+                    : numberFormatter.format(previous);
+
+                return (
+                  <Row key={key} $start={start} $height={size}>
+                    <ListItem
+                      key={itemLabel}
+                      ref={rowVirtualizer.measureElement}
+                      index={index}
+                      left={<MiddleTruncate text={itemLabel} />}
+                      right={
+                        <div
+                          className={clsx(
+                            styles.rightGrid,
+                            currentData ? styles.hasCurrentData : null,
+                            previousData ? styles.hasPreviousData : null,
+                            currentData && previousData ? styles.change : null,
+                          )}
+                        >
+                          {currentData ? (
+                            <Mono color={Colors.textDefault()} className={styles.tableValue}>
+                              {currentFormatted}
+                            </Mono>
+                          ) : null}
+                          {previousData ? (
+                            <Mono color={Colors.textDefault()} className={styles.tableValue}>
+                              {previousFormatted}
+                            </Mono>
+                          ) : null}
+                          {currentData && previousData ? (
+                            <Mono className={styles.tableValue} color={getChangeColor(change)}>
+                              {change === 0 ? (
+                                <>0.0% </>
+                              ) : (
+                                `${change > 0 ? '+' : ''}${(change * 100).toFixed(1)}%`
+                              )}
+                            </Mono>
+                          ) : null}
+                        </div>
+                      }
+                      href={assetDetailsPathForKey(assetKey)}
+                      renderLink={({href, ...rest}) => <Link to={href ?? '#'} {...rest} />}
+                    />
+                  </Row>
+                );
+              })}
+            </Inner>
+          </Container>
+        </div>
       </div>
     );
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/ActivityChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/ActivityChart.tsx
@@ -17,11 +17,12 @@ import {numberFormatterWithMaxFractionDigits} from '../ui/formatters';
 import {useFormatDateTime} from '../ui/useFormatDateTime';
 import styles from './css/ActivityChart.module.css';
 
-type MetricsDialogData<T> = {
-  after: number;
-  before: number;
+export type ActivityChartMetricsDialogData<T> = {
+  current: {
+    before: number;
+    after: number;
+  };
   metric: T;
-  unit: string;
 };
 
 export type ActivityChartDayData = {
@@ -41,7 +42,7 @@ interface Props<T> {
   metrics: ActivityChartData;
   unit: string;
   loading: boolean;
-  openMetricDialog?: (data: MetricsDialogData<T>) => void;
+  openMetricDialog?: (data: ActivityChartMetricsDialogData<T>) => void;
   metric: T;
 }
 
@@ -95,7 +96,7 @@ interface RowProps<T> {
   color: string;
   hoverColor: string;
   unit: string;
-  onClick?: (data: MetricsDialogData<T>) => void;
+  onClick?: (data: ActivityChartMetricsDialogData<T>) => void;
   metric: T;
 }
 
@@ -175,10 +176,11 @@ const InnerActivityChartRow = <T,>(props: RowProps<T>) => {
                     onClick={() => {
                       if (onClick) {
                         onClick({
-                          before: date / 1000 + index * 60 * 60,
-                          after: date / 1000 + (index - 1) * 60 * 60,
+                          current: {
+                            before: date / 1000 + (index - 1) * 60 * 60,
+                            after: date / 1000 + index * 60 * 60,
+                          },
                           metric,
-                          unit,
                         });
                       }
                     }}

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
@@ -80,10 +80,16 @@ export const getDataset = (
 };
 
 export type MetricDialogData<T> = {
-  after: number;
-  before: number;
+  current?: {
+    before: number;
+    after: number;
+  };
+  previous?: {
+    before: number;
+    after: number;
+  };
   metric: T;
-  unit: string;
+  unitType: ReportingUnitType;
 };
 
 interface Props<T> {
@@ -315,21 +321,29 @@ export const InnerLineChartWithComparison = <T,>(props: Props<T>) => {
           }
         }
 
-        const before = metrics.currentPeriod.timestamps[index];
-        if (typeof before !== 'number') {
+        const currentTime = metrics.currentPeriod.timestamps[index];
+        if (typeof currentTime !== 'number') {
           return;
         }
 
-        const after = before - timeSliceSeconds;
+        const previousTime = metrics.prevPeriod.timestamps[index] ?? undefined;
 
         // Only open the dialog if data exists for the clicked index
         // in the current period
         if (metrics.currentPeriod.data[index] && openMetricDialog) {
           openMetricDialog({
-            after,
-            before,
+            current: {
+              before: currentTime - timeSliceSeconds,
+              after: currentTime,
+            },
+            previous: previousTime
+              ? {
+                  before: previousTime - timeSliceSeconds,
+                  after: previousTime,
+                }
+              : undefined,
             metric: metricName,
-            unit: unitType,
+            unitType,
           });
         }
       }


### PR DESCRIPTION
## Summary & Motivation

Corresponds to https://github.com/dagster-io/internal/pull/17713.

Add previous window data to line chart dialog, including “change” information, if applicable.

The dialog contents are now virtualized and sortable as well.

## How I Tested These Changes

Proxy as elementl, verify click behavior, sorting, virtualization.