### PR TITLE
custom DagsterError subclass when an invalid asset selection is parsed

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -54,6 +54,12 @@ def is_coercible_to_asset_selection(
     )
 
 
+class DagsterInvalidAssetSelectionError(DagsterError):
+    """An error raised when an invalid asset selection is provided."""
+
+    pass
+
+
 @public
 class AssetSelection(ABC):
     """An AssetSelection defines a query over a set of assets and asset checks, normally all that are defined in a project.
@@ -548,7 +554,7 @@ class AssetSelection(ABC):
             tag_str = string[len("tag:") :]
             return cls.tag_string(tag_str)
 
-        raise DagsterError(f"Invalid selection string: {string}")
+        raise DagsterInvalidAssetSelectionError(f"Invalid selection string: {string}")
 
     @classmethod
     def from_coercible(cls, selection: CoercibleToAssetSelection) -> "AssetSelection":

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -17,6 +17,7 @@ from dagster._core.definitions.asset_selection import (
     CodeLocationAssetSelection,
     ColumnAssetSelection,
     ColumnTagAssetSelection,
+    DagsterInvalidAssetSelectionError,
     DownstreamAssetSelection,
     GroupsAssetSelection,
     KeyPrefixesAssetSelection,
@@ -752,6 +753,9 @@ def test_to_string_basic():
         == 'key:"prefix/thing*"'
     )
     assert AssetSelection.from_string("column:foo").to_selection_str() == 'column:"foo"'
+
+    with pytest.raises(DagsterInvalidAssetSelectionError):
+        AssetSelection.from_string("kind: or *")
 
 
 def test_to_string_binary_operators():


### PR DESCRIPTION
## Summary & Motivation
Allows custom error handling in the graphql layer when an invalid asset selection is input from the frontend.

## How I Tested These Changes
BK

