### PR TITLE
[ui] Unify timing and pez for jobs/assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
@@ -1,132 +1,61 @@
-import {
-  Body,
-  Box,
-  Colors,
-  Icon,
-  Popover,
-  Skeleton,
-  useDelayedState,
-} from '@dagster-io/ui-components';
+import {Body, Box, Colors, Icon, Popover} from '@dagster-io/ui-components';
 import React, {ReactNode, useMemo} from 'react';
 import {Link} from 'react-router-dom';
-import styled from 'styled-components';
 
-import {AssetHealthSummary} from './AssetHealthSummary';
-import {useRecentAssetEventsForCatalogView} from './useRecentAssetEvents';
-import {useRefreshAtInterval} from '../app/QueryRefresh';
 import {Timestamp} from '../app/time/Timestamp';
-import {AssetEventHistoryEventTypeSelector, RunStatus} from '../graphql/types';
-import {TimeFromNow} from '../ui/TimeFromNow';
+import {RunStatus} from '../graphql/types';
+import {PezItem, calculatePezOpacity} from '../ui/PezItem';
 
-const INTERVAL_MSEC = 30 * 1000;
+interface Props {
+  latestInfo?: EventForPopover;
+  events: EventForPopover[];
+}
 
-export const AssetRecentUpdatesTrend = React.memo(({asset}: {asset: {key: {path: string[]}}}) => {
-  // Wait 100ms to avoid querying during fast scrolling of the table
-  const shouldQuery = useDelayedState(500);
-  const {
-    events: _events,
-    latestInfo,
-    loading,
-    refetch,
-  } = useRecentAssetEventsForCatalogView({
-    assetKey: shouldQuery ? asset.key : undefined,
-    limit: 5,
-    eventTypeSelectors: [
-      AssetEventHistoryEventTypeSelector.MATERIALIZATION,
-      AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE,
-      AssetEventHistoryEventTypeSelector.OBSERVATION,
-    ],
-  });
+export const AssetRecentUpdatesTrend = React.memo(({latestInfo, events}: Props) => {
+  const items = latestInfo ? [latestInfo, ...events] : [...events];
+  const emptyItems = new Array(5 - items.length).fill(null);
+  const allItems = [...items, ...emptyItems].reverse();
 
-  const {events} = useMemo(() => {
-    if (!latestInfo?.inProgressRunIds.length && !latestInfo?.unstartedRunIds.length) {
-      return {events: _events};
+  const states = allItems.map((event, index) => {
+    const opacity = calculatePezOpacity(index, 5);
+
+    const key = () => {
+      switch (event?.__typename) {
+        case 'AssetLatestInfo':
+          return event.latestRun?.id ?? index;
+        case 'FailedToMaterializeEvent':
+        case 'ObservationEvent':
+        case 'MaterializationEvent':
+          return event.runId;
+        default:
+          return index;
+      }
+    };
+
+    if (!event) {
+      return <PezItem key={key()} opacity={opacity} color={Colors.backgroundDisabled()} />;
     }
-    return {events: [latestInfo, ..._events]};
-  }, [latestInfo, _events]);
 
-  useRefreshAtInterval({
-    refresh: refetch,
-    intervalMs: INTERVAL_MSEC,
-    enabled: shouldQuery,
+    const color = () => {
+      switch (event.__typename) {
+        case 'AssetLatestInfo':
+          return Colors.accentBlue();
+        case 'FailedToMaterializeEvent':
+          return Colors.accentRed();
+        default:
+          return Colors.accentGreen();
+      }
+    };
+
+    return (
+      <EventPopover key={key()} event={event}>
+        <PezItem opacity={opacity} color={color()} />
+      </EventPopover>
+    );
   });
 
-  const states = useMemo(() => {
-    return new Array(5).fill(null).map((_, _index) => {
-      const index = 4 - _index;
-      const event = events[index];
-      if (!event) {
-        return <Pill key={index} $index={index} $color={Colors.backgroundDisabled()} />;
-      }
-      if (event.__typename === 'AssetLatestInfo') {
-        return (
-          <EventPopover key={index} event={event}>
-            <Pill $index={index} $color={Colors.accentBlue()} />
-          </EventPopover>
-        );
-      }
-      if (event.__typename === 'FailedToMaterializeEvent') {
-        return (
-          <EventPopover key={index} event={event}>
-            <Pill $index={index} $color={Colors.accentRed()} />
-          </EventPopover>
-        );
-      }
-      return (
-        <EventPopover key={index} event={event}>
-          <Pill $index={index} $color={Colors.accentGreen()} />
-        </EventPopover>
-      );
-    });
-  }, [events]);
-
-  const lastEvent = _events[0];
-
-  return (
-    <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
-      {(loading || !shouldQuery) && !lastEvent ? (
-        <Skeleton $width={100} $height={21} />
-      ) : (
-        <>
-          <EventPopover event={lastEvent}>
-            {lastEvent ? (
-              <Body color={Colors.textLight()}>
-                <TimeFromNow
-                  unixTimestamp={Number(lastEvent.timestamp) / 1000}
-                  showTooltip={false}
-                />
-              </Body>
-            ) : (
-              ' - '
-            )}
-          </EventPopover>
-          <Box flex={{direction: 'row', alignItems: 'center', gap: 2}}>{states}</Box>
-          <div style={{height: 13, width: 1, background: Colors.keylineDefault()}} />
-        </>
-      )}
-      <AssetHealthSummary assetKey={asset.key} iconOnly />
-    </Box>
-  );
+  return <Box flex={{direction: 'row', alignItems: 'center', gap: 2}}>{states}</Box>;
 });
-
-const Pill = styled.div<{$index: number; $color: string}>`
-  border-radius: 2px;
-  height: 16px;
-  width: 6px;
-  background: ${({$color}) => $color};
-  opacity: ${({$index}) => OPACITIES[$index] ?? 1};
-  &:hover {
-    box-shadow: 0 0 0 1px ${Colors.accentGrayHover()};
-  }
-`;
-
-const OPACITIES: Record<number, number> = {
-  0: 1,
-  1: 0.8,
-  2: 0.66,
-  3: 0.4,
-  4: 0.2,
-};
 
 type EventForPopover =
   | {
@@ -141,7 +70,7 @@ type EventForPopover =
   | {__typename: 'ObservationEvent'; runId: string; timestamp: string}
   | {__typename: 'MaterializationEvent'; runId: string; timestamp: string};
 
-const EventPopover = React.memo(
+export const EventPopover = React.memo(
   ({event, children}: {event?: EventForPopover; children: ReactNode}) => {
     const {content, icon, runId, timestamp} = useMemo(() => {
       switch (event?.__typename) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetRecentUpdates.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetRecentUpdates.tsx
@@ -1,0 +1,38 @@
+import {useDelayedState} from '@dagster-io/ui-components';
+
+import {useRecentAssetEventsForCatalogView} from './useRecentAssetEvents';
+import {useRefreshAtInterval} from '../app/QueryRefresh';
+import {AssetEventHistoryEventTypeSelector} from '../graphql/types';
+
+const INTERVAL_MSEC = 30 * 1000;
+
+type Config = {
+  asset: {key: {path: string[]}};
+};
+
+export const useAssetRecentUpdates = ({asset}: Config) => {
+  // Wait 100ms to avoid querying during fast scrolling of the table
+  const shouldQuery = useDelayedState(500);
+  const {
+    events: recentEvents,
+    latestInfo,
+    loading,
+    refetch,
+  } = useRecentAssetEventsForCatalogView({
+    assetKey: shouldQuery ? asset.key : undefined,
+    limit: 5,
+    eventTypeSelectors: [
+      AssetEventHistoryEventTypeSelector.MATERIALIZATION,
+      AssetEventHistoryEventTypeSelector.FAILED_TO_MATERIALIZE,
+      AssetEventHistoryEventTypeSelector.OBSERVATION,
+    ],
+  });
+
+  useRefreshAtInterval({
+    refresh: refetch,
+    intervalMs: INTERVAL_MSEC,
+    enabled: shouldQuery,
+  });
+
+  return {recentEvents, latestInfo, loading: loading || !shouldQuery};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusPez.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusPez.tsx
@@ -9,6 +9,7 @@ import {RunStateSummary, RunTime, titleForRun} from './RunUtils';
 import {RunTimeFragment} from './types/RunUtils.types';
 import {RunStatus} from '../graphql/types';
 import {StepSummaryForRun} from '../instance/StepSummaryForRun';
+import {PezItem} from '../ui/PezItem';
 
 const MIN_OPACITY = 0.2;
 const MAX_OPACITY = 1.0;
@@ -54,7 +55,9 @@ export const RunStatusPezList = (props: ListProps) => {
       {items.map((run, ii) => {
         const opacity = fade ? MAX_OPACITY - (count - ii - 1) * step : 1.0;
         if (!run) {
-          return <Pez key={`empty-${ii}`} $color={Colors.backgroundLighter()} $opacity={opacity} />;
+          return (
+            <PezItem key={`empty-${ii}`} color={Colors.backgroundLighter()} opacity={opacity} />
+          );
         }
 
         return (
@@ -69,7 +72,7 @@ export const RunStatusPezList = (props: ListProps) => {
             }
             hoverOpenDelay={100}
           >
-            <RunStatusPez key={run.id} runId={run.id} status={run.status} opacity={opacity} />
+            <PezItem key={run.id} color={RUN_STATUS_COLORS[run.status]} opacity={opacity} />
           </Popover>
         );
       })}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/PezItem.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/PezItem.tsx
@@ -1,0 +1,27 @@
+import {CSSProperties} from 'react';
+
+import styles from './css/PezItem.module.css';
+
+const MIN_OPACITY = 0.2;
+const MAX_OPACITY = 1.0;
+const MIN_OPACITY_STEPS = 3;
+
+interface Props {
+  color: string;
+  opacity: number;
+}
+
+export const PezItem = ({color, opacity}: Props) => {
+  return (
+    <div
+      className={styles.pezItem}
+      style={{'--pez-color': color, '--pez-opacity': opacity} as CSSProperties}
+    />
+  );
+};
+
+export const calculatePezOpacity = (index: number, total: number) => {
+  const countForStep = Math.max(MIN_OPACITY_STEPS, total);
+  const step = (MAX_OPACITY - MIN_OPACITY) / countForStep;
+  return MAX_OPACITY - (total - index - 1) * step;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/css/PezItem.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/css/PezItem.module.css
@@ -1,0 +1,12 @@
+.pezItem {
+  border-radius: 2px;
+  height: 16px;
+  width: 6px;
+  background: var(--pez-color);
+  opacity: var(--pez-opacity);
+  transition: opacity 0.2s ease-in-out;
+}
+
+.pezItem:hover {
+  opacity: 1;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedObserveJobRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedObserveJobRow.tsx
@@ -18,7 +18,6 @@ import {SINGLE_JOB_QUERY} from './SingleJobQuery';
 import {TimeFromNow} from '../ui/TimeFromNow';
 import {SingleJobQuery, SingleJobQueryVariables} from './types/SingleJobQuery.types';
 import {JobMenu} from '../instance/JobMenu';
-import {RunStatusIndicator} from '../runs/RunStatusDots';
 import {RunStatusOverlay, RunStatusPezList} from '../runs/RunStatusPez';
 import {buildPipelineSelector} from './WorkspaceContext/util';
 import {RepoAddress} from './types';
@@ -97,10 +96,7 @@ export const VirtualizedObserveJobRow = forwardRef(
                   hoverOpenDelay={100}
                 >
                   <HoverButton>
-                    <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
-                      <RunStatusIndicator status={latestRuns[0].status} />
-                      <TimeFromNow unixTimestamp={latestRuns[0].startTime} />
-                    </Box>
+                    <TimeFromNow unixTimestamp={latestRuns[0].startTime} showTooltip={false} />
                   </HoverButton>
                 </Popover>
               ) : null,


### PR DESCRIPTION
## Summary & Motivation

The right-side elements of the job list and catalog list are similar but different, including the "pez" list that shows recent runs and materializations.

Unify these a bit better.

Asset catalog:

<img width="405" height="265" alt="Screenshot 2025-10-01 at 15 33 29" src="https://github.com/user-attachments/assets/7e382c64-9745-4bba-a6d9-745cbe160076" />

Jobs:

<img width="350" height="256" alt="Screenshot 2025-10-01 at 14 52 15" src="https://github.com/user-attachments/assets/a7682875-81a7-4144-9713-cd9b05ade78e" />


## How I Tested These Changes

View Catalog and Job list. Verify that the pez and timing information renders roughly the same in both.