### PR TITLE
re-export `partitioned_config`

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -379,6 +379,7 @@ from dagster._core.definitions.partitions.partitioned_config import (
     dynamic_partitioned_config as dynamic_partitioned_config,
     hourly_partitioned_config as hourly_partitioned_config,
     monthly_partitioned_config as monthly_partitioned_config,
+    partitioned_config as partitioned_config,
     static_partitioned_config as static_partitioned_config,
     weekly_partitioned_config as weekly_partitioned_config,
 )


### PR DESCRIPTION
## Summary & Motivation

Context: https://github.com/dagster-io/dagster/pull/30964

## How I Tested These Changes

`from dagster import partitioned_config`

## Changelog

In `dagster==1.11.1`, `partitioned_config` was unintentionally removed from the public exports of the top-level `dagster` package. This has been fixed.
