### PR TITLE
add backfill permission checks

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -144,9 +144,6 @@ def create_and_launch_partition_backfill(
         repository_selector = RepositorySelector.from_graphql_input(
             partition_set_selector.get("repositorySelector")
         )
-        # assert_permission_for_location(
-        #     graphene_info, Permissions.LAUNCH_PARTITION_BACKFILL, repository_selector.location_name
-        # )
         partitions_sets = graphene_info.context.get_partition_sets(repository_selector)
         matches = [
             partition_set
@@ -154,6 +151,9 @@ def create_and_launch_partition_backfill(
             if partition_set.name == partition_set_selector.get("partitionSetName")
         ]
         if len(matches) != 1:
+            # if no matches, either throw a not found error or a more general invariant violation
+            # but, to maintain the same behavior, we should check location permissions first, which
+            # got deferred to support per-definition permissions
             assert_permission_for_location(
                 graphene_info,
                 Permissions.LAUNCH_PARTITION_BACKFILL,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -323,9 +323,8 @@ def has_permission_for_backfill(
             permission,
         )
 
-    # job backfill
+    # job backfill, check permissions for the job
     if not backfill.partition_set_origin:
-        # does not resolve to a partition set, so need deployment-wide permissions
         return graphene_info.context.has_permission(permission)
 
     partition_selector = backfill.partition_set_origin.selector
@@ -338,7 +337,6 @@ def has_permission_for_backfill(
             repository_name=partition_selector.repository_name,
         )
     )
-
     matches = [
         partition_set
         for partition_set in partition_sets
@@ -351,19 +349,7 @@ def has_permission_for_backfill(
         )
 
     remote_partition_set = next(iter(matches))
-    if not graphene_info.context.has_job(
-        JobSelector(
-            location_name=partition_selector.location_name,
-            repository_name=partition_selector.repository_name,
-            job_name=remote_partition_set.job_name,
-        )
-    ):
-        return graphene_info.context.has_permission_for_location(
-            permission, partition_selector.location_name
-        )
-
-    return has_permission_for_job(
-        graphene_info,
+    return graphene_info.context.has_permission_for_selector(
         permission,
         JobSelector(
             location_name=partition_selector.location_name,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -28,6 +28,7 @@ from dagster._core.definitions.selector import (
     GraphSelector,
     JobSelector,
     JobSubsetSelector,
+    RepositorySelector,
     ScheduleSelector,
     SensorSelector,
 )
@@ -321,38 +322,55 @@ def has_permission_for_backfill(
             cast("list[AssetKey]", backfill.asset_selection),
             permission,
         )
+
+    # job backfill
     if not backfill.partition_set_origin:
         # does not resolve to a partition set, so need deployment-wide permissions
         return graphene_info.context.has_permission(permission)
 
     partition_selector = backfill.partition_set_origin.selector
-    try:
-        code_location = graphene_info.context.get_code_location(partition_selector.location_name)
-    except (DagsterCodeLocationNotFoundError, DagsterCodeLocationLoadError):
-        code_location = None
+    if not graphene_info.context.has_code_location_name(partition_selector.location_name):
+        return graphene_info.context.has_permission(permission)
 
-    if not code_location or not code_location.has_repository(partition_selector.repository_name):
-        repository = None
-    else:
-        repository = code_location.get_repository(partition_selector.repository_name)
+    partition_sets = graphene_info.context.get_partition_sets(
+        repository_selector=RepositorySelector(
+            location_name=partition_selector.location_name,
+            repository_name=partition_selector.repository_name,
+        )
+    )
 
-    if repository:
-        matches = [
-            partition_set
-            for partition_set in repository.get_partition_sets()
-            if partition_set.name == partition_selector.partition_set_name
-        ]
-    else:
-        matches = []
+    matches = [
+        partition_set
+        for partition_set in partition_sets
+        if partition_set.name == partition_selector.partition_set_name
+    ]
 
-    if not repository or len(matches) != 1:
+    if len(matches) != 1:
         return graphene_info.context.has_permission_for_location(
             permission, partition_selector.location_name
         )
 
     remote_partition_set = next(iter(matches))
-    remote_job = repository.get_full_job(remote_partition_set.job_name)
-    return has_permission_for_remote_job(graphene_info, permission, remote_job)
+    if not graphene_info.context.has_job(
+        JobSelector(
+            location_name=partition_selector.location_name,
+            repository_name=partition_selector.repository_name,
+            job_name=remote_partition_set.job_name,
+        )
+    ):
+        return graphene_info.context.has_permission_for_location(
+            permission, partition_selector.location_name
+        )
+
+    return has_permission_for_job(
+        graphene_info,
+        permission,
+        JobSelector(
+            location_name=partition_selector.location_name,
+            repository_name=partition_selector.repository_name,
+            job_name=remote_partition_set.job_name,
+        ),
+    )
 
 
 def assert_permission_for_backfill(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
@@ -13200,6 +13200,895 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Determines when steps will be executed in relation to their upstream dependencies.",
+              "is_required": false,
+              "name": "step_dependency_config",
+              "type_key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0242afee86bb21fdc0580e1b8a2b7d250c760d1e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"permission_partitioned_op\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.4350a304dcf7c83ee382cff5e3fea74c15137ea3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0242afee86bb21fdc0580e1b8a2b7d250c760d1e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4350a304dcf7c83ee382cff5e3fea74c15137ea3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "permission_partitioned_op",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4350a304dcf7c83ee382cff5e3fea74c15137ea3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "true",
+              "description": null,
+              "is_required": false,
+              "name": "require_upstream_step_success",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.f07ed19fc888e3245c2ca562556397f72651e11e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "permission_partitioned_op",
+          "solid_name": "permission_partitioned_op",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "owned_partitioned_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.0242afee86bb21fdc0580e1b8a2b7d250c760d1e"
+      }
+    ],
+    "name": "owned_partitioned_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "permission_partitioned_op",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[115]
+  '1b42afdb2cf17f1eb539d6ac57a721f606094d29'
+# ---
+# name: test_all_snapshot_ids[116]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Selector.2571019f1a5201853d11032145ac3e534067f214": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -14103,10 +14992,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[115]
+# name: test_all_snapshot_ids[117]
   '233628b6438c412a9dad42bde19333aaf049c69d'
 # ---
-# name: test_all_snapshot_ids[116]
+# name: test_all_snapshot_ids[118]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -14992,10 +15881,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[117]
+# name: test_all_snapshot_ids[119]
   'd450ebd7f78aee6ac5a168c0fe067be9d54f73e4'
 # ---
-# name: test_all_snapshot_ids[118]
+# name: test_all_snapshot_ids[11]
+  'ad43fd0ed33d251e59699714c9ed3c2a09e68144'
+# ---
+# name: test_all_snapshot_ids[120]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -15927,13 +16819,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[119]
+# name: test_all_snapshot_ids[121]
   '9b5e553f89ddbc226dbecab4c7089e674e5fad00'
 # ---
-# name: test_all_snapshot_ids[11]
-  'ad43fd0ed33d251e59699714c9ed3c2a09e68144'
-# ---
-# name: test_all_snapshot_ids[120]
+# name: test_all_snapshot_ids[122]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -16867,10 +17756,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[121]
+# name: test_all_snapshot_ids[123]
   'd4e391bb0b67dc2ab123a6b916dde11512c23309'
 # ---
-# name: test_all_snapshot_ids[122]
+# name: test_all_snapshot_ids[124]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -17804,10 +18693,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[123]
+# name: test_all_snapshot_ids[125]
   'c250d86efc3f664a85d230cc60290d1063af136d'
 # ---
-# name: test_all_snapshot_ids[124]
+# name: test_all_snapshot_ids[126]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -18976,10 +19865,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[125]
+# name: test_all_snapshot_ids[127]
   '26153fa2a038ce865a9f760acbb0f835d00d642d'
 # ---
-# name: test_all_snapshot_ids[126]
+# name: test_all_snapshot_ids[128]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -20170,1011 +21059,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[127]
-  '40916e47f71cc225179f16e1507a7e924ab6701c'
-# ---
-# name: test_all_snapshot_ids[128]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Determines when steps will be executed in relation to their upstream dependencies.",
-              "is_required": false,
-              "name": "step_dependency_config",
-              "type_key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.38333f2a1cae02c5cf3896b9a3f453862c72febb": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"start\": {}, \"will_fail\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.771375a24eca0dc65af691c7fe224aef2fb063e4"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"a\": {}, \"b\": {}, \"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.4678ad2ed1f8478f0abd5e4134850ab395b48f25"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.38333f2a1cae02c5cf3896b9a3f453862c72febb",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4678ad2ed1f8478f0abd5e4134850ab395b48f25": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "a",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "b",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4678ad2ed1f8478f0abd5e4134850ab395b48f25",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.771375a24eca0dc65af691c7fe224aef2fb063e4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "start",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "will_fail",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.771375a24eca0dc65af691c7fe224aef2fb063e4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "true",
-              "description": null,
-              "is_required": false,
-              "name": "require_upstream_step_success",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.f07ed19fc888e3245c2ca562556397f72651e11e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "start",
-          "solid_name": "start",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "num",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "start"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "will_fail",
-          "solid_name": "will_fail",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "retry_resource_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": null,
-            "name": "a"
-          },
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": null,
-            "name": "b"
-          },
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.38333f2a1cae02c5cf3896b9a3f453862c72febb"
-      }
-    ],
-    "name": "retry_resource_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "start",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [
-            "a"
-          ],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "num"
-            }
-          ],
-          "name": "will_fail",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [
-            "b"
-          ],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[129]
-  'edf336bed607c5b51c50ae3ffd762803d3bde70f'
+  '40916e47f71cc225179f16e1507a7e924ab6701c'
 # ---
 # name: test_all_snapshot_ids[12]
   '''
@@ -22652,6 +22538,1009 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.38333f2a1cae02c5cf3896b9a3f453862c72febb": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"start\": {}, \"will_fail\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.771375a24eca0dc65af691c7fe224aef2fb063e4"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"a\": {}, \"b\": {}, \"io_manager\": {}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.4678ad2ed1f8478f0abd5e4134850ab395b48f25"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.38333f2a1cae02c5cf3896b9a3f453862c72febb",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4678ad2ed1f8478f0abd5e4134850ab395b48f25": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "a",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "b",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4678ad2ed1f8478f0abd5e4134850ab395b48f25",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.771375a24eca0dc65af691c7fe224aef2fb063e4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "start",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "will_fail",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.771375a24eca0dc65af691c7fe224aef2fb063e4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "true",
+              "description": null,
+              "is_required": false,
+              "name": "require_upstream_step_success",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.f07ed19fc888e3245c2ca562556397f72651e11e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "start",
+          "solid_name": "start",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "num",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "start"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "will_fail",
+          "solid_name": "will_fail",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "retry_resource_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": null,
+            "name": "a"
+          },
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": null,
+            "name": "b"
+          },
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.38333f2a1cae02c5cf3896b9a3f453862c72febb"
+      }
+    ],
+    "name": "retry_resource_job",
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "start",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "a"
+          ],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "num"
+            }
+          ],
+          "name": "will_fail",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [
+            "b"
+          ],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[131]
+  'edf336bed607c5b51c50ae3ffd762803d3bde70f'
+# ---
+# name: test_all_snapshot_ids[132]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Determines when steps will be executed in relation to their upstream dependencies.",
+              "is_required": false,
+              "name": "step_dependency_config",
+              "type_key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -23208,10 +24097,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[131]
+# name: test_all_snapshot_ids[133]
   'f0125e70947cf8501280a5d1b54be384498c97f8'
 # ---
-# name: test_all_snapshot_ids[132]
+# name: test_all_snapshot_ids[134]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -24097,10 +24986,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[133]
+# name: test_all_snapshot_ids[135]
   '23828587fa7961db43eb88d35af5fbccba0ed9a0'
 # ---
-# name: test_all_snapshot_ids[134]
+# name: test_all_snapshot_ids[136]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -24986,10 +25875,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[135]
+# name: test_all_snapshot_ids[137]
   'eba0139bc038cb9dc91b08c8b35ba7f7a06c9ee0'
 # ---
-# name: test_all_snapshot_ids[136]
+# name: test_all_snapshot_ids[138]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -25875,10 +26764,13 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[137]
+# name: test_all_snapshot_ids[139]
   '7604ec2c6ca86555e6a012cd76c284a7b1fdd4cb'
 # ---
-# name: test_all_snapshot_ids[138]
+# name: test_all_snapshot_ids[13]
+  'e3e7246221faa36874b22448f885d15bba1c57db'
+# ---
+# name: test_all_snapshot_ids[140]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -26706,13 +27598,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[139]
+# name: test_all_snapshot_ids[141]
   '104d8b266375c6fc64d4f4757d4525e70a8ca503'
 # ---
-# name: test_all_snapshot_ids[13]
-  'e3e7246221faa36874b22448f885d15bba1c57db'
-# ---
-# name: test_all_snapshot_ids[140]
+# name: test_all_snapshot_ids[142]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -27598,10 +28487,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[141]
+# name: test_all_snapshot_ids[143]
   'ac31af35a98544943af3bfaab4f3b7bdb7beb99e'
 # ---
-# name: test_all_snapshot_ids[142]
+# name: test_all_snapshot_ids[144]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -28889,10 +29778,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[143]
+# name: test_all_snapshot_ids[145]
   '339518e30cc74bb0f75ea056184e5e7d5ab86fd7'
 # ---
-# name: test_all_snapshot_ids[144]
+# name: test_all_snapshot_ids[146]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -29778,10 +30667,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[145]
+# name: test_all_snapshot_ids[147]
   '20dbfd64ae411a5f8ec77ce35136f73801c196dd'
 # ---
-# name: test_all_snapshot_ids[146]
+# name: test_all_snapshot_ids[148]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -30672,1139 +31561,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[147]
-  '914adff8702faf5150d5383dcd65e48aff70e65f'
-# ---
-# name: test_all_snapshot_ids[148]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.2571019f1a5201853d11032145ac3e534067f214": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "env",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.2571019f1a5201853d11032145ac3e534067f214",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Determines when steps will be executed in relation to their upstream dependencies.",
-              "is_required": false,
-              "name": "step_dependency_config",
-              "type_key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "base_dir",
-              "type_key": "StringSourceType"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.41b5264e1c54f8255eb6d4d1c30cc027762e19f8": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "downstream_time_partitioned_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "upstream_time_partitioned_asset",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.41b5264e1c54f8255eb6d4d1c30cc027762e19f8",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f2a71367507edd1b8e64f739222c4312b3691b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.8b3d48aeb9baeb78bbe7fcb8170fbef2fa60bafe": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"downstream_time_partitioned_asset\": {}, \"upstream_time_partitioned_asset\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.41b5264e1c54f8255eb6d4d1c30cc027762e19f8"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {\"config\": {}}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.941705f8db419acef3ba14bcecbc37e693570d4d"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.8b3d48aeb9baeb78bbe7fcb8170fbef2fa60bafe",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.941705f8db419acef3ba14bcecbc37e693570d4d": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "dummy_io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "hanging_asset_resource",
-              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {}}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.941705f8db419acef3ba14bcecbc37e693570d4d",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "file",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "true",
-              "description": null,
-              "is_required": false,
-              "name": "require_upstream_step_success",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.f07ed19fc888e3245c2ca562556397f72651e11e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        },
-        "StringSourceType": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "StringSourceType",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.2571019f1a5201853d11032145ac3e534067f214"
-          ]
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [
-            {
-              "__class__": "InputDependencySnap",
-              "input_name": "upstream_time_partitioned_asset",
-              "is_dynamic_collect": false,
-              "upstream_output_snaps": [
-                {
-                  "__class__": "OutputHandleSnap",
-                  "output_name": "result",
-                  "solid_name": "upstream_time_partitioned_asset"
-                }
-              ]
-            }
-          ],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "downstream_time_partitioned_asset",
-          "solid_name": "downstream_time_partitioned_asset",
-          "tags": {}
-        },
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "upstream_time_partitioned_asset",
-          "solid_name": "upstream_time_partitioned_asset",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "time_partitioned_assets_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": null,
-            "name": "dummy_io_manager"
-          },
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "config",
-              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
-            },
-            "description": null,
-            "name": "hanging_asset_resource"
-          },
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.8b3d48aeb9baeb78bbe7fcb8170fbef2fa60bafe"
-      }
-    ],
-    "name": "time_partitioned_assets_job",
-    "run_tags": {},
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [
-            {
-              "__class__": "InputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "name": "upstream_time_partitioned_asset"
-            }
-          ],
-          "name": "downstream_time_partitioned_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        },
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "upstream_time_partitioned_asset",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[149]
-  'fbe09239fa8ec2ef2b7a3b9ec5ed7ae1d1903604'
+  '914adff8702faf5150d5383dcd65e48aff70e65f'
 # ---
 # name: test_all_snapshot_ids[14]
   '''
