### PR TITLE
[dg] adds `dg api log get`

### DIFF
--- a/.claude/commands/dg_troubleshoot_run.md
+++ b/.claude/commands/dg_troubleshoot_run.md
@@ -1,0 +1,14 @@
+# Summarize failing run in Dagster
+
+Find the errors associated with the run by using the `dg api log get` command for the provided run ID:
+
+    dg api log get $1 --json | jq '.logs[] | select(.level == "ERROR")'
+
+Then, summarize the issue and identify the root cause of the problem.
+
+If there are no errors when filtering with `jq` `select(.level == "ERROR")` then retrieve the full logs:
+
+    dg api log get $1 --json
+
+And provide a summary of the run
+

--- a/.claude/commands/dg_troubleshoot_run.md
+++ b/.claude/commands/dg_troubleshoot_run.md
@@ -11,4 +11,3 @@ If there are no errors when filtering with `jq` `select(.level == "ERROR")` then
     dg api log get $1 --json
 
 And provide a summary of the run
-

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/api/run_event.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/api/run_event.py
@@ -26,8 +26,8 @@ class DgApiRunEventApi:
     ) -> "RunEventList":
         """Get run events with filtering options."""
         from dagster_dg_cli.api_layer.schemas.run_event import (
-            ErrorInfo,
-            RunEvent,
+            DgApiErrorInfo,
+            DgApiRunEvent,
             RunEventLevel,
             RunEventList,
         )
@@ -41,11 +41,11 @@ class DgApiRunEventApi:
             step_key=step_key,
         )
 
-        # Helper function to convert error data to ErrorInfo recursively
-        def _convert_error_info(error_data: Optional[dict]) -> Optional[ErrorInfo]:
+        # Helper function to convert error data to DgApiErrorInfo recursively
+        def _convert_error_info(error_data: Optional[dict]) -> Optional[DgApiErrorInfo]:
             if not error_data:
                 return None
