### PR TITLE
[dagster-dbt] Expose dbt Cloud v2 APIs in dagster-dbt top level

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -18,6 +18,14 @@ from dagster_dbt.cloud import (
     dbt_cloud_run_op as dbt_cloud_run_op,
     load_assets_from_dbt_cloud_job as load_assets_from_dbt_cloud_job,
 )
+from dagster_dbt.cloud_v2 import (
+    DbtCloudCredentials as DbtCloudCredentials,
+    DbtCloudWorkspace as DbtCloudWorkspace,
+    build_dbt_cloud_polling_sensor as build_dbt_cloud_polling_sensor,
+    dbt_cloud_assets as dbt_cloud_assets,
+    load_dbt_cloud_asset_specs as load_dbt_cloud_asset_specs,
+    load_dbt_cloud_check_specs as load_dbt_cloud_check_specs,
+)
 from dagster_dbt.components.dbt_project.component import DbtProjectComponent as DbtProjectComponent
 from dagster_dbt.core.dbt_cli_event import DbtCliEventMessage as DbtCliEventMessage
 from dagster_dbt.core.dbt_cli_invocation import DbtCliInvocation as DbtCliInvocation

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/__init__.py
@@ -1,0 +1,10 @@
+from dagster_dbt.cloud_v2.asset_decorator import dbt_cloud_assets as dbt_cloud_assets
+from dagster_dbt.cloud_v2.resources import (
+    DbtCloudCredentials as DbtCloudCredentials,
+    DbtCloudWorkspace as DbtCloudWorkspace,
+    load_dbt_cloud_asset_specs as load_dbt_cloud_asset_specs,
+    load_dbt_cloud_check_specs as load_dbt_cloud_check_specs,
+)
+from dagster_dbt.cloud_v2.sensor_builder import (
+    build_dbt_cloud_polling_sensor as build_dbt_cloud_polling_sensor,
+)


### PR DESCRIPTION
## Summary & Motivation

To fix API docs [here](https://github.com/dagster-io/dagster/pull/32015/files#r2310631573)

Also, the integration has been around for quite some time now, exposing dbt Cloud v2 even though dbt Cloud v1 is still in the integration seems fine.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
