### PR TITLE
Use hasDefinitionOrRecord in asset view permalink

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -15,7 +15,7 @@
   "AssetMaterializationUpstreamQuery": "754bab88738acc8d310c71f577ac3cf06dc57950bb1f98a18844e6e00bae756d",
   "AssetPartitionDetailQuery": "a5a3c782894d7365cbf791c57bdec279cbccd809cd2d0dc5fd31df1e6237b927",
   "AssetPartitionStaleQuery": "4215f4014e9d7592142e1775c4b07377703e913389396f9ca14dc6bb779ce764",
-  "AssetViewDefinitionQuery": "1bc39b27e9080474973f7426813abf75782273dd4d95bea8ee97ab92b83d3023",
+  "AssetViewDefinitionQuery": "acbaff586d33b171138603f48f01ea6045470c41c6c7ef1afc716f159f6a446f",
   "AssetCatalogTableQuery": "b9fb4b1e1639dcbd1f54b152d8c70e9522db4b57874dce2eb9d59608ac41dbb3",
   "AssetCatalogGroupTableQuery": "e40ea9d79f47b7677feefebd934e0a32808f21f2586e3149fd930d584b135203",
   "AssetsOverviewRootQuery": "77ab0417c979b92c9ec01cd76a0f49b59f5b8ce7af775cab7e9b3e57b7871f7d",

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -269,7 +269,11 @@ const AssetViewImpl = ({assetKey, headerBreadcrumbs, writeAssetVisit, currentPat
     refresh,
   );
 
-  if (definitionQueryResult.data?.assetOrError.__typename === 'AssetNotFoundError') {
+  if (
+    definitionQueryResult.data?.assetOrError.__typename === 'AssetNotFoundError' ||
+    (definitionQueryResult.data?.assetOrError.__typename === 'Asset' &&
+      !definitionQueryResult.data.assetOrError.hasDefinitionOrRecord)
+  ) {
     const assetSelection = getAssetSelectionQueryString();
     let nextPath = `/assets/${currentPath.join('/')}?view=folder${assetSelection ? `&asset-selection=${assetSelection}` : ''}`;
     if (observeEnabled()) {
@@ -417,6 +421,7 @@ export const ASSET_VIEW_DEFINITION_QUERY = gql`
         key {
           path
         }
+        hasDefinitionOrRecord
         assetMaterializations(limit: 1) {
           timestamp
           runId

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
@@ -12,6 +12,7 @@ export type AssetViewDefinitionQuery = {
     | {
         __typename: 'Asset';
         id: string;
+        hasDefinitionOrRecord: boolean;
         key: {__typename: 'AssetKey'; path: Array<string>};
         assetMaterializations: Array<{
           __typename: 'MaterializationEvent';
@@ -32753,4 +32754,4 @@ export type AssetViewDefinitionNodeFragment = {
     | null;
 };
 
-export const AssetViewDefinitionQueryVersion = '1bc39b27e9080474973f7426813abf75782273dd4d95bea8ee97ab92b83d3023';
+export const AssetViewDefinitionQueryVersion = 'acbaff586d33b171138603f48f01ea6045470c41c6c7ef1afc716f159f6a446f';


### PR DESCRIPTION
Summary:
Bring back the redirect removed in https://app.graphite.dev/github/pr/dagster-io/dagster/32282 by checking for a hasDefinitionOrRecord field

Test Plan:
Load an asset key that does not exist, redirect is retained
Load an asset key that does exist, it works as before

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
