### PR TITLE
(chore): changed databricks job run url return value type to UrlMetad…

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -11,7 +11,7 @@ from contextlib import ExitStack, contextmanager
 from typing import Any, Literal, Optional, TextIO, Union
 
 import dagster._check as check
-from dagster._core.definitions.metadata import RawMetadataMapping
+from dagster._core.definitions.metadata import RawMetadataMapping, UrlMetadataValue
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterPipesExecutionError
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
@@ -136,7 +136,7 @@ class BasePipesDatabricksClient(PipesClient):
         metadata["Databricks Job Run ID"] = str(run_id)
 
         if run_page_url := run.run_page_url:
-            metadata["Databricks Job Run URL"] = run_page_url
+            metadata["Databricks Job Run URL"] = UrlMetadataValue(run_page_url)
 
         return metadata
 


### PR DESCRIPTION
Fixes #31976

Changed the return value from `_extract_dagster_metadata` to return `UrlMetadataValue` instead of a raw string.

## Summary & Motivation
When triggering jobs with the `PipesDatabricksClient` you always have to copy and paste the URL manually. Now you can simply click on the run URL field to be taken directly to the Databricks page.

## How I Tested These Changes
I ran a Databricks workflow and verified the changes worked.

## Changelog
[dagster-databricks] Extracted job run url from BasePipesDatabricksClient is now a UrlMetadataValue
