### PR TITLE
feat: add option to modify container name

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -49,7 +49,7 @@ spec:
         {{- toYaml $deployment.initContainers | nindent 8 }}
       {{- end }}
       containers:
-        - name: {{ $.Chart.Name }}
+        - name: {{ $deployment.containerName | default $.Chart.Name }}
           securityContext: {{ $deployment.securityContext | toYaml | nindent 12 }}
           imagePullPolicy: {{ $deployment.image.pullPolicy }}
           image: {{ include "dagster.dagsterImage.name" (list $ $deployment.image) | quote }}

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -159,6 +159,9 @@ deployments:
     service:
       annotations: {}
 
+    # Allow custom container name for the dagster user deployment. Defaults to $.Chart.Name
+    # containerName: "dagster-example-container"
+
 # Specify secrets to run containers based on images in private registries. See:
 # https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
 imagePullSecrets: []


### PR DESCRIPTION
## Summary & Motivation

This feat allows you to change the name of the container for User Deployment. There is a need for this in our observability solution, where we can see logs for a given container. Managing multiple clusters with Dagster deployments, each with multiple user deployments sharing the same container name, would require changes to observability labels. Instead, this change gives us observability out of the box.

## How I Tested These Changes

I run `python -m pytest python_modules/dagster/dagster_tests` and waited 1 hour to see successful tests.

## Changelog

> feat: add optional `containerName` variable to values.yaml, allowing overriding of container name 
