### PR TITLE
[2/so] Add `dg plus deploy refresh-defs-state` command

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -16,7 +16,7 @@ from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.workspace import CodeLocationEntry, CodeLocationLoadStatus
 from dagster.components.core.load_defs import PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 
 from dagster_graphql.implementation.fetch_solids import get_solid, get_solids
 from dagster_graphql.implementation.loader import RepositoryScopedBatchLoader

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Optional, cast
 import click
 import dagster_shared.seven as seven
 from dagster_shared.cli import python_pointer_options
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 
 import dagster._check as check
 from dagster._cli.utils import assert_no_remaining_opts, get_instance_for_cli

--- a/python_modules/dagster/dagster/_cli/code_server.py
+++ b/python_modules/dagster/dagster/_cli/code_server.py
@@ -8,7 +8,7 @@ from typing import Optional
 import click
 import dagster_shared.seven as seven
 from dagster_shared.cli import python_pointer_options
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 
 from dagster._cli.utils import assert_no_remaining_opts
 from dagster._cli.workspace.cli_target import PythonPointerOpts

--- a/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
@@ -7,7 +7,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, TypeVar, cast
 
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 from dagster_shared.serdes.serdes import PackableValue, deserialize_value, serialize_value
 
 from dagster._core.definitions.assets.definition.cacheable_assets_definition import (

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, AbstractSet, Any, NamedTuple, Optional  # noqa: UP035
 
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 from dagster_shared.utils.hash import hash_collection
 
 import dagster._check as check

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -7,7 +7,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, AbstractSet, Any, Optional, Union, cast  # noqa: UP035
 
 from dagster_shared.libraries import DagsterLibraryRegistry
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 
 import dagster._check as check
 from dagster._check import checked

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -11,7 +11,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from enum import Enum
 from typing import Any, Final, NamedTuple, Optional, Union, cast
 
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 from dagster_shared.serdes.serdes import (
     FieldSerializer,
     get_prefix_for_a_serialized,

--- a/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
@@ -3,7 +3,7 @@ import threading
 from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union, cast
 
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 from typing_extensions import TypeGuard
 
 import dagster._check as check

--- a/python_modules/dagster/dagster/_core/storage/defs_state/base.py
+++ b/python_modules/dagster/dagster/_core/storage/defs_state/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import ClassVar, Optional
 
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
 

--- a/python_modules/dagster/dagster/_core/storage/defs_state/blob_storage_state_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/defs_state/blob_storage_state_storage.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 from dagster_shared import check
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 from dagster_shared.serdes.serdes import deserialize_value, serialize_value
 from typing_extensions import Self
 

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -5,7 +5,7 @@ import time
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Optional
 
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 
 import dagster._check as check
 from dagster._core.instance import InstanceRef

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -22,7 +22,7 @@ import grpc
 from dagster_shared.error import remove_system_frames_from_error
 from dagster_shared.ipc import open_ipc_subprocess
 from dagster_shared.libraries import DagsterLibraryRegistry
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 from dagster_shared.utils import find_free_port
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -3,7 +3,7 @@ import zlib
 from collections.abc import Mapping, Sequence
 from typing import AbstractSet, Any, NamedTuple, Optional  # noqa: UP035
 
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 from dagster_shared.serdes.serdes import SetToSequenceFieldSerializer
 
 import dagster._check as check

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/defs_state_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/defs_state_storage.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 import pytest
 from dagster._core.storage.defs_state.base import DefsStateStorage
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 
 
 def _version_map(state_info: Optional[DefsStateInfo]) -> Optional[dict[str, Optional[str]]]:

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/ci/__init__.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/ci/__init__.py
@@ -511,7 +511,9 @@ def init_impl(
             location_name=location.location_name,
             is_branch_deployment=is_branch_deployment,
             build=state.BuildMetadata(
-                git_url=git_url, commit_hash=commit_hash, build_config=location.build
+                git_url=git_url,
+                commit_hash=commit_hash,
+                build_config=location.build,
             ),
             build_output=None,
             status_url=status_url,
@@ -1037,6 +1039,11 @@ def _deploy(
             "location_file": location_state.location_file,
             "git_url": location_state.build.git_url,
             "commit_hash": location_state.build.commit_hash,
+            **(
+                {"defs_state_info": location_state.defs_state_info.model_dump()}
+                if location_state.defs_state_info
+                else {}
+            ),
         }
         if build_output.strategy == "python-executable":
             metrics.instrument_add_tags([CliEventTags.server_strategy.pex])

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/ci/state.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/ci/state.py
@@ -5,6 +5,7 @@ from abc import ABCMeta, abstractmethod
 from enum import Enum
 from typing import Literal, Optional, Union
 
+from dagster_shared.serdes.objects.models import DefsStateInfo
 from pydantic import BaseModel, Extra, Field
 
 from dagster_cloud_cli.config import models
@@ -53,6 +54,7 @@ class LocationState(BaseModel, extra=Extra.forbid):
     build_output: Optional[Union[DockerBuildOutput, PexBuildOutput]] = Field(
         None, discriminator="strategy"
     )
+    defs_state_info: Optional[DefsStateInfo] = None
     status_url: Optional[str]  # link to cicd run url when building and dagster cloud url when done
     history: list[StatusChange] = []
 

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/workspace.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/workspace.py
@@ -3,7 +3,7 @@ from typing import Any, NamedTuple, Optional
 
 from dagster_shared import check
 from dagster_shared.serdes import whitelist_for_serdes
-from dagster_shared.serdes.objects import DefsStateInfo
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 from dagster_shared.serdes.serdes import serialize_value
 
 from dagster_cloud_cli.core.agent_queue import AgentQueue

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/test_ci_commands.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/test_ci_commands.py
@@ -131,6 +131,7 @@ def test_ci_init_local_branch_deployment(monkeypatch, mocker, empty_config) -> N
                 "url": "https://some-org.dagster.cloud",
                 "history": [{"log": "initialized", "status": "pending", "timestamp": "-"}],
                 "status_url": "http://github/run-url",
+                "defs_state_info": None,
             }
 
 
@@ -186,6 +187,7 @@ def test_ci_init(monkeypatch, mocker, empty_config) -> None:
                 "url": "https://some-org.dagster.cloud",
                 "history": [{"log": "initialized", "status": "pending", "timestamp": "-"}],
                 "status_url": "http://github/run-url",
+                "defs_state_info": None,
             }
 
             location_auto = locations[3]

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/defs_state.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/defs_state.py
@@ -1,0 +1,149 @@
+import asyncio
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, Optional
+
+import click
+from dagster_dg_core.utils import exit_with_error
+from dagster_shared.record import record, replace
+
+if TYPE_CHECKING:
+    from dagster._core.storage.defs_state.base import DefsStateStorage
+    from dagster.components.component.state_backed_component import StateBackedComponent
+    from dagster.components.core.component_tree import ComponentTree
+    from dagster_shared.serdes.objects.models import DefsStateInfo
+
+
+@record
+class ComponentStateRefreshStatus:
+    status: Literal["refreshing", "done", "failed"]
+    error: Optional[Exception] = None
+    # For updating: start_time tracks when it began
+    # For completed: duration tracks final elapsed time
+    start_time: float = 0.0
+    duration: Optional[float] = None
+
+    @staticmethod
+    def default() -> "ComponentStateRefreshStatus":
+        return ComponentStateRefreshStatus(status="refreshing", start_time=time.time())
+
+
+def raise_component_state_refresh_errors(statuses: dict[str, ComponentStateRefreshStatus]) -> None:
+    """Raises an error if any of the component state refreshes failed."""
+    errors = [
+        (key, status.error)
+        for key, status in statuses.items()
+        if status.status == "failed" and status.error
+    ]
+
+    if errors:
+        click.echo("\n" + click.style("Detailed error information:", fg="red", bold=True))
+        for key, error in errors:
+            click.echo(
+                f"  {click.style(key, fg='white', bold=True)}: {click.style(str(error), fg='red')}"
+            )
+
+        raise errors[0][1]
+
+
+def _get_components_to_refresh(
+    component_tree: "ComponentTree", defs_state_keys: Optional[set[str]]
+) -> list["StateBackedComponent"]:
+    from dagster.components.component.state_backed_component import StateBackedComponent
+
+    state_backed_components = component_tree.get_all_components(of_type=StateBackedComponent)
+    defs_state_keys = defs_state_keys or {
+        component.get_defs_state_key() for component in state_backed_components
+    }
+
+    components = [
+        component
+        for component in component_tree.get_all_components(of_type=StateBackedComponent)
+        if component.get_defs_state_key() in defs_state_keys
+    ]
+    missing_defs_keys = defs_state_keys - {
+        component.get_defs_state_key() for component in components
+    }
+    if missing_defs_keys:
+        click.echo("Error: The following defs state keys were not found:")
+        for key in sorted(missing_defs_keys):
+            click.echo(f"  {key}")
+        click.echo("Available defs state keys:")
+        for key in sorted(
+            [component.get_defs_state_key() for component in state_backed_components]
+        ):
+            click.echo(f"  {key}")
+        exit_with_error("One or more specified defs state keys were not found.")
+
+    return components
+
+
+async def _refresh_state_for_component(
+    component: "StateBackedComponent", statuses: dict[str, ComponentStateRefreshStatus]
+) -> None:
+    """Refreshes the state of a component and tracks its state in the statuses dictionary as it progresses."""
+    key = component.get_defs_state_key()
+    start_time = time.time()
+    statuses[key] = ComponentStateRefreshStatus(status="refreshing", start_time=start_time)
+
+    try:
+        await component.refresh_state()
+        error = None
+    except Exception as e:
+        error = e
+
+    statuses[key] = replace(
+        statuses[key],
+        duration=time.time() - start_time,
+        status="done" if error is None else "failed",
+        error=error,
+    )
+
+
+async def _refresh_state_for_components(
+    defs_state_storage: "DefsStateStorage",
+    components: list["StateBackedComponent"],
+    statuses: dict[str, ComponentStateRefreshStatus],
+) -> Optional["DefsStateInfo"]:
+    await asyncio.gather(
+        *[_refresh_state_for_component(component, statuses) for component in components]
+    )
+    return defs_state_storage.get_latest_defs_state_info()
+
+
+def get_updated_defs_state_info_task_and_statuses(
+    project_path: Path,
+    defs_state_storage: "DefsStateStorage",
+    defs_state_keys: Optional[set[str]] = None,
+) -> tuple[asyncio.Task[Optional["DefsStateInfo"]], dict[str, ComponentStateRefreshStatus]]:
+    """Creates an asyncio.Task that will refresh the defs state for all selected components within the specified project path.
+
+    Can be used in place of `get_updated_defs_state_info_and_statuses` in cases where the caller wants to do other work
+    (e.g. display progress) while the task is running.
+    """
+    from dagster.components.core.component_tree import ComponentTree
+
+    component_tree = ComponentTree.for_project(project_path)
+    components_to_refresh = _get_components_to_refresh(component_tree, defs_state_keys)
+
+    # shared dictionary to be used for all subtasks
+    statuses = dict()
+    refresh_task = asyncio.create_task(
+        _refresh_state_for_components(defs_state_storage, components_to_refresh, statuses)
+    )
+    return refresh_task, statuses
+
+
+async def get_updated_defs_state_info_and_statuses(
+    project_path: Path,
+    defs_state_storage: "DefsStateStorage",
+    defs_state_keys: Optional[set[str]] = None,
+) -> tuple[Optional["DefsStateInfo"], dict[str, ComponentStateRefreshStatus]]:
+    """Refreshes the defs state for all selected components within the specified project path,
+    and returns the updated defs state info and statuses.
+    """
+    task, statuses = get_updated_defs_state_info_task_and_statuses(
+        project_path, defs_state_storage, defs_state_keys
+    )
+    await task
+    return task.result(), statuses

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import click
 from dagster_dg_core.component import EnvRegistry, all_components_schema_from_dg_context
@@ -30,12 +30,16 @@ from dagster_dg_core.utils.editor import (
 )
 from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
 from dagster_shared import check
-from dagster_shared.record import record, replace
 from dagster_shared.serdes.objects import EnvRegistryKey
 from packaging.version import Version
 from rich.live import Live
 from rich.text import Text
 
+from dagster_dg_cli.cli.defs_state import (
+    ComponentStateRefreshStatus,
+    get_updated_defs_state_info_task_and_statuses,
+    raise_component_state_refresh_errors,
+)
 from dagster_dg_cli.utils.ui import DAGGY_SPINNER_FRAMES, format_duration
 from dagster_dg_cli.utils.yaml_template_generator import (
     generate_defs_yaml_example_values,
@@ -43,8 +47,7 @@ from dagster_dg_cli.utils.yaml_template_generator import (
 )
 
 if TYPE_CHECKING:
-    from dagster.components.component.state_backed_component import StateBackedComponent
-    from dagster.components.core.component_tree import ComponentTree
+    from dagster._core.instance.instance import DagsterInstance
 
 DEFAULT_SCHEMA_FOLDER_NAME = ".dg"
 
@@ -366,39 +369,6 @@ def create_temp_dagster_cloud_yaml_file(dg_context: DgContext, statedir: str) ->
         return temp_dagster_cloud_yaml_file.name
 
 
-@record
-class ComponentStateRefreshStatus:
-    status: Literal["refreshing", "done", "failed"]
-    error: Optional[Exception] = None
-    # For updating: start_time tracks when it began
-    # For completed: duration tracks final elapsed time
-    start_time: float = 0.0
-    duration: Optional[float] = None
-
-    @staticmethod
-    def default() -> "ComponentStateRefreshStatus":
-        return ComponentStateRefreshStatus(status="refreshing", start_time=time.time())
-
-    def display_text(self, key: str, max_key_length: int, spinner_char: str) -> str:
-        padded_key = key.ljust(max_key_length)
-        if self.status == "refreshing":
-            primary_color = "bright_black"
-            elapsed = time.time() - self.start_time
-            status_char = spinner_char
-            duration_str = format_duration(elapsed)
-        elif self.status == "done":
-            primary_color = "green"
-            status_char = "✓"
-            duration_str = f"in {format_duration(self.duration)}"
-        elif self.status == "failed":
-            primary_color = "red"
-            status_char = "✗"
-            duration_str = f"after {format_duration(self.duration)}"
-        else:
-            raise ValueError(f"Invalid status: {self.status}")
-        return f"[ {padded_key} ] {click.style(status_char, fg=primary_color)} {click.style(self.status, fg=primary_color)} {click.style(duration_str, fg='white', dim=True)}"
-
-
 def _get_display_header(statuses: dict[str, ComponentStateRefreshStatus]) -> str:
     """Display progress header based on current status counts."""
     success_count = sum(1 for s in statuses.values() if s.status == "done")
@@ -418,139 +388,77 @@ def _get_display_header(statuses: dict[str, ComponentStateRefreshStatus]) -> str
         return click.style(message, bold=True)
 
 
-def _echo_error_text_and_raise(statuses: dict[str, ComponentStateRefreshStatus]) -> None:
-    errors = []
-    for key, status in statuses.items():
-        if status.status == "failed" and status.error:
-            errors.append((key, status.error))
-
-    if errors:
-        click.echo("\n" + click.style("Detailed error information:", fg="red", bold=True))
-        for key, error in errors:
-            click.echo(
-                f"  {click.style(key, fg='white', bold=True)}: {click.style(str(error), fg='red')}"
-            )
-
-        # Raise the first error (or you could create a composite error)
-        raise errors[0][1]
+def _get_display_text_for_status(
+    status: ComponentStateRefreshStatus, key: str, max_key_length: int, spinner_char: str
+) -> str:
+    padded_key = key.ljust(max_key_length)
+    if status.status == "refreshing":
+        primary_color = "bright_black"
+        elapsed = time.time() - status.start_time
+        status_char = spinner_char
+        duration_str = format_duration(elapsed)
+    elif status.status == "done":
+        primary_color = "green"
+        status_char = "✓"
+        duration_str = f"in {format_duration(status.duration)}"
+    elif status.status == "failed":
+        primary_color = "red"
+        status_char = "✗"
+        duration_str = f"after {format_duration(status.duration)}"
+    else:
+        raise ValueError(f"Invalid status: {status.status}")
+    return f"[ {padded_key} ] {click.style(status_char, fg=primary_color)} {click.style(status.status, fg=primary_color)} {click.style(duration_str, fg='white', dim=True)}"
 
 
 def _get_display_text(statuses: dict[str, ComponentStateRefreshStatus], spinner_char: str) -> str:
     max_key_length = max(len(key) for key in statuses.keys()) if statuses else 0
     task_statuses = [
-        status.display_text(key, max_key_length, spinner_char) for key, status in statuses.items()
+        _get_display_text_for_status(status, key, max_key_length, spinner_char)
+        for key, status in statuses.items()
     ]
     return "\n".join([_get_display_header(statuses)] + task_statuses)
 
 
-def _complete_component_refresh(
-    key: str,
-    statuses: dict[str, ComponentStateRefreshStatus],
-    success: bool,
-    error: Optional[Exception] = None,
+async def _refresh_defs_state_with_live_display(
+    project_path: Path, instance: "DagsterInstance", defs_state_keys: Optional[set[str]] = None
 ) -> None:
-    """Complete a component refresh with the final status and duration."""
-    prev = statuses[key]
-    statuses[key] = replace(
-        prev,
-        duration=time.time() - prev.start_time,
-        status="done" if success else "failed",
-        error=error,
+    defs_state_storage = check.not_none(instance.defs_state_storage)
+    refresh_task, statuses = get_updated_defs_state_info_task_and_statuses(
+        project_path, defs_state_storage, defs_state_keys
     )
-
-
-async def _refresh_component(
-    component: "StateBackedComponent", statuses: dict[str, ComponentStateRefreshStatus]
-) -> None:
-    key = component.get_defs_state_key()
-    start_time = time.time()
-    statuses[key] = ComponentStateRefreshStatus(status="refreshing", start_time=start_time)
-
-    try:
-        await component.refresh_state()
-        _complete_component_refresh(key, statuses, success=True)
-    except Exception as e:
-        _complete_component_refresh(key, statuses, success=False, error=e)
-
-
-def _get_components_to_refresh(
-    tree: "ComponentTree", defs_state_keys: Optional[set[str]]
-) -> list["StateBackedComponent"]:
-    from dagster.components.component.state_backed_component import StateBackedComponent
-
-    state_backed_components = tree.get_all_components(of_type=StateBackedComponent)
-    defs_state_keys = defs_state_keys or {
-        component.get_defs_state_key() for component in state_backed_components
-    }
-
-    components = [
-        component
-        for component in tree.get_all_components(of_type=StateBackedComponent)
-        if component.get_defs_state_key() in defs_state_keys
-    ]
-    missing_defs_keys = defs_state_keys - {
-        component.get_defs_state_key() for component in components
-    }
-    if missing_defs_keys:
-        click.echo("Error: The following defs state keys were not found:")
-        for key in sorted(missing_defs_keys):
-            click.echo(f"  {key}")
-        click.echo("Available defs state keys:")
-        for key in sorted(
-            [component.get_defs_state_key() for component in state_backed_components]
-        ):
-            click.echo(f"  {key}")
-        exit_with_error("One or more specified defs state keys were not found.")
-
-    return components
-
-
-async def _refresh_component_state_impl(
-    tree: "ComponentTree",
-    defs_state_keys: Optional[set[str]],
-) -> None:
-    components = _get_components_to_refresh(tree, defs_state_keys)
-    statuses = {
-        component.get_defs_state_key(): ComponentStateRefreshStatus.default()
-        for component in components
-    }
-
-    tasks = [
-        asyncio.create_task(_refresh_component(component, statuses)) for component in components
-    ]
     with Live(refresh_per_second=10) as live:
         spinner_char = itertools.cycle(DAGGY_SPINNER_FRAMES)
-        while not all(task.done() for task in tasks):
+        while not refresh_task.done():
             live.update(Text.from_ansi(_get_display_text(statuses, next(spinner_char))))
             await asyncio.sleep(0.1)
-        await asyncio.gather(*tasks)
+        await refresh_task
         live.update(Text.from_ansi(_get_display_text(statuses, next(spinner_char))))
 
-    _echo_error_text_and_raise(statuses)
+    raise_component_state_refresh_errors(statuses)
 
 
-@utils_group.command(name="refresh-component-state", cls=DgClickCommand)
+@utils_group.command(name="refresh-defs-state", cls=DgClickCommand)
 @dg_path_options
 @dg_global_options
 @click.option(
     "--defs-state-key",
     multiple=True,
-    help="Only refresh components with the specified defs state key. Can be specified multiple times.",
+    help="Only refresh state for specified defs state key. Can be specified multiple times.",
 )
 @cli_telemetry_wrapper
-def refresh_component_state(
+def refresh_defs_state(
     target_path: Path,
     defs_state_key: tuple[str, ...],
     **other_opts: object,
 ) -> None:
-    """Refresh the component state for the current project."""
+    """Refresh the defs state for the current project."""
     from dagster._cli.utils import get_possibly_temporary_instance_for_cli
-    from dagster.components.core.component_tree import ComponentTree
 
     cli_config = normalize_cli_config(other_opts, click.get_current_context())
     dg_context = DgContext.for_project_environment(target_path, cli_config)
 
-    with get_possibly_temporary_instance_for_cli("dg utils refresh-component-state"):
-        tree = ComponentTree.for_project(dg_context.root_path)
+    with get_possibly_temporary_instance_for_cli("dg utils refresh-defs-state") as instance:
         defs_state_keys = set(defs_state_key) if defs_state_key else None
-        asyncio.run(_refresh_component_state_impl(tree, defs_state_keys))
+        asyncio.run(
+            _refresh_defs_state_with_live_display(dg_context.root_path, instance, defs_state_keys)
+        )

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/build.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/build.py
@@ -1,6 +1,8 @@
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import click
 from dagster_dg_core.config import DgRawBuildConfig, merge_build_configs
@@ -11,6 +13,9 @@ from dagster_shared.plus.config import DagsterPlusCliConfig
 from dagster_dg_cli.cli.plus.constants import DgPlusAgentPlatform, DgPlusAgentType
 from dagster_dg_cli.utils.plus.gql import DEPLOYMENT_INFO_QUERY
 from dagster_dg_cli.utils.plus.gql_client import DagsterPlusGraphQLClient
+
+if TYPE_CHECKING:
+    from dagster._core.storage.defs_state.base import DefsStateStorage
 
 
 def get_dockerfile_path(
@@ -95,3 +100,22 @@ def create_deploy_dockerfile(dst_path: Path, python_version: str, use_editable_d
     with open(dst_path, "w", encoding="utf8") as f:
         f.write(template.render(python_version=python_version))
         f.write("\n")
+
+
+@contextmanager
+def defs_state_storage_from_config(
+    plus_config: DagsterPlusCliConfig,
+) -> Iterator["DefsStateStorage"]:
+    """Creates a DefsStateStorage based on the provided DagsterPlusCliConfig and sets it as the current
+    DefsStateStorage within the bounds of the context manager.
+    """
+    from dagster._core.storage.defs_state.base import DefsStateStorage
+
+    from dagster_dg_cli.utils.plus.defs_state_storage import DagsterPlusCliDefsStateStorage
+
+    try:
+        defs_state_storage = DagsterPlusCliDefsStateStorage.from_config(plus_config)
+        DefsStateStorage.set_current(defs_state_storage)
+        yield defs_state_storage
+    finally:
+        DefsStateStorage.set_current(None)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/defs_state_storage.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/defs_state_storage.py
@@ -1,0 +1,131 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Generic, Optional
+
+from dagster._core.instance.types import T_DagsterInstance
+from dagster._core.storage.defs_state.base import DefsStateStorage
+from dagster_cloud_cli.core.artifacts import download_artifact, upload_artifact
+from dagster_cloud_cli.core.headers.auth import DagsterCloudInstanceScope
+from dagster_shared import check
+from dagster_shared.plus.config import DagsterPlusCliConfig
+from dagster_shared.serdes import deserialize_value
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
+
+from dagster_dg_cli.utils.plus.gql_client import DagsterPlusGraphQLClient
+
+GET_LATEST_DEFS_STATE_INFO_QUERY = """
+    query getLatestDefsStateInfo {
+        latestDefsStateInfo
+    }
+"""
+
+SET_LATEST_VERSION_MUTATION = """
+    mutation setLatestDefsStateVersion($key: String!, $version: String!) {
+        defsState {
+            setLatestDefsStateVersion(key: $key, version: $version) {
+                ok
+            }
+        }
+    }
+"""
+
+
+class BaseGraphQLDefsStateStorage(
+    DefsStateStorage[T_DagsterInstance], ABC, Generic[T_DagsterInstance]
+):
+    """Base implementation of a DefsStateStorage that uses a GraphQL client to
+    interact with the Dagster+ API.
+    """
+
+    @property
+    @abstractmethod
+    def url(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def api_token(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def deployment(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def graphql_client(self) -> Any: ...
+
+    def _execute_query(self, query, variables=None, idempotent_mutation=False):
+        return self.graphql_client.execute(
+            query, variable_values=variables, idempotent_mutation=idempotent_mutation
+        )
+
+    def _get_artifact_key(self, key: str, version: str) -> str:
+        return f"__state__/{key}/{version}"
+
+    def download_state_to_path(self, key: str, version: str, path: Path) -> None:
+        download_artifact(
+            url=self.url,
+            scope=DagsterCloudInstanceScope.DEPLOYMENT,
+            api_token=self.api_token,
+            key=self._get_artifact_key(key, version),
+            path=path,
+            deployment=self.deployment,
+        )
+
+    def upload_state_from_path(self, key: str, version: str, path: Path) -> None:
+        upload_artifact(
+            url=self.url,
+            scope=DagsterCloudInstanceScope.DEPLOYMENT,
+            api_token=self.api_token,
+            key=self._get_artifact_key(key, version),
+            path=path,
+            deployment=self.deployment,
+        )
+        self.set_latest_version(key, version)
+
+    def get_latest_defs_state_info(self) -> Optional[DefsStateInfo]:
+        res = self._execute_query(GET_LATEST_DEFS_STATE_INFO_QUERY)
+        result = res["data"]["latestDefsStateInfo"]
+        if result is not None:
+            return deserialize_value(result, DefsStateInfo)
+        else:
+            return None
+
+    def set_latest_version(self, key: str, version: str) -> None:
+        self._execute_query(SET_LATEST_VERSION_MUTATION, variables={"key": key, "version": version})
+
+
+class DagsterPlusCliDefsStateStorage(BaseGraphQLDefsStateStorage):
+    """DefsStateStorage that can be instantiated from a DagsterPlusCliConfig,
+    intended for use within the CLI.
+    """
+
+    def __init__(self, url: str, api_token: str, deployment: str, graphql_client):
+        self._url = url
+        self._api_token = api_token
+        self._deployment = deployment
+        self._graphql_client = graphql_client
+
+    @staticmethod
+    def from_config(config: DagsterPlusCliConfig) -> "DagsterPlusCliDefsStateStorage":
+        return DagsterPlusCliDefsStateStorage(
+            url=check.not_none(config.url),
+            api_token=check.not_none(config.user_token),
+            deployment=check.not_none(config.default_deployment),
+            graphql_client=DagsterPlusGraphQLClient.from_config(config),
+        )
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    @property
+    def api_token(self) -> str:
+        return self._api_token
+
+    @property
+    def deployment(self) -> str:
+        return self._deployment
+
+    @property
+    def graphql_client(self) -> Any:
+        return self._graphql_client

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/test_refresh_state_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/test_refresh_state_command.py
@@ -24,7 +24,7 @@ def test_refresh_state_command():
         state_storage = DefsStateStorage.get_current()
         assert state_storage is not None
         # no components, nothing to refresh
-        result = runner.invoke("utils", "refresh-component-state")
+        result = runner.invoke("utils", "refresh-defs-state")
         assert_runner_result(result)
         latest_state_info = state_storage.get_latest_defs_state_info()
         assert latest_state_info is None
@@ -44,7 +44,7 @@ def test_refresh_state_command():
 
         # now we have a state-backed component, command should succeed
         # and we should have a new state version
-        result = runner.invoke("utils", "refresh-component-state")
+        result = runner.invoke("utils", "refresh-defs-state")
         assert_runner_result(result)
 
         latest_state_info = state_storage.get_latest_defs_state_info()
@@ -71,7 +71,7 @@ def test_refresh_state_command():
             )
 
         # command should fail, but state should be updated for the non-failing component
-        result = runner.invoke("utils", "refresh-component-state")
+        result = runner.invoke("utils", "refresh-defs-state")
         assert result.exit_code == 1
 
         new_latest_state_info = state_storage.get_latest_defs_state_info()
@@ -132,7 +132,7 @@ def test_refresh_state_command_with_defs_key_filter():
         # Refresh only component1
         result = runner.invoke(
             "utils",
-            "refresh-component-state",
+            "refresh-defs-state",
             "--defs-state-key",
             "SampleStateBackedComponent[first]",
         )
@@ -146,7 +146,7 @@ def test_refresh_state_command_with_defs_key_filter():
         # Refresh both components using multiple --defs-key flags
         result = runner.invoke(
             "utils",
-            "refresh-component-state",
+            "refresh-defs-state",
             "--defs-state-key",
             "SampleStateBackedComponent[first]",
             "--defs-state-key",
@@ -163,9 +163,7 @@ def test_refresh_state_command_with_defs_key_filter():
         }
 
         # Test with non-existent defs-key
-        result = runner.invoke(
-            "utils", "refresh-component-state", "--defs-state-key", "nonexistent"
-        )
+        result = runner.invoke("utils", "refresh-defs-state", "--defs-state-key", "nonexistent")
         assert result.exit_code == 1
         assert "The following defs state keys were not found:" in result.output
         assert "nonexistent" in result.output

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/plus_tests/test_plus_deploy_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/plus_tests/test_plus_deploy_command.py
@@ -1,4 +1,5 @@
 import contextlib
+import sys
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
@@ -6,6 +7,7 @@ from typing import NamedTuple
 from unittest import mock
 from unittest.mock import patch
 
+import dagster as dg
 import pytest
 import responses
 import yaml
@@ -13,7 +15,7 @@ from dagster_cloud_cli.commands.ci import BuildStrategy
 from dagster_cloud_cli.core.pex_builder.deps import BuildMethod
 from dagster_cloud_cli.types import SnapshotBaseDeploymentCondition
 from dagster_dg_cli.cli.plus.deploy import DEFAULT_STATEDIR_PATH
-from dagster_dg_core.utils import pushd
+from dagster_dg_core.utils import activate_venv, pushd
 from dagster_shared.plus.config import DagsterPlusCliConfig
 from dagster_test.dg_utils.utils import (
     ProxyRunner,
@@ -1093,3 +1095,50 @@ def test_plus_deploy_hybrid_with_workspace_build_yaml_scaffold(
                     "directory": str(workspace.resolve() / "foo-bar"),  # from build.yaml
                     "registry": "...",
                 }
+
+
+def _add_state_backed_component(project_path: Path):
+    """Copies in a definition for a state-backed component to the project."""
+    import shutil
+
+    component_dir = project_path / "src/foo_bar_2/defs/the_component"
+    component_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(
+        Path(__file__).parent.parent / "defs_state_tests" / "sample_state_backed_component.py",
+        component_dir / "local.py",
+    )
+    # Create the defs.yaml file
+    with (component_dir / "defs.yaml").open("w") as f:
+        yaml.dump(
+            {"type": ".local.SampleStateBackedComponent"},
+            f,
+        )
+
+
+def test_plus_deploy_with_refresh_defs_state(logged_in_dg_cli_config, workspace, runner, mocker):
+    """Test the `dg plus deploy refresh-defs-state` command."""
+    with (
+        dg.instance_for_test() as instance,
+        mock_external_dagster_cloud_cli_command(),
+        # use a local DefsStateStorage instead of one hitting cloud
+        mocker.patch(
+            "dagster_dg_cli.utils.plus.defs_state_storage.DagsterPlusCliDefsStateStorage.from_config",
+            return_value=instance.defs_state_storage,
+        ),
+        # move into the project directory
+        pushd(workspace / "foo-bar-2"),
+        # activate the virtualenv
+        activate_venv(workspace / "foo-bar-2" / ".venv"),
+    ):
+        sys.path.append(str(workspace / "foo-bar-2" / "src"))
+        # create a state-backed component
+        _add_state_backed_component(workspace / "foo-bar-2")
+
+        result = runner.invoke(
+            "plus",
+            "deploy",
+            "refresh-defs-state",
+        )
+
+        assert result.exit_code == 0, result.output + " : " + str(result.exception)
+        assert "Updated defs_state_info for all locations." in result.output, result.output

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/__init__.py
@@ -1,7 +1,3 @@
-from dagster_shared.serdes.objects.defs_state_info import (
-    DefsKeyStateInfo as DefsKeyStateInfo,
-    DefsStateInfo as DefsStateInfo,
-)
 from dagster_shared.serdes.objects.package_entry import (
     ComponentFeatureData as ComponentFeatureData,
     EnvRegistryKey as EnvRegistryKey,

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/models/__init__.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/models/__init__.py
@@ -1,0 +1,4 @@
+from dagster_shared.serdes.objects.models.defs_state_info import (
+    DefsKeyStateInfo as DefsKeyStateInfo,
+    DefsStateInfo as DefsStateInfo,
+)

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/models/defs_state_info.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/models/defs_state_info.py
@@ -1,30 +1,21 @@
 import time
 from collections.abc import Mapping
-from typing import Any, Optional
+from typing import Optional
 
-from dagster_shared.record import record
+from dagster_shared.dagster_model import DagsterModel
 from dagster_shared.serdes import whitelist_for_serdes
 
 
 @whitelist_for_serdes
-@record
-class DefsKeyStateInfo:
+class DefsKeyStateInfo(DagsterModel):
     """Records information about the version of the state for a given defs key."""
 
     version: str
     create_timestamp: float
 
-    @staticmethod
-    def from_dict(val: dict[str, Any]) -> "DefsKeyStateInfo":
-        return DefsKeyStateInfo(version=val["version"], create_timestamp=val["create_timestamp"])
-
-    def to_dict(self) -> dict[str, Any]:
-        return {"version": self.version, "create_timestamp": self.create_timestamp}
-
 
 @whitelist_for_serdes
-@record
-class DefsStateInfo:
+class DefsStateInfo(DagsterModel):
     """All of the information about the state version that will be used to load a given code location."""
 
     info_mapping: Mapping[str, Optional[DefsKeyStateInfo]]
@@ -44,19 +35,6 @@ class DefsStateInfo:
             return DefsStateInfo(info_mapping={key: new_info})
         else:
             return DefsStateInfo(info_mapping={**current_info.info_mapping, key: new_info})
-
-    @staticmethod
-    def from_dict(val: dict[str, Any]) -> "DefsStateInfo":
-        """Used for converting from the user-facing dict representation."""
-        return DefsStateInfo(
-            info_mapping={
-                key: DefsKeyStateInfo.from_dict(info) if info else None for key, info in val.items()
-            }
-        )
-
-    def to_dict(self) -> dict[str, Any]:
-        """Used for converting to the user-facing dict representation."""
-        return {key: info.to_dict() if info else None for key, info in self.info_mapping.items()}
 
     def get_version(self, key: str) -> Optional[str]:
         info = self.info_mapping.get(key)


### PR DESCRIPTION
## Summary & Motivation

This adds a new optional `dg plus deploy refresh-defs-state` command. In order for this to work, we need to bring in the GraphQLDefsStateStorage and create a version of it that can be instantiated with just the available information in the DagsterPlusCliContext object. All this object needs to do is fire off graphql / rest queries, so things work out nicely as this just requires a user token, a url, and a deployment name, all of which we have available.

High level changes:

- factored out common utilities from the existing `dg utils refresh-defs-state` command (which i renamed from `dg utils refresh-component-state` as I think the new things sounds nicer)
- made `DefsStateInfo` and `DefsKeyStateInfo` DagsterModels so that they can be sub-objects in a pydantic schema. While this does have theoretical performance implications, the total number of StateBackedComponents in a single project is pretty well-bounded (e.g. we would never have 10k of these), and it means we can get rid of the custom logic in the from_dict/to_dict bit and rely on pydantic for all of that, which is nice
  - note: i moved this into `dagster_shared.serdes.objects.models` to avoid hitting the expensive `pydantic` import every time we import `dagster_shared.serdes.objects` for other stuff
- moved the core definition of the GraphQLDefsStateStorage into this repo so that it can be subclassed for use in the CLI
- made it so that we put defs_state_info into the code location deploy document during the build process

## How I Tested These Changes

Honestly, writing a test was pretty challenging as we need to mock out most of the interesting stuff. Open to ideas on more thorough testing here but I was able to at least confirm that we do actually invoke the relevant `StateBackedComponent.refresh_state()` commands.

## Changelog

NOCHANGELOG
