### PR TITLE
[ui] Insights v2: Show time range tooltips on dialog columns

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogHorizontalTopAssetsChart.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogHorizontalTopAssetsChart.module.css
@@ -3,6 +3,9 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+
+  --value-grid-column-width: 112px;
+  --change-grid-column-width: 80px;
 }
 
 .listContainer {
@@ -26,13 +29,21 @@
   padding: 0px 20px 8px 24px;
 }
 
+.headerGrid :global(.bp5-popover-target) {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
 .headerGrid.hasCurrentData,
 .headerGrid.hasPreviousData {
-  grid-template-columns: 1fr 88px;
+  grid-template-columns: 1fr var(--value-grid-column-width);
 }
 
 .headerGrid.change.change {
-  grid-template-columns: 1fr repeat(3, 88px);
+  grid-template-columns: 1fr repeat(2, var(--value-grid-column-width)) var(
+      --change-grid-column-width
+    );
 }
 
 .sortButton.sortButton {
@@ -56,15 +67,15 @@
 
 .rightGrid {
   display: grid;
-  grid-template-columns: repeat(3, 88px);
+  grid-template-columns: repeat(2, var(--value-grid-column-width)) var(--change-grid-column-width);
   gap: 12px;
 }
 
 .rightGrid.hasCurrentData,
 .rightGrid.hasPreviousData {
-  grid-template-columns: 88px;
+  grid-template-columns: var(--value-grid-column-width);
 }
 
 .rightGrid.change.change {
-  grid-template-columns: repeat(3, 88px);
+  grid-template-columns: repeat(2, var(--value-grid-column-width)) var(--change-grid-column-width);
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogHorizontalTopAssetsChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/insights/AssetCatalogHorizontalTopAssetsChart.tsx
@@ -8,11 +8,12 @@ import {
   MiddleTruncate,
   Mono,
   Row,
+  Tooltip,
   UnstyledButton,
 } from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import clsx from 'clsx';
-import React, {useMemo, useRef, useState} from 'react';
+import React, {memo, useMemo, useRef, useState} from 'react';
 import {Link} from 'react-router-dom';
 
 import styles from './AssetCatalogHorizontalTopAssetsChart.module.css';
@@ -56,13 +57,15 @@ const getChangeColor = (change: number) => {
 type MaybeData = null | {labels: string[]; data: number[]};
 
 interface Props {
+  currentTimeString: string;
+  previousTimeString: string;
   currentData: MaybeData;
   previousData: MaybeData;
   unitType: ReportingUnitType;
 }
 
-export const AssetCatalogHorizontalTopAssetsChart = React.memo(
-  ({currentData, previousData, unitType}: Props) => {
+export const AssetCatalogHorizontalTopAssetsChart = memo(
+  ({currentData, previousData, unitType, currentTimeString, previousTimeString}: Props) => {
     const [sortBy, setSortBy] = useState<{by: SortBy; dir: SortDir}>(() => ({
       by: getInitialSortBy(currentData, previousData),
       dir: 'desc',
@@ -164,22 +167,28 @@ export const AssetCatalogHorizontalTopAssetsChart = React.memo(
               <Icon name={sortBy.by === 'name' ? icon : 'expand'} />
             </UnstyledButton>
             {currentData ? (
-              <UnstyledButton
-                onClick={() => onSort('current')}
-                className={clsx(styles.sortButton, sortBy.by === 'current' && styles.active)}
-              >
-                <span>This period</span>
-                <Icon name={sortBy.by === 'current' ? icon : 'expand'} />
-              </UnstyledButton>
+              <Tooltip content={currentTimeString} placement="top">
+                <UnstyledButton
+                  onClick={() => onSort('current')}
+                  className={clsx(styles.sortButton, sortBy.by === 'current' && styles.active)}
+                >
+                  <span>This period</span>
+                  <Icon name="calendar" color={Colors.textLight()} />
+                  <Icon name={sortBy.by === 'current' ? icon : 'expand'} />
+                </UnstyledButton>
+              </Tooltip>
             ) : null}
             {previousData ? (
-              <UnstyledButton
-                onClick={() => onSort('previous')}
-                className={clsx(styles.sortButton, sortBy.by === 'previous' && styles.active)}
-              >
-                <span>Prev period</span>
-                <Icon name={sortBy.by === 'previous' ? icon : 'expand'} />
-              </UnstyledButton>
+              <Tooltip content={previousTimeString} placement="top">
+                <UnstyledButton
+                  onClick={() => onSort('previous')}
+                  className={clsx(styles.sortButton, sortBy.by === 'previous' && styles.active)}
+                >
+                  <span>Prev period</span>
+                  <Icon name="calendar" color={Colors.textLight()} />
+                  <Icon name={sortBy.by === 'previous' ? icon : 'expand'} />
+                </UnstyledButton>
+              </Tooltip>
             ) : null}
             {currentData && previousData ? (
               <UnstyledButton


### PR DESCRIPTION
## Summary & Motivation

OSS counterpart to https://github.com/dagster-io/internal/pull/17831.

Pass timestamp strings to the insights dialog, for display on the table header within tooltips.

<img width="1082" height="108" alt="Screenshot 2025-08-27 at 16 06 13" src="https://github.com/user-attachments/assets/04e44b2a-5f03-4e55-b66e-578f8b95482f" />

<img width="1084" height="114" alt="image" src="https://github.com/user-attachments/assets/620cceae-f395-4748-ac41-e74e529a6b85" />

## How I Tested These Changes

View insights, click on asset line chart. Verify correct rendering and behavior of tooltips on table headers.