### PR TITLE
[dagster-databricks] Support task to asset spec mapping in DatabricksAssetBundleComponent

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
@@ -146,7 +146,7 @@ class DatabricksAssetBundleComponent(Component, Resolvable):
             ],
         ),
     ] = None
-    asset_specs_by_task_key: Optional[dict[str, list[ResolvedAssetSpec]]] = None
+    assets_by_task_key: Optional[dict[str, list[ResolvedAssetSpec]]] = None
 
     @cached_property
     def databricks_config(self) -> DatabricksConfig:
@@ -159,7 +159,7 @@ class DatabricksAssetBundleComponent(Component, Resolvable):
             task_key: self.get_asset_spec(task=task) for task_key, task in tasks_by_task_key.items()
         }
 
-        provided_asset_specs_by_task_key = self.asset_specs_by_task_key or {}
+        provided_asset_specs_by_task_key = self.assets_by_task_key or {}
 
         provided_task_keys = provided_asset_specs_by_task_key.keys()
         missing_task_keys = tasks_by_task_key.keys() - provided_task_keys

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/configs.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/configs.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from functools import cached_property
 from pathlib import Path
 from typing import Any, Generic, Optional, Union
 
@@ -587,6 +588,10 @@ class DatabricksConfig(IHaveNew):
             job_parameters = job_config["job_parameters"]
 
         return job_parameters
+
+    @cached_property
+    def tasks_by_task_key(self) -> dict[str, DatabricksBaseTask]:
+        return {task.task_key: task for task in self.tasks}
 
 
 @preview

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_component.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_component.py
@@ -174,7 +174,7 @@ def test_load_component(
                         "host": TEST_DATABRICKS_WORKSPACE_HOST,
                         "token": TEST_DATABRICKS_WORKSPACE_TOKEN,
                     },
-                    "asset_specs_by_task_key": custom_asset_specs,
+                    "assets_by_task_key": custom_asset_specs,
                 },
             },
         )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_component.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/components/databricks_asset_bundle/test_component.py
@@ -84,6 +84,37 @@ def test_component_asset_spec(
 
 
 @pytest.mark.parametrize(
+    "custom_asset_specs, expected_asset_spec_keys",
+    [
+        (None, {AssetKey(["data_processing_notebook"])}),
+        (
+            {
+                "data_processing_notebook": [
+                    {"key": "data_processing_notebook_asset1"},
+                    {"key": "data_processing_notebook_asset2"},
+                ],
+                "stage_documents": [
+                    {
+                        "key": "stage_documents",
+                        "deps": [
+                            "data_processing_notebook_asset1",
+                            "data_processing_notebook_asset2",
+                        ],
+                    },
+                ],
+            },
+            {
+                AssetKey(["data_processing_notebook_asset1"]),
+                AssetKey(["data_processing_notebook_asset2"]),
+            },
+        ),
+    ],
+    ids=[
+        "no_custom_asset_specs",
+        "custom_asset_specs",
+    ],
+)
+@pytest.mark.parametrize(
     "custom_op_name",
     [
         None,
@@ -115,6 +146,8 @@ def test_load_component(
         ResolvedDatabricksServerlessConfig,
     ],
     custom_op_name: Optional[str],
+    custom_asset_specs: Optional[dict[str, list[dict[str, Any]]]],
+    expected_asset_spec_keys: set[AssetKey],
     databricks_config_path: str,
 ):
     with create_defs_folder_sandbox() as sandbox:
@@ -141,6 +174,7 @@ def test_load_component(
                         "host": TEST_DATABRICKS_WORKSPACE_HOST,
                         "token": TEST_DATABRICKS_WORKSPACE_TOKEN,
                     },
+                    "asset_specs_by_task_key": custom_asset_specs,
                 },
             },
         )
@@ -170,14 +204,16 @@ def test_load_component(
             assert isinstance(databricks_assets.backfill_policy, BackfillPolicy)
             assert databricks_assets.backfill_policy.policy_type == BackfillPolicyType.SINGLE_RUN
 
-            assert defs.resolve_asset_graph().get_all_asset_keys() == {
-                AssetKey(["check_data_quality"]),
-                AssetKey(["data_processing_notebook"]),
-                AssetKey(["existing_job_with_references"]),
-                AssetKey(["hello_world_spark_task"]),
-                AssetKey(["spark_processing_jar"]),
-                AssetKey(["stage_documents"]),
-            }
+            assert defs.resolve_asset_graph().get_all_asset_keys() == (
+                {
+                    AssetKey(["check_data_quality"]),
+                    AssetKey(["existing_job_with_references"]),
+                    AssetKey(["hello_world_spark_task"]),
+                    AssetKey(["spark_processing_jar"]),
+                    AssetKey(["stage_documents"]),
+                }
+                | expected_asset_spec_keys
+            )
 
 
 def test_invalid_compute_config(databricks_config_path: str):


### PR DESCRIPTION
## Summary & Motivation

Databricks tasks don't necessarily map to a single asset - we need a way to pass to what assets a Databricks map.

Currently, we can't add custom fields in required Databricks files (databricks.yml, includes, resources, etc.).

This PR adds a new attribute in the component - asset_specs_by_task_key - that can be customized in defs.yaml. Default asset spec is created for tasks for which asset specs are not defined using this attribute.

```yaml
type: dagster_databricks.components.databricks_asset_bundle.component.DatabricksAssetBundleComponent

attributes:
   asset_specs_by_task_key:
       my_task:
           - key: my_asset_1
             deps: [some_asset]
           - key: my_asset_2
             deps: [some_asset]
```

## How I Tested These Changes

Additional tests with BK

