### PR TITLE
making graph asset config visible in the launchpad UI #23890

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets/job/asset_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/job/asset_job.py
@@ -155,7 +155,14 @@ def build_asset_job(
             ]
         )
     ]
-
+    # Collect config mapping from graph asset to make them visible in UI
+    config = None
+    for asset in asset_graph.assets_defs_for_keys([*asset_graph.executable_asset_keys]):
+        if hasattr(asset, 'node_def'):
+            if (isinstance(asset.node_def, GraphDefinition)):
+                if asset.node_def.config_field is not None:
+                    config = asset.node_def.config_mapping  
+                    
     graph = GraphDefinition(
         name=name,
         node_defs=node_defs,


### PR DESCRIPTION
@Rashida156 and @Bandish1304 worked on this issue 
## Summary & Motivation
      Our aim was to make the graph asset config visible on the launchpad UI

## How I Tested These Changes
      We tested the changes with the graph_decorator.py and asset_job.py, and the production   code provided.  We also tested the changes by creating a separate job for the graph asset within the reproduction code. 

## Changelog

> Insert changelog entry or delete this section.
