### PR TITLE
Add timestamp fields to streamline objects

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_check_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_check_health.py
@@ -25,6 +25,9 @@ class AssetCheckHealthState(LoadableBy[AssetKey]):
     failing_checks: set[AssetCheckKey]
     warning_checks: set[AssetCheckKey]
     all_checks: set[AssetCheckKey]
+    latest_passing_check_timestamp: Optional[float]
+    latest_failing_check_timestamp: Optional[float]
+    latest_warning_check_timestamp: Optional[float]
 
     @classmethod
     def default(cls) -> "AssetCheckHealthState":
@@ -33,6 +36,9 @@ class AssetCheckHealthState(LoadableBy[AssetKey]):
             failing_checks=set(),
             warning_checks=set(),
             all_checks=set(),
+            latest_passing_check_timestamp=None,
+            latest_failing_check_timestamp=None,
+            latest_warning_check_timestamp=None,
         )
 
     @property
@@ -76,6 +82,10 @@ class AssetCheckHealthState(LoadableBy[AssetKey]):
         passing_checks = set()
         warning_checks = set()
         failing_checks = set()
+
+        latest_passing_check_timestamp = None
+        latest_failing_check_timestamp = None
+        latest_warning_check_timestamp = None
 
         check_records = await AssetCheckSummaryRecord.gen_many(
             loading_context,
@@ -125,20 +135,55 @@ class AssetCheckHealthState(LoadableBy[AssetKey]):
                     and last_check_evaluation.severity == AssetCheckSeverity.WARN
                 ):
                     warning_checks.add(check_key)
+                    if check_record.last_completed_check_execution_record is not None and (
+                        latest_warning_check_timestamp is None
+                        or latest_warning_check_timestamp
+                        < check_record.last_completed_check_execution_record.create_timestamp
+                    ):
+                        latest_warning_check_timestamp = (
+                            check_record.last_completed_check_execution_record.create_timestamp
+                        )
                 else:
                     failing_checks.add(check_key)
+                    if check_record.last_completed_check_execution_record is not None and (
+                        latest_failing_check_timestamp is None
+                        or latest_failing_check_timestamp
+                        < check_record.last_completed_check_execution_record.create_timestamp
+                    ):
+                        latest_failing_check_timestamp = (
+                            check_record.last_completed_check_execution_record.create_timestamp
+                        )
             elif last_check_execution_status == AssetCheckExecutionResolvedStatus.EXECUTION_FAILED:
                 # EXECUTION_FAILED checks don't have an evaluation and we want to report them as failures
                 failing_checks.add(check_key)
+                if check_record.last_completed_check_execution_record is not None and (
+                    latest_failing_check_timestamp is None
+                    or latest_failing_check_timestamp
+                    < check_record.last_completed_check_execution_record.create_timestamp
+                ):
+                    latest_failing_check_timestamp = (
+                        check_record.last_completed_check_execution_record.create_timestamp
+                    )
             else:
                 # asset check passed
                 passing_checks.add(check_key)
+                if check_record.last_completed_check_execution_record is not None and (
+                    latest_passing_check_timestamp is None
+                    or latest_passing_check_timestamp
+                    < check_record.last_completed_check_execution_record.create_timestamp
+                ):
+                    latest_passing_check_timestamp = (
+                        check_record.last_completed_check_execution_record.create_timestamp
+                    )
 
         return AssetCheckHealthState(
             passing_checks=passing_checks,
             failing_checks=failing_checks,
             warning_checks=warning_checks,
             all_checks=check_keys,
+            latest_passing_check_timestamp=latest_passing_check_timestamp,
+            latest_failing_check_timestamp=latest_failing_check_timestamp,
+            latest_warning_check_timestamp=latest_warning_check_timestamp,
         )
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_freshness_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_freshness_health.py
@@ -24,6 +24,7 @@ class AssetFreshnessHealthState(LoadableBy[AssetKey]):
     """Maintains the latest freshness state for the asset."""
 
     freshness_state: FreshnessState
+    updated_timestamp: Optional[float]
 
     @property
     def health_status(self) -> AssetHealthStatus:
