### PR TITLE
gql to get the time that an asset's freshness state changed

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -632,6 +632,7 @@ type Asset {
   latestMaterializationTimestamp: Float
   hasDefinitionOrRecord: Boolean!
   latestFailedToMaterializeTimestamp: Float
+  freshnessStatusChangedTimestamp: Float
 }
 
 type AssetResultEventHistoryConnection {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -105,6 +105,7 @@ export type Asset = {
   assetMaterializations: Array<MaterializationEvent>;
   assetObservations: Array<ObservationEvent>;
   definition: Maybe<AssetNode>;
+  freshnessStatusChangedTimestamp: Maybe<Scalars['Float']['output']>;
   hasDefinitionOrRecord: Scalars['Boolean']['output'];
   id: Scalars['String']['output'];
   key: AssetKey;
@@ -6328,6 +6329,10 @@ export const buildAsset = (
         : relationshipsToOmit.has('AssetNode')
           ? ({} as AssetNode)
           : buildAssetNode({}, relationshipsToOmit),
+    freshnessStatusChangedTimestamp:
+      overrides && overrides.hasOwnProperty('freshnessStatusChangedTimestamp')
+        ? overrides.freshnessStatusChangedTimestamp!
+        : 5.61,
     hasDefinitionOrRecord:
       overrides && overrides.hasOwnProperty('hasDefinitionOrRecord')
         ? overrides.hasDefinitionOrRecord!

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -286,6 +286,7 @@ class GrapheneAsset(graphene.ObjectType):
     latestMaterializationTimestamp = graphene.Float()
     hasDefinitionOrRecord = graphene.NonNull(graphene.Boolean)
     latestFailedToMaterializeTimestamp = graphene.Float()
+    freshnessStatusChangedTimestamp = graphene.Float()
 
     class Meta:
         name = "Asset"
@@ -499,6 +500,15 @@ class GrapheneAsset(graphene.ObjectType):
             if latest_failed_to_materialize_event
             else None
         )
+
+    def resolve_freshnessStatusChangedTimestamp(
+        self, graphene_info: ResolveInfo
+    ) -> Optional[float]:
+        freshness_state_record = graphene_info.context.instance.get_freshness_state_records(
+            [self._asset_key]
+        ).get(self._asset_key)
+        if freshness_state_record is not None:
+            return freshness_state_record.updated_at.timestamp() * 1000
 
 
 class GrapheneEventConnection(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -477,7 +477,8 @@ class GrapheneAsset(graphene.ObjectType):
         )
         if min_materialization_state is not None:
             return (
-                min_materialization_state.latest_materialization_timestamp * 1000
+                min_materialization_state.latest_materialization_timestamp
+                * 1000  # FE prefers timestamp in milliseconds
                 if min_materialization_state.latest_materialization_timestamp
                 else None
             )
@@ -485,7 +486,9 @@ class GrapheneAsset(graphene.ObjectType):
         record = await AssetRecord.gen(graphene_info.context, self._asset_key)
         latest_materialization_event = record.asset_entry.last_materialization if record else None
         return (
-            latest_materialization_event.timestamp * 1000 if latest_materialization_event else None
+            latest_materialization_event.timestamp * 1000  # FE prefers timestamp in milliseconds
+            if latest_materialization_event
+            else None
         )
 
     async def resolve_latestFailedToMaterializeTimestamp(
@@ -496,7 +499,8 @@ class GrapheneAsset(graphene.ObjectType):
             record.asset_entry.last_failed_to_materialize_entry if record else None
         )
         return (
-            latest_failed_to_materialize_event.timestamp * 1000
+            latest_failed_to_materialize_event.timestamp
+            * 1000  # FE prefers timestamp in milliseconds
             if latest_failed_to_materialize_event
             else None
         )
@@ -508,7 +512,9 @@ class GrapheneAsset(graphene.ObjectType):
             [self._asset_key]
         ).get(self._asset_key)
         if freshness_state_record is not None:
-            return freshness_state_record.updated_at.timestamp() * 1000
+            return (
+                freshness_state_record.updated_at.timestamp() * 1000
+            )  # FE prefers timestamp in milliseconds
 
 
 class GrapheneEventConnection(graphene.ObjectType):

--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from collections.abc import Iterable, Mapping
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -219,10 +219,10 @@ class FreshnessStateRecord(LoadableBy[AssetKey]):
     @staticmethod
     def from_db_row(db_row):
         return FreshnessStateRecord(
-            entity_key=check.not_none(AssetKey.from_db_string(db_row[0])),
-            freshness_state=FreshnessState(db_row[3]),
-            record_body=deserialize_value(db_row[4], FreshnessStateRecordBody),
-            updated_at=db_row[5],
+            entity_key=check.not_none(AssetKey.from_db_string(db_row.entity_key)),
+            freshness_state=FreshnessState(db_row.freshness_state),
+            record_body=deserialize_value(db_row.record_body, FreshnessStateRecordBody),
+            updated_at=db_row.update_timestamp.replace(tzinfo=timezone.utc),
         )
 
     @staticmethod


### PR DESCRIPTION
We currently compute this in the UI but that requires fetching the freshness policy definition from the asset graph and only works for time window policies. This adds a GQL endpoint that gets the time that the freshness record in the DB updated.



Also updates the `from_db_row`​ method of `FreshnessStateRecord`​ to use dot-access to get the entries we want from the row. There was a bug where the `updated_at`​ attr was sourced from the `created_at`​ column. Also adds timezone info to the datetime object since we store a utc datetime in the DB but read it as a datetime with no timezone. this was causing conversion issues when getting the timestamp to send to the front end



For future perf improvements we can move this to streamline https://linear.app/dagster-labs/issue/OPER-2443/source-timestamps-used-in-the-homepage-from-streamline 