### PR TITLE
[windows] bump timeouts

### DIFF
--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -242,7 +242,7 @@ def _launch_dev_command(
     finally:
         child_processes = _get_child_processes(proc.pid)
         send_ipc_shutdown_message(write_fd)
-        proc.wait(timeout=10)
+        proc.wait(timeout=30)
         # The `dagster dev` command exits before the gRPC servers it spins up have shutdown. Wait
         # for the child processes to exit here to make sure we don't leave any hanging processes.
         #

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -1115,7 +1115,7 @@ def wait_for_all_runs_to_start(instance, timeout=10):
             break
 
 
-def wait_for_all_runs_to_finish(instance, timeout=10):
+def wait_for_all_runs_to_finish(instance, timeout=30):
     start_time = time.time()
     FINISHED_STATES = [
         DagsterRunStatus.SUCCESS,


### PR DESCRIPTION
looking back at recent failures target a few shorter (10s) timeouts that seem to be too tight on azure runnners 

## How I Tested These Changes

azure build
