### PR TITLE
fix: ConfigurableResource.configure_at_launch() type annotation

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -318,7 +318,7 @@ class ConfigurableResourceFactory(
         return self._nested_resources
 
     @classmethod
-    def configure_at_launch(cls: "type[T_Self]", **kwargs) -> "PartialResource[T_Self]":
+    def configure_at_launch(cls: "type[T_Self]", **kwargs) -> "PartialResource[TResValue]":
         """Returns a partially initialized copy of the resource, with remaining config fields
         set at runtime.
         """


### PR DESCRIPTION
## Summary & Motivation
As per documentation, ConfigurableResource can be used to create another object: 

```python 
class WriterResource(ConfigurableResource):
    prefix: str

    def create_resource(self, context: InitResourceContext) -> Writer:
        # Writer is pre-existing class defined else
        return Writer(self.prefix)
```
When you use PartialResource created by .configure_at_launch() and want to assign to another ConfigurableResource (as nested), everything works as expected. Unfortunately the type annotation of configure_at_launch() is incorrect. See screenshots.

```python
# Pure python class, which I want to use in Dagster
@dataclass
class MyClass:
    my_string: str
    my_integer: int

    def hello_world(self):
        return f"Hello, {self.my_string}! Your number is {self.my_integer}."

# ConfigurableResource class wrapping MyClass
class MyResource(ConfigurableResource):
    # I want to allow user to configure only this value
    my_string: str

    # Creating instance of pure python class
    def create_resource(self, context: InitResourceContext) -> MyClass:
        return MyClass(self.my_string, my_integer=42)


class MyIOManager(ConfigurableIOManager):
    my_value: str = "default"
    my_class: ResourceDependency[MyClass]
        
    def load_input(self, context: InputContext) -> tuple[str, int]:
        raise NotImplementedError()

    def handle_output(self, context: InputContext, obj: str) -> None:
        context.log.info(f"{self.my_class=}, {self.my_value=}")

@asset(io_manager_key="my_io_manager")
def my_asset() -> str:
    return ""


my_resource = MyResource.configure_at_launch()
my_io_manager = MyIOManager(my_value="class", my_class=my_resource)

defs = Definitions(
    assets=[my_asset],
    resources={
        "my_resource": my_resource,
        "my_io_manager": my_io_manager,
    },
)
```
Before change:
<img width="1188" height="230" alt="Screenshot 2025-09-10 at 8 09 04" src="https://github.com/user-attachments/assets/0e91e7bd-7886-472c-8bbc-0ed9da76cef1" />
After change:
<img width="641" height="287" alt="Screenshot 2025-09-10 at 8 09 18" src="https://github.com/user-attachments/assets/9d06ac0e-b3f4-47ae-8486-74a743bb8c74" />
## Changelog

> Insert changelog entry or delete this section.
Fix type annotation of ConfigurableResource.configure_at_launchpad()
