### PR TITLE
fixing order of parameters in guides

### DIFF
--- a/examples/use_case_repository/use_case_repository/guides/sftp_file_upload.md
+++ b/examples/use_case_repository/use_case_repository/guides/sftp_file_upload.md
@@ -76,7 +76,7 @@ from dagster_ssh import SSHResource
 def sftp_file(context: AssetExecutionContext, sftp: SSHResource):
     local_file_path = "hello.txt"
     remote_file_path = "/path/to/destination/hello.txt"
-    sftp.sftp_put(local_file_path, remote_file_path)
+    sftp.sftp_put(remote_file_path, local_file_path)
     context.log.info(f"Uploaded {local_file_path} to {remote_file_path} on SFTP server")
 
 

--- a/examples/use_case_repository/use_case_repository/guides/sftp_file_upload.py
+++ b/examples/use_case_repository/use_case_repository/guides/sftp_file_upload.py
@@ -13,7 +13,7 @@ sftp_resource = SSHResource(
 def sftp_file(context: AssetExecutionContext, sftp: SSHResource):
     local_file_path = "hello.txt"
     remote_file_path = "/path/to/destination/hello.txt"
-    sftp.sftp_put(local_file_path, remote_file_path)
+    sftp.sftp_put(remote_file_path, local_file_path)
     context.log.info(f"Uploaded {local_file_path} to {remote_file_path} on SFTP server")
 
 


### PR DESCRIPTION
## Summary & Motivation
Looking at the implementation the order of parameters is 1. remote 2. local path:
https://github.com/dagster-io/dagster/blob/8d6f4f5e86418835a99cc5adb6fce9f34674f01f/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py#L282

The examples in the guides have been wrong.

## How I Tested These Changes
I didn't run the test suite, as this changes is just examples and documentation.


