### PR TITLE
[redo] [Asset health] Only fetch health for assets that have definitions 

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import {observeEnabled} from 'shared/app/observeEnabled.oss';
 
 import {ApolloClient, gql, useApolloClient} from '../apollo-client';
@@ -5,6 +6,7 @@ import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {tokenForAssetKey, tokenToAssetKey} from '../asset-graph/Utils';
+import {useAllAssetsNodes} from '../assets/useAllAssets';
 import {AssetKeyInput} from '../graphql/types';
 import {liveDataFactory} from '../live-data-provider/Factory';
 import {LiveDataThreadID} from '../live-data-provider/LiveDataThread';
@@ -77,9 +79,21 @@ function init() {
 export const AssetHealthData = init();
 
 export function useAssetHealthData(assetKey: AssetKeyInput, thread: LiveDataThreadID = 'default') {
-  const result = AssetHealthData.useLiveDataSingle(tokenForAssetKey(assetKey), thread);
-  useBlockTraceUntilTrue('useAssetHealthData', !!result.liveData);
-  return result;
+  /**
+   * Skip fetching health data for assets that don't have definitions because it is expensive.
+   * Instead we'll just return an empty asset health fragment.
+   */
+  const {allAssetKeys} = useAllAssetsNodes();
+  const shouldSkip = !allAssetKeys.has(tokenForAssetKey(assetKey));
+  const result = AssetHealthData.useLiveDataSingle(tokenForAssetKey(assetKey), thread, shouldSkip);
+  useBlockTraceUntilTrue('useAssetHealthData', !!result.liveData, {skip: shouldSkip});
+  const liveData = useMemo(() => {
+    return shouldSkip ? buildEmptyAssetHealthFragment(tokenForAssetKey(assetKey)) : result.liveData;
+  }, [result.liveData, shouldSkip, assetKey]);
+  return {
+    ...result,
+    liveData,
+  };
 }
 
 const memoizedAssetKeys = weakMapMemoize((assetKeys: AssetKeyInput[]) => {
@@ -93,6 +107,84 @@ type AssetsHealthDataConfig = {
   skip?: boolean;
   loading?: boolean;
 };
+
+/**
+ * Categorizes asset keys based on whether they have definitions or not.
+ * Keys with definitions need health data fetching, while keys without definitions
+ * get empty health fragments.
+ */
+function categorizeAssetKeys(
+  assetKeys: AssetKeyInput[],
+  allAssetKeys: Set<string>,
+): {keysWithDefinitions: AssetKeyInput[]; keysWithoutDefinitions: AssetKeyInput[]} {
+  const keysWithDefinitions: AssetKeyInput[] = [];
+  const keysWithoutDefinitions: AssetKeyInput[] = [];
+
+  assetKeys.forEach((key) => {
+    const tokenKey = tokenForAssetKey(key);
+    if (allAssetKeys.has(tokenKey)) {
+      keysWithDefinitions.push(key);
+    } else {
+      keysWithoutDefinitions.push(key);
+    }
+  });
+
+  return {keysWithDefinitions, keysWithoutDefinitions};
+}
+
+/**
+ * Creates empty health fragments for assets without definitions.
+ * These assets don't need expensive health data fetching.
+ */
+function createEmptyHealthFragments(
+  keysWithoutDefinitions: AssetKeyInput[],
+): Record<string, AssetHealthFragment> {
+  return Object.fromEntries(
+    keysWithoutDefinitions.map((key) => {
+      const tokenKey = tokenForAssetKey(key);
+      return [tokenKey, buildEmptyAssetHealthFragment(tokenKey)];
+    }),
+  );
+}
+
+/**
+ * Merges live data results with empty health fragments for a complete dataset.
+ */
+function mergeHealthData(
+  liveDataResult: ReturnType<typeof AssetHealthData.useLiveData>,
+  emptyFragments: Record<string, AssetHealthFragment>,
+) {
+  return {
+    ...liveDataResult,
+    liveDataByNode: {
+      ...liveDataResult.liveDataByNode,
+      ...emptyFragments,
+    },
+  };
+}
+
+/**
+ * Determines if the trace should be blocked based on loading status and data completeness.
+ */
+function shouldBlockTrace(
+  loading: boolean,
+  blockTrace: boolean,
+  currentDataCount: number,
+  expectedDataCount: number,
+): boolean {
+  // Don't block if still loading
+  if (loading) {
+    return false;
+  }
+
+  // Don't block if blockTrace is disabled
+  if (!blockTrace) {
+    return false;
+  }
+
+  // Block until we have all expected data
+  return currentDataCount === expectedDataCount;
+}
 
 // Get assets health data, with an `observeEnabled` check included to effectively no-op any users
 // who are not gated in.
@@ -112,14 +204,44 @@ export function useAssetsHealthDataWithoutGateCheck({
   skip = false,
   loading = false,
 }: AssetsHealthDataConfig) {
-  const keys = memoizedAssetKeys(assetKeys);
-  const result = AssetHealthData.useLiveData(keys, thread, skip);
-  useBlockTraceUntilTrue(
-    'useAssetsHealthData',
-    !loading && (!blockTrace || !!(Object.keys(result.liveDataByNode).length === assetKeys.length)),
-    {skip},
+  const {allAssetKeys} = useAllAssetsNodes();
+
+  // Step 1: Categorize keys based on whether they have definitions
+  const {keysWithDefinitions, keysWithoutDefinitions} = useMemo(
+    () => categorizeAssetKeys(assetKeys, allAssetKeys),
+    [assetKeys, allAssetKeys],
   );
-  return result;
+
+  // Step 2: Fetch live data for keys with definitions
+  const liveDataResult = AssetHealthData.useLiveData(
+    memoizedAssetKeys(keysWithDefinitions),
+    thread,
+    skip,
+  );
+
+  // Step 3: Create empty fragments for keys without definitions
+  const emptyHealthFragments = useMemo(
+    () => createEmptyHealthFragments(keysWithoutDefinitions),
+    [keysWithoutDefinitions],
+  );
+
+  // Step 4: Merge live data with empty fragments
+  const fullResult = useMemo(
+    () => mergeHealthData(liveDataResult, emptyHealthFragments),
+    [liveDataResult, emptyHealthFragments],
+  );
+
+  // Step 5: Block trace until data is ready
+  const traceReady = shouldBlockTrace(
+    loading,
+    blockTrace,
+    Object.keys(fullResult.liveDataByNode).length,
+    assetKeys.length,
+  );
+
+  useBlockTraceUntilTrue('useAssetsHealthData', traceReady, {skip});
+
+  return fullResult;
 }
 
 export const ASSETS_HEALTH_INFO_QUERY = gql`
@@ -205,4 +327,16 @@ export const ASSETS_HEALTH_INFO_QUERY = gql`
 // For tests
 export function __resetForJest() {
   Object.assign(AssetHealthData, init());
+}
+
+function buildEmptyAssetHealthFragment(key: string): AssetHealthFragment {
+  return {
+    __typename: 'Asset',
+    key: {
+      __typename: 'AssetKey',
+      ...tokenToAssetKey(key),
+    },
+    assetMaterializations: [],
+    assetHealth: null,
+  };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetHealthDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetHealthDataProvider.test.tsx
@@ -1,0 +1,346 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {renderHook, waitFor} from '@testing-library/react';
+
+import {tokenForAssetKey} from '../../asset-graph/Utils';
+import {buildAssetKey} from '../../graphql/types';
+
+// Mock useAllAssetsNodes
+const mockUseAllAssetsNodes = jest.fn();
+jest.mock('../../assets/useAllAssets', () => ({
+  useAllAssetsNodes: mockUseAllAssetsNodes,
+}));
+
+// Mock useBlockTraceUntilTrue
+const mockUseBlockTraceUntilTrue = jest.fn();
+jest.mock('../../performance/TraceContext', () => ({
+  useBlockTraceUntilTrue: mockUseBlockTraceUntilTrue,
+}));
+
+describe('AssetHealthDataProvider integration tests', () => {
+  let useAssetHealthData: any;
+  let useAssetsHealthDataWithoutGateCheck: any;
+  let __resetForJest: any;
+
+  beforeAll(() => {
+    // Import this after mocks are setup
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const module = require('../AssetHealthDataProvider');
+    useAssetHealthData = module.useAssetHealthData;
+    useAssetsHealthDataWithoutGateCheck = module.useAssetsHealthDataWithoutGateCheck;
+    __resetForJest = module.__resetForJest;
+  });
+
+  beforeEach(() => {
+    mockUseAllAssetsNodes.mockReturnValue({
+      allAssetKeys: new Set(),
+      loading: false,
+    });
+    mockUseBlockTraceUntilTrue.mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    __resetForJest();
+  });
+
+  describe('useAssetHealthData behavior', () => {
+    it('should handle assets without definitions differently than assets with definitions', async () => {
+      const assetWithDefinition = buildAssetKey({path: ['asset_with_def']});
+      const assetWithoutDefinition = buildAssetKey({path: ['asset_without_def']});
+
+      // Mock that only one asset has a definition
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set([tokenForAssetKey(assetWithDefinition)]),
+        loading: false,
+      });
+
+      const wrapper = ({children}: {children: React.ReactNode}) => (
+        <MockedProvider>{children}</MockedProvider>
+      );
+
+      // Test asset with definition
+      const {result: resultWithDef} = renderHook(() => useAssetHealthData(assetWithDefinition), {
+        wrapper,
+      });
+
+      // Test asset without definition
+      const {result: resultWithoutDef} = renderHook(
+        () => useAssetHealthData(assetWithoutDefinition),
+        {wrapper},
+      );
+
+      await waitFor(() => {
+        // Asset without definition should get an empty fragment
+        expect(resultWithoutDef.current.liveData).toEqual({
+          __typename: 'Asset',
+          key: expect.objectContaining({
+            __typename: 'AssetKey',
+            path: ['asset_without_def'],
+          }),
+          assetMaterializations: [],
+          assetHealth: null,
+        });
+      });
+
+      // Both should complete without errors
+      expect(resultWithDef.current.error).toBeFalsy();
+      expect(resultWithoutDef.current.error).toBeFalsy();
+    });
+
+    it('should use skip parameter correctly based on asset definitions', () => {
+      const assetKey = buildAssetKey({path: ['test_asset']});
+
+      // Mock that asset has no definition
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(),
+        loading: false,
+      });
+
+      const wrapper = ({children}: {children: React.ReactNode}) => (
+        <MockedProvider>{children}</MockedProvider>
+      );
+
+      renderHook(() => useAssetHealthData(assetKey), {wrapper});
+
+      // Verify that skip was passed as true to useBlockTraceUntilTrue
+      expect(mockUseBlockTraceUntilTrue).toHaveBeenCalledWith(
+        'useAssetHealthData',
+        expect.any(Boolean),
+        {skip: true},
+      );
+    });
+  });
+
+  describe('useAssetsHealthDataWithoutGateCheck behavior', () => {
+    it('should handle mixed assets (some with definitions, some without)', async () => {
+      const assetWithDef1 = buildAssetKey({path: ['asset1']});
+      const assetWithDef2 = buildAssetKey({path: ['asset2']});
+      const assetWithoutDef1 = buildAssetKey({path: ['asset3']});
+      const assetWithoutDef2 = buildAssetKey({path: ['asset4']});
+
+      // Mock that only asset1 and asset2 have definitions
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set([tokenForAssetKey(assetWithDef1), tokenForAssetKey(assetWithDef2)]),
+        loading: false,
+      });
+
+      const wrapper = ({children}: {children: React.ReactNode}) => (
+        <MockedProvider>{children}</MockedProvider>
+      );
+
+      const {result} = renderHook(
+        () =>
+          useAssetsHealthDataWithoutGateCheck({
+            assetKeys: [assetWithDef1, assetWithDef2, assetWithoutDef1, assetWithoutDef2],
+          }),
+        {wrapper},
+      );
+
+      await waitFor(() => {
+        // Should have data for at least the assets without definitions (empty fragments)
+        expect(Object.keys(result.current.liveDataByNode).length).toBeGreaterThanOrEqual(2);
+
+        // Assets without definitions should have empty fragments
+        expect(result.current.liveDataByNode[tokenForAssetKey(assetWithoutDef1)]).toEqual({
+          __typename: 'Asset',
+          key: expect.objectContaining({
+            __typename: 'AssetKey',
+            path: ['asset3'],
+          }),
+          assetMaterializations: [],
+          assetHealth: null,
+        });
+
+        expect(result.current.liveDataByNode[tokenForAssetKey(assetWithoutDef2)]).toEqual({
+          __typename: 'Asset',
+          key: expect.objectContaining({
+            __typename: 'AssetKey',
+            path: ['asset4'],
+          }),
+          assetMaterializations: [],
+          assetHealth: null,
+        });
+      });
+    });
+
+    it('should handle case where no assets have definitions', async () => {
+      const asset1 = buildAssetKey({path: ['asset1']});
+      const asset2 = buildAssetKey({path: ['asset2']});
+
+      // Mock that no assets have definitions
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(),
+        loading: false,
+      });
+
+      const wrapper = ({children}: {children: React.ReactNode}) => (
+        <MockedProvider>{children}</MockedProvider>
+      );
+
+      const {result} = renderHook(
+        () =>
+          useAssetsHealthDataWithoutGateCheck({
+            assetKeys: [asset1, asset2],
+          }),
+        {wrapper},
+      );
+
+      await waitFor(() => {
+        // Should have empty fragments for both assets
+        expect(Object.keys(result.current.liveDataByNode)).toHaveLength(2);
+
+        expect(result.current.liveDataByNode[tokenForAssetKey(asset1)]).toEqual({
+          __typename: 'Asset',
+          key: expect.objectContaining({
+            __typename: 'AssetKey',
+            path: ['asset1'],
+          }),
+          assetMaterializations: [],
+          assetHealth: null,
+        });
+
+        expect(result.current.liveDataByNode[tokenForAssetKey(asset2)]).toEqual({
+          __typename: 'Asset',
+          key: expect.objectContaining({
+            __typename: 'AssetKey',
+            path: ['asset2'],
+          }),
+          assetMaterializations: [],
+          assetHealth: null,
+        });
+      });
+    });
+
+    it('should handle loading state correctly', () => {
+      const asset = buildAssetKey({path: ['asset1']});
+
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set([tokenForAssetKey(asset)]),
+        loading: false,
+      });
+
+      const wrapper = ({children}: {children: React.ReactNode}) => (
+        <MockedProvider>{children}</MockedProvider>
+      );
+
+      // Test with loading = true
+      renderHook(
+        () =>
+          useAssetsHealthDataWithoutGateCheck({
+            assetKeys: [asset],
+            loading: true,
+          }),
+        {wrapper},
+      );
+
+      // Should pass false to useBlockTraceUntilTrue when loading
+      expect(mockUseBlockTraceUntilTrue).toHaveBeenCalledWith('useAssetsHealthData', false, {
+        skip: false,
+      });
+    });
+
+    it('should handle blockTrace parameter correctly', () => {
+      const asset = buildAssetKey({path: ['asset1']});
+
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set([tokenForAssetKey(asset)]),
+        loading: false,
+      });
+
+      const wrapper = ({children}: {children: React.ReactNode}) => (
+        <MockedProvider>{children}</MockedProvider>
+      );
+
+      // Test with blockTrace = false
+      renderHook(
+        () =>
+          useAssetsHealthDataWithoutGateCheck({
+            assetKeys: [asset],
+            blockTrace: false,
+          }),
+        {wrapper},
+      );
+
+      expect(mockUseBlockTraceUntilTrue).toHaveBeenCalled();
+    });
+
+    it('should handle empty asset keys array', async () => {
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(),
+        loading: false,
+      });
+
+      const wrapper = ({children}: {children: React.ReactNode}) => (
+        <MockedProvider>{children}</MockedProvider>
+      );
+
+      const {result} = renderHook(
+        () =>
+          useAssetsHealthDataWithoutGateCheck({
+            assetKeys: [],
+          }),
+        {wrapper},
+      );
+
+      await waitFor(() => {
+        expect(Object.keys(result.current.liveDataByNode)).toHaveLength(0);
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle complex asset key paths', async () => {
+      const complexAsset = buildAssetKey({path: ['namespace', 'deeply', 'nested', 'asset']});
+
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(),
+        loading: false,
+      });
+
+      const wrapper = ({children}: {children: React.ReactNode}) => (
+        <MockedProvider>{children}</MockedProvider>
+      );
+
+      const {result} = renderHook(() => useAssetHealthData(complexAsset), {wrapper});
+
+      await waitFor(() => {
+        expect(result.current.liveData).toEqual({
+          __typename: 'Asset',
+          key: expect.objectContaining({
+            __typename: 'AssetKey',
+            path: ['namespace', 'deeply', 'nested', 'asset'],
+          }),
+          assetMaterializations: [],
+          assetHealth: null,
+        });
+      });
+    });
+
+    it('should handle asset keys with special characters', async () => {
+      const specialAsset = buildAssetKey({path: ['asset-with-dashes', 'asset_with_underscores']});
+
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(),
+        loading: false,
+      });
+
+      const wrapper = ({children}: {children: React.ReactNode}) => (
+        <MockedProvider>{children}</MockedProvider>
+      );
+
+      const {result} = renderHook(() => useAssetHealthData(specialAsset), {wrapper});
+
+      await waitFor(() => {
+        expect(result.current.liveData).toEqual({
+          __typename: 'Asset',
+          key: expect.objectContaining({
+            __typename: 'AssetKey',
+            path: ['asset-with-dashes', 'asset_with_underscores'],
+          }),
+          assetMaterializations: [],
+          assetHealth: null,
+        });
+      });
+    });
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
@@ -18,8 +18,12 @@ import {
   buildAssetConnection,
   buildAssetHealth,
   buildAssetKey,
+  buildAssetNode,
   buildAssetRecord,
   buildAssetRecordConnection,
+  buildRepository,
+  buildRepositoryLocation,
+  buildWorkspaceLocationEntry,
 } from '../../graphql/types';
 import {buildQueryMock, getMockResultFn} from '../../testing/mocking';
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext/WorkspaceContext';
@@ -151,7 +155,23 @@ const getHealthQueryMock = (assetKeys: AssetKey[]) =>
     },
   });
 
