### PR TITLE
Bump watchdog pin

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -103,7 +103,7 @@ setup(
         "structlog",
         "sqlalchemy>=1.0,<3",
         "toposort>=1.0",
-        "watchdog>=0.8.3,<6",
+        "watchdog>=0.8.3,<7",
         'psutil>=1.0; platform_system=="Windows"',
         # https://github.com/mhammond/pywin32/issues/1439
         'pywin32!=226; platform_system=="Windows"',


### PR DESCRIPTION
Summary:
There do not appear to be any breaking changes in the watchdog 6 release that affect us (unlike in watchdog 5). Resolves https://github.com/dagster-io/dagster/issues/32030.

BK, launch a run and watch logs stream in using watchdog under the hood.

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.