### PR TITLE
fix dg imports on python 3.9

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/ai.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/ai.py
@@ -7,13 +7,13 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from time import perf_counter
+from typing import TYPE_CHECKING
 
 import click
 from dagster_shared.record import record
 from dagster_shared.utils.timing import format_duration
 
 from dagster_dg_cli.cli.scaffold.branch.claude.diagnostics import ClaudeDiagnostics
-from dagster_dg_cli.cli.scaffold.branch.claude.sdk_client import OutputChannel
 from dagster_dg_cli.cli.scaffold.branch.constants import (
     ALLOWED_COMMANDS_PLANNING,
     ALLOWED_COMMANDS_SCAFFOLDING,
@@ -21,6 +21,9 @@ from dagster_dg_cli.cli.scaffold.branch.constants import (
 )
 from dagster_dg_cli.cli.scaffold.branch.version_utils import ensure_claude_sdk_python_version
 from dagster_dg_cli.utils.ui import daggy_spinner_context
+
+if TYPE_CHECKING:
+    from dagster_dg_cli.cli.scaffold.branch.claude.sdk_client import OutputChannel
 
 
 @record
@@ -223,7 +226,7 @@ class PrintOutputChannel:
 
 
 @contextmanager
-def enter_waiting_phase(phase_name: str, spin: bool = True) -> Iterator[OutputChannel]:
+def enter_waiting_phase(phase_name: str, spin: bool = True) -> Iterator["OutputChannel"]:
     """Enter a phase of non interactivity where we wait for the CLI agent to complete its work.
 
     This yields an OutputChannel that coordinates with a loading indicator unless spin is disabled.

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/planning.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/branch/planning.py
@@ -14,12 +14,11 @@ from dagster_shared.record import record
 from dagster_shared.utils.timing import format_duration
 
 from dagster_dg_cli.cli.scaffold.branch.claude.diagnostics import ClaudeDiagnostics
-from dagster_dg_cli.cli.scaffold.branch.claude.sdk_client import OutputChannel
 from dagster_dg_cli.cli.scaffold.branch.constants import ALLOWED_COMMANDS_PLANNING, ModelType
 from dagster_dg_cli.cli.scaffold.branch.version_utils import ensure_claude_sdk_python_version
 
 if TYPE_CHECKING:
-    from dagster_dg_cli.cli.scaffold.branch.claude.sdk_client import ClaudeSDKClient
+    from dagster_dg_cli.cli.scaffold.branch.claude.sdk_client import ClaudeSDKClient, OutputChannel
 
 
 @record
@@ -60,7 +59,7 @@ class PlanGenerator:
     def generate_initial_plan(
         self,
         context: PlanningContext,
-        output_channel: OutputChannel,
+        output_channel: "OutputChannel",
     ) -> GeneratedPlan:
         """Generate initial implementation plan from user input.
 
@@ -125,7 +124,7 @@ class PlanGenerator:
         context: PlanningContext,
         current_plan: GeneratedPlan,
         user_feedback: str,
-        output_channel: OutputChannel,
+        output_channel: "OutputChannel",
     ) -> GeneratedPlan:
         """Refine existing plan based on user feedback.
 
@@ -234,7 +233,7 @@ Please generate an improved version of the implementation plan that addresses th
 
 Provide the complete updated plan in the same markdown format as before."""
 
-    def _extract_plan_from_messages(self, messages: list, output_channel: OutputChannel) -> str:
+    def _extract_plan_from_messages(self, messages: list, output_channel: "OutputChannel") -> str:
         """Extract plan content from Claude's response messages.
 
         Args:

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/import_perf_tests/test_import_perf.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/import_perf_tests/test_import_perf.py
@@ -22,6 +22,7 @@ def test_import_perf():
         capture_output=True,
     )
     import_profile = result.stderr.decode("utf-8")
+
     import_profile_lines = import_profile.split("\n")
     import_names = [line.split("|")[-1].strip() for line in import_profile_lines]
 
@@ -46,6 +47,7 @@ def test_import_perf():
         "tomlkit",
         "watchdog",
         "dotenv",
+        "claude_code_sdk",
     ]
     expensive_imports = [
         f"`{lib}`"


### PR DESCRIPTION
## How I Tested These Changes
New test case

## Changelog
Fixed an issue where the `dagster_dg_cli` package failed to import when using python 3.9.