### PR TITLE
Replace redirecting link to dbt component API doc

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-dbt.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-dbt.rst
@@ -17,7 +17,7 @@ DbtProjectComponent
 
 .. autoclass:: DbtProjectComponent
 
-To use the dbt component, see the `dbt component integration guide <https://docs.dagster.io/integrations/libraries/dbt/dbt-component>`_.
+To use the dbt component, see the `dbt component integration guide <https://docs.dagster.io/integrations/libraries/dbt>`_.
 
 Component YAML
 ==============


### PR DESCRIPTION
## Summary & Motivation

Replaces redirecting link to dbt component API doc with direct link.

## How I Tested These Changes

Local build

## Changelog

> Insert changelog entry or delete this section.
