### PR TITLE
update styles for catalog tiles

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryTile.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryTile.module.css
@@ -6,7 +6,7 @@
   justify-content: space-between;
   background-color: var(--color-background-default);
   color: var(--color-text-default);
-  transition: background-color 0.3s ease-in-out;
+  transition: background-color 0.1s ease-in-out;
   cursor: pointer;
   &:hover {
     background-color: var(--color-background-default-hover);
@@ -45,7 +45,7 @@
 }
 
 .title {
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   margin-bottom: 4px;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryTile.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryTile.tsx
@@ -1,4 +1,4 @@
-import {BodySmall, Box, Button, Colors, Icon, MiddleTruncate} from '@dagster-io/ui-components';
+import {BodySmall, Box, Colors, Icon, MiddleTruncate} from '@dagster-io/ui-components';
 import clsx from 'clsx';
 import React, {useMemo} from 'react';
 import {Link} from 'react-router-dom';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryTile.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryTile.tsx
@@ -1,4 +1,4 @@
-import {BodySmall, Box, Colors, Icon, MiddleTruncate} from '@dagster-io/ui-components';
+import {BodySmall, Box, Button, Colors, Icon, MiddleTruncate} from '@dagster-io/ui-components';
 import clsx from 'clsx';
 import React, {useMemo} from 'react';
 import {Link} from 'react-router-dom';
@@ -157,10 +157,12 @@ export const JobTile = ({name, repoAddress}: {name: string; repoAddress: RepoAdd
         className={styles.tile}
       >
         <div className={styles.header}>
-          <div>
+          <Box
+            flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center', gap: 4}}
+          >
             <Icon name="job" size={20} />
-          </div>
-          <div className={styles.title} style={{color: Colors.textLight()}}>
+          </Box>
+          <div className={styles.title} style={{color: Colors.textDefault()}}>
             <MiddleTruncate text={name} />
           </div>
         </div>
@@ -171,7 +173,9 @@ export const JobTile = ({name, repoAddress}: {name: string; repoAddress: RepoAdd
               launched <TimeFromNow unixTimestamp={latestRun.startTime} />
             </BodySmall>
           </Box>
-        ) : null}
+        ) : (
+          <BodySmall color={Colors.textLight()}>Never launched</BodySmall>
+        )}
       </Box>
     </Link>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsGroupedView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsGroupedView.tsx
@@ -374,7 +374,7 @@ export const SelectionTile = React.memo(
   }) => {
     return item.__typename === 'FavoritesView' ? (
       <AssetSelectionSummaryTile
-        icon={<Icon name={item.icon as IconName} size={24} />}
+        icon={<Icon name={item.icon as IconName} size={20} />}
         label={item.name}
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         assets={item.assets.map((assetKey: any) => assetsByAssetKey.get(assetKey)!).filter(Boolean)}
@@ -382,7 +382,7 @@ export const SelectionTile = React.memo(
       />
     ) : (
       <AssetSelectionSummaryTileFromSelection
-        icon={<InsightsIcon name={item.icon as IconName} size={24} />}
+        icon={<InsightsIcon name={item.icon as IconName} size={20} />}
         selection={item}
       />
     );


### PR DESCRIPTION
## Summary & Motivation
Clean up the styles on the asset tiles that show up on the homepage and catalog. In general, made the tiles more compact.

### Before
<img width="1240" height="415" alt="image" src="https://github.com/user-attachments/assets/2af31a3a-63f2-4243-af6e-187a477f5ea4" />

### After
<img width="1244" height="397" alt="image" src="https://github.com/user-attachments/assets/f60f83f1-4478-494c-aecc-68387405a87d" />
