### PR TITLE
[backfill-config] Fix asset selection

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -641,6 +641,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
           assets[0]?.jobNames.find((name) => name.startsWith(__ASSET_JOB_PREFIX)) ||
           __ASSET_JOB_PREFIX
         }
+        assetKeys={assets.map((asset) => asset.assetKey)}
         open={launchpadOpen}
         setOpen={setLaunchpadOpen}
         onSaveConfig={(config: LaunchpadConfig) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadRoot.tsx
@@ -14,6 +14,7 @@ import {__ASSET_JOB_PREFIX} from '../asset-graph/Utils';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {RepoAddress} from '../workspace/types';
 import {LaunchpadRootQuery, LaunchpadRootQueryVariables} from './types/LaunchpadAllowedRoot.types';
+import {AssetKey} from '../graphql/types';
 
 // ########################
 // ##### LAUNCHPAD ROOTS
@@ -58,6 +59,7 @@ export const BackfillLaunchpad = ({
   repoAddress,
   sessionPresets,
   assetJobName,
+  assetKeys,
   open,
   setOpen,
   onSaveConfig,
@@ -66,6 +68,7 @@ export const BackfillLaunchpad = ({
   repoAddress: RepoAddress;
   sessionPresets?: Partial<IExecutionSession>;
   assetJobName: string;
+  assetKeys?: AssetKey[];
   open: boolean;
   setOpen: (open: boolean) => void;
   onSaveConfig: (config: LaunchpadConfig) => void;
@@ -108,12 +111,15 @@ export const BackfillLaunchpad = ({
   // Use the saved config's runConfigYaml as rootDefaultYaml if available
   const rootDefaultYaml = savedConfig?.runConfigYaml;
 
+  // Convert assetKeys to the format expected by sessionPresets.assetSelection
+  const assetSelection = assetKeys?.map((assetKey) => ({
+    assetKey: {path: assetKey.path},
+  }));
+
   return (
     <Dialog
       style={{height: '90vh', width: '80%', minWidth: '1000px'}}
       isOpen={open}
-      canEscapeKeyClose={false}
-      canOutsideClickClose={false}
       onClose={() => setOpen(false)}
     >
       <DialogHeader icon="layers" label={title} />
@@ -123,7 +129,10 @@ export const BackfillLaunchpad = ({
         pipeline={pipelineOrError}
         partitionSets={partitionSetsOrError}
         repoAddress={repoAddress}
-        sessionPresets={sessionPresets || {}}
+        sessionPresets={{
+          ...sessionPresets,
+          assetSelection,
+        }}
         rootDefaultYaml={rootDefaultYaml}
         onSaveConfig={onSaveConfig}
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -566,6 +566,10 @@ const LaunchpadSession = (props: LaunchpadSessionProps) => {
         : '',
     assetSelection: currentSession.assetSelection,
     repositorySelector,
+    // do not fetch config for backfill launchpad because the core job
+    // will often have multiple partitions defs, which will cause the
+    // queries to fail
+    skipConfigQuery: !!onSaveConfig,
   });
   const {
     preview,

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/usePartitionSetDetailsForLaunchpad.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/usePartitionSetDetailsForLaunchpad.tsx
@@ -16,16 +16,18 @@ export function usePartitionSetDetailsForLaunchpad({
   partitionSetName,
   repositorySelector,
   assetSelection,
+  skipConfigQuery,
 }: {
   pipelineName: string;
   partitionSetName: string;
   repositorySelector: RepositorySelector;
   assetSelection?: IExecutionSession['assetSelection'];
+  skipConfigQuery: boolean;
 }) {
   const queryResultNoAssets = useQuery<ConfigPartitionsQuery, ConfigPartitionsQueryVariables>(
     CONFIG_PARTITIONS_QUERY,
     {
-      skip: !!assetSelection,
+      skip: !!assetSelection || skipConfigQuery,
       variables: {repositorySelector, partitionSetName},
       fetchPolicy: 'network-only',
     },
@@ -35,7 +37,7 @@ export function usePartitionSetDetailsForLaunchpad({
     ConfigPartitionsAssetsQuery,
     ConfigPartitionsAssetsQueryVariables
   >(CONFIG_PARTITIONS_ASSETS_QUERY, {
-    skip: !assetSelection,
+    skip: !assetSelection || skipConfigQuery,
     variables: {
       params: {...repositorySelector, pipelineName},
       assetKeys: assetSelection


### PR DESCRIPTION
## Summary & Motivation

Fixes an issue where if you have a sub-selection of assets, in your backfill, we previously would require config to be provided for all assets in the code locaiton.

The skipConfigQuery pattern is a little suspect but it was the simplest solution I could find.

Also makes it possible to click out of the config dialog without saving, as it's kinda annoying not to be able to.

## How I Tested These Changes

manually

## Changelog

Fixed an issue that would require config provided to backfills to contain config for all assets in the conde location rather than just the selected ones.
