### PR TITLE
Speed up assetsLatestInfo calculation

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -1215,21 +1215,7 @@ class GrapheneQuery(graphene.ObjectType):
     ):
         asset_keys = set(AssetKey.from_graphql_input(asset_key) for asset_key in assetKeys)
 
-        remote_nodes = {
-            graphene_info.context.asset_graph.get(asset_key)
-            for asset_key in asset_keys
-            if graphene_info.context.asset_graph.has(asset_key)
-        }
-
-        # Build mapping of asset key to the step keys required to generate the asset
-        step_keys_by_asset: dict[AssetKey, Sequence[str]] = {
-            remote_node.key: remote_node.resolve_to_singular_repo_scoped_node().asset_node_snap.op_names
-            for remote_node in remote_nodes
-        }
-
-        AssetRecord.prepare(graphene_info.context, asset_keys)
-
-        return get_assets_latest_info(graphene_info, step_keys_by_asset)
+        return get_assets_latest_info(graphene_info, asset_keys)
 
     @capture_error
     def resolve_logsForRun(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -2247,7 +2247,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
 
         assert result["asset_1"]["latestRun"] is None
         assert result["asset_1"]["latestMaterialization"] is None
-        assert FAKE_KEY not in result
+        assert result[FAKE_KEY]["latestRun"] is None
 
         # Test with 1 run on all assets
         first_run_id = _create_run(graphql_context, "failure_assets_job")


### PR DESCRIPTION
## Summary & Motivation
The old code here was very mystifying to me. We fetch the nodes, make a map using info in the nodes, then only use the key in that map, and not the values.

The only benefit I can see is that before it was filering out nodes not in the graph, but it seems perfectly reasonable to fetch the latest info for a node not in the graph.

## How I Tested These Changes
BK

## Changelog
