### PR TITLE
increase pytest-timeout value on k8s integration test suite

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tox.ini
+++ b/integration_tests/test_suites/k8s-test-suite/tox.ini
@@ -40,7 +40,7 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  default: pytest --log-cli-level=INFO -m "default" --ignore ./tests/test_k8s_monitoring.py {posargs}
-  subchart: pytest --log-cli-level=INFO -m "subchart" --ignore ./tests/test_k8s_monitoring.py {posargs}
-  default_monitoring: pytest --log-cli-level=INFO -m "default" ./tests/test_k8s_monitoring.py {posargs}
-  subchart_monitoring: pytest --log-cli-level=INFO -m "subchart" ./tests/test_k8s_monitoring.py {posargs}
+  default: pytest --log-cli-level=INFO -m "default" --ignore ./tests/test_k8s_monitoring.py {posargs} --timeout 480
+  subchart: pytest --log-cli-level=INFO -m "subchart" --ignore ./tests/test_k8s_monitoring.py {posargs} --timeout 480
+  default_monitoring: pytest --log-cli-level=INFO -m "default" ./tests/test_k8s_monitoring.py {posargs} --timeout 480
+  subchart_monitoring: pytest --log-cli-level=INFO -m "subchart" ./tests/test_k8s_monitoring.py {posargs} --timeout 480


### PR DESCRIPTION
Summary:
Testing the theory that this test failure was a case of pytest-timeout being a little too aggressive: https://buildkite.com/dagster/dagster-dagster/builds/135221#0199a02f-2fed-465f-9b46-c86f76f1c39a

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.