-            return ErrorInfo(
+            return DgApiErrorInfo(
                 message=error_data.get("message", ""),
                 className=error_data.get("className"),
                 stack=error_data.get("stack"),
@@ -54,7 +54,7 @@ class DgApiRunEventApi:
 
         # Convert to Pydantic models
         events = [
-            RunEvent(
+            DgApiRunEvent(
                 run_id=e["runId"],
                 message=e["message"],
                 timestamp=e["timestamp"],

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/graphql_adapter/run_event.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/graphql_adapter/run_event.py
@@ -4,8 +4,24 @@ from typing import Any, Optional
 
 from dagster_dg_cli.utils.plus.gql_client import IGraphQLClient
 
-# Exact GraphQL query from specification
+# Enhanced GraphQL query with error information
 RUN_EVENTS_QUERY = """
+fragment errorFragment on PythonError {
+    message
+    className
+    stack
+    cause {
+        message
+        className
+        stack
+        cause {
+            message
+            className
+            stack
+        }
+    }
+}
+
 query CliRunEventsQuery($runId: ID!, $limit: Int, $afterCursor: String) {
     logsForRun(runId: $runId, limit: $limit, afterCursor: $afterCursor) {
         __typename
@@ -19,6 +35,17 @@ query CliRunEventsQuery($runId: ID!, $limit: Int, $afterCursor: String) {
                     level
                     stepKey
                     eventType
+                }
+                ... on ExecutionStepFailureEvent {
+                    runId
+                    message
+                    timestamp
+                    level
+                    stepKey
+                    eventType
+                    error {
+                        ...errorFragment
+                    }
                 }
             }
             cursor

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/schemas/run_event.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/schemas/run_event.py
@@ -16,13 +16,13 @@ class RunEventLevel(str, Enum):
     DEBUG = "DEBUG"
 
 
-class ErrorInfo(BaseModel):
+class DgApiErrorInfo(BaseModel):
     """Error information model."""
 
     message: str
     className: Optional[str] = None
     stack: Optional[list[str]] = None
-    cause: Optional["ErrorInfo"] = None
+    cause: Optional["DgApiErrorInfo"] = None
 
     class Config:
         from_attributes = True
@@ -34,7 +34,7 @@ class ErrorInfo(BaseModel):
         return "\n".join(self.stack)
 
 
-class RunEvent(BaseModel):
+class DgApiRunEvent(BaseModel):
     """Single run event model."""
 
     run_id: str
@@ -43,7 +43,7 @@ class RunEvent(BaseModel):
     level: RunEventLevel
     step_key: Optional[str] = None
     event_type: Optional[str] = None
-    error: Optional[ErrorInfo] = None
+    error: Optional[DgApiErrorInfo] = None
 
     class Config:
         from_attributes = True
@@ -52,7 +52,7 @@ class RunEvent(BaseModel):
 class RunEventList(BaseModel):
     """Paginated run events response."""
 
-    items: list[RunEvent]
+    items: list[DgApiRunEvent]
     total: int
     cursor: Optional[str] = None
     has_more: bool = False

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/schemas/run_event.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/api_layer/schemas/run_event.py
@@ -16,6 +16,24 @@ class RunEventLevel(str, Enum):
     DEBUG = "DEBUG"
 
 
+class ErrorInfo(BaseModel):
+    """Error information model."""
+
+    message: str
+    className: Optional[str] = None
+    stack: Optional[list[str]] = None
+    cause: Optional["ErrorInfo"] = None
+
+    class Config:
+        from_attributes = True
+
+    def get_stack_trace_string(self) -> str:
+        """Get the stack trace as a formatted string."""
+        if not self.stack:
+            return ""
+        return "\n".join(self.stack)
+
+
 class RunEvent(BaseModel):
     """Single run event model."""
 
@@ -24,7 +42,8 @@ class RunEvent(BaseModel):
     timestamp: str  # ISO 8601 timestamp
     level: RunEventLevel
     step_key: Optional[str] = None
-    event_type: str
+    event_type: Optional[str] = None
+    error: Optional[ErrorInfo] = None
 
     class Config:
         from_attributes = True

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/cli_group.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/cli_group.py
@@ -6,6 +6,7 @@ from dagster_dg_core.utils import DgClickGroup
 from dagster_dg_cli.cli.api.agent import agent_group
 from dagster_dg_cli.cli.api.asset import asset_group
 from dagster_dg_cli.cli.api.deployment import deployment_group
+from dagster_dg_cli.cli.api.log import log_group
 from dagster_dg_cli.cli.api.run import run_group
 from dagster_dg_cli.cli.api.run_event import run_events_group
 
@@ -18,6 +19,7 @@ from dagster_dg_cli.cli.api.run_event import run_events_group
         "agent": agent_group,
         "asset": asset_group,
         "deployment": deployment_group,
+        "log": log_group,
         "run": run_group,
         "run-events": run_events_group,
     },

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/log.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/log.py
@@ -1,0 +1,192 @@
+"""Log API commands following GitHub CLI patterns."""
+
+import datetime
+import json
+
+import click
+from dagster_dg_core.utils import DgClickCommand, DgClickGroup
+from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
+from dagster_shared.plus.config import DagsterPlusCliConfig
+from dagster_shared.plus.config_utils import dg_api_options
+
+from dagster_dg_cli.api_layer.api.run_event import DgApiRunEventApi
+from dagster_dg_cli.cli.api.client import create_dg_api_graphql_client
+
+
+def format_logs_table(events, run_id: str) -> str:
+    """Format logs as human-readable table."""
+    if not events.items:
+        return f"No logs found for run {run_id}"
+
+    lines = [f"Logs for run {run_id}:", ""]
+
+    # Table header
+    header = f"{'TIMESTAMP':<20} {'LEVEL':<8} {'STEP_KEY':<25} {'MESSAGE'}"
+    separator = "-" * 80
+    lines.extend([header, separator])
+
+    # Table rows
+    for event in events.items:
+        # Convert Unix timestamp to readable format
+        timestamp_ms = int(event.timestamp)
+        dt = datetime.datetime.fromtimestamp(timestamp_ms / 1000.0)
+        timestamp_str = dt.strftime("%Y-%m-%d %H:%M:%S")
+
+        level = event.level.value
+        step_key = (event.step_key or "")[:24]  # Truncate long step keys
+        message = event.message
+
+        row = f"{timestamp_str:<20} {level:<8} {step_key:<25} {message}"
+        lines.append(row)
+
+        # Add stack trace for error events
+        if event.error and event.error.stack:
+            lines.append("")
+            lines.append("Stack Trace:")
+            # Format the stack trace with indentation
+            stack_trace = event.error.get_stack_trace_string()
+            for stack_line in stack_trace.split("\n"):
+                if stack_line.strip():
+                    lines.append(f"  {stack_line}")
+            lines.append("")
+
+    lines.extend(["", f"Total log entries: {events.total}"])
+    if events.has_more:
+        lines.append("Note: More logs available (use --limit to increase or --cursor to paginate)")
+
+    return "\n".join(lines)
+
+
+def format_logs_json(events, run_id: str) -> str:
+    """Format logs as JSON."""
+
+    def error_to_dict(error_info):
+        """Convert ErrorInfo to dictionary recursively."""
+        if not error_info:
+            return None
+        return {
+            "message": error_info.message,
+            "className": error_info.className,
+            "stack": error_info.stack,  # Keep as list for JSON
+            "stackTrace": error_info.get_stack_trace_string(),  # Also provide as string
+            "cause": error_to_dict(error_info.cause) if error_info.cause else None,
+        }
+
+    return json.dumps(
+        {
+            "run_id": run_id,
+            "logs": [
+                {
+                    "runId": event.run_id,
+                    "message": event.message,
+                    "timestamp": event.timestamp,
+                    "level": event.level,
+                    "stepKey": event.step_key,
+                    "eventType": event.event_type,
+                    "error": error_to_dict(event.error) if event.error else None,
+                }
+                for event in events.items
+            ],
+            "count": events.total,
+            "cursor": events.cursor,
+            "hasMore": events.has_more,
+        },
+        indent=2,
+    )
+
+
+@click.command(name="get", cls=DgClickCommand, unlaunched=True)
+@click.argument("run_id", type=str)
+@click.option(
+    "--level",
+    "log_level",
+    help="Filter by log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+)
+@click.option(
+    "--step",
+    "step_key",
+    help="Filter by step key (partial matching)",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=100,
+    help="Maximum number of log entries to return",
+)
+@click.option(
+    "--cursor",
+    "after_cursor",
+    help="Pagination cursor for retrieving more logs",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output in JSON format for machine readability",
+)
+@dg_api_options(deployment_scoped=True)
+@cli_telemetry_wrapper
+@click.pass_context
+def get_logs_command(
+    ctx: click.Context,
+    run_id: str,
+    log_level: str,
+    step_key: str,
+    limit: int,
+    after_cursor: str,
+    output_json: bool,
+    organization: str,
+    deployment: str,
+    api_token: str,
+    view_graphql: bool,
+) -> None:
+    """Get logs for a specific run ID."""
+    config = DagsterPlusCliConfig.create_for_deployment(
+        deployment=deployment,
+        organization=organization,
+        user_token=api_token,
+    )
+    client = create_dg_api_graphql_client(ctx, config, view_graphql=view_graphql)
+    api = DgApiRunEventApi(client)
+
+    try:
+        # Use log level as event type filter if provided
+        event_type = None
+        if log_level:
+            # Convert log level to event types that match that level
+            # For now, we'll pass the level directly and let the filtering happen
+            event_type = log_level.upper()
+
+        logs = api.get_events(
+            run_id=run_id,
+            event_type=event_type,
+            step_key=step_key,
+            limit=limit,
+            after_cursor=after_cursor,
+        )
+
+        if output_json:
+            output = format_logs_json(logs, run_id)
+        else:
+            output = format_logs_table(logs, run_id)
+
+        click.echo(output)
+    except Exception as e:
+        if output_json:
+            error_response = {"error": str(e)}
+            click.echo(json.dumps(error_response), err=True)
+        else:
+            click.echo(f"Error querying Dagster Plus API: {e}", err=True)
+        raise click.ClickException(f"Failed to get logs for run {run_id}: {e}")
+
+
+@click.group(
+    name="log",
+    cls=DgClickGroup,
+    unlaunched=True,
+    commands={
+        "get": get_logs_command,
+    },
+)
+def log_group():
+    """Retrieve logs from Dagster Plus runs."""

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/__snapshots__/test_dynamic_command_execution.ambr
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/__snapshots__/test_dynamic_command_execution.ambr
@@ -4126,54 +4126,660 @@
   
   '''
 # ---
+# name: TestDynamicCommandExecution.test_command_execution[log_error_cursor_no_recording_json_json]
+  '''
+  {"error": "Exhausted 0 responses"}
+  Error: Failed to get logs for run 85156191-170d-4229-8eba-14450b6ca9e3: Exhausted 0 responses
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_error_cursor_no_recording_text_text]
+  '''
+  Error querying Dagster Plus API: Exhausted 0 responses
+  Error: Failed to get logs for run 85156191-170d-4229-8eba-14450b6ca9e3: Exhausted 0 responses
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_error_empty_logs_no_recording_json_json]
+  '''
+  {"error": "Exhausted 0 responses"}
+  Error: Failed to get logs for run empty-run-uuid-0000-0000-000000000000: Exhausted 0 responses
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_error_empty_logs_no_recording_text_text]
+  '''
+  Error querying Dagster Plus API: Exhausted 0 responses
+  Error: Failed to get logs for run empty-run-uuid-0000-0000-000000000000: Exhausted 0 responses
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_error_empty_run_id_json_json]
+  '''
+  {"error": "Exhausted 0 responses"}
+  Error: Failed to get logs for run '': Exhausted 0 responses
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_error_empty_run_id_text_text]
+  '''
+  Error querying Dagster Plus API: Exhausted 0 responses
+  Error: Failed to get logs for run '': Exhausted 0 responses
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_error_invalid_level_json_json]
+  dict({
+    'count': 0,
+    'cursor': 'eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODU1MzE0M30=',
+    'hasMore': False,
+    'logs': list([
+    ]),
+    'run_id': '85156191-170d-4229-8eba-14450b6ca9e3',
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_error_invalid_level_text_text]
+  '''
+  No logs found for run 85156191-170d-4229-8eba-14450b6ca9e3
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_error_malformed_run_id_json_json]
+  '''
+  {"error": "Exhausted 0 responses"}
+  Error: Failed to get logs for run invalid-uuid-format: Exhausted 0 responses
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_error_malformed_run_id_text_text]
+  '''
+  Error querying Dagster Plus API: Exhausted 0 responses
+  Error: Failed to get logs for run invalid-uuid-format: Exhausted 0 responses
+  
+  '''
+# ---
 # name: TestDynamicCommandExecution.test_command_execution[log_error_run_not_found_json_json]
   '''
-  {"error": "Run with id nonexistent-run-uuid-1234-5678-900000000000 not found"}
-  Error: Failed to get logs for run nonexistent-run-uuid-1234-5678-900000000000: Run with id nonexistent-run-uuid-1234-5678-900000000000 not found
+  {"error": "Exhausted 0 responses"}
+  Error: Failed to get logs for run nonexistent-run-uuid-1234-5678-900000000000: Exhausted 0 responses
   
   '''
 # ---
 # name: TestDynamicCommandExecution.test_command_execution[log_error_run_not_found_text_text]
   '''
-  Error querying Dagster Plus API: Run with id nonexistent-run-uuid-1234-5678-900000000000 not found
-  Error: Failed to get logs for run nonexistent-run-uuid-1234-5678-900000000000: Run with id nonexistent-run-uuid-1234-5678-900000000000 not found
+  Error querying Dagster Plus API: Exhausted 0 responses
+  Error: Failed to get logs for run nonexistent-run-uuid-1234-5678-900000000000: Exhausted 0 responses
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_basic_json_json]
+  dict({
+    'count': 20,
+    'cursor': 'eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgyMTg1Nzg2MH0=',
+    'hasMore': True,
+    'logs': list([
+      dict({
+        'error': None,
+        'eventType': 'ASSET_CHECK_EVALUATION_PLANNED',
+        'level': 'DEBUG',
+        'message': 'check_avg_orders_freshness_job intends to execute asset check anomaly_detection_freshness_check on asset ["MARKETING", "avg_orders"]',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': 'anomaly_detection_freshness_check_458e9b8f',
+        'timestamp': '1758817801771',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RUN_ENQUEUED',
+        'level': 'INFO',
+        'message': '',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': None,
+        'timestamp': '1758817801798',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RUN_STARTING',
+        'level': 'INFO',
+        'message': '',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': None,
+        'timestamp': '1758817804629',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': 'Sending a request to the agent to execute steps in the user cloud',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': None,
+        'timestamp': '1758817804660',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': '[DagsterCloudAgent] Agent d0a5374c is launching run b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': None,
+        'timestamp': '1758817804845',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': '[CloudK8sRunLauncher] Creating Kubernetes run worker job',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': None,
+        'timestamp': '1758817804996',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': '[CloudK8sRunLauncher] Kubernetes run worker job created',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': None,
+        'timestamp': '1758817805113',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': 'Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': None,
+        'timestamp': '1758817813386',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': 'Started process for run (pid: 1).',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': None,
+        'timestamp': '1758817813451',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RUN_START',
+        'level': 'DEBUG',
+        'message': 'Started execution of run for "check_avg_orders_freshness_job".',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': None,
+        'timestamp': '1758817827876',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'DEBUG',
+        'message': 'Executing steps using multiprocess executor: parent process (pid: 1)',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': None,
+        'timestamp': '1758817827919',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_WORKER_STARTING',
+        'level': 'DEBUG',
+        'message': 'Launching subprocess for "anomaly_detection_freshness_check_458e9b8f".',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': 'anomaly_detection_freshness_check_458e9b8f',
+        'timestamp': '1758817828047',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_WORKER_STARTED',
+        'level': 'DEBUG',
+        'message': 'Executing step "anomaly_detection_freshness_check_458e9b8f" in subprocess.',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': 'anomaly_detection_freshness_check_458e9b8f',
+        'timestamp': '1758817829513',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RESOURCE_INIT_STARTED',
+        'level': 'DEBUG',
+        'message': 'Starting initialization of resources [io_manager].',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': 'anomaly_detection_freshness_check_458e9b8f',
+        'timestamp': '1758817833373',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RESOURCE_INIT_SUCCESS',
+        'level': 'DEBUG',
+        'message': 'Finished initialization of resources [io_manager].',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': 'anomaly_detection_freshness_check_458e9b8f',
+        'timestamp': '1758817833453',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'LOGS_CAPTURED',
+        'level': 'DEBUG',
+        'message': 'Started capturing logs in process (pid: 19).',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': None,
+        'timestamp': '1758817833507',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_START',
+        'level': 'DEBUG',
+        'message': 'Started execution of step "anomaly_detection_freshness_check_458e9b8f".',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': 'anomaly_detection_freshness_check_458e9b8f',
+        'timestamp': '1758817833533',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_OUTPUT',
+        'level': 'DEBUG',
+        'message': 'Yielded output "MARKETING__avg_orders_anomaly_detection_freshness_check" of type "Any". (Type check passed).',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': 'anomaly_detection_freshness_check_458e9b8f',
+        'timestamp': '1758817833714',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ASSET_CHECK_EVALUATION',
+        'level': 'DEBUG',
+        'message': "Asset check 'anomaly_detection_freshness_check' on 'MARKETING/avg_orders' did not pass. Description: 'Asset is overdue for an update. The last update was 2 days, 16 hours, 25 minutes, 24 seconds ago, which is past the allowed distance of 2 days, 5 minutes, 11 seconds ago.'",
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': 'anomaly_detection_freshness_check_458e9b8f',
+        'timestamp': '1758817833766',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_SUCCESS',
+        'level': 'DEBUG',
+        'message': 'Finished execution of step "anomaly_detection_freshness_check_458e9b8f" in 246ms.',
+        'runId': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+        'stepKey': 'anomaly_detection_freshness_check_458e9b8f',
+        'timestamp': '1758817833807',
+      }),
+    ]),
+    'run_id': 'b45fff8a-7def-43b8-805d-1cf5f435c997',
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_basic_text_text]
+  '''
+  Logs for run b45fff8a-7def-43b8-805d-1cf5f435c997:
+  
+  TIMESTAMP            LEVEL    STEP_KEY                  MESSAGE
+  --------------------------------------------------------------------------------
+  2025-09-25 16:30:01  DEBUG    anomaly_detection_freshn  check_avg_orders_freshness_job intends to execute asset check anomaly_detection_freshness_check on asset ["MARKETING", "avg_orders"]
+  2025-09-25 16:30:01  INFO                               
+  2025-09-25 16:30:04  INFO                               
+  2025-09-25 16:30:04  INFO                               Sending a request to the agent to execute steps in the user cloud
+  2025-09-25 16:30:04  INFO                               [DagsterCloudAgent] Agent d0a5374c is launching run b45fff8a-7def-43b8-805d-1cf5f435c997
+  2025-09-25 16:30:04  INFO                               [CloudK8sRunLauncher] Creating Kubernetes run worker job
+  2025-09-25 16:30:05  INFO                               [CloudK8sRunLauncher] Kubernetes run worker job created
+  2025-09-25 16:30:13  INFO                               Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False
+  2025-09-25 16:30:13  INFO                               Started process for run (pid: 1).
+  2025-09-25 16:30:27  DEBUG                              Started execution of run for "check_avg_orders_freshness_job".
+  2025-09-25 16:30:27  DEBUG                              Executing steps using multiprocess executor: parent process (pid: 1)
+  2025-09-25 16:30:28  DEBUG    anomaly_detection_freshn  Launching subprocess for "anomaly_detection_freshness_check_458e9b8f".
+  2025-09-25 16:30:29  DEBUG    anomaly_detection_freshn  Executing step "anomaly_detection_freshness_check_458e9b8f" in subprocess.
+  2025-09-25 16:30:33  DEBUG    anomaly_detection_freshn  Starting initialization of resources [io_manager].
+  2025-09-25 16:30:33  DEBUG    anomaly_detection_freshn  Finished initialization of resources [io_manager].
+  2025-09-25 16:30:33  DEBUG                              Started capturing logs in process (pid: 19).
+  2025-09-25 16:30:33  DEBUG    anomaly_detection_freshn  Started execution of step "anomaly_detection_freshness_check_458e9b8f".
+  2025-09-25 16:30:33  DEBUG    anomaly_detection_freshn  Yielded output "MARKETING__avg_orders_anomaly_detection_freshness_check" of type "Any". (Type check passed).
+  2025-09-25 16:30:33  DEBUG    anomaly_detection_freshn  Asset check 'anomaly_detection_freshness_check' on 'MARKETING/avg_orders' did not pass. Description: 'Asset is overdue for an update. The last update was 2 days, 16 hours, 25 minutes, 24 seconds ago, which is past the allowed distance of 2 days, 5 minutes, 11 seconds ago.'
+  2025-09-25 16:30:33  DEBUG    anomaly_detection_freshn  Finished execution of step "anomaly_detection_freshness_check_458e9b8f" in 246ms.
+  
+  Total log entries: 20
+  Note: More logs available (use --limit to increase or --cursor to paginate)
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_debug_level_json_json]
+  dict({
+    'count': 0,
+    'cursor': 'eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODUzNTQzOH0=',
+    'hasMore': True,
+    'logs': list([
+    ]),
+    'run_id': '85156191-170d-4229-8eba-14450b6ca9e3',
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_debug_level_text_text]
+  '''
+  No logs found for run 85156191-170d-4229-8eba-14450b6ca9e3
   
   '''
 # ---
 # name: TestDynamicCommandExecution.test_command_execution[log_success_logs_empty_json_json]
-  dict({
-    'count': 0,
-    'cursor': None,
-    'hasMore': False,
-    'logs': list([
-    ]),
-    'run_id': 'empty-run-uuid-0000-0000-000000000000',
-  })
+  '''
+  {"error": "Exhausted 0 responses"}
+  Error: Failed to get logs for run empty-run-uuid-0000-0000-000000000000: Exhausted 0 responses
+  
+  '''
 # ---
 # name: TestDynamicCommandExecution.test_command_execution[log_success_logs_empty_text_text]
   '''
-  No logs found for run empty-run-uuid-0000-0000-000000000000
+  Error querying Dagster Plus API: Exhausted 0 responses
+  Error: Failed to get logs for run empty-run-uuid-0000-0000-000000000000: Exhausted 0 responses
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_error_level_only_json_json]
+  dict({
+    'count': 0,
+    'cursor': 'eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODU1MzE0M30=',
+    'hasMore': False,
+    'logs': list([
+    ]),
+    'run_id': '85156191-170d-4229-8eba-14450b6ca9e3',
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_error_level_only_text_text]
+  '''
+  No logs found for run 85156191-170d-4229-8eba-14450b6ca9e3
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_small_limit_json_json]
+  dict({
+    'count': 5,
+    'cursor': 'eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODUyODM1MX0=',
+    'hasMore': True,
+    'logs': list([
+      dict({
+        'error': None,
+        'eventType': 'ASSET_MATERIALIZATION_PLANNED',
+        'level': 'DEBUG',
+        'message': 'run_etl_pipeline intends to materialize asset ["enriched_data"]',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.concat_chunk_list',
+        'timestamp': '1758808865047',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': 'Launched as an automatic retry',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808865075',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RUN_ENQUEUED',
+        'level': 'INFO',
+        'message': '',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808865098',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RUN_STARTING',
+        'level': 'INFO',
+        'message': '',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808867161',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': 'Sending a request to the agent to execute steps in the user cloud',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808867189',
+      }),
+    ]),
+    'run_id': '85156191-170d-4229-8eba-14450b6ca9e3',
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_small_limit_text_text]
+  '''
+  Logs for run 85156191-170d-4229-8eba-14450b6ca9e3:
+  
+  TIMESTAMP            LEVEL    STEP_KEY                  MESSAGE
+  --------------------------------------------------------------------------------
+  2025-09-25 14:01:05  DEBUG    enriched_data.concat_chu  run_etl_pipeline intends to materialize asset ["enriched_data"]
+  2025-09-25 14:01:05  INFO                               Launched as an automatic retry
+  2025-09-25 14:01:05  INFO                               
+  2025-09-25 14:01:07  INFO                               
+  2025-09-25 14:01:07  INFO                               Sending a request to the agent to execute steps in the user cloud
+  
+  Total log entries: 5
+  Note: More logs available (use --limit to increase or --cursor to paginate)
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_step_filter_json_json]
+  dict({
+    'count': 3,
+    'cursor': 'eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODU0MDMyNn0=',
+    'hasMore': True,
+    'logs': list([
+      dict({
+        'error': None,
+        'eventType': 'STEP_WORKER_STARTING',
+        'level': 'DEBUG',
+        'message': 'Launching subprocess for "enriched_data.process_chunk[11]".',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808871633',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_WORKER_STARTED',
+        'level': 'DEBUG',
+        'message': 'Executing step "enriched_data.process_chunk[11]" in subprocess.',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808872870',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RESOURCE_INIT_STARTED',
+        'level': 'DEBUG',
+        'message': 'Starting initialization of resources [api, io_manager].',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808873361',
+      }),
+    ]),
+    'run_id': '85156191-170d-4229-8eba-14450b6ca9e3',
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_step_filter_text_text]
+  '''
+  Logs for run 85156191-170d-4229-8eba-14450b6ca9e3:
+  
+  TIMESTAMP            LEVEL    STEP_KEY                  MESSAGE
+  --------------------------------------------------------------------------------
+  2025-09-25 14:01:11  DEBUG    enriched_data.process_ch  Launching subprocess for "enriched_data.process_chunk[11]".
+  2025-09-25 14:01:12  DEBUG    enriched_data.process_ch  Executing step "enriched_data.process_chunk[11]" in subprocess.
+  2025-09-25 14:01:13  DEBUG    enriched_data.process_ch  Starting initialization of resources [api, io_manager].
+  
+  Total log entries: 3
+  Note: More logs available (use --limit to increase or --cursor to paginate)
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_with_cursor_json_json]
+  '''
+  {"error": "Exhausted 0 responses"}
+  Error: Failed to get logs for run 85156191-170d-4229-8eba-14450b6ca9e3: Exhausted 0 responses
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_with_cursor_text_text]
+  '''
+  Error querying Dagster Plus API: Exhausted 0 responses
+  Error: Failed to get logs for run 85156191-170d-4229-8eba-14450b6ca9e3: Exhausted 0 responses
   
   '''
 # ---
 # name: TestDynamicCommandExecution.test_command_execution[log_success_logs_with_errors_json_json]
   dict({
-    'count': 6,
-    'cursor': 'eyJza2lwIjo2fQ==',
-    'hasMore': True,
+    'count': 41,
+    'cursor': 'eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODU1MzE0M30=',
+    'hasMore': False,
     'logs': list([
       dict({
         'error': None,
-        'eventType': 'RunStartEvent',
-        'level': 'INFO',
-        'message': 'Starting execution of run for "run_etl_pipeline".',
+        'eventType': 'ASSET_MATERIALIZATION_PLANNED',
+        'level': 'DEBUG',
+        'message': 'run_etl_pipeline intends to materialize asset ["enriched_data"]',
         'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
-        'stepKey': None,
+        'stepKey': 'enriched_data.concat_chunk_list',
         'timestamp': '1758808865047',
       }),
       dict({
         'error': None,
-        'eventType': 'ExecutionStepStartEvent',
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': 'Launched as an automatic retry',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808865075',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RUN_ENQUEUED',
+        'level': 'INFO',
+        'message': '',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808865098',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RUN_STARTING',
+        'level': 'INFO',
+        'message': '',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808867161',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': 'Sending a request to the agent to execute steps in the user cloud',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808867189',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': '[DagsterCloudAgent] Agent 3a659214 is launching run 85156191-170d-4229-8eba-14450b6ca9e3',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808867555',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': '[CloudK8sRunLauncher] Creating Kubernetes run worker job',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808867738',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': '[CloudK8sRunLauncher] Kubernetes run worker job created',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808867910',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': 'Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808870636',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': 'Started process for run (pid: 1).',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808870686',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RUN_START',
+        'level': 'DEBUG',
+        'message': 'Started execution of run for "run_etl_pipeline".',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808871488',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'DEBUG',
+        'message': 'Executing steps using multiprocess executor: parent process (pid: 1)',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808871524',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_WORKER_STARTING',
+        'level': 'DEBUG',
+        'message': 'Launching subprocess for "enriched_data.process_chunk[11]".',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808871633',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_WORKER_STARTED',
+        'level': 'DEBUG',
+        'message': 'Executing step "enriched_data.process_chunk[11]" in subprocess.',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808872870',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RESOURCE_INIT_STARTED',
+        'level': 'DEBUG',
+        'message': 'Starting initialization of resources [api, io_manager].',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808873361',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RESOURCE_INIT_SUCCESS',
+        'level': 'DEBUG',
+        'message': 'Finished initialization of resources [api, io_manager].',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808873521',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'LOGS_CAPTURED',
+        'level': 'DEBUG',
+        'message': 'Started capturing logs in process (pid: 16).',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808873570',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_START',
         'level': 'DEBUG',
         'message': 'Started execution of step "enriched_data.process_chunk[11]".',
         'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
@@ -4182,12 +4788,156 @@
       }),
       dict({
         'error': None,
-        'eventType': 'MessageEvent',
+        'eventType': None,
         'level': 'DEBUG',
         'message': 'Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...',
         'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
         'stepKey': 'enriched_data.process_chunk[11]',
         'timestamp': '1758808873644',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_UP_FOR_RETRY',
+        'level': 'DEBUG',
+        'message': 'Execution of step "enriched_data.process_chunk[11]" failed and has requested a retry.',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808873697',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_WORKER_STARTING',
+        'level': 'DEBUG',
+        'message': 'Launching subprocess for "enriched_data.process_chunk[11]".',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808873742',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_WORKER_STARTED',
+        'level': 'DEBUG',
+        'message': 'Executing step "enriched_data.process_chunk[11]" in subprocess.',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808874924',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RESOURCE_INIT_STARTED',
+        'level': 'DEBUG',
+        'message': 'Starting initialization of resources [api, io_manager].',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808875309',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RESOURCE_INIT_SUCCESS',
+        'level': 'DEBUG',
+        'message': 'Finished initialization of resources [api, io_manager].',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808875444',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'LOGS_CAPTURED',
+        'level': 'DEBUG',
+        'message': 'Started capturing logs in process (pid: 26).',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808875526',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_RESTARTED',
+        'level': 'DEBUG',
+        'message': 'Started re-execution (attempt # 2) of step "enriched_data.process_chunk[11]".',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808875655',
+      }),
+      dict({
+        'error': None,
+        'eventType': None,
+        'level': 'DEBUG',
+        'message': 'Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808875737',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_UP_FOR_RETRY',
+        'level': 'DEBUG',
+        'message': 'Execution of step "enriched_data.process_chunk[11]" failed and has requested a retry.',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808875801',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_WORKER_STARTING',
+        'level': 'DEBUG',
+        'message': 'Launching subprocess for "enriched_data.process_chunk[11]".',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808875835',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_WORKER_STARTED',
+        'level': 'DEBUG',
+        'message': 'Executing step "enriched_data.process_chunk[11]" in subprocess.',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808876893',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RESOURCE_INIT_STARTED',
+        'level': 'DEBUG',
+        'message': 'Starting initialization of resources [api, io_manager].',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808877224',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RESOURCE_INIT_SUCCESS',
+        'level': 'DEBUG',
+        'message': 'Finished initialization of resources [api, io_manager].',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808877380',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'LOGS_CAPTURED',
+        'level': 'DEBUG',
+        'message': 'Started capturing logs in process (pid: 36).',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808877439',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'STEP_RESTARTED',
+        'level': 'DEBUG',
+        'message': 'Started re-execution (attempt # 3) of step "enriched_data.process_chunk[11]".',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808877601',
+      }),
+      dict({
+        'error': None,
+        'eventType': None,
+        'level': 'DEBUG',
+        'message': 'Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808877680',
       }),
       dict({
         'error': dict({
@@ -4273,7 +5023,7 @@
           }),
           'className': 'RetryRequestedFromPolicy',
           'message': '''
-            RetryRequestedFromPolicy: Exceeded max_retries of 2
+            Exceeded max_retries of 2
   
           ''',
           'stack': list([
@@ -4333,7 +5083,7 @@
   
           ''',
         }),
-        'eventType': 'ExecutionStepFailureEvent',
+        'eventType': 'STEP_FAILURE',
         'level': 'ERROR',
         'message': 'Execution of step "enriched_data.process_chunk[11]" failed.',
         'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
@@ -4342,7 +5092,7 @@
       }),
       dict({
         'error': None,
-        'eventType': 'MessageEvent',
+        'eventType': None,
         'level': 'ERROR',
         'message': "Dependencies for step enriched_data.concat_chunk_list failed: ['enriched_data.process_chunk[11]']. Not executing.",
         'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
@@ -4351,12 +5101,39 @@
       }),
       dict({
         'error': None,
-        'eventType': 'RunFailureEvent',
+        'eventType': 'ENGINE_EVENT',
+        'level': 'DEBUG',
+        'message': 'Multiprocess executor: parent process exiting after 6.79s (pid: 1)',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808878387',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RUN_FAILURE',
         'level': 'ERROR',
         'message': 'Execution of run for "run_etl_pipeline" failed. Steps failed: [\'enriched_data.process_chunk[11]\'].',
         'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
         'stepKey': None,
         'timestamp': '1758808878519',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ENGINE_EVENT',
+        'level': 'INFO',
+        'message': 'Process for run exited (pid: 1).',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808878602',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ASSET_FAILED_TO_MATERIALIZE',
+        'level': 'INFO',
+        'message': 'Asset ["enriched_data"] failed to materialize',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.concat_chunk_list',
+        'timestamp': '1758808880071',
       }),
     ]),
     'run_id': '85156191-170d-4229-8eba-14450b6ca9e3',
@@ -4368,9 +5145,41 @@
   
   TIMESTAMP            LEVEL    STEP_KEY                  MESSAGE
   --------------------------------------------------------------------------------
-  2025-09-25 14:01:05  INFO                               Starting execution of run for "run_etl_pipeline".
+  2025-09-25 14:01:05  DEBUG    enriched_data.concat_chu  run_etl_pipeline intends to materialize asset ["enriched_data"]
+  2025-09-25 14:01:05  INFO                               Launched as an automatic retry
+  2025-09-25 14:01:05  INFO                               
+  2025-09-25 14:01:07  INFO                               
+  2025-09-25 14:01:07  INFO                               Sending a request to the agent to execute steps in the user cloud
+  2025-09-25 14:01:07  INFO                               [DagsterCloudAgent] Agent 3a659214 is launching run 85156191-170d-4229-8eba-14450b6ca9e3
+  2025-09-25 14:01:07  INFO                               [CloudK8sRunLauncher] Creating Kubernetes run worker job
+  2025-09-25 14:01:07  INFO                               [CloudK8sRunLauncher] Kubernetes run worker job created
+  2025-09-25 14:01:10  INFO                               Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False
+  2025-09-25 14:01:10  INFO                               Started process for run (pid: 1).
+  2025-09-25 14:01:11  DEBUG                              Started execution of run for "run_etl_pipeline".
+  2025-09-25 14:01:11  DEBUG                              Executing steps using multiprocess executor: parent process (pid: 1)
+  2025-09-25 14:01:11  DEBUG    enriched_data.process_ch  Launching subprocess for "enriched_data.process_chunk[11]".
+  2025-09-25 14:01:12  DEBUG    enriched_data.process_ch  Executing step "enriched_data.process_chunk[11]" in subprocess.
+  2025-09-25 14:01:13  DEBUG    enriched_data.process_ch  Starting initialization of resources [api, io_manager].
+  2025-09-25 14:01:13  DEBUG    enriched_data.process_ch  Finished initialization of resources [api, io_manager].
+  2025-09-25 14:01:13  DEBUG                              Started capturing logs in process (pid: 16).
   2025-09-25 14:01:13  DEBUG    enriched_data.process_ch  Started execution of step "enriched_data.process_chunk[11]".
   2025-09-25 14:01:13  DEBUG    enriched_data.process_ch  Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...
+  2025-09-25 14:01:13  DEBUG    enriched_data.process_ch  Execution of step "enriched_data.process_chunk[11]" failed and has requested a retry.
+  2025-09-25 14:01:13  DEBUG    enriched_data.process_ch  Launching subprocess for "enriched_data.process_chunk[11]".
+  2025-09-25 14:01:14  DEBUG    enriched_data.process_ch  Executing step "enriched_data.process_chunk[11]" in subprocess.
+  2025-09-25 14:01:15  DEBUG    enriched_data.process_ch  Starting initialization of resources [api, io_manager].
+  2025-09-25 14:01:15  DEBUG    enriched_data.process_ch  Finished initialization of resources [api, io_manager].
+  2025-09-25 14:01:15  DEBUG                              Started capturing logs in process (pid: 26).
+  2025-09-25 14:01:15  DEBUG    enriched_data.process_ch  Started re-execution (attempt # 2) of step "enriched_data.process_chunk[11]".
+  2025-09-25 14:01:15  DEBUG    enriched_data.process_ch  Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...
+  2025-09-25 14:01:15  DEBUG    enriched_data.process_ch  Execution of step "enriched_data.process_chunk[11]" failed and has requested a retry.
+  2025-09-25 14:01:15  DEBUG    enriched_data.process_ch  Launching subprocess for "enriched_data.process_chunk[11]".
+  2025-09-25 14:01:16  DEBUG    enriched_data.process_ch  Executing step "enriched_data.process_chunk[11]" in subprocess.
+  2025-09-25 14:01:17  DEBUG    enriched_data.process_ch  Starting initialization of resources [api, io_manager].
+  2025-09-25 14:01:17  DEBUG    enriched_data.process_ch  Finished initialization of resources [api, io_manager].
+  2025-09-25 14:01:17  DEBUG                              Started capturing logs in process (pid: 36).
+  2025-09-25 14:01:17  DEBUG    enriched_data.process_ch  Started re-execution (attempt # 3) of step "enriched_data.process_chunk[11]".
+  2025-09-25 14:01:17  DEBUG    enriched_data.process_ch  Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...
   2025-09-25 14:01:17  ERROR    enriched_data.process_ch  Execution of step "enriched_data.process_chunk[11]" failed.
   
   Stack Trace:
@@ -4390,10 +5199,12 @@
         raise RetryRequestedFromPolicy(
   
   2025-09-25 14:01:17  ERROR    enriched_data.concat_chu  Dependencies for step enriched_data.concat_chunk_list failed: ['enriched_data.process_chunk[11]']. Not executing.
+  2025-09-25 14:01:18  DEBUG                              Multiprocess executor: parent process exiting after 6.79s (pid: 1)
   2025-09-25 14:01:18  ERROR                              Execution of run for "run_etl_pipeline" failed. Steps failed: ['enriched_data.process_chunk[11]'].
+  2025-09-25 14:01:18  INFO                               Process for run exited (pid: 1).
+  2025-09-25 14:01:20  INFO     enriched_data.concat_chu  Asset ["enriched_data"] failed to materialize
   
-  Total log entries: 6
-  Note: More logs available (use --limit to increase or --cursor to paginate)
+  Total log entries: 41
   
   '''
 # ---

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/__snapshots__/test_dynamic_command_execution.ambr
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/__snapshots__/test_dynamic_command_execution.ambr
@@ -4126,6 +4126,277 @@
   
   '''
 # ---
+# name: TestDynamicCommandExecution.test_command_execution[log_error_run_not_found_json_json]
+  '''
+  {"error": "Run with id nonexistent-run-uuid-1234-5678-900000000000 not found"}
+  Error: Failed to get logs for run nonexistent-run-uuid-1234-5678-900000000000: Run with id nonexistent-run-uuid-1234-5678-900000000000 not found
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_error_run_not_found_text_text]
+  '''
+  Error querying Dagster Plus API: Run with id nonexistent-run-uuid-1234-5678-900000000000 not found
+  Error: Failed to get logs for run nonexistent-run-uuid-1234-5678-900000000000: Run with id nonexistent-run-uuid-1234-5678-900000000000 not found
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_empty_json_json]
+  dict({
+    'count': 0,
+    'cursor': None,
+    'hasMore': False,
+    'logs': list([
+    ]),
+    'run_id': 'empty-run-uuid-0000-0000-000000000000',
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_empty_text_text]
+  '''
+  No logs found for run empty-run-uuid-0000-0000-000000000000
+  
+  '''
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_with_errors_json_json]
+  dict({
+    'count': 6,
+    'cursor': 'eyJza2lwIjo2fQ==',
+    'hasMore': True,
+    'logs': list([
+      dict({
+        'error': None,
+        'eventType': 'RunStartEvent',
+        'level': 'INFO',
+        'message': 'Starting execution of run for "run_etl_pipeline".',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808865047',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ExecutionStepStartEvent',
+        'level': 'DEBUG',
+        'message': 'Started execution of step "enriched_data.process_chunk[11]".',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808873607',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'MessageEvent',
+        'level': 'DEBUG',
+        'message': 'Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808873644',
+      }),
+      dict({
+        'error': dict({
+          'cause': dict({
+            'cause': None,
+            'className': 'FileNotFoundError',
+            'message': '''
+              FileNotFoundError: [Errno 2] No such file or directory: '/opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11'
+  
+            ''',
+            'stack': list([
+              '''
+                  File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py", line 57, in op_execution_error_boundary
+                    yield
+  
+              ''',
+              '''
+                  File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py", line 619, in _load_input_with_input_manager
+                    value = input_manager.load_input(context)
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+              ''',
+              '''
+                  File "/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py", line 406, in load_input
+                    return self._load_single_input(path, context)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+              ''',
+              '''
+                  File "/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py", line 273, in _load_single_input
+                    obj = self.load_from_path(context=context, path=path)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+              ''',
+              '''
+                  File "/usr/local/lib/python3.12/site-packages/dagster/_core/storage/fs_io_manager.py", line 284, in load_from_path
+                    with path.open("rb") as file:
+                         ^^^^^^^^^^^^^^^
+  
+              ''',
+              '''
+                  File "/usr/local/lib/python3.12/site-packages/upath/implementations/local.py", line 134, in open
+                    return PosixPath.open(self, mode, buffering, encoding, errors, newline)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+              ''',
+              '''
+                  File "/usr/local/lib/python3.12/pathlib.py", line 1013, in open
+                    return io.open(self, mode, buffering, encoding, errors, newline)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+              ''',
+            ]),
+            'stackTrace': '''
+                File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py", line 57, in op_execution_error_boundary
+                  yield
+              
+                File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py", line 619, in _load_input_with_input_manager
+                  value = input_manager.load_input(context)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              
+                File "/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py", line 406, in load_input
+                  return self._load_single_input(path, context)
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              
+                File "/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py", line 273, in _load_single_input
+                  obj = self.load_from_path(context=context, path=path)
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              
+                File "/usr/local/lib/python3.12/site-packages/dagster/_core/storage/fs_io_manager.py", line 284, in load_from_path
+                  with path.open("rb") as file:
+                       ^^^^^^^^^^^^^^^
+              
+                File "/usr/local/lib/python3.12/site-packages/upath/implementations/local.py", line 134, in open
+                  return PosixPath.open(self, mode, buffering, encoding, errors, newline)
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              
+                File "/usr/local/lib/python3.12/pathlib.py", line 1013, in open
+                  return io.open(self, mode, buffering, encoding, errors, newline)
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+            ''',
+          }),
+          'className': 'RetryRequestedFromPolicy',
+          'message': '''
+            RetryRequestedFromPolicy: Exceeded max_retries of 2
+  
+          ''',
+          'stack': list([
+            '''
+                File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_plan.py", line 246, in dagster_event_sequence_for_step
+                  yield from check.generator(step_events)
+  
+            ''',
+            '''
+                File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_step.py", line 468, in core_dagster_event_sequence_for_step
+                  for event_or_input_value in step_input.source.load_input_object(
+                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+            ''',
+            '''
+                File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py", line 364, in load_input_object
+                  yield from _load_input_with_input_manager(input_manager, load_input_context)
+  
+            ''',
+            '''
+                File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py", line 612, in _load_input_with_input_manager
+                  with op_execution_error_boundary(
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+            ''',
+            '''
+                File "/usr/local/lib/python3.12/contextlib.py", line 158, in __exit__
+                  self.gen.throw(value)
+  
+            ''',
+            '''
+                File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py", line 75, in op_execution_error_boundary
+                  raise RetryRequestedFromPolicy(
+  
+            ''',
+          ]),
+          'stackTrace': '''
+              File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_plan.py", line 246, in dagster_event_sequence_for_step
+                yield from check.generator(step_events)
+            
+              File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_step.py", line 468, in core_dagster_event_sequence_for_step
+                for event_or_input_value in step_input.source.load_input_object(
+                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            
+              File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py", line 364, in load_input_object
+                yield from _load_input_with_input_manager(input_manager, load_input_context)
+            
+              File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py", line 612, in _load_input_with_input_manager
+                with op_execution_error_boundary(
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            
+              File "/usr/local/lib/python3.12/contextlib.py", line 158, in __exit__
+                self.gen.throw(value)
+            
+              File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py", line 75, in op_execution_error_boundary
+                raise RetryRequestedFromPolicy(
+  
+          ''',
+        }),
+        'eventType': 'ExecutionStepFailureEvent',
+        'level': 'ERROR',
+        'message': 'Execution of step "enriched_data.process_chunk[11]" failed.',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.process_chunk[11]',
+        'timestamp': '1758808877726',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'MessageEvent',
+        'level': 'ERROR',
+        'message': "Dependencies for step enriched_data.concat_chunk_list failed: ['enriched_data.process_chunk[11]']. Not executing.",
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': 'enriched_data.concat_chunk_list',
+        'timestamp': '1758808877786',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RunFailureEvent',
+        'level': 'ERROR',
+        'message': 'Execution of run for "run_etl_pipeline" failed. Steps failed: [\'enriched_data.process_chunk[11]\'].',
+        'runId': '85156191-170d-4229-8eba-14450b6ca9e3',
+        'stepKey': None,
+        'timestamp': '1758808878519',
+      }),
+    ]),
+    'run_id': '85156191-170d-4229-8eba-14450b6ca9e3',
+  })
+# ---
+# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_with_errors_text_text]
+  '''
+  Logs for run 85156191-170d-4229-8eba-14450b6ca9e3:
+  
+  TIMESTAMP            LEVEL    STEP_KEY                  MESSAGE
+  --------------------------------------------------------------------------------
+  2025-09-25 14:01:05  INFO                               Starting execution of run for "run_etl_pipeline".
+  2025-09-25 14:01:13  DEBUG    enriched_data.process_ch  Started execution of step "enriched_data.process_chunk[11]".
+  2025-09-25 14:01:13  DEBUG    enriched_data.process_ch  Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...
+  2025-09-25 14:01:17  ERROR    enriched_data.process_ch  Execution of step "enriched_data.process_chunk[11]" failed.
+  
+  Stack Trace:
+      File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_plan.py", line 246, in dagster_event_sequence_for_step
+        yield from check.generator(step_events)
+      File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_step.py", line 468, in core_dagster_event_sequence_for_step
+        for event_or_input_value in step_input.source.load_input_object(
+                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py", line 364, in load_input_object
+        yield from _load_input_with_input_manager(input_manager, load_input_context)
+      File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py", line 612, in _load_input_with_input_manager
+        with op_execution_error_boundary(
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      File "/usr/local/lib/python3.12/contextlib.py", line 158, in __exit__
+        self.gen.throw(value)
+      File "/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py", line 75, in op_execution_error_boundary
+        raise RetryRequestedFromPolicy(
+  
+  2025-09-25 14:01:17  ERROR    enriched_data.concat_chu  Dependencies for step enriched_data.concat_chunk_list failed: ['enriched_data.process_chunk[11]']. Not executing.
+  2025-09-25 14:01:18  ERROR                              Execution of run for "run_etl_pipeline" failed. Steps failed: ['enriched_data.process_chunk[11]'].
+  
+  Total log entries: 6
+  Note: More logs available (use --limit to increase or --cursor to paginate)
+  
+  '''
+# ---
 # name: TestDynamicCommandExecution.test_command_execution[run_error_invalid_run_id_json]
   dict({
     'error': "Run not found: ''",

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/Makefile
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/Makefile
@@ -1,0 +1,13 @@
+.PHONY: rerecord test clean
+
+rerecord:
+	dagster-dev dg-api-record log
+
+test:
+	pytest . -v
+
+snapshot:
+	pytest . --snapshot-update -v
+
+clean:
+	rm -rf recordings/

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/__snapshots__/test_business_logic.ambr
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/__snapshots__/test_business_logic.ambr
@@ -1,0 +1,332 @@
+# serializer version: 1
+# name: TestFormatLogs.test_format_empty_logs_json_output[0]
+  dict({
+    'count': 0,
+    'cursor': None,
+    'hasMore': False,
+    'logs': list([
+    ]),
+    'run_id': 'empty-run-67890',
+  })
+# ---
+# name: TestFormatLogs.test_format_empty_logs_table_output[0]
+  'No logs found for run empty-run-67890'
+# ---
+# name: TestFormatLogs.test_format_logs_all_levels[0]
+  '''
+  Logs for run level-test-run:
+  
+  TIMESTAMP            LEVEL    STEP_KEY                  MESSAGE
+  --------------------------------------------------------------------------------
+  2022-01-01 14:20:00  CRITICAL test_step                 This is a CRITICAL level message
+  2022-01-01 14:20:00  ERROR    test_step                 This is a ERROR level message
+  2022-01-01 14:20:00  WARNING  test_step                 This is a WARNING level message
+  2022-01-01 14:20:00  INFO                               This is a INFO level message
+  2022-01-01 14:20:00  DEBUG    test_step                 This is a DEBUG level message
+  
+  Total log entries: 5
+  '''
+# ---
+# name: TestFormatLogs.test_format_logs_json_output[0]
+  dict({
+    'count': 5,
+    'cursor': None,
+    'hasMore': False,
+    'logs': list([
+      dict({
+        'error': None,
+        'eventType': 'RunStartEvent',
+        'level': 'INFO',
+        'message': 'Starting execution of run for "test_pipeline".',
+        'runId': 'test-run-12345',
+        'stepKey': None,
+        'timestamp': '1641046800000',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'ExecutionStepStartEvent',
+        'level': 'DEBUG',
+        'message': 'Started execution of step "process_data".',
+        'runId': 'test-run-12345',
+        'stepKey': 'process_data',
+        'timestamp': '1641046805000',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'MessageEvent',
+        'level': 'DEBUG',
+        'message': 'Loading input from path: /tmp/input.json',
+        'runId': 'test-run-12345',
+        'stepKey': 'process_data',
+        'timestamp': '1641046810000',
+      }),
+      dict({
+        'error': dict({
+          'cause': None,
+          'className': 'ValueError',
+          'message': '''
+            ValueError: Invalid input data format
+  
+          ''',
+          'stack': list([
+            '''
+                File "/app/pipeline.py", line 42, in process_data
+                  data = json.loads(input_str)
+  
+            ''',
+            '''
+                File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
+                  return _default_decoder.decode(s)
+  
+            ''',
+            '''
+                File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
+                  obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+  
+            ''',
+          ]),
+          'stackTrace': '''
+              File "/app/pipeline.py", line 42, in process_data
+                data = json.loads(input_str)
+            
+              File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
+                return _default_decoder.decode(s)
+            
+              File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
+                obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+  
+          ''',
+        }),
+        'eventType': 'ExecutionStepFailureEvent',
+        'level': 'ERROR',
+        'message': 'Execution of step "process_data" failed.',
+        'runId': 'test-run-12345',
+        'stepKey': 'process_data',
+        'timestamp': '1641046815000',
+      }),
+      dict({
+        'error': None,
+        'eventType': 'RunFailureEvent',
+        'level': 'ERROR',
+        'message': 'Execution of run for "test_pipeline" failed. Steps failed: [\'process_data\'].',
+        'runId': 'test-run-12345',
+        'stepKey': None,
+        'timestamp': '1641046820000',
+      }),
+    ]),
+    'run_id': 'test-run-12345',
+  })
+# ---
+# name: TestFormatLogs.test_format_logs_table_output[0]
+  '''
+  Logs for run test-run-12345:
+  
+  TIMESTAMP            LEVEL    STEP_KEY                  MESSAGE
+  --------------------------------------------------------------------------------
+  2022-01-01 14:20:00  INFO                               Starting execution of run for "test_pipeline".
+  2022-01-01 14:20:05  DEBUG    process_data              Started execution of step "process_data".
+  2022-01-01 14:20:10  DEBUG    process_data              Loading input from path: /tmp/input.json
+  2022-01-01 14:20:15  ERROR    process_data              Execution of step "process_data" failed.
+  
+  Stack Trace:
+      File "/app/pipeline.py", line 42, in process_data
+        data = json.loads(input_str)
+      File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
+        return _default_decoder.decode(s)
+      File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
+        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+  
+  2022-01-01 14:20:20  ERROR                              Execution of run for "test_pipeline" failed. Steps failed: ['process_data'].
+  
+  Total log entries: 5
+  '''
+# ---
+# name: TestFormatLogs.test_format_logs_with_long_step_key[0]
+  '''
+  Logs for run truncation-test-run:
+  
+  TIMESTAMP            LEVEL    STEP_KEY                  MESSAGE
+  --------------------------------------------------------------------------------
+  2022-01-01 14:20:30  INFO     very_long_step_name_that  Processing large dataset chunk.
+  
+  Total log entries: 1
+  '''
+# ---
+# name: TestFormatLogs.test_format_logs_with_nested_errors[0]
+  '''
+  Logs for run nested-error-run:
+  
+  TIMESTAMP            LEVEL    STEP_KEY                  MESSAGE
+  --------------------------------------------------------------------------------
+  2022-01-01 14:20:25  ERROR    database_query            Database connection failed with retry exhausted.
+  
+  Stack Trace:
+      File "/app/database.py", line 25, in execute_query
+        return self._execute_with_retry(query)
+      File "/app/database.py", line 45, in _execute_with_retry
+        raise RetryRequestedFromPolicy(f"Exceeded max_retries of {max_retries}")
+  
+  
+  Total log entries: 1
+  '''
+# ---
+# name: TestFormatLogs.test_format_logs_with_nested_errors_json[0]
+  dict({
+    'count': 1,
+    'cursor': None,
+    'hasMore': False,
+    'logs': list([
+      dict({
+        'error': dict({
+          'cause': dict({
+            'cause': None,
+            'className': 'ConnectionError',
+            'message': '''
+              ConnectionError: [Errno 111] Connection refused
+  
+            ''',
+            'stack': list([
+              '''
+                  File "/app/database.py", line 35, in _execute_with_retry
+                    result = self.connection.execute(query)
+  
+              ''',
+              '''
+                  File "/usr/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1418, in execute
+                    return connection.execute(statement, parameters)
+  
+              ''',
+              '''
+                  File "/usr/lib/python3.12/site-packages/psycopg2/__init__.py", line 122, in connect
+                    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+  
+              ''',
+            ]),
+            'stackTrace': '''
+                File "/app/database.py", line 35, in _execute_with_retry
+                  result = self.connection.execute(query)
+              
+                File "/usr/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1418, in execute
+                  return connection.execute(statement, parameters)
+              
+                File "/usr/lib/python3.12/site-packages/psycopg2/__init__.py", line 122, in connect
+                  conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+  
+            ''',
+          }),
+          'className': 'RetryRequestedFromPolicy',
+          'message': '''
+            RetryRequestedFromPolicy: Exceeded max_retries of 3
+  
+          ''',
+          'stack': list([
+            '''
+                File "/app/database.py", line 25, in execute_query
+                  return self._execute_with_retry(query)
+  
+            ''',
+            '''
+                File "/app/database.py", line 45, in _execute_with_retry
+                  raise RetryRequestedFromPolicy(f"Exceeded max_retries of {max_retries}")
+  
+            ''',
+          ]),
+          'stackTrace': '''
+              File "/app/database.py", line 25, in execute_query
+                return self._execute_with_retry(query)
+            
+              File "/app/database.py", line 45, in _execute_with_retry
+                raise RetryRequestedFromPolicy(f"Exceeded max_retries of {max_retries}")
+  
+          ''',
+        }),
+        'eventType': 'ExecutionStepFailureEvent',
+        'level': 'ERROR',
+        'message': 'Database connection failed with retry exhausted.',
+        'runId': 'nested-error-run',
+        'stepKey': 'database_query',
+        'timestamp': '1641046825000',
+      }),
+    ]),
+    'run_id': 'nested-error-run',
+  })
+# ---
+# name: TestFormatLogs.test_format_logs_with_pagination_info[0]
+  '''
+  Logs for run paginated-run:
+  
+  TIMESTAMP            LEVEL    STEP_KEY                  MESSAGE
+  --------------------------------------------------------------------------------
+  2022-01-01 14:20:00  INFO                               First log entry
+  2022-01-01 14:20:05  DEBUG    step_1                    Second log entry
+  
+  Total log entries: 2
+  Note: More logs available (use --limit to increase or --cursor to paginate)
+  '''
+# ---
+# name: TestLogDataProcessing.test_run_event_creation_with_all_levels[0]
+  dict({
+    'cursor': None,
+    'has_more': False,
+    'items': list([
+      dict({
+        'error': None,
+        'event_type': 'MessageEvent',
+        'level': 'CRITICAL',
+        'message': 'Message at CRITICAL level',
+        'run_id': 'level-critical-run',
+        'step_key': 'step_critical',
+        'timestamp': '1641046800000',
+      }),
+      dict({
+        'error': None,
+        'event_type': 'MessageEvent',
+        'level': 'ERROR',
+        'message': 'Message at ERROR level',
+        'run_id': 'level-error-run',
+        'step_key': 'step_error',
+        'timestamp': '1641046800000',
+      }),
+      dict({
+        'error': None,
+        'event_type': 'MessageEvent',
+        'level': 'WARNING',
+        'message': 'Message at WARNING level',
+        'run_id': 'level-warning-run',
+        'step_key': 'step_warning',
+        'timestamp': '1641046800000',
+      }),
+      dict({
+        'error': None,
+        'event_type': 'MessageEvent',
+        'level': 'INFO',
+        'message': 'Message at INFO level',
+        'run_id': 'level-info-run',
+        'step_key': None,
+        'timestamp': '1641046800000',
+      }),
+      dict({
+        'error': None,
+        'event_type': 'MessageEvent',
+        'level': 'DEBUG',
+        'message': 'Message at DEBUG level',
+        'run_id': 'level-debug-run',
+        'step_key': 'step_debug',
+        'timestamp': '1641046800000',
+      }),
+    ]),
+    'total': 5,
+  })
+# ---
+# name: TestLogDataProcessing.test_timestamp_handling_edge_cases[0]
+  '''
+  Logs for run timestamp-test:
+  
+  TIMESTAMP            LEVEL    STEP_KEY                  MESSAGE
+  --------------------------------------------------------------------------------
+  1970-01-01 00:00:00  INFO                               Epoch timestamp
+  3000-01-01 00:00:00  DEBUG                              Large timestamp
+  
+  Total log entries: 2
+  '''
+# ---

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/error_invalid_level_json/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/error_invalid_level_json/01_response.json
@@ -1,0 +1,404 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODU1MzE0M30=",
+    "events": [
+      {
+        "__typename": "AssetMaterializationPlannedEvent",
+        "eventType": "ASSET_MATERIALIZATION_PLANNED",
+        "level": "DEBUG",
+        "message": "run_etl_pipeline intends to materialize asset [\"enriched_data\"]",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808865047"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Launched as an automatic retry",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865075"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865098"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867161"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867189"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[DagsterCloudAgent] Agent 3a659214 is launching run 85156191-170d-4229-8eba-14450b6ca9e3",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867555"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Creating Kubernetes run worker job",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867738"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Kubernetes run worker job created",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867910"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870636"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Started process for run (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870686"
+      },
+      {
+        "__typename": "RunStartEvent",
+        "eventType": "RUN_START",
+        "level": "DEBUG",
+        "message": "Started execution of run for \"run_etl_pipeline\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871488"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Executing steps using multiprocess executor: parent process (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871524"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808871633"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808872870"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873361"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873521"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 16).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808873570"
+      },
+      {
+        "__typename": "ExecutionStepStartEvent",
+        "eventType": "STEP_START",
+        "level": "DEBUG",
+        "message": "Started execution of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873607"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873644"
+      },
+      {
+        "__typename": "ExecutionStepUpForRetryEvent",
+        "eventType": "STEP_UP_FOR_RETRY",
+        "level": "DEBUG",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed and has requested a retry.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873697"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873742"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808874924"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875309"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875444"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 26).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808875526"
+      },
+      {
+        "__typename": "ExecutionStepRestartEvent",
+        "eventType": "STEP_RESTARTED",
+        "level": "DEBUG",
+        "message": "Started re-execution (attempt # 2) of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875655"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875737"
+      },
+      {
+        "__typename": "ExecutionStepUpForRetryEvent",
+        "eventType": "STEP_UP_FOR_RETRY",
+        "level": "DEBUG",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed and has requested a retry.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875801"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875835"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808876893"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877224"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877380"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 36).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808877439"
+      },
+      {
+        "__typename": "ExecutionStepRestartEvent",
+        "eventType": "STEP_RESTARTED",
+        "level": "DEBUG",
+        "message": "Started re-execution (attempt # 3) of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877601"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877680"
+      },
+      {
+        "__typename": "ExecutionStepFailureEvent",
+        "error": {
+          "cause": {
+            "cause": null,
+            "className": "FileNotFoundError",
+            "message": "FileNotFoundError: [Errno 2] No such file or directory: '/opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11'\n",
+            "stack": [
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py\", line 57, in op_execution_error_boundary\n    yield\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 619, in _load_input_with_input_manager\n    value = input_manager.load_input(context)\n            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py\", line 406, in load_input\n    return self._load_single_input(path, context)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py\", line 273, in _load_single_input\n    obj = self.load_from_path(context=context, path=path)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/fs_io_manager.py\", line 284, in load_from_path\n    with path.open(\"rb\") as file:\n         ^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/upath/implementations/local.py\", line 134, in open\n    return PosixPath.open(self, mode, buffering, encoding, errors, newline)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/pathlib.py\", line 1013, in open\n    return io.open(self, mode, buffering, encoding, errors, newline)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+            ]
+          },
+          "className": "RetryRequestedFromPolicy",
+          "message": "Exceeded max_retries of 2\n",
+          "stack": [
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_plan.py\", line 246, in dagster_event_sequence_for_step\n    yield from check.generator(step_events)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_step.py\", line 468, in core_dagster_event_sequence_for_step\n    for event_or_input_value in step_input.source.load_input_object(\n                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 364, in load_input_object\n    yield from _load_input_with_input_manager(input_manager, load_input_context)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 612, in _load_input_with_input_manager\n    with op_execution_error_boundary(\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/contextlib.py\", line 158, in __exit__\n    self.gen.throw(value)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py\", line 75, in op_execution_error_boundary\n    raise RetryRequestedFromPolicy(\n"
+          ]
+        },
+        "eventType": "STEP_FAILURE",
+        "level": "ERROR",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877726"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "ERROR",
+        "message": "Dependencies for step enriched_data.concat_chunk_list failed: ['enriched_data.process_chunk[11]']. Not executing.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808877786"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Multiprocess executor: parent process exiting after 6.79s (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878387"
+      },
+      {
+        "__typename": "RunFailureEvent",
+        "eventType": "RUN_FAILURE",
+        "level": "ERROR",
+        "message": "Execution of run for \"run_etl_pipeline\" failed. Steps failed: ['enriched_data.process_chunk[11]'].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878519"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Process for run exited (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878602"
+      },
+      {
+        "__typename": "FailedToMaterializeEvent",
+        "eventType": "ASSET_FAILED_TO_MATERIALIZE",
+        "level": "INFO",
+        "message": "Asset [\"enriched_data\"] failed to materialize",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808880071"
+      }
+    ],
+    "hasMore": false
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/error_invalid_level_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/error_invalid_level_text/01_response.json
@@ -1,0 +1,404 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODU1MzE0M30=",
+    "events": [
+      {
+        "__typename": "AssetMaterializationPlannedEvent",
+        "eventType": "ASSET_MATERIALIZATION_PLANNED",
+        "level": "DEBUG",
+        "message": "run_etl_pipeline intends to materialize asset [\"enriched_data\"]",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808865047"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Launched as an automatic retry",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865075"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865098"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867161"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867189"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[DagsterCloudAgent] Agent 3a659214 is launching run 85156191-170d-4229-8eba-14450b6ca9e3",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867555"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Creating Kubernetes run worker job",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867738"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Kubernetes run worker job created",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867910"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870636"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Started process for run (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870686"
+      },
+      {
+        "__typename": "RunStartEvent",
+        "eventType": "RUN_START",
+        "level": "DEBUG",
+        "message": "Started execution of run for \"run_etl_pipeline\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871488"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Executing steps using multiprocess executor: parent process (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871524"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808871633"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808872870"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873361"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873521"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 16).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808873570"
+      },
+      {
+        "__typename": "ExecutionStepStartEvent",
+        "eventType": "STEP_START",
+        "level": "DEBUG",
+        "message": "Started execution of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873607"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873644"
+      },
+      {
+        "__typename": "ExecutionStepUpForRetryEvent",
+        "eventType": "STEP_UP_FOR_RETRY",
+        "level": "DEBUG",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed and has requested a retry.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873697"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873742"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808874924"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875309"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875444"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 26).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808875526"
+      },
+      {
+        "__typename": "ExecutionStepRestartEvent",
+        "eventType": "STEP_RESTARTED",
+        "level": "DEBUG",
+        "message": "Started re-execution (attempt # 2) of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875655"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875737"
+      },
+      {
+        "__typename": "ExecutionStepUpForRetryEvent",
+        "eventType": "STEP_UP_FOR_RETRY",
+        "level": "DEBUG",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed and has requested a retry.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875801"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875835"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808876893"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877224"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877380"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 36).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808877439"
+      },
+      {
+        "__typename": "ExecutionStepRestartEvent",
+        "eventType": "STEP_RESTARTED",
+        "level": "DEBUG",
+        "message": "Started re-execution (attempt # 3) of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877601"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877680"
+      },
+      {
+        "__typename": "ExecutionStepFailureEvent",
+        "error": {
+          "cause": {
+            "cause": null,
+            "className": "FileNotFoundError",
+            "message": "FileNotFoundError: [Errno 2] No such file or directory: '/opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11'\n",
+            "stack": [
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py\", line 57, in op_execution_error_boundary\n    yield\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 619, in _load_input_with_input_manager\n    value = input_manager.load_input(context)\n            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py\", line 406, in load_input\n    return self._load_single_input(path, context)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py\", line 273, in _load_single_input\n    obj = self.load_from_path(context=context, path=path)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/fs_io_manager.py\", line 284, in load_from_path\n    with path.open(\"rb\") as file:\n         ^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/upath/implementations/local.py\", line 134, in open\n    return PosixPath.open(self, mode, buffering, encoding, errors, newline)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/pathlib.py\", line 1013, in open\n    return io.open(self, mode, buffering, encoding, errors, newline)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+            ]
+          },
+          "className": "RetryRequestedFromPolicy",
+          "message": "Exceeded max_retries of 2\n",
+          "stack": [
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_plan.py\", line 246, in dagster_event_sequence_for_step\n    yield from check.generator(step_events)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_step.py\", line 468, in core_dagster_event_sequence_for_step\n    for event_or_input_value in step_input.source.load_input_object(\n                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 364, in load_input_object\n    yield from _load_input_with_input_manager(input_manager, load_input_context)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 612, in _load_input_with_input_manager\n    with op_execution_error_boundary(\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/contextlib.py\", line 158, in __exit__\n    self.gen.throw(value)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py\", line 75, in op_execution_error_boundary\n    raise RetryRequestedFromPolicy(\n"
+          ]
+        },
+        "eventType": "STEP_FAILURE",
+        "level": "ERROR",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877726"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "ERROR",
+        "message": "Dependencies for step enriched_data.concat_chunk_list failed: ['enriched_data.process_chunk[11]']. Not executing.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808877786"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Multiprocess executor: parent process exiting after 6.79s (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878387"
+      },
+      {
+        "__typename": "RunFailureEvent",
+        "eventType": "RUN_FAILURE",
+        "level": "ERROR",
+        "message": "Execution of run for \"run_etl_pipeline\" failed. Steps failed: ['enriched_data.process_chunk[11]'].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878519"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Process for run exited (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878602"
+      },
+      {
+        "__typename": "FailedToMaterializeEvent",
+        "eventType": "ASSET_FAILED_TO_MATERIALIZE",
+        "level": "INFO",
+        "message": "Asset [\"enriched_data\"] failed to materialize",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808880071"
+      }
+    ],
+    "hasMore": false
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_basic_json/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_basic_json/01_response.json
@@ -1,0 +1,189 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgyMTg1Nzg2MH0=",
+    "events": [
+      {
+        "__typename": "AssetCheckEvaluationPlannedEvent",
+        "eventType": "ASSET_CHECK_EVALUATION_PLANNED",
+        "level": "DEBUG",
+        "message": "check_avg_orders_freshness_job intends to execute asset check anomaly_detection_freshness_check on asset [\"MARKETING\", \"avg_orders\"]",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817801771"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817801798"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817804629"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817804660"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[DagsterCloudAgent] Agent d0a5374c is launching run b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817804845"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Creating Kubernetes run worker job",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817804996"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Kubernetes run worker job created",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817805113"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817813386"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Started process for run (pid: 1).",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817813451"
+      },
+      {
+        "__typename": "RunStartEvent",
+        "eventType": "RUN_START",
+        "level": "DEBUG",
+        "message": "Started execution of run for \"check_avg_orders_freshness_job\".",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817827876"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Executing steps using multiprocess executor: parent process (pid: 1)",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817827919"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"anomaly_detection_freshness_check_458e9b8f\".",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817828047"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"anomaly_detection_freshness_check_458e9b8f\" in subprocess.",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817829513"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [io_manager].",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817833373"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [io_manager].",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817833453"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 19).",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817833507"
+      },
+      {
+        "__typename": "ExecutionStepStartEvent",
+        "eventType": "STEP_START",
+        "level": "DEBUG",
+        "message": "Started execution of step \"anomaly_detection_freshness_check_458e9b8f\".",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817833533"
+      },
+      {
+        "__typename": "ExecutionStepOutputEvent",
+        "eventType": "STEP_OUTPUT",
+        "level": "DEBUG",
+        "message": "Yielded output \"MARKETING__avg_orders_anomaly_detection_freshness_check\" of type \"Any\". (Type check passed).",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817833714"
+      },
+      {
+        "__typename": "AssetCheckEvaluationEvent",
+        "eventType": "ASSET_CHECK_EVALUATION",
+        "level": "DEBUG",
+        "message": "Asset check 'anomaly_detection_freshness_check' on 'MARKETING/avg_orders' did not pass. Description: 'Asset is overdue for an update. The last update was 2 days, 16 hours, 25 minutes, 24 seconds ago, which is past the allowed distance of 2 days, 5 minutes, 11 seconds ago.'",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817833766"
+      },
+      {
+        "__typename": "ExecutionStepSuccessEvent",
+        "eventType": "STEP_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished execution of step \"anomaly_detection_freshness_check_458e9b8f\" in 246ms.",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817833807"
+      }
+    ],
+    "hasMore": true
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_basic_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_basic_text/01_response.json
@@ -1,0 +1,189 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgyMTg1Nzg2MH0=",
+    "events": [
+      {
+        "__typename": "AssetCheckEvaluationPlannedEvent",
+        "eventType": "ASSET_CHECK_EVALUATION_PLANNED",
+        "level": "DEBUG",
+        "message": "check_avg_orders_freshness_job intends to execute asset check anomaly_detection_freshness_check on asset [\"MARKETING\", \"avg_orders\"]",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817801771"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817801798"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817804629"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817804660"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[DagsterCloudAgent] Agent d0a5374c is launching run b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817804845"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Creating Kubernetes run worker job",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817804996"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Kubernetes run worker job created",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817805113"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817813386"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Started process for run (pid: 1).",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817813451"
+      },
+      {
+        "__typename": "RunStartEvent",
+        "eventType": "RUN_START",
+        "level": "DEBUG",
+        "message": "Started execution of run for \"check_avg_orders_freshness_job\".",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817827876"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Executing steps using multiprocess executor: parent process (pid: 1)",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817827919"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"anomaly_detection_freshness_check_458e9b8f\".",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817828047"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"anomaly_detection_freshness_check_458e9b8f\" in subprocess.",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817829513"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [io_manager].",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817833373"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [io_manager].",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817833453"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 19).",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": null,
+        "timestamp": "1758817833507"
+      },
+      {
+        "__typename": "ExecutionStepStartEvent",
+        "eventType": "STEP_START",
+        "level": "DEBUG",
+        "message": "Started execution of step \"anomaly_detection_freshness_check_458e9b8f\".",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817833533"
+      },
+      {
+        "__typename": "ExecutionStepOutputEvent",
+        "eventType": "STEP_OUTPUT",
+        "level": "DEBUG",
+        "message": "Yielded output \"MARKETING__avg_orders_anomaly_detection_freshness_check\" of type \"Any\". (Type check passed).",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817833714"
+      },
+      {
+        "__typename": "AssetCheckEvaluationEvent",
+        "eventType": "ASSET_CHECK_EVALUATION",
+        "level": "DEBUG",
+        "message": "Asset check 'anomaly_detection_freshness_check' on 'MARKETING/avg_orders' did not pass. Description: 'Asset is overdue for an update. The last update was 2 days, 16 hours, 25 minutes, 24 seconds ago, which is past the allowed distance of 2 days, 5 minutes, 11 seconds ago.'",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817833766"
+      },
+      {
+        "__typename": "ExecutionStepSuccessEvent",
+        "eventType": "STEP_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished execution of step \"anomaly_detection_freshness_check_458e9b8f\" in 246ms.",
+        "runId": "b45fff8a-7def-43b8-805d-1cf5f435c997",
+        "stepKey": "anomaly_detection_freshness_check_458e9b8f",
+        "timestamp": "1758817833807"
+      }
+    ],
+    "hasMore": true
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_debug_level_json/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_debug_level_json/01_response.json
@@ -1,0 +1,99 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODUzNTQzOH0=",
+    "events": [
+      {
+        "__typename": "AssetMaterializationPlannedEvent",
+        "eventType": "ASSET_MATERIALIZATION_PLANNED",
+        "level": "DEBUG",
+        "message": "run_etl_pipeline intends to materialize asset [\"enriched_data\"]",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808865047"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Launched as an automatic retry",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865075"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865098"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867161"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867189"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[DagsterCloudAgent] Agent 3a659214 is launching run 85156191-170d-4229-8eba-14450b6ca9e3",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867555"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Creating Kubernetes run worker job",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867738"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Kubernetes run worker job created",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867910"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870636"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Started process for run (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870686"
+      }
+    ],
+    "hasMore": true
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_debug_level_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_debug_level_text/01_response.json
@@ -1,0 +1,99 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODUzNTQzOH0=",
+    "events": [
+      {
+        "__typename": "AssetMaterializationPlannedEvent",
+        "eventType": "ASSET_MATERIALIZATION_PLANNED",
+        "level": "DEBUG",
+        "message": "run_etl_pipeline intends to materialize asset [\"enriched_data\"]",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808865047"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Launched as an automatic retry",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865075"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865098"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867161"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867189"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[DagsterCloudAgent] Agent 3a659214 is launching run 85156191-170d-4229-8eba-14450b6ca9e3",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867555"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Creating Kubernetes run worker job",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867738"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Kubernetes run worker job created",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867910"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870636"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Started process for run (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870686"
+      }
+    ],
+    "hasMore": true
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_error_level_only_json/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_error_level_only_json/01_response.json
@@ -1,0 +1,404 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODU1MzE0M30=",
+    "events": [
+      {
+        "__typename": "AssetMaterializationPlannedEvent",
+        "eventType": "ASSET_MATERIALIZATION_PLANNED",
+        "level": "DEBUG",
+        "message": "run_etl_pipeline intends to materialize asset [\"enriched_data\"]",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808865047"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Launched as an automatic retry",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865075"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865098"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867161"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867189"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[DagsterCloudAgent] Agent 3a659214 is launching run 85156191-170d-4229-8eba-14450b6ca9e3",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867555"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Creating Kubernetes run worker job",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867738"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Kubernetes run worker job created",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867910"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870636"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Started process for run (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870686"
+      },
+      {
+        "__typename": "RunStartEvent",
+        "eventType": "RUN_START",
+        "level": "DEBUG",
+        "message": "Started execution of run for \"run_etl_pipeline\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871488"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Executing steps using multiprocess executor: parent process (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871524"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808871633"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808872870"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873361"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873521"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 16).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808873570"
+      },
+      {
+        "__typename": "ExecutionStepStartEvent",
+        "eventType": "STEP_START",
+        "level": "DEBUG",
+        "message": "Started execution of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873607"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873644"
+      },
+      {
+        "__typename": "ExecutionStepUpForRetryEvent",
+        "eventType": "STEP_UP_FOR_RETRY",
+        "level": "DEBUG",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed and has requested a retry.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873697"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873742"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808874924"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875309"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875444"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 26).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808875526"
+      },
+      {
+        "__typename": "ExecutionStepRestartEvent",
+        "eventType": "STEP_RESTARTED",
+        "level": "DEBUG",
+        "message": "Started re-execution (attempt # 2) of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875655"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875737"
+      },
+      {
+        "__typename": "ExecutionStepUpForRetryEvent",
+        "eventType": "STEP_UP_FOR_RETRY",
+        "level": "DEBUG",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed and has requested a retry.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875801"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875835"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808876893"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877224"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877380"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 36).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808877439"
+      },
+      {
+        "__typename": "ExecutionStepRestartEvent",
+        "eventType": "STEP_RESTARTED",
+        "level": "DEBUG",
+        "message": "Started re-execution (attempt # 3) of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877601"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877680"
+      },
+      {
+        "__typename": "ExecutionStepFailureEvent",
+        "error": {
+          "cause": {
+            "cause": null,
+            "className": "FileNotFoundError",
+            "message": "FileNotFoundError: [Errno 2] No such file or directory: '/opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11'\n",
+            "stack": [
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py\", line 57, in op_execution_error_boundary\n    yield\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 619, in _load_input_with_input_manager\n    value = input_manager.load_input(context)\n            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py\", line 406, in load_input\n    return self._load_single_input(path, context)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py\", line 273, in _load_single_input\n    obj = self.load_from_path(context=context, path=path)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/fs_io_manager.py\", line 284, in load_from_path\n    with path.open(\"rb\") as file:\n         ^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/upath/implementations/local.py\", line 134, in open\n    return PosixPath.open(self, mode, buffering, encoding, errors, newline)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/pathlib.py\", line 1013, in open\n    return io.open(self, mode, buffering, encoding, errors, newline)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+            ]
+          },
+          "className": "RetryRequestedFromPolicy",
+          "message": "Exceeded max_retries of 2\n",
+          "stack": [
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_plan.py\", line 246, in dagster_event_sequence_for_step\n    yield from check.generator(step_events)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_step.py\", line 468, in core_dagster_event_sequence_for_step\n    for event_or_input_value in step_input.source.load_input_object(\n                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 364, in load_input_object\n    yield from _load_input_with_input_manager(input_manager, load_input_context)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 612, in _load_input_with_input_manager\n    with op_execution_error_boundary(\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/contextlib.py\", line 158, in __exit__\n    self.gen.throw(value)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py\", line 75, in op_execution_error_boundary\n    raise RetryRequestedFromPolicy(\n"
+          ]
+        },
+        "eventType": "STEP_FAILURE",
+        "level": "ERROR",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877726"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "ERROR",
+        "message": "Dependencies for step enriched_data.concat_chunk_list failed: ['enriched_data.process_chunk[11]']. Not executing.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808877786"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Multiprocess executor: parent process exiting after 6.79s (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878387"
+      },
+      {
+        "__typename": "RunFailureEvent",
+        "eventType": "RUN_FAILURE",
+        "level": "ERROR",
+        "message": "Execution of run for \"run_etl_pipeline\" failed. Steps failed: ['enriched_data.process_chunk[11]'].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878519"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Process for run exited (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878602"
+      },
+      {
+        "__typename": "FailedToMaterializeEvent",
+        "eventType": "ASSET_FAILED_TO_MATERIALIZE",
+        "level": "INFO",
+        "message": "Asset [\"enriched_data\"] failed to materialize",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808880071"
+      }
+    ],
+    "hasMore": false
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_error_level_only_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_error_level_only_text/01_response.json
@@ -1,0 +1,404 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODU1MzE0M30=",
+    "events": [
+      {
+        "__typename": "AssetMaterializationPlannedEvent",
+        "eventType": "ASSET_MATERIALIZATION_PLANNED",
+        "level": "DEBUG",
+        "message": "run_etl_pipeline intends to materialize asset [\"enriched_data\"]",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808865047"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Launched as an automatic retry",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865075"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865098"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867161"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867189"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[DagsterCloudAgent] Agent 3a659214 is launching run 85156191-170d-4229-8eba-14450b6ca9e3",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867555"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Creating Kubernetes run worker job",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867738"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Kubernetes run worker job created",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867910"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870636"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Started process for run (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870686"
+      },
+      {
+        "__typename": "RunStartEvent",
+        "eventType": "RUN_START",
+        "level": "DEBUG",
+        "message": "Started execution of run for \"run_etl_pipeline\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871488"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Executing steps using multiprocess executor: parent process (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871524"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808871633"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808872870"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873361"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873521"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 16).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808873570"
+      },
+      {
+        "__typename": "ExecutionStepStartEvent",
+        "eventType": "STEP_START",
+        "level": "DEBUG",
+        "message": "Started execution of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873607"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873644"
+      },
+      {
+        "__typename": "ExecutionStepUpForRetryEvent",
+        "eventType": "STEP_UP_FOR_RETRY",
+        "level": "DEBUG",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed and has requested a retry.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873697"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873742"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808874924"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875309"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875444"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 26).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808875526"
+      },
+      {
+        "__typename": "ExecutionStepRestartEvent",
+        "eventType": "STEP_RESTARTED",
+        "level": "DEBUG",
+        "message": "Started re-execution (attempt # 2) of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875655"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875737"
+      },
+      {
+        "__typename": "ExecutionStepUpForRetryEvent",
+        "eventType": "STEP_UP_FOR_RETRY",
+        "level": "DEBUG",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed and has requested a retry.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875801"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875835"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808876893"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877224"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877380"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 36).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808877439"
+      },
+      {
+        "__typename": "ExecutionStepRestartEvent",
+        "eventType": "STEP_RESTARTED",
+        "level": "DEBUG",
+        "message": "Started re-execution (attempt # 3) of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877601"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877680"
+      },
+      {
+        "__typename": "ExecutionStepFailureEvent",
+        "error": {
+          "cause": {
+            "cause": null,
+            "className": "FileNotFoundError",
+            "message": "FileNotFoundError: [Errno 2] No such file or directory: '/opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11'\n",
+            "stack": [
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py\", line 57, in op_execution_error_boundary\n    yield\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 619, in _load_input_with_input_manager\n    value = input_manager.load_input(context)\n            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py\", line 406, in load_input\n    return self._load_single_input(path, context)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py\", line 273, in _load_single_input\n    obj = self.load_from_path(context=context, path=path)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/fs_io_manager.py\", line 284, in load_from_path\n    with path.open(\"rb\") as file:\n         ^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/upath/implementations/local.py\", line 134, in open\n    return PosixPath.open(self, mode, buffering, encoding, errors, newline)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/pathlib.py\", line 1013, in open\n    return io.open(self, mode, buffering, encoding, errors, newline)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+            ]
+          },
+          "className": "RetryRequestedFromPolicy",
+          "message": "Exceeded max_retries of 2\n",
+          "stack": [
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_plan.py\", line 246, in dagster_event_sequence_for_step\n    yield from check.generator(step_events)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_step.py\", line 468, in core_dagster_event_sequence_for_step\n    for event_or_input_value in step_input.source.load_input_object(\n                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 364, in load_input_object\n    yield from _load_input_with_input_manager(input_manager, load_input_context)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 612, in _load_input_with_input_manager\n    with op_execution_error_boundary(\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/contextlib.py\", line 158, in __exit__\n    self.gen.throw(value)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py\", line 75, in op_execution_error_boundary\n    raise RetryRequestedFromPolicy(\n"
+          ]
+        },
+        "eventType": "STEP_FAILURE",
+        "level": "ERROR",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877726"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "ERROR",
+        "message": "Dependencies for step enriched_data.concat_chunk_list failed: ['enriched_data.process_chunk[11]']. Not executing.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808877786"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Multiprocess executor: parent process exiting after 6.79s (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878387"
+      },
+      {
+        "__typename": "RunFailureEvent",
+        "eventType": "RUN_FAILURE",
+        "level": "ERROR",
+        "message": "Execution of run for \"run_etl_pipeline\" failed. Steps failed: ['enriched_data.process_chunk[11]'].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878519"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Process for run exited (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878602"
+      },
+      {
+        "__typename": "FailedToMaterializeEvent",
+        "eventType": "ASSET_FAILED_TO_MATERIALIZE",
+        "level": "INFO",
+        "message": "Asset [\"enriched_data\"] failed to materialize",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808880071"
+      }
+    ],
+    "hasMore": false
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_small_limit_json/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_small_limit_json/01_response.json
@@ -1,0 +1,54 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODUyODM1MX0=",
+    "events": [
+      {
+        "__typename": "AssetMaterializationPlannedEvent",
+        "eventType": "ASSET_MATERIALIZATION_PLANNED",
+        "level": "DEBUG",
+        "message": "run_etl_pipeline intends to materialize asset [\"enriched_data\"]",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808865047"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Launched as an automatic retry",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865075"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865098"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867161"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867189"
+      }
+    ],
+    "hasMore": true
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_small_limit_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_small_limit_text/01_response.json
@@ -1,0 +1,54 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODUyODM1MX0=",
+    "events": [
+      {
+        "__typename": "AssetMaterializationPlannedEvent",
+        "eventType": "ASSET_MATERIALIZATION_PLANNED",
+        "level": "DEBUG",
+        "message": "run_etl_pipeline intends to materialize asset [\"enriched_data\"]",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808865047"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Launched as an automatic retry",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865075"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865098"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867161"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867189"
+      }
+    ],
+    "hasMore": true
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_step_filter_json/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_step_filter_json/01_response.json
@@ -1,0 +1,144 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODU0MDMyNn0=",
+    "events": [
+      {
+        "__typename": "AssetMaterializationPlannedEvent",
+        "eventType": "ASSET_MATERIALIZATION_PLANNED",
+        "level": "DEBUG",
+        "message": "run_etl_pipeline intends to materialize asset [\"enriched_data\"]",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808865047"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Launched as an automatic retry",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865075"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865098"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867161"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867189"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[DagsterCloudAgent] Agent 3a659214 is launching run 85156191-170d-4229-8eba-14450b6ca9e3",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867555"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Creating Kubernetes run worker job",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867738"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Kubernetes run worker job created",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867910"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870636"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Started process for run (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870686"
+      },
+      {
+        "__typename": "RunStartEvent",
+        "eventType": "RUN_START",
+        "level": "DEBUG",
+        "message": "Started execution of run for \"run_etl_pipeline\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871488"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Executing steps using multiprocess executor: parent process (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871524"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808871633"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808872870"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873361"
+      }
+    ],
+    "hasMore": true
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_step_filter_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_step_filter_text/01_response.json
@@ -1,0 +1,144 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODU0MDMyNn0=",
+    "events": [
+      {
+        "__typename": "AssetMaterializationPlannedEvent",
+        "eventType": "ASSET_MATERIALIZATION_PLANNED",
+        "level": "DEBUG",
+        "message": "run_etl_pipeline intends to materialize asset [\"enriched_data\"]",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808865047"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Launched as an automatic retry",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865075"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865098"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867161"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867189"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[DagsterCloudAgent] Agent 3a659214 is launching run 85156191-170d-4229-8eba-14450b6ca9e3",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867555"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Creating Kubernetes run worker job",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867738"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Kubernetes run worker job created",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867910"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870636"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Started process for run (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870686"
+      },
+      {
+        "__typename": "RunStartEvent",
+        "eventType": "RUN_START",
+        "level": "DEBUG",
+        "message": "Started execution of run for \"run_etl_pipeline\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871488"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Executing steps using multiprocess executor: parent process (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871524"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808871633"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808872870"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873361"
+      }
+    ],
+    "hasMore": true
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_with_errors_json/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_with_errors_json/01_response.json
@@ -1,0 +1,404 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODU1MzE0M30=",
+    "events": [
+      {
+        "__typename": "AssetMaterializationPlannedEvent",
+        "eventType": "ASSET_MATERIALIZATION_PLANNED",
+        "level": "DEBUG",
+        "message": "run_etl_pipeline intends to materialize asset [\"enriched_data\"]",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808865047"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Launched as an automatic retry",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865075"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865098"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867161"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867189"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[DagsterCloudAgent] Agent 3a659214 is launching run 85156191-170d-4229-8eba-14450b6ca9e3",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867555"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Creating Kubernetes run worker job",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867738"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Kubernetes run worker job created",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867910"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870636"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Started process for run (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870686"
+      },
+      {
+        "__typename": "RunStartEvent",
+        "eventType": "RUN_START",
+        "level": "DEBUG",
+        "message": "Started execution of run for \"run_etl_pipeline\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871488"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Executing steps using multiprocess executor: parent process (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871524"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808871633"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808872870"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873361"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873521"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 16).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808873570"
+      },
+      {
+        "__typename": "ExecutionStepStartEvent",
+        "eventType": "STEP_START",
+        "level": "DEBUG",
+        "message": "Started execution of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873607"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873644"
+      },
+      {
+        "__typename": "ExecutionStepUpForRetryEvent",
+        "eventType": "STEP_UP_FOR_RETRY",
+        "level": "DEBUG",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed and has requested a retry.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873697"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873742"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808874924"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875309"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875444"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 26).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808875526"
+      },
+      {
+        "__typename": "ExecutionStepRestartEvent",
+        "eventType": "STEP_RESTARTED",
+        "level": "DEBUG",
+        "message": "Started re-execution (attempt # 2) of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875655"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875737"
+      },
+      {
+        "__typename": "ExecutionStepUpForRetryEvent",
+        "eventType": "STEP_UP_FOR_RETRY",
+        "level": "DEBUG",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed and has requested a retry.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875801"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875835"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808876893"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877224"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877380"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 36).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808877439"
+      },
+      {
+        "__typename": "ExecutionStepRestartEvent",
+        "eventType": "STEP_RESTARTED",
+        "level": "DEBUG",
+        "message": "Started re-execution (attempt # 3) of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877601"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877680"
+      },
+      {
+        "__typename": "ExecutionStepFailureEvent",
+        "error": {
+          "cause": {
+            "cause": null,
+            "className": "FileNotFoundError",
+            "message": "FileNotFoundError: [Errno 2] No such file or directory: '/opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11'\n",
+            "stack": [
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py\", line 57, in op_execution_error_boundary\n    yield\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 619, in _load_input_with_input_manager\n    value = input_manager.load_input(context)\n            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py\", line 406, in load_input\n    return self._load_single_input(path, context)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py\", line 273, in _load_single_input\n    obj = self.load_from_path(context=context, path=path)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/fs_io_manager.py\", line 284, in load_from_path\n    with path.open(\"rb\") as file:\n         ^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/upath/implementations/local.py\", line 134, in open\n    return PosixPath.open(self, mode, buffering, encoding, errors, newline)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/pathlib.py\", line 1013, in open\n    return io.open(self, mode, buffering, encoding, errors, newline)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+            ]
+          },
+          "className": "RetryRequestedFromPolicy",
+          "message": "Exceeded max_retries of 2\n",
+          "stack": [
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_plan.py\", line 246, in dagster_event_sequence_for_step\n    yield from check.generator(step_events)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_step.py\", line 468, in core_dagster_event_sequence_for_step\n    for event_or_input_value in step_input.source.load_input_object(\n                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 364, in load_input_object\n    yield from _load_input_with_input_manager(input_manager, load_input_context)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 612, in _load_input_with_input_manager\n    with op_execution_error_boundary(\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/contextlib.py\", line 158, in __exit__\n    self.gen.throw(value)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py\", line 75, in op_execution_error_boundary\n    raise RetryRequestedFromPolicy(\n"
+          ]
+        },
+        "eventType": "STEP_FAILURE",
+        "level": "ERROR",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877726"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "ERROR",
+        "message": "Dependencies for step enriched_data.concat_chunk_list failed: ['enriched_data.process_chunk[11]']. Not executing.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808877786"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Multiprocess executor: parent process exiting after 6.79s (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878387"
+      },
+      {
+        "__typename": "RunFailureEvent",
+        "eventType": "RUN_FAILURE",
+        "level": "ERROR",
+        "message": "Execution of run for \"run_etl_pipeline\" failed. Steps failed: ['enriched_data.process_chunk[11]'].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878519"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Process for run exited (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878602"
+      },
+      {
+        "__typename": "FailedToMaterializeEvent",
+        "eventType": "ASSET_FAILED_TO_MATERIALIZE",
+        "level": "INFO",
+        "message": "Asset [\"enriched_data\"] failed to materialize",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808880071"
+      }
+    ],
+    "hasMore": false
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_with_errors_text/01_response.json
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/recordings/success_logs_with_errors_text/01_response.json
@@ -1,0 +1,404 @@
+{
+  "logsForRun": {
+    "__typename": "EventConnection",
+    "cursor": "eyJ0eXBlIjogIlNUT1JBR0VfSUQiLCAidmFsdWUiOiA0ODgwODU1MzE0M30=",
+    "events": [
+      {
+        "__typename": "AssetMaterializationPlannedEvent",
+        "eventType": "ASSET_MATERIALIZATION_PLANNED",
+        "level": "DEBUG",
+        "message": "run_etl_pipeline intends to materialize asset [\"enriched_data\"]",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808865047"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Launched as an automatic retry",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865075"
+      },
+      {
+        "__typename": "RunEnqueuedEvent",
+        "eventType": "RUN_ENQUEUED",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808865098"
+      },
+      {
+        "__typename": "RunStartingEvent",
+        "eventType": "RUN_STARTING",
+        "level": "INFO",
+        "message": "",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867161"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Sending a request to the agent to execute steps in the user cloud",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867189"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[DagsterCloudAgent] Agent 3a659214 is launching run 85156191-170d-4229-8eba-14450b6ca9e3",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867555"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Creating Kubernetes run worker job",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867738"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "[CloudK8sRunLauncher] Kubernetes run worker job created",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808867910"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Starting run metrics thread with container_metrics_enabled=True and python_metrics_enabled=False",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870636"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Started process for run (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808870686"
+      },
+      {
+        "__typename": "RunStartEvent",
+        "eventType": "RUN_START",
+        "level": "DEBUG",
+        "message": "Started execution of run for \"run_etl_pipeline\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871488"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Executing steps using multiprocess executor: parent process (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808871524"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808871633"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808872870"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873361"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873521"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 16).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808873570"
+      },
+      {
+        "__typename": "ExecutionStepStartEvent",
+        "eventType": "STEP_START",
+        "level": "DEBUG",
+        "message": "Started execution of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873607"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873644"
+      },
+      {
+        "__typename": "ExecutionStepUpForRetryEvent",
+        "eventType": "STEP_UP_FOR_RETRY",
+        "level": "DEBUG",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed and has requested a retry.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873697"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808873742"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808874924"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875309"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875444"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 26).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808875526"
+      },
+      {
+        "__typename": "ExecutionStepRestartEvent",
+        "eventType": "STEP_RESTARTED",
+        "level": "DEBUG",
+        "message": "Started re-execution (attempt # 2) of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875655"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875737"
+      },
+      {
+        "__typename": "ExecutionStepUpForRetryEvent",
+        "eventType": "STEP_UP_FOR_RETRY",
+        "level": "DEBUG",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed and has requested a retry.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875801"
+      },
+      {
+        "__typename": "StepWorkerStartingEvent",
+        "eventType": "STEP_WORKER_STARTING",
+        "level": "DEBUG",
+        "message": "Launching subprocess for \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808875835"
+      },
+      {
+        "__typename": "StepWorkerStartedEvent",
+        "eventType": "STEP_WORKER_STARTED",
+        "level": "DEBUG",
+        "message": "Executing step \"enriched_data.process_chunk[11]\" in subprocess.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808876893"
+      },
+      {
+        "__typename": "ResourceInitStartedEvent",
+        "eventType": "RESOURCE_INIT_STARTED",
+        "level": "DEBUG",
+        "message": "Starting initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877224"
+      },
+      {
+        "__typename": "ResourceInitSuccessEvent",
+        "eventType": "RESOURCE_INIT_SUCCESS",
+        "level": "DEBUG",
+        "message": "Finished initialization of resources [api, io_manager].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877380"
+      },
+      {
+        "__typename": "LogsCapturedEvent",
+        "eventType": "LOGS_CAPTURED",
+        "level": "DEBUG",
+        "message": "Started capturing logs in process (pid: 36).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808877439"
+      },
+      {
+        "__typename": "ExecutionStepRestartEvent",
+        "eventType": "STEP_RESTARTED",
+        "level": "DEBUG",
+        "message": "Started re-execution (attempt # 3) of step \"enriched_data.process_chunk[11]\".",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877601"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "DEBUG",
+        "message": "Loading file from: /opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11 using PickledObjectFilesystemIOManager...",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877680"
+      },
+      {
+        "__typename": "ExecutionStepFailureEvent",
+        "error": {
+          "cause": {
+            "cause": null,
+            "className": "FileNotFoundError",
+            "message": "FileNotFoundError: [Errno 2] No such file or directory: '/opt/dagster/dagster_home/storage/385defa2-7ac6-4d18-8a88-585a42393d9c/enriched_data.split_rows/result/11'\n",
+            "stack": [
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py\", line 57, in op_execution_error_boundary\n    yield\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 619, in _load_input_with_input_manager\n    value = input_manager.load_input(context)\n            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py\", line 406, in load_input\n    return self._load_single_input(path, context)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/upath_io_manager.py\", line 273, in _load_single_input\n    obj = self.load_from_path(context=context, path=path)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/storage/fs_io_manager.py\", line 284, in load_from_path\n    with path.open(\"rb\") as file:\n         ^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/site-packages/upath/implementations/local.py\", line 134, in open\n    return PosixPath.open(self, mode, buffering, encoding, errors, newline)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+              "  File \"/usr/local/lib/python3.12/pathlib.py\", line 1013, in open\n    return io.open(self, mode, buffering, encoding, errors, newline)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+            ]
+          },
+          "className": "RetryRequestedFromPolicy",
+          "message": "Exceeded max_retries of 2\n",
+          "stack": [
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_plan.py\", line 246, in dagster_event_sequence_for_step\n    yield from check.generator(step_events)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/execute_step.py\", line 468, in core_dagster_event_sequence_for_step\n    for event_or_input_value in step_input.source.load_input_object(\n                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 364, in load_input_object\n    yield from _load_input_with_input_manager(input_manager, load_input_context)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py\", line 612, in _load_input_with_input_manager\n    with op_execution_error_boundary(\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "  File \"/usr/local/lib/python3.12/contextlib.py\", line 158, in __exit__\n    self.gen.throw(value)\n",
+            "  File \"/usr/local/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py\", line 75, in op_execution_error_boundary\n    raise RetryRequestedFromPolicy(\n"
+          ]
+        },
+        "eventType": "STEP_FAILURE",
+        "level": "ERROR",
+        "message": "Execution of step \"enriched_data.process_chunk[11]\" failed.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.process_chunk[11]",
+        "timestamp": "1758808877726"
+      },
+      {
+        "__typename": "LogMessageEvent",
+        "eventType": null,
+        "level": "ERROR",
+        "message": "Dependencies for step enriched_data.concat_chunk_list failed: ['enriched_data.process_chunk[11]']. Not executing.",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808877786"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "DEBUG",
+        "message": "Multiprocess executor: parent process exiting after 6.79s (pid: 1)",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878387"
+      },
+      {
+        "__typename": "RunFailureEvent",
+        "eventType": "RUN_FAILURE",
+        "level": "ERROR",
+        "message": "Execution of run for \"run_etl_pipeline\" failed. Steps failed: ['enriched_data.process_chunk[11]'].",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878519"
+      },
+      {
+        "__typename": "EngineEvent",
+        "eventType": "ENGINE_EVENT",
+        "level": "INFO",
+        "message": "Process for run exited (pid: 1).",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": null,
+        "timestamp": "1758808878602"
+      },
+      {
+        "__typename": "FailedToMaterializeEvent",
+        "eventType": "ASSET_FAILED_TO_MATERIALIZE",
+        "level": "INFO",
+        "message": "Asset [\"enriched_data\"] failed to materialize",
+        "runId": "85156191-170d-4229-8eba-14450b6ca9e3",
+        "stepKey": "enriched_data.concat_chunk_list",
+        "timestamp": "1758808880071"
+      }
+    ],
+    "hasMore": false
+  }
+}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/scenarios.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/scenarios.yaml
@@ -13,7 +13,7 @@ success_logs_basic_json:
 success_logs_basic_text:
   command: "dg api log get b45fff8a-7def-43b8-805d-1cf5f435c997 --limit 20"
 
-# Filtered scenarios (no recordings - these are complex to set up)
+# Filtered scenarios (now have recordings!)
 success_logs_error_level_only_json:
   command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --level ERROR --json"
 
@@ -34,33 +34,35 @@ success_logs_step_filter_text:
 
 success_logs_small_limit_json:
   command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --json --limit 5"
-  has_recording: false
 
 success_logs_small_limit_text:
   command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --limit 5"
-  has_recording: false
 
-success_logs_with_cursor_json:
+error_cursor_no_recording_json:
   command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --json --limit 10 --cursor eyJza2lwIjo1fQ=="
   has_recording: false
 
-success_logs_with_cursor_text:
+error_cursor_no_recording_text:
   command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --limit 10 --cursor eyJza2lwIjo1fQ=="
   has_recording: false
 
-# Empty logs scenario
-success_logs_empty_json:
+# Empty logs scenario (no recording to test actual empty response)
+error_empty_logs_no_recording_json:
   command: "dg api log get empty-run-uuid-0000-0000-000000000000 --json"
+  has_recording: false
 
-success_logs_empty_text:
+error_empty_logs_no_recording_text:
   command: "dg api log get empty-run-uuid-0000-0000-000000000000"
+  has_recording: false
 
 # Error scenarios
 error_run_not_found_json:
   command: "dg api log get nonexistent-run-uuid-1234-5678-900000000000 --json"
+  has_recording: false
 
 error_run_not_found_text:
   command: "dg api log get nonexistent-run-uuid-1234-5678-900000000000"
+  has_recording: false
 
 error_malformed_run_id_json:
   command: "dg api log get invalid-uuid-format --json"
@@ -80,8 +82,6 @@ error_empty_run_id_text:
 
 error_invalid_level_json:
   command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --level INVALID --json"
-  has_recording: false
 
 error_invalid_level_text:
   command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --level INVALID"
-  has_recording: false

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/scenarios.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/scenarios.yaml
@@ -1,0 +1,87 @@
+# Success scenarios for log get with various run IDs and options
+
+# Basic success scenarios - logs with different content types
+success_logs_with_errors_json:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --json --limit 50"
+
+success_logs_with_errors_text:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --limit 50"
+
+success_logs_basic_json:
+  command: "dg api log get b45fff8a-7def-43b8-805d-1cf5f435c997 --json --limit 20"
+
+success_logs_basic_text:
+  command: "dg api log get b45fff8a-7def-43b8-805d-1cf5f435c997 --limit 20"
+
+# Filtered scenarios (no recordings - these are complex to set up)
+success_logs_error_level_only_json:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --level ERROR --json"
+
+success_logs_error_level_only_text:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --level ERROR"
+
+success_logs_debug_level_json:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --level DEBUG --json --limit 10"
+
+success_logs_debug_level_text:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --level DEBUG --limit 10"
+
+success_logs_step_filter_json:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --step process_chunk --json --limit 15"
+
+success_logs_step_filter_text:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --step process_chunk --limit 15"
+
+success_logs_small_limit_json:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --json --limit 5"
+  has_recording: false
+
+success_logs_small_limit_text:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --limit 5"
+  has_recording: false
+
+success_logs_with_cursor_json:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --json --limit 10 --cursor eyJza2lwIjo1fQ=="
+  has_recording: false
+
+success_logs_with_cursor_text:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --limit 10 --cursor eyJza2lwIjo1fQ=="
+  has_recording: false
+
+# Empty logs scenario
+success_logs_empty_json:
+  command: "dg api log get empty-run-uuid-0000-0000-000000000000 --json"
+
+success_logs_empty_text:
+  command: "dg api log get empty-run-uuid-0000-0000-000000000000"
+
+# Error scenarios
+error_run_not_found_json:
+  command: "dg api log get nonexistent-run-uuid-1234-5678-900000000000 --json"
+
+error_run_not_found_text:
+  command: "dg api log get nonexistent-run-uuid-1234-5678-900000000000"
+
+error_malformed_run_id_json:
+  command: "dg api log get invalid-uuid-format --json"
+  has_recording: false
+
+error_malformed_run_id_text:
+  command: "dg api log get invalid-uuid-format"
+  has_recording: false
+
+error_empty_run_id_json:
+  command: "dg api log get '' --json"
+  has_recording: false
+
+error_empty_run_id_text:
+  command: "dg api log get ''"
+  has_recording: false
+
+error_invalid_level_json:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --level INVALID --json"
+  has_recording: false
+
+error_invalid_level_text:
+  command: "dg api log get 85156191-170d-4229-8eba-14450b6ca9e3 --level INVALID"
+  has_recording: false

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/test_business_logic.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/test_business_logic.py
@@ -1,0 +1,451 @@
+"""Test log business logic functions without mocks.
+
+These tests focus on testing pure functions that process data without requiring
+GraphQL client mocking or external dependencies.
+"""
+
+from dagster_dg_cli.api_layer.schemas.run_event import (
+    ErrorInfo,
+    RunEvent,
+    RunEventLevel,
+    RunEventList,
+)
+from dagster_dg_cli.cli.api.log import format_logs_json, format_logs_table
+
+
+class TestFormatLogs:
+    """Test the log formatting functions."""
+
+    def _create_sample_log_list(self):
+        """Create sample RunEventList for testing."""
+        events = [
+            RunEvent(
+                run_id="test-run-12345",
+                message='Starting execution of run for "test_pipeline".',
+                timestamp="1641046800000",  # 2022-01-01 14:20:00 UTC (as milliseconds)
+                level=RunEventLevel.INFO,
+                step_key=None,
+                event_type="RunStartEvent",
+                error=None,
+            ),
+            RunEvent(
+                run_id="test-run-12345",
+                message='Started execution of step "process_data".',
+                timestamp="1641046805000",  # 2022-01-01 14:20:05 UTC
+                level=RunEventLevel.DEBUG,
+                step_key="process_data",
+                event_type="ExecutionStepStartEvent",
+                error=None,
+            ),
+            RunEvent(
+                run_id="test-run-12345",
+                message="Loading input from path: /tmp/input.json",
+                timestamp="1641046810000",  # 2022-01-01 14:20:10 UTC
+                level=RunEventLevel.DEBUG,
+                step_key="process_data",
+                event_type="MessageEvent",
+                error=None,
+            ),
+            RunEvent(
+                run_id="test-run-12345",
+                message='Execution of step "process_data" failed.',
+                timestamp="1641046815000",  # 2022-01-01 14:20:15 UTC
+                level=RunEventLevel.ERROR,
+                step_key="process_data",
+                event_type="ExecutionStepFailureEvent",
+                error=ErrorInfo(
+                    message="ValueError: Invalid input data format\n",
+                    className="ValueError",
+                    stack=[
+                        '  File "/app/pipeline.py", line 42, in process_data\n    data = json.loads(input_str)\n',
+                        '  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads\n    return _default_decoder.decode(s)\n',
+                        '  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode\n    obj, end = self.raw_decode(s, idx=_w(s, 0).end())\n',
+                    ],
+                    cause=None,
+                ),
+            ),
+            RunEvent(
+                run_id="test-run-12345",
+                message="Execution of run for \"test_pipeline\" failed. Steps failed: ['process_data'].",
+                timestamp="1641046820000",  # 2022-01-01 14:20:20 UTC
+                level=RunEventLevel.ERROR,
+                step_key=None,
+                event_type="RunFailureEvent",
+                error=None,
+            ),
+        ]
+        return RunEventList(items=events, total=5, cursor=None, has_more=False)
+
+    def _create_empty_log_list(self):
+        """Create empty RunEventList for testing."""
+        return RunEventList(items=[], total=0, cursor=None, has_more=False)
+
+    def _create_log_with_nested_error(self):
+        """Create log with nested error causes."""
+        return RunEvent(
+            run_id="nested-error-run",
+            message="Database connection failed with retry exhausted.",
+            timestamp="1641046825000",
+            level=RunEventLevel.ERROR,
+            step_key="database_query",
+            event_type="ExecutionStepFailureEvent",
+            error=ErrorInfo(
+                message="RetryRequestedFromPolicy: Exceeded max_retries of 3\n",
+                className="RetryRequestedFromPolicy",
+                stack=[
+                    '  File "/app/database.py", line 25, in execute_query\n    return self._execute_with_retry(query)\n',
+                    '  File "/app/database.py", line 45, in _execute_with_retry\n    raise RetryRequestedFromPolicy(f"Exceeded max_retries of {max_retries}")\n',
+                ],
+                cause=ErrorInfo(
+                    message="ConnectionError: [Errno 111] Connection refused\n",
+                    className="ConnectionError",
+                    stack=[
+                        '  File "/app/database.py", line 35, in _execute_with_retry\n    result = self.connection.execute(query)\n',
+                        '  File "/usr/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1418, in execute\n    return connection.execute(statement, parameters)\n',
+                        '  File "/usr/lib/python3.12/site-packages/psycopg2/__init__.py", line 122, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\n',
+                    ],
+                    cause=None,
+                ),
+            ),
+        )
+
+    def _create_log_with_very_long_step_key(self):
+        """Create log with very long step key to test truncation."""
+        return RunEvent(
+            run_id="truncation-test-run",
+            message="Processing large dataset chunk.",
+            timestamp="1641046830000",
+            level=RunEventLevel.INFO,
+            step_key="very_long_step_name_that_exceeds_the_display_limit_and_should_be_truncated",
+            event_type="MessageEvent",
+            error=None,
+        )
+
+    def test_format_logs_table_output(self, snapshot):
+        """Test formatting logs as text table."""
+        from dagster_shared.utils.timing import fixed_timezone
+
+        log_list = self._create_sample_log_list()
+        with fixed_timezone("UTC"):
+            result = format_logs_table(log_list, "test-run-12345")
+
+        # Snapshot the entire text output
+        snapshot.assert_match(result)
+
+    def test_format_logs_json_output(self, snapshot):
+        """Test formatting logs as JSON."""
+        log_list = self._create_sample_log_list()
+        result = format_logs_json(log_list, "test-run-12345")
+
+        # For JSON, we want to snapshot the parsed structure to avoid formatting differences
+        import json
+
+        parsed = json.loads(result)
+        snapshot.assert_match(parsed)
+
+    def test_format_empty_logs_table_output(self, snapshot):
+        """Test formatting empty log list as text."""
+        log_list = self._create_empty_log_list()
+        result = format_logs_table(log_list, "empty-run-67890")
+
+        snapshot.assert_match(result)
+
+    def test_format_empty_logs_json_output(self, snapshot):
+        """Test formatting empty log list as JSON."""
+        log_list = self._create_empty_log_list()
+        result = format_logs_json(log_list, "empty-run-67890")
+
+        import json
+
+        parsed = json.loads(result)
+        snapshot.assert_match(parsed)
+
+    def test_format_logs_with_nested_errors(self, snapshot):
+        """Test formatting logs with nested error causes."""
+        from dagster_shared.utils.timing import fixed_timezone
+
+        log_with_nested_error = self._create_log_with_nested_error()
+        log_list = RunEventList(items=[log_with_nested_error], total=1)
+
+        with fixed_timezone("UTC"):
+            result = format_logs_table(log_list, "nested-error-run")
+
+        snapshot.assert_match(result)
+
+    def test_format_logs_with_nested_errors_json(self, snapshot):
+        """Test formatting logs with nested errors as JSON."""
+        log_with_nested_error = self._create_log_with_nested_error()
+        log_list = RunEventList(items=[log_with_nested_error], total=1)
+
+        result = format_logs_json(log_list, "nested-error-run")
+
+        import json
+
+        parsed = json.loads(result)
+        snapshot.assert_match(parsed)
+
+    def test_format_logs_with_long_step_key(self, snapshot):
+        """Test formatting logs with step key truncation."""
+        from dagster_shared.utils.timing import fixed_timezone
+
+        log_with_long_key = self._create_log_with_very_long_step_key()
+        log_list = RunEventList(items=[log_with_long_key], total=1)
+
+        with fixed_timezone("UTC"):
+            result = format_logs_table(log_list, "truncation-test-run")
+
+        snapshot.assert_match(result)
+
+    def test_format_logs_with_pagination_info(self, snapshot):
+        """Test formatting logs with pagination indicators."""
+        from dagster_shared.utils.timing import fixed_timezone
+
+        # Create log list that has more data available
+        log_list = RunEventList(
+            items=[
+                RunEvent(
+                    run_id="paginated-run",
+                    message="First log entry",
+                    timestamp="1641046800000",
+                    level=RunEventLevel.INFO,
+                    step_key=None,
+                    event_type="MessageEvent",
+                    error=None,
+                ),
+                RunEvent(
+                    run_id="paginated-run",
+                    message="Second log entry",
+                    timestamp="1641046805000",
+                    level=RunEventLevel.DEBUG,
+                    step_key="step_1",
+                    event_type="MessageEvent",
+                    error=None,
+                ),
+            ],
+            total=2,
+            cursor="cursor_token_12345",
+            has_more=True,
+        )
+
+        with fixed_timezone("UTC"):
+            result = format_logs_table(log_list, "paginated-run")
+
+        snapshot.assert_match(result)
+
+    def test_format_logs_all_levels(self, snapshot):
+        """Test formatting logs with all log levels."""
+        from dagster_shared.utils.timing import fixed_timezone
+
+        events = [
+            RunEvent(
+                run_id="level-test-run",
+                message=f"This is a {level.value} level message",
+                timestamp="1641046800000",
+                level=level,
+                step_key="test_step" if level != RunEventLevel.INFO else None,
+                event_type="MessageEvent",
+                error=None,
+            )
+            for level in RunEventLevel
+        ]
+
+        log_list = RunEventList(items=events, total=len(events))
+
+        with fixed_timezone("UTC"):
+            result = format_logs_table(log_list, "level-test-run")
+
+        snapshot.assert_match(result)
+
+
+class TestLogDataProcessing:
+    """Test processing of log data structures.
+
+    This class tests the data model creation and processing logic
+    for run events and error information.
+    """
+
+    def test_error_info_stack_trace_formatting(self):
+        """Test ErrorInfo stack trace string conversion."""
+        error = ErrorInfo(
+            message="Test error message",
+            className="TestError",
+            stack=[
+                '  File "/app/test.py", line 10, in test_function\n    raise TestError("Something went wrong")\n',
+                '  File "/app/main.py", line 5, in main\n    test_function()\n',
+            ],
+            cause=None,
+        )
+
+        stack_trace = error.get_stack_trace_string()
+        expected = (
+            '  File "/app/test.py", line 10, in test_function\n'
+            '    raise TestError("Something went wrong")\n\n'
+            '  File "/app/main.py", line 5, in main\n'
+            "    test_function()\n"
+        )
+
+        assert stack_trace == expected
+
+    def test_error_info_empty_stack(self):
+        """Test ErrorInfo with empty stack."""
+        error = ErrorInfo(
+            message="Error with no stack",
+            className="EmptyStackError",
+            stack=None,
+            cause=None,
+        )
+
+        assert error.get_stack_trace_string() == ""
+
+        # Test with empty list too
+        error_empty_list = ErrorInfo(
+            message="Error with empty stack list",
+            className="EmptyStackError",
+            stack=[],
+            cause=None,
+        )
+
+        assert error_empty_list.get_stack_trace_string() == ""
+
+    def test_run_event_creation_with_all_levels(self, snapshot):
+        """Test creating run events with all possible log levels."""
+        events = [
+            RunEvent(
+                run_id=f"level-{level.value.lower()}-run",
+                message=f"Message at {level.value} level",
+                timestamp="1641046800000",
+                level=level,
+                step_key=f"step_{level.value.lower()}" if level != RunEventLevel.INFO else None,
+                event_type="MessageEvent",
+                error=None,
+            )
+            for level in RunEventLevel
+        ]
+
+        log_list = RunEventList(items=events, total=len(events))
+
+        # Test JSON serialization works correctly for all levels
+        result = log_list.model_dump_json(indent=2)
+        import json
+
+        parsed = json.loads(result)
+        snapshot.assert_match(parsed)
+
+    def test_run_event_list_pagination_handling(self):
+        """Test RunEventList pagination properties."""
+        events = [
+            RunEvent(
+                run_id=f"pagination-run-{i}",
+                message=f"Message {i}",
+                timestamp=f"164104680{i}000",
+                level=RunEventLevel.INFO,
+                step_key=None,
+                event_type="MessageEvent",
+                error=None,
+            )
+            for i in range(3)
+        ]
+
+        # Test with pagination info
+        log_list = RunEventList(
+            items=events,
+            total=10,  # Total could be different from items length (pagination)
+            cursor="next_page_cursor",
+            has_more=True,
+        )
+
+        assert len(log_list.items) == 3
+        assert log_list.total == 10
+        assert log_list.cursor == "next_page_cursor"
+        assert log_list.has_more is True
+
+    def test_nested_error_cause_chain(self):
+        """Test deeply nested error cause chains."""
+        # Create a 3-level deep error chain
+        root_error = ErrorInfo(
+            message="IOError: File not found",
+            className="IOError",
+            stack=[
+                "  File \"/app/io.py\", line 15, in read_file\n    with open(filename, 'r') as f:\n"
+            ],
+            cause=None,
+        )
+
+        middle_error = ErrorInfo(
+            message="ProcessingError: Failed to process file",
+            className="ProcessingError",
+            stack=[
+                '  File "/app/processor.py", line 25, in process\n    content = read_file(filename)\n'
+            ],
+            cause=root_error,
+        )
+
+        top_error = ErrorInfo(
+            message="PipelineError: Pipeline execution failed",
+            className="PipelineError",
+            stack=[
+                '  File "/app/pipeline.py", line 50, in run\n    result = process(input_file)\n'
+            ],
+            cause=middle_error,
+        )
+
+        # Verify the chain is properly constructed
+        assert top_error.cause is middle_error
+        assert middle_error.cause is root_error
+        assert root_error.cause is None
+
+        # Test stack trace formatting works for all levels
+        assert "Pipeline execution failed" in top_error.message
+        assert "Failed to process file" in top_error.cause.message
+        assert "File not found" in top_error.cause.cause.message
+
+    def test_run_event_with_no_optional_fields(self):
+        """Test RunEvent creation with minimal required fields."""
+        event = RunEvent(
+            run_id="minimal-run",
+            message="Minimal event",
+            timestamp="1641046800000",
+            level=RunEventLevel.INFO,
+            # All optional fields are None by default
+        )
+
+        assert event.run_id == "minimal-run"
+        assert event.message == "Minimal event"
+        assert event.timestamp == "1641046800000"
+        assert event.level == RunEventLevel.INFO
+        assert event.step_key is None
+        assert event.event_type is None
+        assert event.error is None
+
+    def test_timestamp_handling_edge_cases(self, snapshot):
+        """Test timestamp formatting with edge case values."""
+        from dagster_shared.utils.timing import fixed_timezone
+
+        # Test various timestamp formats
+        events = [
+            RunEvent(
+                run_id="timestamp-test",
+                message="Epoch timestamp",
+                timestamp="0",  # Unix epoch
+                level=RunEventLevel.INFO,
+                step_key=None,
+                event_type="MessageEvent",
+                error=None,
+            ),
+            RunEvent(
+                run_id="timestamp-test",
+                message="Large timestamp",
+                timestamp="32503680000000",  # Year 3000
+                level=RunEventLevel.DEBUG,
+                step_key=None,
+                event_type="MessageEvent",
+                error=None,
+            ),
+        ]
+
+        log_list = RunEventList(items=events, total=len(events))
+
+        with fixed_timezone("UTC"):
+            result = format_logs_table(log_list, "timestamp-test")
+
+        snapshot.assert_match(result)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/test_business_logic.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/log_tests/test_business_logic.py
@@ -396,7 +396,9 @@ class TestLogDataProcessing:
 
         # Test stack trace formatting works for all levels
         assert "Pipeline execution failed" in top_error.message
+        assert top_error.cause is not None
         assert "Failed to process file" in top_error.cause.message
+        assert top_error.cause.cause is not None
         assert "File not found" in top_error.cause.cause.message
 
     def test_run_event_with_no_optional_fields(self):


### PR DESCRIPTION
## Summary & Motivation

Implemented for troubleshooting AI workflows, eg.

```
> /dg_troubleshoot_run is running… 0e7d073a-5fdb-48bd-bb1a-4bb0359c528f

⏺ I'll troubleshoot the failing run by first checking for errors in the logs.

⏺ Bash(dg api log get 0e7d073a-5fdb-48bd-bb1a-4bb0359c528f --json | jq '.logs[] | select(.level == "ERROR")')
  ⎿  {
       "runId": "0e7d073a-5fdb-48bd-bb1a-4bb0359c528f",
       "message": "Execution of step \"poll_snowflake_query_history_hour\" failed.",
     … +144 lines (ctrl+o to expand)

⏺ Run Failure Summary

  Run ID: 0e7d073a-5fdb-48bd-bb1a-4bb0359c528f

  Root Cause: Snowflake user account has been temporarily locked

  Failed Step: poll_snowflake_query_history_hour

  Error Details:
  - Primary Issue: snowflake.connector.errors.DatabaseError: 250001 (08001): Failed to connect to DB:
  na94824.us-east-1.snowflakecomputing.com:443
  - Specific Message: "Your user account has been temporarily locked. Try again later or contact your account administrator
  for assistance."

  Resolution Steps:
  1. Wait for the account lock to expire automatically
  2. Contact the Snowflake account administrator to unlock the account
  3. Check Snowflake's error documentation at: https://community.snowflake.com/s/error-your-user-login-has-been-locked

  This is an external infrastructure issue with the Snowflake connection, not a problem with the Dagster code or pipeline
  logic. The run will succeed once Snowflake access is restored.
```
  
## How I Tested These Changes

## Changelog

- [dg] adds a `dg api log get` command
