### PR TITLE
Fix tutorial.py

### DIFF
--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster-tutorial/src/dagster_tutorial/components/tutorial.py
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster-tutorial/src/dagster_tutorial/components/tutorial.py
@@ -26,8 +26,8 @@ class Tutorial(dg.Component, dg.Model, dg.Resolvable):
             @dg.asset(
                 name=etl.table,
             )
-            def _table(database: DuckDBResource):
-                with database.get_connection() as conn:
+            def _table(duckdb: DuckDBResource):
+                with duckdb.get_connection() as conn:
                     conn.execute(
                         f"""
                         create or replace table {etl.table} as (


### PR DESCRIPTION


## Summary & Motivation

This will fix an error below. It seems like the resource `database` doesn't refer the right key.
```
2025-09-05 10:22:58 +0900 - dagster - ERROR - Validation failed for code location dagster-tutorial:

dagster._core.errors.DagsterInvalidDefinitionError: resource with key 'database' required by op 'customers' was not provided. Please provide a ResourceDefinition to key 'database', or change the required key to one of the following keys which points to an ResourceDefinition: ['io_manager', 'duckdb']

Stack Trace:
  [17 dagster system frames hidden, run with --verbose to see the full stack trace]

2025-09-05 10:22:58 +0900 - dagster - ERROR - Validation for 1 code locations failed.
```

## How I Tested These Changes

```
dg check defs
```

## Changelog

> Fix a wrong variable name
