### PR TITLE
[docs] fix Sphinx build for `dagster-polars` due to mocked imports

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -128,7 +128,6 @@ autodoc_mock_imports = [
     "orjson",
     "pandas_gbq",
     "pandera",
-    "polars",
     "prometheus_client",
     "psycopg2",
     "pypd",

--- a/python_modules/automation/automation/dagster_docs/exclude_lists.py
+++ b/python_modules/automation/automation/dagster_docs/exclude_lists.py
@@ -404,8 +404,9 @@ EXCLUDE_MISSING_PUBLIC = {
     "dagster.RunLauncher",
     "dagster.Scheduler",
     "dagster.ScheduleStorage",
+    "dagster_polars.patito.patito_model_to_dagster_type",
 }
-# Total: 297 symbols
+# Total: 298 symbols
 
 # Modules to exclude from @public scanning
 EXCLUDE_MODULES_FROM_PUBLIC_SCAN = set()


### PR DESCRIPTION
## Summary & Motivation

 * polars was listed in Sphinx's autodoc_mock_imports in `docs/sphinx/conf.py`
 * When Sphinx mocks a module, attribute access like `pl.__version__` returns the attribute name as a string
  ('__version__') instead of the actual attribute value
 * The `dagster-polars` package (from community integrations) tries to parse `pl.__version__` using `parse_version()` at
  import time in delta.py:21
 * `parse_version('__version__')` fails because it expects a version string like '1.33.1', not the literal
  '__version__'

## How I Tested These Changes

`yarn build-api-docs`

## Changelog

NOCHANGELOG
