### PR TITLE
DOC-1218 Add link to Python primer to docs

### DIFF
--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -251,3 +251,4 @@ Congratulations! You've just built and run your first pipeline with Dagster. Nex
 
 - Follow the [Tutorial](/dagster-basics-tutorial) to learn how to build a more complex ETL pipeline
 - [Create your own Dagster project](/guides/build/projects/creating-a-new-project) and [add assets](/guides/build/assets/defining-assets) to it
+- Check out our [Python primer series](https://dagster.io/blog/python-packages-primer-1) for an in-depth tour of Python modules, packages and imports

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -5,7 +5,16 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Getting Started',
       collapsed: false,
-      items: ['intro', 'getting-started/quickstart', 'getting-started/installation', 'getting-started/concepts'],
+      items: ['intro',
+              'getting-started/quickstart',
+              'getting-started/installation',
+              'getting-started/concepts',
+              {
+                type: 'link',
+                label: 'Python primer',
+                href: 'https://dagster.io/blog/python-packages-primer-1'
+              }
+            ],
     },
     {
       type: 'category',

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -5,16 +5,17 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Getting Started',
       collapsed: false,
-      items: ['intro',
-              'getting-started/quickstart',
-              'getting-started/installation',
-              'getting-started/concepts',
-              {
-                type: 'link',
-                label: 'Python primer',
-                href: 'https://dagster.io/blog/python-packages-primer-1'
-              }
-            ],
+      items: [
+        'intro',
+        'getting-started/quickstart',
+        'getting-started/installation',
+        'getting-started/concepts',
+        {
+          type: 'link',
+          label: 'Python primer',
+          href: 'https://dagster.io/blog/python-packages-primer-1',
+        },
+      ],
     },
     {
       type: 'category',


### PR DESCRIPTION
## Summary & Motivation

Adds link to Python primer to Getting Started section in docs.

## How I Tested These Changes

Local build.

## Changelog

> Insert changelog entry or delete this section.
