### PR TITLE
[components] Allow `freshness_policy` to be set in `ResolvedAssetSpec`

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/core_models.py
+++ b/python_modules/dagster/dagster/components/resolved/core_models.py
@@ -13,6 +13,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
 )
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.freshness import InternalFreshnessPolicy
 from dagster._core.definitions.partitions.definition import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
@@ -255,6 +256,14 @@ class SharedAssetKwargs(Resolvable):
                 TimeWindowPartitionsDefinitionModel,
                 StaticPartitionsDefinitionModel,
             ],
+        ),
+    ] = None
+    freshness_policy: Annotated[
+        Optional[InternalFreshnessPolicy],
+        Resolver.default(
+            model_field_type=Optional[str],
+            description="The freshness policy for the asset.",
+            examples=["{{ custom_freshness_template_var() }}"],
         ),
     ] = None
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_example
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_example
@@ -33,6 +33,7 @@ attributes:
       end_date: "example_string"
       timezone: "example_string"
       minute_offset: 1
+    freshness_policy: "example_string"
     key: "example_string"
     key_prefix:
       - "example_string"

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_schema
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_schema
@@ -69,5 +69,6 @@ attributes:  # Optional: Attributes details
       # partition_keys:  # Optional: List of string items
         - <string>
       #
+    freshness_policy: <string>  # Optional: The freshness policy for the asset.
     key: <string>  # Optional: 
     key_prefix: <one of: string, array of string>  # Optional: Prefix the existing asset key with the provided value.

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/dbt_project/expected_example
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/dbt_project/expected_example
@@ -45,6 +45,7 @@ attributes:
       end_date: "example_string"
       timezone: "example_string"
       minute_offset: 1
+    freshness_policy: "example_string"
     key: "example_string"
     key_prefix:
       - "example_string"

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/dbt_project/expected_schema
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/dbt_project/expected_schema
@@ -77,6 +77,7 @@ attributes:  # Optional: Attributes details
       # partition_keys:  # Optional: List of string items
         - <string>
       #
+    freshness_policy: <string>  # Optional: The freshness policy for the asset.
     key: <string>  # Optional: 
     key_prefix: <one of: string, array of string>  # Optional: Prefix the existing asset key with the provided value.
   translation_settings:  # Optional: Allows enabling or disabling various features for translating dbt models in to Dagster assets.

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/python_script/expected_example
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/python_script/expected_example
@@ -23,6 +23,7 @@ attributes:
         end_date: "example_string"
         timezone: "example_string"
         minute_offset: 1
+      freshness_policy: "example_string"
       key: "example_string"
   checks:
     -

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/python_script/expected_schema
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/python_script/expected_schema
@@ -52,6 +52,7 @@ attributes:  # Optional: Attributes details
         # partition_keys:  # Optional: List of string items
           - <string>
         #
+      freshness_policy: <string>  # Optional: The freshness policy for the asset.
       key: <string>  # Required: A unique identifier for the asset.
   checks:  # Optional: 
     - # Array of AssetCheckSpecKwargsModel objects:

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/sling_replication_collection/expected_example
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/sling_replication_collection/expected_example
@@ -34,6 +34,7 @@ attributes:
           end_date: "example_string"
           timezone: "example_string"
           minute_offset: 1
+        freshness_policy: "example_string"
         key: "example_string"
         key_prefix:
           - "example_string"

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/sling_replication_collection/expected_schema
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/sling_replication_collection/expected_schema
@@ -69,6 +69,7 @@ attributes:  # Optional: Attributes details
           # partition_keys:  # Optional: List of string items
             - <string>
           #
+        freshness_policy: <string>  # Optional: The freshness policy for the asset.
         key: <string>  # Optional: 
         key_prefix: <one of: string, array of string>  # Optional: Prefix the existing asset key with the provided value.
       include_metadata: <one of: array of string, string>  # Optional: Optionally include additional metadata in materializations generated while executing your Sling models


### PR DESCRIPTION
## Summary & Motivation

This is a field on AssetSpec, you should be able to set it. No yaml schema for this for now, but we can always add that later. For now, you just use template vars.

## How I Tested These Changes

unit

## Changelog

`ResolvedAssetSpec` and related resolvers now support setting the `freshness_policy` field.
