### PR TITLE
support inf/-inf in float metadata values

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2957,6 +2957,7 @@ type FloatMetadataEntry implements MetadataEntry {
   label: String!
   description: String
   floatValue: Float
+  floatRepr: String!
 }
 
 type IntMetadataEntry implements MetadataEntry {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1884,6 +1884,7 @@ export type FieldsNotDefinedConfigError = PipelineConfigValidationError & {
 export type FloatMetadataEntry = MetadataEntry & {
   __typename: 'FloatMetadataEntry';
   description: Maybe<Scalars['String']['output']>;
+  floatRepr: Scalars['String']['output'];
   floatValue: Maybe<Scalars['Float']['output']>;
   label: Scalars['String']['output'];
 };
@@ -9342,6 +9343,7 @@ export const buildFloatMetadataEntry = (
     __typename: 'FloatMetadataEntry',
     description:
       overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'iusto',
+    floatRepr: overrides && overrides.hasOwnProperty('floatRepr') ? overrides.floatRepr! : 'omnis',
     floatValue: overrides && overrides.hasOwnProperty('floatValue') ? overrides.floatValue! : 5.68,
     label: overrides && overrides.hasOwnProperty('label') ? overrides.label! : 'velit',
   };

--- a/python_modules/dagster-graphql/dagster_graphql/client/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/query.py
@@ -23,6 +23,7 @@ fragment metadataEntryFragment on MetadataEntry {
   description
   ... on FloatMetadataEntry {
     floatValue
+    floatRepr
   }
   ... on IntMetadataEntry {
     intRepr

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -120,13 +120,16 @@ def iterate_metadata_entries(metadata: Mapping[str, MetadataValue]) -> Iterator[
         elif isinstance(value, FloatMetadataValue):
             float_val = value.value
 
-            # coerce NaN to null
-            if float_val is not None and isnan(float_val):
+            # coerce NaN and inf/-inf to null
+            if float_val is not None and (
+                isnan(float_val) or (float_val in [float("inf"), float("-inf")])
+            ):
                 float_val = None
 
             yield GrapheneFloatMetadataEntry(
                 label=key,
                 floatValue=float_val,
+                floatRepr=str(value.value),
             )
         elif isinstance(value, IntMetadataValue):
             # coerce > 32 bit ints to null

--- a/python_modules/dagster-graphql/dagster_graphql/schema/metadata.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/metadata.py
@@ -108,6 +108,10 @@ class GraphenePythonArtifactMetadataEntry(graphene.ObjectType):
 
 class GrapheneFloatMetadataEntry(graphene.ObjectType):
     floatValue = graphene.Field(graphene.Float)
+    floatRepr = graphene.NonNull(
+        graphene.String,
+        description="String representation of the float to support nan/inf/-inf",
+    )
 
     class Meta:
         interfaces = (GrapheneMetadataEntry,)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -728,6 +728,8 @@ def materialization_job():
                 ),
                 "my job": MetadataValue.job("materialization_job", location_name="test_location"),
                 "some_class": ObjectMetadataValue(SomeClass()),
+                "float inf": float("inf"),
+                "float -inf": float("-inf"),
             },
         )
         yield Output(None)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_materializations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_materializations.py
@@ -100,6 +100,16 @@ class TestMaterializations(ExecutingGraphQLContextTestMatrix):
         assert entry["__typename"] == "TextMetadataEntry"
         assert entry["text"] == "SomeClass"
 
+        entry = mat["metadataEntries"][16]
+        assert entry["__typename"] == "FloatMetadataEntry"
+        assert entry["floatValue"] is None
+        assert entry["floatRepr"] == "inf"
+
+        entry = mat["metadataEntries"][17]
+        assert entry["__typename"] == "FloatMetadataEntry"
+        assert entry["floatValue"] is None
+        assert entry["floatRepr"] == "-inf"
+
         non_engine_event_logs = [
             message for message in logs if message["__typename"] != "EngineEvent"
         ]


### PR DESCRIPTION
Summary:
These are valid python float values but not graphql float values. Add a floatRepr field similar to intRepr so that there is some way to expose those values in the graphql layer.

## How I Tested These Changes
BK

## Changelog
Fixed an issue where setting a FloatMetadataValue to float('inf') or float('-inf') would cause an error when loading that metadata over graphql.

