### PR TITLE
[cached_method] no args fast path

### DIFF
--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/cached_method.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/cached_method.py
@@ -105,9 +105,11 @@ def cached_method(method: Callable[Concatenate[S, P], T]) -> Callable[Concatenat
                 cache_dict[method.__name__] = {}
 
             cache = cache_dict[method.__name__]
-
-            canonical_kwargs = get_canonical_kwargs(*args, **kwargs)
-            key = make_cached_method_cache_key(canonical_kwargs)
+            if not args and not kwargs:
+                key = NO_ARGS_HASH_VALUE
+            else:
+                canonical_kwargs = get_canonical_kwargs(*args, **kwargs)
+                key = make_cached_method_cache_key(canonical_kwargs)
 
             if key not in cache:
                 result = await method(self, *args, **kwargs)
@@ -128,9 +130,12 @@ def cached_method(method: Callable[Concatenate[S, P], T]) -> Callable[Concatenat
                 cache_dict[method.__name__] = {}
 
             cache = cache_dict[method.__name__]
+            if not args and not kwargs:
+                key = NO_ARGS_HASH_VALUE
+            else:
+                canonical_kwargs = get_canonical_kwargs(*args, **kwargs)
+                key = make_cached_method_cache_key(canonical_kwargs)
 
-            canonical_kwargs = get_canonical_kwargs(*args, **kwargs)
-            key = make_cached_method_cache_key(canonical_kwargs)
             if key not in cache:
                 result = method(self, *args, **kwargs)
                 cache[key] = result


### PR DESCRIPTION
not a super common pattern but when we use `cached_method` on a fn with no args the extra fn calls to discern `NO_ARGS_HASH_VALUE` add up 

## How I Tested These Changes


```
import timeit

from dagster._utils.cached_method import cached_method


class Obj:
    @cached_method
    def cached(self):
        return Obj()


N = 10_000_000


defaults_cached_t = timeit.Timer(
    "obj.cached()",
    setup="obj = Obj(); obj.cached()",
    globals=globals(),
)
print(f"Time: {defaults_cached_t.timeit(N)}")
```

before: `Time: 1.7275132079957984`

after: `Time: 1.1115726659772918`