### PR TITLE
[ui] Prefer the global graph with a group filter over asset group pages

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/BaseFallthroughRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/BaseFallthroughRoot.tsx
@@ -6,7 +6,6 @@ import {Route} from './Route';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {WorkspaceContext} from '../workspace/WorkspaceContext/WorkspaceContext';
 import {DagsterRepoOption} from '../workspace/WorkspaceContext/util';
-import {workspacePath} from '../workspace/workspacePath';
 
 export const BaseFallthroughRoot = () => {
   return (
@@ -55,21 +54,9 @@ const FinalRedirectOrLoadingRoot = () => {
   }
 
   // If we have no repos with jobs, see if we have an asset group and route to it.
-  const repoWithAssetGroup = allRepos.find((r) => r.repository.assetGroups.length);
-  if (repoWithAssetGroup) {
-    const {repository, repositoryLocation} = repoWithAssetGroup;
-    const assetGroup = repository.assetGroups[0]; // Should always be non-null from the find()
-    if (assetGroup) {
-      return (
-        <Redirect
-          to={workspacePath(
-            repository.name,
-            repositoryLocation.name,
-            `/asset-groups/${assetGroup.groupName}`,
-          )}
-        />
-      );
-    }
+  const hasAnyAssets = allRepos.find((r) => r.repository.assetGroups.length);
+  if (hasAnyAssets) {
+    return <Redirect to="/asset-groups/" />;
   }
 
   // Ben note: We only reach here if anyReposWithVisibleJobs is false,

--- a/js_modules/dagster-ui/packages/ui-core/src/app/BaseFallthroughRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/BaseFallthroughRoot.tsx
@@ -54,9 +54,9 @@ const FinalRedirectOrLoadingRoot = () => {
   }
 
   // If we have no repos with jobs, see if we have an asset group and route to it.
-  const hasAnyAssets = allRepos.find((r) => r.repository.assetGroups.length);
+  const hasAnyAssets = allRepos.some((r) => r.repository.assetGroups.length);
   if (hasAnyAssets) {
-    return <Redirect to="/asset-groups/" />;
+    return <Redirect to="/asset-groups" />;
   }
 
   // Ben note: We only reach here if anyReposWithVisibleJobs is false,

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/BaseFallthroughRoot.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/BaseFallthroughRoot.test.tsx
@@ -183,7 +183,7 @@ describe('BaseFallthroughRoot', () => {
       </MockedProvider>,
     );
     await waitFor(() => {
-      expect(getByTestId('path').textContent).toEqual('/asset-groups/');
+      expect(getByTestId('path').textContent).toEqual('/asset-groups');
     });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/BaseFallthroughRoot.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/BaseFallthroughRoot.test.tsx
@@ -183,9 +183,7 @@ describe('BaseFallthroughRoot', () => {
       </MockedProvider>,
     );
     await waitFor(() => {
-      expect(getByTestId('path').textContent).toEqual(
-        '/locations/repo_with_pseudo_job@location_with_dunder_job/asset-groups/group1',
-      );
+      expect(getByTestId('path').textContent).toEqual('/asset-groups/');
     });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
@@ -95,7 +95,7 @@ export const AssetActionMenu = memo((props: Props) => {
               to={
                 definition
                   ? globalAssetGraphPathForGroup(definition.groupName, definition.assetKey)
-                  : '/asset-groups/'
+                  : '/asset-groups'
               }
               disabled={!definition}
               icon="asset_group"

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
@@ -13,6 +13,7 @@ import {AddToFavoritesMenuItem} from 'shared/assets/AddToFavoritesMenuItem.oss';
 
 import {optionsForExecuteButton, useMaterializationAction} from './LaunchAssetExecutionButton';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
+import {globalAssetGraphPathForGroup} from './globalAssetGraphPathToString';
 import {AssetTableDefinitionFragment} from './types/AssetTableFragment.types';
 import {useDeleteDynamicPartitionsDialog} from './useDeleteDynamicPartitionsDialog';
 import {useObserveAction} from './useObserveAction';
@@ -23,7 +24,6 @@ import {showSharedToaster} from '../app/DomUtils';
 import {AssetKeyInput} from '../graphql/types';
 import {MenuLink} from '../ui/MenuLink';
 import {RepoAddress} from '../workspace/types';
-import {workspacePathFromAddress} from '../workspace/workspacePath';
 interface Props {
   path: string[];
   definition: AssetTableDefinitionFragment | null;
@@ -93,9 +93,9 @@ export const AssetActionMenu = memo((props: Props) => {
             <MenuLink
               text="Show in group"
               to={
-                repoAddress && definition?.groupName
-                  ? workspacePathFromAddress(repoAddress, `/asset-groups/${definition.groupName}`)
-                  : ''
+                definition
+                  ? globalAssetGraphPathForGroup(definition.groupName, definition.assetKey)
+                  : '/asset-groups/'
               }
               disabled={!definition}
               icon="asset_group"

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogAssetGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogAssetGraph.tsx
@@ -8,8 +8,8 @@ import {AssetLocation} from '../../asset-graph/useFindAssetLocation';
 import {useOpenInNewTab} from '../../hooks/useOpenInNewTab';
 import {useStateWithStorage} from '../../hooks/useStateWithStorage';
 import {ExplorerPath} from '../../pipelines/PipelinePathUtils';
-import {workspacePathFromAddress} from '../../workspace/workspacePath';
 import {assetDetailsPathForKey} from '../assetDetailsPathForKey';
+import {globalAssetGraphPathForGroup} from '../globalAssetGraphPathToString';
 
 export const AssetCatalogAssetGraph = React.memo(
   ({
@@ -28,13 +28,10 @@ export const AssetCatalogAssetGraph = React.memo(
       (e: Pick<React.MouseEvent<any>, 'metaKey'>, node: AssetLocation) => {
         let path;
         if (node.groupName && node.repoAddress) {
-          path = workspacePathFromAddress(
-            node.repoAddress,
-            `/asset-groups/${node.groupName}/lineage/${node.assetKey.path
-              .map(encodeURIComponent)
-              .join('/')}`,
-          );
+          // It is defined elsewhere, go to the global graph where it should be resolved to a full node
+          path = globalAssetGraphPathForGroup(node.groupName, node.assetKey);
         } else {
+          // It is not defined in another repo, just go to stub definition page
           path = assetDetailsPathForKey(node.assetKey, {view: 'definition'});
         }
         if (e.metaKey) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/globalAssetGraphPathToString.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/globalAssetGraphPathToString.tsx
@@ -30,6 +30,14 @@ export function globalAssetGraphPathForAssets(
 
   return globalAssetGraphPathToString({opNames, opsQuery});
 }
+
 export function globalAssetGraphPathForAssetsAndDescendants(assetKeys: AssetKeyInput[]) {
   return globalAssetGraphPathForAssets(assetKeys, true);
+}
+
+export function globalAssetGraphPathForGroup(groupName: string, assetKeyInContext?: AssetKeyInput) {
+  return globalAssetGraphPathToString({
+    opsQuery: `group:"${groupName}"`,
+    opNames: assetKeyInContext ? [tokenForAssetKey(assetKeyInContext)] : [],
+  });
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/DefinitionSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/DefinitionSection.tsx
@@ -27,7 +27,7 @@ import {CopyIconButton} from '../../ui/CopyButton';
 import {buildTagString} from '../../ui/tagAsString';
 import {WorkspaceLocationNodeFragment} from '../../workspace/WorkspaceContext/types/WorkspaceQueries.types';
 import {RepoAddress} from '../../workspace/types';
-import {workspacePathFromAddress} from '../../workspace/workspacePath';
+import {globalAssetGraphPathForGroup} from '../globalAssetGraphPathToString';
 import {AssetTableDefinitionFragment} from '../types/AssetTableFragment.types';
 import {AssetViewDefinitionNodeFragment} from '../types/AssetView.types';
 
@@ -59,10 +59,9 @@ export const DefinitionSection = ({
       <AttributeAndValue label="Group">
         <Tag icon="asset_group">
           <Link
-            to={workspacePathFromAddress(
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              repoAddress!,
-              `/asset-groups/${cachedOrLiveAssetNode.groupName}`,
+            to={globalAssetGraphPathForGroup(
+              cachedOrLiveAssetNode.groupName,
+              cachedOrLiveAssetNode.assetKey,
             )}
           >
             {cachedOrLiveAssetNode.groupName}

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickMaterializationsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickMaterializationsTable.tsx
@@ -27,10 +27,10 @@ import {AssetLink} from '../assets/AssetLink';
 import {AssetKeysDialogEmptyState} from '../assets/AutoMaterializePolicyPage/AssetKeysDialog';
 import {EvaluationDetailDialog} from '../assets/AutoMaterializePolicyPage/EvaluationDetailDialog';
 import {AssetDaemonTickFragment} from '../assets/auto-materialization/types/AssetDaemonTicksQuery.types';
+import {globalAssetGraphPathForGroup} from '../assets/globalAssetGraphPathToString';
 import {AssetKeyInput} from '../graphql/types';
 import {Container, HeaderRow} from '../ui/VirtualizedTable';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 const TEMPLATE_COLUMNS = '30% 17% 53%';
 
@@ -182,9 +182,7 @@ const AssetDetailRow = ({
         <RowCell>
           {data ? (
             definition && definition.groupName && repoAddress ? (
-              <Link
-                to={workspacePathFromAddress(repoAddress, `/asset-groups/${definition.groupName}`)}
-              >
+              <Link to={globalAssetGraphPathForGroup(definition.groupName, assetKey)}>
                 <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
                   <Icon color={Colors.textLight()} name="asset_group" />
                   {definition.groupName}

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -26,13 +26,13 @@ import {groupAssetsByStatus} from '../asset-graph/util';
 import {partitionCountString} from '../assets/AssetNodePartitionCounts';
 import {useAllAssets} from '../assets/AssetsCatalogTable';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
+import {globalAssetGraphPathForGroup} from '../assets/globalAssetGraphPathToString';
 import {AssetCatalogTableQuery} from '../assets/types/AssetsCatalogTable.types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {Container, HeaderCell, HeaderRow, Inner, Row, RowCell} from '../ui/VirtualizedTable';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 type Props = {
   Header: React.ComponentType<{refreshState: RefreshState}>;
@@ -254,7 +254,7 @@ function VirtualRow({height, start, group}: RowProps) {
                 {group.groupName ? (
                   <Link
                     style={{fontWeight: 700}}
-                    to={workspacePathFromAddress(repoAddress, `/asset-groups/${group.groupName}`)}
+                    to={globalAssetGraphPathForGroup(group.groupName)}
                   >
                     {group.groupName}
                   </Link>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -5,12 +5,11 @@ import {getAssetSelectionQueryString} from 'shared/asset-selection/useAssetSelec
 import styled from 'styled-components';
 
 import {RepoAddress} from './types';
+import {gql, useQuery} from '../apollo-client';
 import {
   SingleNonSdaAssetQuery,
   SingleNonSdaAssetQueryVariables,
 } from './types/VirtualizedAssetRow.types';
-import {workspacePathFromAddress} from './workspacePath';
-import {gql, useQuery} from '../apollo-client';
 import {useAssetsLiveData} from '../asset-data/AssetLiveDataProvider';
 import {buildAssetNodeStatusContent} from '../asset-graph/AssetNodeStatusContent';
 import {AssetRunLink} from '../asset-graph/AssetRunLinking';
@@ -20,6 +19,7 @@ import {AssetLink} from '../assets/AssetLink';
 import {PartitionCountLabels, partitionCountString} from '../assets/AssetNodePartitionCounts';
 import {StaleReasonsLabel} from '../assets/Stale';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
+import {globalAssetGraphPathForGroup} from '../assets/globalAssetGraphPathToString';
 import {AssetTableDefinitionFragment} from '../assets/types/AssetTableFragment.types';
 import {AssetViewType} from '../assets/useAssetView';
 import {AssetKind} from '../graph/KindTags';
@@ -146,10 +146,7 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
                 <RepositoryLink repoAddress={repoAddress} showIcon showRefresh={false} />
                 {definition && definition.groupName ? (
                   <Link
-                    to={workspacePathFromAddress(
-                      repoAddress,
-                      `/asset-groups/${definition.groupName}`,
-                    )}
+                    to={globalAssetGraphPathForGroup(definition.groupName, definition.assetKey)}
                   >
                     <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
                       <Icon color={Colors.accentGray()} name="asset_group" />


### PR DESCRIPTION
## Summary & Motivation

Related: https://linear.app/dagster-labs/issue/FE-982/make-lineage-ignore-code-locations-in-groupings

We’d like to remove the asset group pages which live at paths scoped to a code location.  We can’t /quite/ get rid of these pages yet, but this PR reduces the number of places in the app that link to them.

Instead of linking to the asset group page, we link to the global graph with a `group: “groupname”` filter.  The impacted callsites are mostly 1) "View in group" (menu option on assets),  2) links to the group name on the definition page, etc., and 3) the root page of the app when assets and no jobs are present.

After this PR, the groups pages are really only accessible via the old Jobs left nav.

## How I Tested These Changes

I tested these manually and added a new helper.