### PR TITLE
[ui] Run compute log: Add title to step selector items

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
@@ -184,14 +184,18 @@ export const ComputeLogToolbar = ({
               itemPredicate={(query, item) =>
                 fileKeyText(item).toLocaleLowerCase().includes(query.toLocaleLowerCase())
               }
-              itemRenderer={(item, itemProps) => (
-                <MenuItem
-                  active={itemProps.modifiers.active}
-                  onClick={(e) => itemProps.handleClick(e)}
-                  text={fileKeyText(item)}
-                  key={item}
-                />
-              )}
+              itemRenderer={(item, itemProps) => {
+                const text = fileKeyText(item);
+                return (
+                  <MenuItem
+                    active={itemProps.modifiers.active}
+                    onClick={(e) => itemProps.handleClick(e)}
+                    text={text}
+                    key={item}
+                    title={text}
+                  />
+                );
+              }}
               menuWidth={500}
               onItemSelect={(fileKey) => {
                 onSetComputeLogKey(fileKey);


### PR DESCRIPTION
## Summary & Motivation

On the logs toolbar step selector, add a "title" to allow displaying the entire string on hover. This is useful in cases where step names are super long.

I wasn't able to get `data-tooltip` to work here, possibly because of the DOM nesting involved in the select menu. But since it would require hovering anyway, it works to just show the native title.

## How I Tested These Changes

Hover on items in the step selector dropdown in the compute log UI, verify that the title appears with the full string.