### PR TITLE
[dagster-dbt] pin `duckdb<1.4.0` in dagster-dbt[test]

### DIFF
--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -64,6 +64,7 @@ setup(
             "dagster-duckdb",
             "dagster-duckdb-pandas",
             "dbt-duckdb<1.9.2",  # concurrency issues
+            "duckdb<1.4.0",  # compat issues
         ],
     },
     entry_points={


### PR DESCRIPTION
## Summary & Motivation

New major release broke some tests, my guess is this will resolve itself with a patch release on their end but for now let's get our CI passing.

## How I Tested These Changes

## Changelog

NOCHANGELOG
