### PR TITLE
Allow custom height on IndeterminateLoadingBar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/IndeterminateLoadingBar.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/IndeterminateLoadingBar.module.css
@@ -1,4 +1,5 @@
 .loadingBar {
+  z-index: 1;
   height: 0px;
   width: 100%;
   flex-shrink: 0;
@@ -6,10 +7,10 @@
   position: relative;
   &::before {
     position: absolute;
-    top: -2px;
+    top: calc(var(--height) * -1);
     content: '';
     display: block;
-    height: 2px;
+    height: var(--height);
     width: 100%;
     background: var(--color-background-gray);
   }
@@ -18,10 +19,10 @@
 .loading {
   &::after {
     position: absolute;
-    top: -2px;
+    top: calc(var(--height) * -1); 
     content: ' ';
     display: block;
-    height: 2px;
+    height: var(--height);
     width: 100%;
     background: var(--color-text-disabled);
     transform-origin: left center;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/IndeterminateLoadingBar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/IndeterminateLoadingBar.tsx
@@ -4,10 +4,17 @@ import styles from './IndeterminateLoadingBar.module.css';
 
 export const IndeterminateLoadingBar = ({
   $loading,
+  $height = 2,
   style,
 }: {
   $loading: boolean | undefined;
+  $height?: number;
   style?: React.CSSProperties;
 }) => {
-  return <div className={clsx(styles.loadingBar, $loading && styles.loading)} style={style} />;
+  return (
+    <div
+      className={clsx(styles.loadingBar, $loading && styles.loading)}
+      style={{...style, '--height': `${$height}px`} as React.CSSProperties}
+    />
+  );
 };


### PR DESCRIPTION
<img width="730" height="243" alt="Screenshot 2025-08-21 at 4 10 41 PM" src="https://github.com/user-attachments/assets/1a97d399-2e16-4d94-8bb2-fc8e51080171" />
 used internally with 1px height