### PR TITLE
Ensure that failed partition subset and materialized subset are sourced from the same data in both asset health and partition statuses

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -521,9 +521,9 @@ def build_partition_statuses(
             in_progress_keys = in_progress_partitions_subset.get_partition_keys()
 
             return GrapheneDefaultPartitionStatuses(
-                materializedPartitions=set(materialized_keys)
-                - set(failed_keys)
-                - set(in_progress_keys),
+                materializedPartitions=sorted(
+                    set(materialized_keys) - set(failed_keys) - set(in_progress_keys)
+                ),
                 failedPartitions=failed_keys,
                 unmaterializedPartitions=materialized_partitions_subset.get_partition_keys_not_in_subset(
                     partitions_def=partitions_def

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
@@ -1,6 +1,9 @@
+import asyncio
 from typing import Optional
 
-from dagster import _check as check
+from dagster._core.definitions.asset_health.asset_materialization_health import (
+    AssetMaterializationHealthState,
+)
 from dagster._core.definitions.partitions.subset import PartitionsSubset
 from dagster._core.instance.types import CachingDynamicPartitionsLoader
 from dagster._core.remote_representation.external_data import AssetNodeSnap
@@ -11,32 +14,45 @@ from dagster._core.workspace.context import WorkspaceRequestContext
 async def regenerate_and_check_partition_subsets(
     context: WorkspaceRequestContext,
     asset_node_snap: AssetNodeSnap,
-    dynamic_partitions_loader: Optional[CachingDynamicPartitionsLoader],
-) -> tuple[PartitionsSubset[str], PartitionsSubset[str], PartitionsSubset[str]]:
-    if not dynamic_partitions_loader:
-        check.failed("dynamic_partitions_loader must be provided to get partition keys")
-
+    dynamic_partitions_loader: CachingDynamicPartitionsLoader,
+) -> tuple[
+    Optional[PartitionsSubset[str]],
+    Optional[PartitionsSubset[str]],
+    Optional[PartitionsSubset[str]],
+]:
     (
-        materialized_partition_subset,
-        failed_partition_subset,
-        in_progress_subset,
-    ) = await get_partition_subsets(
-        context.instance,
-        context,
-        asset_node_snap.asset_key,
-        dynamic_partitions_loader,
-        (
-            asset_node_snap.partitions.get_partitions_definition()
-            if asset_node_snap.partitions
-            else None
+        asset_health_state,
+        (materialized_partition_subset, failed_partition_subset, in_progress_subset),
+    ) = await asyncio.gather(
+        AssetMaterializationHealthState.gen(context, asset_node_snap.asset_key),
+        get_partition_subsets(
+            context.instance,
+            context,
+            asset_node_snap.asset_key,
+            dynamic_partitions_loader,
+            (
+                asset_node_snap.partitions.get_partitions_definition()
+                if asset_node_snap.partitions
+                else None
+            ),
         ),
     )
 
-    if (
-        materialized_partition_subset is None
-        or failed_partition_subset is None
-        or in_progress_subset is None
-    ):
-        check.failed("Expected partitions subset for a partitioned asset")
+    if asset_health_state:
+        # prefer sourcing materialized and failed subsets from the health object if possible
+        materialized_partition_subset = (
+            asset_health_state.materialized_subset.subset_value
+            if asset_health_state.materialized_subset.is_partitioned
+            else None
+        )
+        failed_partition_subset = (
+            asset_health_state.failed_subset.subset_value
+            if asset_health_state.failed_subset.is_partitioned
+            else None
+        )
 
-    return materialized_partition_subset, failed_partition_subset, in_progress_subset
+    return (
+        materialized_partition_subset,
+        failed_partition_subset,
+        in_progress_subset,
+    )


### PR DESCRIPTION
Summary:
This prevents an issue where in rare circumstances, asset health and asset partition status could show different results for which partitions had failed, by ensuring that the materialized and failed subsets are always sourced from the same place (Specifically, the AssetMaterializationHealthState object). We still have to fetch the in progress subset separately, since that is not currently available on AssetMaterializationHealthState. This should not result in significant additional data fetching since either the AssetMaterializationHealthState will be cached and quick to compute, or it will fall back to computing its data from the asset status partition cache, the potentially expensive part of which is currently cached at the loader level after https://app.graphite.dev/github/pr/dagster-io/dagster/32108.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
