### PR TITLE
[dg] make dg projects work when properly installed

### DIFF
--- a/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
+++ b/python_modules/libraries/create-dagster/create_dagster/templates/PROJECT_NAME_PLACEHOLDER/pyproject.toml.jinja
@@ -11,6 +11,9 @@ version = "0.1.0"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+force-include = { "pyproject.toml" = "pyproject.toml" }
+
 [tool.dg]
 directory_type = "project"
 


### PR DESCRIPTION
dg projects currently do not work when installed non-editable as we seek to read a single source of truth of config from pyproject.toml / dg.toml at runtime which is not included in the package output by default.

To address this, update hatch settings to include the file in output.

## How I Tested These Changes

added test