-const workspaceMocks = buildWorkspaceMocks([]);
+const workspaceMocks = buildWorkspaceMocks([
+  buildWorkspaceLocationEntry({
+    locationOrLoadError: buildRepositoryLocation({
+      repositories: [
+        buildRepository({
+          assetNodes: [
+            buildAssetNode({assetKey: asset1}),
+            buildAssetNode({assetKey: asset2}),
+            buildAssetNode({assetKey: asset3}),
+            buildAssetNode({assetKey: asset4}),
+            buildAssetNode({assetKey: asset5}),
+          ],
+        }),
+      ],
+    }),
+  }),
+]);
 
 describe('AssetCatalogTableV2', () => {
   it('renders', async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetHealthSummary.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetHealthSummary.test.tsx
@@ -1,0 +1,325 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {tokenForAssetKey} from '../../asset-graph/Utils';
+import {buildAssetKey} from '../../graphql/types';
+
+// Mock useAllAssetsNodes
+const mockUseAllAssetsNodes = jest.fn();
+jest.mock('../useAllAssets', () => ({
+  useAllAssetsNodes: mockUseAllAssetsNodes,
+}));
+
+// Mock useAssetHealthData
+const mockUseAssetHealthData = jest.fn();
+jest.mock('../../asset-data/AssetHealthDataProvider', () => ({
+  useAssetHealthData: mockUseAssetHealthData,
+}));
+
+// Mock useTrackEvent
+const mockUseTrackEvent = jest.fn();
+jest.mock('../../app/analytics', () => ({
+  useTrackEvent: mockUseTrackEvent,
+}));
+
+describe('AssetHealthSummary integration tests', () => {
+  let AssetHealthSummaryPopover: any;
+
+  beforeAll(() => {
+    // Import this after mocks are setup
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const module = require('../AssetHealthSummary');
+    AssetHealthSummaryPopover = module.AssetHealthSummaryPopover;
+  });
+
+  beforeEach(() => {
+    mockUseTrackEvent.mockReturnValue(jest.fn());
+    mockUseAssetHealthData.mockReturnValue({
+      liveData: null,
+      loading: false,
+      error: null,
+    });
+    mockUseAllAssetsNodes.mockReturnValue({
+      allAssetKeys: new Set(),
+      loading: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('no-definition behavior', () => {
+    it('should show missing software definition for assets without definitions', async () => {
+      const user = userEvent.setup();
+      const assetKey = buildAssetKey({path: ['missing_asset']});
+
+      // Mock that this asset is not in the workspace
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(), // Empty set means no definitions
+        loading: false,
+      });
+
+      mockUseAssetHealthData.mockReturnValue({
+        liveData: {
+          assetHealth: null,
+        },
+        loading: false,
+        error: null,
+      });
+
+      render(
+        <MockedProvider>
+          <AssetHealthSummaryPopover assetKey={assetKey}>
+            <div>Trigger</div>
+          </AssetHealthSummaryPopover>
+        </MockedProvider>,
+      );
+
+      // Hover over the trigger to show popover
+      await user.hover(screen.getByText('Trigger'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Missing software definition')).toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'It may have been deleted or be a stub imported through an integration.',
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should show normal health criteria for assets with definitions', async () => {
+      const user = userEvent.setup();
+      const assetKey = buildAssetKey({path: ['existing_asset']});
+
+      // Mock that this asset is in the workspace
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set([tokenForAssetKey(assetKey)]),
+        loading: false,
+      });
+
+      mockUseAssetHealthData.mockReturnValue({
+        liveData: {
+          assetHealth: {
+            materializationStatus: 'HEALTHY',
+            freshnessStatus: 'HEALTHY',
+            assetChecksStatus: 'HEALTHY',
+            materializationStatusMetadata: null,
+            freshnessStatusMetadata: null,
+            assetChecksStatusMetadata: null,
+          },
+        },
+        loading: false,
+        error: null,
+      });
+
+      render(
+        <MockedProvider>
+          <AssetHealthSummaryPopover assetKey={assetKey}>
+            <div>Trigger</div>
+          </AssetHealthSummaryPopover>
+        </MockedProvider>,
+      );
+
+      // Hover over the trigger to show popover
+      await user.hover(screen.getByText('Trigger'));
+
+      await waitFor(() => {
+        // Should show the standard criteria instead of missing definition
+        expect(screen.queryByText('Missing software definition')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should wait for loading to complete before showing no-definition message', async () => {
+      const user = userEvent.setup();
+      const assetKey = buildAssetKey({path: ['loading_asset']});
+
+      // Mock loading state
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(),
+        loading: true, // Still loading
+      });
+
+      render(
+        <MockedProvider>
+          <AssetHealthSummaryPopover assetKey={assetKey}>
+            <div>Trigger</div>
+          </AssetHealthSummaryPopover>
+        </MockedProvider>,
+      );
+
+      // Hover over the trigger to show popover
+      await user.hover(screen.getByText('Trigger'));
+
+      // Should show normal criteria while loading, not the no-definition message
+      await waitFor(() => {
+        expect(screen.queryByText('Missing software definition')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should handle asset key that transitions from loading to no-definition', async () => {
+      const user = userEvent.setup();
+      const assetKey = buildAssetKey({path: ['transitioning_asset']});
+
+      // Start with loading state
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(),
+        loading: true,
+      });
+
+      const {rerender} = render(
+        <MockedProvider>
+          <AssetHealthSummaryPopover assetKey={assetKey}>
+            <div>Trigger</div>
+          </AssetHealthSummaryPopover>
+        </MockedProvider>,
+      );
+
+      // Hover over the trigger to show popover
+      await user.hover(screen.getByText('Trigger'));
+
+      // Should not show no-definition message while loading
+      await waitFor(() => {
+        expect(screen.queryByText('Missing software definition')).not.toBeInTheDocument();
+      });
+
+      // Update to finished loading with no definitions
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(),
+        loading: false,
+      });
+
+      rerender(
+        <MockedProvider>
+          <AssetHealthSummaryPopover assetKey={assetKey}>
+            <div>Trigger</div>
+          </AssetHealthSummaryPopover>
+        </MockedProvider>,
+      );
+
+      // Now should show the no-definition message
+      await waitFor(() => {
+        expect(screen.getByText('Missing software definition')).toBeInTheDocument();
+      });
+    });
+
+    it('should handle complex asset keys correctly', async () => {
+      const user = userEvent.setup();
+      const assetKey = buildAssetKey({path: ['namespace', 'complex', 'asset_name']});
+
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(), // Asset not in definitions
+        loading: false,
+      });
+
+      render(
+        <MockedProvider>
+          <AssetHealthSummaryPopover assetKey={assetKey}>
+            <div>Trigger</div>
+          </AssetHealthSummaryPopover>
+        </MockedProvider>,
+      );
+
+      await user.hover(screen.getByText('Trigger'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Missing software definition')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('styling and layout', () => {
+    it('should apply correct maxWidth styling for criteria', async () => {
+      const user = userEvent.setup();
+      const assetKey = buildAssetKey({path: ['styled_asset']});
+
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(),
+        loading: false,
+      });
+
+      mockUseAssetHealthData.mockReturnValue({
+        liveData: {
+          assetHealth: null,
+        },
+        loading: false,
+        error: null,
+      });
+
+      render(
+        <MockedProvider>
+          <AssetHealthSummaryPopover assetKey={assetKey}>
+            <div>Trigger</div>
+          </AssetHealthSummaryPopover>
+        </MockedProvider>,
+      );
+
+      await user.hover(screen.getByText('Trigger'));
+
+      await waitFor(() => {
+        const criteriaElement = screen.getByText('Missing software definition').closest('div');
+        expect(criteriaElement).toHaveStyle({maxWidth: '300px'});
+      });
+    });
+
+    it('should maintain full opacity for no-definition criteria', async () => {
+      const user = userEvent.setup();
+      const assetKey = buildAssetKey({path: ['dim_asset']});
+
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(),
+        loading: false,
+      });
+
+      render(
+        <MockedProvider>
+          <AssetHealthSummaryPopover assetKey={assetKey}>
+            <div>Trigger</div>
+          </AssetHealthSummaryPopover>
+        </MockedProvider>,
+      );
+
+      await user.hover(screen.getByText('Trigger'));
+
+      await waitFor(() => {
+        const criteriaElement = screen.getByText('Missing software definition').closest('div');
+        expect(criteriaElement).toHaveStyle({opacity: '1'});
+      });
+    });
+  });
+
+  describe('explanation text', () => {
+    it('should show correct explanation text for no-definition case', async () => {
+      const user = userEvent.setup();
+      const assetKey = buildAssetKey({path: ['explanation_asset']});
+
+      mockUseAllAssetsNodes.mockReturnValue({
+        allAssetKeys: new Set(),
+        loading: false,
+      });
+
+      render(
+        <MockedProvider>
+          <AssetHealthSummaryPopover assetKey={assetKey}>
+            <div>Trigger</div>
+          </AssetHealthSummaryPopover>
+        </MockedProvider>,
+      );
+
+      await user.hover(screen.getByText('Trigger'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'It may have been deleted or be a stub imported through an integration.',
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAllAssetsNodes.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/useAllAssetsNodes.test.tsx
@@ -1,0 +1,469 @@
+import {renderHook} from '@testing-library/react';
+import {useContext} from 'react';
+
+import {buildAssetKey} from '../../graphql/types';
+import {WorkspaceContext} from '../../workspace/WorkspaceContext/WorkspaceContext';
+
+// Mock WorkspaceContext
+const mockWorkspaceContext = {
+  assetEntries: {},
+  loadingAssets: false,
+};
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn(),
+}));
+
+const mockUseContext = useContext as jest.MockedFunction<typeof useContext>;
+
+describe('useAllAssetsNodes integration tests', () => {
+  let useAllAssetsNodes: any;
+
+  beforeAll(() => {
+    // Import after mocks are set up
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const module = require('../useAllAssets');
+    useAllAssetsNodes = module.useAllAssetsNodes;
+  });
+
+  beforeEach(() => {
+    mockUseContext.mockImplementation((context: any) => {
+      if (context === WorkspaceContext) {
+        return mockWorkspaceContext;
+      }
+      return jest.requireActual('react').useContext(context);
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('allAssetKeys functionality', () => {
+    it('should return allAssetKeys as a Set of tokenized asset keys', () => {
+      // Mock the asset entries to return specific assets
+      const mockAssetEntries = {
+        'test-location': {
+          workspaceLocationEntryOrError: {
+            __typename: 'WorkspaceLocationEntry' as const,
+            locationOrLoadError: {
+              __typename: 'RepositoryLocation' as const,
+              repositories: [
+                {
+                  assetNodes: [
+                    {
+                      id: 'asset1-id',
+                      assetKey: buildAssetKey({path: ['asset1']}),
+                    },
+                    {
+                      id: 'asset2-id',
+                      assetKey: buildAssetKey({path: ['namespace', 'asset2']}),
+                    },
+                    {
+                      id: 'asset3-id',
+                      assetKey: buildAssetKey({path: ['complex', 'nested', 'asset3']}),
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      mockUseContext.mockImplementation((context: any) => {
+        if (context === WorkspaceContext) {
+          return {
+            assetEntries: mockAssetEntries,
+            loadingAssets: false,
+          };
+        }
+        return jest.requireActual('react').useContext(context);
+      });
+
+      const {result} = renderHook(() => useAllAssetsNodes());
+
+      expect(result.current.allAssetKeys).toBeInstanceOf(Set);
+      expect(result.current.allAssetKeys.size).toBe(3);
+
+      // Check that the Set contains tokenized versions of the asset keys
+      expect(result.current.allAssetKeys.has('asset1')).toBe(true);
+      expect(result.current.allAssetKeys.has('namespace/asset2')).toBe(true);
+      expect(result.current.allAssetKeys.has('complex/nested/asset3')).toBe(true);
+    });
+
+    it('should return empty Set when no asset nodes exist', () => {
+      mockUseContext.mockImplementation((context: any) => {
+        if (context === WorkspaceContext) {
+          return {
+            assetEntries: {},
+            loadingAssets: false,
+          };
+        }
+        return jest.requireActual('react').useContext(context);
+      });
+
+      const {result} = renderHook(() => useAllAssetsNodes());
+
+      expect(result.current.allAssetKeys).toBeInstanceOf(Set);
+      expect(result.current.allAssetKeys.size).toBe(0);
+    });
+
+    it('should maintain backward compatibility with assets property', () => {
+      const mockAssetEntries = {
+        'test-location': {
+          workspaceLocationEntryOrError: {
+            __typename: 'WorkspaceLocationEntry' as const,
+            locationOrLoadError: {
+              __typename: 'RepositoryLocation' as const,
+              repositories: [
+                {
+                  assetNodes: [
+                    {
+                      id: 'asset1-id',
+                      assetKey: buildAssetKey({path: ['asset1']}),
+                    },
+                    {
+                      id: 'asset2-id',
+                      assetKey: buildAssetKey({path: ['asset2']}),
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      mockUseContext.mockImplementation((context: any) => {
+        if (context === WorkspaceContext) {
+          return {
+            assetEntries: mockAssetEntries,
+            loadingAssets: false,
+          };
+        }
+        return jest.requireActual('react').useContext(context);
+      });
+
+      const {result} = renderHook(() => useAllAssetsNodes());
+
+      // Existing assets property should still be available
+      expect(result.current.assets).toBeDefined();
+      expect(Array.isArray(result.current.assets)).toBe(true);
+      expect(result.current.assets.length).toBe(2);
+    });
+
+    it('should maintain loading property', () => {
+      // Test with loading = true
+      mockUseContext.mockImplementation((context: any) => {
+        if (context === WorkspaceContext) {
+          return {
+            assetEntries: {},
+            loadingAssets: true,
+          };
+        }
+        return jest.requireActual('react').useContext(context);
+      });
+
+      const {result} = renderHook(() => useAllAssetsNodes());
+
+      expect(result.current.loading).toBe(true);
+
+      // Test with loading = false
+      mockUseContext.mockImplementation((context: any) => {
+        if (context === WorkspaceContext) {
+          return {
+            assetEntries: {},
+            loadingAssets: false,
+          };
+        }
+        return jest.requireActual('react').useContext(context);
+      });
+
+      const {result: result2} = renderHook(() => useAllAssetsNodes());
+
+      expect(result2.current.loading).toBe(false);
+    });
+
+    it('should handle complex nested asset key paths', () => {
+      const mockAssetEntries = {
+        'test-location': {
+          workspaceLocationEntryOrError: {
+            __typename: 'WorkspaceLocationEntry' as const,
+            locationOrLoadError: {
+              __typename: 'RepositoryLocation' as const,
+              repositories: [
+                {
+                  assetNodes: [
+                    {
+                      id: 'complex-asset-id',
+                      assetKey: buildAssetKey({
+                        path: ['very', 'deeply', 'nested', 'namespace', 'asset_name'],
+                      }),
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      mockUseContext.mockImplementation((context: any) => {
+        if (context === WorkspaceContext) {
+          return {
+            assetEntries: mockAssetEntries,
+            loadingAssets: false,
+          };
+        }
+        return jest.requireActual('react').useContext(context);
+      });
+
+      const {result} = renderHook(() => useAllAssetsNodes());
+
+      expect(result.current.allAssetKeys.size).toBe(1);
+      expect(result.current.allAssetKeys.has('very/deeply/nested/namespace/asset_name')).toBe(true);
+    });
+
+    it('should handle special characters in asset keys', () => {
+      const mockAssetEntries = {
+        'test-location': {
+          workspaceLocationEntryOrError: {
+            __typename: 'WorkspaceLocationEntry' as const,
+            locationOrLoadError: {
+              __typename: 'RepositoryLocation' as const,
+              repositories: [
+                {
+                  assetNodes: [
+                    {
+                      id: 'special-chars-id',
+                      assetKey: buildAssetKey({
+                        path: ['asset-with-dashes', 'asset_with_underscores', 'asset.with.dots'],
+                      }),
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      mockUseContext.mockImplementation((context: any) => {
+        if (context === WorkspaceContext) {
+          return {
+            assetEntries: mockAssetEntries,
+            loadingAssets: false,
+          };
+        }
+        return jest.requireActual('react').useContext(context);
+      });
+
+      const {result} = renderHook(() => useAllAssetsNodes());
+
+      expect(result.current.allAssetKeys.size).toBe(1);
+      expect(
+        result.current.allAssetKeys.has('asset-with-dashes/asset_with_underscores/asset.with.dots'),
+      ).toBe(true);
+    });
+
+    it('should return correct structure with all three properties', () => {
+      const mockAssetEntries = {
+        'test-location': {
+          workspaceLocationEntryOrError: {
+            __typename: 'WorkspaceLocationEntry' as const,
+            locationOrLoadError: {
+              __typename: 'RepositoryLocation' as const,
+              repositories: [
+                {
+                  assetNodes: [
+                    {
+                      id: 'test-asset-id',
+                      assetKey: buildAssetKey({path: ['test']}),
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      mockUseContext.mockImplementation((context: any) => {
+        if (context === WorkspaceContext) {
+          return {
+            assetEntries: mockAssetEntries,
+            loadingAssets: false,
+          };
+        }
+        return jest.requireActual('react').useContext(context);
+      });
+
+      const {result} = renderHook(() => useAllAssetsNodes());
+
+      // Check that all expected properties are present
+      expect(result.current).toHaveProperty('assets');
+      expect(result.current).toHaveProperty('allAssetKeys');
+      expect(result.current).toHaveProperty('loading');
+
+      // Check types
+      expect(Array.isArray(result.current.assets)).toBe(true);
+      expect(result.current.allAssetKeys).toBeInstanceOf(Set);
+      expect(typeof result.current.loading).toBe('boolean');
+
+      // Check the new allAssetKeys property specifically
+      expect(result.current.allAssetKeys.size).toBe(1);
+      expect(result.current.allAssetKeys.has('test')).toBe(true);
+    });
+
+    it('should handle multiple repositories in same location', () => {
+      const mockAssetEntries = {
+        'test-location': {
+          workspaceLocationEntryOrError: {
+            __typename: 'WorkspaceLocationEntry' as const,
+            locationOrLoadError: {
+              __typename: 'RepositoryLocation' as const,
+              repositories: [
+                {
+                  assetNodes: [
+                    {
+                      id: 'repo1-asset-id',
+                      assetKey: buildAssetKey({path: ['repo1_asset']}),
+                    },
+                  ],
+                },
+                {
+                  assetNodes: [
+                    {
+                      id: 'repo2-asset-id',
+                      assetKey: buildAssetKey({path: ['repo2_asset']}),
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      mockUseContext.mockImplementation((context: any) => {
+        if (context === WorkspaceContext) {
+          return {
+            assetEntries: mockAssetEntries,
+            loadingAssets: false,
+          };
+        }
+        return jest.requireActual('react').useContext(context);
+      });
+
+      const {result} = renderHook(() => useAllAssetsNodes());
+
+      expect(result.current.allAssetKeys.size).toBe(2);
+      expect(result.current.allAssetKeys.has('repo1_asset')).toBe(true);
+      expect(result.current.allAssetKeys.has('repo2_asset')).toBe(true);
+    });
+
+    it('should handle multiple locations', () => {
+      const mockAssetEntries = {
+        location1: {
+          workspaceLocationEntryOrError: {
+            __typename: 'WorkspaceLocationEntry' as const,
+            locationOrLoadError: {
+              __typename: 'RepositoryLocation' as const,
+              repositories: [
+                {
+                  assetNodes: [
+                    {
+                      id: 'loc1-asset-id',
+                      assetKey: buildAssetKey({path: ['location1_asset']}),
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+        location2: {
+          workspaceLocationEntryOrError: {
+            __typename: 'WorkspaceLocationEntry' as const,
+            locationOrLoadError: {
+              __typename: 'RepositoryLocation' as const,
+              repositories: [
+                {
+                  assetNodes: [
+                    {
+                      id: 'loc2-asset-id',
+                      assetKey: buildAssetKey({path: ['location2_asset']}),
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      mockUseContext.mockImplementation((context: any) => {
+        if (context === WorkspaceContext) {
+          return {
+            assetEntries: mockAssetEntries,
+            loadingAssets: false,
+          };
+        }
+        return jest.requireActual('react').useContext(context);
+      });
+
+      const {result} = renderHook(() => useAllAssetsNodes());
+
+      expect(result.current.allAssetKeys.size).toBe(2);
+      expect(result.current.allAssetKeys.has('location1_asset')).toBe(true);
+      expect(result.current.allAssetKeys.has('location2_asset')).toBe(true);
+    });
+
+    it('should handle error states in workspace entries', () => {
+      const mockAssetEntries = {
+        'error-location': {
+          workspaceLocationEntryOrError: {
+            __typename: 'PythonError' as const,
+            message: 'Location failed to load',
+          },
+        },
+        'good-location': {
+          workspaceLocationEntryOrError: {
+            __typename: 'WorkspaceLocationEntry' as const,
+            locationOrLoadError: {
+              __typename: 'RepositoryLocation' as const,
+              repositories: [
+                {
+                  assetNodes: [
+                    {
+                      id: 'good-asset-id',
+                      assetKey: buildAssetKey({path: ['good_asset']}),
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      mockUseContext.mockImplementation((context: any) => {
+        if (context === WorkspaceContext) {
+          return {
+            assetEntries: mockAssetEntries,
+            loadingAssets: false,
+          };
+        }
+        return jest.requireActual('react').useContext(context);
+      });
+
+      const {result} = renderHook(() => useAllAssetsNodes());
+
+      // Should only have the asset from the good location
+      expect(result.current.allAssetKeys.size).toBe(1);
+      expect(result.current.allAssetKeys.has('good_asset')).toBe(true);
+    });
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAllAssets.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAllAssets.tsx
@@ -33,7 +33,12 @@ const DEFAULT_BATCH_LIMIT = 1000;
 export function useAllAssetsNodes() {
   const {assetEntries, loadingAssets: loading} = useContext(WorkspaceContext);
   const allAssetNodes = useMemo(() => getAllAssetNodes(assetEntries), [assetEntries]);
-  return {assets: allAssetNodes, loading};
+
+  const allAssetKeys = useMemo(() => {
+    return new Set(allAssetNodes.map((node) => tokenForAssetKey(node.key)));
+  }, [allAssetNodes]);
+
+  return {assets: allAssetNodes, allAssetKeys, loading};
 }
 
 export function useAllAssets({

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataProvider.tsx
@@ -136,25 +136,30 @@ export function useLiveData<T>(
     };
   }, [keys, manager, thread, updateManager]);
 
-  return {
-    liveDataByNode: data,
+  const refresh = React.useCallback(() => {
+    manager.invalidateCache(keys);
+    setIsRefreshing(true);
+  }, [keys, manager]);
 
-    refresh: React.useCallback(() => {
-      manager.invalidateCache(keys);
-      setIsRefreshing(true);
-    }, [keys, manager]),
+  const refreshing = React.useMemo(() => {
+    if (isRefreshing && !manager.areKeysRefreshing(keys)) {
+      setTimeout(() => {
+        setIsRefreshing(false);
+      });
+      return false;
+    }
+    return true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keys, data, isRefreshing]);
 
-    refreshing: React.useMemo(() => {
-      if (isRefreshing && !manager.areKeysRefreshing(keys)) {
-        setTimeout(() => {
-          setIsRefreshing(false);
-        });
-        return false;
-      }
-      return true;
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [keys, data, isRefreshing]),
-  };
+  return useMemo(
+    () => ({
+      liveDataByNode: data,
+      refresh,
+      refreshing,
+    }),
+    [data, refresh, refreshing],
+  );
 }
 
 const LiveDataProviderTyped = <T,>({


### PR DESCRIPTION
Redo of https://github.com/dagster-io/dagster/pull/32044 but with the missing mocks for AssetCatalogTablev2.test.tsx