### PR TITLE
fix broken docs links

### DIFF
--- a/docs/docs/deployment/dagster-plus/authentication-and-access-control/scim/entra-id-scim.md
+++ b/docs/docs/deployment/dagster-plus/authentication-and-access-control/scim/entra-id-scim.md
@@ -11,7 +11,7 @@ In this guide, we'll walk you through configuring [Microsoft Entra ID provisioni
 
 To complete the steps in this guide, you'll need:
 
-- **To have set up Entra ID SSO for Dagster+.** For more information, see the [Entra ID setup guide](//dagster-plus/features/authentication-and-access-control/sso/azure-ad-sso).
+- **To have set up Entra ID SSO for Dagster+.** For more information, see the [Entra ID setup guide](/deployment/dagster-plus/authentication-and-access-control/sso/azure-ad-sso).
 - **Permissions in Entra ID that allow you to configure SSO and SCIM provisioning.**
 - **The following in Dagster+:**
   - A Pro plan

--- a/docs/docs/deployment/dagster-plus/authentication-and-access-control/scim/okta-scim.md
+++ b/docs/docs/deployment/dagster-plus/authentication-and-access-control/scim/okta-scim.md
@@ -22,7 +22,7 @@ Dagster+ currently supports the following attributes for SCIM syncing:
 
 To complete the steps in this guide, you'll need:
 
-- **To have set up Okta SSO for Dagster+.** For more information, see the [Okta SSO setup guide](//dagster-plus/features/authentication-and-access-control/sso/okta-sso).
+- **To have set up Okta SSO for Dagster+.** For more information, see the [Okta SSO setup guide](/deployment/dagster-plus/authentication-and-access-control/sso/okta-sso).
 - **Permissions in Okta that allow you to configure applications.**
 - **The following in Dagster+:**
   - A Pro plan


### PR DESCRIPTION
Summary:
These links were missing a prefix. At one point we had some kind of linting for this i thought?

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
