### PR TITLE
[dagster-dbt] add ability to configure included metadata in `DbtProjectComponent`

### DIFF
--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -56,7 +56,16 @@ class SlingReplicationSpecModel(Resolvable):
             ),
         ]
     ] = None
-    include_metadata: list[SlingMetadataAddons] = field(default_factory=list)
+    include_metadata: Annotated[
+        list[SlingMetadataAddons],
+        Resolver.default(
+            description="Optionally include additional metadata in materializations generated while executing your Sling models",
+            examples=[
+                ["row_count"],
+                ["row_count", "column_metadata"],
+            ],
+        ),
+    ] = field(default_factory=list)
 
     @cached_property
     def translator(self):


### PR DESCRIPTION
## Summary & Motivation

Closes https://github.com/dagster-io/dagster/issues/32305


Adds configuration on `DbtProjectComponent`:

```
  include_metadata:
    - row_count
    - column_metadata
```


## How I Tested These Changes

bk

## Changelog

- [dagster-dbt] added `include_metadata` on `DbtProjectComponent`
