### PR TITLE
allow spaces in partition dialog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/CreatePartitionDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/CreatePartitionDialog.tsx
@@ -59,7 +59,6 @@ const INVALID_PARTITION_SUBSTRINGS_READABLE = [
   '","',
   '[',
   ']',
-  '" "',
 ];
 
 export const CreatePartitionDialog = ({


### PR DESCRIPTION
## Summary

We disallow a broader set of chars in the UI than in the partition APIs:
https://github.com/dagster-io/dagster/blob/master/js_modules/dagster-ui/packages/ui-core/src/partitions/CreatePartitionDialog.tsx#L33-L63
vs
https://github.com/dagster-io/dagster/blob/b32508036370678ad0bbc0f117f138fa29b0c33d/python_modules/dagster/dagster/_core/definitions/multi_dimensional_partitions.py#L39
https://github.com/dagster-io/dagster/blob/b32508036370678ad0bbc0f117f138fa29b0c33d/python_modules/dagster/dagster/_core/definitions/partition.py#L92

This PR enables the space char to be used in the UI, since it is not disallowed in the backend