@@ -33425,6 +33183,1137 @@
           "scalar_kind": null,
           "type_param_keys": null
         },
+        "Shape.41b5264e1c54f8255eb6d4d1c30cc027762e19f8": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "downstream_time_partitioned_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "upstream_time_partitioned_asset",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.41b5264e1c54f8255eb6d4d1c30cc027762e19f8",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f2a71367507edd1b8e64f739222c4312b3691b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.8b3d48aeb9baeb78bbe7fcb8170fbef2fa60bafe": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"downstream_time_partitioned_asset\": {}, \"upstream_time_partitioned_asset\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.41b5264e1c54f8255eb6d4d1c30cc027762e19f8"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"io_manager\": {\"config\": {}}}",
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": false,
+              "name": "resources",
+              "type_key": "Shape.941705f8db419acef3ba14bcecbc37e693570d4d"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.8b3d48aeb9baeb78bbe7fcb8170fbef2fa60bafe",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.941705f8db419acef3ba14bcecbc37e693570d4d": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "dummy_io_manager",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "hanging_asset_resource",
+              "type_key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {}}",
+              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+              "is_required": false,
+              "name": "io_manager",
+              "type_key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.941705f8db419acef3ba14bcecbc37e693570d4d",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "file",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.b13a6c5637084590cc1538f9522324bfeb4b46b3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "true",
+              "description": null,
+              "is_required": false,
+              "name": "require_upstream_step_success",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [],
+          "given_name": null,
+          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "console",
+              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.f07ed19fc888e3245c2ca562556397f72651e11e": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
+              "description": "Execute all steps in a single process.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "String": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "String",
+          "key": "String",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.STRING"
+          },
+          "type_param_keys": null
+        },
+        "StringSourceType": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "StringSourceType",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.2571019f1a5201853d11032145ac3e534067f214"
+          ]
+        }
+      }
+    },
+    "dagster_type_namespace_snapshot": {
+      "__class__": "DagsterTypeNamespaceSnapshot",
+      "all_dagster_type_snaps_by_key": {
+        "Any": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Any",
+          "is_builtin": true,
+          "key": "Any",
+          "kind": {
+            "__enum__": "DagsterTypeKind.ANY"
+          },
+          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "materializer_schema_key": null,
+          "name": "Any",
+          "type_param_keys": []
+        },
+        "Bool": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Bool",
+          "is_builtin": true,
+          "key": "Bool",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "materializer_schema_key": null,
+          "name": "Bool",
+          "type_param_keys": []
+        },
+        "Float": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Float",
+          "is_builtin": true,
+          "key": "Float",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "materializer_schema_key": null,
+          "name": "Float",
+          "type_param_keys": []
+        },
+        "Int": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Int",
+          "is_builtin": true,
+          "key": "Int",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "materializer_schema_key": null,
+          "name": "Int",
+          "type_param_keys": []
+        },
+        "Nothing": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "Nothing",
+          "is_builtin": true,
+          "key": "Nothing",
+          "kind": {
+            "__enum__": "DagsterTypeKind.NOTHING"
+          },
+          "loader_schema_key": null,
+          "materializer_schema_key": null,
+          "name": "Nothing",
+          "type_param_keys": []
+        },
+        "String": {
+          "__class__": "DagsterTypeSnap",
+          "description": null,
+          "display_name": "String",
+          "is_builtin": true,
+          "key": "String",
+          "kind": {
+            "__enum__": "DagsterTypeKind.SCALAR"
+          },
+          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "materializer_schema_key": null,
+          "name": "String",
+          "type_param_keys": []
+        }
+      }
+    },
+    "dep_structure_snapshot": {
+      "__class__": "DependencyStructureSnapshot",
+      "solid_invocation_snaps": [
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [
+            {
+              "__class__": "InputDependencySnap",
+              "input_name": "upstream_time_partitioned_asset",
+              "is_dynamic_collect": false,
+              "upstream_output_snaps": [
+                {
+                  "__class__": "OutputHandleSnap",
+                  "output_name": "result",
+                  "solid_name": "upstream_time_partitioned_asset"
+                }
+              ]
+            }
+          ],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "downstream_time_partitioned_asset",
+          "solid_name": "downstream_time_partitioned_asset",
+          "tags": {}
+        },
+        {
+          "__class__": "SolidInvocationSnap",
+          "input_dep_snaps": [],
+          "is_dynamic_mapped": false,
+          "solid_def_name": "upstream_time_partitioned_asset",
+          "solid_name": "upstream_time_partitioned_asset",
+          "tags": {}
+        }
+      ]
+    },
+    "description": null,
+    "graph_def_name": "time_partitioned_assets_job",
+    "lineage_snapshot": null,
+    "mode_def_snaps": [
+      {
+        "__class__": "ModeDefSnap",
+        "description": null,
+        "logger_def_snaps": [
+          {
+            "__class__": "LoggerDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            },
+            "description": "The default colored console logger.",
+            "name": "console"
+          }
+        ],
+        "name": "default",
+        "resource_def_snaps": [
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Any"
+            },
+            "description": null,
+            "name": "dummy_io_manager"
+          },
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "config",
+              "type_key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e"
+            },
+            "description": null,
+            "name": "hanging_asset_resource"
+          },
+          {
+            "__class__": "ResourceDefSnap",
+            "config_field_snap": {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
+            },
+            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
+            "name": "io_manager"
+          }
+        ],
+        "root_config_key": "Shape.8b3d48aeb9baeb78bbe7fcb8170fbef2fa60bafe"
+      }
+    ],
+    "name": "time_partitioned_assets_job",
+    "run_tags": {},
+    "solid_definitions_snapshot": {
+      "__class__": "SolidDefinitionsSnapshot",
+      "composite_solid_def_snaps": [],
+      "solid_def_snaps": [
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [
+            {
+              "__class__": "InputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "name": "upstream_time_partitioned_asset"
+            }
+          ],
+          "name": "downstream_time_partitioned_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        },
+        {
+          "__class__": "SolidDefSnap",
+          "config_field_snap": {
+            "__class__": "ConfigFieldSnap",
+            "default_provided": false,
+            "default_value_as_json_str": null,
+            "description": null,
+            "is_required": false,
+            "name": "config",
+            "type_key": "Any"
+          },
+          "description": null,
+          "input_def_snaps": [],
+          "name": "upstream_time_partitioned_asset",
+          "output_def_snaps": [
+            {
+              "__class__": "OutputDefSnap",
+              "dagster_type_key": "Any",
+              "description": null,
+              "is_dynamic": false,
+              "is_required": true,
+              "name": "result"
+            }
+          ],
+          "required_resource_keys": [],
+          "tags": {}
+        }
+      ]
+    },
+    "tags": {}
+  }
+  '''
+# ---
+# name: test_all_snapshot_ids[151]
+  'fbe09239fa8ec2ef2b7a3b9ec5ed7ae1d1903604'
+# ---
+# name: test_all_snapshot_ids[152]
+  '''
+  {
+    "__class__": "PipelineSnapshot",
+    "config_schema_snapshot": {
+      "__class__": "ConfigSchemaSnapshot",
+      "all_config_snaps_by_key": {
+        "Any": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Any",
+          "key": "Any",
+          "kind": {
+            "__enum__": "ConfigTypeKind.ANY"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Bool": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Bool",
+          "key": "Bool",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.BOOL"
+          },
+          "type_param_keys": null
+        },
+        "Float": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Float",
+          "key": "Float",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.FLOAT"
+          },
+          "type_param_keys": null
+        },
+        "Int": {
+          "__class__": "ConfigTypeSnap",
+          "description": "",
+          "enum_values": null,
+          "fields": null,
+          "given_name": "Int",
+          "key": "Int",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR"
+          },
+          "scalar_kind": {
+            "__enum__": "ConfigScalarKind.INT"
+          },
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.2571019f1a5201853d11032145ac3e534067f214": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "env",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.2571019f1a5201853d11032145ac3e534067f214",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Determines when steps will be executed in relation to their upstream dependencies.",
+              "is_required": false,
+              "name": "step_dependency_config",
+              "type_key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "base_dir",
+              "type_key": "StringSourceType"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
         "Shape.44f2a71367507edd1b8e64f739222c4312b3691b": {
           "__class__": "ConfigTypeSnap",
           "description": null,
@@ -34045,10 +34934,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[151]
+# name: test_all_snapshot_ids[153]
   'd0045ede985fd1587c4805554a4869994aa6619e'
 # ---
-# name: test_all_snapshot_ids[152]
+# name: test_all_snapshot_ids[154]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -35060,10 +35949,10 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[153]
+# name: test_all_snapshot_ids[155]
   'a0e093c8cc63edec2e7d25b157b675c09ce1394b'
 # ---
-# name: test_all_snapshot_ids[154]
+# name: test_all_snapshot_ids[156]
   '''
   {
     "__class__": "PipelineSnapshot",
@@ -36286,897 +37175,8 @@
   }
   '''
 # ---
-# name: test_all_snapshot_ids[155]
-  'd5c05fa7d8a780d311ebfa0ee60864dd6d93d987'
-# ---
-# name: test_all_snapshot_ids[156]
-  '''
-  {
-    "__class__": "PipelineSnapshot",
-    "config_schema_snapshot": {
-      "__class__": "ConfigSchemaSnapshot",
-      "all_config_snaps_by_key": {
-        "Any": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Any",
-          "key": "Any",
-          "kind": {
-            "__enum__": "ConfigTypeKind.ANY"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Bool": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Bool",
-          "key": "Bool",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.BOOL"
-          },
-          "type_param_keys": null
-        },
-        "Float": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Float",
-          "key": "Float",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.FLOAT"
-          },
-          "type_param_keys": null
-        },
-        "Int": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "Int",
-          "key": "Int",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.INT"
-          },
-          "type_param_keys": null
-        },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Determines when steps will be executed in relation to their upstream dependencies.",
-              "is_required": false,
-              "name": "step_dependency_config",
-              "type_key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-              "is_required": false,
-              "name": "io_manager",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.26938b5b08825878a2aee89ed343cf529be5016c": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "permission_test_op",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.26938b5b08825878a2aee89ed343cf529be5016c",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.51fd0d067099831d81cc2341005ad616b20be826": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"permission_test_op\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.26938b5b08825878a2aee89ed343cf529be5016c"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"io_manager\": {}}",
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": false,
-              "name": "resources",
-              "type_key": "Shape.1578133c1c71e8e3c9cf3ad46c216eb51b48c778"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.51fd0d067099831d81cc2341005ad616b20be826",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.743e47901855cb245064dd633e217bfcb49a11a7": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "true",
-              "description": null,
-              "is_required": false,
-              "name": "require_upstream_step_success",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [],
-          "given_name": null,
-          "key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "console",
-              "type_key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.f07ed19fc888e3245c2ca562556397f72651e11e": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"retries\": {\"enabled\": {}}}",
-              "description": "Execute all steps in a single process.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "String": {
-          "__class__": "ConfigTypeSnap",
-          "description": "",
-          "enum_values": null,
-          "fields": null,
-          "given_name": "String",
-          "key": "String",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR"
-          },
-          "scalar_kind": {
-            "__enum__": "ConfigScalarKind.STRING"
-          },
-          "type_param_keys": null
-        }
-      }
-    },
-    "dagster_type_namespace_snapshot": {
-      "__class__": "DagsterTypeNamespaceSnapshot",
-      "all_dagster_type_snaps_by_key": {
-        "Any": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Any",
-          "is_builtin": true,
-          "key": "Any",
-          "kind": {
-            "__enum__": "DagsterTypeKind.ANY"
-          },
-          "loader_schema_key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "materializer_schema_key": null,
-          "name": "Any",
-          "type_param_keys": []
-        },
-        "Bool": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Bool",
-          "is_builtin": true,
-          "key": "Bool",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "materializer_schema_key": null,
-          "name": "Bool",
-          "type_param_keys": []
-        },
-        "Float": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Float",
-          "is_builtin": true,
-          "key": "Float",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "materializer_schema_key": null,
-          "name": "Float",
-          "type_param_keys": []
-        },
-        "Int": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Int",
-          "is_builtin": true,
-          "key": "Int",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "materializer_schema_key": null,
-          "name": "Int",
-          "type_param_keys": []
-        },
-        "Nothing": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "Nothing",
-          "is_builtin": true,
-          "key": "Nothing",
-          "kind": {
-            "__enum__": "DagsterTypeKind.NOTHING"
-          },
-          "loader_schema_key": null,
-          "materializer_schema_key": null,
-          "name": "Nothing",
-          "type_param_keys": []
-        },
-        "String": {
-          "__class__": "DagsterTypeSnap",
-          "description": null,
-          "display_name": "String",
-          "is_builtin": true,
-          "key": "String",
-          "kind": {
-            "__enum__": "DagsterTypeKind.SCALAR"
-          },
-          "loader_schema_key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "materializer_schema_key": null,
-          "name": "String",
-          "type_param_keys": []
-        }
-      }
-    },
-    "dep_structure_snapshot": {
-      "__class__": "DependencyStructureSnapshot",
-      "solid_invocation_snaps": [
-        {
-          "__class__": "SolidInvocationSnap",
-          "input_dep_snaps": [],
-          "is_dynamic_mapped": false,
-          "solid_def_name": "permission_test_op",
-          "solid_name": "permission_test_op",
-          "tags": {}
-        }
-      ]
-    },
-    "description": null,
-    "graph_def_name": "unowned_job",
-    "lineage_snapshot": null,
-    "mode_def_snaps": [
-      {
-        "__class__": "ModeDefSnap",
-        "description": null,
-        "logger_def_snaps": [
-          {
-            "__class__": "LoggerDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            },
-            "description": "The default colored console logger.",
-            "name": "console"
-          }
-        ],
-        "name": "default",
-        "resource_def_snaps": [
-          {
-            "__class__": "ResourceDefSnap",
-            "config_field_snap": {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Any"
-            },
-            "description": "Built-in filesystem IO manager that stores and retrieves values using pickling.",
-            "name": "io_manager"
-          }
-        ],
-        "root_config_key": "Shape.51fd0d067099831d81cc2341005ad616b20be826"
-      }
-    ],
-    "name": "unowned_job",
-    "solid_definitions_snapshot": {
-      "__class__": "SolidDefinitionsSnapshot",
-      "composite_solid_def_snaps": [],
-      "solid_def_snaps": [
-        {
-          "__class__": "SolidDefSnap",
-          "config_field_snap": {
-            "__class__": "ConfigFieldSnap",
-            "default_provided": false,
-            "default_value_as_json_str": null,
-            "description": null,
-            "is_required": false,
-            "name": "config",
-            "type_key": "Any"
-          },
-          "description": null,
-          "input_def_snaps": [],
-          "name": "permission_test_op",
-          "output_def_snaps": [
-            {
-              "__class__": "OutputDefSnap",
-              "dagster_type_key": "Any",
-              "description": null,
-              "is_dynamic": false,
-              "is_required": true,
-              "name": "result"
-            }
-          ],
-          "required_resource_keys": [],
-          "tags": {}
-        }
-      ]
-    },
-    "tags": {}
-  }
-  '''
-# ---
 # name: test_all_snapshot_ids[157]
-  '36d4589856c8fc7798735287ec51a18ed4700b7f'
+  'd5c05fa7d8a780d311ebfa0ee60864dd6d93d987'
 # ---
 # name: test_all_snapshot_ids[158]
   '''

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_solids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_solids.ambr
@@ -2358,6 +2358,30 @@
         dict({
           '__typename': 'UsedSolid',
           'definition': dict({
+            'name': 'permission_partitioned_op',
+          }),
+          'invocations': list([
+            dict({
+              'pipeline': dict({
+                'name': 'owned_partitioned_job',
+              }),
+              'solidHandle': dict({
+                'handleID': 'permission_partitioned_op',
+              }),
+            }),
+            dict({
+              'pipeline': dict({
+                'name': 'unowned_partitioned_job',
+              }),
+              'solidHandle': dict({
+                'handleID': 'permission_partitioned_op',
+              }),
+            }),
+          ]),
+        }),
+        dict({
+          '__typename': 'UsedSolid',
+          'definition': dict({
             'name': 'permission_test_op',
           }),
           'invocations': list([

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -2205,6 +2205,8 @@ def define_standard_jobs() -> Sequence[JobDefinition]:
         some_external_job,
         owned_job,
         unowned_job,
+        owned_partitioned_job,
+        unowned_partitioned_job,
     ]
 
 
@@ -2244,6 +2246,22 @@ def owned_job():
 @job
 def unowned_job():
     permission_test_op()
+
+
+@op
+def permission_partitioned_op(context):
+    context.log.info(f"Processing partition: {context.partition_key}")
+    return context.partition_key
+
+
+@job(partitions_def=partitions_def_for_permissions)
+def owned_partitioned_job():
+    permission_partitioned_op()
+
+
+@job(partitions_def=partitions_def_for_permissions)
+def unowned_partitioned_job():
+    permission_partitioned_op()
 
 
 @sensor(job=owned_job)


### PR DESCRIPTION
## Summary & Motivation
Changes the graphql backfill mutations to use the new definition permission checks enabled by https://github.com/dagster-io/dagster/pull/32151.

Asset backfills use the asset definition checks added in https://github.com/dagster-io/dagster/pull/32151.  Job backfills use the job definition checks added in https://github.com/dagster-io/dagster/pull/32285

## How I Tested These Changes
BK
