### PR TITLE
Speed up counting minute-ly partition sets

### DIFF
--- a/python_modules/dagster/dagster/_utils/cronstring.py
+++ b/python_modules/dagster/dagster/_utils/cronstring.py
@@ -9,6 +9,10 @@ def is_basic_hourly(cron_schedule: str) -> bool:
     return cron_schedule == "0 * * * *"
 
 
+def is_basic_minutely(cron_schedule: str) -> bool:
+    return cron_schedule == "* * * * *"
+
+
 def get_fixed_minute_interval(cron_schedule: str) -> Optional[int]:
     """Given a cronstring, returns whether or not it is safe to
     assume there is a fixed number of minutes between every tick. For
@@ -19,6 +23,9 @@ def get_fixed_minute_interval(cron_schedule: str) -> Optional[int]:
     """
     if is_basic_hourly(cron_schedule):
         return 60
+
+    if is_basic_minutely(cron_schedule):
+        return 1
 
     cron_parts = cron_schedule.split()
     is_wildcard = [part == "*" for part in cron_parts]

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1340,6 +1340,17 @@ def test_time_window_partition_len():
     with partition_loading_context(current_time):
         assert partitions_def.get_num_partitions() == len(partitions_def.get_partition_keys())
 
+    partitions_def = dg.TimeWindowPartitionsDefinition(
+        cron_schedule="* * * * *",
+        start="2020-11-01-00:30",
+        timezone="US/Pacific",
+        fmt="%Y-%m-%d-%H:%M",
+    )
+    current_time = datetime.strptime("2020-11-05-02:30", "%Y-%m-%d-%H:%M")
+
+    with partition_loading_context(current_time):
+        assert partitions_def.get_num_partitions() == len(partitions_def.get_partition_keys())
+
     @dg.daily_partitioned_config(start_date="2020-01-01", timezone="US/Pacific")
     def my_daily_dst_transition_partitioned_config(_start, _end):
         return {}


### PR DESCRIPTION
Summary:
We were handling things like */15 and */30 correctly, but not "* * * * *". Easy fix.

New test case

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
