### PR TITLE
[dagster-snowflake] Allow bytes for private key

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -127,7 +127,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext,
         ),
     )
 
-    private_key: Optional[str] = Field(
+    private_key: Optional[Union[str, bytes]] = Field(
         default=None,
         description=(
             "Raw private key to use. See the `Snowflake documentation"


### PR DESCRIPTION
## Summary & Motivation

When you load the private key from a secretsmanager, it's expected to be raw bytes rather than a string. Because of this, we should accept having those raw bytes passed directly in as a parameter. Pydantic does strict type-checking by default so this was previously not allowed.

## How I Tested These Changes

## Changelog

[dagster-snowflake] The `private_key` attribute of `SnowflakeResource` now accepts `bytes` in addition to `str` as an input type to align with recommended Snowflake practices.
