### PR TITLE
[ui] Fix null defsStateInfo

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefsStateComparisonSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefsStateComparisonSection.tsx
@@ -4,16 +4,23 @@ import {useQuery} from '../apollo-client';
 import {CodeLocationDefsStateComparison} from './CodeLocationDefsStateComparison';
 import {CODE_LOCATION_DEFS_STATE_QUERY} from './CodeLocationDefsStateQuery';
 import {CodeLocationOverviewSectionHeader} from './CodeLocationOverviewSectionHeader';
+import {
+  CodeLocationDefsStateQuery,
+  CodeLocationDefsStateQueryVariables,
+} from './types/CodeLocationDefsStateQuery.types';
 
 interface Props {
   locationName: string;
 }
 
 export const CodeLocationDefsStateComparisonSection = ({locationName}: Props) => {
-  const {data, loading, error} = useQuery(CODE_LOCATION_DEFS_STATE_QUERY, {
-    variables: {locationName},
-    fetchPolicy: 'cache-and-network',
-  });
+  const {data, loading} = useQuery<CodeLocationDefsStateQuery, CodeLocationDefsStateQueryVariables>(
+    CODE_LOCATION_DEFS_STATE_QUERY,
+    {
+      variables: {locationName},
+      fetchPolicy: 'cache-and-network',
+    },
+  );
 
   if (loading && !data) {
     return (
@@ -23,24 +30,20 @@ export const CodeLocationDefsStateComparisonSection = ({locationName}: Props) =>
     );
   }
 
-  if (error) {
-    return null; // Silently fail if there's an error
-  }
-
-  const latestDefsStateInfo = data?.latestDefsStateInfo || null;
   const defsStateInfo =
     data?.workspaceLocationEntryOrError?.__typename === 'WorkspaceLocationEntry'
       ? data.workspaceLocationEntryOrError.defsStateInfo
       : null;
 
   // Don't show the section if there are no versions available in the current state
-  if (!defsStateInfo.keyStateInfo || defsStateInfo.keyStateInfo.length === 0) {
+  if (!defsStateInfo?.keyStateInfo || defsStateInfo.keyStateInfo.length === 0) {
     return null;
   }
 
+  const latestDefsStateInfo = data?.latestDefsStateInfo ?? null;
   return (
     <>
-      <CodeLocationOverviewSectionHeader label="Defs State Versions" />
+      <CodeLocationOverviewSectionHeader label="Defs state versions" />
       <CodeLocationDefsStateComparison
         latestDefsStateInfo={latestDefsStateInfo}
         defsStateInfo={defsStateInfo}


### PR DESCRIPTION
## Summary & Motivation

Fix an unexpected null in `CodeLocationDefsStateComparisonSection`.

We're missing the type parameters on `useQuery` (not sure why lint isn't catching this!) which leads to values not being correctly checked for nulls.

## How I Tested These Changes

View code location in proxy, verify that the "Cannot read properties of null" error not longer appears.