### PR TITLE
[databricks-pipes] Enable usage of notebook_task for PipesDatabricksClient

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -328,7 +328,15 @@ class PipesDatabricksClient(BasePipesDatabricksClient, TreatAsResourceParam):
                         f'Passing Pipes bootstrap parameters via Databricks parameters as "{key}.parameters". Make sure to use the PipesCliArgsParamsLoader in the task.'  # pyright: ignore[reportPossiblyUnboundVariable]
                     )
                     break
-
+                
+            # use env vars to pass pipes context in case of notebook_task
+            pipes_env_vars = session.get_bootstrap_env_vars()
+            if submit_task_dict.get("notebook_task"):
+                existing_params = submit_task_dict["notebook_task"].get("base_parameters", {})
+                # merge the existing parameters with the CLI arguments
+                existing_params = {**existing_params, **session.get_bootstrap_env_vars()}
+                submit_task_dict["notebook_task"]["base_parameters"] = existing_params
+                
         else:
             pipes_env_vars = session.get_bootstrap_env_vars()
 


### PR DESCRIPTION
## Summary & Motivation
Currently only `spark_python_task` and `python_wheel_task` are supported for `PipesDatabricksClient`. This PR enables us to use `notebook_task` as well.

## Changelog
* Add support for `notebook_task` in `PipesDatabricksClient`