### PR TITLE
Loaderify remote job loading in graphql layer

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_pipelines.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_pipelines.py
@@ -13,13 +13,13 @@ if TYPE_CHECKING:
     from dagster_graphql.schema.pipelines.snapshot import GraphenePipelineSnapshot
 
 
-def get_job_snapshot_or_error_from_job_selector(
+async def get_job_snapshot_or_error_from_job_selector(
     graphene_info: ResolveInfo, job_selector: JobSubsetSelector
 ) -> "GraphenePipelineSnapshot":
     from dagster_graphql.schema.pipelines.snapshot import GraphenePipelineSnapshot
 
     check.inst_param(job_selector, "pipeline_selector", JobSubsetSelector)
-    return GraphenePipelineSnapshot(get_full_remote_job_or_raise(graphene_info, job_selector))
+    return GraphenePipelineSnapshot(await get_full_remote_job_or_raise(graphene_info, job_selector))
 
 
 def get_job_snapshot_or_error_from_snapshot_id(
@@ -30,7 +30,7 @@ def get_job_snapshot_or_error_from_snapshot_id(
     return _get_job_snapshot_from_instance(graphene_info.context.instance, snapshot_id)
 
 
-def get_job_snapshot_or_error_from_snap_or_selector(
+async def get_job_snapshot_or_error_from_snap_or_selector(
     graphene_info: ResolveInfo,
     job_selector: JobSubsetSelector,
     snapshot_id: str,
@@ -42,7 +42,7 @@ def get_job_snapshot_or_error_from_snap_or_selector(
         if job_snapshot:
             return GraphenePipelineSnapshot(job_snapshot)
 
-    return get_job_snapshot_or_error_from_job_selector(graphene_info, job_selector)
+    return await get_job_snapshot_or_error_from_job_selector(graphene_info, job_selector)
 
 
 # extracted this out to test

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -297,7 +297,7 @@ def get_runs_count(graphene_info: "ResolveInfo", filters: Optional[RunsFilter]) 
     return graphene_info.context.instance.get_runs_count(filters)
 
 
-def validate_pipeline_config(
+async def validate_pipeline_config(
     graphene_info: "ResolveInfo",
     selector: JobSubsetSelector,
     run_config: Union[str, Mapping[str, object]],
@@ -306,12 +306,12 @@ def validate_pipeline_config(
 
     check.inst_param(selector, "selector", JobSubsetSelector)
 
-    remote_job = get_remote_job_or_raise(graphene_info, selector)
+    remote_job = await get_remote_job_or_raise(graphene_info, selector)
     ensure_valid_config(remote_job, run_config)
     return GraphenePipelineConfigValidationValid(pipeline_name=remote_job.name)
 
 
-def get_execution_plan(
+async def get_execution_plan(
     graphene_info: "ResolveInfo",
     selector: JobSubsetSelector,
     run_config: Mapping[str, Any],
@@ -320,7 +320,7 @@ def get_execution_plan(
 
     check.inst_param(selector, "selector", JobSubsetSelector)
 
-    remote_job = get_remote_job_or_raise(graphene_info, selector)
+    remote_job = await get_remote_job_or_raise(graphene_info, selector)
     ensure_valid_config(remote_job, run_config)
     return GrapheneExecutionPlan(
         graphene_info.context.get_execution_plan(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/run_config_schema.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/run_config_schema.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from dagster_graphql.schema.run_config import GrapheneRunConfigSchema
 
 
-def resolve_run_config_schema_or_error(
+async def resolve_run_config_schema_or_error(
     graphene_info: ResolveInfo, selector: JobSubsetSelector, mode: Optional[str] = None
 ) -> "GrapheneRunConfigSchema":
     from dagster_graphql.schema.run_config import GrapheneRunConfigSchema
@@ -29,7 +29,7 @@ def resolve_run_config_schema_or_error(
     if mode and mode != DEFAULT_MODE_NAME:
         return GrapheneModeNotFoundError(selector=selector, mode=mode)
 
-    remote_job = get_remote_job_or_raise(graphene_info, selector)
+    remote_job = await get_remote_job_or_raise(graphene_info, selector)
 
     return GrapheneRunConfigSchema(
         represented_job=remote_job,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -102,7 +102,7 @@ from dagster_graphql.schema.sensors import (
 from dagster_graphql.schema.util import ResolveInfo, non_null_list
 
 
-def create_execution_params(graphene_info, graphql_execution_params):
+async def create_execution_params(graphene_info, graphql_execution_params):
     preset_name = graphql_execution_params.get("preset")
     selector = pipeline_selector_from_graphql(graphql_execution_params["selector"])
     if preset_name:
@@ -123,7 +123,7 @@ def create_execution_params(graphene_info, graphql_execution_params):
                 )
             )
 
-        external_pipeline = get_full_remote_job_or_raise(
+        external_pipeline = await get_full_remote_job_or_raise(
             graphene_info,
             selector,
         )
@@ -288,14 +288,14 @@ class GrapheneTerminateRunsResultOrError(graphene.Union):
         name = "TerminateRunsResultOrError"
 
 
-def create_execution_params_and_launch_pipeline_exec(graphene_info, execution_params_dict):
-    execution_params = create_execution_params(graphene_info, execution_params_dict)
+async def create_execution_params_and_launch_pipeline_exec(graphene_info, execution_params_dict):
+    execution_params = await create_execution_params(graphene_info, execution_params_dict)
     assert_permission_for_location(
         graphene_info,
         Permissions.LAUNCH_PIPELINE_EXECUTION,
         execution_params.selector.location_name,
     )
-    return launch_pipeline_execution(
+    return await launch_pipeline_execution(
         graphene_info,
         execution_params,
     )
@@ -314,10 +314,12 @@ class GrapheneLaunchRunMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.LAUNCH_PIPELINE_EXECUTION)
-    def mutate(
+    async def mutate(
         self, graphene_info: ResolveInfo, executionParams: GrapheneExecutionParams
     ) -> Union[GrapheneLaunchRunSuccess, GrapheneError, GraphenePythonError]:
-        return create_execution_params_and_launch_pipeline_exec(graphene_info, executionParams)
+        return await create_execution_params_and_launch_pipeline_exec(
+            graphene_info, executionParams
+        )
 
 
 class GrapheneLaunchMultipleRunsMutation(graphene.Mutation):
@@ -332,7 +334,7 @@ class GrapheneLaunchMultipleRunsMutation(graphene.Mutation):
         name = "LaunchMultipleRunsMutation"
 
     @capture_error
-    def mutate(
+    async def mutate(
         self, graphene_info: ResolveInfo, executionParamsList: list[GrapheneExecutionParams]
     ) -> Union[
         GrapheneLaunchMultipleRunsResult,
@@ -342,8 +344,10 @@ class GrapheneLaunchMultipleRunsMutation(graphene.Mutation):
         launch_multiple_runs_result = []
 
         for execution_params in executionParamsList:
-            result = GrapheneLaunchRunMutation.mutate(
-                None, graphene_info, executionParams=execution_params
+            result = await GrapheneLaunchRunMutation.mutate(
+                None,  # type: ignore
+                graphene_info,
+                executionParams=execution_params,
             )
             launch_multiple_runs_result.append(result)
 
@@ -482,14 +486,14 @@ class GrapheneDeleteDynamicPartitionsMutation(graphene.Mutation):
         )
 
 
-def create_execution_params_and_launch_pipeline_reexec(graphene_info, execution_params_dict):
-    execution_params = create_execution_params(graphene_info, execution_params_dict)
+async def create_execution_params_and_launch_pipeline_reexec(graphene_info, execution_params_dict):
+    execution_params = await create_execution_params(graphene_info, execution_params_dict)
     assert_permission_for_location(
         graphene_info,
         Permissions.LAUNCH_PIPELINE_REEXECUTION,
         execution_params.selector.location_name,
     )
-    return launch_pipeline_reexecution(graphene_info, execution_params=execution_params)
+    return await launch_pipeline_reexecution(graphene_info, execution_params=execution_params)
 
 
 class GrapheneLaunchRunReexecutionMutation(graphene.Mutation):
@@ -506,7 +510,7 @@ class GrapheneLaunchRunReexecutionMutation(graphene.Mutation):
 
     @capture_error
     @require_permission_check(Permissions.LAUNCH_PIPELINE_REEXECUTION)
-    def mutate(
+    async def mutate(
         self,
         graphene_info: ResolveInfo,
         executionParams: Optional[GrapheneExecutionParams] = None,
@@ -518,7 +522,7 @@ class GrapheneLaunchRunReexecutionMutation(graphene.Mutation):
             )
 
         if executionParams:
-            return create_execution_params_and_launch_pipeline_reexec(
+            return await create_execution_params_and_launch_pipeline_reexec(
                 graphene_info,
                 execution_params_dict=executionParams,
             )
@@ -531,7 +535,7 @@ class GrapheneLaunchRunReexecutionMutation(graphene.Mutation):
             if reexecutionParams.get("useParentRunTags") is not None:
                 use_parent_run_tags = reexecutionParams["useParentRunTags"]
 
-            return launch_reexecution_from_parent_run(
+            return await launch_reexecution_from_parent_run(
                 graphene_info,
                 parent_run_id=reexecutionParams["parentRunId"],
                 strategy=reexecutionParams["strategy"],

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -693,7 +693,7 @@ class GrapheneQuery(graphene.ObjectType):
         return fetch_location_statuses(graphene_info.context)
 
     @capture_error
-    def resolve_pipelineSnapshotOrError(
+    async def resolve_pipelineSnapshotOrError(
         self,
         graphene_info: ResolveInfo,
         snapshotId: Optional[str] = None,
@@ -702,10 +702,10 @@ class GrapheneQuery(graphene.ObjectType):
         if activePipelineSelector:
             job_selector = pipeline_selector_from_graphql(activePipelineSelector)
             if snapshotId:
-                return get_job_snapshot_or_error_from_snap_or_selector(
+                return await get_job_snapshot_or_error_from_snap_or_selector(
                     graphene_info, job_selector, snapshotId
                 )
-            return get_job_snapshot_or_error_from_job_selector(graphene_info, job_selector)
+            return await get_job_snapshot_or_error_from_job_selector(graphene_info, job_selector)
         elif snapshotId:
             return get_job_snapshot_or_error_from_snapshot_id(graphene_info, snapshotId)
         else:
@@ -838,9 +838,11 @@ class GrapheneQuery(graphene.ObjectType):
         )
 
     @capture_error
-    def resolve_pipelineOrError(self, graphene_info: ResolveInfo, params: GraphenePipelineSelector):
+    async def resolve_pipelineOrError(
+        self, graphene_info: ResolveInfo, params: GraphenePipelineSelector
+    ):
         return GraphenePipeline(
-            get_remote_job_or_raise(graphene_info, pipeline_selector_from_graphql(params))
+            await get_remote_job_or_raise(graphene_info, pipeline_selector_from_graphql(params))
         )
 
     @capture_error
@@ -994,41 +996,41 @@ class GrapheneQuery(graphene.ObjectType):
         return get_run_group(graphene_info, runId)
 
     @capture_error
-    def resolve_isPipelineConfigValid(
+    async def resolve_isPipelineConfigValid(
         self,
         graphene_info: ResolveInfo,
         pipeline: GraphenePipelineSelector,
         mode: str,
         runConfigData: Optional[Any] = None,  # custom scalar (GrapheneRunConfigData)
     ):
-        return validate_pipeline_config(
+        return await validate_pipeline_config(
             graphene_info,
             pipeline_selector_from_graphql(pipeline),
             parse_run_config_input(runConfigData or {}, raise_on_error=False),
         )
 
     @capture_error
-    def resolve_executionPlanOrError(
+    async def resolve_executionPlanOrError(
         self,
         graphene_info: ResolveInfo,
         pipeline: GraphenePipelineSelector,
         mode: str,
         runConfigData: Optional[Any] = None,  # custom scalar (GrapheneRunConfigData)
     ):
-        return get_execution_plan(
+        return await get_execution_plan(
             graphene_info,
             pipeline_selector_from_graphql(pipeline),
             parse_run_config_input(runConfigData or {}, raise_on_error=True),  # type: ignore  # (possible str)
         )
 
     @capture_error
-    def resolve_runConfigSchemaOrError(
+    async def resolve_runConfigSchemaOrError(
         self,
         graphene_info: ResolveInfo,
         selector: GraphenePipelineSelector,
         mode: Optional[str] = None,
     ):
-        return resolve_run_config_schema_or_error(
+        return await resolve_run_config_schema_or_error(
             graphene_info, pipeline_selector_from_graphql(selector), mode
         )
 

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -173,17 +173,8 @@ class CodeLocation(AbstractContextManager):
         subset_result = self._get_subset_remote_job_result(selector)
         return self._get_remote_job_from_subset_result(selector, subset_result)
 
-    async def gen_job(self, selector: JobSubsetSelector) -> RemoteJob:
-        """Return the RemoteJob for a specific pipeline. Subclasses only
-        need to implement gen_subset_remote_job_result to handle the case where
-        an op selection is specified, which requires access to the underlying JobDefinition
-        to generate the subsetted pipeline snapshot.
-        """
-        if not selector.is_subset_selection:
-            return self.get_repository(selector.repository_name).get_full_job(selector.job_name)
-
+    async def gen_subset_job(self, selector: JobSubsetSelector) -> RemoteJob:
         subset_result = await self._gen_subset_remote_job_result(selector)
-
         return self._get_remote_job_from_subset_result(selector, subset_result)
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -319,7 +319,10 @@ class BaseWorkspaceRequestContext(LoadingContext):
         self,
         selector: JobSubsetSelector,
     ) -> RemoteJob:
-        return await self.get_code_location(selector.location_name).gen_job(selector)
+        if not selector.is_subset_selection:
+            return self.get_full_job(selector)
+
+        return await self.get_code_location(selector.location_name).gen_subset_job(selector)
 
     def get_execution_plan(
         self,

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
@@ -78,20 +78,7 @@ async def test_async_job_snapshot_api_grpc(instance):
 
         assert (
             code_location.get_job(subset_selector).job_snapshot
-            == (await code_location.gen_job(subset_selector)).job_snapshot
-        )
-
-        full_selector = JobSubsetSelector(
-            location_name=code_location.name,
-            repository_name="bar_repo",
-            job_name="foo",
-            op_selection=None,
-            asset_selection=None,
-        )
-
-        assert (
-            code_location.get_job(full_selector).job_snapshot
-            == (await code_location.gen_job(full_selector)).job_snapshot
+            == (await code_location.gen_subset_job(subset_selector)).job_snapshot
         )
 
 


### PR DESCRIPTION
Summary:
Ensures that when we fetch teh run config schema and remote job in teh same graphql query, they go through a shared batching layer (as long as they pass in the same selector).

Test Plan:
Bk

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
