### PR TITLE
[sbc] Fix refresh-defs-state storage

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/config_utils.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/config_utils.py
@@ -500,6 +500,7 @@ def get_location_document(name: Optional[str], kwargs: dict[str, Any]) -> dict[s
                 if kwargs.get("pex_tag")
                 else None
             ),
+            "defs_state_info": kwargs.get("defs_state_info"),
         }
     )
     return deep_merge_dicts(location_doc_from_file, location_doc_from_kwargs)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/defs_state_storage.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/defs_state_storage.py
@@ -104,14 +104,14 @@ class DagsterPlusCliDefsStateStorage(DefsStateStorage[T_DagsterInstance]):
 
     def get_latest_defs_state_info(self) -> Optional[DefsStateInfo]:
         res = self._execute_query(GET_LATEST_DEFS_STATE_INFO_QUERY)
-        latest_info = res["data"]["latestDefsStateInfo"]
-        return DefsStateInfo.from_graphql(latest_info) if latest_info else None
+        latest_info = res["latestDefsStateInfo"]
+        return DefsStateInfo.from_graphql(latest_info)
 
     def set_latest_version(self, key: str, version: str) -> None:
         result = self._execute_query(
             SET_LATEST_VERSION_MUTATION, variables={"key": key, "version": version}
         )
         check.invariant(
-            result["data"].get("setLatestDefsStateVersion", {}).get("ok"),
-            "Failed to set latest version",
+            result.get("setLatestDefsStateVersion", {}).get("ok"),
+            f"Failed to set latest version. Result: {result}",
         )


### PR DESCRIPTION
## Summary & Motivation

`gql` automatically pulls out the `result["data"]` field (fun!)

also noticed that we weren't actually pulling this into the code location deploy document

## How I Tested These Changes

pain

## Changelog

NOCHANGELOG
