### PR TITLE
Short circuit in asset check health state when the asset key is not in the graph or has no checks

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_check_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_check_health.py
@@ -197,6 +197,12 @@ async def get_asset_check_status_and_metadata(
         # asset graph. If check results are reported for assets or checks that are not in the asset graph, those
         # results will not be picked up. If we add storage methods to get all check results for an asset by
         # asset key, rather than by check keys, we could compute check health for the asset in this case.
+
+        if not context.asset_graph.has(
+            asset_key
+        ) or not context.asset_graph.get_check_keys_for_assets({asset_key}):
+            return AssetHealthStatus.UNKNOWN, None
+
         remote_check_nodes = context.asset_graph.get_checks_for_asset(asset_key)
         asset_check_health_state = await AssetCheckHealthState.compute_for_asset_checks(
             {remote_check_node.asset_check.key for remote_check_node in remote_check_nodes},


### PR DESCRIPTION
Summary:
The old logic required a full asset graph fetch in this case, now it does not.

Test Plan:
BK, dry run on a slow asset asset health load

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.