### PR TITLE
[ui] Insights v2: Fix time range

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/insights/ActivityChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/ActivityChart.tsx
@@ -177,8 +177,8 @@ const InnerActivityChartRow = <T,>(props: RowProps<T>) => {
                       if (onClick) {
                         onClick({
                           current: {
-                            before: date / 1000 + (index - 1) * 60 * 60,
-                            after: date / 1000 + index * 60 * 60,
+                            before: date / 1000 + index * 60 * 60,
+                            after: date / 1000 + (index - 1) * 60 * 60,
                           },
                           metric,
                         });

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/LineChartWithComparison.tsx
@@ -337,6 +337,7 @@ export const InnerLineChartWithComparison = <T,>(props: Props<T>) => {
       if (element) {
         const index = element.index;
         let timeSliceSeconds = 60 * 60; // Default to 1 hour
+
         if (metrics.currentPeriod.timestamps.length >= 2) {
           const timeSliceStart = metrics.currentPeriod.timestamps[0];
           const timeSliceEnd = metrics.currentPeriod.timestamps[1];
@@ -347,23 +348,19 @@ export const InnerLineChartWithComparison = <T,>(props: Props<T>) => {
 
         const currentTime = metrics.currentPeriod.timestamps[index];
         const previousTime = metrics.prevPeriod.timestamps[index];
-        const currentDataAtIndex = metrics.currentPeriod.data[index];
-        const previousDataAtIndex = metrics.prevPeriod.data[index];
 
-        const current =
-          currentTime && currentDataAtIndex
-            ? {
-                before: currentTime - timeSliceSeconds,
-                after: currentTime,
-              }
-            : undefined;
-        const previous =
-          previousTime && previousDataAtIndex
-            ? {
-                before: previousTime - timeSliceSeconds,
-                after: previousTime,
-              }
-            : undefined;
+        const current = currentTime
+          ? {
+              after: currentTime - timeSliceSeconds,
+              before: currentTime,
+            }
+          : undefined;
+        const previous = previousTime
+          ? {
+              after: previousTime - timeSliceSeconds,
+              before: previousTime,
+            }
+          : undefined;
 
         if (current || previous) {
           openMetricDialog({


### PR DESCRIPTION
## Summary & Motivation

Fix time range math for opening the dialog from line charts and activity charts. I think this was probably some bad vibing on my part.

The "before" timestamp should be greater than the "after" timestamp. Right now, they're backward.

I think the backend may be swapping them automatically if they're out of order, because the data retrieved seems unchanged. Still, we should try to get this correct in JS.

## How I Tested These Changes

View Insights, click on line chart and activity charts. The query vars now look correct.