### PR TITLE
[dg scaffold component] Fix: nested root_folder / nested component

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/scaffold.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/scaffold.py
@@ -21,7 +21,7 @@ def scaffold_component(
 ) -> None:
     module_parts = module_name.split(".")
     module_path = dg_context.root_path
-    for i in range(len(module_parts) - 1):
+    for i in range(len(dg_context.root_module_name.split(".")), len(module_parts) - 1):
         module = ".".join(module_parts[: i + 1])
         module_path = dg_context.get_path_for_local_module(module, require_exists=False)
         if not module_path.exists():


### PR DESCRIPTION
The scaffolding tool would previously fail to create a component and exit with
dagster_dg_core.error.DgError: Module `foo` is not part of the current project
if the root_module is not simple like root_module=foobar but nested like
root_module=foo.bar

fixed by adjusting the loop as OwenKephart proposed.

## Summary & Motivation
Fixing "dg scaffold component" for a) nested root_module and/or b) nested scaffolded Component. These previously gave errors or a wrong filename:

a)  `dg scaffold component Foo` gave an error (ie `dagster_dg_core.error.DgError: Module ``mycompany`` is not part of the current project.`) when the code location / project has nested root_module (ie `root_module="mycompany.myproduct.dagster.testproject2`")

b) (removed from commits) `dg scaffold component testproject1.components.more.nested.TestComponent` would have been created as file `src/testproject1.components.more.nested.py` instead of `src/testproject1.components.more.nested.test_component.py`, this is fixed too.

I'm aware project scaffolding supports only simple project_name=root_module right now as do test utilities (dagster_test/dg_utils/utils.py), but the `dg scaffold component` cli command can be fixed to work with any manually created projects.

Notes (see also comments in "How I Tested These Changes"):
* for simple root_module, if ./src subfolder is desired, it needs to be created before invoking `dg scaffold component`, otherwise it is not created and used.
* with the fix, in case of a nested root_module, the folder structure down to root_module should be created to prevent `FileNotFoundError` (you'd get a `dagster_dg_core.error.DgError` before whether folder exists or not)

## How I Tested These Changes
### Test1, with simple root_module ("testproject1")
#### Create code location:
```
$ mkdir /scaffoldtest1
$ cd /scaffoldtest1
$ cat << EOF > pyproject.toml
[build-system]
requires = ["setuptools"]
build-backend = "setuptools.build_meta"

[project]
name = "testproject1"
version = "0.1.0"
requires-python = ">=3.11,<3.13"
dependencies = [
    "dagster>=1.11.12"
]

[tool.dg]
directory_type = "project"

[tool.dg.project]
root_module = "testproject1"
code_location_name = "testproject1"
registry_modules = [
    "testproject1.components.*",
]
EOF
$ pip install -e .
$ mkdir src # this seems to be needed so ./src/testproject1 will be used 
            # instead of ./testproject1
```

#### Test simple component name:
(working without this PR)

`$ dg scaffold component TestComponent1`
should output these last lines:
```
Creating module at: /scaffoldtest1/src/testproject1
Creating module at: /scaffoldtest1/src/testproject1/components
Scaffolded Dagster component at /scaffoldtest1/src/testproject1/components/test_component1.py.
```

#### Test nested component:
(fixed by this PR)
`$ dg scaffold component testproject1.components.more.nested.TestComponent2`
should output these last lines:
```
Creating module at: /scaffoldtest1/src/testproject1/components/more
Creating module at: /scaffoldtest1/src/testproject1/components/more/nested
Scaffolded Dagster component at /scaffoldtest1/src/testproject1/components/more/nested/test_component2.py.
```

### Test2, with nested root_module ("mycompany.myproduct.dagster.testproject2")
#### Create code location
```
$ mkdir /scaffoldtest2
$ cd /scaffoldtest2
$ cat << EOF > pyproject.toml
[build-system]
requires = ["setuptools"]
build-backend = "setuptools.build_meta"

[project]
name = "myproduct-testproject2"
version = "0.1.0"
requires-python = ">=3.11,<3.13"
dependencies = [
    "dagster>=1.11.12"
]

[tool.dg]
directory_type = "project"

[tool.dg.project]
root_module = "mycompany.myproduct.dagster.testproject2"
code_location_name = "myproduct-testproject2"
registry_modules = [
    "mycompany.myproduct.dagster.testproject2.components.*",
]
EOF
$ pip install -e .
$ mkdir -p src/mycompany/myproduct/dagster/ # this is needed because of limitations of _parse_component_name
```

#### Test simple component name:
(fixed by this PR)
`$ dg scaffold component TestComponent3`
should output these last lines:
```
Creating module at: /scaffoldtest2/src/mycompany/myproduct/dagster/testproject2
Creating module at: /scaffoldtest2/src/mycompany/myproduct/dagster/testproject2/components
Scaffolded Dagster component at /scaffoldtest2/src/mycompany/myproduct/dagster/testproject2/components/test_component3.py.
```

#### Test nested component name:
(not fixed by this PR - fix not needed, see conversation)
`$ dg scaffold component mycompany.myproduct.dagster.testproject2.more.nested.TestComponent4`
should output these last lines:
```
Creating module at: /scaffoldtest2/src/mycompany/myproduct/dagster/testproject2/more
Creating module at: /scaffoldtest2/src/mycompany/myproduct/dagster/testproject2/more/nested
Scaffolded Dagster component at /scaffoldtest2/src/mycompany/myproduct/dagster/testproject2/more/nested/test_component4.py.
```

