### PR TITLE
Throw DagsterInvalidDefinitionError when an asset selection fails in a job definition.

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets/job/asset_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/job/asset_job.py
@@ -241,14 +241,16 @@ def get_asset_graph_for_job(
     try:
         selected_keys = selection.resolve(parent_asset_graph)
     except KeyError as e:
+
         raise DagsterInvalidDefinitionError(
             "Selected keys must be a subset of existing executable asset keys."
             f" Invalid selected keys: {e.args}",
-        )
-    except Exception:
+        ) from e
+    except Exception as e:
         raise DagsterInvalidDefinitionError(
             f"Invalid asset selection: {selection}",
-        )
+        ) from e
+
 
     invalid_keys = selected_keys - parent_asset_graph.executable_asset_keys
     if invalid_keys:


### PR DESCRIPTION
## Summary & Motivation

This just improves the stack trace of invalid definitions in the case of a bunch of invalid asset selections.

## How I Tested These Changes

bk + using this with invalid asset selection and running dg check defs --verbose

## Changelog

> Insert changelog entry or delete this section.