### PR TITLE
ADOPT-1195: Add missing Alert Policies tab to asset graph job sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphJobSidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphJobSidebar.tsx
@@ -1,3 +1,6 @@
+import {Box, ErrorBoundary, Tab, Tabs} from '@dagster-io/ui-components';
+import {useJobSidebarAlertsTabConfig} from 'shared/pipelines/useJobSidebarAlertsTabConfig.oss';
+
 import {gql, useQuery} from '../apollo-client';
 import {
   AssetGraphSidebarQuery,
@@ -5,13 +8,17 @@ import {
 } from './types/AssetGraphJobSidebar.types';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PipelineSelector} from '../graphql/types';
+import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
+import {RightInfoPanelContent} from '../pipelines/GraphExplorer';
 import {NonIdealPipelineQueryResult} from '../pipelines/NonIdealPipelineQueryResult';
 import {
   SIDEBAR_ROOT_CONTAINER_FRAGMENT,
   SidebarContainerOverview,
 } from '../pipelines/SidebarContainerOverview';
+import {TabDefinition} from '../pipelines/types';
 import {Loading} from '../ui/Loading';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
+import {RepoAddress} from '../workspace/types';
 
 interface Props {
   pipelineSelector: PipelineSelector;
@@ -40,11 +47,61 @@ export const AssetGraphJobSidebar = ({pipelineSelector}: Props) => {
             />
           );
         }
+
         return (
-          <SidebarContainerOverview container={pipelineSnapshotOrError} repoAddress={repoAddress} />
+          <AssetGraphJobSidebarContent
+            pipelineSelector={pipelineSelector}
+            pipelineSnapshot={pipelineSnapshotOrError}
+            repoAddress={repoAddress}
+          />
         );
       }}
     </Loading>
+  );
+};
+
+export const AssetGraphJobSidebarContent = ({
+  repoAddress,
+  pipelineSelector,
+  pipelineSnapshot,
+}: Props & {
+  repoAddress: RepoAddress;
+  pipelineSnapshot: Extract<
+    AssetGraphSidebarQuery['pipelineSnapshotOrError'],
+    {__typename: 'PipelineSnapshot'}
+  >;
+}) => {
+  const [activeTab, setActiveTab] = useQueryPersistedState({
+    queryKey: 'tab',
+    defaults: {tab: 'info'},
+  });
+
+  const tabDefinitions: TabDefinition[] = [
+    {
+      name: 'Info',
+      key: 'info' as const,
+      content: () => (
+        <SidebarContainerOverview container={pipelineSnapshot} repoAddress={repoAddress} />
+      ),
+    },
+    useJobSidebarAlertsTabConfig({repoAddress, jobName: pipelineSelector.pipelineName}),
+  ].filter((tab) => tab !== null);
+
+  return (
+    <>
+      <Box padding={{horizontal: 24}} border="bottom">
+        <Tabs selectedTabId={activeTab}>
+          {tabDefinitions.map(({name, key}) => (
+            <Tab id={key} key={key} onClick={() => setActiveTab(key)} title={name} />
+          ))}
+        </Tabs>
+      </Box>
+      <RightInfoPanelContent>
+        <ErrorBoundary region="tab" resetErrorOnChange={[activeTab, pipelineSelector.pipelineName]}>
+          {tabDefinitions.find((t) => t.key === activeTab)?.content()}
+        </ErrorBoundary>
+      </RightInfoPanelContent>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary & Motivation

This is a bit of an old one - https://linear.app/dagster-labs/issue/ADOPT-1195/the-alert-policies-of-a-job-are-only-visibile-if-you-toggle-from-asset.

On the Op Job overview, the graph sidebar has Info, Types, and Alert Policies tabs. In the Asset Job overview, there are no tabs in the sidebar and there's no way to see the alert policies of the job. You can see them by toggling off "View as Asset Graph".

This PR brings the same tab style used in the Op Job sidebar to the Asset Job sidebar and adds the Alert Policies tab:

Before:
<img width="1721" height="777" alt="image" src="https://github.com/user-attachments/assets/7d1f05c4-d796-4846-8a8a-763c290b00b1" />


After:
<img width="1727" height="661" alt="image" src="https://github.com/user-attachments/assets/1fc96d72-45aa-4768-8e79-b232d10ac543" />


## How I Tested These Changes

- Verified that there's no impact in the global graph or catalog graph pages
- Verified that the tab query param is handled properly and doesn't get cleared by other params on the graph

## Changelog

[ui] When viewing an asset job, alert policies are now visible from a tab in the right sidebar.