### PR TITLE
RFC: Remove valid parent subset check in asset backfill logic

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -287,20 +287,6 @@ def assert_valid_asset_partition_backfill(
                 )
             )
 
-        for parent_key in asset_graph.get(asset_key).parent_keys:
-            _parent_subset, required_but_nonexistent_subset = (
-                asset_graph_view.compute_parent_subset_and_required_but_nonexistent_subset(
-                    parent_key,
-                    entity_subset,
-                )
-            )
-
-            if not required_but_nonexistent_subset.is_empty:
-                raise DagsterInvariantViolationError(
-                    f"Targeted partition subset {entity_subset}"
-                    f" depends on non-existent partitions: {required_but_nonexistent_subset}"
-                )
-
 
 def _noop(_) -> None:
     pass

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1715,18 +1715,12 @@ def _should_backfill_atomic_asset_subset_unit(
         if entity_subset_to_filter.is_empty:
             break
 
-        parent_subset, required_but_nonexistent_subset = (
+        parent_subset, _ = (
             asset_graph_view.compute_parent_subset_and_required_but_nonexistent_subset(
                 parent_key,
                 entity_subset_to_filter,
             )
         )
-
-        if not required_but_nonexistent_subset.is_empty:
-            raise DagsterInvariantViolationError(
-                f"Asset partition subset {entity_subset_to_filter}"
-                f" depends on non-existent partitions {required_but_nonexistent_subset}"
-            )
 
         parent_materialized_subset = asset_graph_view.get_entity_subset_from_asset_graph_subset(
             materialized_subset, parent_key


### PR DESCRIPTION
## Summary & Motivation
I'm unclear why exactly this check exists, and am sending out this PR in hopes of learning what we would be losing by removing it. We already have checks that all partitions targeted by the backfill exit, and we let you launch runs (with a warning) in similar circumstances. So why be stricter for backfills?
