### PR TITLE
Use RepositorySelector instead of RepositoryOrigin in asset graph methods

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/remote_asset_graph.py
@@ -48,7 +48,7 @@ from dagster._record import ImportFrom, record
 from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
-    from dagster._core.remote_origin import RemoteRepositoryOrigin
+    from dagster._core.definitions.selector import RepositorySelector
     from dagster._core.remote_representation.external_data import AssetCheckNodeSnap, AssetNodeSnap
 
 
@@ -69,7 +69,7 @@ class RemoteAssetNode(BaseAssetNode, ABC):
 
     @abstractmethod
     def resolve_to_repo_scoped_node(
-        self, repository_origin: "RemoteRepositoryOrigin"
+        self, repository_selector: "RepositorySelector"
     ) -> Optional["RemoteRepositoryAssetNode"]: ...
 
     @property
@@ -164,12 +164,11 @@ class RemoteRepositoryAssetNode(RemoteAssetNode):
         return object.__hash__(self)
 
     def resolve_to_repo_scoped_node(
-        self, repository_origin: "RemoteRepositoryOrigin"
+        self, repository_selector: "RepositorySelector"
     ) -> Optional["RemoteRepositoryAssetNode"]:
         return (
             self
-            if self.repository_handle.get_remote_origin().get_selector()
-            == repository_origin.get_selector()
+            if self.repository_handle.get_remote_origin().get_selector() == repository_selector
             else None
         )
 
@@ -352,13 +351,14 @@ class RemoteWorkspaceAssetNode(RemoteAssetNode):
         return self._materializable_node_snap.backfill_policy if self.is_materializable else None
 
     def resolve_to_repo_scoped_node(
-        self, repository_origin: "RemoteRepositoryOrigin"
+        self, repository_selector: "RepositorySelector"
     ) -> Optional["RemoteRepositoryAssetNode"]:
         return next(
             iter(
                 info.asset_node
                 for info in self.repo_scoped_asset_infos
-                if info.asset_node.repository_handle.get_remote_origin() == repository_origin
+                if info.asset_node.repository_handle.get_remote_origin().get_selector()
+                == repository_selector
             ),
             None,
         )
@@ -687,12 +687,12 @@ class RemoteWorkspaceAssetGraph(RemoteAssetGraph[RemoteWorkspaceAssetNode]):
             return self.remote_asset_check_nodes_by_key[key].handle
 
     def get_repo_scoped_node(
-        self, key: EntityKey, repository_origin: "RemoteRepositoryOrigin"
+        self, key: EntityKey, repository_selector: "RepositorySelector"
     ) -> Optional[Union[RemoteRepositoryAssetNode, RemoteAssetCheckNode]]:
         if isinstance(key, AssetKey):
             if not self.has(key):
                 return None
-            return self.get(key).resolve_to_repo_scoped_node(repository_origin)
+            return self.get(key).resolve_to_repo_scoped_node(repository_selector)
         else:
             raise Exception("Key must be an asset key for get_repo_scoped_node")
 

--- a/python_modules/dagster/dagster/_core/instance/runs/run_domain.py
+++ b/python_modules/dagster/dagster/_core/instance/runs/run_domain.py
@@ -775,7 +775,7 @@ class RunDomain:
             return cast(
                 "Optional[BaseAssetNode]",
                 asset_graph.get_repo_scoped_node(
-                    asset_key, check.not_none(remote_job_origin).repository_origin
+                    asset_key, check.not_none(remote_job_origin).repository_origin.get_selector()
                 ),
             )
 

--- a/python_modules/dagster/dagster/_core/remote_origin.py
+++ b/python_modules/dagster/dagster/_core/remote_origin.py
@@ -12,6 +12,7 @@ from dagster._core.instance.config import DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIME
 from dagster._core.origin import DEFAULT_DAGSTER_ENTRY_POINT
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._serdes import create_snapshot_id, whitelist_for_serdes
+from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
     from dagster._core.definitions.selector import (
@@ -394,6 +395,7 @@ class RemoteRepositoryOrigin(LegacyNamedTupleMixin):
     def get_selector_id(self) -> str:
         return create_snapshot_id(self.get_selector())
 
+    @cached_method
     def get_selector(self) -> "RepositorySelector":
         from dagster._core.definitions.selector import RepositorySelector
 


### PR DESCRIPTION
Summary:
Not clear why this used an origin.

BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
