### PR TITLE
[asset graph] Minor sidebar refactor + Fix asset graph sidebar tree view auto-scrolling

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -699,7 +699,8 @@ const AssetGraphExplorerWithData = ({
   if (!nextLayoutLoading && isInitialLayout.current) {
     isInitialLayout.current = false;
   }
-  const loading = (layoutLoading || dataLoading) && isInitialLayout.current;
+  const sidebarLoading = dataLoading && isInitialLayout.current;
+  const loading = sidebarLoading || nextLayoutLoading;
 
   const [errorState, setErrorState] = useState<SyntaxError[]>([]);
 
@@ -734,7 +735,7 @@ const AssetGraphExplorerWithData = ({
       firstMinSize={400}
       secondMinSize={400}
       first={
-        loading ? (
+        sidebarLoading ? (
           <LoadingContainer>
             <Box margin={{bottom: 24}}>Loading assets…</Box>
             <Spinner purpose="page" />

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarListView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarListView.tsx
@@ -22,7 +22,11 @@ export interface AssetSidebarListViewProps {
   setSelectedNode: React.Dispatch<
     React.SetStateAction<null | {id: string; path: string} | {id: string}>
   >;
-  selectNode: (e: React.MouseEvent<any> | React.KeyboardEvent<any>, nodeId: string) => void;
+  selectNode: (
+    e: React.MouseEvent<any> | React.KeyboardEvent<any>,
+    nodeId: string,
+    sidebarNodeInfo?: {path: string; direction: 'root-to-leaf' | 'leaf-to-root'},
+  ) => void;
   explorerPath: ExplorerPath;
   onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
   onFilterToGroup: (group: AssetGroup) => void;
@@ -121,7 +125,7 @@ export const AssetSidebarListView = ({
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             renderedNodes[(nextIndex + renderedNodes.length) % renderedNodes.length]!;
           setSelectedNode(nextNode);
-          selectNode(e, nextNode.id);
+          selectNode(e, nextNode.id, 'path' in nextNode ? nextNode.path : undefined);
         } else if (e.code === 'ArrowLeft' || e.code === 'ArrowRight') {
           const open = e.code === 'ArrowRight';
           const node = renderedNodes[indexOfLastSelectedNode];
@@ -173,12 +177,12 @@ export const AssetSidebarListView = ({
                     });
                   }}
                   collapseAllNodes={collapseAllNodes}
-                  selectNode={(e, id) => {
-                    selectNode(e, id);
+                  selectNode={(e, id, path) => {
+                    selectNode(e, id, path);
                   }}
                   selectThisNode={(e) => {
                     setSelectedNode(node);
-                    selectNode(e, node.id);
+                    selectNode(e, node.id, 'path' in node ? node.path : undefined);
                   }}
                   explorerPath={explorerPath}
                   onChangeExplorerPath={onChangeExplorerPath}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarListView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarListView.tsx
@@ -125,7 +125,11 @@ export const AssetSidebarListView = ({
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             renderedNodes[(nextIndex + renderedNodes.length) % renderedNodes.length]!;
           setSelectedNode(nextNode);
-          selectNode(e, nextNode.id, 'path' in nextNode ? nextNode.path : undefined);
+          selectNode(
+            e,
+            nextNode.id,
+            'path' in nextNode ? {path: nextNode.path, direction} : undefined,
+          );
         } else if (e.code === 'ArrowLeft' || e.code === 'ArrowRight') {
           const open = e.code === 'ArrowRight';
           const node = renderedNodes[indexOfLastSelectedNode];
@@ -182,7 +186,11 @@ export const AssetSidebarListView = ({
                   }}
                   selectThisNode={(e) => {
                     setSelectedNode(node);
-                    selectNode(e, node.id, 'path' in node ? node.path : undefined);
+                    selectNode(
+                      e,
+                      node.id,
+                      'path' in node ? {path: node.path, direction} : undefined,
+                    );
                   }}
                   explorerPath={explorerPath}
                   onChangeExplorerPath={onChangeExplorerPath}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
@@ -33,7 +33,11 @@ type AssetSidebarNodeProps = {
   level: number;
   toggleOpen: () => void;
   selectThisNode: (e: React.MouseEvent<any> | React.KeyboardEvent<any>) => void;
-  selectNode: (e: React.MouseEvent<any> | React.KeyboardEvent<any>, nodeId: string) => void;
+  selectNode: (
+    e: React.MouseEvent<any> | React.KeyboardEvent<any>,
+    nodeId: string,
+    sidebarNodeInfo?: {path: string; direction: 'root-to-leaf' | 'leaf-to-root'},
+  ) => void;
   isOpen: boolean;
   isLastSelected: boolean;
   isSelected: boolean;
@@ -129,7 +133,11 @@ export const AssetSidebarNode = (props: AssetSidebarNodeProps) => {
 type AssetSidebarAssetLabelProps = {
   fullAssetGraphData?: GraphData;
   node: AssetNodeMenuProps['node'] & StatusDotNode;
-  selectNode: (e: React.MouseEvent<any> | React.KeyboardEvent<any>, nodeId: string) => void;
+  selectNode: (
+    e: React.MouseEvent<any> | React.KeyboardEvent<any>,
+    nodeId: string,
+    sidebarNodeInfo?: {path: string; direction: 'root-to-leaf' | 'leaf-to-root'},
+  ) => void;
   isLastSelected: boolean;
   isSelected: boolean;
   explorerPath: ExplorerPath;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SearchInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SearchInput.tsx
@@ -17,8 +17,7 @@ export const SearchInput = ({allAssetKeys, selectNode}: SearchInputProps) => {
   const searchValues = React.useMemo(() => {
     return allAssetKeys.map((key) => ({
       value: JSON.stringify(key.path),
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      label: key.path[key.path.length - 1]!,
+      label: key.path[key.path.length - 1] ?? '',
     }));
   }, [allAssetKeys]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SearchInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SearchInput.tsx
@@ -1,0 +1,30 @@
+import {Box} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {AssetKey} from '../../assets/types';
+import {SearchFilter} from '../sidebar/SearchFilter';
+
+interface SearchInputProps {
+  allAssetKeys: AssetKey[];
+  selectNode: (
+    e: React.MouseEvent<any> | React.KeyboardEvent<any>,
+    nodeId: string,
+    sidebarNodeInfo?: {path: string; direction: 'root-to-leaf' | 'leaf-to-root'},
+  ) => void;
+}
+
+export const SearchInput = ({allAssetKeys, selectNode}: SearchInputProps) => {
+  const searchValues = React.useMemo(() => {
+    return allAssetKeys.map((key) => ({
+      value: JSON.stringify(key.path),
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      label: key.path[key.path.length - 1]!,
+    }));
+  }, [allAssetKeys]);
+
+  return (
+    <Box padding={{vertical: 8, horizontal: 12}}>
+      <SearchFilter values={searchValues} onSelectValue={selectNode} />
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -1,18 +1,19 @@
-import {
-  Box,
-  Button,
-  ButtonGroup,
-  Colors,
-  HoverButton,
-  Icon,
-  Tooltip,
-} from '@dagster-io/ui-components';
+import {Box} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {useMemo} from 'react';
-import styled from 'styled-components';
 
 import {AssetSidebarListView} from './AssetSidebarListView';
-import {FolderNodeType, TreeNodeType, getDisplayName} from './util';
+import {SearchInput} from './SearchInput';
+import {SidebarHeader} from './SidebarHeader';
+import {TreeViewPanel} from './TreeViewPanel';
+import {
+  buildFolderNodes,
+  buildTreeNodesLeafToRoot,
+  buildTreeNodesRootToLeaf,
+  getLeafNodes,
+  getRootNodes,
+} from './treeBuilders';
+import {useSidebarSelectionState} from './useSidebarSelectionState';
 import {LayoutContext} from '../../app/LayoutProvider';
 import {usePrefixedCacheKey} from '../../app/usePrefixedCacheKey';
 import {AssetKey} from '../../assets/types';
@@ -20,10 +21,23 @@ import {useQueryAndLocalStoragePersistedState} from '../../hooks/useQueryAndLoca
 import {ExplorerPath} from '../../pipelines/PipelinePathUtils';
 import {buildRepoPathForHuman} from '../../workspace/buildRepoAddress';
 import {AssetGroup} from '../AssetGraphExplorer';
-import {AssetGraphViewType, GraphData, GraphNode, groupIdForNode, tokenForAssetKey} from '../Utils';
-import {SearchFilter} from '../sidebar/SearchFilter';
+import {AssetGraphViewType, GraphData, GraphNode} from '../Utils';
 
-const COLLATOR = new Intl.Collator(navigator.language, {sensitivity: 'base', numeric: true});
+interface AssetGraphExplorerSidebarProps {
+  assetGraphData: GraphData;
+  fullAssetGraphData: GraphData;
+  selectedNodes: GraphNode[];
+  selectNode: (e: React.MouseEvent<any> | React.KeyboardEvent<any>, nodeId: string) => void;
+  explorerPath: ExplorerPath;
+  onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
+  allAssetKeys: AssetKey[];
+  expandedGroups: string[];
+  setExpandedGroups: (a: string[]) => void;
+  hideSidebar: () => void;
+  viewType: AssetGraphViewType;
+  onFilterToGroup: (group: AssetGroup) => void;
+  loading: boolean;
+}
 
 export const AssetGraphExplorerSidebar = React.memo(
   ({
@@ -38,21 +52,7 @@ export const AssetGraphExplorerSidebar = React.memo(
     viewType,
     onFilterToGroup,
     loading,
-  }: {
-    assetGraphData: GraphData;
-    fullAssetGraphData: GraphData;
-    selectedNodes: GraphNode[];
-    selectNode: (e: React.MouseEvent<any> | React.KeyboardEvent<any>, nodeId: string) => void;
-    explorerPath: ExplorerPath;
-    onChangeExplorerPath: (path: ExplorerPath, mode: 'replace' | 'push') => void;
-    allAssetKeys: AssetKey[];
-    expandedGroups: string[];
-    setExpandedGroups: (a: string[]) => void;
-    hideSidebar: () => void;
-    viewType: AssetGraphViewType;
-    onFilterToGroup: (group: AssetGroup) => void;
-    loading: boolean;
-  }) => {
+  }: AssetGraphExplorerSidebarProps) => {
     const lastSelectedNode = selectedNodes[selectedNodes.length - 1];
     // In the empty stay when no query is typed use the full asset graph data to populate the sidebar
     const graphData = Object.keys(assetGraphData.nodes).length
@@ -73,7 +73,18 @@ export const AssetGraphExplorerSidebar = React.memo(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectWhenDataAvailable, selectedNodeHasDataAvailable]);
 
-    const selectNode: typeof _selectNode = (e, id) => {
+    const selectNode = (
+      e: React.MouseEvent<any> | React.KeyboardEvent<any>,
+      id: string,
+      sidebarNodeInfo?: {path: string; direction: 'root-to-leaf' | 'leaf-to-root'} | undefined,
+    ) => {
+      if (sidebarNodeInfo) {
+        if (sidebarNodeInfo.direction === 'root-to-leaf') {
+          setLastSelectedSidebarNodeRootToLeaf({id, path: sidebarNodeInfo.path});
+        } else {
+          setLastSelectedSidebarNodeLeafToRoot({id, path: sidebarNodeInfo.path});
+        }
+      }
       setSelectWhenDataAvailable([e, id]);
       if (!assetGraphData.nodes[id]) {
         try {
@@ -92,21 +103,6 @@ export const AssetGraphExplorerSidebar = React.memo(
         }
       }
     };
-    // State for root-to-leaf view
-    const [openNodesRootToLeaf, setOpenNodesRootToLeaf] = React.useState<Set<string>>(
-      () => new Set(),
-    );
-    const [selectedNodeRootToLeaf, setSelectedNodeRootToLeaf] = React.useState<
-      null | {id: string; path: string} | {id: string}
-    >(null);
-
-    // State for leaf-to-root view
-    const [openNodesLeafToRoot, setOpenNodesLeafToRoot] = React.useState<Set<string>>(
-      () => new Set(),
-    );
-    const [selectedNodeLeafToRoot, setSelectedNodeLeafToRoot] = React.useState<
-      null | {id: string; path: string} | {id: string}
-    >(null);
 
     const [sidebarViewType, setSidebarViewType] = useQueryAndLocalStoragePersistedState<
       'tree' | 'group'
@@ -121,200 +117,43 @@ export const AssetGraphExplorerSidebar = React.memo(
       },
       isEmptyState: (val) => val === null || val === 'group',
     });
-    const collapseAllNodes = useMemo(() => {
-      if (sidebarViewType === 'group') {
-        return;
-      }
-      if (openNodesRootToLeaf.size === 0 && openNodesLeafToRoot.size === 0) {
-        return;
-      }
-      return () => {
-        setOpenNodesRootToLeaf(new Set());
-        setOpenNodesLeafToRoot(new Set());
-      };
-    }, [sidebarViewType, openNodesRootToLeaf, openNodesLeafToRoot]);
 
-    const rootNodes = React.useMemo(
-      () =>
-        Object.keys(graphData.nodes)
-          .filter(
-            (id) =>
-              // When we filter to a subgraph, the nodes at the root aren't real roots, but since
-              // their upstream graph is cutoff we want to show them as roots in the sidebar.
-              // Find these nodes by filtering on whether there parent nodes are in assetGraphData
-              !Object.keys(graphData.upstream[id] ?? {}).filter((id) => graphData.nodes[id]).length,
-          )
-          .sort((a, b) =>
-            COLLATOR.compare(
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              getDisplayName(graphData.nodes[a]!),
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              getDisplayName(graphData.nodes[b]!),
-            ),
-          ),
-      [graphData],
+    const {
+      selectedNodeRootToLeaf,
+      setSelectedNodeRootToLeaf,
+      selectedNodeLeafToRoot,
+      setSelectedNodeLeafToRoot,
+      openNodesRootToLeaf,
+      setOpenNodesRootToLeaf,
+      openNodesLeafToRoot,
+      setOpenNodesLeafToRoot,
+      collapseAllNodes,
+      setLastSelectedSidebarNodeRootToLeaf,
+      setLastSelectedSidebarNodeLeafToRoot,
+    } = useSidebarSelectionState({
+      lastSelectedNode,
+      graphData,
+      sidebarViewType,
+      buildRepoPathForHuman,
+    });
+
+    const rootNodes = React.useMemo(() => getRootNodes(graphData), [graphData]);
+    const leafNodes = React.useMemo(() => getLeafNodes(graphData), [graphData]);
+
+    const treeNodesRootToLeaf = React.useMemo(
+      () => buildTreeNodesRootToLeaf(graphData, rootNodes, openNodesRootToLeaf),
+      [graphData, rootNodes, openNodesRootToLeaf],
     );
 
-    const leafNodes = React.useMemo(
-      () =>
-        Object.keys(graphData.nodes)
-          .filter(
-            (id) =>
-              // Leaf nodes are those with no downstream dependencies
-              !Object.keys(graphData.downstream[id] ?? {}).filter((id) => graphData.nodes[id])
-                .length,
-          )
-          .sort((a, b) =>
-            COLLATOR.compare(
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              getDisplayName(graphData.nodes[a]!),
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              getDisplayName(graphData.nodes[b]!),
-            ),
-          ),
-      [graphData],
+    const treeNodesLeafToRoot = React.useMemo(
+      () => buildTreeNodesLeafToRoot(graphData, leafNodes, openNodesLeafToRoot),
+      [graphData, leafNodes, openNodesLeafToRoot],
     );
 
-    const treeNodesRootToLeaf = React.useMemo(() => {
-      const queue = rootNodes.map((id) => ({level: 1, id, path: id}));
-
-      const treeNodes: TreeNodeType[] = [];
-      while (true) {
-        const node = queue.shift();
-        if (!node) {
-          break;
-        }
-        treeNodes.push(node);
-        if (openNodesRootToLeaf.has(node.path)) {
-          const downstream = Object.keys(graphData.downstream[node.id] || {}).filter(
-            (id) => graphData.nodes[id],
-          );
-          queue.unshift(
-            ...downstream.map((id) => ({level: node.level + 1, id, path: `${node.path}:${id}`})),
-          );
-        }
-      }
-      return treeNodes;
-    }, [graphData.downstream, graphData.nodes, openNodesRootToLeaf, rootNodes]);
-
-    const treeNodesLeafToRoot = React.useMemo(() => {
-      const queue = leafNodes.map((id) => ({level: 1, id, path: id}));
-
-      const treeNodes: TreeNodeType[] = [];
-      while (true) {
-        const node = queue.shift();
-        if (!node) {
-          break;
-        }
-        treeNodes.push(node);
-        if (openNodesLeafToRoot.has(node.path)) {
-          const upstream = Object.keys(graphData.upstream[node.id] || {}).filter(
-            (id) => graphData.nodes[id],
-          );
-          queue.unshift(
-            ...upstream.map((id) => ({level: node.level + 1, id, path: `${node.path}:${id}`})),
-          );
-        }
-      }
-      return treeNodes;
-    }, [graphData.upstream, graphData.nodes, openNodesLeafToRoot, leafNodes]);
-
-    const folderNodes = React.useMemo(() => {
-      const folderNodes: FolderNodeType[] = [];
-
-      // Map of Code Locations -> Groups -> Assets
-      const codeLocationNodes: Record<
-        string,
-        {
-          locationName: string;
-          groups: Record<
-            string,
-            {
-              groupName: string;
-              assets: GraphNode[];
-              repositoryName: string;
-              repositoryLocationName: string;
-            }
-          >;
-        }
-      > = {};
-
-      let groupsCount = 0;
-      Object.values(graphData.nodes).forEach((node) => {
-        const locationName = node.definition.repository.location.name;
-        const repositoryName = node.definition.repository.name;
-        const groupName = node.definition.groupName || 'default';
-        const groupId = groupIdForNode(node);
-        const codeLocation = buildRepoPathForHuman(repositoryName, locationName);
-        codeLocationNodes[codeLocation] = codeLocationNodes[codeLocation] || {
-          locationName: codeLocation,
-          groups: {},
-        };
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        if (!codeLocationNodes[codeLocation]!.groups[groupId]!) {
-          groupsCount += 1;
-        }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        codeLocationNodes[codeLocation]!.groups[groupId] = codeLocationNodes[codeLocation]!.groups[
-          groupId
-        ] || {
-          groupName,
-          assets: [],
-          repositoryName,
-          repositoryLocationName: locationName,
-        };
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        codeLocationNodes[codeLocation]!.groups[groupId]!.assets.push(node);
-      });
-      const codeLocationsCount = Object.keys(codeLocationNodes).length;
-      Object.entries(codeLocationNodes)
-        .sort(([_1, a], [_2, b]) => COLLATOR.compare(a.locationName, b.locationName))
-        .forEach(([locationName, locationNode]) => {
-          folderNodes.push({
-            locationName,
-            id: locationName,
-            level: 1,
-            openAlways: codeLocationsCount === 1,
-          });
-          if (openNodesRootToLeaf.has(locationName) || codeLocationsCount === 1) {
-            Object.entries(locationNode.groups)
-              .sort(([_1, a], [_2, b]) => COLLATOR.compare(a.groupName, b.groupName))
-              .forEach(([id, groupNode]) => {
-                folderNodes.push({
-                  groupNode,
-                  id,
-                  level: 2,
-                });
-                if (openNodesRootToLeaf.has(id) || groupsCount === 1) {
-                  groupNode.assets
-                    .sort((a, b) => COLLATOR.compare(a.id, b.id))
-                    .forEach((assetNode) => {
-                      folderNodes.push({
-                        id: assetNode.id,
-                        path: [
-                          locationName,
-                          groupNode.groupName,
-                          tokenForAssetKey(assetNode.assetKey),
-                        ].join(':'),
-                        level: 3,
-                      });
-                    });
-                }
-              });
-          }
-        });
-
-      if (groupsCount === 1) {
-        return folderNodes
-          .filter((node) => node.level === 3)
-          .map((node) => ({
-            ...node,
-            level: 1,
-          }));
-      }
-
-      return folderNodes;
-    }, [graphData.nodes, openNodesRootToLeaf]);
+    const folderNodes = React.useMemo(
+      () => buildFolderNodes(graphData, openNodesRootToLeaf),
+      [graphData, openNodesRootToLeaf],
+    );
 
     const renderedNodesRootToLeaf = sidebarViewType === 'tree' ? treeNodesRootToLeaf : folderNodes;
     const renderedNodesLeafToRoot = treeNodesLeafToRoot; // Leaf-to-root only supports tree view
@@ -327,100 +166,6 @@ export const AssetGraphExplorerSidebar = React.memo(
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [viewType]);
-
-    React.useLayoutEffect(() => {
-      if (lastSelectedNode) {
-        // Update root-to-leaf view
-        setOpenNodesRootToLeaf((prevOpenNodes) => {
-          if (sidebarViewType === 'tree') {
-            let path = lastSelectedNode.id;
-            let currentId = lastSelectedNode.id;
-            let next: string | undefined;
-            while ((next = Object.keys(graphData.upstream[currentId] ?? {})[0])) {
-              if (!graphData.nodes[next]) {
-                break;
-              }
-              path = `${next}:${path}`;
-              currentId = next;
-            }
-
-            const nodesInPath = path.split(':');
-            let currentPath = nodesInPath[0];
-
-            if (!currentPath) {
-              return prevOpenNodes;
-            }
-
-            const nextOpenNodes = new Set(prevOpenNodes);
-            nextOpenNodes.add(currentPath);
-            for (let i = 1; i < nodesInPath.length; i++) {
-              currentPath = `${currentPath}:${nodesInPath[i]}`;
-              nextOpenNodes.add(currentPath);
-            }
-            if (selectedNodeRootToLeaf?.id !== lastSelectedNode.id) {
-              setSelectedNodeRootToLeaf({id: lastSelectedNode.id, path: currentPath});
-            }
-            return nextOpenNodes;
-          }
-          const nextOpenNodes = new Set(prevOpenNodes);
-          const assetNode = graphData.nodes[lastSelectedNode.id];
-          if (assetNode) {
-            const locationName = buildRepoPathForHuman(
-              assetNode.definition.repository.name,
-              assetNode.definition.repository.location.name,
-            );
-            const groupName = assetNode.definition.groupName || 'default';
-            nextOpenNodes.add(locationName);
-            nextOpenNodes.add(locationName + ':' + groupName);
-          }
-          if (selectedNodeRootToLeaf?.id !== lastSelectedNode.id) {
-            setSelectedNodeRootToLeaf({id: lastSelectedNode.id});
-          }
-          return nextOpenNodes;
-        });
-
-        // Update leaf-to-root view
-        setOpenNodesLeafToRoot((prevOpenNodes) => {
-          let path = lastSelectedNode.id;
-          let currentId = lastSelectedNode.id;
-          let next: string | undefined;
-          while ((next = Object.keys(graphData.downstream[currentId] ?? {})[0])) {
-            if (!graphData.nodes[next]) {
-              break;
-            }
-            path = `${next}:${path}`;
-            currentId = next;
-          }
-
-          const nodesInPath = path.split(':');
-          let currentPath = nodesInPath[0];
-
-          if (!currentPath) {
-            return prevOpenNodes;
-          }
-
-          const nextOpenNodes = new Set(prevOpenNodes);
-          nextOpenNodes.add(currentPath);
-          for (let i = 1; i < nodesInPath.length; i++) {
-            currentPath = `${currentPath}:${nodesInPath[i]}`;
-            nextOpenNodes.add(currentPath);
-          }
-          if (selectedNodeLeafToRoot?.id !== lastSelectedNode.id) {
-            setSelectedNodeLeafToRoot({id: lastSelectedNode.id, path: currentPath});
-          }
-          return nextOpenNodes;
-        });
-      } else {
-        setSelectedNodeRootToLeaf(null);
-        setSelectedNodeLeafToRoot(null);
-      }
-    }, [
-      lastSelectedNode,
-      graphData,
-      sidebarViewType,
-      selectedNodeRootToLeaf?.id,
-      selectedNodeLeafToRoot?.id,
-    ]);
 
     const [expandedPanel, setExpandedPanel] = React.useState<'bottom' | 'top' | null>(null);
 
@@ -443,148 +188,64 @@ export const AssetGraphExplorerSidebar = React.memo(
           height: '100%',
         }}
       >
-        <Box
-          style={{
-            display: 'grid',
-            gridTemplateColumns: '1fr auto',
-            gap: '6px',
-            padding: '12px',
-          }}
-        >
-          <ButtonGroupWrapper>
-            <ButtonGroup
-              activeItems={new Set([sidebarViewType])}
-              buttons={[
-                {id: 'group', label: 'Group view', icon: 'asset_group'},
-                {id: 'tree', label: 'Tree view', icon: 'gantt_flat'},
-              ]}
-              onClick={(id: 'tree' | 'group') => {
-                setSidebarViewType(id);
-              }}
-            />
-          </ButtonGroupWrapper>
-          <Tooltip content="Hide sidebar">
-            <Button icon={<Icon name="panel_show_right" />} onClick={hideSidebar} />
-          </Tooltip>
-        </Box>
-        <Box padding={{vertical: 8, horizontal: 12}}>
-          <SearchFilter
-            values={React.useMemo(() => {
-              return allAssetKeys.map((key) => ({
-                value: JSON.stringify(key.path),
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                label: key.path[key.path.length - 1]!,
-              }));
-            }, [allAssetKeys])}
-            onSelectValue={selectNode}
-          />
-        </Box>
+        <SidebarHeader
+          sidebarViewType={sidebarViewType}
+          setSidebarViewType={setSidebarViewType}
+          hideSidebar={hideSidebar}
+        />
+        <SearchInput allAssetKeys={allAssetKeys} selectNode={selectNode} />
         {sidebarViewType === 'tree' ? (
           <div style={{display: 'grid', gridTemplateRows: treeViewRows}}>
-            <Box flex={{direction: 'column', gap: 4}}>
-              <Box
-                background={Colors.backgroundLight()}
-                padding={{horizontal: 24, vertical: 8}}
-                style={{fontWeight: 500, position: 'sticky', top: 0, zIndex: 1}}
-                flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
-                border={isTopPanelHidden ? 'top' : 'top-and-bottom'}
-              >
-                <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-                  Downstream{' '}
-                  <Tooltip content="Parent asset to child assets">
-                    <Icon name="info" />
-                  </Tooltip>
-                </Box>
-                <Box>
-                  <HoverButton
-                    onClick={() => {
-                      setExpandedPanel((prev) => (prev !== 'top' ? 'top' : null));
-                    }}
-                  >
-                    <Icon name={expandedPanel === 'top' ? 'collapse_arrows' : 'expand_arrows'} />
-                  </HoverButton>
-                </Box>
-              </Box>
-              <div
-                style={{
-                  display: isTopPanelHidden ? 'none' : 'block',
-                  height: isTopPanelHidden ? 0 : '100%',
-                  overflow: 'hidden',
-                }}
-              >
-                <AssetSidebarListView
-                  loading={loading}
-                  renderedNodes={renderedNodesRootToLeaf}
-                  graphData={graphData}
-                  fullAssetGraphData={fullAssetGraphData}
-                  selectedNodes={selectedNodes}
-                  selectedNode={selectedNodeRootToLeaf}
-                  lastSelectedNode={lastSelectedNode}
-                  openNodes={openNodesRootToLeaf}
-                  setOpenNodes={setOpenNodesRootToLeaf}
-                  collapseAllNodes={collapseAllNodes}
-                  setSelectedNode={setSelectedNodeRootToLeaf}
-                  selectNode={selectNode}
-                  explorerPath={explorerPath}
-                  onChangeExplorerPath={onChangeExplorerPath}
-                  onFilterToGroup={onFilterToGroup}
-                  viewType={sidebarViewType}
-                  direction="root-to-leaf"
-                />
-              </div>
-            </Box>
-            <Box flex={{direction: 'column', gap: 4}}>
-              <Box
-                background={Colors.backgroundLight()}
-                padding={{horizontal: 24, vertical: 8}}
-                flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
-                style={{fontWeight: 500, position: 'sticky', top: 0, zIndex: 1}}
-                border="top-and-bottom"
-              >
-                <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
-                  Upstream{' '}
-                  <Tooltip content="Child asset to parent assets">
-                    <Icon name="info" />
-                  </Tooltip>
-                </Box>
-                <Box>
-                  <HoverButton
-                    onClick={() => {
-                      setExpandedPanel((prev) => (prev !== 'bottom' ? 'bottom' : null));
-                    }}
-                  >
-                    <Icon name={expandedPanel === 'bottom' ? 'collapse_arrows' : 'expand_arrows'} />
-                  </HoverButton>
-                </Box>
-              </Box>
-              <div
-                style={{
-                  display: isBottomPanelHidden ? 'none' : 'block',
-                  height: isBottomPanelHidden ? 0 : '100%',
-                  overflow: 'hidden',
-                }}
-              >
-                <AssetSidebarListView
-                  loading={loading}
-                  renderedNodes={renderedNodesLeafToRoot}
-                  graphData={graphData}
-                  fullAssetGraphData={fullAssetGraphData}
-                  selectedNodes={selectedNodes}
-                  selectedNode={selectedNodeLeafToRoot}
-                  lastSelectedNode={lastSelectedNode}
-                  openNodes={openNodesLeafToRoot}
-                  setOpenNodes={setOpenNodesLeafToRoot}
-                  collapseAllNodes={collapseAllNodes}
-                  setSelectedNode={setSelectedNodeLeafToRoot}
-                  selectNode={selectNode}
-                  explorerPath={explorerPath}
-                  onChangeExplorerPath={onChangeExplorerPath}
-                  onFilterToGroup={onFilterToGroup}
-                  viewType={sidebarViewType}
-                  direction="leaf-to-root"
-                />
-              </div>
-            </Box>
+            <TreeViewPanel
+              title="Downstream"
+              tooltipContent="Parent asset to child assets"
+              expandedPanel={expandedPanel}
+              setExpandedPanel={setExpandedPanel}
+              position="top"
+              isHidden={isTopPanelHidden}
+              loading={loading}
+              renderedNodes={renderedNodesRootToLeaf}
+              graphData={graphData}
+              fullAssetGraphData={fullAssetGraphData}
+              selectedNodes={selectedNodes}
+              selectedNode={selectedNodeRootToLeaf}
+              lastSelectedNode={lastSelectedNode}
+              openNodes={openNodesRootToLeaf}
+              setOpenNodes={setOpenNodesRootToLeaf}
+              collapseAllNodes={collapseAllNodes}
+              setSelectedNode={setSelectedNodeRootToLeaf}
+              selectNode={selectNode}
+              explorerPath={explorerPath}
+              onChangeExplorerPath={onChangeExplorerPath}
+              onFilterToGroup={onFilterToGroup}
+              viewType={sidebarViewType}
+              direction="root-to-leaf"
+            />
+            <TreeViewPanel
+              title="Upstream"
+              tooltipContent="Child asset to parent assets"
+              expandedPanel={expandedPanel}
+              setExpandedPanel={setExpandedPanel}
+              position="bottom"
+              isHidden={isBottomPanelHidden}
+              loading={loading}
+              renderedNodes={renderedNodesLeafToRoot}
+              graphData={graphData}
+              fullAssetGraphData={fullAssetGraphData}
+              selectedNodes={selectedNodes}
+              selectedNode={selectedNodeLeafToRoot}
+              lastSelectedNode={lastSelectedNode}
+              openNodes={openNodesLeafToRoot}
+              setOpenNodes={setOpenNodesLeafToRoot}
+              collapseAllNodes={collapseAllNodes}
+              setSelectedNode={setSelectedNodeLeafToRoot}
+              selectNode={selectNode}
+              explorerPath={explorerPath}
+              onChangeExplorerPath={onChangeExplorerPath}
+              onFilterToGroup={onFilterToGroup}
+              viewType={sidebarViewType}
+              direction="leaf-to-root"
+            />
           </div>
         ) : (
           <Box border="top" padding={{top: 4}}>
@@ -611,16 +272,3 @@ export const AssetGraphExplorerSidebar = React.memo(
     );
   },
 );
-
-const ButtonGroupWrapper = styled.div`
-  > * {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    > * {
-      place-content: center;
-    }
-    span {
-      flex: initial;
-    }
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SidebarHeader.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SidebarHeader.module.css
@@ -1,0 +1,12 @@
+.buttonGroupWrapper > * {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.buttonGroupWrapper > * > * {
+  place-content: center;
+}
+
+.buttonGroupWrapper > * span {
+  flex: initial;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SidebarHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SidebarHeader.tsx
@@ -1,6 +1,7 @@
 import {Box, Button, ButtonGroup, Icon, Tooltip} from '@dagster-io/ui-components';
 import * as React from 'react';
-import styled from 'styled-components';
+
+import styles from './SidebarHeader.module.css';
 
 interface SidebarHeaderProps {
   sidebarViewType: 'tree' | 'group';
@@ -8,11 +9,11 @@ interface SidebarHeaderProps {
   hideSidebar: () => void;
 }
 
-export const SidebarHeader: React.FC<SidebarHeaderProps> = ({
+export const SidebarHeader = ({
   sidebarViewType,
   setSidebarViewType,
   hideSidebar,
-}) => {
+}: SidebarHeaderProps) => {
   return (
     <Box
       style={{
@@ -22,7 +23,7 @@ export const SidebarHeader: React.FC<SidebarHeaderProps> = ({
         padding: '12px',
       }}
     >
-      <ButtonGroupWrapper>
+      <div className={styles.buttonGroupWrapper}>
         <ButtonGroup
           activeItems={new Set([sidebarViewType])}
           buttons={[
@@ -33,23 +34,10 @@ export const SidebarHeader: React.FC<SidebarHeaderProps> = ({
             setSidebarViewType(id);
           }}
         />
-      </ButtonGroupWrapper>
+      </div>
       <Tooltip content="Hide sidebar">
         <Button icon={<Icon name="panel_show_right" />} onClick={hideSidebar} />
       </Tooltip>
     </Box>
   );
 };
-
-const ButtonGroupWrapper = styled.div`
-  > * {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    > * {
-      place-content: center;
-    }
-    span {
-      flex: initial;
-    }
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SidebarHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/SidebarHeader.tsx
@@ -1,0 +1,55 @@
+import {Box, Button, ButtonGroup, Icon, Tooltip} from '@dagster-io/ui-components';
+import * as React from 'react';
+import styled from 'styled-components';
+
+interface SidebarHeaderProps {
+  sidebarViewType: 'tree' | 'group';
+  setSidebarViewType: (viewType: 'tree' | 'group') => void;
+  hideSidebar: () => void;
+}
+
+export const SidebarHeader: React.FC<SidebarHeaderProps> = ({
+  sidebarViewType,
+  setSidebarViewType,
+  hideSidebar,
+}) => {
+  return (
+    <Box
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr auto',
+        gap: '6px',
+        padding: '12px',
+      }}
+    >
+      <ButtonGroupWrapper>
+        <ButtonGroup
+          activeItems={new Set([sidebarViewType])}
+          buttons={[
+            {id: 'group', label: 'Group view', icon: 'asset_group'},
+            {id: 'tree', label: 'Tree view', icon: 'gantt_flat'},
+          ]}
+          onClick={(id: 'tree' | 'group') => {
+            setSidebarViewType(id);
+          }}
+        />
+      </ButtonGroupWrapper>
+      <Tooltip content="Hide sidebar">
+        <Button icon={<Icon name="panel_show_right" />} onClick={hideSidebar} />
+      </Tooltip>
+    </Box>
+  );
+};
+
+const ButtonGroupWrapper = styled.div`
+  > * {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    > * {
+      place-content: center;
+    }
+    span {
+      flex: initial;
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/TreeViewPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/TreeViewPanel.tsx
@@ -51,7 +51,7 @@ export const TreeViewPanel = ({
       <div
         style={{
           display: isHidden ? 'none' : 'block',
-          height: isHidden ? 0 : '100%',
+          height: '100%',
           overflow: 'hidden',
         }}
       >

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/TreeViewPanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/TreeViewPanel.tsx
@@ -1,0 +1,62 @@
+import {Box, Colors, HoverButton, Icon, Tooltip} from '@dagster-io/ui-components';
+import * as React from 'react';
+
+import {AssetSidebarListView, AssetSidebarListViewProps} from './AssetSidebarListView';
+
+interface TreeViewPanelProps extends AssetSidebarListViewProps {
+  title: string;
+  tooltipContent: string;
+  expandedPanel: 'bottom' | 'top' | null;
+  setExpandedPanel: React.Dispatch<React.SetStateAction<'bottom' | 'top' | null>>;
+  position: 'top' | 'bottom';
+  isHidden: boolean;
+}
+
+export const TreeViewPanel = ({
+  title,
+  tooltipContent,
+  expandedPanel,
+  setExpandedPanel,
+  position,
+  isHidden,
+  ...listViewProps
+}: TreeViewPanelProps) => {
+  const isExpanded = expandedPanel === position;
+
+  return (
+    <Box flex={{direction: 'column', gap: 4}}>
+      <Box
+        background={Colors.backgroundLight()}
+        padding={{horizontal: 24, vertical: 8}}
+        style={{fontWeight: 500, position: 'sticky', top: 0, zIndex: 1}}
+        flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+        border={isHidden ? 'top' : 'top-and-bottom'}
+      >
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+          {title}{' '}
+          <Tooltip content={tooltipContent}>
+            <Icon name="info" />
+          </Tooltip>
+        </Box>
+        <Box>
+          <HoverButton
+            onClick={() => {
+              setExpandedPanel((prev) => (prev !== position ? position : null));
+            }}
+          >
+            <Icon name={isExpanded ? 'collapse_arrows' : 'expand_arrows'} />
+          </HoverButton>
+        </Box>
+      </Box>
+      <div
+        style={{
+          display: isHidden ? 'none' : 'block',
+          height: isHidden ? 0 : '100%',
+          overflow: 'hidden',
+        }}
+      >
+        <AssetSidebarListView {...listViewProps} />
+      </div>
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/treeBuilders.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/treeBuilders.ts
@@ -14,12 +14,7 @@ export function getRootNodes(graphData: GraphData): string[] {
         !Object.keys(graphData.upstream[id] ?? {}).filter((id) => graphData.nodes[id]).length,
     )
     .sort((a, b) =>
-      COLLATOR.compare(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        getDisplayName(graphData.nodes[a]!),
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        getDisplayName(graphData.nodes[b]!),
-      ),
+      COLLATOR.compare(getDisplayName(graphData.nodes[a]), getDisplayName(graphData.nodes[b])),
     );
 }
 
@@ -32,10 +27,8 @@ export function getLeafNodes(graphData: GraphData): string[] {
     )
     .sort((a, b) =>
       COLLATOR.compare(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        getDisplayName(graphData.nodes[a]!),
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        getDisplayName(graphData.nodes[b]!),
+        graphData.nodes[a] ? getDisplayName(graphData.nodes[a]) : '',
+        graphData.nodes[b] ? getDisplayName(graphData.nodes[b]) : '',
       ),
     );
 }
@@ -193,7 +186,6 @@ export function buildFolderNodes(
   return folderNodes;
 }
 
-function getDisplayName(node: GraphNode) {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return node.assetKey.path[node.assetKey.path.length - 1]!;
+function getDisplayName(node?: GraphNode) {
+  return node?.assetKey.path[node?.assetKey.path.length - 1] ?? '';
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/treeBuilders.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/treeBuilders.ts
@@ -1,0 +1,199 @@
+import {FolderNodeType, TreeNodeType} from './util';
+import {buildRepoPathForHuman} from '../../workspace/buildRepoAddress';
+import {GraphData, GraphNode, groupIdForNode, tokenForAssetKey} from '../Utils';
+
+const COLLATOR = new Intl.Collator(navigator.language, {sensitivity: 'base', numeric: true});
+
+export function getRootNodes(graphData: GraphData): string[] {
+  return Object.keys(graphData.nodes)
+    .filter(
+      (id) =>
+        // When we filter to a subgraph, the nodes at the root aren't real roots, but since
+        // their upstream graph is cutoff we want to show them as roots in the sidebar.
+        // Find these nodes by filtering on whether there parent nodes are in assetGraphData
+        !Object.keys(graphData.upstream[id] ?? {}).filter((id) => graphData.nodes[id]).length,
+    )
+    .sort((a, b) =>
+      COLLATOR.compare(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        getDisplayName(graphData.nodes[a]!),
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        getDisplayName(graphData.nodes[b]!),
+      ),
+    );
+}
+
+export function getLeafNodes(graphData: GraphData): string[] {
+  return Object.keys(graphData.nodes)
+    .filter(
+      (id) =>
+        // Leaf nodes are those with no downstream dependencies
+        !Object.keys(graphData.downstream[id] ?? {}).filter((id) => graphData.nodes[id]).length,
+    )
+    .sort((a, b) =>
+      COLLATOR.compare(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        getDisplayName(graphData.nodes[a]!),
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        getDisplayName(graphData.nodes[b]!),
+      ),
+    );
+}
+
+export function buildTreeNodesRootToLeaf(
+  graphData: GraphData,
+  rootNodes: string[],
+  openNodesRootToLeaf: Set<string>,
+): TreeNodeType[] {
+  const queue = rootNodes.map((id) => ({level: 1, id, path: id}));
+  const treeNodes: TreeNodeType[] = [];
+
+  while (true) {
+    const node = queue.shift();
+    if (!node) {
+      break;
+    }
+    treeNodes.push(node);
+    if (openNodesRootToLeaf.has(node.path)) {
+      const downstream = Object.keys(graphData.downstream[node.id] || {}).filter(
+        (id) => graphData.nodes[id],
+      );
+      queue.unshift(
+        ...downstream.map((id) => ({level: node.level + 1, id, path: `${node.path}:${id}`})),
+      );
+    }
+  }
+  return treeNodes;
+}
+
+export function buildTreeNodesLeafToRoot(
+  graphData: GraphData,
+  leafNodes: string[],
+  openNodesLeafToRoot: Set<string>,
+): TreeNodeType[] {
+  const queue = leafNodes.map((id) => ({level: 1, id, path: id}));
+  const treeNodes: TreeNodeType[] = [];
+
+  while (true) {
+    const node = queue.shift();
+    if (!node) {
+      break;
+    }
+    treeNodes.push(node);
+    if (openNodesLeafToRoot.has(node.path)) {
+      const upstream = Object.keys(graphData.upstream[node.id] || {}).filter(
+        (id) => graphData.nodes[id],
+      );
+      queue.unshift(
+        ...upstream.map((id) => ({level: node.level + 1, id, path: `${node.path}:${id}`})),
+      );
+    }
+  }
+  return treeNodes;
+}
+
+export function buildFolderNodes(
+  graphData: GraphData,
+  openNodesRootToLeaf: Set<string>,
+): FolderNodeType[] {
+  const folderNodes: FolderNodeType[] = [];
+
+  // Map of Code Locations -> Groups -> Assets
+  const codeLocationNodes: Record<
+    string,
+    {
+      locationName: string;
+      groups: Record<
+        string,
+        {
+          groupName: string;
+          assets: GraphNode[];
+          repositoryName: string;
+          repositoryLocationName: string;
+        }
+      >;
+    }
+  > = {};
+
+  let groupsCount = 0;
+  Object.values(graphData.nodes).forEach((node) => {
+    const locationName = node.definition.repository.location.name;
+    const repositoryName = node.definition.repository.name;
+    const groupName = node.definition.groupName || 'default';
+    const groupId = groupIdForNode(node);
+    const codeLocation = buildRepoPathForHuman(repositoryName, locationName);
+    codeLocationNodes[codeLocation] = codeLocationNodes[codeLocation] || {
+      locationName: codeLocation,
+      groups: {},
+    };
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    if (!codeLocationNodes[codeLocation]!.groups[groupId]!) {
+      groupsCount += 1;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    codeLocationNodes[codeLocation]!.groups[groupId] = codeLocationNodes[codeLocation]!.groups[
+      groupId
+    ] || {
+      groupName,
+      assets: [],
+      repositoryName,
+      repositoryLocationName: locationName,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    codeLocationNodes[codeLocation]!.groups[groupId]!.assets.push(node);
+  });
+
+  const codeLocationsCount = Object.keys(codeLocationNodes).length;
+  Object.entries(codeLocationNodes)
+    .sort(([_1, a], [_2, b]) => COLLATOR.compare(a.locationName, b.locationName))
+    .forEach(([locationName, locationNode]) => {
+      folderNodes.push({
+        locationName,
+        id: locationName,
+        level: 1,
+        openAlways: codeLocationsCount === 1,
+      });
+      if (openNodesRootToLeaf.has(locationName) || codeLocationsCount === 1) {
+        Object.entries(locationNode.groups)
+          .sort(([_1, a], [_2, b]) => COLLATOR.compare(a.groupName, b.groupName))
+          .forEach(([id, groupNode]) => {
+            folderNodes.push({
+              groupNode,
+              id,
+              level: 2,
+            });
+            if (openNodesRootToLeaf.has(id) || groupsCount === 1) {
+              groupNode.assets
+                .sort((a, b) => COLLATOR.compare(a.id, b.id))
+                .forEach((assetNode) => {
+                  folderNodes.push({
+                    id: assetNode.id,
+                    path: [
+                      locationName,
+                      groupNode.groupName,
+                      tokenForAssetKey(assetNode.assetKey),
+                    ].join(':'),
+                    level: 3,
+                  });
+                });
+            }
+          });
+      }
+    });
+
+  if (groupsCount === 1) {
+    return folderNodes
+      .filter((node) => node.level === 3)
+      .map((node) => ({
+        ...node,
+        level: 1,
+      }));
+  }
+
+  return folderNodes;
+}
+
+function getDisplayName(node: GraphNode) {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return node.assetKey.path[node.assetKey.path.length - 1]!;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/useSidebarSelectionState.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/useSidebarSelectionState.ts
@@ -1,0 +1,200 @@
+import * as React from 'react';
+
+import {GraphData, GraphNode} from '../Utils';
+
+interface SelectedNode {
+  id: string;
+  path?: string;
+}
+
+interface UseSidebarSelectionStateArgs {
+  lastSelectedNode: GraphNode | undefined;
+  graphData: GraphData;
+  sidebarViewType: 'tree' | 'group';
+  buildRepoPathForHuman: (repoName: string, locationName: string) => string;
+}
+
+export function useSidebarSelectionState({
+  lastSelectedNode,
+  graphData,
+  sidebarViewType,
+  buildRepoPathForHuman,
+}: UseSidebarSelectionStateArgs) {
+  const [lastSelectedSidebarNodeRootToLeaf, setLastSelectedSidebarNodeRootToLeaf] =
+    React.useState<SelectedNode | null>(null);
+  const [lastSelectedSidebarNodeLeafToRoot, setLastSelectedSidebarNodeLeafToRoot] =
+    React.useState<SelectedNode | null>(null);
+  // State for root-to-leaf view
+  const [openNodesRootToLeaf, setOpenNodesRootToLeaf] = React.useState<Set<string>>(
+    () => new Set(),
+  );
+  const [selectedNodeRootToLeaf, setSelectedNodeRootToLeaf] = React.useState<SelectedNode | null>(
+    null,
+  );
+
+  // State for leaf-to-root view
+  const [openNodesLeafToRoot, setOpenNodesLeafToRoot] = React.useState<Set<string>>(
+    () => new Set(),
+  );
+  const [selectedNodeLeafToRoot, setSelectedNodeLeafToRoot] = React.useState<SelectedNode | null>(
+    null,
+  );
+
+  const collapseAllNodes = React.useMemo(() => {
+    if (sidebarViewType === 'group') {
+      return;
+    }
+    if (openNodesRootToLeaf.size === 0 && openNodesLeafToRoot.size === 0) {
+      return;
+    }
+    return () => {
+      setOpenNodesRootToLeaf(new Set());
+      setOpenNodesLeafToRoot(new Set());
+    };
+  }, [sidebarViewType, openNodesRootToLeaf, openNodesLeafToRoot]);
+
+  React.useLayoutEffect(() => {
+    if (lastSelectedNode) {
+      // Update root-to-leaf view
+      setOpenNodesRootToLeaf((prevOpenNodes) => {
+        if (sidebarViewType === 'tree') {
+          let path;
+          if (lastSelectedSidebarNodeRootToLeaf?.id === lastSelectedNode?.id) {
+            path = lastSelectedSidebarNodeRootToLeaf.path;
+          }
+          if (!path) {
+            path = getNodePath(lastSelectedNode, 'root-to-leaf', graphData);
+          }
+
+          const nodesInPath = path.split(':');
+          let currentPath = nodesInPath[0];
+
+          if (!currentPath) {
+            return prevOpenNodes;
+          }
+
+          const nextOpenNodes = new Set(prevOpenNodes);
+          nextOpenNodes.add(currentPath);
+          for (let i = 1; i < nodesInPath.length; i++) {
+            currentPath = `${currentPath}:${nodesInPath[i]}`;
+            nextOpenNodes.add(currentPath);
+          }
+          if (selectedNodeRootToLeaf?.id !== lastSelectedNode.id) {
+            setSelectedNodeRootToLeaf({id: lastSelectedNode.id, path: currentPath});
+          }
+          return nextOpenNodes;
+        }
+        const nextOpenNodes = new Set(prevOpenNodes);
+        const assetNode = graphData.nodes[lastSelectedNode.id];
+        if (assetNode) {
+          const locationName = buildRepoPathForHuman(
+            assetNode.definition.repository.name,
+            assetNode.definition.repository.location.name,
+          );
+          const groupName = assetNode.definition.groupName || 'default';
+          nextOpenNodes.add(locationName);
+          nextOpenNodes.add(locationName + ':' + groupName);
+        }
+        if (selectedNodeRootToLeaf?.id !== lastSelectedNode.id) {
+          setSelectedNodeRootToLeaf({id: lastSelectedNode.id});
+        }
+        return nextOpenNodes;
+      });
+
+      // Update leaf-to-root view
+      setOpenNodesLeafToRoot((prevOpenNodes) => {
+        let path;
+        if (lastSelectedSidebarNodeLeafToRoot?.id === lastSelectedNode?.id) {
+          path = lastSelectedSidebarNodeLeafToRoot.path;
+        }
+        if (!path) {
+          path = getNodePath(lastSelectedNode, 'leaf-to-root', graphData);
+        }
+
+        const nodesInPath = path.split(':');
+        let currentPath = nodesInPath[0];
+
+        if (!currentPath) {
+          return prevOpenNodes;
+        }
+
+        const nextOpenNodes = new Set(prevOpenNodes);
+        nextOpenNodes.add(currentPath);
+        for (let i = 1; i < nodesInPath.length; i++) {
+          currentPath = `${currentPath}:${nodesInPath[i]}`;
+          nextOpenNodes.add(currentPath);
+        }
+        if (selectedNodeLeafToRoot?.id !== lastSelectedNode.id) {
+          setSelectedNodeLeafToRoot({id: lastSelectedNode.id, path: currentPath});
+        }
+        return nextOpenNodes;
+      });
+    } else {
+      setSelectedNodeRootToLeaf(null);
+      setSelectedNodeLeafToRoot(null);
+    }
+  }, [
+    lastSelectedNode,
+    lastSelectedSidebarNodeRootToLeaf,
+    lastSelectedSidebarNodeLeafToRoot,
+    graphData,
+    sidebarViewType,
+    selectedNodeRootToLeaf?.id,
+    selectedNodeLeafToRoot?.id,
+    buildRepoPathForHuman,
+  ]);
+
+  return {
+    selectedNodeRootToLeaf,
+    setSelectedNodeRootToLeaf,
+    selectedNodeLeafToRoot,
+    setSelectedNodeLeafToRoot,
+    openNodesRootToLeaf,
+    setOpenNodesRootToLeaf,
+    openNodesLeafToRoot,
+    setOpenNodesLeafToRoot,
+    collapseAllNodes,
+    setLastSelectedSidebarNodeRootToLeaf,
+    setLastSelectedSidebarNodeLeafToRoot,
+  };
+}
+
+function getNodePath(
+  node: GraphNode,
+  direction: 'root-to-leaf' | 'leaf-to-root',
+  graphData: GraphData,
+) {
+  let path = node.id;
+  let currentId = node.id;
+  let next: string[];
+  while ((next = getAdjacentNodes(graphData, currentId, direction))) {
+    const candidates = next;
+    if (!candidates.length) {
+      break;
+    }
+    while (true) {
+      const next = candidates.shift();
+      if (!next) {
+        break;
+      }
+      if (graphData.nodes[next]) {
+        path = `${next}:${path}`;
+        currentId = next;
+      } else {
+        break;
+      }
+    }
+  }
+  return path;
+}
+
+function getAdjacentNodes(
+  graphData: GraphData,
+  id: string,
+  direction: 'root-to-leaf' | 'leaf-to-root',
+) {
+  if (direction === 'root-to-leaf') {
+    return Object.keys(graphData.upstream[id] ?? {});
+  }
+  return Object.keys(graphData.downstream[id] ?? {});
+}


### PR DESCRIPTION
## Summary & Motivation

Currently when you click on an asset there is a chance you get scrolled to another instance of the same asset elsewhere in the tree. This is because the current onClick handlers on record the key of the asset being clicked and not the exact path. To fix this record the exact path of the node that is clicked in the sidebar.

## How I Tested These Changes

https://github.com/user-attachments/assets/d1207215-aac0-4f4c-bd82-a5bd9be75655

