### PR TITLE
Attempt to reproduce an issue where DA sensors that emit backfills hit an exception due to producing run requests with KeyRangePartitionSubsets and no partition load context

### DIFF
--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/backfill_dynamic_user_code.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/daemon_tests/definitions/backfill_dynamic_user_code.py
@@ -1,0 +1,53 @@
+import dagster as dg
+import dagster._check as check
+from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
+from dagster._core.definitions.partitions.snap.snap import PartitionsSnap
+from dagster._core.definitions.partitions.subset.key_ranges import KeyRangesPartitionsSubset
+
+dynamic_partitions1 = dg.DynamicPartitionsDefinition(name="dynamic1")
+
+
+class AlwaysEmitFullKeyRangeSubsetCondition(dg.AutomationCondition):
+    """Custom condition that ensures that a KeyRangesPartitionsSubset is always emitted,
+    to ensure that we don't have partition_loading_context issues.
+    """
+
+    def evaluate(self, context):
+        partitions_def = context.asset_graph.get(context.key).partitions_def
+
+        partitions_subset = KeyRangesPartitionsSubset(
+            key_ranges=[
+                dg.PartitionKeyRange(
+                    start=partitions_def.get_first_partition_key(),
+                    end=partitions_def.get_last_partition_key(),
+                )
+            ],
+            partitions_snap=PartitionsSnap.from_def(partitions_def),
+        )
+
+        return dg.AutomationResult(
+            true_subset=check.not_none(
+                context.asset_graph_view.get_subset_from_serializable_subset(
+                    serializable_subset=SerializableEntitySubset(
+                        key=context.key,
+                        value=partitions_subset,
+                    )
+                )
+            ),
+            context=context,
+        )
+
+
+@dg.asset(
+    automation_condition=AlwaysEmitFullKeyRangeSubsetCondition(),
+    partitions_def=dynamic_partitions1,
+)
+def A() -> None: ...
+
+
+defs = dg.Definitions(
+    assets=[A],
+    sensors=[
+        dg.AutomationConditionSensorDefinition("the_sensor", target="*", use_user_code_server=True)
+    ],
+)


### PR DESCRIPTION
Summary:
This is my (currently failed) attempt to reproduce a reported issue where a DA sensor that emits backfills and runs in user code fails here:
```
dagster_shared.check.functions.CheckError: Invariant failed. Description: This function can only be called within a partition_loading_context with both a datetime and dynamic_partitions_store set
  File "/usr/local/lib/python3.12/site-packages/dagster/_core/errors.py", line 279, in user_code_error_boundary
    yield
  File "/usr/local/lib/python3.12/site-packages/dagster/_grpc/impl.py", line 404, in get_external_sensor_execution
    return sensor_def.evaluate_tick(sensor_context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dagster/_core/definitions/sensor_definition.py", line 1009, in evaluate_tick
    *self.validate_backfill_requests(
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dagster/_core/definitions/sensor_definition.py", line 1118, in validate_backfill_requests
    asset_keys = run_request.asset_graph_subset.asset_keys
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dagster/_core/definitions/assets/graph/asset_graph_subset.py", line 55, in asset_keys
    key for key, subset in self.partitions_subsets_by_asset_key.items() if len(subset) > 0
                                                                           ^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dagster/_core/definitions/partitions/context.py", line 75, in wrapper
    check.invariant(
  File "/usr/local/lib/python3.12/site-packages/dagster_shared/check/functions.py", line 1697, in invariant
    raise CheckError(f"Invariant failed. Description: {desc}")
```

I confirmed that the test produces backfills, and that KeyRangePartitionsSubsets are produced during the DA tick, but they all have DefaultPartitionSubsets in the final RunRequst. Hoping to get this test to fail so that I can verify that I've actually fixed the problem.

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
