### PR TITLE
types: make DagsterType.unique_name non-Optional and clarify usage

### DIFF
--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -227,9 +227,13 @@ class DagsterType:
 
     @public
     @property
-    def unique_name(self) -> t.Optional[str]:
-        """The unique name of this type. Can be None if the type is not unique, such as container types."""
-        # TODO: docstring and body inconsistent-- can this be None or not?
+    def unique_name(self) -> str:
+        """The unique user-facing name for this type.
+
+        For types that do not have a unique name (e.g. container/parameterized types like List or
+        Optional), access is invalid. Use ``has_unique_name`` to guard access, or use
+        ``display_name`` if you need a human-readable label regardless of uniqueness.
+        """
         check.invariant(
             self._name is not None,
             f"unique_name requested but is None for type {self.display_name}",


### PR DESCRIPTION
This pull request updates the `unique_name` property in the `DagsterType` class to clarify its usage and improve type safety. The property now always returns a string and raises an error if accessed for types without a unique name, rather than returning `None`.

Type system improvements:

* Changed the return type of the `unique_name` property in `dagster_type.py` from `Optional[str]` to `str`, and updated the docstring to clarify that it should only be accessed when the type has a unique name. Accessing it for types without a unique name (like container or parameterized types) is now considered invalid, and users are advised to check `has_unique_name` 

