### PR TITLE
Refactor ComponentTree state

### DIFF
--- a/python_modules/dagster/dagster/components/core/component_tree.py
+++ b/python_modules/dagster/dagster/components/core/component_tree.py
@@ -1,7 +1,4 @@
 import importlib
-import uuid
-from collections import defaultdict
-from collections.abc import Sequence
 from contextlib import contextmanager
 from functools import cached_property
 from pathlib import Path
@@ -11,11 +8,6 @@ from unittest import mock
 
 from dagster_shared import check
 from dagster_shared.record import IHaveNew, record
-from dagster_shared.utils.cached_method import (
-    cached_method,
-    get_cached_method_cache,
-    make_cached_method_cache_key,
-)
 from dagster_shared.utils.config import (
     discover_config_file,
     get_canonical_defs_module_name,
@@ -24,8 +16,8 @@ from dagster_shared.utils.config import (
 from typing_extensions import Self, TypeVar
 
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster.components.component.component import Component
+from dagster.components.core.component_tree_state import ComponentTreeStateTracker
 from dagster.components.core.context import ComponentDeclLoadContext, ComponentLoadContext
 from dagster.components.core.decl import (
     ComponentDecl,
@@ -39,161 +31,25 @@ from dagster.components.core.defs_module import (
     CompositeYamlComponent,
     DefsFolderComponent,
     PythonFileComponent,
+    ResolvableToComponentPath,
 )
 from dagster.components.resolved.context import ResolutionContext
 from dagster.components.utils import get_path_from_module
 
 PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY = "plugin_component_types_json"
 
+T = TypeVar("T", bound=Component)
 TComponent = TypeVar("TComponent", bound=Component)
-
-_ComponentPathTuple = tuple[str, Optional[Union[int, str]]]
-ResolvableToComponentPath = Union[Path, ComponentPath, str, _ComponentPathTuple]
-
-
-def resolve_to_component_path(path: ResolvableToComponentPath) -> ComponentPath:
-    if isinstance(path, str):
-        return ComponentPath(file_path=Path(path), instance_key=None)
-    elif isinstance(path, Path):
-        return ComponentPath(file_path=path, instance_key=None)
-    elif isinstance(path, ComponentPath):
-        return path
-    elif isinstance(path, tuple):
-        return ComponentPath(file_path=Path(path[0]), instance_key=path[1])
-    else:
-        raise ValueError(f"Invalid path: {path}")
-
-
-def _get_canonical_path_string(root_path: Path, path: Path) -> str:
-    """Returns a canonical string representation of the given path (the absolute, POSIX path)
-    to use for e.g. dict keys or path comparisons.
-    """
-    return (root_path / path if not path.is_absolute() else path).absolute().as_posix()
-
-
-def _get_canonical_component_path(
-    root_path: Path, path: ResolvableToComponentPath
-) -> _ComponentPathTuple:
-    resolved_path = resolve_to_component_path(path)
-    return _get_canonical_path_string(
-        root_path, resolved_path.file_path
-    ), resolved_path.instance_key
 
 
 @record
 class ComponentWithContext:
-    path: Path
     component: Component
     component_decl: ComponentDecl
 
 
-T = TypeVar("T", bound=Component)
-
-
 class ComponentTreeException(Exception):
     pass
-
-
-class ComponentTreeStateTracker:
-    """Stateful class which tracks the state of the component tree
-    as it is loaded.
-    """
-
-    def __init__(self):
-        self._component_load_dependents_dict = defaultdict(set)
-        self._component_defs_dependents_dict = defaultdict(set)
-        self._component_defs_state_key_dict = dict()
-        self._cache_keys = dict()
-
-    def get_cache_key(
-        self, defs_module_path: Path, component_path: ResolvableToComponentPath
-    ) -> str:
-        canonical_path = _get_canonical_component_path(defs_module_path, component_path)
-        cache_path = canonical_path[0]
-        if cache_path not in self._cache_keys:
-            self._cache_keys[cache_path] = str(uuid.uuid4())
-        return self._cache_keys[cache_path]
-
-    def invalidate_cache_key(
-        self, defs_module_path: Path, component_path: ResolvableToComponentPath
-    ) -> None:
-        """Invalidates the cache key for a given component path."""
-        canonical_path = _get_canonical_component_path(defs_module_path, component_path)
-        cache_path = canonical_path[0]
-        if cache_path in self._cache_keys:
-            del self._cache_keys[cache_path]
-            # todo: better graph traversal
-            for dep_path in {
-                *self._component_load_dependents_dict[canonical_path],
-                *self._component_defs_dependents_dict[canonical_path],
-            }:
-                self.invalidate_cache_key(defs_module_path, dep_path)
-
-    def mark_component_load_dependency(
-        self, defs_module_path: Path, from_path: ComponentPath, to_path: ResolvableToComponentPath
-    ) -> None:
-        self._component_load_dependents_dict[
-            _get_canonical_component_path(defs_module_path, to_path)
-        ].add(_get_canonical_component_path(defs_module_path, from_path))
-
-    def mark_component_defs_dependency(
-        self, defs_module_path: Path, from_path: ComponentPath, to_path: ResolvableToComponentPath
-    ) -> None:
-        self._component_defs_dependents_dict[
-            _get_canonical_component_path(defs_module_path, to_path)
-        ].add(_get_canonical_component_path(defs_module_path, from_path))
-
-    def mark_component_defs_state_key(
-        self, defs_module_path: Path, component_path: ComponentPath, defs_state_key: str
-    ) -> None:
-        # ensures that no components share the same defs state key
-        canonical_path = _get_canonical_component_path(defs_module_path, component_path)
-        existing_path = self._component_defs_state_key_dict.get(defs_state_key)
-        if existing_path is not None and existing_path != canonical_path:
-            raise DagsterInvalidDefinitionError(
-                f"Multiple components have the same defs state key: {defs_state_key}\n"
-                "Component paths: \n"
-                f"  {existing_path}\n"
-                f"  {canonical_path}\n"
-                "Configure or override the `get_defs_state_key` method on one or both components to disambiguate."
-            )
-        self._component_defs_state_key_dict[defs_state_key] = canonical_path
-
-    def get_direct_load_dependents_of_component(
-        self, defs_module_path: Path, component_path: ComponentPath
-    ) -> set[ComponentPath]:
-        """Returns the set of components that directly depend on the given component.
-
-        Args:
-            defs_module_path: The path to the defs module.
-            component_path: The path to the component to get the direct load dependents of.
-        """
-        return set(
-            ComponentPath(
-                file_path=Path(file_path).relative_to(defs_module_path), instance_key=instance_key
-            )
-            for file_path, instance_key in self._component_load_dependents_dict[
-                _get_canonical_component_path(defs_module_path, component_path)
-            ]
-        )
-
-    def get_direct_defs_dependents_of_component(
-        self, defs_module_path: Path, component_path: ComponentPath
-    ) -> set[ComponentPath]:
-        """Returns the set of components that directly depend on the given component's defs.
-
-        Args:
-            defs_module_path: The path to the defs module.
-            component_path: The path to the component to get the direct defs dependents of.
-        """
-        return set(
-            ComponentPath(
-                file_path=Path(file_path).relative_to(defs_module_path), instance_key=instance_key
-            )
-            for file_path, instance_key in self._component_defs_dependents_dict[
-                _get_canonical_component_path(defs_module_path, component_path)
-            ]
-        )
 
 
 @record(
@@ -213,18 +69,19 @@ class ComponentTree(IHaveNew):
 
     @cached_property
     def state_tracker(self) -> ComponentTreeStateTracker:
-        return ComponentTreeStateTracker()
+        return ComponentTreeStateTracker(self.defs_module_path)
 
     @contextmanager
     def augment_component_tree_exception(
-        self, path: ComponentPath, msg_for_path: Callable[[str], str]
+        self, path: ResolvableToComponentPath, msg_for_path: Callable[[str], str]
     ):
         try:
             yield
         except Exception as e:
+            resolved_path = ComponentPath.from_resolvable(self.defs_module_path, path)
             if not isinstance(e, ComponentTreeException):
                 raise ComponentTreeException(
-                    f"{msg_for_path(path.get_relative_key(self.defs_module_path))}:\n{self.to_string_representation(include_load_and_build_status=True, match_path=path)}"
+                    f"{msg_for_path(resolved_path.get_relative_key(self.defs_module_path))}:\n{self.to_string_representation(include_load_and_build_status=True, match_path=resolved_path)}"
                 ) from e
             raise
 
@@ -297,129 +154,62 @@ class ComponentTree(IHaveNew):
 
         return cls(defs_module=defs_module, project_root=path_within_project)
 
-    @cached_method
-    def _decl_load_context(self, _cache_key: str) -> ComponentDeclLoadContext:
-        return ComponentDeclLoadContext(
-            component_path=ComponentPath(file_path=self.defs_module_path, instance_key=None),
-            project_root=self.project_root,
-            defs_module_path=self.defs_module_path,
-            defs_module_name=self.defs_module_name,
-            resolution_context=ResolutionContext.default(),
-            terminate_autoloading_on_keyword_files=False,
-            component_tree=self,
+    @property
+    def decl_load_context(self) -> ComponentDeclLoadContext:
+        if self.state_tracker.get_cache_data(self.defs_module_path).decl_load_context is None:
+            self.state_tracker.set_cache_data(
+                self.defs_module_path,
+                decl_load_context=ComponentDeclLoadContext(
+                    component_path=ComponentPath.from_path(self.defs_module_path),
+                    project_root=self.project_root,
+                    defs_module_path=self.defs_module_path,
+                    defs_module_name=self.defs_module_name,
+                    resolution_context=ResolutionContext.default(),
+                    terminate_autoloading_on_keyword_files=False,
+                    component_tree=self,
+                ),
+            )
+        return check.not_none(
+            self.state_tracker.get_cache_data(self.defs_module_path).decl_load_context
         )
 
     @property
-    def decl_load_context(self):
-        return self._decl_load_context(
-            _cache_key=self.state_tracker.get_cache_key(
-                self.defs_module_path, self.defs_module_path
+    def load_context(self) -> ComponentLoadContext:
+        if self.state_tracker.get_cache_data(self.defs_module_path).load_context is None:
+            self.state_tracker.set_cache_data(
+                self.defs_module_path,
+                load_context=ComponentLoadContext.from_decl_load_context(
+                    self.decl_load_context, self.find_root_decl()
+                ),
             )
-        )
-
-    @cached_method
-    def _load_context(self, _cache_key: str) -> ComponentLoadContext:
-        return ComponentLoadContext.from_decl_load_context(
-            self.decl_load_context, self.find_root_decl()
-        )
-
-    @property
-    def load_context(self):
-        return self._load_context(
-            _cache_key=self.state_tracker.get_cache_key(
-                self.defs_module_path, self.defs_module_path
-            )
-        )
+        return check.not_none(self.state_tracker.get_cache_data(self.defs_module_path).load_context)
 
     def load_root_component(self) -> Component:
         return self.load_structural_component_at_path(self.defs_module_path)
 
-    @cached_method
-    def _find_root_decl(self, _cache_key: str) -> ComponentDecl:
-        return check.not_none(build_component_decl_from_context(self.decl_load_context))
-
     def find_root_decl(self) -> ComponentDecl:
-        return self._find_root_decl(
-            _cache_key=self.state_tracker.get_cache_key(
-                self.defs_module_path, self.defs_module_path
+        if self.state_tracker.get_cache_data(self.defs_module_path).component_decl is None:
+            self.state_tracker.set_cache_data(
+                self.defs_module_path,
+                component_decl=build_component_decl_from_context(self.decl_load_context),
             )
-        )
-
-    @cached_method
-    def _build_defs(self, _cache_key: str) -> Definitions:
-        from dagster.components.core.load_defs import get_library_json_enriched_defs
-
-        return Definitions.merge(
-            self.build_defs_at_path(self.defs_module_path),
-            get_library_json_enriched_defs(self),
+        return check.not_none(
+            self.state_tracker.get_cache_data(self.defs_module_path).component_decl
         )
 
     def build_defs(self) -> Definitions:
-        return self._build_defs(
-            _cache_key=self.state_tracker.get_cache_key(
-                self.defs_module_path, self.defs_module_path
+        from dagster.components.core.load_defs import get_library_json_enriched_defs
+
+        if self.state_tracker.get_cache_data(self.defs_module_path).defs is None:
+            defs = Definitions.merge(
+                self.build_defs_at_path(self.defs_module_path),
+                get_library_json_enriched_defs(self),
             )
-        )
+            self.state_tracker.set_cache_data(self.defs_module_path, defs=defs)
 
-    def _component_decl_tree(self) -> Sequence[tuple[ComponentPath, ComponentDecl]]:
-        """Constructs or returns the full component declaration tree from cache."""
-        root_decl = self.find_root_decl()
-        return list(root_decl.iterate_path_component_decl_pairs())
+        return check.not_none(self.state_tracker.get_cache_data(self.defs_module_path).defs)
 
-    def _component_decl_at_posix_path(
-        self, defs_path_posix: str, instance_key: Optional[Union[int, str]]
-    ) -> Optional[tuple[Path, ComponentDecl]]:
-        """Locates a component declaration matching the given canonical string path."""
-        for cp, component_decl in self._component_decl_tree():
-            if (
-                cp.file_path.absolute().as_posix() == defs_path_posix
-                and cp.instance_key == instance_key
-            ):
-                return (cp.file_path, component_decl)
-        return None
-
-    @cached_method
-    def _component_and_context_at_posix_path(
-        self, defs_path_posix: str, instance_key: Optional[Union[int, str]], _cache_key: str
-    ) -> Optional[ComponentWithContext]:
-        with self.augment_component_tree_exception(
-            ComponentPath(file_path=Path(defs_path_posix), instance_key=instance_key),
-            lambda path: f"Error while loading component {path}",
-        ):
-            component_decl_and_path = self._component_decl_at_posix_path(
-                defs_path_posix, instance_key
-            )
-            if component_decl_and_path:
-                path, component_decl = component_decl_and_path
-                return ComponentWithContext(
-                    path=path,
-                    component=component_decl._load_component(),  # noqa: SLF001
-                    component_decl=component_decl,
-                )
-            return None
-
-    @cached_method
-    def _defs_at_posix_path(
-        self, defs_path_posix: str, instance_key: Optional[Union[int, str]], _cache_key: str
-    ) -> Optional[Definitions]:
-        with self.augment_component_tree_exception(
-            ComponentPath(file_path=Path(defs_path_posix), instance_key=instance_key),
-            lambda path: f"Error while building definitions for {path}",
-        ):
-            component_info = self._component_and_context_at_posix_path(
-                defs_path_posix, instance_key, _cache_key
-            )
-            if component_info is None:
-                return None
-            component = component_info.component
-            component_decl = component_info.component_decl
-
-            clc = ComponentLoadContext.from_decl_load_context(
-                component_decl.context, component_decl
-            )
-            return component.build_defs(clc)
-
-    def find_decl_at_path(self, defs_path: Union[Path, ComponentPath, str]) -> ComponentDecl:
+    def find_decl_at_path(self, defs_path: ResolvableToComponentPath) -> ComponentDecl:
         """Loads a component declaration from the given path.
 
         Args:
@@ -428,15 +218,14 @@ class ComponentTree(IHaveNew):
         Returns:
             ComponentDecl: The component declaration loaded from the given path.
         """
-        component_decl_and_path = self._component_decl_at_posix_path(
-            *_get_canonical_component_path(self.defs_module_path, defs_path)
-        )
-        if component_decl_and_path is None:
+        resolved_path = ComponentPath.from_resolvable(self.defs_module_path, defs_path)
+        decl = self._component_decl_tree().get(resolved_path)
+        if decl is None:
             raise Exception(f"No component decl found for path {defs_path}")
-        return component_decl_and_path[1]
+        return decl
 
     def mark_component_load_dependency(
-        self, from_path: ComponentPath, to_path: ResolvableToComponentPath
+        self, from_path: ComponentPath, to_path: ComponentPath
     ) -> None:
         """Marks a dependency between the component at `from_path` and the component at `to_path`.
 
@@ -444,10 +233,10 @@ class ComponentTree(IHaveNew):
             from_path: The path to the component that depends on the component at `to_path`.
             to_path: The path to the component that the component at `from_path` depends on.
         """
-        self.state_tracker.mark_component_load_dependency(self.defs_module_path, from_path, to_path)
+        self.state_tracker.mark_component_load_dependency(from_path, to_path)
 
     def mark_component_defs_dependency(
-        self, from_path: ComponentPath, to_path: ResolvableToComponentPath
+        self, from_path: ComponentPath, to_path: ComponentPath
     ) -> None:
         """Marks a dependency between the component at `from_path` on the defs of
         the component at `to_path`.
@@ -456,7 +245,7 @@ class ComponentTree(IHaveNew):
             from_path: The path to the component that depends on the defs of the component at `to_path`.
             to_path: The path to the component that the component at `from_path` depends on.
         """
-        self.state_tracker.mark_component_defs_dependency(self.defs_module_path, from_path, to_path)
+        self.state_tracker.mark_component_defs_dependency(from_path, to_path)
 
     def mark_component_defs_state_key(
         self, component_path: ComponentPath, defs_state_key: str
@@ -467,9 +256,7 @@ class ComponentTree(IHaveNew):
             component_path: The path to the component to mark the state key for.
             defs_state_key: The state key to mark.
         """
-        self.state_tracker.mark_component_defs_state_key(
-            self.defs_module_path, component_path, defs_state_key
-        )
+        self.state_tracker.mark_component_defs_state_key(component_path, defs_state_key)
 
     @overload
     def load_component_at_path(self, defs_path: Union[Path, ComponentPath, str]) -> Component: ...
@@ -504,9 +291,55 @@ class ComponentTree(IHaveNew):
 
         return component
 
-    def load_structural_component_at_path(
-        self, defs_path: Union[Path, ComponentPath, str]
-    ) -> Component:
+    def _component_decl_tree(self) -> dict[ComponentPath, ComponentDecl]:
+        """Constructs or returns the full component declaration tree from cache."""
+        root_decl = self.find_root_decl()
+        return dict(root_decl.iterate_path_component_decl_pairs())
+
+    def _component_and_context_at_path(
+        self, defs_path: ResolvableToComponentPath
+    ) -> Optional[tuple[Component, ComponentDecl]]:
+        if self.state_tracker.get_cache_data(defs_path).component is None:
+            with self.augment_component_tree_exception(
+                defs_path,
+                lambda path: f"Error while loading component {path}",
+            ):
+                resolved_path = ComponentPath.from_resolvable(self.defs_module_path, defs_path)
+                component_decl = self._component_decl_tree().get(resolved_path)
+                if component_decl:
+                    self.state_tracker.set_cache_data(
+                        defs_path,
+                        component=component_decl._load_component(),  # noqa: SLF001
+                        component_decl=component_decl,
+                    )
+        cache_data = self.state_tracker.get_cache_data(defs_path)
+        if cache_data.component is None or cache_data.component_decl is None:
+            return None
+        return (cache_data.component, cache_data.component_decl)
+
+    def _build_defs_at_path(self, defs_path: ResolvableToComponentPath) -> Optional[Definitions]:
+        cached_data = self.state_tracker.get_cache_data(defs_path)
+        if cached_data.defs:
+            return cached_data.defs
+
+        with self.augment_component_tree_exception(
+            defs_path,
+            lambda path: f"Error while building definitions for {path}",
+        ):
+            component_info = self._component_and_context_at_path(defs_path)
+            if component_info is None:
+                raise Exception(f"No component found for path {defs_path}")
+
+            component, component_decl = component_info
+            clc = ComponentLoadContext.from_decl_load_context(
+                component_decl.context, component_decl
+            )
+
+            defs = component.build_defs(clc)
+            self.state_tracker.set_cache_data(defs_path, defs=defs)
+            return defs
+
+    def load_structural_component_at_path(self, defs_path: ResolvableToComponentPath) -> Component:
         """Loads a component from the given path, does not resolve e.g. CompositeYamlComponent to an underlying
         component type.
 
@@ -516,16 +349,12 @@ class ComponentTree(IHaveNew):
         Returns:
             Component: The component loaded from the given path.
         """
-        component = self._component_and_context_at_posix_path(
-            *_get_canonical_component_path(self.defs_module_path, defs_path),
-            _cache_key=self.state_tracker.get_cache_key(self.defs_module_path, defs_path),
-        )
-        if component is None:
+        component_with_context = self._component_and_context_at_path(defs_path)
+        if component_with_context is None:
             raise Exception(f"No component found for path {defs_path}")
+        return component_with_context[0]
 
-        return component.component
-
-    def build_defs_at_path(self, defs_path: Union[Path, ComponentPath, str]) -> Definitions:
+    def build_defs_at_path(self, defs_path: ResolvableToComponentPath) -> Definitions:
         """Builds definitions from the given defs subdirectory. Currently
         does not incorporate postprocessing from parent defs modules.
 
@@ -535,10 +364,7 @@ class ComponentTree(IHaveNew):
         Returns:
             Definitions: The definitions loaded from the given path.
         """
-        defs = self._defs_at_posix_path(
-            *_get_canonical_component_path(self.defs_module_path, defs_path),
-            _cache_key=self.state_tracker.get_cache_key(self.defs_module_path, defs_path),
-        )
+        defs = self._build_defs_at_path(defs_path)
         if defs is None:
             raise Exception(f"No definitions found for path {defs_path}")
         return defs
@@ -557,29 +383,13 @@ class ComponentTree(IHaveNew):
             if isinstance(component, of_type)
         ]
 
-    def _has_loaded_component_at_path(self, path: Union[Path, ComponentPath]) -> bool:
-        cache = get_cached_method_cache(self, "_component_and_context_at_posix_path")
-        canonical_path = _get_canonical_component_path(self.defs_module_path, path)
-        key = make_cached_method_cache_key(
-            {
-                "defs_path_posix": canonical_path[0],
-                "instance_key": canonical_path[1],
-                "_cache_key": self.state_tracker.get_cache_key(self.defs_module_path, path),
-            }
-        )
-        return key in cache
+    def _has_loaded_component_at_path(self, path: ResolvableToComponentPath) -> bool:
+        resolved_path = ComponentPath.from_resolvable(self.defs_module_path, path)
+        return self.state_tracker.get_cache_data(resolved_path).component is not None
 
     def _has_built_defs_at_path(self, path: Union[Path, ComponentPath]) -> bool:
-        cache = get_cached_method_cache(self, "_defs_at_posix_path")
-        canonical_path = _get_canonical_component_path(self.defs_module_path, path)
-        key = make_cached_method_cache_key(
-            {
-                "defs_path_posix": canonical_path[0],
-                "instance_key": canonical_path[1],
-                "_cache_key": self.state_tracker.get_cache_key(self.defs_module_path, path),
-            }
-        )
-        return key in cache
+        resolved_path = ComponentPath.from_resolvable(self.defs_module_path, path)
+        return self.state_tracker.get_cache_data(resolved_path).defs is not None
 
     def is_fully_loaded(self) -> bool:
         return self._has_loaded_component_at_path(self.defs_module_path)
@@ -712,7 +522,7 @@ class TestComponentTree(ComponentTree):
     @property
     def decl_load_context(self):
         return ComponentDeclLoadContext(
-            component_path=ComponentPath(file_path=self.defs_module_path, instance_key=None),
+            component_path=ComponentPath.from_path(self.defs_module_path),
             project_root=self.project_root,
             defs_module_path=self.defs_module_path,
             defs_module_name=self.defs_module_name,
@@ -737,7 +547,7 @@ class LegacyAutoloadingComponentTree(ComponentTree):
     @property
     def decl_load_context(self):
         return ComponentDeclLoadContext(
-            component_path=ComponentPath(file_path=self.defs_module_path, instance_key=None),
+            component_path=ComponentPath.from_path(self.defs_module_path),
             project_root=self.project_root,
             defs_module_path=self.defs_module_path,
             defs_module_name=self.defs_module_name,

--- a/python_modules/dagster/dagster/components/core/component_tree_state.py
+++ b/python_modules/dagster/dagster/components/core/component_tree_state.py
@@ -1,0 +1,116 @@
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+from dagster_shared.record import record, replace
+from typing_extensions import TypeVar
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster.components.component.component import Component
+from dagster.components.core.context import ComponentDeclLoadContext, ComponentLoadContext
+from dagster.components.core.decl import ComponentDecl
+from dagster.components.core.defs_module import ComponentPath, ResolvableToComponentPath
+
+PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY = "plugin_component_types_json"
+
+T = TypeVar("T", bound=Component)
+
+
+class ComponentTreeException(Exception):
+    pass
+
+
+@record
+class _CacheData:
+    """Data that is cached for a given component path."""
+
+    defs: Optional[Definitions] = None
+    component: Optional[Component] = None
+    load_context: Optional[ComponentLoadContext] = None
+    component_decl: Optional[ComponentDecl] = None
+    decl_load_context: Optional[ComponentDeclLoadContext] = None
+
+
+class ComponentTreeStateTracker:
+    """Stateful class which tracks the state of the component tree
+    as it is loaded.
+    """
+
+    def __init__(self, defs_module_path: Path):
+        self._defs_module_path = defs_module_path
+        self._component_load_dependents_dict: dict[ComponentPath, set[ComponentPath]] = defaultdict(
+            set
+        )
+        self._component_defs_dependents_dict: dict[ComponentPath, set[ComponentPath]] = defaultdict(
+            set
+        )
+        self._component_defs_state_key_dict: dict[str, ComponentPath] = {}
+        self._cache: dict[ComponentPath, _CacheData] = defaultdict(_CacheData)
+
+    def _invalidate_path_inner(self, path: ComponentPath, visited: set[ComponentPath]) -> None:
+        """Invalidate the cache for a given component path and all of its dependents."""
+        # we invalidate both the fully-specified path and the generic path (without an instance key)
+        # because some cache data (e.g. component decl information) is stored on the generic path
+        # because it is generated before we know the instance key
+        for p in [path, path.without_instance_key()]:
+            self._cache.pop(p, None)
+            visited.add(p)
+            deps = self.get_direct_defs_dependents(p) | self.get_direct_load_dependents(p)
+            for d in deps:
+                if d not in visited:
+                    self._invalidate_path_inner(d, visited)
+
+    def invalidate_path(self, path: ResolvableToComponentPath) -> None:
+        """Invalidates the cache for a given component path and all of its dependents."""
+        path = ComponentPath.from_resolvable(self._defs_module_path, path)
+        self._invalidate_path_inner(path, set())
+
+    def get_cache_data(self, path: ResolvableToComponentPath) -> _CacheData:
+        resolved_path = ComponentPath.from_resolvable(self._defs_module_path, path)
+        return self._cache[resolved_path]
+
+    def set_cache_data(self, path: ResolvableToComponentPath, **kwargs) -> None:
+        resolved_path = ComponentPath.from_resolvable(self._defs_module_path, path)
+        current_data = self._cache[resolved_path]
+        self._cache[resolved_path] = replace(current_data, **kwargs)
+
+    def mark_component_load_dependency(
+        self, from_path: ComponentPath, to_path: ComponentPath
+    ) -> None:
+        self._component_load_dependents_dict[to_path].add(from_path)
+
+    def mark_component_defs_dependency(
+        self, from_path: ComponentPath, to_path: ComponentPath
+    ) -> None:
+        self._component_defs_dependents_dict[to_path].add(from_path)
+
+    def mark_component_defs_state_key(self, path: ComponentPath, defs_state_key: str) -> None:
+        # ensures that no components share the same defs state key
+        existing_path = self._component_defs_state_key_dict.get(defs_state_key)
+        if existing_path is not None and existing_path != path:
+            raise DagsterInvalidDefinitionError(
+                f"Multiple components have the same defs state key: {defs_state_key}\n"
+                "Component paths: \n"
+                f"  {existing_path}\n"
+                f"  {path}\n"
+                "Configure or override the `get_defs_state_key` method on one or both components to disambiguate."
+            )
+        self._component_defs_state_key_dict[defs_state_key] = path
+
+    def get_direct_load_dependents(self, path: ComponentPath) -> set[ComponentPath]:
+        """Returns the set of components that directly depend on the given component.
+
+        Args:
+            path: The path to the component to get the direct load dependents of.
+        """
+        return self._component_load_dependents_dict[path]
+
+    def get_direct_defs_dependents(self, path: ComponentPath) -> set[ComponentPath]:
+        """Returns the set of components that directly depend on the given component's defs.
+
+        Args:
+            defs_module_path: The path to the defs module.
+            component_path: The path to the component to get the direct defs dependents of.
+        """
+        return self._component_defs_dependents_dict[path]

--- a/python_modules/dagster/dagster/components/core/decl.py
+++ b/python_modules/dagster/dagster/components/core/decl.py
@@ -283,7 +283,7 @@ def build_component_decl_from_context(context: ComponentDeclLoadContext) -> Opti
     ):
         return PythonFileDecl(
             context=context,
-            path=ComponentPath(file_path=context.path / "definitions.py", instance_key=None),
+            path=ComponentPath.from_path(context.path / "definitions.py"),
             decls={},
         )
     elif context.path.suffix == ".py":
@@ -294,7 +294,7 @@ def build_component_decl_from_context(context: ComponentDeclLoadContext) -> Opti
         if children:
             return DefsFolderDecl(
                 context=context,
-                path=ComponentPath(file_path=context.path, instance_key=None),
+                path=ComponentPath.from_path(context.path),
                 children=children,
                 source_tree=None,
                 component_file_model=None,
@@ -315,7 +315,7 @@ def build_component_decls_from_directory_items(
             context,
             DefsFolderComponent,
             component_file_model.template_vars_module if component_file_model else None,
-        ).for_component_path(ComponentPath(file_path=subpath, instance_key=None))
+        ).for_component_path(ComponentPath.from_path(subpath))
 
         component_node = build_component_decl_from_context(path_context)
         if component_node:
@@ -332,15 +332,13 @@ def build_component_decl_from_python_file(
     component_loaders = list(inspect.getmembers(module, is_component_loader))
 
     return PythonFileDecl(
-        path=ComponentPath(file_path=context.path, instance_key=None),
+        path=ComponentPath.from_path(context.path),
         context=context,
         decls={
             attr: ComponentLoaderDecl(
-                context=context.for_component_path(
-                    ComponentPath(file_path=context.path, instance_key=attr)
-                ),
+                context=context.for_component_path(ComponentPath.from_path(context.path, attr)),
                 component_node_fn=component_loader,
-                path=ComponentPath(file_path=context.path, instance_key=attr),
+                path=ComponentPath.from_path(context.path, attr),
             )
             for attr, component_loader in component_loaders
         },
@@ -366,17 +364,15 @@ def build_component_decl_from_yaml_file(
     for i, source_tree in enumerate(source_trees):
         component_nodes.append(
             build_component_decl_from_yaml_document(
-                context=context.for_component_path(
-                    ComponentPath(file_path=context.path, instance_key=i)
-                ),
+                context=context.for_component_path(ComponentPath.from_path(context.path, i)),
                 source_tree=source_tree,
-                path=ComponentPath(file_path=context.path, instance_key=i),
+                path=ComponentPath.from_path(context.path, i),
             )
         )
 
     check.invariant(len(component_nodes) > 0, "No components found in YAML file")
     return YamlFileDecl(
-        path=ComponentPath(file_path=context.path, instance_key=None),
+        path=ComponentPath.from_path(context.path),
         context=context,
         decls=component_nodes,
         source_positions=[

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/test_definitions_autoload.py
@@ -25,20 +25,14 @@ from dagster_tests.components_tests.utils import create_project_from_components
 def assert_tree_node_structure_matches(
     tree: ComponentTree, structure: dict[Union[str, ComponentPath], type[ComponentDecl]]
 ):
-    nodes_by_path = {
-        ComponentPath(
-            file_path=node_path.file_path.relative_to(tree.defs_module_path),
-            instance_key=node_path.instance_key,
-        ): node
-        for node_path, node in tree.find_root_decl().iterate_path_component_decl_pairs()
-    }
+    nodes_by_path = dict(tree.find_root_decl().iterate_path_component_decl_pairs())
     unrepresented_paths = set(nodes_by_path.keys())
 
     for path, expected_type in structure.items():
         component_path = (
             path
             if isinstance(path, ComponentPath)
-            else ComponentPath(file_path=Path(path), instance_key=None)
+            else ComponentPath.from_path(path=tree.defs_module_path / Path(path), instance_key=None)
         )
         matching_node = next(
             (
@@ -167,29 +161,21 @@ def test_autoload_single_file(component_tree: ComponentTree) -> None:
     defs = component_tree.build_defs()
     assert component_tree.has_built_all_defs()
 
-    assert component_tree.state_tracker.get_direct_load_dependents_of_component(
-        component_tree.defs_module_path,
-        ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None),
-    ) == {ComponentPath(file_path=Path("single_file"), instance_key=None)}
+    assert component_tree.state_tracker.get_direct_load_dependents(
+        ComponentPath.from_resolvable(component_tree.defs_module_path, "single_file/some_file.py"),
+    ) == {ComponentPath.from_resolvable(component_tree.defs_module_path, "single_file")}
 
-    assert component_tree.state_tracker.get_direct_defs_dependents_of_component(
-        component_tree.defs_module_path,
-        ComponentPath(file_path=Path("single_file/some_file.py"), instance_key=None),
-    ) == {ComponentPath(file_path=Path("single_file"), instance_key=None)}
+    assert component_tree.state_tracker.get_direct_defs_dependents(
+        ComponentPath.from_resolvable(component_tree.defs_module_path, "single_file/some_file.py"),
+    ) == {ComponentPath.from_resolvable(component_tree.defs_module_path, "single_file")}
 
-    assert component_tree.state_tracker.get_direct_load_dependents_of_component(
-        component_tree.defs_module_path,
-        ComponentPath(file_path=Path("single_file"), instance_key=None),
-    ) == {
-        ComponentPath(file_path=Path("."), instance_key=None),
-    }
+    assert component_tree.state_tracker.get_direct_load_dependents(
+        ComponentPath.from_resolvable(component_tree.defs_module_path, "single_file")
+    ) == {ComponentPath.from_resolvable(component_tree.defs_module_path, ".")}
 
-    assert component_tree.state_tracker.get_direct_load_dependents_of_component(
-        component_tree.defs_module_path,
-        ComponentPath(file_path=Path("__init__.py"), instance_key=None),
-    ) == {
-        ComponentPath(file_path=Path("."), instance_key=None),
-    }
+    assert component_tree.state_tracker.get_direct_load_dependents(
+        ComponentPath.from_resolvable(component_tree.defs_module_path, "__init__.py")
+    ) == {ComponentPath.from_resolvable(component_tree.defs_module_path, ".")}
 
     assert {spec.key for spec in defs.resolve_all_asset_specs()} == {dg.AssetKey("an_asset")}
     assert (
@@ -337,24 +323,24 @@ def test_ignored_empty_dir():
             tree,
             {
                 ".": YamlFileDecl,
-                ComponentPath(file_path=Path("."), instance_key=0): DefsFolderDecl,
+                ComponentPath.from_path(tree.defs_module_path, 0): DefsFolderDecl,
                 "top_level.py": PythonFileDecl,
                 "loose_defs": YamlFileDecl,
-                ComponentPath(file_path=Path("loose_defs"), instance_key=0): DefsFolderDecl,
+                ComponentPath.from_path(tree.defs_module_path / "loose_defs", 0): DefsFolderDecl,
                 "loose_defs/asset.py": PythonFileDecl,
                 "loose_defs/inner": DefsFolderDecl,
                 "loose_defs/inner/asset.py": PythonFileDecl,
                 "loose_defs/inner/innerer": DefsFolderDecl,
                 "loose_defs/inner/innerer/asset.py": PythonFileDecl,
                 "loose_defs/inner/innerer/another_level": YamlFileDecl,
-                ComponentPath(
-                    file_path=Path("loose_defs/inner/innerer/another_level"), instance_key=0
+                ComponentPath.from_path(
+                    tree.defs_module_path / "loose_defs/inner/innerer/another_level", 0
                 ): DefsFolderDecl,
                 "loose_defs/inner/innerer/another_level/in_init": DefsFolderDecl,
                 "loose_defs/inner/innerer/another_level/in_init/__init__.py": PythonFileDecl,
                 "loose_defs/inner/innerer/another_level/innerest/definitions.py": PythonFileDecl,  # no folder bc definitions.py special name
                 "defs_object": YamlFileDecl,
-                ComponentPath(file_path=Path("defs_object"), instance_key=0): DefsFolderDecl,
+                ComponentPath.from_path(tree.defs_module_path / "defs_object", 0): DefsFolderDecl,
                 "defs_object/defs_object/definitions.py": PythonFileDecl,  # no folder bc definitions.py special name
             },
         )

--- a/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
+++ b/python_modules/dagster/dagster_tests/components_tests/unit_tests/test_component_decl.py
@@ -44,7 +44,7 @@ def test_component_loader_decl(component_tree: MockComponentTree):
     my_component = MyComponent()
     decl = ComponentLoaderDecl(
         context=component_tree.decl_load_context,
-        path=ComponentPath(file_path=Path(__file__).parent, instance_key=None),
+        path=ComponentPath.from_path(Path(__file__).parent),
         component_node_fn=lambda context: my_component,
     )
 
@@ -56,11 +56,11 @@ def test_composite_python_decl(component_tree: MockComponentTree):
     my_component = MyComponent()
     loader_decl = ComponentLoaderDecl(
         context=component_tree.decl_load_context,
-        path=ComponentPath(file_path=Path(__file__).parent, instance_key="my_component"),
+        path=ComponentPath.from_path(Path(__file__).parent, "my_component"),
         component_node_fn=lambda context: my_component,
     )
     decl = PythonFileDecl(
-        path=ComponentPath(file_path=Path(__file__).parent, instance_key=None),
+        path=ComponentPath.from_path(Path(__file__).parent),
         context=component_tree.decl_load_context,
         decls={"my_component": loader_decl},
     )
@@ -75,23 +75,21 @@ def test_defs_folder_decl(component_tree: MockComponentTree):
     my_component = MyComponent()
     loader_decl = ComponentLoaderDecl(
         context=component_tree.decl_load_context,
-        path=ComponentPath(file_path=Path(__file__).parent / "my_component", instance_key=None),
+        path=ComponentPath.from_path(Path(__file__).parent / "my_component"),
         component_node_fn=lambda context: my_component,
     )
 
     my_other_component = MyComponent()
     my_other_loader_decl = ComponentLoaderDecl(
         context=component_tree.decl_load_context,
-        path=ComponentPath(
-            file_path=Path(__file__).parent / "my_other_component", instance_key=None
-        ),
+        path=ComponentPath.from_path(Path(__file__).parent / "my_other_component"),
         component_node_fn=lambda context: my_other_component,
     )
 
     defs_path = Path(__file__).parent
     decl = DefsFolderDecl(
         context=component_tree.decl_load_context,
-        path=ComponentPath(file_path=defs_path, instance_key=None),
+        path=ComponentPath.from_path(defs_path),
         children={
             defs_path / "my_component": loader_decl,
             defs_path / "my_other_component": my_other_loader_decl,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/dependency_on_dbt_project_location/defs/depends_on_dbt/definitions.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/code_locations/dependency_on_dbt_project_location/defs/depends_on_dbt/definitions.py
@@ -8,7 +8,7 @@ from dagster_dbt import DbtProjectComponent
 @dg.definitions
 def defs(context: dg.ComponentLoadContext) -> dg.Definitions:
     customers_asset_key = context.load_component_at_path(
-        ComponentPath(file_path=Path("jaffle_shop_dbt"), instance_key=0),
+        ComponentPath.from_path(Path(__file__).parent.parent / "jaffle_shop_dbt", instance_key=0),
         expected_type=DbtProjectComponent,
     ).asset_key_for_model("customers")
 


### PR DESCRIPTION
## Summary & Motivation

This is a refactor and (ideally) simplification of how we manage component tree state. There are a few things going on here:

1. moved ComponentTreeStateTracker into its own file
2. reworked how we manage ComponentPaths. They are now always fully resolved (i.e. they contain absolute paths), meaning they can be used as dictionary keys for caches and other such objects. This removes the need for the _get_canonical_path type functions, as ComponentPaths *are* the canonical paths
3. reworked the caching mechanism from the previous pr to be much more explicit. we now have an explicit cache that routes from a given ComponentPath to a state object with a collection of properties. I use this pattern of having a single dictionary instead of one dictionary per cacheable object type for simplicity -- it makes it much easier to invalidate the entire set of cache objects at once. I think given the nature of the types of cache operations we'll eventually want to do, we sorta need to have complete control over the cache, so the approach in the previous pr of relying on `cached_method` with a cache key was doomed to hit a wall eventually.

## How I Tested These Changes

## Changelog

NOCHANGELOG
