### PR TITLE
Enable adding output_metadata via build_output_context

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -836,6 +836,7 @@ def build_output_context(
     partition_key: Optional[str] = None,
     # deprecated
     metadata: Optional[Mapping[str, RawMetadataValue]] = None,
+    output_metadata: Optional[Mapping[str, RawMetadataValue]] = None,
 ) -> "OutputContext":
     """Builds output context from provided parameters.
 
@@ -863,6 +864,8 @@ def build_output_context(
             output.
         partition_key: Optional[str]: String value representing partition key to execute with.
         metadata (Optional[Mapping[str, Any]]): Deprecated. Use definition_metadata instead.
+        output_metadata (Optional[Mapping[str, Any]]): A dict of the metadata that is assigned to the
+            output at execution time.
 
     Examples:
         .. code-block:: python
@@ -896,6 +899,7 @@ def build_output_context(
     op_def = check.opt_inst_param(op_def, "op_def", OpDefinition)
     asset_key = AssetKey.from_coercible(asset_key) if asset_key else None
     partition_key = check.opt_str_param(partition_key, "partition_key")
+    output_metadata = check.opt_mapping_param(output_metadata, "output_metadata", key_type=str)
 
     return OutputContext(
         step_key=step_key,
@@ -914,4 +918,5 @@ def build_output_context(
         op_def=op_def,
         asset_key=asset_key,
         partition_key=partition_key,
+        output_metadata=output_metadata,
     )

--- a/python_modules/dagster/dagster_tests/execution_tests/context_tests/test_output.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/context_tests/test_output.py
@@ -29,3 +29,18 @@ def test_build_output_context_asset_spec():
             pass
 
     dg.materialize([asset_spec], resources={"io_manager": TestIOManager()})
+
+
+def test_build_output_context_with_output_metadata():
+    expected_metadata = {"foo": "bar"}
+    output_context = dg.build_output_context(output_metadata=expected_metadata)
+
+    class TestIOManager(dg.IOManager):
+        def handle_output(self, context: OutputContext, obj: object):
+            assert context.output_metadata == expected_metadata
+
+        def load_input(self, context: InputContext) -> Any:
+            pass
+
+    io_manager = TestIOManager()
+    io_manager.handle_output(output_context, "test")


### PR DESCRIPTION
## Summary & Motivation
While working on a PR for dagster-iceberg I found that `build_output_context` doesn't expose the `output_metadata` attribute of `OutputContext` for configuration. 

I tried using `context.add_output_metadata`, but found that it unintuitively does not actually mutate the `output_metadata` value of the `OutputContext` instance, so it can't be used to add `output_metadata` to an existing `OutputContext` instance created by `build_output_context`.

These changes enable a user to pass `output_metadata` to `build_output_context` and have it be set on the resulting `OutputContext` object.

## How I Tested These Changes
Added a unit test covering the new functionality. Ran the rest of the unit tests

## Changelog

- Enable passing `output_metadata` into `build_output_context`
