### PR TITLE
Make get_dynamic_partitions_definition_id abstract on DynamicPartitionsStore

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -629,6 +629,18 @@ class DagsterInstance(
         """
         return self._event_storage.get_dynamic_partitions(partitions_def_name)
 
+    def get_dynamic_partitions_definition_id(self, partitions_def_name: str) -> str:
+        from dagster._core.definitions.partitions.context import partition_loading_context
+        from dagster._core.definitions.partitions.utils import (
+            generate_partition_key_based_definition_id,
+        )
+
+        with partition_loading_context() as calling_context:
+            dynamic_partitions_store = calling_context.dynamic_partitions_store or self
+            # matches the base implementation of the get_serializable_unique_identifier on PartitionsDefinition
+            partition_keys = dynamic_partitions_store.get_dynamic_partitions(partitions_def_name)
+            return generate_partition_key_based_definition_id(partition_keys)
+
     @public
     @traced
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:

--- a/python_modules/dagster/dagster/_core/instance/types.py
+++ b/python_modules/dagster/dagster/_core/instance/types.py
@@ -135,14 +135,8 @@ class DynamicPartitionsStore(Protocol):
     @abstractmethod
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool: ...
 
-    def get_dynamic_partitions_definition_id(self, partitions_def_name: str) -> str:
-        from dagster._core.definitions.partitions.utils import (
-            generate_partition_key_based_definition_id,
-        )
-
-        # matches the base implementation of the get_serializable_unique_identifier on PartitionsDefinition
-        partition_keys = self.get_dynamic_partitions(partitions_def_name)
-        return generate_partition_key_based_definition_id(partition_keys)
+    @abstractmethod
+    def get_dynamic_partitions_definition_id(self, partitions_def_name: str) -> str: ...
 
 
 class CachingDynamicPartitionsLoader(DynamicPartitionsStore):
@@ -168,6 +162,10 @@ class CachingDynamicPartitionsLoader(DynamicPartitionsStore):
     @cached_method
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
         return self._instance.has_dynamic_partition(partitions_def_name, partition_key)
+
+    @cached_method
+    def get_dynamic_partitions_definition_id(self, partitions_def_name: str) -> str:
+        return self._instance.get_dynamic_partitions_definition_id(partitions_def_name)
 
 
 @record
@@ -241,4 +239,9 @@ class DynamicPartitionsStoreAfterRequests(DynamicPartitionsStore):
             or self.wrapped_dynamic_partitions_store.has_dynamic_partition(
                 partitions_def_name, partition_key
             )
+        )
+
+    def get_dynamic_partitions_definition_id(self, partitions_def_name: str) -> str:
+        return self.wrapped_dynamic_partitions_store.get_dynamic_partitions_definition_id(
+            partitions_def_name
         )

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -656,6 +656,9 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
         return partition_key in self.get_dynamic_partitions(partitions_def_name)
 
+    def get_dynamic_partitions_definition_id(self, partitions_def_name: str) -> str:
+        return self.instance.get_dynamic_partitions_definition_id(partitions_def_name)
+
     @cached_method
     def asset_partitions_with_newly_updated_parents_and_new_cursor(
         self,


### PR DESCRIPTION
## Summary & Motivation
Fixes an issue where callsites using DynamicPartitionsStore were using one implementation of get_dynamic_partitions_definition_id and callsites using CachingDynamicParittionsStore were using another implementation.

## How I Tested These Changes
Dry run scripts that compute asset status cache values in daemon vs. dagit now match

