### PR TITLE
[sbc] Use ExitStack for DefsStateStorage context management

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -524,10 +524,13 @@ class ConfigurableResourceFactory(
                 post_processed_config,
             )
 
-        with self.from_resource_context_cm(
-            build_init_resource_context(config=post_processed_config.value),
-            nested_resources=self.nested_resources,
-        ) as out:
+        with (
+            build_init_resource_context(config=post_processed_config.value) as context,
+            self.from_resource_context_cm(
+                context,
+                nested_resources=self.nested_resources,
+            ) as out,
+        ):
             yield out
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
@@ -65,7 +65,7 @@ class DefinitionsLoadContext:
         if load_type == DefinitionsLoadType.INITIALIZATION and defs_state_info is None:
             # defs_state_info is passed in during INITIALIZATION if explicit state versions
             # are provided via CLI arguments, otherwise we use the latest available state info
-            state_storage = DefsStateStorage.get_current()
+            state_storage = DefsStateStorage.get()
             self._defs_state_info = (
                 state_storage.get_latest_defs_state_info() if state_storage else None
             )
@@ -150,7 +150,7 @@ class DefinitionsLoadContext:
     @contextmanager
     def temp_state_path(self, key: str) -> Iterator[Optional[Path]]:
         """Context manager that creates a temporary path to hold local state for a component."""
-        state_storage = DefsStateStorage.get_current()
+        state_storage = DefsStateStorage.get()
         if state_storage is None:
             raise DagsterInvalidInvocationError(
                 "Attempted to get a temp state path without a StateStorage in context. "

--- a/python_modules/dagster/dagster/_core/execution/context/init.py
+++ b/python_modules/dagster/dagster/_core/execution/context/init.py
@@ -200,13 +200,17 @@ class UnboundInitResourceContext(InitResourceContext):
 
     def __exit__(self, *exc):
         self._resources_cm.__exit__(*exc)
-        if self._instance_provided:
+        # if an instance was provided, assume the outer context will handle disposing of it
+        if not self._instance_provided:
             self._instance_cm.__exit__(*exc)
 
     def __del__(self):
         if self._resources_cm and self._resources_contain_cm and not self._cm_scope_entered:
             self._resources_cm.__exit__(None, None, None)
-        if self._instance_provided and not self._cm_scope_entered:
+        # if an instance was provided, assume the outer context will handle disposing of it
+        # if _cm_scope_entered is True, then we can rely on __exit__ being called to dispose
+        # of the instance if necessary
+        if not self._instance_provided and not self._cm_scope_entered:
             self._instance_cm.__exit__(None, None, None)
 
     @property
@@ -260,7 +264,7 @@ def build_init_resource_context(
     config: Optional[Mapping[str, Any]] = None,
     resources: Optional[Mapping[str, Any]] = None,
     instance: Optional[DagsterInstance] = None,
-) -> InitResourceContext:
+) -> UnboundInitResourceContext:
     """Builds resource initialization context from provided parameters.
 
     ``build_init_resource_context`` can be used as either a function or context manager. If there is a

--- a/python_modules/dagster/dagster/_core/storage/defs_state/base.py
+++ b/python_modules/dagster/dagster/_core/storage/defs_state/base.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
-from typing import ClassVar, Optional
+from typing import Optional
 
 from dagster_shared.serdes.objects.models.defs_state_info import DefsStateInfo
 
@@ -8,6 +10,21 @@ from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
 
 # constant indicating where to store the latest defs state info in a kvs context
 DEFS_STATE_INFO_CURSOR_KEY = "__latest_defs_state_info__"
+
+_current_storage: ContextVar[Optional["DefsStateStorage"]] = ContextVar(
+    "_current_storage", default=None
+)
+
+
+@contextmanager
+def set_defs_state_storage(storage: Optional["DefsStateStorage"]):
+    """Context manager to set the current DefsStateStorage, accessible via `DefsStateStorage.get()`."""
+    token = _current_storage.set(storage)
+
+    try:
+        yield
+    finally:
+        _current_storage.reset(token)
 
 
 class DefsStateStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
@@ -17,8 +34,6 @@ class DefsStateStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     using the `set` class method. This is used to ensure a StateStore is available to code
     that is loading definitions.
     """
