### PR TITLE
[docs] Update insights retention length

### DIFF
--- a/docs/docs/guides/observe/insights/index.md
+++ b/docs/docs/guides/observe/insights/index.md
@@ -30,7 +30,7 @@ To access Insights views, you can either:
 
 ![Insights UI](/images/guides/observe/insights/insights-ui.png)
 
-Key asset health metrics, like materialization and failure count, are prominently displayed for assets and selections, and additional metrics are displayed for jobs and deployments. Historical Insights data is retained for 120 days.
+Key asset health metrics, like materialization and failure count, are prominently displayed for assets and selections, and additional metrics are displayed for jobs and deployments. Historical Insights data can be queried for up to 30 days.
 
 For a full list of metrics, see the [supported metrics](#supported-metrics) section.
 


### PR DESCRIPTION
## Summary & Motivation
This used the 120 day timeline from insights v1, while v2 only supports 30 days right now.

Also updated the phrasing to clarify this is about query lookback, not how long they're retained, to not misrepresent data retention from a compliance perspective.

## How I Tested These Changes
Locally
