### PR TITLE
[state-backed-components] Don't mkdir eagerly

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/defs_state/blob_storage_state_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/defs_state/blob_storage_state_storage.py
@@ -23,7 +23,6 @@ class BlobStorageStateStorage(DefsStateStorage, ConfigurableClass):
     def __init__(self, base_path: "UPath", inst_data: Optional[ConfigurableClassData] = None):
         self._inst_data = inst_data
         self._base_path = base_path
-        self._base_path.mkdir(parents=True, exist_ok=True)
 
     @property
     def base_path(self) -> "UPath":


### PR DESCRIPTION
## Summary & Motivation

There's no need to make this directory before we call `upload_state_from_path` (as this also makes sure that the directory is made). So for users not interacting with this set of features, we shouldn't make a directory for them

## How I Tested These Changes

## Changelog

NOCHANGELOG
