### PR TITLE
return partition keys in get_partition_keys_not_in_subset in order

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/all.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/all.py
@@ -41,7 +41,7 @@ class AllPartitionsSubset(PartitionsSubset):
     def get_partition_keys_not_in_subset(
         self, partitions_def: PartitionsDefinition
     ) -> Iterable[str]:
-        return set()
+        return []
 
     @use_partition_loading_context
     def get_partition_key_ranges(

--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/default.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/default.py
@@ -35,7 +35,7 @@ class DefaultPartitionsSubset(
     def get_partition_keys_not_in_subset(
         self, partitions_def: PartitionsDefinition
     ) -> Iterable[str]:
-        return set(partitions_def.get_partition_keys()) - set(self.subset)
+        return [key for key in partitions_def.get_partition_keys() if key not in self.subset]
 
     def get_partition_keys(self) -> Iterable[str]:
         return self.subset

--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/key_ranges.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/key_ranges.py
@@ -26,7 +26,8 @@ class KeyRangesPartitionsSubset(PartitionsSubset):
     def get_partition_keys_not_in_subset(
         self, partitions_def: PartitionsDefinition
     ) -> Iterable[str]:
-        return set(partitions_def.get_partition_keys()) - set(self.get_partition_keys())
+        partition_key_set = set(self.get_partition_keys())
+        return [key for key in partitions_def.get_partition_keys() if key not in partition_key_set]
 
     @property
     def is_empty(self) -> bool:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -305,7 +305,9 @@ def test_multi_partition_subset_to_range_conversion():
 
 
 def test_key_ranges_subset():
-    color_partition = dg.StaticPartitionsDefinition(["red", "yellow", "blue", "green", "orange"])
+    color_partition = dg.StaticPartitionsDefinition(
+        ["red", "yellow", "blue", "green", "purple", "orange"]
+    )
 
     key_ranges_subset = KeyRangesPartitionsSubset(
         key_ranges=[
@@ -326,7 +328,10 @@ def test_key_ranges_subset():
             effective_dt=get_current_datetime(), dynamic_partitions_store=instance
         ),
     ):
-        assert key_ranges_subset.get_partition_keys_not_in_subset(color_partition) == {"green"}
+        assert key_ranges_subset.get_partition_keys_not_in_subset(color_partition) == [
+            "green",
+            "purple",
+        ]
         assert not key_ranges_subset.is_empty
         assert key_ranges_subset.partitions_definition == color_partition
 

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -148,10 +148,10 @@ def test_static_partitions_subset():
     assert len(subset) == 0
     assert "bar" not in subset
     with_some_partitions = subset.with_partition_keys(["foo", "bar"])
-    assert with_some_partitions.get_partition_keys_not_in_subset(partitions) == {"baz", "qux"}
+    assert with_some_partitions.get_partition_keys_not_in_subset(partitions) == ["baz", "qux"]
     serialized = with_some_partitions.serialize()
     deserialized = partitions.deserialize_subset(serialized)
-    assert deserialized.get_partition_keys_not_in_subset(partitions) == {"baz", "qux"}
+    assert deserialized.get_partition_keys_not_in_subset(partitions) == ["baz", "qux"]
     assert len(with_some_partitions) == 2
     assert len(deserialized) == 2
     assert "bar" in with_some_partitions

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -265,7 +265,7 @@ def test_multipartitions_subset_addition(initial, added):
     assert initial_subset.get_partition_keys() == set(initial_subset_keys)
     assert added_subset.get_partition_keys() == set(added_subset_keys + initial_subset_keys)
     with partition_loading_context(effective_dt=current_day):
-        assert added_subset.get_partition_keys_not_in_subset(multipartitions_def) == set(
+        assert sorted(added_subset.get_partition_keys_not_in_subset(multipartitions_def)) == sorted(
             expected_keys_not_in_updated_subset
         )
 


### PR DESCRIPTION
Summary:
Noticed this when tests were producing inconsistent results. get_partition_keys has an ordering, so get_partition_keys_not_in_subset should too.

BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
