### PR TITLE
[dagster-dbt] Add `dbt-core` dependency back in

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -4,7 +4,7 @@ import shutil
 import uuid
 from argparse import ArgumentParser, Namespace
 from collections.abc import Sequence
-from functools import cached_property
+from functools import cache, cached_property
 from pathlib import Path
 from subprocess import check_output
 from typing import Any, Optional, Union, cast
@@ -35,7 +35,15 @@ from dagster_dbt.dbt_project import DbtProject
 logger = get_dagster_logger()
 
 
-DBT_EXECUTABLE = "dbt"
+@cache
+def _get_dbt_executable() -> str:
+    if shutil.which("dbtf"):
+        return "dbtf"
+    else:
+        return "dbt"
+
+
+DBT_EXECUTABLE = _get_dbt_executable()
 DBT_PROJECT_YML_NAME = "dbt_project.yml"
 DBT_PROFILES_YML_NAME = "profiles.yml"
 
@@ -171,7 +179,7 @@ class DbtCliResource(ConfigurableResource):
     )
     dbt_executable: str = Field(
         default=DBT_EXECUTABLE,
-        description="The path to the dbt executable.",
+        description="The path to the dbt executable. Defaults to `dbtf` if available, otherwise `dbt`.",
     )
     state_path: Optional[str] = Field(
         default=None,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_fusion_support.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_fusion_support.py
@@ -29,7 +29,7 @@ def test_basic(project: DbtProject, fail: bool) -> None:
     n_assets = len(list(the_assets.specs))
     n_checks = len(list(the_assets.check_specs))
     assert n_assets == 8
-    assert n_checks == 19
+    assert n_checks == 20
 
     result = dg.materialize(
         [the_assets],
@@ -43,8 +43,8 @@ def test_basic(project: DbtProject, fail: bool) -> None:
     if fail:
         # one asset fails, no materialization
         assert n_materializations == n_assets - 1
-        # two checks on that asset, no check evaluations for them
-        assert n_check_evaluations == n_checks - 2
+        # three checks on that asset, no check evaluations for them
+        assert n_check_evaluations == n_checks - 3
     else:
         assert n_materializations == n_assets
         assert n_check_evaluations == n_checks

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/fusion_compatible/jaffle_shop/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/fusion_compatible/jaffle_shop/models/schema.yml
@@ -44,8 +44,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('customers')
-              field: customer_id
+              arguments:
+                to: ref('customers')
+                field: customer_id
 
       - name: order_date
         description: Date (UTC) that the order was placed
@@ -54,8 +55,15 @@ models:
         description: '{{ doc("orders_status") }}'
         tests:
           - accepted_values:
-              values:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              arguments:
+                values:
+                  [
+                    "placed",
+                    "shipped",
+                    "completed",
+                    "return_pending",
+                    "returned",
+                  ]
 
       - name: amount
         description: Total amount (AUD) of the order

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/fusion_compatible/jaffle_shop/models/staging/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/fusion_compatible/jaffle_shop/models/staging/schema.yml
@@ -17,8 +17,15 @@ models:
       - name: status
         tests:
           - accepted_values:
-              values:
-                ["placed", "shipped", "completed", "return_pending", "returned"]
+              arguments:
+                values:
+                  [
+                    "placed",
+                    "shipped",
+                    "completed",
+                    "return_pending",
+                    "returned",
+                  ]
 
   - name: stg_payments
     columns:
@@ -29,4 +36,5 @@ models:
       - name: payment_method
         tests:
           - accepted_values:
-              values: ["credit_card", "coupon", "bank_transfer", "gift_card"]
+              arguments:
+                values: ["credit_card", "coupon", "bank_transfer", "gift_card"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/install_dbt_fusion.sh
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/install_dbt_fusion.sh
@@ -386,11 +386,6 @@ install_package() {
         return 0
     fi
 
-    # If we get here, version is different, so check if we can proceed
-    if [ -e "$dest/$package_name" ] && [ "$update" = false ]; then
-        err "$package_name already exists in $dest, use the --update flag to reinstall"
-        return 1
-    fi
 
     log "Installing $package_name to: $dest"
     # Create the directory if it doesn't exist
@@ -438,7 +433,7 @@ install_package() {
             continue
         }
 
-        if [ -e "$dest/$package_name" ] && [ "$update" = true ]; then
+        if [ -e "$dest/$package_name" ]; then
             # Remove file - no sudo needed for home directory
             rm -f "$dest/$package_name" || {
                 err "Error: Failed to remove existing $package_name binary."

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -41,6 +41,8 @@ setup(
     python_requires=">=3.9,<3.14",
     install_requires=[
         f"dagster{pin}",
+        # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core
+        f"dbt-core>=1.7,<{DBT_CORE_VERSION_UPPER_BOUND}",
         "Jinja2",
         "networkx",
         "orjson",

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -43,7 +43,7 @@ allowlist_externals =
   /bin/bash
   uv
 commands =
-  dbtfusion: /bin/bash -c 'sh dagster_dbt_tests/install_dbt_fusion.sh --to {envbindir} --version 2.0.0-beta.37; export PATH={envbindir}:$PATH'
+  dbtfusion: /bin/bash -c 'sh dagster_dbt_tests/install_dbt_fusion.sh --to {envbindir} --version 2.0.0-preview.7; export PATH={envbindir}:$PATH'
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   cloud: pytest --ignore=./kitchen-sink --durations 10  --reruns 3 -m "cloud" -vv {posargs}
   core-main: pytest --ignore=./kitchen-sink --durations 10  --reruns 3 -m "core and not snowflake and not bigquery and not derived_metadata and not fusion" -vv {posargs}


### PR DESCRIPTION
## Summary & Motivation

Adds the `dbt-core` dependency back in to avoid erroring in cases where users are using the dbt Cloud integration (which requires dbt-core in order to parse dbt selection strings against a manifest).

## How I Tested These Changes

## Changelog

[dagster-dbt] Added the `dbt-core` dependency back to `dagster-dbt` as it is still required for the dbt Cloud integration. If both `dbt-core` and `dbt Fusion` are installed, `dagster-dbt` will still prefer using `dbt Fusion` by default.
