### PR TITLE
[dg scaffold branch] RFC remove max_turns limit

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/ai.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/ai.py
@@ -33,9 +33,6 @@ class BranchNameGeneration:
     generation_metadata: dict[str, Any]
 
 
-MAX_TURNS = 20
-
-
 def invoke_anthropic_api_direct(
     prompt: str,
     diagnostics: ClaudeDiagnostics,

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/claude/sdk_client.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/claude/sdk_client.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from time import perf_counter
-from typing import Any, Optional, Protocol
+from typing import Any, Final, Optional, Protocol
 
 from claude_code_sdk import query
 from claude_code_sdk.types import (
@@ -15,6 +15,8 @@ from claude_code_sdk.types import (
 
 from dagster_dg_cli.cli.scaffold.branch.claude.diagnostics import AIInteraction, ClaudeDiagnostics
 from dagster_dg_cli.cli.scaffold.branch.constants import ModelType
+
+MAX_TURNS: Final = 100
 
 
 class OutputChannel(Protocol):
@@ -85,6 +87,7 @@ class ClaudeSDKClient:
             options = ClaudeCodeOptions(
                 allowed_tools=allowed_tools,
                 permission_mode="acceptEdits",  # Auto-accept file edits for scaffolding
+                max_turns=MAX_TURNS,
                 model=model,
             )
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/claude/sdk_client.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/claude/sdk_client.py
@@ -85,7 +85,6 @@ class ClaudeSDKClient:
             options = ClaudeCodeOptions(
                 allowed_tools=allowed_tools,
                 permission_mode="acceptEdits",  # Auto-accept file edits for scaffolding
-                max_turns=20,  # Match existing MAX_TURNS
                 model=model,
             )
 


### PR DESCRIPTION
arguments for: 
* user is seeing messages stream through and can ctrl-c if its gone off the rails
* forcing it to stop in the middle of its work does not leave things in a useful state 

I can be convinced theres some limit we should set

## How I Tested These Changes

`dg scaffold branch "Scaffold a new component that runs a Python script over Dagster pipes representing a single asset." --verbose` actually compleetes everything that is planned