### PR TITLE
Change base implementation of PartitionsSubset.is_empty

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/partitions_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/partitions_subset.py
@@ -18,7 +18,7 @@ class PartitionsSubset(ABC, Generic[T_str]):
 
     @property
     def is_empty(self) -> bool:
-        return len(list(self.get_partition_keys())) == 0
+        return len(self) == 0
 
     @abstractmethod
     def get_partition_keys_not_in_subset(


### PR DESCRIPTION
Summary:
Follow-on to https://github.com/dagster-io/dagster/pull/32199. I didn't notice any specific problems here, but seems like a gotcha if you have a partitions subset that has implemented an efficient __len__ but forgot to override is_empty as well.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
