### PR TITLE
Remove the specality tags in examples

### DIFF
--- a/docs/docs/examples/mini-examples/resource-caching.md
+++ b/docs/docs/examples/mini-examples/resource-caching.md
@@ -5,7 +5,6 @@ last_update:
   author: Dennis Hume
 sidebar_custom_props:
   logo: images/dagster-primary-mark.svg
-  miniProject: true
 tags: [mini-project]
 ---
 

--- a/docs/docs/examples/mini-examples/resource-caching.md
+++ b/docs/docs/examples/mini-examples/resource-caching.md
@@ -5,7 +5,6 @@ last_update:
   author: Dennis Hume
 sidebar_custom_props:
   logo: images/dagster-primary-mark.svg
-tags: [mini-project]
 ---
 
 In this example, we'll explore different ways to handle caching in Dagster. Caching is especially useful for assets that rely on expensive operations, such as API calls, database queries, or heavy computations, as it can dramatically improve performance, reduce costs, and make pipelines more efficient. In practice, it’s usually best to implement caching within [resources](/guides/build/external-resources) rather than [assets](/guides/build/assets), since this makes the functionality easier to share and reuse.

--- a/docs/docs/examples/mini-examples/shared-module.md
+++ b/docs/docs/examples/mini-examples/shared-module.md
@@ -5,7 +5,6 @@ last_update:
   author: Dennis Hume
 sidebar_custom_props:
   logo: images/dagster-primary-mark.svg
-  miniProject: true
 tags: [mini-project]
 ---
 

--- a/docs/docs/examples/mini-examples/shared-module.md
+++ b/docs/docs/examples/mini-examples/shared-module.md
@@ -5,7 +5,6 @@ last_update:
   author: Dennis Hume
 sidebar_custom_props:
   logo: images/dagster-primary-mark.svg
-tags: [mini-project]
 ---
 
 In this example, we'll explore strategies for sharing code across Dagster [code locations](/deployment/code-locations). This is useful when you have utility functions, factories, or helpers that are used in multiple places and you want to avoid duplication.

--- a/docs/docs/examples/reference-architectures/bi.md
+++ b/docs/docs/examples/reference-architectures/bi.md
@@ -5,7 +5,6 @@ last_update:
   author: Dennis Hume
 sidebar_custom_props:
   logo: images/integrations/looker.svg
-  referenceArchitecture: true
 tags: [reference-architecture]
 ---
 

--- a/docs/docs/examples/reference-architectures/bi.md
+++ b/docs/docs/examples/reference-architectures/bi.md
@@ -5,7 +5,6 @@ last_update:
   author: Dennis Hume
 sidebar_custom_props:
   logo: images/integrations/looker.svg
-tags: [reference-architecture]
 ---
 
 ## Objective

--- a/docs/docs/examples/reference-architectures/etl-reverse-etl.md
+++ b/docs/docs/examples/reference-architectures/etl-reverse-etl.md
@@ -5,7 +5,6 @@ last_update:
   author: Dennis Hume
 sidebar_custom_props:
   logo: images/integrations/snowflake.svg
-tags: [reference-architecture]
 ---
 
 ## Objective

--- a/docs/docs/examples/reference-architectures/etl-reverse-etl.md
+++ b/docs/docs/examples/reference-architectures/etl-reverse-etl.md
@@ -5,7 +5,6 @@ last_update:
   author: Dennis Hume
 sidebar_custom_props:
   logo: images/integrations/snowflake.svg
-  referenceArchitecture: true
 tags: [reference-architecture]
 ---
 

--- a/docs/docs/examples/reference-architectures/rag.md
+++ b/docs/docs/examples/reference-architectures/rag.md
@@ -5,7 +5,6 @@ last_update:
   author: Dennis Hume
 sidebar_custom_props:
   logo: images/integrations/weaviate.png
-tags: [reference-architecture]
 ---
 
 ## Objective

--- a/docs/docs/examples/reference-architectures/rag.md
+++ b/docs/docs/examples/reference-architectures/rag.md
@@ -5,7 +5,6 @@ last_update:
   author: Dennis Hume
 sidebar_custom_props:
   logo: images/integrations/weaviate.png
-  referenceArchitecture: true
 tags: [reference-architecture]
 ---
 

--- a/docs/docs/examples/reference-architectures/real-time.md
+++ b/docs/docs/examples/reference-architectures/real-time.md
@@ -5,7 +5,6 @@ last_update:
   author: Dennis Hume
 sidebar_custom_props:
   logo: images/integrations/clickhouse.png
