### PR TITLE
[sbc] Fix context var error

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/defs_state/base.py
+++ b/python_modules/dagster/dagster/_core/storage/defs_state/base.py
@@ -24,7 +24,13 @@ def set_defs_state_storage(storage: Optional["DefsStateStorage"]):
     try:
         yield
     finally:
-        _current_storage.reset(token)
+        try:
+            _current_storage.reset(token)
+        except ValueError:
+            # in certain async contexts, we exit the context manager in a separate
+            # async task from the one that created the token. in these cases, we
+            # can't reset the token value, so we just set it to None
+            _current_storage.set(None)
 
 
 class DefsStateStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):


### PR DESCRIPTION
## Summary & Motivation

This issue crops up as a side effect of other errors when inside of a webserver that does fancy async things.

The actual error is generally harmless (the process was already in the process of erroring, this just gets added to the stack trace), but we should handle this more gracefully in general and the original behavior here was to set the current storage to None on exit anyway (the contextvar stuff is really just necessary for some pretty niche scenarios) so messing with this isn't the end of the world.

## How I Tested These Changes

verified the test produced the originally observed error, and now no longer does

## Changelog

NOCHANGELOG
