### PR TITLE
DOC-1461 Add beta admonition to Insights docs

### DIFF
--- a/docs/docs/guides/observe/insights/google-bigquery.md
+++ b/docs/docs/guides/observe/insights/google-bigquery.md
@@ -19,7 +19,7 @@ The BigQuery cost metric is based off of the bytes billed for queries executed w
 
 :::info
 
-Support for integrating asset metadata is coming soon in updated Insights. To use legacy Insights, toggle off "New homepage & observability UIs" in your user settings.
+Support for tracking external metrics is coming soon in updated Insights. To use legacy Insights, toggle off "New homepage & observability UIs" in your user settings.
 
 :::
 

--- a/docs/docs/guides/observe/insights/index.md
+++ b/docs/docs/guides/observe/insights/index.md
@@ -7,9 +7,12 @@ canonicalUrl: '/guides/observe/insights'
 slug: '/guides/observe/insights'
 ---
 
+import Beta from '@site/docs/partials/\_Beta.md';
 import DagsterPlus from '@site/docs/partials/\_DagsterPlus.md';
 
 <DagsterPlus />
+
+<Beta />
 
 Using Dagster+ Insights, you can gain visibility into historical usage and trends, such as execution time, success rate, and time to resolving failures. You can also build custom reports to compare different deployments or selections of assets against each other to quickly identify issues across your data platform.
 

--- a/docs/docs/guides/observe/insights/snowflake.md
+++ b/docs/docs/guides/observe/insights/snowflake.md
@@ -13,7 +13,7 @@ Dagster+ allows you to track external metrics, such as Snowflake usage, in the I
 
 :::info
 
-Support for integrating asset metadata is coming soon in updated Insights. To use legacy Insights, toggle off "New homepage & observability UIs" in your user settings.
+Support for tracking external metrics is coming soon in updated Insights. To use legacy Insights, toggle off "New homepage & observability UIs" in your user settings.
 
 :::
 

--- a/docs/docs/partials/_Beta.md
+++ b/docs/docs/partials/_Beta.md
@@ -1,4 +1,4 @@
-:::info
+:::info Beta feature
 
 This feature is considered in a beta stage. It is still being tested and may change. For more information, see the [API lifecycle stages documentation](/api/api-lifecycle/api-lifecycle-stages).
 

--- a/docs/docs/partials/_Deprecated.md
+++ b/docs/docs/partials/_Deprecated.md
@@ -1,4 +1,4 @@
-:::warning
+:::warning Deprecated feature
 
 This feature is considered deprecated. It is still available, but will be removed in the future, and we recommend avoiding new usage. For more information, see the [API lifecycle stages documentation](/api/api-lifecycle/api-lifecycle-stages).
 

--- a/docs/docs/partials/_Preview.md
+++ b/docs/docs/partials/_Preview.md
@@ -1,4 +1,4 @@
-:::info
+:::info Preview feature
 
 This feature is considered in a preview stage, and is under active development, and not considered ready for production use. You may encounter feature gaps, and the APIs may change. For more information, see the [API lifecycle stages documentation](/api/api-lifecycle/api-lifecycle-stages).
 

--- a/docs/docs/partials/_Superseded.md
+++ b/docs/docs/partials/_Superseded.md
@@ -1,4 +1,4 @@
-:::warning
+:::warning Superseded feature
 
 This feature is considered superseded. While it is still available, it is no longer the best practice. For more information, see the [API lifecycle stages documentation](/api/api-lifecycle/api-lifecycle-stages).
 


### PR DESCRIPTION
## Summary & Motivation

* Adds beta admonition to Insights docs index page (**Note:** I wasn't sure if we wanted this admonition on all Insights docs pages or just the page that pertained to updated Insights; I can add it to the other pages if need be.)
* Updates product lifecycle admonitions to make them easier to identify and distinguish from other admonitions
* Fixes language in admonitions on external metrics integration pages (Snowflake, BigQuery)

## How I Tested These Changes

Local build

## Changelog

> Insert changelog entry or delete this section.
