### PR TITLE
Sort planned events by asset key before they are batch inserted into the database

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1660,7 +1660,7 @@ class TestEventLogStorage:
         with environ(
             {
                 "DAGSTER_EVENT_BATCH_SIZE": "25",
-                "DAGSTER_BATCH_PLANNED_EVENTS": "1" if batch_planned_events else "",
+                "DAGSTER_EMIT_PLANNED_EVENTS_INDIVIDUALLY": "1" if not batch_planned_events else "",
             }
         ):
             result = materialize([my_asset], instance=instance)


### PR DESCRIPTION
Summary:
Resolves a very rare issue where the same asset keys being inserted in different orders by different runs simultaneously could cause issues in the storage layer.

## How I Tested These Changes
Existing test coverage of planned event batching
