### PR TITLE
[ui] Avoid unmount + remount of viewport when hiding explorer sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/SplitPanelContainer.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/SplitPanelContainer.tsx
@@ -8,7 +8,7 @@ const DIVIDER_THICKNESS = 2;
 interface SplitPanelContainerProps {
   axis?: 'horizontal' | 'vertical';
   identifier: string;
-  first: React.ReactNode;
+  first: React.ReactNode | null;
   firstInitialPercent: number;
   firstMinSize?: number;
   secondMinSize?: number;
@@ -62,15 +62,25 @@ export const SplitPanelContainer = forwardRef<SplitPanelContainerHandle, SplitPa
     // Note: The divider appears after the first panel, so making the first panel 100% wide
     // hides the divider offscreen. To prevent this, we subtract the divider depth.
     if (axis === 'horizontal') {
-      firstPaneStyles.minWidth = firstMinSize;
-      firstPaneStyles.width = `calc(${firstSize / 100} * (100% - ${
-        DIVIDER_THICKNESS + (second ? secondMinSize : 0)
-      }px))`;
+      if (!first) {
+        firstPaneStyles.minWidth = 0;
+        firstPaneStyles.width = 0;
+      } else {
+        firstPaneStyles.minWidth = firstMinSize;
+        firstPaneStyles.width = `calc(${firstSize / 100} * (100% - ${
+          DIVIDER_THICKNESS + (second ? secondMinSize : 0)
+        }px))`;
+      }
     } else {
-      firstPaneStyles.minHeight = firstMinSize;
-      firstPaneStyles.height = `calc(${firstSize / 100} * (100% - ${
-        DIVIDER_THICKNESS + (second ? secondMinSize : 0)
-      }px))`;
+      if (!first) {
+        firstPaneStyles.minHeight = 0;
+        firstPaneStyles.height = 0;
+      } else {
+        firstPaneStyles.minHeight = firstMinSize;
+        firstPaneStyles.height = `calc(${firstSize / 100} * (100% - ${
+          DIVIDER_THICKNESS + (second ? secondMinSize : 0)
+        }px))`;
+      }
     }
 
     return (
@@ -78,13 +88,15 @@ export const SplitPanelContainer = forwardRef<SplitPanelContainerHandle, SplitPa
         <div className="split-panel" style={firstPaneStyles}>
           {first}
         </div>
-        <PanelDivider
-          axis={axis}
-          resizing={resizing}
-          secondMinSize={secondMinSize}
-          onSetResizing={setResizing}
-          onMove={onChangeSize}
-        />
+        {first && second ? (
+          <PanelDivider
+            axis={axis}
+            resizing={resizing}
+            secondMinSize={secondMinSize}
+            onSetResizing={setResizing}
+            onMove={onChangeSize}
+          />
+        ) : undefined}
         <div className="split-panel" style={{flex: 1}}>
           {second}
         </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -895,15 +895,15 @@ const AssetGraphExplorerWithData = ({
     />
   );
 
-  if (showSidebar) {
-    return (
-      <SplitPanelContainer
-        key="explorer-wrapper"
-        identifier="explorer-wrapper"
-        firstMinSize={300}
-        firstInitialPercent={0}
-        secondMinSize={400}
-        first={
+  return (
+    <SplitPanelContainer
+      key="explorer-wrapper"
+      identifier="explorer-wrapper"
+      firstMinSize={300}
+      firstInitialPercent={0}
+      secondMinSize={400}
+      first={
+        showSidebar ? (
           <AssetGraphExplorerSidebar
             viewType={viewType}
             allAssetKeys={allAssetKeys}
@@ -921,12 +921,11 @@ const AssetGraphExplorerWithData = ({
             onFilterToGroup={onFilterToGroup}
             loading={loading}
           />
-        }
-        second={explorer}
-      />
-    );
-  }
-  return explorer;
+        ) : null
+      }
+      second={explorer}
+    />
+  );
 };
 
 export interface AssetGroup {


### PR DESCRIPTION
## Summary & Motivation

Related: https://dagsterlabs.slack.com/archives/C03CCE471E0/p1755645402070769

Right now, when you close the sidebar on the asset lineage page the component hierarchy changes so the SVGViewport is unmounted and remounted. We use a context to preserve some viewport state within the SVGViewport between layout changes, but this is higher in the tree.

We support passing a null `second` view to the SplitPaneContainer and animates the second panel in when the value changes. This PR just allows us to do the same for the `first` pane so we can hide the sidebar panel without remounting the viewport.

