### PR TITLE
add sensor/schedule permission checks

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -16,7 +16,7 @@ from dagster_graphql.implementation.loader import RepositoryScopedBatchLoader
 from dagster_graphql.implementation.utils import (
     UserFacingGraphQLError,
     assert_permission,
-    assert_permission_for_location,
+    assert_permission_for_definition,
 )
 from dagster_graphql.schema.util import ResolveInfo
 
@@ -68,11 +68,7 @@ def stop_schedule(
     schedule = schedules.get(schedule_origin_id)
 
     if schedule:
-        assert_permission_for_location(
-            graphene_info,
-            Permissions.STOP_RUNNING_SCHEDULE,
-            schedule.selector.location_name,
-        )
+        assert_permission_for_definition(graphene_info, Permissions.STOP_RUNNING_SCHEDULE, schedule)
     else:
         assert_permission(
             graphene_info,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -16,7 +16,7 @@ from dagster_graphql.implementation.loader import RepositoryScopedBatchLoader
 from dagster_graphql.implementation.utils import (
     UserFacingGraphQLError,
     assert_permission,
-    assert_permission_for_definition,
+    assert_permission_for_schedule,
 )
 from dagster_graphql.schema.util import ResolveInfo
 
@@ -68,7 +68,9 @@ def stop_schedule(
     schedule = schedules.get(schedule_origin_id)
 
     if schedule:
-        assert_permission_for_definition(graphene_info, Permissions.STOP_RUNNING_SCHEDULE, schedule)
+        assert_permission_for_schedule(
+            graphene_info, Permissions.STOP_RUNNING_SCHEDULE, schedule.schedule_selector
+        )
     else:
         assert_permission(
             graphene_info,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -24,7 +24,13 @@ from dagster._core.definitions.asset_checks.asset_check_spec import AssetCheckKe
 from dagster._core.definitions.assets.graph.remote_asset_graph import RemoteWorkspaceAssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.partitions.definition import PartitionsDefinition
-from dagster._core.definitions.selector import GraphSelector, JobSelector, JobSubsetSelector
+from dagster._core.definitions.selector import (
+    GraphSelector,
+    JobSelector,
+    JobSubsetSelector,
+    ScheduleSelector,
+    SensorSelector,
+)
 from dagster._core.definitions.temporal_context import TemporalContext
 from dagster._core.errors import DagsterError, DagsterInvariantViolationError
 from dagster._core.execution.backfill import PartitionBackfill
@@ -226,6 +232,30 @@ def assert_permission_for_job(
 
     if not has_permission_for_job(graphene_info, permission, job_selector, asset_keys):
         raise UserFacingGraphQLError(GrapheneUnauthorizedError())
+
+
+def assert_permission_for_sensor(
+    graphene_info: "ResolveInfo",
+    permission: Permissions,
+    sensor_selector: SensorSelector,
+):
+    remote_sensor = graphene_info.context.get_sensor(sensor_selector)
+    if not remote_sensor:
+        assert_permission_for_location(graphene_info, permission, sensor_selector.location_name)
+    else:
+        assert_permission_for_definition(graphene_info, permission, remote_sensor)
+
+
+def assert_permission_for_schedule(
+    graphene_info: "ResolveInfo",
+    permission: Permissions,
+    schedule_selector: ScheduleSelector,
+):
+    remote_schedule = graphene_info.context.get_schedule(schedule_selector)
+    if not remote_schedule:
+        assert_permission_for_location(graphene_info, permission, schedule_selector.location_name)
+    else:
+        assert_permission_for_definition(graphene_info, permission, remote_schedule)
 
 
 def assert_valid_job_partition_backfill(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -239,11 +239,10 @@ def assert_permission_for_sensor(
     permission: Permissions,
     sensor_selector: SensorSelector,
 ):
-    remote_sensor = graphene_info.context.get_sensor(sensor_selector)
-    if not remote_sensor:
-        assert_permission_for_location(graphene_info, permission, sensor_selector.location_name)
-    else:
-        assert_permission_for_definition(graphene_info, permission, remote_sensor)
+    from dagster_graphql.schema.errors import GrapheneUnauthorizedError
+
+    if not graphene_info.context.has_permission_for_selector(permission, sensor_selector):
+        raise UserFacingGraphQLError(GrapheneUnauthorizedError())
 
 
 def assert_permission_for_schedule(
@@ -251,11 +250,10 @@ def assert_permission_for_schedule(
     permission: Permissions,
     schedule_selector: ScheduleSelector,
 ):
-    remote_schedule = graphene_info.context.get_schedule(schedule_selector)
-    if not remote_schedule:
-        assert_permission_for_location(graphene_info, permission, schedule_selector.location_name)
-    else:
-        assert_permission_for_definition(graphene_info, permission, remote_schedule)
+    from dagster_graphql.schema.errors import GrapheneUnauthorizedError
+
+    if not graphene_info.context.has_permission_for_selector(permission, schedule_selector):
+        raise UserFacingGraphQLError(GrapheneUnauthorizedError())
 
 
 def assert_valid_job_partition_backfill(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/__init__.py
@@ -12,7 +12,7 @@ from dagster_graphql.implementation.fetch_schedules import (
     stop_schedule,
 )
 from dagster_graphql.implementation.utils import (
-    assert_permission_for_location,
+    assert_permission_for_schedule,
     capture_error,
     require_permission_check,
 )
@@ -89,9 +89,7 @@ class GrapheneStartScheduleMutation(graphene.Mutation):
     @require_permission_check(Permissions.START_SCHEDULE)
     def mutate(self, graphene_info: ResolveInfo, schedule_selector):
         selector = ScheduleSelector.from_graphql_input(schedule_selector)
-        assert_permission_for_location(
-            graphene_info, Permissions.START_SCHEDULE, selector.location_name
-        )
+        assert_permission_for_schedule(graphene_info, Permissions.START_SCHEDULE, selector)
         return start_schedule(graphene_info, selector)
 
 
@@ -151,12 +149,8 @@ class GrapheneResetScheduleMutation(graphene.Mutation):
     def mutate(self, graphene_info: ResolveInfo, schedule_selector):
         selector = ScheduleSelector.from_graphql_input(schedule_selector)
 
-        assert_permission_for_location(
-            graphene_info, Permissions.START_SCHEDULE, selector.location_name
-        )
-        assert_permission_for_location(
-            graphene_info, Permissions.STOP_RUNNING_SCHEDULE, selector.location_name
-        )
+        assert_permission_for_schedule(graphene_info, Permissions.START_SCHEDULE, selector)
+        assert_permission_for_schedule(graphene_info, Permissions.STOP_RUNNING_SCHEDULE, selector)
 
         return reset_schedule(graphene_info, selector)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -22,7 +22,7 @@ from dagster_graphql.implementation.fetch_sensors import (
 )
 from dagster_graphql.implementation.loader import RepositoryScopedBatchLoader
 from dagster_graphql.implementation.utils import (
-    assert_permission_for_location,
+    assert_permission_for_sensor,
     capture_error,
     require_permission_check,
 )
@@ -204,12 +204,10 @@ class GrapheneStartSensorMutation(graphene.Mutation):
         name = "StartSensorMutation"
 
     @capture_error
-    @require_permission_check(Permissions.UPDATE_SENSOR_CURSOR)
+    @require_permission_check(Permissions.EDIT_SENSOR)
     def mutate(self, graphene_info: ResolveInfo, sensor_selector):
         selector = SensorSelector.from_graphql_input(sensor_selector)
-        assert_permission_for_location(
-            graphene_info, Permissions.UPDATE_SENSOR_CURSOR, selector.location_name
-        )
+        assert_permission_for_sensor(graphene_info, Permissions.EDIT_SENSOR, selector)
         return start_sensor(graphene_info, selector)
 
 
@@ -293,9 +291,7 @@ class GrapheneResetSensorMutation(graphene.Mutation):
     def mutate(self, graphene_info: ResolveInfo, sensor_selector):
         selector = SensorSelector.from_graphql_input(sensor_selector)
 
-        assert_permission_for_location(
-            graphene_info, Permissions.EDIT_SENSOR, selector.location_name
-        )
+        assert_permission_for_sensor(graphene_info, Permissions.EDIT_SENSOR, selector)
 
         return reset_sensor(graphene_info, selector)
 
@@ -313,11 +309,10 @@ class GrapheneSetSensorCursorMutation(graphene.Mutation):
         name = "SetSensorCursorMutation"
 
     @capture_error
+    @require_permission_check(Permissions.UPDATE_SENSOR_CURSOR)
     def mutate(self, graphene_info: ResolveInfo, sensor_selector, cursor=None):
         selector = SensorSelector.from_graphql_input(sensor_selector)
-        assert_permission_for_location(
-            graphene_info, Permissions.UPDATE_SENSOR_CURSOR, selector.location_name
-        )
+        assert_permission_for_sensor(graphene_info, Permissions.UPDATE_SENSOR_CURSOR, selector)
         return set_sensor_cursor(graphene_info, selector, cursor)
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
@@ -301,6 +301,26 @@
     dict({
       'description': None,
       'minIntervalSeconds': 30,
+      'name': 'owned_sensor',
+      'sensorState': dict({
+        'runs': list([
+        ]),
+        'runsCount': 0,
+        'status': 'STOPPED',
+        'ticks': list([
+        ]),
+      }),
+      'targets': list([
+        dict({
+          'mode': 'default',
+          'pipelineName': 'owned_job',
+          'solidSelection': None,
+        }),
+      ]),
+    }),
+    dict({
+      'description': None,
+      'minIntervalSeconds': 30,
       'name': 'run_key_sensor',
       'sensorState': dict({
         'runs': list([
@@ -411,6 +431,26 @@
         ]),
       }),
       'targets': list([
+      ]),
+    }),
+    dict({
+      'description': None,
+      'minIntervalSeconds': 30,
+      'name': 'unowned_sensor',
+      'sensorState': dict({
+        'runs': list([
+        ]),
+        'runsCount': 0,
+        'status': 'STOPPED',
+        'ticks': list([
+        ]),
+      }),
+      'targets': list([
+        dict({
+          'mode': 'default',
+          'pipelineName': 'unowned_job',
+          'solidSelection': None,
+        }),
       ]),
     }),
     dict({

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1155,6 +1155,8 @@ def define_schedules():
         provide_config_schedule,
         always_error,
         jobless_schedule,
+        owned_schedule,
+        unowned_schedule,
     ]
 
 
@@ -1303,6 +1305,8 @@ def define_sensors():
         every_asset_sensor,
         invalid_asset_selection_error,
         jobless_sensor,
+        owned_sensor,
+        unowned_sensor,
     ]
 
 
@@ -2240,6 +2244,26 @@ def owned_job():
 @job
 def unowned_job():
     permission_test_op()
+
+
+@sensor(job=owned_job)
+def owned_sensor():
+    pass
+
+
+@sensor(job=unowned_job)
+def unowned_sensor():
+    pass
+
+
+@schedule(job=owned_job, cron_schedule="* * * * *")
+def owned_schedule():
+    return {}
+
+
+@schedule(job=unowned_job, cron_schedule="* * * * *")
+def unowned_schedule():
+    return {}
 
 
 def define_assets():


### PR DESCRIPTION
## Summary & Motivation
This changes the sensor / schedule graphql mutations to per-definition permission checks enabled by https://github.com/dagster-io/dagster/pull/32151

## How I Tested These Changes
BK
