### PR TITLE
[test-all] fix dg test snapshots on python 3.9

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/run.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/run.py
@@ -15,7 +15,7 @@ def format_run_table(run) -> str:
     """Format run as human-readable table."""
     lines = [
         f"Run ID: {run.id}",
-        f"Status: {run.status}",
+        f"Status: {run.status.value}",
         f"Created: {run.created_at}",
     ]
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/__snapshots__/test_dynamic_command_execution.ambr
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/__snapshots__/test_dynamic_command_execution.ambr
@@ -1442,20 +1442,6 @@
   
   '''
 # ---
-# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_empty_json_json]
-  '''
-  {"error": "Exhausted 0 responses"}
-  Error: Failed to get logs for run empty-run-uuid-0000-0000-000000000000: Exhausted 0 responses
-  
-  '''
-# ---
-# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_empty_text_text]
-  '''
-  Error querying Dagster Plus API: Exhausted 0 responses
-  Error: Failed to get logs for run empty-run-uuid-0000-0000-000000000000: Exhausted 0 responses
-  
-  '''
-# ---
 # name: TestDynamicCommandExecution.test_command_execution[log_success_logs_error_level_only_json_json]
   dict({
     'count': 0,
@@ -1593,20 +1579,6 @@
   
   Total log entries: 3
   Note: More logs available (use --limit to increase or --cursor to paginate)
-  
-  '''
-# ---
-# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_with_cursor_json_json]
-  '''
-  {"error": "Exhausted 0 responses"}
-  Error: Failed to get logs for run 85156191-170d-4229-8eba-14450b6ca9e3: Exhausted 0 responses
-  
-  '''
-# ---
-# name: TestDynamicCommandExecution.test_command_execution[log_success_logs_with_cursor_text_text]
-  '''
-  Error querying Dagster Plus API: Exhausted 0 responses
-  Error: Failed to get logs for run 85156191-170d-4229-8eba-14450b6ca9e3: Exhausted 0 responses
   
   '''
 # ---
@@ -2244,7 +2216,7 @@
 # name: TestDynamicCommandExecution.test_command_execution[run_success_single_run_text_text]
   '''
   Run ID: 2e562bd3-7e72-4448-9f05-32bad2ea8046
-  Status: DgApiRunStatus.SUCCESS
+  Status: SUCCESS
   Created: 1757703683.741368
   Started: 1757703690.474944
   Ended: 1757703732.670455

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/run_tests/__snapshots__/test_business_logic.ambr
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/run_tests/__snapshots__/test_business_logic.ambr
@@ -12,7 +12,7 @@
 # name: TestFormatRun.test_format_canceled_run_text_output[0]
   '''
   Run ID: canceled-run-789
-  Status: DgApiRunStatus.CANCELED
+  Status: CANCELED
   Created: 1705311000.0
   Started: 1705311060.0
   Ended: 1705311120.0
@@ -32,7 +32,7 @@
 # name: TestFormatRun.test_format_failed_run_text_output[0]
   '''
   Run ID: failed-run-456
-  Status: DgApiRunStatus.FAILURE
+  Status: FAILURE
   Created: 1705311000.0
   Started: 1705311060.0
   Ended: 1705311180.0
@@ -52,7 +52,7 @@
 # name: TestFormatRun.test_format_minimal_run_text_output[0]
   '''
   Run ID: minimal-run-123
-  Status: DgApiRunStatus.QUEUED
+  Status: QUEUED
   Created: 1705311000.0
   '''
 # ---
@@ -69,7 +69,7 @@
 # name: TestFormatRun.test_format_run_text_output[0]
   '''
   Run ID: 123e4567-e89b-12d3-a456-426614174000
-  Status: DgApiRunStatus.SUCCESS
+  Status: SUCCESS
   Created: 1705311000.0
   Started: 1705311060.0
   Ended: 1705311900.0

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/run_tests/test_business_logic.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/api_tests/run_tests/test_business_logic.py
@@ -13,7 +13,7 @@ def format_run_table(run) -> str:
     """Format run as human-readable table."""
     lines = [
         f"Run ID: {run.id}",
-        f"Status: {run.status}",
+        f"Status: {run.status.value}",
         f"Created: {run.created_at}",
     ]
 


### PR DESCRIPTION
Summary:
[test-all] Get the release branch green and also remove the enum from the string, win win

Test plan: BK