### PR TITLE
GroupsAssetSelection speedup, round 2

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -941,16 +941,12 @@ class GroupsAssetSelection(AssetSelection):
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
-        base_set = (
-            asset_graph.get_all_asset_keys()
-            if self.include_sources
-            else asset_graph.materializable_asset_keys
-        )
         return {
             key
             for group in self.selected_groups
-            for key in asset_graph.asset_keys_for_group(group)
-            if key is not None and key in base_set
+            for key in asset_graph.asset_keys_for_group(
+                group, require_materializable=not self.include_sources
+            )
         }
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":

--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/base_asset_graph.py
@@ -366,8 +366,17 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
         return {node.key for node in self.asset_nodes if not node.is_partitioned}
 
     @cached_method
-    def asset_keys_for_group(self, group_name: str) -> AbstractSet[AssetKey]:
-        return {node.key for node in self.asset_nodes if node.group_name == group_name}
+    def asset_keys_for_group(
+        self, group_name: str, require_materializable: bool = False
+    ) -> AbstractSet[AssetKey]:
+        if require_materializable:
+            return {
+                node.key
+                for node in self.asset_nodes
+                if node.group_name == group_name and node.is_materializable
+            }
+        else:
+            return {node.key for node in self.asset_nodes if node.group_name == group_name}
 
     @cached_method
     def asset_keys_for_partitions_def(


### PR DESCRIPTION
Summary:
Use this as a filter to asset_keys_for_group rather than doing an intersection of two very large sets

BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
