### PR TITLE
FE-776: Disable the Materialize button if it’s scope is stale

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -801,9 +801,11 @@ const AssetGraphExplorerWithData = ({
                     <LaunchAssetExecutionButton
                       preferredJobName={explorerPath.pipelineName}
                       scope={
-                        selectedDefinitions.length
-                          ? {selected: selectedDefinitions}
-                          : {all: allDefinitionsForMaterialize}
+                        nextLayoutLoading
+                          ? {all: []}
+                          : selectedDefinitions.length
+                            ? {selected: selectedDefinitions}
+                            : {all: allDefinitionsForMaterialize}
                       }
                       additionalDropdownOptions={extraDropdownOptions}
                     />


### PR DESCRIPTION
This is a tiny fix for https://linear.app/dagster-labs/issue/FE-776/lineage-view-materialize-action-not-reflecting-asset-selection-if

## Summary & Motivation

If you type a query into the asset graph filter box both the graph data and layout can change. A loading bar appears, but while the UI is loading, clicking the Materialize button does not reflect your new filters.

## How I Tested These Changes

I tested this manually with some jumping around the asset graph. Most of the time, filters apply ~immediately and the disabled state is not noticeable.

## Changelog

[ui] Lineage view Materialize button is disabled while the view is updating, rather than allowing Materialization of your previous asset query.