### PR TITLE
[buildkite] fix CommandStepBuilder.with_retry

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -1,5 +1,5 @@
 import os
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from glob import glob
 from pathlib import Path
@@ -160,7 +160,7 @@ class PackageSpec:
         if self.run_pytest:
             default_python_versions = AvailablePythonVersion.get_pytest_defaults()
 
-            tox_factors: list[Optional[ToxFactor]] = (
+            tox_factors: Sequence[Optional[ToxFactor]] = (
                 self.pytest_tox_factors if self.pytest_tox_factors else [None]
             )
 


### PR DESCRIPTION
do not blank out the existing default retry configuration if `with_retry` is called with `None` which happens in tox step building

## How I Tested These Changes
run
`
BUILDKITE_MESSAGE="foo" BUILDKITE_COMMIT=50419a68e244e199575f20adf54c3abc27d8185c BUILDKITE_BRANCH=master dagster-buildkite
`
and see that `dagster-dbt` has expected automatic retry config 

