### PR TITLE
[sbc] ensure DAGSTER_HOME is set for refresh-defs-state

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
@@ -453,6 +453,19 @@ def refresh_defs_state(
 ) -> None:
     """Refresh the defs state for the current project."""
     from dagster._cli.utils import get_possibly_temporary_instance_for_cli
+    from dagster._core.instance.config import is_dagster_home_set
+
+    # Check if DAGSTER_HOME is set before proceeding
+    if not is_dagster_home_set():
+        raise click.UsageError(
+            "DAGSTER_HOME is not set, which means defs state cannot be stored in a persistent location, "
+            "please set it to use this command.\n"
+            "You can resolve this error by exporting the environment variable. "
+            "For example, you can run the following command in your shell or "
+            "include it in your shell configuration file:\n"
+            '\texport DAGSTER_HOME="~/dagster_home"'
+            "\n\n"
+        )
 
     cli_config = normalize_cli_config(other_opts, click.get_current_context())
     dg_context = DgContext.for_project_environment(target_path, cli_config)


### PR DESCRIPTION
## Summary & Motivation

Ran into this while experimenting -- you get confusing behavior if DAGSTER_HOME is not set, because the command will successfully write state, but it will write it to a temporary directory and instantly be cleared away. so if you have a separate terminal running `dg dev`, that will not actually be impacted by that updated state.

## How I Tested These Changes

unit

## Changelog

NOCHANGELOG
