### PR TITLE
[ui] Fix materialization reporting for non-partitioned assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsDialog.tsx
@@ -235,6 +235,22 @@ const ReportEventDialogBody = ({
     }
   };
 
+  const tooltipState = useMemo(() => {
+    if (!asset.hasReportRunlessAssetEventPermission) {
+      return {
+        content: DEFAULT_DISABLED_REASON,
+        canShow: true,
+      };
+    }
+    if (asset.isPartitioned && keysFiltered.length === 0) {
+      return {
+        content: 'No partitions selected',
+        canShow: true,
+      };
+    }
+    return {content: '', canShow: false};
+  }, [asset, keysFiltered.length]);
+
   return (
     <>
       <DialogHeader
@@ -309,26 +325,21 @@ const ReportEventDialogBody = ({
       </Box>
       <DialogFooter topBorder>
         <Button onClick={() => setIsOpen(false)}>Cancel</Button>
-        <Tooltip content="No partitions selected" canShow={keysFiltered.length === 0}>
-          <Tooltip
-            content={DEFAULT_DISABLED_REASON}
-            canShow={!asset.hasReportRunlessAssetEventPermission}
+        <Tooltip content={tooltipState.content} canShow={tooltipState.canShow}>
+          <Button
+            intent="primary"
+            onClick={onReportEvent}
+            disabled={
+              !asset.hasReportRunlessAssetEventPermission ||
+              isReporting ||
+              (asset.isPartitioned && keysFiltered.length === 0)
+            }
+            loading={isReporting}
           >
-            <Button
-              intent="primary"
-              onClick={onReportEvent}
-              disabled={
-                !asset.hasReportRunlessAssetEventPermission ||
-                isReporting ||
-                keysFiltered.length === 0
-              }
-              loading={isReporting}
-            >
-              {keysFiltered.length > 1
-                ? `Report ${keysFiltered.length.toLocaleString()} events`
-                : 'Report event'}
-            </Button>
-          </Tooltip>
+            {keysFiltered.length > 1
+              ? `Report ${keysFiltered.length.toLocaleString()} events`
+              : 'Report event'}
+          </Button>
         </Tooltip>
       </DialogFooter>
     </>


### PR DESCRIPTION
## Summary & Motivation

When trying to report materializations on non-partitioned assets, the report dialog is disabled because it's expecting partitions to have been selected.

Don't disable the button if the asset is non-partitioned.

Also consolidate the nested Tooltip elements.

<img width="723" height="284" alt="Screenshot 2025-09-12 at 13 40 17" src="https://github.com/user-attachments/assets/9b9ded71-cbb1-46af-b4d9-8361d24e8f9d" />

## How I Tested These Changes

View a non-partitioned asset, open dialog to report materialization. Verify that the button is not disabled.

Open it for a partitioned asset, verify that its behavior is correct.

## Changelog

[ui] Fix "Report materialization" dialog for non-partitioned assets.