-
-    _current: ClassVar[Optional["DefsStateStorage"]] = None
 
     def get_latest_version(self, key: str) -> Optional[str]:
         """Returns the saved state version for the given defs key, if it exists.
@@ -85,11 +100,6 @@ class DefsStateStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         return f"__state__/{key}/{version}"
 
     @classmethod
-    def set_current(cls, state_storage: Optional["DefsStateStorage"]) -> None:
-        """Set the current StateStorage."""
-        cls._current = state_storage
-
-    @classmethod
-    def get_current(cls) -> Optional["DefsStateStorage"]:
+    def get(cls) -> Optional["DefsStateStorage"]:
         """Get the current StateStorage, if it has been set."""
-        return cls._current
+        return _current_storage.get()

--- a/python_modules/dagster/dagster/components/component/state_backed_component.py
+++ b/python_modules/dagster/dagster/components/component/state_backed_component.py
@@ -41,7 +41,7 @@ class StateBackedComponent(Component):
     async def refresh_state(self) -> None:
         """Rebuilds the state for this component and persists it to the current StateStore."""
         key = self.get_defs_state_key()
-        state_storage = DefsStateStorage.get_current()
+        state_storage = DefsStateStorage.get()
         if state_storage is None:
             raise DagsterInvalidInvocationError(
                 f"Attempted to refresh state of {key} without a StateStorage in context. "

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_build_init_resource_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_build_init_resource_context.py
@@ -50,7 +50,7 @@ def test_build_with_cm_resource():
     del context
     assert entered == ["true"]
 
-    with dg.build_init_resource_context(resources={"foo": foo}) as context:  # pyright: ignore[reportGeneralTypeIssues]
+    with dg.build_init_resource_context(resources={"foo": foo}) as context:
         assert context.resources.foo == "foo"
         assert reqs_cm_resource(context) == "foobar"
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/build.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/build.py
@@ -109,13 +109,10 @@ def defs_state_storage_from_config(
     """Creates a DefsStateStorage based on the provided DagsterPlusCliConfig and sets it as the current
     DefsStateStorage within the bounds of the context manager.
     """
-    from dagster._core.storage.defs_state.base import DefsStateStorage
+    from dagster._core.storage.defs_state.base import set_defs_state_storage
 
     from dagster_dg_cli.utils.plus.defs_state_storage import DagsterPlusCliDefsStateStorage
 
-    try:
-        defs_state_storage = DagsterPlusCliDefsStateStorage.from_config(plus_config)
-        DefsStateStorage.set_current(defs_state_storage)
+    defs_state_storage = DagsterPlusCliDefsStateStorage.from_config(plus_config)
+    with set_defs_state_storage(defs_state_storage):
         yield defs_state_storage
-    finally:
-        DefsStateStorage.set_current(None)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/test_refresh_state_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/test_refresh_state_command.py
@@ -21,7 +21,7 @@ def test_refresh_state_command():
         activate_venv(project_dir / ".venv"),
         dg.instance_for_test(),
     ):
-        state_storage = DefsStateStorage.get_current()
+        state_storage = DefsStateStorage.get()
         assert state_storage is not None
         # no components, nothing to refresh
         result = runner.invoke("utils", "refresh-defs-state")
@@ -92,7 +92,7 @@ def test_refresh_state_command_with_defs_key_filter():
         activate_venv(project_dir / ".venv"),
         dg.instance_for_test(),
     ):
-        state_storage = DefsStateStorage.get_current()
+        state_storage = DefsStateStorage.get()
         assert state_storage is not None
         # Create two components
         component1_dir = project_dir / "src/foo_bar/defs/component1"


### PR DESCRIPTION
## Summary & Motivation

Found a pretty nasty bug when attempting to use a StateBackedComponent in a project that used `FivetranWorkspace.load_asset_specs()` (which uses the old StateBackedDefinitionsLoader functionality). The basic issue is that this ends up using a contextmanager that (among other things), constructs an `UnboundInitResourceContext` object.

This object requires an instance to be made available, so it uses the `ephemeral_instance_if_missing()` context manager in the case that an explicit DagsterInstance is not provided, which it is not in this case. This means that we end up `__enter__`ing a separate DagsterInstance object, which in turn sets the current DefsStateStorage to the defs_state_storage of that new ephemeral instance, which happens to be `None` (although it'd also be bad if it was a non-None default value).

There are two core issues here:

- The UnboundInitResourceContext is kinda unholy in how it manages state because it doesn't require you to `__enter__` it, it can't guarantee that `__exit__` is called (and so it also does some cleanup in `__del__`). This logic contains a bug in that it only cleans up the instance if an instance was NOT provided explicitly, but this is actually the opposite of what you would expect. For example, imagine:

```python

with instance_for_test() as instance:
    with UnboundInitResourceContext(instance=instance) as resource_context:
        ...
    # at this point, instance.__exit__ is called because we are
    # exiting the UnboundInitResourceContext and we explicitly
    # provided an instance, even though we haven't left the
    # outer context!
    
    instance.foo()
    instance.bar()
```

In reality, we should only call __exit__ on instances that we created within the UnboundInitResourceContext, as these are the ones that won't get cleaned up through other means.

So the full fix here is to 1) update the __exit__ / __del__ logic 2) use UnboundInitResourceContext as a contextmanager in the appropriate code path


- The second issue is that when a DagsterInstance was `__exit__`ed before, it would always just set the current DefsStateStorage back to `None`, regardless of what the previous value was. Now, we have a special-purpose context manager that handles state transitions properly, so that once we `__exit__` the ephemeral instance, we get our original DefsStateStorage back.


## How I Tested These Changes

## Changelog

NOCHANGELOG
