### PR TITLE
[docs] add tips on updating the github action tag

### DIFF
--- a/docs/docs/deployment/dagster-plus/ci-cd/ci-cd-in-hybrid.md
+++ b/docs/docs/deployment/dagster-plus/ci-cd/ci-cd-in-hybrid.md
@@ -6,6 +6,8 @@ sidebar_position: 7200
 tags: [dagster-plus-feature]
 ---
 
+import UpdateGitHubActionVersion from '@site/docs/partials/_UpdateGitHubActionVersion.md';
+
 :::note
 
 This guide only applies to [Dagster+ Hybrid deployments](/deployment/dagster-plus/hybrid).
@@ -42,9 +44,7 @@ After you make the above changes and commit the workflow file, the CI process sh
 
 During the deployment, the agent will attempt to load your code and update the metadata in Dagster+. When that has finished, you should see the GitHub Action complete successfully, and also be able to see the code location under the **Deployment** tag in Dagster+.
 
-:::tip
-We recommend periodically (every 6 months or so) updating the version of the Dagster GitHub Actions in your workflow files. These actions use version tags that follow the Dagster release convention (e.g., `@v1.11.13`). You can find the most [recent Dagster release](https://github.com/dagster-io/dagster/releases) on GitHub.
-:::
+<UpdateGitHubActionVersion />
 
 ## Non-GitHub CI/CD provider \{#non-github}
 

--- a/docs/docs/deployment/dagster-plus/ci-cd/ci-cd-in-hybrid.md
+++ b/docs/docs/deployment/dagster-plus/ci-cd/ci-cd-in-hybrid.md
@@ -42,6 +42,10 @@ After you make the above changes and commit the workflow file, the CI process sh
 
 During the deployment, the agent will attempt to load your code and update the metadata in Dagster+. When that has finished, you should see the GitHub Action complete successfully, and also be able to see the code location under the **Deployment** tag in Dagster+.
 
+:::tip
+We recommend periodically (every 6 months or so) updating the version of the Dagster GitHub Actions in your workflow files. These actions use version tags that follow the Dagster release convention (e.g., `@v1.11.13`). You can find the most [recent Dagster release](https://github.com/dagster-io/dagster/releases) on GitHub.
+:::
+
 ## Non-GitHub CI/CD provider \{#non-github}
 
 If you are using a non-GitHub CI/CD provider, your system should use the `dagster-cloud ci` command to deploy code locations to Dagster+.

--- a/docs/docs/deployment/dagster-plus/ci-cd/ci-cd-in-serverless.md
+++ b/docs/docs/deployment/dagster-plus/ci-cd/ci-cd-in-serverless.md
@@ -6,6 +6,8 @@ sidebar_label: CI/CD in Serverless
 tags: [dagster-plus-feature]
 ---
 
+import UpdateGitHubActionVersion from '@site/docs/partials/_UpdateGitHubActionVersion.md';
+
 :::note
 
 This guide only applies to [Dagster+ Serverless deployments](/deployment/dagster-plus/serverless).
@@ -37,9 +39,7 @@ If you're a GitHub user, with a single click our GitHub app with GitHub Actions 
 
 :::
 
-:::tip
-We recommend periodically (every 6 months or so) updating the version of the Dagster GitHub Actions in your workflow files. These actions use version tags that follow the Dagster release convention (e.g., `@v1.11.13`). You can find the most [recent Dagster release](https://github.com/dagster-io/dagster/releases) on GitHub.
-:::
+<UpdateGitHubActionVersion />
 
 </TabItem>
 

--- a/docs/docs/deployment/dagster-plus/ci-cd/ci-cd-in-serverless.md
+++ b/docs/docs/deployment/dagster-plus/ci-cd/ci-cd-in-serverless.md
@@ -37,6 +37,10 @@ If you're a GitHub user, with a single click our GitHub app with GitHub Actions 
 
 :::
 
+:::tip
+We recommend periodically (every 6 months or so) updating the version of the Dagster GitHub Actions in your workflow files. These actions use version tags that follow the Dagster release convention (e.g., `@v1.11.13`). You can find the most [recent Dagster release](https://github.com/dagster-io/dagster/releases) on GitHub.
+:::
+
 </TabItem>
 
 <TabItem value="GitLab" label="With GitLab">

--- a/docs/docs/partials/_UpdateGitHubActionVersion.md
+++ b/docs/docs/partials/_UpdateGitHubActionVersion.md
@@ -1,0 +1,5 @@
+:::tip
+
+We recommend periodically (every 6 months or so) updating the version of the Dagster GitHub Actions in your workflow files. These actions use version tags that follow the Dagster release convention (e.g., `@v1.11.13`). You can find the most [recent Dagster release](https://github.com/dagster-io/dagster/releases) on GitHub.
+
+:::


### PR DESCRIPTION
## Summary & Motivation

We are now recommending that folks use our version tags for the github action (it follow the Dagster release tagging strategy). Added similar language to our dagster+ agent for how often to upgrade the github action release.

This only applies to github, gitlab and the others do not need to be updated.

Hybrid:
<img width="770" height="685" alt="image" src="https://github.com/user-attachments/assets/8f2a5354-a18d-4619-afea-1522d533fa75" />

Serverless:
<img width="783" height="711" alt="image" src="https://github.com/user-attachments/assets/02cef3ca-f7f9-4ee0-9a28-218c98911d3f" />

## How I Tested These Changes

yarn lint and yarn start and 👀 
