### PR TITLE
fix break condition in parentsPoppingItemsDeeperThan preventing auto-complete from working

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/configeditor/codemirror-yaml/mode.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/configeditor/codemirror-yaml/mode.tsx
@@ -41,7 +41,7 @@ interface IParseState {
 function parentsPoppingItemsDeeperThan(parents: IParseStateParent[], indent: number) {
   while (parents.length > 0) {
     const immediateParent = parents[parents.length - 1];
-    if (!immediateParent || immediateParent.indent >= indent) {
+    if (!immediateParent || immediateParent.indent < indent) {
       break;
     }
     parents = parents.slice(0, parents.length - 1);


### PR DESCRIPTION
## Summary & Motivation
Fixes an issue introduced in https://github.com/dagster-io/dagster/pull/32255. The old while loop condition was >=, so the break condition should be <, not >=.

## How I Tested These Changes
Launchpad autocomplete for nested config fields now works as expected.

## Changelog
Fixed an issue introduced in the 1.11.12 release where auto-complete in the Launchpad for nested fields stopped working.
