### PR TITLE
Remove expensive asset graph check from GrapheneAsset constructor

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -630,6 +630,7 @@ type Asset {
   latestEventSortKey: ID
   assetHealth: AssetHealth
   latestMaterializationTimestamp: Float
+  hasDefinitionOrRecord: Boolean!
 }
 
 type AssetResultEventHistoryConnection {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -105,6 +105,7 @@ export type Asset = {
   assetMaterializations: Array<MaterializationEvent>;
   assetObservations: Array<ObservationEvent>;
   definition: Maybe<AssetNode>;
+  hasDefinitionOrRecord: Scalars['Boolean']['output'];
   id: Scalars['String']['output'];
   key: AssetKey;
   latestEventSortKey: Maybe<Scalars['ID']['output']>;
@@ -6326,6 +6327,10 @@ export const buildAsset = (
         : relationshipsToOmit.has('AssetNode')
           ? ({} as AssetNode)
           : buildAssetNode({}, relationshipsToOmit),
+    hasDefinitionOrRecord:
+      overrides && overrides.hasOwnProperty('hasDefinitionOrRecord')
+        ? overrides.hasDefinitionOrRecord!
+        : true,
     id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'omnis',
     key:
       overrides && overrides.hasOwnProperty('key')

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -203,18 +203,8 @@ def get_asset_node(
     return GrapheneAssetNode(remote_node)
 
 
-def get_asset(
-    graphene_info: "ResolveInfo", asset_key: AssetKey
-) -> Union["GrapheneAsset", "GrapheneAssetNotFoundError"]:
-    from dagster_graphql.schema.errors import GrapheneAssetNotFoundError
+def get_asset(asset_key: AssetKey) -> "GrapheneAsset":
     from dagster_graphql.schema.pipelines.pipeline import GrapheneAsset
-
-    check.inst_param(asset_key, "asset_key", AssetKey)
-    instance = graphene_info.context.instance
-
-    has_remote_node = graphene_info.context.asset_graph.has(asset_key)
-    if not has_remote_node and not instance.has_asset_key(asset_key):
-        return GrapheneAssetNotFoundError(asset_key=asset_key)
 
     return GrapheneAsset(key=asset_key)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
@@ -55,8 +55,7 @@ class GrapheneAssetSelection(graphene.ObjectType):
 
     def _get_assets(self, graphene_info: ResolveInfo):
         return [
-            get_asset(graphene_info, asset_key)
-            for asset_key in self._get_resolved_and_sorted_keys(graphene_info)
+            get_asset(asset_key) for asset_key in self._get_resolved_and_sorted_keys(graphene_info)
         ]
 
     def resolve_assets(self, graphene_info: ResolveInfo):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -283,6 +283,7 @@ class GrapheneAsset(graphene.ObjectType):
     latestEventSortKey = graphene.Field(graphene.ID)
     assetHealth = graphene.Field(GrapheneAssetHealth)
     latestMaterializationTimestamp = graphene.Float()
+    hasDefinitionOrRecord = graphene.NonNull(graphene.Boolean)
 
     class Meta:
         name = "Asset"
@@ -457,6 +458,12 @@ class GrapheneAsset(graphene.ObjectType):
         return GrapheneAssetHealth(
             asset_key=self._asset_key,
             dynamic_partitions_loader=graphene_info.context.dynamic_partitions_loader,
+        )
+
+    async def resolve_hasDefinitionOrRecord(self, graphene_info: ResolveInfo) -> bool:
+        return (
+            graphene_info.context.asset_graph.has(self._asset_key)
+            or await AssetRecord.gen(graphene_info.context, self._asset_key) is not None
         )
 
     async def resolve_latestMaterializationTimestamp(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -1153,7 +1153,7 @@ class GrapheneQuery(graphene.ObjectType):
         )
 
     def resolve_assetOrError(self, graphene_info: ResolveInfo, assetKey: GrapheneAssetKeyInput):
-        return get_asset(graphene_info, AssetKey.from_graphql_input(assetKey))
+        return get_asset(AssetKey.from_graphql_input(assetKey))
 
     def resolve_assetNodeAdditionalRequiredKeys(
         self,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_assets.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_assets.ambr
@@ -1083,13 +1083,16 @@
           'label': 'a',
         }),
       ]),
+      'hasDefinitionOrRecord': True,
     }),
   })
 # ---
 # name: TestAssetAwareEventLog.test_get_asset_key_not_found[0]
   dict({
     'assetOrError': dict({
-      '__typename': 'AssetNotFoundError',
+      'assetMaterializations': list([
+      ]),
+      'hasDefinitionOrRecord': False,
     }),
   })
 # ---


### PR DESCRIPTION
Summary:
This makes the method unneccesarily slow. Checking whether an asset has ever existed in the database is not particularly useful, and you can check asset { definition } to see if its in the graph.

Test Plan:
BK, dry runs of slow queries
