### PR TITLE
Apply a default chunk size to RunRecord loader

### DIFF
--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -63,6 +63,7 @@ from dagster._core.instance_for_test import (
     instance_for_test as instance_for_test,
 )
 from dagster._core.launcher import RunLauncher
+from dagster._core.loader import LoadingContext
 from dagster._core.remote_origin import InProcessCodeLocationOrigin
 from dagster._core.remote_representation.code_location import CodeLocation
 from dagster._core.remote_representation.external import RemoteRepository
@@ -830,3 +831,19 @@ def get_paginated_partition_keys(
             raise Exception("Too many pages")
 
     return all_results
+
+
+class BasicLoadingContext(LoadingContext):
+    def __init__(self, instance: Optional[DagsterInstance] = None):
+        from unittest import mock
+
+        self._loaders = {}
+        self._instance = instance or mock.MagicMock()
+
+    @property
+    def loaders(self):
+        return self._loaders
+
+    @property
+    def instance(self):
+        return self._instance

--- a/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
@@ -4,10 +4,15 @@ from contextlib import contextmanager
 
 import dagster as dg
 import pytest
-from dagster import DagsterInstance
+from dagster import (
+    DagsterInstance,
+    _check as check,
+)
 from dagster._core.storage.legacy_storage import LegacyRunStorage
 from dagster._core.storage.runs import InMemoryRunStorage, SqliteRunStorage
 from dagster._core.storage.sqlite_storage import DagsterSqliteStorage
+from dagster._core.test_utils import BasicLoadingContext, environ
+from dagster_test.utils.data_factory import dagster_run
 
 from dagster_tests.storage_tests.utils.run_storage import TestRunStorage
 
@@ -139,3 +144,33 @@ class TestLegacyRunStorage(TestRunStorage):
 
     def test_storage_telemetry(self, storage):
         pass
+
+
+@pytest.mark.asyncio
+async def test_batch_run_loader():
+    with dg.instance_for_test() as instance:
+        context = BasicLoadingContext(instance)
+        run_1 = instance.run_storage.add_run(
+            dagster_run(job_name="some_pipeline", tags={"foo": "bar"})
+        )
+        run_2 = instance.run_storage.add_run(
+            dagster_run(job_name="some_pipeline", tags={"foo": "bar"})
+        )
+        run_3 = instance.run_storage.add_run(
+            dagster_run(job_name="some_pipeline", tags={"foo": "bar"})
+        )
+
+        records = await dg.RunRecord.gen_many(context, [run_1.run_id, run_2.run_id, run_3.run_id])
+        assert records
+        records = list(records)
+
+        assert len(records) == 3
+        assert check.not_none(records[0]).dagster_run.run_id == run_1.run_id
+        assert check.not_none(records[1]).dagster_run.run_id == run_2.run_id
+        assert check.not_none(records[2]).dagster_run.run_id == run_3.run_id
+
+        with environ({"DAGSTER_RUN_RECORD_LOADER_BATCH_SIZE": "2"}):
+            chunk_records = await dg.RunRecord.gen_many(
+                context, [run_1.run_id, run_2.run_id, run_3.run_id]
+            )
+            assert chunk_records == records


### PR DESCRIPTION
## Summary & Motivation
Applies a limit to the number of runs that the run record loader will fetch in a single storage / sql call, to guard against statement timeouts.

Came up on https://github.com/dagster-io/dagster/pull/32141 where I initially added chunking around RunRecord.gen and owen suggested that it should be part of the default loader implementation instead.

## How I Tested These Changes
BK