### PR TITLE
[dbt-cloud] Emit asset events before step failure

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/cli_invocation.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/cli_invocation.py
@@ -53,15 +53,15 @@ class DbtCloudCliInvocation:
     def wait(
         self, timeout: Optional[float] = None
     ) -> Iterator[Union[AssetCheckEvaluation, AssetCheckResult, AssetMaterialization, Output]]:
-        self.run_handler.wait_for_success(timeout=timeout)
-        if "run_results.json" not in self.run_handler.list_run_artifacts():
-            return
-        run_results = DbtCloudJobRunResults.from_run_results_json(
-            run_results_json=self.run_handler.get_run_results()
-        )
-        yield from run_results.to_default_asset_events(
-            client=self.client,
-            manifest=self.manifest,
-            dagster_dbt_translator=self.dagster_dbt_translator,
-            context=self.context,
-        )
+        run = self.run_handler.wait(timeout=timeout)
+        if "run_results.json" in self.run_handler.list_run_artifacts():
+            run_results = DbtCloudJobRunResults.from_run_results_json(
+                run_results_json=self.run_handler.get_run_results()
+            )
+            yield from run_results.to_default_asset_events(
+                client=self.client,
+                manifest=self.manifest,
+                dagster_dbt_translator=self.dagster_dbt_translator,
+                context=self.context,
+            )
+        run.raise_for_status()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/client.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, Optional, cast
 
 import requests
-from dagster import Failure, MetadataValue, get_dagster_logger
+from dagster import Failure, get_dagster_logger
 from dagster._utils.cached_method import cached_method
 from dagster_shared.dagster_model import DagsterModel
 from pydantic import Field
@@ -326,18 +326,12 @@ class DbtCloudWorkspaceClient(DagsterModel):
         while time.time() - start_time < poll_timeout:
             run_details = self.get_run_details(run_id)
             run = DbtCloudRun.from_run_details(run_details=run_details)
-            if run.status == DbtCloudJobRunStatusType.SUCCESS:
-                return run_details
-            elif run.status in {
+            if run.status in {
+                DbtCloudJobRunStatusType.SUCCESS,
                 DbtCloudJobRunStatusType.ERROR,
                 DbtCloudJobRunStatusType.CANCELLED,
             }:
-                raise Failure(
-                    f"dbt Cloud run '{run.id}' failed!",
-                    metadata={
-                        "run_details": MetadataValue.json(run_details),
-                    },
-                )
+                return run_details
             # Sleep for the configured time interval before polling again.
             time.sleep(poll_interval)
         raise Exception(f"Run {run.id} did not complete within {poll_timeout} seconds.")  # pyright: ignore[reportPossiblyUnboundVariable]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/resources.py
@@ -224,7 +224,8 @@ class DbtCloudWorkspace(ConfigurableResource):
             args=["parse"],
             client=self.get_client(),
         )
-        run_handler.wait_for_success()
+        run = run_handler.wait()
+        run.raise_for_status()
         return DbtCloudWorkspaceData(
             project_id=self.project_id,
             environment_id=self.environment_id,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -16,7 +16,7 @@ from dateutil import parser
 
 from dagster_dbt.asset_utils import build_dbt_specs, get_asset_check_key_for_test
 from dagster_dbt.cloud_v2.client import DbtCloudWorkspaceClient
-from dagster_dbt.cloud_v2.types import DbtCloudJobRunStatusType, DbtCloudRun
+from dagster_dbt.cloud_v2.types import DbtCloudRun
 from dagster_dbt.compat import REFABLE_NODE_TYPES, NodeStatus, NodeType, TestStatus
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
@@ -47,12 +47,10 @@ class DbtCloudJobRunHandler:
             client=client,
         )
 
-    def wait_for_success(
-        self, timeout: Optional[float] = None
-    ) -> Optional[DbtCloudJobRunStatusType]:
+    def wait(self, timeout: Optional[float] = None) -> DbtCloudRun:
         run_details = self.client.poll_run(run_id=self.run_id, poll_timeout=timeout)
         dbt_cloud_run = DbtCloudRun.from_run_details(run_details=run_details)
-        return dbt_cloud_run.status
+        return dbt_cloud_run
 
     def get_run_results(self) -> Mapping[str, Any]:
         return self.client.get_run_results_json(run_id=self.run_id)
@@ -181,7 +179,7 @@ class DbtCloudJobRunResults:
                         asset_key=spec.key,
                         metadata=metadata,
                     )
-            elif resource_type == NodeType.Test and result_status == NodeStatus.Pass:
+            elif resource_type == NodeType.Test:
                 metadata = {
                     **default_metadata,
                     "status": result_status,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_resources.py
@@ -8,7 +8,7 @@ from dagster._core.test_utils import environ
 from dagster_dbt.asset_utils import DBT_INDIRECT_SELECTION_ENV
 from dagster_dbt.cloud_v2.asset_decorator import dbt_cloud_assets
 from dagster_dbt.cloud_v2.resources import DbtCloudCredentials, DbtCloudWorkspace
-from dagster_dbt.cloud_v2.types import DbtCloudJobRunStatusType
+from dagster_dbt.cloud_v2.types import DbtCloudJobRunStatusType, DbtCloudRun
 
 from dagster_dbt_tests.cloud_v2.conftest import (
     SAMPLE_CUSTOM_CREATE_JOB_RESPONSE,
@@ -315,7 +315,10 @@ def test_poll_run(n_polls, last_status, succeed_at_end, workspace: DbtCloudWorks
                 status=200,
             )
 
-            return client.poll_run(TEST_RUN_ID, poll_interval=0.1)
+            run_data = client.poll_run(TEST_RUN_ID, poll_interval=0.1)
+            run = DbtCloudRun.from_run_details(run_details=run_data)
+            run.raise_for_status()
+            return run_data
 
     if succeed_at_end:
         assert (


### PR DESCRIPTION
## Summary & Motivation

Previously, the `poll_run` command would immediately raise an error when a run failure was detected. This is a bit confusing (in my opinion), and is not actually noted in the docstring. I've updated the code to:

- Not error at all in `poll_run`, instead add a new `wait()` method on the run_handler
  - removed `wait_for_success` and instead replaced that call with a `wait()`, followed by a `raise_for_status`.
- Add a `raise_for_status` method on the run object. this is modeled after the `responses` library, where you get a `Response` object and then can decide if/when you want to generate an error based off of that response.
- Removed a check for the test status being PASS when emitting check events -- this brings it in line with the existing implementation for dbt core

With those changes, I was able to move the error raising behavior to the bottom of the `cli()` command, meaning we always yield asset events BEFORE the failure is raised.

## How I Tested These Changes

## Changelog

[dbt-cloud] Fixed an issue that would cause the DbtCloudWorkspace to error before yielding asset events if the associated dbt Cloud run failed. Now, it will raise the error *after* all relevant asset events have been produced.
