### PR TITLE
[dagster-snowflake-polars] pin polars<1.33.0

### DIFF
--- a/python_modules/libraries/dagster-snowflake-polars/setup.py
+++ b/python_modules/libraries/dagster-snowflake-polars/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         f"dagster-snowflake{pin}",
-        "polars>=1.0.0",
+        "polars>=1.0.0,<1.33.0",  # https://github.com/dagster-io/dagster/issues/32041
         "requests",
         "adbc-driver-snowflake>=1.6.0",
     ],


### PR DESCRIPTION
example error in https://github.com/dagster-io/dagster/issues/32041, many tests are failing so pin until a fix is made in this or dependent library 

## How I Tested These Changes

bk passes with new pin 