### PR TITLE
Return an empty list in assetsOrError if an empty list is passed in

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -1133,7 +1133,7 @@ class GrapheneQuery(graphene.ObjectType):
             asset_keys=[
                 AssetKey.from_graphql_input(asset_key_input) for asset_key_input in assetKeys
             ]
-            if assetKeys
+            if assetKeys is not None
             else None,
         )
 


### PR DESCRIPTION
## Summary & Motivation
Before this would return every asset when an empty list was passed in. Now it returns no assets.

## How I Tested These Changes
New test cases

## Changelog
Fixed an issue where passing in an empty list in the `assetKeys` argument of the `assetsOrError` field in the GraphQL API would return every asset instead of an empty list of assets.