-tags: [reference-architecture]
 ---
 
 ## Objective

--- a/docs/docs/examples/reference-architectures/real-time.md
+++ b/docs/docs/examples/reference-architectures/real-time.md
@@ -5,7 +5,6 @@ last_update:
   author: Dennis Hume
 sidebar_custom_props:
   logo: images/integrations/clickhouse.png
-  referenceArchitecture: true
 tags: [reference-architecture]
 ---
 

--- a/docs/docs/tags.yml
+++ b/docs/docs/tags.yml
@@ -42,18 +42,10 @@ other:
   label: 'other'
   permalink: '/integrations/other'
   description: 'Other integrations'
-reference-architecture:
-  label: 'reference-architecture'
-  permalink: '/examples/reference-architecture'
-  description: 'Reference architecture.'
 code-example:
   label: 'code-example'
   permalink: '/examples/code-example'
   description: 'Code example.'
-mini-project:
-  label: 'mini-project'
-  permalink: '/examples/mini-project'
-  description: 'Mini project.'
 dagster-plus-feature:
   label: 'dagster-plus-feature'
   permalink: '/features/dagster-plus-feature'

--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -47,16 +47,12 @@ function CardLayout({
   title,
   description,
   community,
-  referenceArchitecture,
-  miniProject,
 }: {
   href: string;
   title: string;
   logo?: string;
   description?: string;
   community: boolean;
-  referenceArchitecture: boolean;
-  miniProject: boolean;
 }): ReactNode {
   return (
     <CardContainer href={href}>
@@ -83,16 +79,6 @@ function CardLayout({
                 <div className={clsx(styles.cardTags)}>Community</div>
               </span>
             )}
-            {referenceArchitecture && (
-              <span style={{marginLeft: 'auto'}}>
-                <div className={clsx(styles.cardTags)}>Reference architecture</div>
-              </span>
-            )}
-            {miniProject && (
-              <span style={{marginLeft: 'auto'}}>
-                <div className={clsx(styles.cardTags)}>Mini</div>
-              </span>
-            )}
           </div>
           {description && (
             <p className={clsx(styles.cardDescription)} title={description}>
@@ -115,7 +101,6 @@ function CardCategory({item}: {item: PropSidebarItemCategory}): ReactNode {
   }
 
   const logo: string | null = (item?.customProps?.logo as string) || null;
-  const miniProject: boolean = (item?.customProps?.miniProject as boolean) || false;
 
   return (
     <CardLayout
@@ -124,8 +109,6 @@ function CardCategory({item}: {item: PropSidebarItemCategory}): ReactNode {
       logo={logo}
       description={item.description ?? categoryItemsPlural(item.items.length)}
       community={false}
-      referenceArchitecture={false}
-      miniProject={false}
     />
   );
 }
@@ -135,8 +118,6 @@ function CardLink({item}: {item: PropSidebarItemLink}): ReactNode {
   //const icon = item?.customProps?.myEmoji ?? (isInternalUrl(item.href) ? '📄️' : '🔗');
   const logo: string | null = (item?.customProps?.logo as string) || null;
   const community: boolean = (item?.customProps?.community as boolean) || false;
-  const referenceArchitecture: boolean = (item?.customProps?.referenceArchitecture as boolean) || false;
-  const miniProject: boolean = (item?.customProps?.miniProject as boolean) || false;
   const doc = useDocById(item.docId ?? undefined);
 
   return (
@@ -146,8 +127,6 @@ function CardLink({item}: {item: PropSidebarItemLink}): ReactNode {
       title={item.label}
       description={item.description ?? doc?.description}
       community={community}
-      referenceArchitecture={referenceArchitecture}
-      miniProject={miniProject}
     />
   );
 }


### PR DESCRIPTION
## Summary & Motivation

Remove the specialty tags for mini examples (`miniProject`) and reference architectures (`referenceArchitecture`)

Before:

<img width="1353" height="494" alt="Screenshot 2025-10-01 at 3 18 36 PM" src="https://github.com/user-attachments/assets/4d0112b9-aac6-4ab5-b811-ee2d0bff84df" />

After:

<img width="1350" height="482" alt="Screenshot 2025-10-01 at 3 36 10 PM" src="https://github.com/user-attachments/assets/29b9ee29-7818-49a5-a4c4-214ded000406" />

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
