### PR TITLE
Fix code snippets for alert policies yaml

### DIFF
--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/agent-unavailable-alert-email.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/agent-unavailable-alert-email.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends an email when a Hybrid agent hasn't sent a heartbeat in the last
+- description: Sends an email when a Hybrid agent hasn't sent a heartbeat in the last
     5 minutes.
   event_types:
   - AGENT_UNAVAILABLE

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/agent-unavailable-alert-microsoft_teams.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/agent-unavailable-alert-microsoft_teams.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends a Microsoft Teams webhook when a Hybrid agent hasn't sent a heartbeat
+- description: Sends a Microsoft Teams webhook when a Hybrid agent hasn't sent a heartbeat
     in the last 5 minutes.
   event_types:
   - AGENT_UNAVAILABLE

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/agent-unavailable-alert-pagerduty.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/agent-unavailable-alert-pagerduty.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends a PagerDuty alert when a Hybrid agent hasn't sent a heartbeat
+- description: Sends a PagerDuty alert when a Hybrid agent hasn't sent a heartbeat
     in the last 5 minutes.
   event_types:
   - AGENT_UNAVAILABLE

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/agent-unavailable-alert-slack.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/agent-unavailable-alert-slack.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends a Slack message when a Hybrid agent hasn't sent a heartbeat in
+- description: Sends a Slack message when a Hybrid agent hasn't sent a heartbeat in
     the last 5 minutes.
   event_types:
   - AGENT_UNAVAILABLE

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-check-failed-email.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-check-failed-email.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  alert_targets:
+- alert_targets:
   - asset_key_target:
       asset_key:
       - s3

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-check-failed-microsoft_teams.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-check-failed-microsoft_teams.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  alert_targets:
+- alert_targets:
   - asset_key_target:
       asset_key:
       - s3

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-check-failed-pagerduty.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-check-failed-pagerduty.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  alert_targets:
+- alert_targets:
   - asset_key_target:
       asset_key:
       - s3

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-check-failed-slack.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-check-failed-slack.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  alert_targets:
+- alert_targets:
   - asset_key_target:
       asset_key:
       - s3

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-materialization-failure-alert-email.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-materialization-failure-alert-email.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  alert_targets:
+- alert_targets:
   - asset_key_target:
       asset_key:
       - s3

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-materialization-failure-alert-microsoft_teams.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-materialization-failure-alert-microsoft_teams.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  alert_targets:
+- alert_targets:
   - asset_key_target:
       asset_key:
       - s3

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-materialization-failure-alert-pagerduty.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-materialization-failure-alert-pagerduty.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  alert_targets:
+- alert_targets:
   - asset_key_target:
       asset_key:
       - s3

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-materialization-failure-alert-slack.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/asset-materialization-failure-alert-slack.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  alert_targets:
+- alert_targets:
   - asset_key_target:
       asset_key:
       - s3

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/code-location-error-email.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/code-location-error-email.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends an email when a code location fails to load.
+- description: Sends an email when a code location fails to load.
   event_types:
   - CODE_LOCATION_ERROR
   name: code-location-error-email

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/code-location-error-microsoft_teams.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/code-location-error-microsoft_teams.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends a Microsoft Teams webhook when a code location fails to load.
+- description: Sends a Microsoft Teams webhook when a code location fails to load.
   event_types:
   - CODE_LOCATION_ERROR
   name: code-location-error-microsoft_teams

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/code-location-error-pagerduty.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/code-location-error-pagerduty.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends a PagerDuty alert when a code location fails to load.
+- description: Sends a PagerDuty alert when a code location fails to load.
   event_types:
   - CODE_LOCATION_ERROR
   name: code-location-error-pagerduty

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/code-location-error-slack.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/code-location-error-slack.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends a Slack message when a code location fails to load.
+- description: Sends a Slack message when a code location fails to load.
   event_types:
   - CODE_LOCATION_ERROR
   name: code-location-error-slack

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/generate_alerts_config_code_snippets.py
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/generate_alerts_config_code_snippets.py
@@ -155,13 +155,15 @@ def _make_yaml_code_snippet(alert: AlertType, service: NotificationService) -> N
     alert_name = f"{alert.alert_name}-{service.name}"
     yaml_block = yaml.dump(
         dict(
-            alert_policies=dict(
-                name=alert_name,
-                event_types=alert.event_types,
-                description=f"Sends {service.effect_description} {alert.condition_description}.",
-                **(alert.config_snippet if alert.config_snippet else {}),
-                notification_service={service.name: service.config_snippet},
-            )
+            alert_policies=[
+                dict(
+                    name=alert_name,
+                    event_types=alert.event_types,
+                    description=f"Sends {service.effect_description} {alert.condition_description}.",
+                    **(alert.config_snippet if alert.config_snippet else {}),
+                    notification_service={service.name: service.config_snippet},
+                )
+            ]
         ),
     )
     path = f"{alert_name}.yaml"

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/insights-credit-alert-email.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/insights-credit-alert-email.yaml
@@ -1,0 +1,21 @@
+# alert_policies.yaml
+
+alert_policies:
+- alert_targets:
+  - insights_asset_threshold_target:
+      asset_key:
+      - s3
+      - report
+      metric_name: __dagster_dagster_credits
+      operator: GREATER_THAN
+      selection_period_days: 7
+      threshold: 50
+  description: Sends an email when an asset has exceeded a credit usage threshold.
+  event_types:
+  - INSIGHTS_CONSUMPTION_EXCEEDED
+  name: insights-credit-alert-email
+  notification_service:
+    email:
+      email_addresses:
+      - richard.hendricks@hooli.com
+      - nelson.bighetti@hooli.com

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/insights-credit-alert-microsoft_teams.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/insights-credit-alert-microsoft_teams.yaml
@@ -1,0 +1,20 @@
+# alert_policies.yaml
+
+alert_policies:
+- alert_targets:
+  - insights_asset_threshold_target:
+      asset_key:
+      - s3
+      - report
+      metric_name: __dagster_dagster_credits
+      operator: GREATER_THAN
+      selection_period_days: 7
+      threshold: 50
+  description: Sends a Microsoft Teams webhook when an asset has exceeded a credit
+    usage threshold.
+  event_types:
+  - INSIGHTS_CONSUMPTION_EXCEEDED
+  name: insights-credit-alert-microsoft_teams
+  notification_service:
+    microsoft_teams:
+      webhook_url: https://yourdomain.webhook.office.com/...

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/insights-credit-alert-pagerduty.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/insights-credit-alert-pagerduty.yaml
@@ -1,0 +1,19 @@
+# alert_policies.yaml
+
+alert_policies:
+- alert_targets:
+  - insights_asset_threshold_target:
+      asset_key:
+      - s3
+      - report
+      metric_name: __dagster_dagster_credits
+      operator: GREATER_THAN
+      selection_period_days: 7
+      threshold: 50
+  description: Sends a PagerDuty alert when an asset has exceeded a credit usage threshold.
+  event_types:
+  - INSIGHTS_CONSUMPTION_EXCEEDED
+  name: insights-credit-alert-pagerduty
+  notification_service:
+    pagerduty:
+      integration_key: <pagerduty_integration_key>

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/insights-credit-alert-slack.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/insights-credit-alert-slack.yaml
@@ -1,0 +1,20 @@
+# alert_policies.yaml
+
+alert_policies:
+- alert_targets:
+  - insights_asset_threshold_target:
+      asset_key:
+      - s3
+      - report
+      metric_name: __dagster_dagster_credits
+      operator: GREATER_THAN
+      selection_period_days: 7
+      threshold: 50
+  description: Sends a Slack message when an asset has exceeded a credit usage threshold.
+  event_types:
+  - INSIGHTS_CONSUMPTION_EXCEEDED
+  name: insights-credit-alert-slack
+  notification_service:
+    slack:
+      slack_channel_name: notifications
+      slack_workspace_name: hooli

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/job-running-over-one-hour-email.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/job-running-over-one-hour-email.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  alert_targets:
+- alert_targets:
   - long_running_job_threshold_target:
       threshold_seconds: 3600
   description: Sends an email when a run is taking too long to complete.

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/job-running-over-one-hour-microsoft_teams.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/job-running-over-one-hour-microsoft_teams.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  alert_targets:
+- alert_targets:
   - long_running_job_threshold_target:
       threshold_seconds: 3600
   description: Sends a Microsoft Teams webhook when a run is taking too long to complete.

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/job-running-over-one-hour-pagerduty.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/job-running-over-one-hour-pagerduty.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  alert_targets:
+- alert_targets:
   - long_running_job_threshold_target:
       threshold_seconds: 3600
   description: Sends a PagerDuty alert when a run is taking too long to complete.

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/job-running-over-one-hour-slack.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/job-running-over-one-hour-slack.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  alert_targets:
+- alert_targets:
   - long_running_job_threshold_target:
       threshold_seconds: 3600
   description: Sends a Slack message when a run is taking too long to complete.

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/run-alert-failure-email.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/run-alert-failure-email.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends an email when a run fails.
+- description: Sends an email when a run fails.
   event_types:
   - JOB_FAILURE
   name: run-alert-failure-email

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/run-alert-failure-microsoft_teams.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/run-alert-failure-microsoft_teams.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends a Microsoft Teams webhook when a run fails.
+- description: Sends a Microsoft Teams webhook when a run fails.
   event_types:
   - JOB_FAILURE
   name: run-alert-failure-microsoft_teams

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/run-alert-failure-pagerduty.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/run-alert-failure-pagerduty.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends a PagerDuty alert when a run fails.
+- description: Sends a PagerDuty alert when a run fails.
   event_types:
   - JOB_FAILURE
   name: run-alert-failure-pagerduty

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/run-alert-failure-slack.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/run-alert-failure-slack.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends a Slack message when a run fails.
+- description: Sends a Slack message when a run fails.
   event_types:
   - JOB_FAILURE
   name: run-alert-failure-slack

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/schedule-sensor-failure-email.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/schedule-sensor-failure-email.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends an email when a schedule or sensor tick fails.
+- description: Sends an email when a schedule or sensor tick fails.
   event_types:
   - TICK_FAILURE
   name: schedule-sensor-failure-email

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/schedule-sensor-failure-microsoft_teams.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/schedule-sensor-failure-microsoft_teams.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends a Microsoft Teams webhook when a schedule or sensor tick fails.
+- description: Sends a Microsoft Teams webhook when a schedule or sensor tick fails.
   event_types:
   - TICK_FAILURE
   name: schedule-sensor-failure-microsoft_teams

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/schedule-sensor-failure-pagerduty.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/schedule-sensor-failure-pagerduty.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends a PagerDuty alert when a schedule or sensor tick fails.
+- description: Sends a PagerDuty alert when a schedule or sensor tick fails.
   event_types:
   - TICK_FAILURE
   name: schedule-sensor-failure-pagerduty

--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/schedule-sensor-failure-slack.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/alerts/schedule-sensor-failure-slack.yaml
@@ -1,7 +1,7 @@
 # alert_policies.yaml
 
 alert_policies:
-  description: Sends a Slack message when a schedule or sensor tick fails.
+- description: Sends a Slack message when a schedule or sensor tick fails.
   event_types:
   - TICK_FAILURE
   name: schedule-sensor-failure-slack


### PR DESCRIPTION
## Summary & Motivation
Our alert policy yaml spec mandates a list for the top-level `alert_policies` field:

```
# alert_policies.yaml

alert_policies:
  - description: "an alert policy"
     event_types: ...

     # ...

  - description: "another alert policy"
     # etc etc etc
```

We use a custom script to generate the alert policy yaml code snippets, the script was incorrectly creating policy yamls with an object being passed to the top-level `alert_policies` field:

```
alert_policies:
  description: "an alert policy"
  ...
```

Using these code snippets as-is fails our alert policy validation.

This PR fixes the script so it generates the yaml correctly, also regenerates all code snippets.

## How I Tested These Changes

## Changelog

- Fix incorrect YAML code snippets for alert policies docs page