### PR TITLE
Speed up DefaultPartitionsSubset.is_empty

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/default.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/default.py
@@ -28,6 +28,10 @@ class DefaultPartitionsSubset(
         check.opt_set_param(subset, "subset")
         return super().__new__(cls, subset or set())
 
+    @property
+    def is_empty(self) -> bool:
+        return len(self.subset) == 0
+
     def get_partition_keys_not_in_subset(
         self, partitions_def: PartitionsDefinition
     ) -> Iterable[str]:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -25,6 +25,14 @@ from dagster._serdes import deserialize_value, serialize_value
 from dagster._time import create_datetime, get_current_datetime
 
 
+def test_default_subset():
+    default_subset = DefaultPartitionsSubset({"a", "b", "c"})
+    assert not default_subset.is_empty
+
+    empty_subset = DefaultPartitionsSubset(set())
+    assert empty_subset.is_empty
+
+
 def test_default_subset_cannot_deserialize_invalid_version():
     static_partitions_def = dg.StaticPartitionsDefinition(["a", "b", "c", "d"])
     serialized_subset = (


### PR DESCRIPTION
Summary:
The base class implementation re-enumarates the partition keys in a list. This is going to be faster since we can just use the set that is already sitting in memory.

BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
