### PR TITLE
Use loaders more when generating asset status cache values

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
@@ -8,7 +8,7 @@ from dagster._core.storage.partition_status_cache import get_partition_subsets
 from dagster._core.workspace.context import WorkspaceRequestContext
 
 
-def regenerate_and_check_partition_subsets(
+async def regenerate_and_check_partition_subsets(
     context: WorkspaceRequestContext,
     asset_node_snap: AssetNodeSnap,
     dynamic_partitions_loader: Optional[CachingDynamicPartitionsLoader],
@@ -20,7 +20,7 @@ def regenerate_and_check_partition_subsets(
         materialized_partition_subset,
         failed_partition_subset,
         in_progress_subset,
-    ) = get_partition_subsets(
+    ) = await get_partition_subsets(
         context.instance,
         context,
         asset_node_snap.asset_key,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1121,7 +1121,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         run_record = graphene_info.context.instance.get_run_record_by_id(planned_info.run_id)
         return GrapheneRun(run_record) if run_record else None
 
-    def resolve_assetPartitionStatuses(
+    async def resolve_assetPartitionStatuses(
         self, graphene_info: ResolveInfo
     ) -> Union[
         "GrapheneTimePartitionStatuses",
@@ -1140,7 +1140,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             materialized_partition_subset,
             failed_partition_subset,
             in_progress_subset,
-        ) = get_partition_subsets(
+        ) = await get_partition_subsets(
             graphene_info.context.instance,
             graphene_info.context,
             asset_key,
@@ -1156,7 +1156,7 @@ class GrapheneAssetNode(graphene.ObjectType):
             partitions_def,
         )
 
-    def resolve_partitionStats(
+    async def resolve_partitionStats(
         self, graphene_info: ResolveInfo
     ) -> Optional[GraphenePartitionStats]:
         partitions_snap = self._asset_node_snap.partitions
@@ -1168,7 +1168,7 @@ class GrapheneAssetNode(graphene.ObjectType):
                     materialized_partition_subset,
                     failed_partition_subset,
                     in_progress_subset,
-                ) = regenerate_and_check_partition_subsets(
+                ) = await regenerate_and_check_partition_subsets(
                     graphene_info.context,
                     self._asset_node_snap,
                     graphene_info.context.dynamic_partitions_loader,

--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
@@ -139,7 +139,7 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
                 materialized_partition_subset,
                 failed_partition_subset,
                 _,
-            ) = get_partition_subsets(
+            ) = await get_partition_subsets(
                 loading_context.instance,
                 loading_context,
                 asset_key,

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -760,11 +760,23 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         context: LoadingContext,
     ) -> Sequence[Optional["AssetStatusCacheValue"]]:
         """Get the cached status information for each asset."""
+        from dagster._core.workspace.context import BaseWorkspaceRequestContext
+
         values = []
+
+        if isinstance(context, BaseWorkspaceRequestContext):
+            dynamic_partitions_loader = context.dynamic_partitions_loader
+        else:
+            dynamic_partitions_loader = None
+
         for asset_key, partitions_def in partitions_defs_by_key:
             values.append(
                 get_and_update_asset_status_cache_value(
-                    self._instance, asset_key, partitions_def, loading_context=context
+                    self._instance,
+                    asset_key,
+                    partitions_def,
+                    dynamic_partitions_loader=dynamic_partitions_loader,
+                    loading_context=context,
                 )
             )
         return values

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -491,7 +491,7 @@ def get_and_update_asset_status_cache_value(
         return updated_cache_value
 
 
-def get_partition_subsets(
+async def get_partition_subsets(
     instance: DagsterInstance,
     loading_context: LoadingContext,
     asset_key: AssetKey,
@@ -510,13 +510,10 @@ def get_partition_subsets(
         if instance.can_read_asset_status_cache() and is_cacheable_partition_type(partitions_def):
             # When the "cached_status_data" column exists in storage, update the column to contain
             # the latest partition status values
-            updated_cache_value = get_and_update_asset_status_cache_value(
-                instance,
-                asset_key,
-                partitions_def,
-                dynamic_partitions_loader,
-                loading_context,
+            updated_cache_value = await AssetStatusCacheValue.gen(
+                loading_context, (asset_key, partitions_def)
             )
+
             materialized_subset = (
                 updated_cache_value.deserialize_materialized_partition_subsets(partitions_def)
                 if updated_cache_value


### PR DESCRIPTION
Summary:
Using the loader here more ensures that if this data is fetched more than once in a single graphql request, it will be cached.

Test Plan:
Existing BK