### PR TITLE
Tags fivetran assets

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -728,7 +728,7 @@ def load_assets_from_fivetran_instance(
         )
     except Exception as e:
         logger.warning(
-            "An error occured while loading an asset from a fivetran instance",
+            "An error occurred while loading an asset from a fivetran instance",
             f"Exception: {e}",
             exc_info=True,
         )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -407,6 +407,7 @@ def _build_fivetran_assets_from_metadata(
     poll_timeout: Optional[float],
     fetch_column_metadata: bool,
     translator: Optional[type[DagsterFivetranTranslator]] = None,
+    tags: Optional[Mapping[str, Any]] = None, 
 ) -> AssetsDefinition:
     metadata = cast("Mapping[str, Any]", assets_defn_meta.extra_metadata)
     connector_id = cast("str", metadata["connector_id"])
@@ -434,7 +435,7 @@ def _build_fivetran_assets_from_metadata(
         group_name=assets_defn_meta.group_name,
         poll_interval=poll_interval,
         poll_timeout=poll_timeout,
-        asset_tags=build_kind_tag(storage_kind) if storage_kind else None,
+        asset_tags={**(build_kind_tag(storage_kind) if storage_kind else {}), **(tags or {})},
         fetch_column_metadata=fetch_column_metadata,
         infer_missing_tables=False,
         op_tags=None,
@@ -457,6 +458,7 @@ class FivetranInstanceCacheableAssetsDefinition(CacheableAssetsDefinition):
         poll_timeout: Optional[float],
         fetch_column_metadata: bool,
         translator: Optional[type[DagsterFivetranTranslator]] = None,
+        tags: Optional[Mapping[str, Any]] = None,
     ):
         self._fivetran_resource_def = fivetran_resource_def
         if isinstance(fivetran_resource_def, FivetranResource):
@@ -487,6 +489,7 @@ class FivetranInstanceCacheableAssetsDefinition(CacheableAssetsDefinition):
         self._poll_timeout = poll_timeout
         self._fetch_column_metadata = fetch_column_metadata
         self._translator = translator
+        self._tags = tags
 
         contents = hashlib.sha1()
         contents.update(",".join(key_prefix).encode("utf-8"))
@@ -578,6 +581,7 @@ class FivetranInstanceCacheableAssetsDefinition(CacheableAssetsDefinition):
                 poll_timeout=self._poll_timeout,
                 fetch_column_metadata=self._fetch_column_metadata,
                 translator=self._translator,
+                tags=self._tags,
             )
             for meta in data
         ]
@@ -605,6 +609,7 @@ def load_assets_from_fivetran_instance(
     poll_timeout: Optional[float] = None,
     fetch_column_metadata: bool = True,
     translator: Optional[type[DagsterFivetranTranslator]] = None,
+    tags: Optional[Mapping[str, Any]] = None, 
 ) -> CacheableAssetsDefinition:
     """Loads Fivetran connector assets from a configured FivetranResource instance. This fetches information
     about defined connectors at initialization time, and will error on workspace load if the Fivetran
@@ -706,6 +711,7 @@ def load_assets_from_fivetran_instance(
         poll_timeout=poll_timeout,
         fetch_column_metadata=fetch_column_metadata,
         translator=translator,
+        tags=tags,
     )
 
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -407,7 +407,7 @@ def _build_fivetran_assets_from_metadata(
     poll_timeout: Optional[float],
     fetch_column_metadata: bool,
     translator: Optional[type[DagsterFivetranTranslator]] = None,
-    tags: Optional[Mapping[str, Any]] = None, 
+    tags: Optional[Mapping[str, Any]] = None,
 ) -> AssetsDefinition:
     metadata = cast("Mapping[str, Any]", assets_defn_meta.extra_metadata)
     connector_id = cast("str", metadata["connector_id"])
@@ -609,7 +609,7 @@ def load_assets_from_fivetran_instance(
     poll_timeout: Optional[float] = None,
     fetch_column_metadata: bool = True,
     translator: Optional[type[DagsterFivetranTranslator]] = None,
-    tags: Optional[Mapping[str, Any]] = None, 
+    tags: Optional[Mapping[str, Any]] = None,
 ) -> CacheableAssetsDefinition:
     """Loads Fivetran connector assets from a configured FivetranResource instance. This fetches information
     about defined connectors at initialization time, and will error on workspace load if the Fivetran

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/deprecated/test_tags_load_from_instance.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/deprecated/test_tags_load_from_instance.py
@@ -2,16 +2,13 @@ import responses
 from dagster import EnvVar
 from dagster._core.instance_for_test import environ
 from dagster_fivetran import FivetranResource
