### PR TITLE
FE-949: Fix clear button in the ranged partition input

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeInput.tsx
@@ -68,12 +68,17 @@ export const DimensionRangeInput = ({
       onBlur={tryCommit}
       disabled={disabled}
       rightElement={
-        <ClearButton
-          style={{display: valueString.length ? 'initial' : 'none'}}
-          onClick={() => onChange([])}
-        >
-          <Icon name="cancel" />
-        </ClearButton>
+        disabled ? undefined : (
+          <ClearButton
+            style={{display: valueString.length ? 'initial' : 'none'}}
+            onClick={() => {
+              setValueString('');
+              onChange([]);
+            }}
+          >
+            <Icon name="cancel" />
+          </ClearButton>
+        )
       }
     />
   );


### PR DESCRIPTION
## Summary & Motivation

This is happening because the clear button only changes the controlled value, not the state of the text input. I think it was recently broken out to support the presets at the top of the dialog.

This PR also hides the Clear icon when the input is `disabled`, you can't edit the text so I believe clear should also not do anything.

<img width="731" height="214" alt="image" src="https://github.com/user-attachments/assets/3cee3e16-abd1-4844-a6b7-e54aea50d41c" />

## How I Tested These Changes

Enter both valid and invalid selections, click "X" to clear. 

## Changelog

[ui] The "Clear" button in the dimension partition text input now clears invalid selections as expected.