### PR TITLE
[prototype 1]  config to define an in-app check

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_checks/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_checks/asset_check_spec.py
@@ -6,6 +6,7 @@ from dagster_shared.record import (
     IHaveNew,
     ImportFrom,
     LegacyNamedTupleMixin,
+    record,
     record_custom,
     replace,
 )
@@ -137,3 +138,20 @@ class AssetCheckSpec(IHaveNew, LegacyNamedTupleMixin):
 
     def with_metadata(self, metadata: Mapping[str, Any]) -> "AssetCheckSpec":
         return replace(self, metadata=metadata)
+
+
+"""
+Prototype for the config information we will need to create an in-app check.
+"""
+
+
+class AssetCheckType(Enum):
+    METADATA_THRESHOLD = "METADATA_THRESHOLD"
+
+
+@record
+class AssetCheckConfig:
+    check_spec: AssetCheckSpec
+    severity: AssetCheckSeverity
+    check_type: AssetCheckType
+    config: dict

--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -14,6 +14,7 @@ from typing_extensions import Self, TypeAlias
 
 import dagster._check as check
 from dagster._annotations import public
+from dagster._core.definitions.asset_checks.asset_check_spec import AssetCheckConfig
 from dagster._core.instance.config import DAGSTER_CONFIG_YAML_FILENAME
 from dagster._core.instance.methods.asset_methods import AssetMethods
 from dagster._core.instance.methods.daemon_methods import DaemonMethods
@@ -965,3 +966,7 @@ class DagsterInstance(
 
     def dagster_observe_supported(self) -> bool:
         return False
+
+    def get_in_app_checks(self) -> Sequence[AssetCheckConfig]:
+        """OSS version returns nothing."""
+        return []


### PR DESCRIPTION
Defines an `AssetCheckConfig` class that represents what info we would need to store from the user to make an in-app check. It's an incomplete set of config, but enough to get a demo together. 

Also adds an instance method to fetch in-app checks. For OSS this returns an empty list

Internal PR https://github.com/dagster-io/internal/pull/18244
