### PR TITLE
[ui] Fix asset overview live data not triggering events refresh

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
@@ -29,11 +29,16 @@ export const SimpleStakeholderAssetStatus = ({
     return <span />;
   }
 
-  if ((liveData.inProgressRunIds || []).length > 0) {
+  const [inProgressRunId] = liveData.inProgressRunIds || [];
+  if (inProgressRunId) {
     return (
       <Caption>
-        {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
-        <AssetRunLink assetKey={assetNode.assetKey} runId={liveData.inProgressRunIds[0]!} />
+        <Tag intent="none">
+          <Box flex={{gap: 4, alignItems: 'center'}}>
+            <StatusCaseDot statusCase={StatusCase.MATERIALIZING} />
+            <AssetRunLink assetKey={assetNode.assetKey} runId={inProgressRunId} />
+          </Box>
+        </Tag>
       </Caption>
     );
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestEvents.tsx
@@ -26,7 +26,6 @@ export function useLatestEvents(
   });
 
   const {data, refetch} = queryResult;
-
   const refreshHint = usePredicateChangeSignal(
     (prevHints, [lastMaterializationTimestamp, assetNodeLoadTimestamp]) => {
       const [prevLastMaterializationTimestamp, prevAssetNodeLoadTimestamp] =

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/usePredicateChangeSignal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/usePredicateChangeSignal.tsx
@@ -15,8 +15,8 @@ export const usePredicateChangeSignal = <T extends ReadonlyArray<unknown>>(
 
   const resultValueRef = React.useRef<1 | 0>(1);
 
+  previousDepsRef.current = currentDeps;
   if (didChange) {
-    previousDepsRef.current = currentDeps;
     resultValueRef.current = resultValueRef.current === 1 ? 0 : 1;
   }
   return resultValueRef.current;


### PR DESCRIPTION
https://linear.app/dagster-labs/issue/FE-926/mismatched-latest-materialization-time-in-the-ui

## Summary & Motivation

We have a hook called `usePredicateChangeSignal` that is only used in this location. It's meant to let you filter inputs and trigger a simple number to flip from `0 | 1`, which is then used as a dep in downstream hooks. The problem is that `usePredicateChangeSignal` only updates the "previous inputs" it passes to the predicate IF the predicate returns true, and the predicate we implemented (below) does not return true unless the previous inputs are present, so it never returned true.

```
const refreshHint = usePredicateChangeSignal(
    (prevHints, [lastMaterializationTimestamp, assetNodeLoadTimestamp]) => {
      const [prevLastMaterializationTimestamp, prevAssetNodeLoadTimestamp] =
        prevHints || ([undefined, undefined] as const);

      return !!(
        /**
         * Trigger a refetch only if a previous a timestamp hint existed and has changed.
         * This avoids redundant queries since these timestamps are fetched in parallel.
         */
        (
          (prevLastMaterializationTimestamp &&
            lastMaterializationTimestamp !== prevLastMaterializationTimestamp) ||
          (prevAssetNodeLoadTimestamp && prevAssetNodeLoadTimestamp !== assetNodeLoadTimestamp)
        )
      );
    },
    [lastMaterializationTimestamp, assetNodeLoadTimestamp],
  );
```

Sidenote: I also made the "in progress" state look better - this is the new version. I believe that with some refactoring, it must have lost a tag container because it was just rendering as a bare 8-character text link.  

<img width="323" height="183" alt="image" src="https://github.com/user-attachments/assets/73cb5258-096e-4a23-abf6-8ee4658045f0" />

I tested these changes locally by materializing repeatedly and making sure that the asset overview reflects the changes fully. Previously the tag would update, but the name of the partition and the latest event metadata shown on the page would not. 