### PR TITLE
only include filterFailed and filterMissing checkbox values on reported events if the checkboxes are visible

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsDialog.tsx
@@ -168,7 +168,7 @@ const ReportEventDialogBody = ({
   const [filterMissing, setFilterMissing] = useState(true);
   const keysFiltered = useMemo(() => {
     return explodePartitionKeysInSelectionMatching(selections, (keyIdx) => {
-      if (!filterFailed && !filterMissing) {
+      if (selections.length <= 1 || (!filterFailed && !filterMissing)) {
         return true;
       }
 


### PR DESCRIPTION
## Summary & Motivation
The new flags added in https://github.com/dagster-io/dagster/pull/31878 are checked even if the checkboxes that set them are not visible. Instead, only check them if the checkboxes are visible.

## How I Tested These Changes
Locally, materialize a partitioned asset, then try to report the materialization.

## Changelog
Fixed an issue where the "Report materialization events" dialog for partitioned assets only worked if the partition was failed or missing.