### PR TITLE
[dg] Put mcp, anthropic, claude-code-sdk under ai extra (ADOPT-1839)

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/setup.py
+++ b/python_modules/libraries/dagster-dg-cli/setup.py
@@ -43,9 +43,9 @@ setup(
     extras_require={
         "test": ["syrupy>=4.0.0"],
         "ai": [
-            "anthropic",
-            "claude-code-sdk>=0.0.19",
-            "mcp",
+            "anthropic; python_version>='3.10'",
+            "claude-code-sdk>=0.0.19; python_version>='3.10'",
+            "mcp; python_version>='3.10'",
         ],
     },
     entry_points={

--- a/python_modules/libraries/dagster-dg-cli/setup.py
+++ b/python_modules/libraries/dagster-dg-cli/setup.py
@@ -38,12 +38,16 @@ setup(
         f"dagster-dg-core{pin}",
         f"dagster{pin}",
         f"dagster-cloud-cli{pin}",
-        "anthropic; python_version>='3.10'",  # anthropic not available for 3.9
-        "claude-code-sdk>=0.0.19; python_version>='3.10'",  # claude-code-sdk not available for 3.9
-        "mcp; python_version>='3.10'",  # mcp not available for 3.9
         "typer",
     ],
-    extras_require={"test": ["syrupy>=4.0.0"]},
+    extras_require={
+        "test": ["syrupy>=4.0.0"],
+        "ai": [
+            "anthropic",
+            "claude-code-sdk>=0.0.19",
+            "mcp",
+        ],
+    },
     entry_points={
         "console_scripts": [
             "dg = dagster_dg_cli.cli:main",

--- a/python_modules/libraries/dagster-dg-cli/tox.ini
+++ b/python_modules/libraries/dagster-dg-cli/tox.ini
@@ -32,7 +32,7 @@ deps =
   plus: -e ../../../python_modules/libraries/dagster-aws
   plus: -e ../../../python_modules/libraries/dagster-k8s
   plus: -e ../../../python_modules/libraries/dagster-docker
-  -e .
+  -e .[ai]
 allowlist_externals =
   /bin/bash
   uv


### PR DESCRIPTION
## Summary & Motivation

Fixes #31927

Put `anthropic`, `mcp`, and `claude-code-sdk` under a new `ai` extra so that `dg-cli` can be installed without these packages, which are not always installable in sensitive environments.

## How I Tested These Changes

Existing test suite.

## Changelog

`anthropic`, `mcp`, and `claude-code-sdk` dependencies of `dagster-dg-cli` are now under a separate `ai` extra, allowing `dagster-dg-cli` to be installed without these dependencies.