-from dagster_fivetran.asset_defs import (
-    load_assets_from_fivetran_instance,
-)
+from dagster_fivetran.asset_defs import load_assets_from_fivetran_instance
 
 from dagster_fivetran_tests.deprecated.utils import mock_responses
 
 
 @responses.activate
-def test_load_from_instance_with_tags(
-) -> None:
+def test_load_from_instance_with_tags() -> None:
     with environ({"FIVETRAN_API_KEY": "some_key", "FIVETRAN_API_SECRET": "some_secret"}):
         ft_resource = FivetranResource(
             api_key=EnvVar("FIVETRAN_API_KEY"), api_secret=EnvVar("FIVETRAN_API_SECRET")
@@ -23,7 +20,7 @@ def test_load_from_instance_with_tags(
             ft_resource,
             poll_interval=10,
             poll_timeout=600,
-            tags={"dagster/max_retries": "3"}, 
+            tags={"dagster/max_retries": "3"},
         )
         ft_assets = ft_cacheable_assets.build_definitions(
             ft_cacheable_assets.compute_cacheable_data()
@@ -31,5 +28,5 @@ def test_load_from_instance_with_tags(
 
         assets_def = ft_assets[0]
 
-        for key, metadata in assets_def.metadata_by_key.items():
+        for key in assets_def.metadata_by_key.keys():
             assert "dagster/max_retries" in assets_def.tags_by_key[key]

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/deprecated/test_tags_load_from_instance.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/deprecated/test_tags_load_from_instance.py
@@ -1,0 +1,35 @@
+import responses
+from dagster import EnvVar
+from dagster._core.instance_for_test import environ
+from dagster_fivetran import FivetranResource
+from dagster_fivetran.asset_defs import (
+    load_assets_from_fivetran_instance,
+)
+
+from dagster_fivetran_tests.deprecated.utils import mock_responses
+
+
+@responses.activate
+def test_load_from_instance_with_tags(
+) -> None:
+    with environ({"FIVETRAN_API_KEY": "some_key", "FIVETRAN_API_SECRET": "some_secret"}):
+        ft_resource = FivetranResource(
+            api_key=EnvVar("FIVETRAN_API_KEY"), api_secret=EnvVar("FIVETRAN_API_SECRET")
+        )
+
+        mock_responses(ft_resource)
+
+        ft_cacheable_assets = load_assets_from_fivetran_instance(
+            ft_resource,
+            poll_interval=10,
+            poll_timeout=600,
+            tags={"dagster/max_retries": "3"}, 
+        )
+        ft_assets = ft_cacheable_assets.build_definitions(
+            ft_cacheable_assets.compute_cacheable_data()
+        )
+
+        assets_def = ft_assets[0]
+
+        for key, metadata in assets_def.metadata_by_key.items():
+            assert "dagster/max_retries" in assets_def.tags_by_key[key]


### PR DESCRIPTION
## Summary & Motivation
Me and my partner @aconst26 wanted to tackle this issue https://github.com/dagster-io/dagster/issues/25873. That being false positives for errors when using the function load_assets_from_fivetran_instance. Since it's asking us to update deprecated code it's a great way to have someone look at our attempt to fix a problem for an inconsequential piece of the codebase that will most likely get deleted soon. We're additionally working with CTI, and CodeDay Labs in order to get some experience with open source that might help both of us in the future.

## How We Tested These Changes
A mix of just running the function mentioned in the issue load_assets_from_fivetran_instance and then looking through the error messages. As well as using pytest for a more comprehensive look through the working of the code.

## Changelog
We added the RetryPolicy to the building of Fivetran assets, and functionality for tags to customize how this RetryPolicy would function. We added comments on the function about the new argument, and set up some logging for both testing of how our changes worked out, and so that theoretical future users can understand what's going on.


