### PR TITLE
Update DA docs to reflect new run tags rule

### DIFF
--- a/docs/docs/guides/automate/declarative-automation/customizing-automation-conditions/customizing-eager-condition.md
+++ b/docs/docs/guides/automate/declarative-automation/customizing-automation-conditions/customizing-eager-condition.md
@@ -45,7 +45,7 @@ This can be combined with `AutomationCondition.eager()` to ensure that your asse
 
 By default, `AutomationCondition.eager()` materializes a target whenever any upstream event occurs, regardless of the source of that event.
 
-It can be useful to ignore runs of certain types when determining if an upstream asset should be considered "updated". This can be done using `AutomationCondition.executed_with_tags()` to filter updates for runs with tags matching particular keys:
+It can be useful to ignore runs of certain types when determining if an upstream asset should be considered "updated". This can be done using `AutomationCondition.any_new_update_has_run_tags()` to filter updates for runs with tags matching particular keys:
 
 <CodeExample
   path="docs_snippets/docs_snippets/concepts/declarative_automation/eager/executed_with_tags_condition.py"

--- a/examples/docs_snippets/docs_snippets/concepts/declarative_automation/eager/executed_with_tags_condition.py
+++ b/examples/docs_snippets/docs_snippets/concepts/declarative_automation/eager/executed_with_tags_condition.py
@@ -1,7 +1,7 @@
 import dagster as dg
 
-# detects if the latest run of the target was executed via an automation condition
-executed_via_condition = dg.AutomationCondition.executed_with_tags(
+# detects if any of the new updates of the target was executed via an automation condition
+executed_via_condition = dg.AutomationCondition.any_new_update_has_run_tags(
     tag_values={"dagster/from_automation_condition": "true"}
 )
 


### PR DESCRIPTION
Summary:
This new rule is more resilient to multiple runs materializing the same asset at the same time.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
