### PR TITLE
[dagster-dbt] Update DbtProjectComponent with configurable CLI args

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/invocation.py
+++ b/python_modules/dagster/dagster/_core/execution/context/invocation.py
@@ -518,6 +518,10 @@ class DirectOpExecutionContext(OpExecutionContext, BaseDirectExecutionContext):
         check.failed("Tried to access partition_key for a non-partitioned run")
 
     @property
+    def has_partition_key_range(self) -> bool:
+        return self._partition_key_range is not None
+
+    @property
     def partition_keys(self) -> Sequence[str]:
         key_range = self.partition_key_range
         partitions_def = self.assets_def.partitions_def

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/dbt_project/expected_example
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/dbt_project/expected_example
@@ -8,6 +8,9 @@ attributes:
     target: "example_string"
     packaged_project_dir: "example_string"
     state_path: "example_string"
+  cli_args:
+    -
+      key: "value"
   op:
     name: "example_string"
     tags:

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/dbt_project/expected_schema
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/dbt_project/expected_schema
@@ -9,6 +9,7 @@ attributes:  # Optional: Attributes details
     target: <string>  # Optional: 
     packaged_project_dir: <string>  # Optional: 
     state_path: <string>  # Optional: 
+  cli_args: <one of: array of item, string>  # Optional: Arguments to pass to the dbt CLI when executing. Defaults to `['build']`.
   op:  # Optional: Op related arguments to set on the generated @dbt_assets
     name: <string>  # Optional: 
     tags: <one of: object, string>  # Optional: 


### PR DESCRIPTION
## Summary & Motivation

This updates the DbtProjectCompnent to allow users to pass in custom arguments to the cli invocation.

We could definitely get away with the signature of the `cli_args` field being just `list[str]`, but the way the `--vars` parameter works means that it'd be pretty tough to actually format things in a yaml document (because that param expects json-formatted data). So I added the option to just specify things in dictionary format.

In theory, this is technically a bit overly-specified, in that it's possible that a user's component subclass does not use this configuration at all (i.e. maybe it invokes two completely separate commands or something). However, in the vast majority of cases, it seems likely that people will only invoke one dbt command for the actual execution of their assets (maybe they do other commands for other reasons afterwards), and so it feels ok to name this field this way.

## How I Tested These Changes

## Changelog

The DbtProjectComponent now takes an optional `cli_args` configuration to allow customizing the command that is run when your assets are executed.
