### PR TITLE
[dg] Remove hidden flag from dg scaffold defs inline-component (ENG-113)

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/defs.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/defs.py
@@ -317,7 +317,6 @@ def scaffold_defs_group(context: click.Context, help_: bool, **global_options: o
 @scaffold_defs_group.command(
     name="inline-component",
     cls=ScaffoldDefsSubCommand,
-    hidden=True,  # hiding for initial launch of 1.11 as it is undocumented. Will push out incrementally in later release -- schrockn 2025-06-20
 )
 @click.argument("path", type=str)
 @click.option(


### PR DESCRIPTION
## Summary & Motivation

Unhide the `inline-component` command in the scaffold defs CLI group. This command was previously hidden for the initial 1.11 launch as it was undocumented, but is now ready to be exposed to users.

## How I Tested These Changes

Verified that the `inline-component` command now appears in the CLI help output when running `dagster-dg scaffold defs --help`.

## Changelog

Added `inline-component` command to the publicly available scaffold commands in the Dagster CLI.