### PR TITLE
[ui] Move Asset Catalog tabs to internal

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
@@ -1,4 +1,4 @@
-import {Tab, Tabs} from '@dagster-io/ui-components';
+import {Tab, Tabs, Tooltip} from '@dagster-io/ui-components';
 import qs from 'qs';
 import {useMemo} from 'react';
 
@@ -17,9 +17,20 @@ export const AssetTabs = (props: Props) => {
     <Tabs size="large" selectedTabId={selectedTab}>
       {tabs
         .filter((tab) => !tab.hidden)
-        .map(({id, title, to, disabled}) => {
+        .map(({id, title, to, tooltip, disabled}) => {
           if (disabled) {
-            return <Tab disabled key={id} id={id} title={title} />;
+            return (
+              <Tab
+                disabled
+                key={id}
+                id={id}
+                title={
+                  <Tooltip content={tooltip || ''} canShow={!!tooltip} placement="top">
+                    {title}
+                  </Tooltip>
+                }
+              />
+            );
           }
           return <TabLink key={id} id={id} title={title} to={to} disabled={disabled} />;
         })}
@@ -54,6 +65,7 @@ export type AssetTabConfig = {
   title: string;
   to: string;
   disabled?: boolean;
+  tooltip?: string;
   hidden?: boolean;
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogAlerts.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogAlerts.oss.tsx
@@ -1,7 +1,3 @@
-export const useShouldShowAssetCatalogAlerts = () => {
-  return null;
-};
-
 export const AssetCatalogAlerts = (_: any) => {
   return null;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -9,8 +9,6 @@ import {
   Select,
   Skeleton,
   Subtitle1,
-  Tab,
-  Tabs,
   Tag,
   UnstyledButton,
   ifPlural,
@@ -19,10 +17,8 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
 import {CreateCatalogViewButton} from 'shared/assets/CreateCatalogViewButton.oss';
-import {
-  AssetCatalogAlerts,
-  useShouldShowAssetCatalogAlerts,
-} from 'shared/assets/catalog/AssetCatalogAlerts.oss';
+import {AssetCatalogAlerts} from 'shared/assets/catalog/AssetCatalogAlerts.oss';
+import {AssetCatalogTabs} from 'shared/assets/catalog/AssetCatalogTabs.oss';
 import {useCatalogExtraDropdownOptions} from 'shared/assets/catalog/useCatalogExtraDropdownOptions.oss';
 import {AssetCatalogInsights} from 'shared/assets/insights/AssetCatalogInsights.oss';
 import {useFavoriteAssets} from 'shared/assets/useFavoriteAssets.oss';
@@ -170,26 +166,10 @@ export const AssetCatalogTableV2 = React.memo(() => {
 
   const {isFullScreen} = useFullScreen();
 
-  const shouldShowCatalogAlerts = useShouldShowAssetCatalogAlerts();
-
-  const tabs = useMemo(
-    () => (
-      <Box border="bottom">
-        {isFullScreen ? null : (
-          <Tabs
-            onChange={onChangeTab}
-            selectedTabId={selectedTab}
-            style={{marginLeft: 24, marginRight: 24}}
-          >
-            <Tab id="assets" title="Assets" />
-            <Tab id="lineage" title="Lineage" />
-            <Tab id="insights" title="Insights" />
-            {shouldShowCatalogAlerts ? <Tab id="alerts" title="Alert Policies" /> : null}
-          </Tabs>
-        )}
-      </Box>
-    ),
-    [isFullScreen, onChangeTab, selectedTab, shouldShowCatalogAlerts],
+  const tabs = isFullScreen ? null : (
+    <Box border="bottom" padding={{left: 24, right: 24}}>
+      <AssetCatalogTabs onChangeTab={onChangeTab} selectedTab={selectedTab} />
+    </Box>
   );
 
   const content = () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTabs.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTabs.oss.tsx
@@ -1,0 +1,8 @@
+export interface AssetCatalogTabsProps {
+  onChangeTab: (tab: string) => void;
+  selectedTab: string;
+}
+
+export const AssetCatalogTabs = (_: AssetCatalogTabsProps) => {
+  return null;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/JobTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/JobTabs.tsx
@@ -34,8 +34,7 @@ export const JobTabs = (props: Props) => {
   }, [matchingTab, tabs]);
 
   return (
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    <Tabs size="large" selectedTabId={selectedTab!.id}>
+    <Tabs size="large" selectedTabId={selectedTab?.id}>
       {tabs
         .filter((tab) => !tab.isHidden)
         .map((tab) => {


### PR DESCRIPTION
## Summary & Motivation

Corresponds to https://github.com/dagster-io/internal/pull/18428.

Move asset catalog tabs to internal, since they're not visible in OSS anywhere anyway right now, and I need to be able to disable the Insights tab in certain circumstances.

## How I Tested These Changes

View asset catalog as observe user, verify that tabs render correctly.