### PR TITLE
[dg scaffold branch] use verbose flag in scaffolding phase

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/ai.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/ai.py
@@ -333,6 +333,7 @@ def scaffold_content_for_prompt(
     user_input: str,
     input_type: type[InputType],
     diagnostics: ClaudeDiagnostics,
+    verbose: bool,
     use_spinner: bool = True,
     model: ModelType = "sonnet",
 ) -> None:
@@ -353,15 +354,13 @@ def scaffold_content_for_prompt(
         ):
             claude_sdk = ClaudeSDKClient(diagnostics)
 
-            # Run the async SDK operation with verbose mode for debug diagnostics
-            verbose_mode = diagnostics.level == "debug"
             asyncio.run(
                 claude_sdk.scaffold_with_streaming(
                     prompt=prompt,
                     allowed_tools=allowed_tools,
                     output_channel=channel,
                     disallowed_tools=["Bash(python:*)", "WebSearch", "WebFetch"],
-                    verbose=verbose_mode,
+                    verbose=verbose,
                 )
             )
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/command.py
@@ -416,6 +416,7 @@ def execute_scaffold_branch_command(
                 prompt_text,
                 input_type,
                 diagnostics,
+                verbose=cli_config.get("verbose", False),
                 use_spinner=not disable_progress,
                 model=execution_model,
             )


### PR DESCRIPTION


## How I Tested These Changes

`dg scaffold branch "Scaffold a new component that runs a Python script over Dagster pipes representing a single asset." --verbose` 

and continue through to execution instead of canceling 