### PR TITLE
Quietly turn the next link click into a reload when GraphQL version changes

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -182,7 +182,7 @@
   "SingleSensorQuery": "dbda5ba47d4ba10f8c527c9a7cd45fba0811276441a17a8ac6f173ed588f025b",
   "WorkspaceAssetsQuery": "8e60e278ee64dbc08867486462047b5db1852bbcb23777cd6fbae587703e7ebe",
   "LocationWorkspaceQuery": "dc3c765d258d59c8c265f45109e72281af380ac95cb06b3e8faf799e7edba7ef",
-  "CodeLocationStatusQuery": "5491629a2659feca3a6cf0cc976c6f59c8e78dff1193e07d7850ae4355698b04",
+  "CodeLocationStatusQuery": "a59c78731fe8ad448abb72ddb95b72e8767e25368df2931ec061a6b183da8675",
   "LocationWorkspaceAssetsQuery": "61195fc88cb53d325132085b835ac95f0315c431e9a80a86dddd51815ef4c77f",
   "WorkspaceGraphsQuery": "ccbef870f327b56beb0d781a476c8afbbc22ff2621181c8576861daaf7667ecf"
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -12,6 +12,7 @@ import {AppContext} from './AppContext';
 import {CustomAlertProvider} from './CustomAlertProvider';
 import {CustomConfirmationProvider} from './CustomConfirmationProvider';
 import {GlobalStyleProvider} from './GlobalStyleProvider';
+import {ReloadOnHistoryChangeIfNewVersionAvailable} from './GraphQLVersion';
 import {LayoutProvider} from './LayoutProvider';
 import {createOperationQueryStringApolloLink} from './OperationQueryStringApolloLink';
 import {PermissionsProvider} from './Permissions';
@@ -183,6 +184,7 @@ export const AppProvider = (props: AppProviderProps) => {
         <ApolloProvider client={apolloClient}>
           <PermissionsProvider>
             <BrowserRouter basename={basePath || ''}>
+              <ReloadOnHistoryChangeIfNewVersionAvailable />
               <GlobalStyleProvider />
               <CompatRouter>
                 <TimeProvider>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/GraphQLVersion.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/GraphQLVersion.tsx
@@ -1,0 +1,46 @@
+import {useEffect} from 'react';
+import {useHistory} from 'react-router-dom';
+import {atom, selector, useRecoilState} from 'recoil';
+
+export const graphQLVersionAtom = atom<string | undefined>({
+  key: 'graphQLVersionAtom',
+  default: undefined,
+});
+
+export const initialGraphQLVersionAtom = atom<string | undefined>({
+  key: 'initialGraphQLVersionAtom',
+  default: undefined,
+});
+
+export const initialGraphQLVersionOnceAtom = selector<string | undefined>({
+  key: 'initialGraphQLVersionOnceAtom',
+  get: ({get}) => get(initialGraphQLVersionAtom),
+  set: ({get, set}, newValue) => {
+    const current = get(initialGraphQLVersionAtom);
+    if (!current && typeof newValue === 'string') {
+      set(initialGraphQLVersionAtom, newValue);
+    }
+  },
+});
+
+export function ReloadOnHistoryChangeIfNewVersionAvailable() {
+  const [latestVersion] = useRecoilState(graphQLVersionAtom);
+  const [initialVersion] = useRecoilState(initialGraphQLVersionAtom);
+  const versionChanged = latestVersion && initialVersion && latestVersion !== initialVersion;
+
+  const history = useHistory();
+
+  useEffect(() => {
+    const unlisten = history.listen((_location, action) => {
+      if (action === 'POP') {
+        return; // Browser "Back" action
+      }
+      if (versionChanged) {
+        window.location.reload();
+      }
+    });
+    return unlisten;
+  }, [history, versionChanged]);
+
+  return null;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceManager.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceManager.ts
@@ -32,7 +32,7 @@ export class WorkspaceManager {
     readonly localCacheIdPrefix: string | undefined;
     readonly getData: ReturnType<typeof useGetData>;
     readonly setData: (data: Data) => void;
-    readonly setCodeLocationStatusAtom: (status: CodeLocationStatusQuery) => void;
+    readonly setCodeLocationStatus: (status: CodeLocationStatusQuery, fromCache: boolean) => void;
   }) {
     this.client = args.client;
     this.localCacheIdPrefix = args.localCacheIdPrefix;
@@ -46,7 +46,7 @@ export class WorkspaceManager {
     this.statusPoller = new WorkspaceStatusPoller({
       localCacheIdPrefix: this.localCacheIdPrefix,
       getData: this.getData,
-      setCodeLocationStatusAtom: args.setCodeLocationStatusAtom,
+      setCodeLocationStatus: args.setCodeLocationStatus,
     });
     this.dataFetchers = {
       locationEntries: new WorkspaceLocationDataFetcher({

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceQueries.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceQueries.tsx
@@ -254,6 +254,7 @@ export const LOCATION_WORKSPACE_QUERY = gql`
 
 export const CODE_LOCATION_STATUS_QUERY = gql`
   query CodeLocationStatusQuery {
+    version
     locationStatusesOrError {
       ... on WorkspaceLocationStatusEntries {
         entries {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/types/WorkspaceQueries.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/types/WorkspaceQueries.types.ts
@@ -924,6 +924,7 @@ export type CodeLocationStatusQueryVariables = Types.Exact<{[key: string]: never
 
 export type CodeLocationStatusQuery = {
   __typename: 'Query';
+  version: string;
   locationStatusesOrError:
     | {__typename: 'PythonError'}
     | {
@@ -1510,6 +1511,6 @@ export type WorkspaceRepositoryFragment = {
 
 export const LocationWorkspaceQueryVersion = 'dc3c765d258d59c8c265f45109e72281af380ac95cb06b3e8faf799e7edba7ef';
 
-export const CodeLocationStatusQueryVersion = '5491629a2659feca3a6cf0cc976c6f59c8e78dff1193e07d7850ae4355698b04';
+export const CodeLocationStatusQueryVersion = 'a59c78731fe8ad448abb72ddb95b72e8767e25368df2931ec061a6b183da8675';
 
 export const LocationWorkspaceAssetsQueryVersion = '61195fc88cb53d325132085b835ac95f0315c431e9a80a86dddd51815ef4c77f';


### PR DESCRIPTION
## Summary & Motivation

@hellendag I know you've put thought into [FE-856](https://linear.app/dagster-labs/issue/FE-856/prompt-users-to-reload-on-old-versions) so I'm curious to get your thoughts about this. I noticed the Linear desktop app does something like this and it seemed like an interesting lightweight solution, but it's not as nice as the headers approach discussed in that ticket.

- I updated the CodeLocationStatusQuery to fetch `version` as well as `locationStatusesOrError` 
- I updated the WorkspaceContext to store the first seen version and latest version result into Recoil along with the location statuses.
- If they are both present and not the same, we add a listener to the react-router `history`. The next time the history changes (user clicks a link, navigates away, etc.) we trigger a navigate + reload() instead of in-app navigation.

One thing I don't love about this is that it adds unrelated stuff to the already very complicated Workspace loading... but it seemed like a way to avoid having to make a separate polling query or do add backend headers?

## How I Tested These Changes

Tested against OSS by manually fiddling with the return value of `resolve_version` . Here's what it looks like:

https://www.loom.com/share/75f3ad687c6c46bd8870de4eea198f86