@@ -49,9 +50,11 @@ class AssetFreshnessHealthState(LoadableBy[AssetKey]):
             # freshness policy has no evaluations yet
             return cls(
                 freshness_state=FreshnessState.UNKNOWN,
+                updated_timestamp=None,
             )
         return cls(
             freshness_state=freshness_state_record.freshness_state,
+            updated_timestamp=freshness_state_record.updated_at.timestamp(),
         )
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
@@ -35,6 +35,7 @@ class MinimalAssetMaterializationHealthState(LoadableBy[AssetKey]):
     num_failed_partitions: int
     num_currently_materialized_partitions: int
     partitions_snap: Optional[PartitionsSnap]
+    latest_failed_to_materialize_timestamp: Optional[float]
 
     @property
     def health_status(self) -> AssetHealthStatus:
@@ -62,6 +63,7 @@ class MinimalAssetMaterializationHealthState(LoadableBy[AssetKey]):
             num_failed_partitions=asset_materialization_health_state.failed_subset.size,
             num_currently_materialized_partitions=asset_materialization_health_state.currently_materialized_subset.size,
             partitions_snap=asset_materialization_health_state.partitions_snap,
+            latest_failed_to_materialize_timestamp=asset_materialization_health_state.latest_failed_to_materialize_timestamp,
         )
 
     @classmethod
@@ -101,6 +103,7 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
     partitions_snap: Optional[PartitionsSnap]
     latest_terminal_run_id: Optional[str]
     latest_materialization_timestamp: Optional[float] = None
+    latest_failed_to_materialize_timestamp: Optional[float] = None
 
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:
@@ -152,6 +155,7 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
 
             last_run_id = None
             latest_materialization_timestamp = None
+            latest_failed_to_materialize_timestamp = None
             if asset_record is not None:
                 entry = asset_record.asset_entry
                 latest_record = max(
@@ -167,6 +171,11 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
                     if entry.last_materialization_record
                     else None
                 )
+                latest_failed_to_materialize_timestamp = (
+                    entry.last_failed_to_materialize_record.timestamp
+                    if entry.last_failed_to_materialize_record
+                    else None
+                )
 
             return cls(
                 materialized_subset=SerializableEntitySubset(
@@ -178,6 +187,7 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
                 partitions_snap=PartitionsSnap.from_def(partitions_def),
                 latest_terminal_run_id=last_run_id,
                 latest_materialization_timestamp=latest_materialization_timestamp,
+                latest_failed_to_materialize_timestamp=latest_failed_to_materialize_timestamp,
             )
 
         if asset_record is None:
@@ -187,12 +197,18 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
                 partitions_snap=None,
                 latest_terminal_run_id=None,
                 latest_materialization_timestamp=None,
+                latest_failed_to_materialize_timestamp=None,
             )
 
         asset_entry = asset_record.asset_entry
         latest_materialization_timestamp = (
             asset_entry.last_materialization_record.timestamp
             if asset_entry.last_materialization_record
+            else None
+        )
+        latest_failed_to_materialize_timestamp = (
+            asset_entry.last_failed_to_materialize_record.timestamp
+            if asset_entry.last_failed_to_materialize_record
             else None
         )
         if asset_entry.last_run_id is None:
@@ -202,6 +218,7 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
                 partitions_snap=None,
                 latest_terminal_run_id=None,
                 latest_materialization_timestamp=latest_materialization_timestamp,
+                latest_failed_to_materialize_timestamp=latest_failed_to_materialize_timestamp,
             )
 
         has_ever_materialized = asset_entry.last_materialization is not None
@@ -218,6 +235,7 @@ class AssetMaterializationHealthState(LoadableBy[AssetKey]):
             partitions_snap=None,
             latest_terminal_run_id=latest_terminal_run_id,
             latest_materialization_timestamp=latest_materialization_timestamp,
+            latest_failed_to_materialize_timestamp=latest_failed_to_materialize_timestamp,
         )
 
     @classmethod


### PR DESCRIPTION
Adds some timestamp fields to various streamline objects that we maintain for asset health. We want to use these timestamps in the UI and this will give us an efficient way to fetch them in the UI

Internal PR: [https://app.graphite.dev/github/pr/dagster-io/internal/18442/[wip]-timestamps-in-streamline](https://app.graphite.dev/github/pr/dagster-io/internal/18442/%5Bwip%5D-timestamps-in-streamline)