### PR TITLE
[dg] adds `dg api sensor list` and `dg api sensor get`

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/api/sensor.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/api/sensor.py
@@ -1,0 +1,52 @@
+"""Sensor API implementation."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from dagster_dg_cli.api_layer.graphql_adapter.sensor import (
+    get_sensor_via_graphql,
+    list_sensors_via_graphql,
+)
+from dagster_dg_cli.utils.plus.gql_client import IGraphQLClient
+
+if TYPE_CHECKING:
+    from dagster_dg_cli.api_layer.schemas.sensor import DgApiSensor, DgApiSensorList
+
+
+@dataclass(frozen=True)
+class DgApiSensorApi:
+    """API for sensor operations."""
+
+    client: IGraphQLClient
+
+    def list_sensors(
+        self,
+        repository_location_name: Optional[str] = None,
+        repository_name: Optional[str] = None,
+    ) -> "DgApiSensorList":
+        """List all sensors, optionally filtered by repository location and name."""
+        return list_sensors_via_graphql(
+            self.client,
+            repository_location_name=repository_location_name,
+            repository_name=repository_name,
+        )
+
+    def get_sensor(
+        self,
+        sensor_name: str,
+        repository_location_name: str,
+        repository_name: str,
+    ) -> "DgApiSensor":
+        """Get sensor by name and repository details."""
+        return get_sensor_via_graphql(
+            self.client,
+            sensor_name=sensor_name,
+            repository_location_name=repository_location_name,
+            repository_name=repository_name,
+        )
+
+    def get_sensor_by_name(self, sensor_name: str) -> "DgApiSensor":
+        """Get sensor by name, searching across all repositories."""
+        from dagster_dg_cli.api_layer.graphql_adapter.sensor import get_sensor_by_name_via_graphql
+
+        return get_sensor_by_name_via_graphql(self.client, sensor_name=sensor_name)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/graphql_adapter/sensor.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/graphql_adapter/sensor.py
@@ -267,12 +267,16 @@ def get_sensor_via_graphql(
         }
     }
 
+
     try:
         result = client.execute(GET_SENSOR_QUERY, variables)
-    except Exception:
-        raise Exception(f"Sensor not found: {sensor_name}")
+        if result.get("data", {}).get("sensorOrError", {}).get("__typename") == "SensorNotFoundError":
+            raise Exception(f"Sensor not found: {sensor_name}")
+        return process_sensor_response(result)
+    except Exception as e:
+        # Re-raise the original exception with its traceback preserved
+        raise
 
-    return process_sensor_response(result)
 
 
 def get_sensor_by_name_via_graphql(client: IGraphQLClient, sensor_name: str) -> "DgApiSensor":

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/graphql_adapter/sensor.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/graphql_adapter/sensor.py
@@ -1,0 +1,297 @@
+"""GraphQL implementation for sensor operations."""
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from dagster_dg_cli.utils.plus.gql_client import IGraphQLClient
+
+if TYPE_CHECKING:
+    from dagster_dg_cli.api_layer.schemas.sensor import DgApiSensor, DgApiSensorList
+
+# GraphQL queries
+# Query for when we have a specific repository
+LIST_SENSORS_QUERY = """
+query ListSensors($repositorySelector: RepositorySelector!) {
+    sensorsOrError(repositorySelector: $repositorySelector) {
+        __typename
+        ... on Sensors {
+            results {
+                id
+                name
+                sensorState {
+                    status
+                }
+                sensorType
+                description
+            }
+        }
+        ... on RepositoryNotFoundError {
+            message
+        }
+        ... on PythonError {
+            message
+            stack
+        }
+    }
+}
+"""
+
+# Query to get all repositories so we can list all sensors
+LIST_REPOSITORIES_QUERY = """
+query ListRepositories {
+    repositoriesOrError {
+        __typename
+        ... on RepositoryConnection {
+            nodes {
+                name
+                location {
+                    name
+                }
+                sensors {
+                    id
+                    name
+                    sensorState {
+                        status
+                    }
+                    sensorType
+                    description
+                }
+            }
+        }
+        ... on PythonError {
+            message
+            stack
+        }
+    }
+}
+"""
+
+GET_SENSOR_QUERY = """
+query GetSensor($sensorSelector: SensorSelector!) {
+    sensorOrError(sensorSelector: $sensorSelector) {
+        __typename
+        ... on Sensor {
+            id
+            name
+            sensorState {
+                status
+            }
+            sensorType
+            description
+        }
+        ... on SensorNotFoundError {
+            message
+        }
+        ... on PythonError {
+            message
+            stack
+        }
+    }
+}
+"""
+
+
+def process_repositories_response(graphql_response: dict[str, Any]) -> "DgApiSensorList":
+    """Process GraphQL response from repositories query into DgApiSensorList."""
+    # Import pydantic models only when needed
+    from dagster_dg_cli.api_layer.schemas.sensor import (
+        DgApiSensor,
+        DgApiSensorList,
+        DgApiSensorStatus,
+        DgApiSensorType,
+    )
+
+    repositories_result = graphql_response.get("repositoriesOrError")
+    if not repositories_result:
+        raise Exception("No repositories data in GraphQL response")
+
+    typename = repositories_result.get("__typename")
+    if typename != "RepositoryConnection":
+        error_msg = repositories_result.get("message", f"GraphQL error: {typename}")
+        raise Exception(error_msg)
+
+    repositories_data = repositories_result.get("nodes", [])
+
+    sensors = []
+    for repo in repositories_data:
+        repo_name = repo.get("name", "")
+        location_name = repo.get("location", {}).get("name", "")
+        repository_origin = f"{location_name}@{repo_name}" if location_name and repo_name else None
+
+        for s in repo.get("sensors", []):
+            # Extract status from sensor state
+            sensor_state = s.get("sensorState", {})
+            status = sensor_state.get("status", "STOPPED")
+
+            sensor = DgApiSensor(
+                id=s["id"],
+                name=s["name"],
+                status=DgApiSensorStatus(status),
+                sensor_type=DgApiSensorType(s.get("sensorType", "STANDARD")),
+                description=s.get("description"),
+                repository_origin=repository_origin,
+                next_tick_timestamp=None,  # Not available in this query
+            )
+            sensors.append(sensor)
+
+    return DgApiSensorList(
+        items=sensors,
+        total=len(sensors),
+    )
+
+
+def process_sensors_response(graphql_response: dict[str, Any]) -> "DgApiSensorList":
+    """Process GraphQL response into DgApiSensorList.
+
+    Args:
+        graphql_response: Raw GraphQL response containing "sensorsOrError"
+
+    Returns:
+        DgApiSensorList: Processed sensor data
+    """
+    # Import pydantic models only when needed
+    from dagster_dg_cli.api_layer.schemas.sensor import (
+        DgApiSensor,
+        DgApiSensorList,
+        DgApiSensorStatus,
+        DgApiSensorType,
+    )
+
+    sensors_result = graphql_response.get("sensorsOrError")
+    if not sensors_result:
+        raise Exception("No sensors data in GraphQL response")
+
+    typename = sensors_result.get("__typename")
+    if typename != "Sensors":
+        error_msg = sensors_result.get("message", f"GraphQL error: {typename}")
+        raise Exception(error_msg)
+
+    sensors_data = sensors_result.get("results", [])
+
+    sensors = []
+    for s in sensors_data:
+        # Extract status from sensor state
+        sensor_state = s.get("sensorState", {})
+        status = sensor_state.get("status", "STOPPED")
+
+        sensor = DgApiSensor(
+            id=s["id"],
+            name=s["name"],
+            status=DgApiSensorStatus(status),
+            sensor_type=DgApiSensorType(s.get("sensorType", "STANDARD")),
+            description=s.get("description"),
+            repository_origin=None,  # Will be populated later when we fix the schema
+            next_tick_timestamp=None,  # Will be populated later when we fix the schema
+        )
+        sensors.append(sensor)
+
+    return DgApiSensorList(
+        items=sensors,
+        total=len(sensors),
+    )
+
+
+def process_sensor_response(graphql_response: dict[str, Any]) -> "DgApiSensor":
+    """Process GraphQL response into DgApiSensor.
+
+    Args:
+        graphql_response: Raw GraphQL response containing "sensorOrError"
+
+    Returns:
+        DgApiSensor: Processed sensor data
+    """
+    # Import pydantic models only when needed
+    from dagster_dg_cli.api_layer.schemas.sensor import (
+        DgApiSensor,
+        DgApiSensorStatus,
+        DgApiSensorType,
+    )
+
+    sensor_result = graphql_response.get("sensorOrError")
+    if not sensor_result:
+        raise Exception("No sensor data in GraphQL response")
+
+    typename = sensor_result.get("__typename")
+    if typename != "Sensor":
+        error_msg = sensor_result.get("message", f"GraphQL error: {typename}")
+        raise Exception(error_msg)
+
+    # Extract status from sensor state
+    sensor_state = sensor_result.get("sensorState", {})
+    status = sensor_state.get("status", "STOPPED")
+
+    return DgApiSensor(
+        id=sensor_result["id"],
+        name=sensor_result["name"],
+        status=DgApiSensorStatus(status),
+        sensor_type=DgApiSensorType(sensor_result.get("sensorType", "STANDARD")),
+        description=sensor_result.get("description"),
+        repository_origin=None,  # Will be populated later when we fix the schema
+        next_tick_timestamp=None,  # Will be populated later when we fix the schema
+    )
+
+
+def list_sensors_via_graphql(
+    client: IGraphQLClient,
+    repository_location_name: Optional[str] = None,
+    repository_name: Optional[str] = None,
+) -> "DgApiSensorList":
+    """Fetch sensors using GraphQL."""
+    if repository_location_name and repository_name:
+        # Query specific repository
+        variables = {
+            "repositorySelector": {
+                "repositoryLocationName": repository_location_name,
+                "repositoryName": repository_name,
+            }
+        }
+        result = client.execute(LIST_SENSORS_QUERY, variables)
+        return process_sensors_response(result)
+    else:
+        # Query all repositories to get all sensors
+        result = client.execute(LIST_REPOSITORIES_QUERY)
+        return process_repositories_response(result)
+
+
+def get_sensor_via_graphql(
+    client: IGraphQLClient,
+    sensor_name: str,
+    repository_location_name: str,
+    repository_name: str,
+) -> "DgApiSensor":
+    """Get single sensor via GraphQL."""
+    variables = {
+        "sensorSelector": {
+            "sensorName": sensor_name,
+            "repositoryLocationName": repository_location_name,
+            "repositoryName": repository_name,
+        }
+    }
+
+    try:
+        result = client.execute(GET_SENSOR_QUERY, variables)
+    except Exception:
+        raise Exception(f"Sensor not found: {sensor_name}")
+
+    return process_sensor_response(result)
+
+
+def get_sensor_by_name_via_graphql(client: IGraphQLClient, sensor_name: str) -> "DgApiSensor":
+    """Get sensor by name, searching across all repositories."""
+    # First, get all sensors
+    result = client.execute(LIST_REPOSITORIES_QUERY)
+    all_sensors = process_repositories_response(result)
+
+    # Find the sensor with the matching name
+    matching_sensors = [sensor for sensor in all_sensors.items if sensor.name == sensor_name]
+
+    if not matching_sensors:
+        raise Exception(f"Sensor not found: {sensor_name}")
+
+    if len(matching_sensors) > 1:
+        # If there are multiple sensors with the same name, provide helpful error
+        repo_origins = [sensor.repository_origin for sensor in matching_sensors]
+        raise Exception(
+            f"Multiple sensors found with name '{sensor_name}' in repositories: {', '.join(repo_origins)}"
+        )
+
+    return matching_sensors[0]

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/graphql_adapter/sensor.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/graphql_adapter/sensor.py
@@ -289,7 +289,7 @@ def get_sensor_by_name_via_graphql(client: IGraphQLClient, sensor_name: str) -> 
 
     if len(matching_sensors) > 1:
         # If there are multiple sensors with the same name, provide helpful error
-        repo_origins = [sensor.repository_origin for sensor in matching_sensors]
+        repo_origins = [sensor.repository_origin or "unknown" for sensor in matching_sensors]
         raise Exception(
             f"Multiple sensors found with name '{sensor_name}' in repositories: {', '.join(repo_origins)}"
         )

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/schemas/sensor.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/schemas/sensor.py
@@ -1,0 +1,46 @@
+"""Sensor metadata schema definitions."""
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class DgApiSensorStatus(str, Enum):
+    """Sensor execution status."""
+
+    RUNNING = "RUNNING"
+    STOPPED = "STOPPED"
+    PAUSED = "PAUSED"
+
+
+class DgApiSensorType(str, Enum):
+    """Sensor type classification."""
+
+    STANDARD = "STANDARD"
+    MULTI_ASSET = "MULTI_ASSET"
+    FRESHNESS_POLICY = "FRESHNESS_POLICY"
+    AUTO_MATERIALIZE = "AUTO_MATERIALIZE"
+    ASSET = "ASSET"
+
+
+class DgApiSensor(BaseModel):
+    """Single sensor metadata model."""
+
+    id: str
+    name: str
+    status: DgApiSensorStatus
+    sensor_type: DgApiSensorType
+    description: Optional[str] = None
+    repository_origin: Optional[str] = None
+    next_tick_timestamp: Optional[float] = None  # Unix timestamp
+
+    class Config:
+        from_attributes = True
+
+
+class DgApiSensorList(BaseModel):
+    """GET /api/sensors response."""
+
+    items: list[DgApiSensor]
+    total: int

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/API_IMPLEMENTATION_PLAN.md
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/API_IMPLEMENTATION_PLAN.md
@@ -151,11 +151,14 @@ dg api schedule stop <schedule-name> --location <name>
 
 **GraphQL**: `schedulesOrError`, `scheduleOrError`
 
-### 13. **sensor**
+### 13. **sensor** ✅ _list/get implemented_
 
 ```bash
-dg api sensor list [--location <name>] [--status <running|stopped>] [--json]
-dg api sensor get <sensor-name> --location <name> [--json]
+# Implemented
+dg api sensor list [--status <running|stopped>] [--json]
+dg api sensor get <sensor-name> [--json]
+
+# Future verbs
 dg api sensor start <sensor-name> --location <name>
 dg api sensor stop <sensor-name> --location <name>
 ```
@@ -380,6 +383,7 @@ dagster_dg_cli/cli/plus/api/
 ## **Implementation Status**
 
 - ✅ **deployment list** - Completed
+- ✅ **sensor list/get** - Completed (repository concepts hidden from end users)
 - 🚧 **Next**: secret, agent, run, asset (Phase 1)
 - 📋 **Planned**: 22 additional nouns across 4 more phases
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/cli_group.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/cli_group.py
@@ -8,6 +8,7 @@ from dagster_dg_cli.cli.api.asset import asset_group
 from dagster_dg_cli.cli.api.deployment import deployment_group
 from dagster_dg_cli.cli.api.run import run_group
 from dagster_dg_cli.cli.api.run_event import run_events_group
+from dagster_dg_cli.cli.api.sensor import sensor_group
 
 
 @click.group(
@@ -20,6 +21,7 @@ from dagster_dg_cli.cli.api.run_event import run_events_group
         "deployment": deployment_group,
         "run": run_group,
         "run-events": run_events_group,
+        "sensor": sensor_group,
     },
 )
 def api_group():

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/sensor.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/sensor.py
@@ -1,0 +1,200 @@
+"""Sensor API commands following GitHub CLI patterns."""
+
+import datetime
+import json
+from typing import TYPE_CHECKING
+
+import click
+from dagster_dg_core.utils import DgClickCommand, DgClickGroup
+from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
+from dagster_shared.plus.config import DagsterPlusCliConfig
+from dagster_shared.plus.config_utils import dg_api_options
+
+from dagster_dg_cli.cli.api.client import create_dg_api_graphql_client
+
+if TYPE_CHECKING:
+    from dagster_dg_cli.api_layer.schemas.sensor import DgApiSensor, DgApiSensorList
+
+
+def format_sensors(sensors: "DgApiSensorList", as_json: bool) -> str:
+    """Format sensor list for output."""
+    if as_json:
+        # For JSON output, remove repository_origin to hide repository concepts
+        sensors_dict = sensors.model_dump()
+        for sensor in sensors_dict["items"]:
+            sensor.pop("repository_origin", None)
+        return json.dumps(sensors_dict, indent=2)
+
+    lines = []
+    for sensor in sensors.items:
+        sensor_lines = [
+            f"Name: {sensor.name}",
+            f"ID: {sensor.id}",
+            f"Status: {sensor.status.value}",
+            f"Type: {sensor.sensor_type.value}",
+            f"Description: {sensor.description or 'None'}",
+        ]
+
+        # Hide repository information from end users
+        # if sensor.repository_origin:
+        #     sensor_lines.append(f"Repository: {sensor.repository_origin}")
+
+        if sensor.next_tick_timestamp:
+            try:
+                dt = datetime.datetime.fromtimestamp(sensor.next_tick_timestamp)
+                next_tick_str = dt.strftime("%Y-%m-%d %H:%M:%S")
+            except (ValueError, OSError):
+                next_tick_str = f"Invalid timestamp: {sensor.next_tick_timestamp}"
+            sensor_lines.append(f"Next Tick: {next_tick_str}")
+
+        sensor_lines.append("")  # Empty line between sensors
+        lines.extend(sensor_lines)
+
+    return "\n".join(lines).rstrip()  # Remove trailing empty line
+
+
+def format_sensor(sensor: "DgApiSensor", as_json: bool) -> str:
+    """Format single sensor for output."""
+    if as_json:
+        # For JSON output, remove repository_origin to hide repository concepts
+        sensor_dict = sensor.model_dump()
+        sensor_dict.pop("repository_origin", None)
+        return json.dumps(sensor_dict, indent=2)
+
+    lines = [
+        f"Name: {sensor.name}",
+        f"ID: {sensor.id}",
+        f"Status: {sensor.status.value}",
+        f"Type: {sensor.sensor_type.value}",
+        f"Description: {sensor.description or 'None'}",
+    ]
+
+    # Hide repository information from end users
+    # if sensor.repository_origin:
+    #     lines.append(f"Repository: {sensor.repository_origin}")
+
+    if sensor.next_tick_timestamp:
+        try:
+            dt = datetime.datetime.fromtimestamp(sensor.next_tick_timestamp)
+            next_tick_str = dt.strftime("%Y-%m-%d %H:%M:%S")
+        except (ValueError, OSError):
+            next_tick_str = f"Invalid timestamp: {sensor.next_tick_timestamp}"
+        lines.append(f"Next Tick: {next_tick_str}")
+
+    return "\n".join(lines)
+
+
+@click.command(name="list", cls=DgClickCommand, unlaunched=True)
+@click.option(
+    "--status",
+    type=click.Choice(["RUNNING", "STOPPED", "PAUSED"]),
+    help="Filter sensors by status",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output in JSON format for machine readability",
+)
+@dg_api_options(deployment_scoped=True)
+@cli_telemetry_wrapper
+@click.pass_context
+def list_sensors_command(
+    ctx: click.Context,
+    status: str,
+    output_json: bool,
+    organization: str,
+    deployment: str,
+    api_token: str,
+    view_graphql: bool,
+) -> None:
+    """List sensors in the deployment."""
+    config = DagsterPlusCliConfig.create_for_deployment(
+        deployment=deployment,
+        organization=organization,
+        user_token=api_token,
+    )
+    client = create_dg_api_graphql_client(ctx, config, view_graphql=view_graphql)
+    from dagster_dg_cli.api_layer.api.sensor import DgApiSensorApi
+
+    api = DgApiSensorApi(client)
+
+    try:
+        # Always list all sensors (no repository filtering for end users)
+        sensors = api.list_sensors()
+
+        # Apply status filter if specified
+        if status:
+            from dagster_dg_cli.api_layer.schemas.sensor import DgApiSensorList, DgApiSensorStatus
+
+            filtered_sensors = [
+                sensor for sensor in sensors.items if sensor.status == DgApiSensorStatus(status)
+            ]
+            sensors = DgApiSensorList(items=filtered_sensors, total=len(filtered_sensors))
+
+        output = format_sensors(sensors, as_json=output_json)
+        click.echo(output)
+    except Exception as e:
+        if output_json:
+            error_response = {"error": str(e)}
+            click.echo(json.dumps(error_response), err=True)
+        else:
+            click.echo(f"Error querying Dagster Plus API: {e}", err=True)
+        raise click.ClickException(f"Failed to list sensors: {e}")
+
+
+@click.command(name="get", cls=DgClickCommand, unlaunched=True)
+@click.argument("sensor_name", type=str)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output in JSON format for machine readability",
+)
+@dg_api_options(deployment_scoped=True)
+@cli_telemetry_wrapper
+@click.pass_context
+def get_sensor_command(
+    ctx: click.Context,
+    sensor_name: str,
+    output_json: bool,
+    organization: str,
+    deployment: str,
+    api_token: str,
+    view_graphql: bool,
+) -> None:
+    """Get specific sensor details."""
+    config = DagsterPlusCliConfig.create_for_deployment(
+        deployment=deployment,
+        organization=organization,
+        user_token=api_token,
+    )
+    client = create_dg_api_graphql_client(ctx, config, view_graphql=view_graphql)
+    from dagster_dg_cli.api_layer.api.sensor import DgApiSensorApi
+
+    api = DgApiSensorApi(client)
+
+    try:
+        sensor = api.get_sensor_by_name(sensor_name=sensor_name)
+        output = format_sensor(sensor, as_json=output_json)
+        click.echo(output)
+    except Exception as e:
+        if output_json:
+            error_response = {"error": str(e)}
+            click.echo(json.dumps(error_response), err=True)
+        else:
+            click.echo(f"Error querying Dagster Plus API: {e}", err=True)
+        raise click.ClickException(f"Failed to get sensor: {e}")
+
+
+@click.group(
+    name="sensor",
+    cls=DgClickGroup,
+    unlaunched=True,
+    commands={
+        "list": list_sensors_command,
+        "get": get_sensor_command,
+    },
+)
+def sensor_group():
+    """Manage sensors in Dagster Plus."""

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/sensor.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/sensor.py
@@ -19,17 +19,17 @@ if TYPE_CHECKING:
 def format_sensors(sensors: "DgApiSensorList", as_json: bool) -> str:
     """Format sensor list for output."""
     if as_json:
-        # For JSON output, remove repository_origin to hide repository concepts
+        # For JSON output, remove repository_origin and id to hide internal concepts
         sensors_dict = sensors.model_dump()
         for sensor in sensors_dict["items"]:
             sensor.pop("repository_origin", None)
+            sensor.pop("id", None)
         return json.dumps(sensors_dict, indent=2)
 
     lines = []
     for sensor in sensors.items:
         sensor_lines = [
             f"Name: {sensor.name}",
-            f"ID: {sensor.id}",
             f"Status: {sensor.status.value}",
             f"Type: {sensor.sensor_type.value}",
             f"Description: {sensor.description or 'None'}",
@@ -56,14 +56,14 @@ def format_sensors(sensors: "DgApiSensorList", as_json: bool) -> str:
 def format_sensor(sensor: "DgApiSensor", as_json: bool) -> str:
     """Format single sensor for output."""
     if as_json:
-        # For JSON output, remove repository_origin to hide repository concepts
+        # For JSON output, remove repository_origin and id to hide internal concepts
         sensor_dict = sensor.model_dump()
         sensor_dict.pop("repository_origin", None)
+        sensor_dict.pop("id", None)
         return json.dumps(sensor_dict, indent=2)
 
     lines = [
         f"Name: {sensor.name}",
-        f"ID: {sensor.id}",
         f"Status: {sensor.status.value}",
         f"Type: {sensor.sensor_type.value}",
         f"Description: {sensor.description or 'None'}",
@@ -138,9 +138,9 @@ def list_sensors_command(
         if output_json:
             error_response = {"error": str(e)}
             click.echo(json.dumps(error_response), err=True)
+            ctx.exit(1)
         else:
-            click.echo(f"Error querying Dagster Plus API: {e}", err=True)
-        raise click.ClickException(f"Failed to list sensors: {e}")
+            raise click.ClickException(f"Failed to list sensors: {e}")
 
 
 @click.command(name="get", cls=DgClickCommand, unlaunched=True)
@@ -182,9 +182,9 @@ def get_sensor_command(
         if output_json:
             error_response = {"error": str(e)}
             click.echo(json.dumps(error_response), err=True)
+            ctx.exit(1)
         else:
-            click.echo(f"Error querying Dagster Plus API: {e}", err=True)
-        raise click.ClickException(f"Failed to get sensor: {e}")
+            raise click.ClickException(f"Failed to get sensor: {e}")
 
 
 @click.group(

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/sensor.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/sensor.py
@@ -1,6 +1,5 @@
 """Sensor API commands following GitHub CLI patterns."""
 
-import datetime
 import json
 from typing import TYPE_CHECKING
 
@@ -11,6 +10,7 @@ from dagster_shared.plus.config import DagsterPlusCliConfig
 from dagster_shared.plus.config_utils import dg_api_options
 
 from dagster_dg_cli.cli.api.client import create_dg_api_graphql_client
+from dagster_dg_cli.cli.api.formatters import _format_timestamp
 
 if TYPE_CHECKING:
     from dagster_dg_cli.api_layer.schemas.sensor import DgApiSensor, DgApiSensorList
@@ -40,11 +40,7 @@ def format_sensors(sensors: "DgApiSensorList", as_json: bool) -> str:
         #     sensor_lines.append(f"Repository: {sensor.repository_origin}")
 
         if sensor.next_tick_timestamp:
-            try:
-                dt = datetime.datetime.fromtimestamp(sensor.next_tick_timestamp)
-                next_tick_str = dt.strftime("%Y-%m-%d %H:%M:%S")
-            except (ValueError, OSError):
-                next_tick_str = f"Invalid timestamp: {sensor.next_tick_timestamp}"
+            next_tick_str = _format_timestamp(sensor.next_tick_timestamp)
             sensor_lines.append(f"Next Tick: {next_tick_str}")
 
         sensor_lines.append("")  # Empty line between sensors
@@ -74,11 +70,7 @@ def format_sensor(sensor: "DgApiSensor", as_json: bool) -> str:
     #     lines.append(f"Repository: {sensor.repository_origin}")
 
     if sensor.next_tick_timestamp:
-        try:
-            dt = datetime.datetime.fromtimestamp(sensor.next_tick_timestamp)
-            next_tick_str = dt.strftime("%Y-%m-%d %H:%M:%S")
-        except (ValueError, OSError):
-            next_tick_str = f"Invalid timestamp: {sensor.next_tick_timestamp}"
+        next_tick_str = _format_timestamp(sensor.next_tick_timestamp)
         lines.append(f"Next Tick: {next_tick_str}")
 
     return "\n".join(lines)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/sensor.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/sensor.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
 def format_sensors(sensors: "DgApiSensorList", as_json: bool) -> str:
     """Format sensor list for output."""
     if as_json:
-        # For JSON output, remove repository_origin and id to hide internal concepts
         sensors_dict = sensors.model_dump()
         for sensor in sensors_dict["items"]:
             sensor.pop("repository_origin", None)
@@ -35,10 +34,6 @@ def format_sensors(sensors: "DgApiSensorList", as_json: bool) -> str:
             f"Description: {sensor.description or 'None'}",
         ]
 
-        # Hide repository information from end users
-        # if sensor.repository_origin:
-        #     sensor_lines.append(f"Repository: {sensor.repository_origin}")
-
         if sensor.next_tick_timestamp:
             next_tick_str = _format_timestamp(sensor.next_tick_timestamp)
             sensor_lines.append(f"Next Tick: {next_tick_str}")
@@ -52,7 +47,6 @@ def format_sensors(sensors: "DgApiSensorList", as_json: bool) -> str:
 def format_sensor(sensor: "DgApiSensor", as_json: bool) -> str:
     """Format single sensor for output."""
     if as_json:
-        # For JSON output, remove repository_origin and id to hide internal concepts
         sensor_dict = sensor.model_dump()
         sensor_dict.pop("repository_origin", None)
         sensor_dict.pop("id", None)
@@ -64,10 +58,6 @@ def format_sensor(sensor: "DgApiSensor", as_json: bool) -> str:
         f"Type: {sensor.sensor_type.value}",
         f"Description: {sensor.description or 'None'}",
     ]
-
-    # Hide repository information from end users
-    # if sensor.repository_origin:
-    #     lines.append(f"Repository: {sensor.repository_origin}")
 
     if sensor.next_tick_timestamp:
         next_tick_str = _format_timestamp(sensor.next_tick_timestamp)
@@ -112,10 +102,8 @@ def list_sensors_command(
     api = DgApiSensorApi(client)
 
     try:
-        # Always list all sensors (no repository filtering for end users)
         sensors = api.list_sensors()
 
-        # Apply status filter if specified
         if status:
             from dagster_dg_cli.api_layer.schemas.sensor import DgApiSensorList, DgApiSensorStatus
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/__snapshots__/test_dynamic_command_execution.ambr
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/__snapshots__/test_dynamic_command_execution.ambr
@@ -4178,3 +4178,459 @@
   
   '''
 # ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_empty_filtered_sensors_json]
+  dict({
+    'items': list([
+      dict({
+        'description': None,
+        'name': 'default_automation_condition_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'AUTO_MATERIALIZE',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'orders_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'ASSET',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'watch_s3_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': '''
+          
+              This sensor launches execution of freshness checks for the provided assets. The sensor will
+              only launch a new execution of a freshness check if the check previously passed, but enough
+              time has passed that the check could be overdue again. Once a check has failed, the sensor
+              will not launch a new execution until the asset has been updated (which should automatically
+              execute the check).
+              
+        ''',
+        'name': 'weekly_freshness_check_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'default_automation_condition_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'AUTO_MATERIALIZE',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'mwaa_hooli_airflow_01__airflow_dag_status_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+    ]),
+    'total': 6,
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_empty_sensors_json]
+  dict({
+    'items': list([
+      dict({
+        'description': None,
+        'name': 'dbt_code_version_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'STOPPED',
+      }),
+      dict({
+        'description': None,
+        'name': 'default_automation_condition_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'AUTO_MATERIALIZE',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'orders_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'ASSET',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'watch_s3_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': '''
+          
+              This sensor launches execution of freshness checks for the provided assets. The sensor will
+              only launch a new execution of a freshness check if the check previously passed, but enough
+              time has passed that the check could be overdue again. Once a check has failed, the sensor
+              will not launch a new execution until the asset has been updated (which should automatically
+              execute the check).
+              
+        ''',
+        'name': 'weekly_freshness_check_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'default_automation_condition_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'AUTO_MATERIALIZE',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'mwaa_hooli_airflow_01__airflow_dag_status_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+    ]),
+    'total': 7,
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_empty_sensors_text_text]
+  '''
+  Name: dbt_code_version_sensor
+  Status: STOPPED
+  Type: STANDARD
+  Description: None
+  
+  Name: default_automation_condition_sensor
+  Status: RUNNING
+  Type: AUTO_MATERIALIZE
+  Description: None
+  
+  Name: orders_sensor
+  Status: RUNNING
+  Type: ASSET
+  Description: None
+  
+  Name: watch_s3_sensor
+  Status: RUNNING
+  Type: STANDARD
+  Description: None
+  
+  Name: weekly_freshness_check_sensor
+  Status: RUNNING
+  Type: STANDARD
+  Description: 
+      This sensor launches execution of freshness checks for the provided assets. The sensor will
+      only launch a new execution of a freshness check if the check previously passed, but enough
+      time has passed that the check could be overdue again. Once a check has failed, the sensor
+      will not launch a new execution until the asset has been updated (which should automatically
+      execute the check).
+      
+  
+  Name: default_automation_condition_sensor
+  Status: RUNNING
+  Type: AUTO_MATERIALIZE
+  Description: None
+  
+  Name: mwaa_hooli_airflow_01__airflow_dag_status_sensor
+  Status: RUNNING
+  Type: STANDARD
+  Description: None
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_error_empty_sensor_name_json]
+  dict({
+    'error': 'Exhausted 0 responses',
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_error_invalid_status_filter_json]
+  '''
+  Usage: dg api sensor list [OPTIONS]
+  Try 'dg api sensor list -h' for help.
+  
+  Error: Invalid value for '--status': 'INVALID_STATUS' is not one of 'RUNNING', 'STOPPED', 'PAUSED'.
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_error_multiple_sensors_same_name_json]
+  dict({
+    'error': 'Exhausted 0 responses',
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_error_sensor_not_found_json]
+  dict({
+    'error': 'Exhausted 0 responses',
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_error_sensor_not_found_text_text]
+  '''
+  Error: Failed to get sensor: Exhausted 0 responses
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_success_filtered_sensors_paused_json]
+  dict({
+    'items': list([
+    ]),
+    'total': 0,
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_success_filtered_sensors_paused_text_text]
+  '''
+  
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_success_filtered_sensors_running_json]
+  dict({
+    'items': list([
+      dict({
+        'description': None,
+        'name': 'default_automation_condition_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'AUTO_MATERIALIZE',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'orders_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'ASSET',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'watch_s3_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': '''
+          
+              This sensor launches execution of freshness checks for the provided assets. The sensor will
+              only launch a new execution of a freshness check if the check previously passed, but enough
+              time has passed that the check could be overdue again. Once a check has failed, the sensor
+              will not launch a new execution until the asset has been updated (which should automatically
+              execute the check).
+              
+        ''',
+        'name': 'weekly_freshness_check_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'default_automation_condition_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'AUTO_MATERIALIZE',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'mwaa_hooli_airflow_01__airflow_dag_status_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+    ]),
+    'total': 6,
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_success_filtered_sensors_running_text_text]
+  '''
+  Name: default_automation_condition_sensor
+  Status: RUNNING
+  Type: AUTO_MATERIALIZE
+  Description: None
+  
+  Name: orders_sensor
+  Status: RUNNING
+  Type: ASSET
+  Description: None
+  
+  Name: watch_s3_sensor
+  Status: RUNNING
+  Type: STANDARD
+  Description: None
+  
+  Name: weekly_freshness_check_sensor
+  Status: RUNNING
+  Type: STANDARD
+  Description: 
+      This sensor launches execution of freshness checks for the provided assets. The sensor will
+      only launch a new execution of a freshness check if the check previously passed, but enough
+      time has passed that the check could be overdue again. Once a check has failed, the sensor
+      will not launch a new execution until the asset has been updated (which should automatically
+      execute the check).
+      
+  
+  Name: default_automation_condition_sensor
+  Status: RUNNING
+  Type: AUTO_MATERIALIZE
+  Description: None
+  
+  Name: mwaa_hooli_airflow_01__airflow_dag_status_sensor
+  Status: RUNNING
+  Type: STANDARD
+  Description: None
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_success_filtered_sensors_stopped_json]
+  dict({
+    'items': list([
+      dict({
+        'description': None,
+        'name': 'dbt_code_version_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'STOPPED',
+      }),
+    ]),
+    'total': 1,
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_success_filtered_sensors_stopped_text_text]
+  '''
+  Name: dbt_code_version_sensor
+  Status: STOPPED
+  Type: STANDARD
+  Description: None
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_success_multiple_sensors_json]
+  dict({
+    'items': list([
+      dict({
+        'description': None,
+        'name': 'dbt_code_version_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'STOPPED',
+      }),
+      dict({
+        'description': None,
+        'name': 'default_automation_condition_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'AUTO_MATERIALIZE',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'orders_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'ASSET',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'watch_s3_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': '''
+          
+              This sensor launches execution of freshness checks for the provided assets. The sensor will
+              only launch a new execution of a freshness check if the check previously passed, but enough
+              time has passed that the check could be overdue again. Once a check has failed, the sensor
+              will not launch a new execution until the asset has been updated (which should automatically
+              execute the check).
+              
+        ''',
+        'name': 'weekly_freshness_check_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'default_automation_condition_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'AUTO_MATERIALIZE',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': None,
+        'name': 'mwaa_hooli_airflow_01__airflow_dag_status_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+    ]),
+    'total': 7,
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_success_multiple_sensors_text_text]
+  '''
+  Name: dbt_code_version_sensor
+  Status: STOPPED
+  Type: STANDARD
+  Description: None
+  
+  Name: default_automation_condition_sensor
+  Status: RUNNING
+  Type: AUTO_MATERIALIZE
+  Description: None
+  
+  Name: orders_sensor
+  Status: RUNNING
+  Type: ASSET
+  Description: None
+  
+  Name: watch_s3_sensor
+  Status: RUNNING
+  Type: STANDARD
+  Description: None
+  
+  Name: weekly_freshness_check_sensor
+  Status: RUNNING
+  Type: STANDARD
+  Description: 
+      This sensor launches execution of freshness checks for the provided assets. The sensor will
+      only launch a new execution of a freshness check if the check previously passed, but enough
+      time has passed that the check could be overdue again. Once a check has failed, the sensor
+      will not launch a new execution until the asset has been updated (which should automatically
+      execute the check).
+      
+  
+  Name: default_automation_condition_sensor
+  Status: RUNNING
+  Type: AUTO_MATERIALIZE
+  Description: None
+  
+  Name: mwaa_hooli_airflow_01__airflow_dag_status_sensor
+  Status: RUNNING
+  Type: STANDARD
+  Description: None
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_success_single_sensor_running_json]
+  dict({
+    'description': None,
+    'name': 'orders_sensor',
+    'next_tick_timestamp': None,
+    'sensor_type': 'ASSET',
+    'status': 'RUNNING',
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[sensor_success_single_sensor_running_text_text]
+  '''
+  Name: orders_sensor
+  Status: RUNNING
+  Type: ASSET
+  Description: None
+  
+  '''
+# ---

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/Makefile
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/Makefile
@@ -1,0 +1,13 @@
+.PHONY: rerecord test clean
+
+rerecord:
+	dagster-dev dg-api-record sensor
+
+test:
+	pytest . -v
+
+snapshot:
+	pytest . --snapshot-update -v
+
+clean:
+	rm -rf recordings/

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/__snapshots__/test_business_logic.ambr
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/__snapshots__/test_business_logic.ambr
@@ -31,7 +31,7 @@
   Status: RUNNING
   Type: AUTO_MATERIALIZE
   Description: Critical production sensor
-  Next Tick: 2024-01-15 04:45:00
+  Next Tick: 2024-01-15 09:45:00
   '''
 # ---
 # name: TestFormatSensors.test_format_sensors_json_output[0]
@@ -68,7 +68,7 @@
   Status: RUNNING
   Type: STANDARD
   Description: Daily processing sensor
-  Next Tick: 2024-01-15 04:30:00
+  Next Tick: 2024-01-15 09:30:00
   
   Name: asset_sensor
   Status: STOPPED

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/__snapshots__/test_business_logic.ambr
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/__snapshots__/test_business_logic.ambr
@@ -1,0 +1,155 @@
+# serializer version: 1
+# name: TestFormatSensors.test_format_minimal_sensor_json_output[0]
+  dict({
+    'description': None,
+    'name': 'minimal_sensor',
+    'next_tick_timestamp': None,
+    'sensor_type': 'STANDARD',
+    'status': 'PAUSED',
+  })
+# ---
+# name: TestFormatSensors.test_format_minimal_sensor_text_output[0]
+  '''
+  Name: minimal_sensor
+  Status: PAUSED
+  Type: STANDARD
+  Description: None
+  '''
+# ---
+# name: TestFormatSensors.test_format_sensor_json_output[0]
+  dict({
+    'description': 'Critical production sensor',
+    'name': 'critical_sensor',
+    'next_tick_timestamp': 1705311900.0,
+    'sensor_type': 'AUTO_MATERIALIZE',
+    'status': 'RUNNING',
+  })
+# ---
+# name: TestFormatSensors.test_format_sensor_text_output[0]
+  '''
+  Name: critical_sensor
+  Status: RUNNING
+  Type: AUTO_MATERIALIZE
+  Description: Critical production sensor
+  Next Tick: 2024-01-15 04:45:00
+  '''
+# ---
+# name: TestFormatSensors.test_format_sensors_json_output[0]
+  dict({
+    'items': list([
+      dict({
+        'description': 'Daily processing sensor',
+        'name': 'daily_sensor',
+        'next_tick_timestamp': 1705311000.0,
+        'sensor_type': 'STANDARD',
+        'status': 'RUNNING',
+      }),
+      dict({
+        'description': 'Asset change sensor',
+        'name': 'asset_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'ASSET',
+        'status': 'STOPPED',
+      }),
+      dict({
+        'description': None,
+        'name': 'minimal_sensor',
+        'next_tick_timestamp': None,
+        'sensor_type': 'MULTI_ASSET',
+        'status': 'PAUSED',
+      }),
+    ]),
+    'total': 3,
+  })
+# ---
+# name: TestFormatSensors.test_format_sensors_text_output[0]
+  '''
+  Name: daily_sensor
+  Status: RUNNING
+  Type: STANDARD
+  Description: Daily processing sensor
+  Next Tick: 2024-01-15 04:30:00
+  
+  Name: asset_sensor
+  Status: STOPPED
+  Type: ASSET
+  Description: Asset change sensor
+  
+  Name: minimal_sensor
+  Status: PAUSED
+  Type: MULTI_ASSET
+  Description: None
+  '''
+# ---
+# name: TestProcessSensorResponses.test_process_repositories_response_empty[0]
+  DgApiSensorList(items=[], total=0)
+# ---
+# name: TestProcessSensorResponses.test_process_repositories_response_success[0]
+  DgApiSensorList(items=[DgApiSensor(id='sensor1-id', name='daily_sensor', status=<DgApiSensorStatus.RUNNING: 'RUNNING'>, sensor_type=<DgApiSensorType.STANDARD: 'STANDARD'>, description='Daily processing sensor', repository_origin='main_location@main_repo', next_tick_timestamp=None), DgApiSensor(id='sensor2-id', name='asset_sensor', status=<DgApiSensorStatus.PAUSED: 'PAUSED'>, sensor_type=<DgApiSensorType.MULTI_ASSET: 'MULTI_ASSET'>, description='Asset change sensor', repository_origin='main_location@main_repo', next_tick_timestamp=None), DgApiSensor(id='sensor3-id', name='hourly_sensor', status=<DgApiSensorStatus.STOPPED: 'STOPPED'>, sensor_type=<DgApiSensorType.FRESHNESS_POLICY: 'FRESHNESS_POLICY'>, description=None, repository_origin='secondary_location@secondary_repo', next_tick_timestamp=None)], total=3)
+# ---
+# name: TestProcessSensorResponses.test_process_sensor_response_not_found_error[0]
+  dict({
+    'error': "Sensor 'nonexistent_sensor' not found",
+  })
+# ---
+# name: TestProcessSensorResponses.test_process_sensor_response_success[0]
+  DgApiSensor(id='single-sensor-id', name='critical_sensor', status=<DgApiSensorStatus.RUNNING: 'RUNNING'>, sensor_type=<DgApiSensorType.AUTO_MATERIALIZE: 'AUTO_MATERIALIZE'>, description='Critical production sensor', repository_origin=None, next_tick_timestamp=None)
+# ---
+# name: TestProcessSensorResponses.test_process_sensors_response_empty[0]
+  DgApiSensorList(items=[], total=0)
+# ---
+# name: TestProcessSensorResponses.test_process_sensors_response_error_typename[0]
+  dict({
+    'error': 'Repository not found',
+  })
+# ---
+# name: TestProcessSensorResponses.test_process_sensors_response_missing_key[0]
+  dict({
+    'error': 'No sensors data in GraphQL response',
+  })
+# ---
+# name: TestProcessSensorResponses.test_process_sensors_response_success[0]
+  DgApiSensorList(items=[DgApiSensor(id='sensor1-id', name='daily_sensor', status=<DgApiSensorStatus.RUNNING: 'RUNNING'>, sensor_type=<DgApiSensorType.STANDARD: 'STANDARD'>, description='Daily processing sensor', repository_origin=None, next_tick_timestamp=None), DgApiSensor(id='sensor2-id', name='asset_sensor', status=<DgApiSensorStatus.STOPPED: 'STOPPED'>, sensor_type=<DgApiSensorType.ASSET: 'ASSET'>, description='Asset change sensor', repository_origin=None, next_tick_timestamp=None)], total=2)
+# ---
+# name: TestSensorDataProcessing.test_sensor_creation_with_all_fields[0]
+  dict({
+    'description': 'Comprehensive test sensor with all fields',
+    'id': 'complete-sensor-xyz',
+    'name': 'comprehensive_sensor',
+    'next_tick_timestamp': 1705311000.0,
+    'repository_origin': 'test_location@test_repo',
+    'sensor_type': 'FRESHNESS_POLICY',
+    'status': 'RUNNING',
+  })
+# ---
+# name: TestSensorDataProcessing.test_sensor_timestamp_handling[0]
+  list([
+    dict({
+      'description': None,
+      'id': 'sensor1',
+      'name': 'normal_timestamp',
+      'next_tick_timestamp': 1705311000.0,
+      'repository_origin': None,
+      'sensor_type': 'STANDARD',
+      'status': 'RUNNING',
+    }),
+    dict({
+      'description': None,
+      'id': 'sensor2',
+      'name': 'no_timestamp',
+      'next_tick_timestamp': None,
+      'repository_origin': None,
+      'sensor_type': 'STANDARD',
+      'status': 'STOPPED',
+    }),
+    dict({
+      'description': None,
+      'id': 'sensor3',
+      'name': 'future_timestamp',
+      'next_tick_timestamp': 2000000000.0,
+      'repository_origin': None,
+      'sensor_type': 'STANDARD',
+      'status': 'PAUSED',
+    }),
+  ])
+# ---

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/empty_filtered_sensors/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/empty_filtered_sensors/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/empty_sensors/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/empty_sensors/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/empty_sensors_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/empty_sensors_text/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/error_empty_sensor_name/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/error_empty_sensor_name/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/error_multiple_sensors_same_name/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/error_multiple_sensors_same_name/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/error_sensor_not_found/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/error_sensor_not_found/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/error_sensor_not_found_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/error_sensor_not_found_text/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_filtered_sensors_paused/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_filtered_sensors_paused/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_filtered_sensors_paused_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_filtered_sensors_paused_text/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_filtered_sensors_running/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_filtered_sensors_running/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_filtered_sensors_running_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_filtered_sensors_running_text/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_filtered_sensors_stopped/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_filtered_sensors_stopped/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_filtered_sensors_stopped_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_filtered_sensors_stopped_text/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_multiple_sensors/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_multiple_sensors/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_multiple_sensors_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_multiple_sensors_text/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_single_sensor_running/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_single_sensor_running/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_single_sensor_running_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/recordings/success_single_sensor_running_text/01_response.json
@@ -1,0 +1,121 @@
+{
+  "repositoriesOrError": {
+    "__typename": "RepositoryConnection",
+    "nodes": [
+      {
+        "location": {
+          "name": "basics"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "batch_enrichment"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "data-eng-pipeline"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "724c964095cdedc50cedd03a245a263d37becd99::ca9937809e3046f25a8fb5c296fdff1c5f12bcf7",
+            "name": "dbt_code_version_sensor",
+            "sensorState": {
+              "status": "STOPPED"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": null,
+            "id": "e978000fa5b80d672b498a2668c291bc62cf7b46::e60638d37f3f02db40f907c5f1efd7bbb67fc8f1",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "4b12429d4c77624d0b61681623d2cb9180406eae::01471ff0a6a807ad3b7f2cff81c4ebbe375bac85",
+            "name": "orders_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "ASSET"
+          },
+          {
+            "description": null,
+            "id": "4c2bb07fe127bdefbe6e6526abe6086db6fb876e::d61d76331cbadbca7a26e3d94fc77416038818e6",
+            "name": "watch_s3_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          },
+          {
+            "description": "\n    This sensor launches execution of freshness checks for the provided assets. The sensor will\n    only launch a new execution of a freshness check if the check previously passed, but enough\n    time has passed that the check could be overdue again. Once a check has failed, the sensor\n    will not launch a new execution until the asset has been updated (which should automatically\n    execute the check).\n    ",
+            "id": "323dcd58a32efb9ec810d95bc9cd99572809de24::04f66d6b3ed306555381c2f9d815656a813769ed",
+            "name": "weekly_freshness_check_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_airlift"
+        },
+        "name": "__repository__",
+        "sensors": [
+          {
+            "description": null,
+            "id": "29af2b4a57d8e09fa53485d31d59571b2f143973::6be20a075ae25f5a057f7fe8634cfdc2419c56bd",
+            "name": "default_automation_condition_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "AUTO_MATERIALIZE"
+          },
+          {
+            "description": null,
+            "id": "b608513f9f81b03a3426b8bf65c6f3039f28c42b::f4f5420a81959a874c0a1b08578b6adbc7264bc5",
+            "name": "mwaa_hooli_airflow_01__airflow_dag_status_sensor",
+            "sensorState": {
+              "status": "RUNNING"
+            },
+            "sensorType": "STANDARD"
+          }
+        ]
+      },
+      {
+        "location": {
+          "name": "hooli_bi"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "hooli_data_ingest"
+        },
+        "name": "__repository__",
+        "sensors": []
+      },
+      {
+        "location": {
+          "name": "snowflake_insights"
+        },
+        "name": "__repository__",
+        "sensors": []
+      }
+    ]
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/scenarios.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/scenarios.yaml
@@ -34,10 +34,10 @@ empty_filtered_sensors:
 
 # Success scenarios - get single sensor
 success_single_sensor_running:
-  command: "dg api sensor get run_assets_30min --json"
+  command: "dg api sensor get orders_sensor --json"
 
 success_single_sensor_running_text:
-  command: "dg api sensor get run_assets_30min"
+  command: "dg api sensor get orders_sensor"
 
 # Error scenarios
 error_sensor_not_found:

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/scenarios.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/scenarios.yaml
@@ -1,0 +1,61 @@
+# Success scenarios - list sensors
+success_multiple_sensors:
+  command: "dg api sensor list --json"
+
+success_multiple_sensors_text:
+  command: "dg api sensor list"
+
+success_filtered_sensors_running:
+  command: "dg api sensor list --status RUNNING --json"
+
+success_filtered_sensors_stopped:
+  command: "dg api sensor list --status STOPPED --json"
+
+success_filtered_sensors_paused:
+  command: "dg api sensor list --status PAUSED --json"
+
+success_filtered_sensors_running_text:
+  command: "dg api sensor list --status RUNNING"
+
+success_filtered_sensors_stopped_text:
+  command: "dg api sensor list --status STOPPED"
+
+success_filtered_sensors_paused_text:
+  command: "dg api sensor list --status PAUSED"
+
+empty_sensors:
+  command: "dg api sensor list --json"
+
+empty_sensors_text:
+  command: "dg api sensor list"
+
+empty_filtered_sensors:
+  command: "dg api sensor list --status RUNNING --json"
+
+# Success scenarios - get single sensor
+success_single_sensor_running:
+  command: "dg api sensor get run_assets_30min --json"
+
+success_single_sensor_running_text:
+  command: "dg api sensor get run_assets_30min"
+
+# Error scenarios
+error_sensor_not_found:
+  command: "dg api sensor get nonexistent_sensor --json"
+  has_recording: false
+
+error_sensor_not_found_text:
+  command: "dg api sensor get nonexistent_sensor"
+  has_recording: false
+
+error_empty_sensor_name:
+  command: "dg api sensor get '' --json"
+  has_recording: false
+
+error_invalid_status_filter:
+  command: "dg api sensor list --status INVALID_STATUS --json"
+  has_recording: false
+
+error_multiple_sensors_same_name:
+  command: "dg api sensor get duplicate_name_sensor --json"
+  has_recording: false

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/test_business_logic.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/test_business_logic.py
@@ -220,8 +220,11 @@ class TestFormatSensors:
 
     def test_format_sensors_text_output(self, snapshot):
         """Test formatting sensors as text."""
+        from dagster_shared.utils.timing import fixed_timezone
+
         sensor_list = self._create_sample_sensor_list()
-        result = format_sensors(sensor_list, as_json=False)
+        with fixed_timezone("UTC"):
+            result = format_sensors(sensor_list, as_json=False)
 
         # Snapshot the entire text output
         snapshot.assert_match(result)
@@ -237,8 +240,11 @@ class TestFormatSensors:
 
     def test_format_sensor_text_output(self, snapshot):
         """Test formatting single sensor as text."""
+        from dagster_shared.utils.timing import fixed_timezone
+
         sensor = self._create_sample_sensor()
-        result = format_sensor(sensor, as_json=False)
+        with fixed_timezone("UTC"):
+            result = format_sensor(sensor, as_json=False)
 
         # Snapshot the text output
         snapshot.assert_match(result)
@@ -254,6 +260,8 @@ class TestFormatSensors:
 
     def test_format_minimal_sensor_text_output(self, snapshot):
         """Test formatting minimal sensor as text."""
+        from dagster_shared.utils.timing import fixed_timezone
+
         sensor = DgApiSensor(
             id="minimal-id",
             name="minimal_sensor",
@@ -263,7 +271,8 @@ class TestFormatSensors:
             repository_origin=None,
             next_tick_timestamp=None,
         )
-        result = format_sensor(sensor, as_json=False)
+        with fixed_timezone("UTC"):
+            result = format_sensor(sensor, as_json=False)
 
         snapshot.assert_match(result)
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/test_business_logic.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/sensor_tests/test_business_logic.py
@@ -1,0 +1,409 @@
+"""Test sensor business logic functions without mocks.
+
+These tests focus on testing pure functions that process data without requiring
+GraphQL client mocking or external dependencies.
+"""
+
+import json
+
+from dagster_dg_cli.api_layer.graphql_adapter.sensor import (
+    process_repositories_response,
+    process_sensor_response,
+    process_sensors_response,
+)
+from dagster_dg_cli.api_layer.schemas.sensor import (
+    DgApiSensor,
+    DgApiSensorList,
+    DgApiSensorStatus,
+    DgApiSensorType,
+)
+from dagster_dg_cli.cli.api.sensor import format_sensor, format_sensors
+
+
+class TestProcessSensorResponses:
+    """Test the pure functions that process GraphQL responses."""
+
+    def test_process_sensors_response_success(self, snapshot):
+        """Test processing a successful sensors GraphQL response."""
+        # Sample GraphQL response structure
+        response = {
+            "sensorsOrError": {
+                "__typename": "Sensors",
+                "results": [
+                    {
+                        "id": "sensor1-id",
+                        "name": "daily_sensor",
+                        "sensorState": {"status": "RUNNING"},
+                        "sensorType": "STANDARD",
+                        "description": "Daily processing sensor",
+                    },
+                    {
+                        "id": "sensor2-id",
+                        "name": "asset_sensor",
+                        "sensorState": {"status": "STOPPED"},
+                        "sensorType": "ASSET",
+                        "description": "Asset change sensor",
+                    },
+                ],
+            }
+        }
+        result = process_sensors_response(response)
+
+        # Snapshot the entire result to capture structure and data
+        snapshot.assert_match(result)
+
+    def test_process_sensors_response_empty(self, snapshot):
+        """Test processing an empty sensors GraphQL response."""
+        response = {"sensorsOrError": {"__typename": "Sensors", "results": []}}
+        result = process_sensors_response(response)
+
+        # Snapshot empty result
+        snapshot.assert_match(result)
+
+    def test_process_sensors_response_missing_key(self, snapshot):
+        """Test processing a response missing the sensorsOrError key."""
+        malformed_response = {}
+        try:
+            result = process_sensors_response(malformed_response)
+            # If no exception, snapshot the result
+            snapshot.assert_match(result)
+        except Exception as e:
+            # Snapshot the error message
+            snapshot.assert_match({"error": str(e)})
+
+    def test_process_sensors_response_error_typename(self, snapshot):
+        """Test processing a sensors response with error typename."""
+        error_response = {
+            "sensorsOrError": {
+                "__typename": "RepositoryNotFoundError",
+                "message": "Repository not found",
+            }
+        }
+        try:
+            result = process_sensors_response(error_response)
+            snapshot.assert_match(result)
+        except Exception as e:
+            snapshot.assert_match({"error": str(e)})
+
+    def test_process_repositories_response_success(self, snapshot):
+        """Test processing a successful repositories GraphQL response."""
+        response = {
+            "repositoriesOrError": {
+                "__typename": "RepositoryConnection",
+                "nodes": [
+                    {
+                        "name": "main_repo",
+                        "location": {"name": "main_location"},
+                        "sensors": [
+                            {
+                                "id": "sensor1-id",
+                                "name": "daily_sensor",
+                                "sensorState": {"status": "RUNNING"},
+                                "sensorType": "STANDARD",
+                                "description": "Daily processing sensor",
+                            },
+                            {
+                                "id": "sensor2-id",
+                                "name": "asset_sensor",
+                                "sensorState": {"status": "PAUSED"},
+                                "sensorType": "MULTI_ASSET",
+                                "description": "Asset change sensor",
+                            },
+                        ],
+                    },
+                    {
+                        "name": "secondary_repo",
+                        "location": {"name": "secondary_location"},
+                        "sensors": [
+                            {
+                                "id": "sensor3-id",
+                                "name": "hourly_sensor",
+                                "sensorState": {"status": "STOPPED"},
+                                "sensorType": "FRESHNESS_POLICY",
+                                "description": None,
+                            }
+                        ],
+                    },
+                ],
+            }
+        }
+        result = process_repositories_response(response)
+
+        # Snapshot the entire result to capture structure and data
+        snapshot.assert_match(result)
+
+    def test_process_repositories_response_empty(self, snapshot):
+        """Test processing an empty repositories GraphQL response."""
+        response = {"repositoriesOrError": {"__typename": "RepositoryConnection", "nodes": []}}
+        result = process_repositories_response(response)
+
+        snapshot.assert_match(result)
+
+    def test_process_sensor_response_success(self, snapshot):
+        """Test processing a successful single sensor GraphQL response."""
+        response = {
+            "sensorOrError": {
+                "__typename": "Sensor",
+                "id": "single-sensor-id",
+                "name": "critical_sensor",
+                "sensorState": {"status": "RUNNING"},
+                "sensorType": "AUTO_MATERIALIZE",
+                "description": "Critical production sensor",
+            }
+        }
+        result = process_sensor_response(response)
+
+        snapshot.assert_match(result)
+
+    def test_process_sensor_response_not_found_error(self, snapshot):
+        """Test processing a sensor not found error."""
+        error_response = {
+            "sensorOrError": {
+                "__typename": "SensorNotFoundError",
+                "message": "Sensor 'nonexistent_sensor' not found",
+            }
+        }
+        try:
+            result = process_sensor_response(error_response)
+            snapshot.assert_match(result)
+        except Exception as e:
+            snapshot.assert_match({"error": str(e)})
+
+
+class TestFormatSensors:
+    """Test the sensor formatting functions."""
+
+    def _create_sample_sensor_list(self):
+        """Create sample DgApiSensorList for testing."""
+        sensors = [
+            DgApiSensor(
+                id="sensor1-id",
+                name="daily_sensor",
+                status=DgApiSensorStatus.RUNNING,
+                sensor_type=DgApiSensorType.STANDARD,
+                description="Daily processing sensor",
+                repository_origin="main_location@main_repo",
+                next_tick_timestamp=1705311000.0,  # 2024-01-15T10:30:00Z
+            ),
+            DgApiSensor(
+                id="sensor2-id",
+                name="asset_sensor",
+                status=DgApiSensorStatus.STOPPED,
+                sensor_type=DgApiSensorType.ASSET,
+                description="Asset change sensor",
+                repository_origin="main_location@main_repo",
+                next_tick_timestamp=None,
+            ),
+            DgApiSensor(
+                id="sensor3-id",
+                name="minimal_sensor",
+                status=DgApiSensorStatus.PAUSED,
+                sensor_type=DgApiSensorType.MULTI_ASSET,
+                description=None,
+                repository_origin=None,
+                next_tick_timestamp=None,
+            ),
+        ]
+        return DgApiSensorList(items=sensors, total=len(sensors))
+
+    def _create_sample_sensor(self):
+        """Create sample DgApiSensor for testing."""
+        return DgApiSensor(
+            id="single-sensor-id",
+            name="critical_sensor",
+            status=DgApiSensorStatus.RUNNING,
+            sensor_type=DgApiSensorType.AUTO_MATERIALIZE,
+            description="Critical production sensor",
+            repository_origin="prod_location@prod_repo",
+            next_tick_timestamp=1705311900.0,  # 2024-01-15T10:45:00Z
+        )
+
+    def test_format_sensors_text_output(self, snapshot):
+        """Test formatting sensors as text."""
+        sensor_list = self._create_sample_sensor_list()
+        result = format_sensors(sensor_list, as_json=False)
+
+        # Snapshot the entire text output
+        snapshot.assert_match(result)
+
+    def test_format_sensors_json_output(self, snapshot):
+        """Test formatting sensors as JSON."""
+        sensor_list = self._create_sample_sensor_list()
+        result = format_sensors(sensor_list, as_json=True)
+
+        # For JSON, we want to snapshot the parsed structure to avoid formatting differences
+        parsed = json.loads(result)
+        snapshot.assert_match(parsed)
+
+    def test_format_sensor_text_output(self, snapshot):
+        """Test formatting single sensor as text."""
+        sensor = self._create_sample_sensor()
+        result = format_sensor(sensor, as_json=False)
+
+        # Snapshot the text output
+        snapshot.assert_match(result)
+
+    def test_format_sensor_json_output(self, snapshot):
+        """Test formatting single sensor as JSON."""
+        sensor = self._create_sample_sensor()
+        result = format_sensor(sensor, as_json=True)
+
+        # For JSON, we want to snapshot the parsed structure to avoid formatting differences
+        parsed = json.loads(result)
+        snapshot.assert_match(parsed)
+
+    def test_format_minimal_sensor_text_output(self, snapshot):
+        """Test formatting minimal sensor as text."""
+        sensor = DgApiSensor(
+            id="minimal-id",
+            name="minimal_sensor",
+            status=DgApiSensorStatus.PAUSED,
+            sensor_type=DgApiSensorType.STANDARD,
+            description=None,
+            repository_origin=None,
+            next_tick_timestamp=None,
+        )
+        result = format_sensor(sensor, as_json=False)
+
+        snapshot.assert_match(result)
+
+    def test_format_minimal_sensor_json_output(self, snapshot):
+        """Test formatting minimal sensor as JSON."""
+        sensor = DgApiSensor(
+            id="minimal-id",
+            name="minimal_sensor",
+            status=DgApiSensorStatus.PAUSED,
+            sensor_type=DgApiSensorType.STANDARD,
+            description=None,
+            repository_origin=None,
+            next_tick_timestamp=None,
+        )
+        result = format_sensor(sensor, as_json=True)
+
+        parsed = json.loads(result)
+        snapshot.assert_match(parsed)
+
+
+class TestSensorDataProcessing:
+    """Test processing of sensor data structures.
+
+    This class tests pure functions and domain model functionality
+    without requiring external dependencies.
+    """
+
+    def test_sensor_creation_with_all_fields(self, snapshot):
+        """Test creating sensor with all possible fields."""
+        sensor = DgApiSensor(
+            id="complete-sensor-xyz",
+            name="comprehensive_sensor",
+            status=DgApiSensorStatus.RUNNING,
+            sensor_type=DgApiSensorType.FRESHNESS_POLICY,
+            description="Comprehensive test sensor with all fields",
+            repository_origin="test_location@test_repo",
+            next_tick_timestamp=1705311000.0,
+        )
+
+        # Test JSON serialization works correctly
+        result = sensor.model_dump_json(indent=2)
+        parsed = json.loads(result)
+        snapshot.assert_match(parsed)
+
+    def test_sensor_status_enum_values(self):
+        """Test that all expected SensorStatus enum values are available."""
+        expected_statuses = ["RUNNING", "STOPPED", "PAUSED"]
+
+        actual_statuses = [status.value for status in DgApiSensorStatus]
+        assert set(actual_statuses) == set(expected_statuses)
+
+    def test_sensor_type_enum_values(self):
+        """Test that all expected SensorType enum values are available."""
+        expected_types = [
+            "STANDARD",
+            "MULTI_ASSET",
+            "FRESHNESS_POLICY",
+            "AUTO_MATERIALIZE",
+            "ASSET",
+        ]
+
+        actual_types = [sensor_type.value for sensor_type in DgApiSensorType]
+        assert set(actual_types) == set(expected_types)
+
+    def test_sensor_with_missing_optional_fields(self):
+        """Test sensor creation with None values for optional fields."""
+        sensor = DgApiSensor(
+            id="sparse-sensor-123",
+            name="sparse_sensor",
+            status=DgApiSensorStatus.STOPPED,
+            sensor_type=DgApiSensorType.STANDARD,
+            description=None,
+            repository_origin=None,
+            next_tick_timestamp=None,
+        )
+
+        assert sensor.id == "sparse-sensor-123"
+        assert sensor.name == "sparse_sensor"
+        assert sensor.status == DgApiSensorStatus.STOPPED
+        assert sensor.sensor_type == DgApiSensorType.STANDARD
+        assert sensor.description is None
+        assert sensor.repository_origin is None
+        assert sensor.next_tick_timestamp is None
+
+    def test_sensor_list_creation(self):
+        """Test SensorList creation and basic functionality."""
+        sensors = [
+            DgApiSensor(
+                id="sensor1",
+                name="first_sensor",
+                status=DgApiSensorStatus.RUNNING,
+                sensor_type=DgApiSensorType.STANDARD,
+            ),
+            DgApiSensor(
+                id="sensor2",
+                name="second_sensor",
+                status=DgApiSensorStatus.PAUSED,
+                sensor_type=DgApiSensorType.ASSET,
+            ),
+        ]
+        sensor_list = DgApiSensorList(items=sensors, total=len(sensors))
+
+        assert len(sensor_list.items) == 2
+        assert sensor_list.total == 2
+        assert sensor_list.items[0].name == "first_sensor"
+        assert sensor_list.items[1].name == "second_sensor"
+
+    def test_sensor_timestamp_handling(self, snapshot):
+        """Test sensor with various timestamp values."""
+        test_cases = [
+            # Normal timestamp
+            DgApiSensor(
+                id="sensor1",
+                name="normal_timestamp",
+                status=DgApiSensorStatus.RUNNING,
+                sensor_type=DgApiSensorType.STANDARD,
+                next_tick_timestamp=1705311000.0,
+            ),
+            # No timestamp
+            DgApiSensor(
+                id="sensor2",
+                name="no_timestamp",
+                status=DgApiSensorStatus.STOPPED,
+                sensor_type=DgApiSensorType.STANDARD,
+                next_tick_timestamp=None,
+            ),
+            # Future timestamp
+            DgApiSensor(
+                id="sensor3",
+                name="future_timestamp",
+                status=DgApiSensorStatus.PAUSED,
+                sensor_type=DgApiSensorType.STANDARD,
+                next_tick_timestamp=2000000000.0,  # Far future
+            ),
+        ]
+
+        results = []
+        for sensor in test_cases:
+            # Test serialization
+            serialized = json.loads(sensor.model_dump_json())
+            results.append(serialized)
+
+        snapshot.assert_match(results)


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

```
▸ dg api sensor list
Name: dbt_code_version_sensor
Status: STOPPED
Type: STANDARD
Description: None

Name: default_automation_condition_sensor
Status: RUNNING
Type: AUTO_MATERIALIZE
Description: None

Name: orders_sensor
Status: RUNNING
Type: ASSET
Description: None

Name: watch_s3_sensor
Status: RUNNING
Type: STANDARD
Description: None

Name: weekly_freshness_check_sensor
Status: RUNNING
Type: STANDARD
Description:
    This sensor launches execution of freshness checks for the provided assets. The sensor will
    only launch a new execution of a freshness check if the check previously passed, but enough
    time has passed that the check could be overdue again. Once a check has failed, the sensor
    will not launch a new execution until the asset has been updated (which should automatically
    execute the check).


Name: default_automation_condition_sensor
Status: RUNNING
Type: AUTO_MATERIALIZE
Description: None

Name: mwaa_hooli_airflow_01__airflow_dag_status_sensor
Status: RUNNING
Type: STANDARD
Description: None
```

```
▸ dg api sensor get orders_sensor
Name: orders_sensor
Status: RUNNING
Type: ASSET
Description: None
```

## Changelog

- [dg] adds `dg api sensor list` and `dg api sensor get`
