### PR TITLE
Drop last distutils usages in favor of shutil.which

### DIFF
--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
@@ -2,6 +2,7 @@
 import json
 import os
 import random
+import shutil
 import subprocess
 import time
 from collections.abc import Mapping, Sequence
@@ -30,11 +31,9 @@ def check_output(*args, **kwargs):
 
 
 def which_(exe):
-    """Uses distutils to look for an executable, mimicking unix which."""
-    from distutils import spawn
-
-    # https://github.com/PyCQA/pylint/issues/73
-    return spawn.find_executable(exe)
+    """Uses shutil to look for an executable, mimicking unix which."""
+    # Replaced distutils.spawn with shutil.which for Python 3.12+ compatibility
+    return shutil.which(exe)
 
 
 def get_test_namespace(prefix="dagster-test"):

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/integration_utils.py
@@ -2,7 +2,6 @@
 import json
 import os
 import random
-import shutil
 import subprocess
 import time
 from collections.abc import Mapping, Sequence
@@ -28,12 +27,6 @@ def check_output(*args, **kwargs):
     except subprocess.CalledProcessError as exc:
         output = exc.output.decode("utf-8")
         raise Exception(output) from exc
-
-
-def which_(exe):
-    """Uses shutil to look for an executable, mimicking unix which."""
-    # Replaced distutils.spawn with shutil.which for Python 3.12+ compatibility
-    return shutil.which(exe)
 
 
 def get_test_namespace(prefix="dagster-test"):

--- a/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/kind.py
+++ b/integration_tests/python_modules/dagster-k8s-test-infra/dagster_k8s_test_infra/kind.py
@@ -2,6 +2,7 @@
 
 import os
 import random
+import shutil
 import subprocess
 import time
 import uuid
@@ -13,12 +14,7 @@ import kubernetes
 from dagster._utils import safe_tempfile_path
 
 from dagster_k8s_test_infra.cluster import ClusterConfig
-from dagster_k8s_test_infra.integration_utils import (
-    IS_BUILDKITE,
-    check_output,
-    which_,
-    within_docker,
-)
+from dagster_k8s_test_infra.integration_utils import IS_BUILDKITE, check_output, within_docker
 
 CLUSTER_INFO_DUMP_DIR = "kind-info-dump"
 
@@ -354,7 +350,7 @@ def kind_sync_dockerconfig():
     """
     print("--- Syncing docker config to nodes...")
 
-    docker_exe = which_("docker")
+    docker_exe = shutil.which("docker")
 
     nodes = kubernetes.client.CoreV1Api().list_node().items
     for node in nodes:

--- a/python_modules/automation/automation/utils.py
+++ b/python_modules/automation/automation/utils.py
@@ -1,8 +1,8 @@
 import os
+import shutil
 import subprocess
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
-from distutils import spawn
 from pathlib import Path
 
 import click
@@ -19,9 +19,9 @@ def check_output(cmd: list[str], dry_run: bool = True, cwd: str | None = None) -
 
 
 def which_(exe: str) -> str | None:
-    """Uses distutils to look for an executable, mimicking unix which."""
-    # https://github.com/PyCQA/pylint/issues/73
-    return spawn.find_executable(exe)
+    """Uses shutil to look for an executable, mimicking unix which."""
+    # Replaced distutils.spawn with shutil.which for Python 3.12+ compatibility
+    return shutil.which(exe)
 
 
 def all_equal(iterable: Iterable[object]) -> bool:

--- a/python_modules/automation/automation/utils.py
+++ b/python_modules/automation/automation/utils.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import subprocess
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
@@ -16,12 +15,6 @@ def check_output(cmd: list[str], dry_run: bool = True, cwd: str | None = None) -
         return None
     else:
         return subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT, cwd=cwd)
-
-
-def which_(exe: str) -> str | None:
-    """Uses shutil to look for an executable, mimicking unix which."""
-    # Replaced distutils.spawn with shutil.which for Python 3.12+ compatibility
-    return shutil.which(exe)
 
 
 def all_equal(iterable: Iterable[object]) -> bool:


### PR DESCRIPTION
## Summary & Motivation

`distutils` was removed from the standard library in Python 3.12 (PEP 632). The two remaining `distutils.spawn.find_executable` usages in the repo still worked because setuptools ships a `distutils` shim, but that is a deprecated compatibility path and not something to rely on.

Both usages lived in a small `which_` wrapper. The `automation` copy had no callers, and the `dagster-k8s-test-infra` copy had a single caller in `kind.py`. Rather than migrate the wrappers, this removes them and calls `shutil.which` directly at the one call site. No `distutils` references remain in the tree.

## Test Plan

- `ruff check` / `ruff format --check` on the touched packages.
- Confirmed no remaining `which_` callers or `distutils` imports via `rg`.
- CI.