### PR TITLE
[5/b] Add more complicated non-subsettable multi asset case, fix error

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -15,7 +15,10 @@ from dagster import _check as check
 from dagster._check import CheckError
 from dagster._core.asset_graph_view.asset_graph_subset_view import AssetGraphSubsetView
 from dagster._core.asset_graph_view.entity_subset import EntitySubset, _ValidatedEntitySubsetValue
-from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
+from dagster._core.asset_graph_view.serializable_entity_subset import (
+    EntitySubsetValue,
+    SerializableEntitySubset,
+)
 from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey, EntityKey, T_EntityKey
 from dagster._core.definitions.assets.graph.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
@@ -245,6 +248,12 @@ class AssetGraphView(LoadingContext):
         return EntitySubset(
             self, key=key, value=_ValidatedEntitySubsetValue(serializable_subset.value)
         )
+
+    @use_partition_loading_context
+    def get_entity_subset_from_subset_value(
+        self, key: AssetKey, value: EntitySubsetValue
+    ) -> EntitySubset[AssetKey]:
+        return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
 
     def _with_current_partitions_def(
         self, serializable_subset: SerializableEntitySubset


### PR DESCRIPTION
## Summary & Motivation

To avoid extremely painful rebasing issues, I left this bug in downstack PRs (that being said, we didn't have test coverage for this prior to this stack, which was somewhat surprising).

Previous PRs in the stack ripped out all non-subsettable-multi-asset-aware logic from the asset backfill system. I've now added it back in in as clean a way as I could manage. This lets the core asset backfill logic not think AT ALL about the subsettability of multi-assets, and instead offloads that work to the outer loop, which enforces that all assets always have identical requested subsets. It does this by delaying evaluation of any asset until ALL members of its execution set have been seen in the topological iteration. From there, it iterates over the execution set in topological order, and whenever any member of the subset is evaluated, we go back through any previously-generated results and intersect their value with the new result's value, and add in a rejection reason if necessary.

One thing to note is that this is slightly different conceptually from the previous logic, which would evaluate the entire execution set as soon as the FIRST element of the asset was encountered. There is not a particular reason to prefer one of these over the other as far as I can tell. The reason I did it this way was because it means we can topologically sort the elements of the execution set "for free", as we just track them as we iterate through the already toposorted asset keys. The net effect should be that now it is more likely for downstream asset to get grouped together in the same run as the multi-asset, and less likely for the multi-asset to be grouped together with upstream assets.

## How I Tested These Changes

## Changelog

NOCHANGELOG
