### PR TITLE
[sbc] Store state in reconstruction metadata optionally

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
@@ -9,9 +9,11 @@ from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, TypeVar, cas
 
 from dagster_shared import check
 from dagster_shared.serdes.objects.models.defs_state_info import (
+    CODE_SERVER_STATE_VERSION,
     DefsKeyStateInfo,
     DefsStateInfo,
     DefsStateStorageLocation,
+    get_code_server_metadata_key,
     get_local_state_path,
 )
 from dagster_shared.serdes.serdes import PackableValue, deserialize_value, serialize_value
@@ -23,7 +25,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.metadata.metadata_value import (
     CodeLocationReconstructionMetadataValue,
 )
-from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
+from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.defs_state.base import DefsStateStorage
 
 if TYPE_CHECKING:
@@ -104,6 +106,13 @@ class DefinitionsLoadContext:
     def add_to_pending_reconstruction_metadata(self, key: str, metadata: Any) -> None:
         self._pending_reconstruction_metadata[key] = metadata
 
+    def add_code_server_defs_state_info(self, key: str, metadata: Any) -> None:
+        """Marks state that was stored during the code server initialization process."""
+        self._defs_state_info = DefsStateInfo.add_version(
+            self._defs_state_info, key, CODE_SERVER_STATE_VERSION
+        )
+        self.add_to_pending_reconstruction_metadata(get_code_server_metadata_key(key), metadata)
+
     def get_pending_reconstruction_metadata(self) -> Mapping[str, Any]:
         return self._pending_reconstruction_metadata
 
@@ -153,15 +162,16 @@ class DefinitionsLoadContext:
             self._defs_state_info = DefsStateInfo.add_version(current_info, key, None)
         return key_info
 
+    def _get_defs_state_from_reconstruction_metadata(self, key: str) -> str:
+        metadata_key = get_code_server_metadata_key(key)
+        if self.load_type == DefinitionsLoadType.RECONSTRUCTION:
+            return self.reconstruction_metadata[metadata_key]
+        else:
+            return self._pending_reconstruction_metadata[metadata_key]
+
     @contextmanager
-    def state_path(self, key: str) -> Iterator[Optional[Path]]:
+    def state_path(self, key: str, state_storage: DefsStateStorage) -> Iterator[Optional[Path]]:
         """Context manager that creates a temporary path to hold local state for a component."""
-        state_storage = DefsStateStorage.get()
-        if state_storage is None:
-            raise DagsterInvalidInvocationError(
-                "Attempted to get a temp state path without a StateStorage in context. "
-                "This is likely the result of an internal framework error."
-            )
         # if no state has ever been written for this key, we return None to indicate that no state is available
         key_info = self._get_defs_key_state_info(key)
         if key_info is None:
@@ -181,6 +191,13 @@ class DefinitionsLoadContext:
             with tempfile.TemporaryDirectory() as temp_dir:
                 state_path = Path(temp_dir) / key
                 state_storage.download_state_to_path(key, key_info.version, state_path)
+                yield state_path
+        elif key_info.storage_location == DefsStateStorageLocation.LEGACY_CODE_SERVER_SNAPSHOTS:
+            # state is stored in the reconstruction metadata
+            with tempfile.TemporaryDirectory() as temp_dir:
+                state_path = Path(temp_dir) / key
+                state = self._get_defs_state_from_reconstruction_metadata(key)
+                state_path.write_text(state)
                 yield state_path
         else:
             raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/_core/storage/defs_state/base.py
+++ b/python_modules/dagster/dagster/_core/storage/defs_state/base.py
@@ -10,7 +10,6 @@ from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
 
 # constant indicating where to store the latest defs state info in a kvs context
 DEFS_STATE_INFO_CURSOR_KEY = "__latest_defs_state_info__"
-LOCAL_STATE_VERSION = "__local__"
 
 _current_storage: ContextVar[Optional["DefsStateStorage"]] = ContextVar(
     "_current_storage", default=None


### PR DESCRIPTION
## Summary & Motivation

Adds a third mode for state backed components which uses the "traditional" reconstruction metadata approach.

This approach has the following downsides (hence the revamped system):

- It refreshes every time the code server is reloaded, meaning there is no stability and no way to roll back.
- The above also means that if there's some transient issue with hitting the remote system, this will prevent the code location from loading entirely
- Finally, storing large amounts of serialized metadata in execution plan snapshots is not the most scalable thing in the world compared to the other approaches

However, it's still the easiest / simplest thing on the user's end as it requires no special infra or setup, and we have many pre-existing integrations that use this method. So having this integrate transparently with the rest of the StateBackedComponent infra and allows users to opt in to the fancier bits with just a bit of config

## How I Tested These Changes

## Changelog

NOCHANGELOG
