### PR TITLE
Give dagster-dg-cli more splits

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -794,7 +794,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: list[PackageSpec] = [
     PackageSpec(
         "python_modules/libraries/dagster-dg-cli",
         pytest_tox_factors=[
-            ToxFactor("general", splits=2),
+            ToxFactor("general", splits=3),
             ToxFactor("docs"),
             ToxFactor("plus"),
         ],


### PR DESCRIPTION
Summary:
This is our slowest test suite (making the test suite faster is of course another option), so add more parallelism.

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
