### PR TITLE
[ui] Allow filtering runs feed by code location

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
@@ -43,6 +43,7 @@ const filters: RunFilterTokenType[] = [
   'partition',
   'backfill',
   'status',
+  'code_location',
 ];
 
 export const RunsFeedRoot = () => {


### PR DESCRIPTION
## Summary & Motivation

Allow filtering the runs feed by code location, leveraging the hidden `.dagster/repository` tag.

![Screenshot 2025-10-02 at 14.03.05.png](https://app.graphite.dev/user-attachments/assets/9858feef-1421-46b4-a56b-81f8e764fc3f.png)



## How I Tested These Changes

Proxy elementl, view Runs and filter by code location. Verify correct filtering behavior.

## Changelog

[ui] The Runs list can now be filtered by code location.