### PR TITLE
Allow custom key prefix in PipesS3ContextInjector

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/context_injectors.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/context_injectors.py
@@ -4,15 +4,15 @@ import random
 import string
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
-import boto3
 import dagster._check as check
 from dagster._core.pipes.client import PipesContextInjector, PipesParams
 from dagster._core.pipes.utils import PipesEnvContextInjector
 
 if TYPE_CHECKING:
     from dagster_pipes import PipesContextData
+    from mypy_boto3_s3 import S3Client
 
 _CONTEXT_FILENAME = "context.json"
 
@@ -22,20 +22,21 @@ class PipesS3ContextInjector(PipesContextInjector):
 
     Args:
         bucket (str): The S3 bucket to write to.
-        client (boto3.client): A boto3 client to use to write to S3.
+        client (S3Client): A boto3 client to use to write to S3.
         key_prefix (Optional[str]): An optional prefix to use for the S3 key. Defaults to a random
             string.
 
     """
 
-    def __init__(self, *, bucket: str, client: boto3.client):  # pyright: ignore (reportGeneralTypeIssues)
+    def __init__(self, *, bucket: str, client: "S3Client", key_prefix: Optional[str] = None):
         super().__init__()
         self.bucket = check.str_param(bucket, "bucket")
         self.client = client
+        self.key_prefix = key_prefix
 
     @contextmanager
     def inject_context(self, context: "PipesContextData") -> Iterator[PipesParams]:  # pyright: ignore[reportIncompatibleMethodOverride]
-        key_prefix = "".join(random.choices(string.ascii_letters, k=30))
+        key_prefix = f"{self.key_prefix or ''}{''.join(random.choices(string.ascii_letters, k=30))}"
         key = os.path.join(key_prefix, _CONTEXT_FILENAME)
         self.client.put_object(
             Body=json.dumps(context).encode("utf-8"), Bucket=self.bucket, Key=key


### PR DESCRIPTION
Fixes https://github.com/dagster-io/dagster/issues/31974

- TL;DR the docstring for PipesS3ContextInjector says it's intended to support a custom key prefix, but this isn't implemented in the code
- I've swapped boto3.client for S3Client in type hints as the former isn't a type but a function
- I've added a test for the class though I've noticed that overall `pipes_tests` are pretty high-level so happy to remove it if it's considered not useful.
