### PR TITLE
[dagster-sling] resolve issue with log parser and INF

### DIFF
--- a/python_modules/libraries/dagster-sling/dagster_sling/resources.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/resources.py
@@ -279,8 +279,12 @@ class SlingResource(ConfigurableResource):
             yield
 
     def _clean_line(self, line: str) -> str:
-        """Removes ANSI escape sequences from a line of output."""
-        return ANSI_ESCAPE.sub("", line).replace("INF", "")
+        """Removes ANSI escape sequences and Sling log prefixes from a line of output."""
+        line = ANSI_ESCAPE.sub("", line)
+        # Remove Sling log format prefix: "{timestamp} {LEVEL} " (e.g., "1:04PM INF ")
+        # Match pattern: optional timestamp followed by log level (INF, WRN, ERR, DBG) and space
+        line = re.sub(r"^\d{1,2}:\d{2}[AP]M\s+(INF|WRN|ERR|DBG)\s+", "", line)
+        return line
 
     def _clean_timestamp_log(self, line: str):
         """Remove timestamp from log gather from sling cli to reduce redundency in dagster log.


### PR DESCRIPTION
## Summary & Motivation

Resolves #32208

### Problem

Stream names containing "INF" (like CUSTOMERINFO) were being corrupted during log parsing, causing DagsterInvariantViolationError.

### Root Cause

The _clean_line() method used .replace("INF", "") which stripped ALL "INF" occurrences from log lines, not just the Sling log level prefix. Sling outputs logs as {timestamp} INF {message} where "INF" is the log level indicator.

### Solution

Updated the regex pattern to only remove the log level prefix at the start of lines:

- Changed from: .replace("INF", "")
- Changed to: re.sub(r"^\d{1,2}:\d{2}[AP]M\s+(INF|WRN|ERR|DBG)\s+", "", line)

## How I Tested These Changes

Including new test cases for:
  - Standard Sling log format with INF in stream names
  - Multiple INF occurrences in messages
  - Different log levels (WRN, ERR, DBG)
  - Edge cases with INF at various positions

## Changelog

- [dagster-sling] resolves issue where log parses incorrectly strips INF text
