### PR TITLE
[gql] `latestMaterializationTimestamp` that can source from streamline

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -629,7 +629,7 @@ type Asset {
   definition: AssetNode
   latestEventSortKey: ID
   assetHealth: AssetHealth
-  latestMaterializationTimestamp: Int
+  latestMaterializationTimestamp: Float
 }
 
 type AssetResultEventHistoryConnection {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -108,7 +108,7 @@ export type Asset = {
   id: Scalars['String']['output'];
   key: AssetKey;
   latestEventSortKey: Maybe<Scalars['ID']['output']>;
-  latestMaterializationTimestamp: Maybe<Scalars['Int']['output']>;
+  latestMaterializationTimestamp: Maybe<Scalars['Float']['output']>;
 };
 
 export type AssetAssetEventHistoryArgs = {
@@ -6337,7 +6337,7 @@ export const buildAsset = (
     latestMaterializationTimestamp:
       overrides && overrides.hasOwnProperty('latestMaterializationTimestamp')
         ? overrides.latestMaterializationTimestamp!
-        : 1036,
+        : 1.04,
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -282,7 +282,7 @@ class GrapheneAsset(graphene.ObjectType):
     definition = graphene.Field("dagster_graphql.schema.asset_graph.GrapheneAssetNode")
     latestEventSortKey = graphene.Field(graphene.ID)
     assetHealth = graphene.Field(GrapheneAssetHealth)
-    latestMaterializationTimestamp = graphene.Int()
+    latestMaterializationTimestamp = graphene.Float()
 
     class Meta:
         name = "Asset"
@@ -461,13 +461,13 @@ class GrapheneAsset(graphene.ObjectType):
 
     async def resolve_latestMaterializationTimestamp(
         self, graphene_info: ResolveInfo
-    ) -> Optional[int]:
+    ) -> Optional[float]:
         min_materialization_state = await MinimalAssetMaterializationHealthState.gen(
             graphene_info.context, self._asset_key
         )
         if min_materialization_state is not None:
             return (
-                int(min_materialization_state.latest_materialization_timestamp * 1000)
+                min_materialization_state.latest_materialization_timestamp * 1000
                 if min_materialization_state.latest_materialization_timestamp
                 else None
             )
@@ -475,9 +475,7 @@ class GrapheneAsset(graphene.ObjectType):
         record = await AssetRecord.gen(graphene_info.context, self._asset_key)
         latest_materialization_event = record.asset_entry.last_materialization if record else None
         return (
-            int(latest_materialization_event.timestamp * 1000)
-            if latest_materialization_event
-            else None
+            latest_materialization_event.timestamp * 1000 if latest_materialization_event else None
         )
 
 


### PR DESCRIPTION
The AssetHealthQuery is slow because we fetch the latest materialization of each asset to get the most recent materialization timestamp

```
fragment AssetHealthFragment on Asset {
    key {
      path
    }

    assetMaterializations(limit: 1) {
      timestamp
    }
...
```

This PR adds a `lastMaterializationTimestamp`​field to the GQL layer that fetches this data from streamline which will be much faster than querying the DB. It falls back on querying the DB if streamline state doesn’t exist.

We previously had discussed using the last event for the asset (materialization, failed materialization, observation) as the sort key for how we display assets in the UI, but that’s not what we do currently in the UI. If we want to change the behavior, we’ll need to update `latestEventSortKey`​ to not require a DB fetch - to do that we’d need fst paths to get the lastest failed materialization and observation time, which we don’t currently have

tests in internal https://github.com/dagster-io/internal/pull/17915