### PR TITLE
DOC-1392 client module disables slash hotkey

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -20,6 +20,9 @@ const config: Config = {
     mermaid: true,
   },
   themes: ['@docusaurus/theme-mermaid'],
+  clientModules: [
+    require.resolve('./src/clientModules/disableSlashSearch.js')
+  ],
   i18n: {defaultLocale: 'en', locales: ['en']},
   plugins: [
     require.resolve('docusaurus-plugin-sass'),

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -20,9 +20,7 @@ const config: Config = {
     mermaid: true,
   },
   themes: ['@docusaurus/theme-mermaid'],
-  clientModules: [
-    require.resolve('./src/clientModules/disableSlashSearch.js')
-  ],
+  clientModules: [require.resolve('./src/clientModules/disableSlashSearch.js')],
   i18n: {defaultLocale: 'en', locales: ['en']},
   plugins: [
     require.resolve('docusaurus-plugin-sass'),

--- a/docs/src/clientModules/disableSlashSearch.js
+++ b/docs/src/clientModules/disableSlashSearch.js
@@ -1,0 +1,14 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+if (ExecutionEnvironment.canUseDOM) {
+  document.addEventListener('keydown', (event) => {
+    if (event.key === '/' && !event.ctrlKey && !event.metaKey) {
+      const activeElement = document.activeElement;
+
+      // Check if focus is within scout-copilot element
+      if (activeElement?.closest('scout-copilot')) {
+        event.stopPropagation();
+      }
+    }
+  }, true);
+}

--- a/docs/src/clientModules/disableSlashSearch.js
+++ b/docs/src/clientModules/disableSlashSearch.js
@@ -1,14 +1,18 @@
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 if (ExecutionEnvironment.canUseDOM) {
-  document.addEventListener('keydown', (event) => {
-    if (event.key === '/' && !event.ctrlKey && !event.metaKey) {
-      const activeElement = document.activeElement;
+  document.addEventListener(
+    'keydown',
+    (event) => {
+      if (event.key === '/' && !event.ctrlKey && !event.metaKey) {
+        const activeElement = document.activeElement;
 
-      // Check if focus is within scout-copilot element
-      if (activeElement?.closest('scout-copilot')) {
-        event.stopPropagation();
+        // Check if focus is within scout-copilot element
+        if (activeElement?.closest('scout-copilot')) {
+          event.stopPropagation();
+        }
       }
-    }
-  }, true);
+    },
+    true,
+  );
 }


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/DOC-1392/algolia-hot-key-steals-focus-from-ask-ai-input-area

Check if Scout is in focus and then, if so, stop "/" event from opening Algolia window.

I explored opening a PR with docusaurus to add more native support for Algolia keyboardShortcuts but learned docusaurus is still running an Algolia version that doesn't support that param, and so we'll likely need to wait. Because this only blocks events that fire within scout widget, I think it's pretty harmless.

## How I Tested These Changes

I modified the docusaurus configuration to load Algolia docsearch widget locally and confirm everything behaves as expected. I also added a conditional console log to confirm that "/" events are handled normally if scout is in focus (but deleted console test before committing).

## Changelog

> Insert changelog entry or delete this section.
