### PR TITLE
[ui] Use execution plan asset keys to determine asset lineage link on Run page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -148,7 +148,7 @@
   "RunActionButtonsTestQuery": "604a93ec19ca72ff504447fb4bae7309f0ae8ab24ec5d7b688d7312d3a00848d",
   "CheckBackfillStatus": "d102ea2a2b731fdbefb7b6762c94aa0a8468b7977c9143cec33a8ea900f2e469",
   "RunsRootQuery": "091646e47ecea81ba4765a3f2cead18880b09ee400d1d7e9dcb6e194ee364e51",
-  "RunsFeedRootQuery": "595b8ee4f5fa5b704053ff7a3c36b8af752935c61e35b39bc75b541d5322d043",
+  "RunsFeedRootQuery": "508fd17076ac393f40a5e4ae7e72d6a9dd2db681a1e893ab5fc7c1f3da178bed",
   "OngoingRunTimelineQuery": "7437e39dbde776b1bbaa231d1cfdd4611117e72eabd0f8fc9f64d13ec150c82b",
   "CompletedRunTimelineQuery": "1f34f13f13209633691baabedf021000f45052a8cc5499108393013cae3e1f00",
   "FutureTicksQuery": "9b947053273ecaa20ef19df02f0aa8e6f33b8a1628175987670e3c73a350e640",

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenuRunFragment.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenuRunFragment.tsx
@@ -8,6 +8,11 @@ export const RUN_ACTIONS_MENU_RUN_FRAGMENT = gql`
         path
       }
     }
+    executionPlan {
+      assetKeys {
+        path
+      }
+    }
     assetCheckSelection {
       name
       assetKey {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/externalRuns.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/externalRuns.tsx
@@ -1,12 +1,15 @@
-import {Run} from '../graphql/types';
+type RunTag = {
+  key: string;
+  value: string;
+};
 
-export const isExternalRun = (run: Pick<Run, 'tags'>) => {
+export const isExternalRun = (run: {tags: RunTag[]}) => {
   return run.tags.some(
     (tag) => tag.key === 'dagster/external_job_source' && tag.value.toLowerCase() === 'airflow',
   );
 };
 
-export const getExternalRunUrl = (run: Pick<Run, 'tags'>) => {
+export const getExternalRunUrl = (run: {tags: RunTag[]}) => {
   const airflowUrl = run.tags.find(
     (tag) => tag.key === 'dagster-airlift/airflow-dag-run-url',
   )?.value;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunActionsMenuRunFragment.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunActionsMenuRunFragment.types.ts
@@ -15,6 +15,10 @@ export type RunActionsMenuRunFragment = {
   pipelineSnapshotId: string | null;
   hasRunMetricsEnabled: boolean;
   assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
+  executionPlan: {
+    __typename: 'ExecutionPlan';
+    assetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;
+  } | null;
   assetCheckSelection: Array<{
     __typename: 'AssetCheckhandle';
     name: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsFeedTableEntryFragment.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsFeedTableEntryFragment.types.ts
@@ -69,6 +69,10 @@ export type RunsFeedTableEntryFragment_Run = {
     name: string;
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
   }> | null;
+  executionPlan: {
+    __typename: 'ExecutionPlan';
+    assetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;
+  } | null;
 };
 
 export type RunsFeedTableEntryFragment =

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsFeedEntries.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsFeedEntries.types.ts
@@ -93,9 +93,13 @@ export type RunsFeedRootQuery = {
                 name: string;
                 assetKey: {__typename: 'AssetKey'; path: Array<string>};
               }> | null;
+              executionPlan: {
+                __typename: 'ExecutionPlan';
+                assetKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;
+              } | null;
             }
         >;
       };
 };
 
-export const RunsFeedRootQueryVersion = '595b8ee4f5fa5b704053ff7a3c36b8af752935c61e35b39bc75b541d5322d043';
+export const RunsFeedRootQueryVersion = '508fd17076ac393f40a5e4ae7e72d6a9dd2db681a1e893ab5fc7c1f3da178bed';


### PR DESCRIPTION
## Summary & Motivation

Now that @OwenKephart has added the execution plan `assetKeys` to runs, we can use this to correctly build an href from a run to view asset lineage.

- If there is an asset selection, link to that.
- Else, if there is a list of asset keys in the execution plan, link to that.

## How I Tested These Changes

View a run that has an `assetSelection`, verify that it links correctly. View a run that only has asset keys on `executionPlan`, verify that it links correctly.

## Changelog

[ui] Fixed the link to "View asset lineage" on runs that don't specify an asset selection.
