### PR TITLE
[docs] Remove hardcode path in tutorial

### DIFF
--- a/docs/docs/dagster-basics-tutorial/0-projects.md
+++ b/docs/docs/dagster-basics-tutorial/0-projects.md
@@ -116,7 +116,7 @@ Your new Dagster project should have the following structure:
     ├── pyproject.toml
     ├── README.md
     ├── src
-    │   └── dagster_tutorial
+    │   └── <your project>
     │       ├── __init__.py
     │       ├── definitions.py
     │       └── defs
@@ -129,7 +129,7 @@ Your new Dagster project should have the following structure:
 
 - `pyproject.toml` defines the metadata and Python dependencies for the project.
 - The `src` directory will contain code for the project.
-- `src/definitions.py` defines the main Dagster project object.
+- `src/<your project>/definitions.py` defines the main Dagster project object.
 - The `tests` directory will contain tests for the project.
 
 ## 2. Start the Dagster webserver

--- a/docs/docs/dagster-basics-tutorial/0-projects.md
+++ b/docs/docs/dagster-basics-tutorial/0-projects.md
@@ -100,7 +100,7 @@ Your new Dagster project should have the following structure:
     ├── pyproject.toml
     ├── README.md
     ├── src
-    │   └── dagster_tutorial
+    │   └── my_project
     │       ├── __init__.py
     │       ├── definitions.py
     │       └── defs
@@ -116,7 +116,7 @@ Your new Dagster project should have the following structure:
     ├── pyproject.toml
     ├── README.md
     ├── src
-    │   └── <your project>
+    │   └── my_project
     │       ├── __init__.py
     │       ├── definitions.py
     │       └── defs
@@ -129,7 +129,7 @@ Your new Dagster project should have the following structure:
 
 - `pyproject.toml` defines the metadata and Python dependencies for the project.
 - The `src` directory will contain code for the project.
-- `src/<your project>/definitions.py` defines the main Dagster project object.
+- `src/my_project/definitions.py` defines the main Dagster project object.
 - The `tests` directory will contain tests for the project.
 
 ## 2. Start the Dagster webserver

--- a/docs/docs/dagster-basics-tutorial/1-assets.md
+++ b/docs/docs/dagster-basics-tutorial/1-assets.md
@@ -16,7 +16,7 @@ When building assets, the first step is to scaffold an assets file with the [`dg
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-assets.txt" />
 
-This adds a file called `assets.py` to the `dagster-tutorial` module, which will contain your asset code. Using `dg` to create the file ensures it is placed where Dagster can automatically discover it:
+This adds a file called `assets.py` to your Dagster project, which will contain your asset code. Using `dg` to create the file ensures it is placed where Dagster can automatically discover it:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/assets.txt" />
 
@@ -50,7 +50,7 @@ In Dagster, all defined objects (such as assets) need to be associated with a to
   title="src/dagster_tutorial/definitions.py"
 />
 
-This `Definitions` object loads the `dagster-tutorial` module and automatically discovers all assets and other Dagster objects. There is no need to explicitly reference assets as they are created. However, it is good practice to check that the `Definitions` object can be loaded without error as new Dagster objects are added.
+This `Definitions` object loads the module and automatically discovers all assets and other Dagster objects. There is no need to explicitly reference assets as they are created. However, it is good practice to check that the `Definitions` object can be loaded without error as new Dagster objects are added.
 
 You can use the [`dg check defs`](/api/clis/dg-cli/dg-cli-reference#dg-check) command to ensure everything in your module loads correctly, and that your project is deployable:
 

--- a/docs/docs/dagster-basics-tutorial/2-resources.md
+++ b/docs/docs/dagster-basics-tutorial/2-resources.md
@@ -76,7 +76,7 @@ Run `dg check` again to confirm that the assets and resources are configured cor
 
 Back in the UI, your assets will not look different, but you can view the resource in the **Definitions** tab:
 
-1. Click **Deployment**, then click "<your project>" to see your deployment.
+1. Click **Deployment**, then click on your project to see your deployment.
 2. Click **Definitions**.
 3. Navigate to the "Resources" section to view all of your resources, then select "duckdb":
 

--- a/docs/docs/dagster-basics-tutorial/2-resources.md
+++ b/docs/docs/dagster-basics-tutorial/2-resources.md
@@ -40,7 +40,7 @@ Next, scaffold a resources file:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-resources.txt" />
 
-This adds a generic resources file to your project. The `resources.py` file is now part of the `dagster-tutorial` module:
+This adds a generic resources file to your project. The `resources.py` file is now part of your project module:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/resources.txt" />
 
@@ -76,7 +76,7 @@ Run `dg check` again to confirm that the assets and resources are configured cor
 
 Back in the UI, your assets will not look different, but you can view the resource in the **Definitions** tab:
 
-1. Click **Deployment**, then click "dagster-tutorial" to see your deployment.
+1. Click **Deployment**, then click "<your project>" to see your deployment.
 2. Click **Definitions**.
 3. Navigate to the "Resources" section to view all of your resources, then select "duckdb":
 

--- a/docs/docs/dagster-basics-tutorial/5-schedules.md
+++ b/docs/docs/dagster-basics-tutorial/5-schedules.md
@@ -18,7 +18,7 @@ Use the `dg scaffold defs` command to scaffold a new schedule object:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-schedules.txt" />
 
-This will add a generic schedules file to your project. The `schedules.py` file is now part of the `dagster-tutorial` module:
+This will add a generic schedules file to your project. The `schedules.py` file is now part of the module:
 
 <CliInvocationExample path="docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/schedules.txt" />
 

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-create-custom-component.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-create-custom-component.txt
@@ -1,4 +1,4 @@
 dg scaffold component Tutorial
 
-Creating module at: <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/components
-Scaffolded Dagster component at <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/components/tutorial.py.
+Creating module at: <YOUR PATH>/my-project/src/my_project/components
+Scaffolded Dagster component at <YOUR PATH>/my-project/src/my_project/components/tutorial.py.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-create-custom-component.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-create-custom-component.txt
@@ -1,4 +1,4 @@
 dg scaffold component Tutorial
 
-Creating module at: <YOUR PATH>/dagster-tutorial/src/dagster_tutorial/components
-Scaffolded Dagster component at <YOUR PATH>/dagster-tutorial/src/dagster_tutorial/components/tutorial.py.
+Creating module at: <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/components
+Scaffolded Dagster component at <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/components/tutorial.py.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-assets.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-assets.txt
@@ -1,3 +1,3 @@
 dg scaffold defs dagster.asset assets.py
 
-Creating a component at <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/defs/assets.py.
+Creating a component at <YOUR PATH>/my-project/src/my_project/defs/assets.py.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-assets.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-assets.txt
@@ -1,3 +1,3 @@
 dg scaffold defs dagster.asset assets.py
 
-Creating a component at <YOUR PATH>/dagster-tutorial/src/dagster_tutorial/defs/assets.py.
+Creating a component at <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/defs/assets.py.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-custom-component.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-custom-component.txt
@@ -1,3 +1,3 @@
-dg scaffold defs dagster_tutorial.components.tutorial.Tutorial tutorial
+dg scaffold defs <your project>.components.tutorial.Tutorial tutorial
 
-Creating defs at <YOUR PATH>/dagster-tutorial/src/dagster_tutorial/defs/tutorial.
+Creating defs at <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/defs/tutorial.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-custom-component.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-custom-component.txt
@@ -1,3 +1,3 @@
-dg scaffold defs <your project>.components.tutorial.Tutorial tutorial
+dg scaffold defs my_project.components.tutorial.Tutorial tutorial
 
-Creating defs at <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/defs/tutorial.
+Creating defs at <YOUR PATH>/my-project/src/my_project/defs/tutorial.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-python-component.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-python-component.txt
@@ -1,3 +1,3 @@
 dg scaffold defs dagster.PythonScriptComponent script
 
-Creating defs at <YOUR PATH>/dagster-tutorial/src/dagster_tutorial/defs/script.
+Creating defs at <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/defs/script.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-python-component.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-python-component.txt
@@ -1,3 +1,3 @@
 dg scaffold defs dagster.PythonScriptComponent script
 
-Creating defs at <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/defs/script.
+Creating defs at <YOUR PATH>/my-project/src/my_project/defs/script.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-resources.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-resources.txt
@@ -1,3 +1,3 @@
 dg scaffold defs dagster.resources resources.py
 
-Creating a component at <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/defs/resources.py.
+Creating a component at <YOUR PATH>/my-project/src/my_project/defs/resources.py.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-resources.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-resources.txt
@@ -1,3 +1,3 @@
 dg scaffold defs dagster.resources resources.py
 
-Creating a component at <YOUR PATH>/dagster-tutorial/src/dagster_tutorial/defs/resources.py.
+Creating a component at <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/defs/resources.py.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-schedules.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-schedules.txt
@@ -1,3 +1,3 @@
 dg scaffold defs dagster.schedule schedules.py
 
-Creating a component at <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/defs/schedules.py.
+Creating a component at <YOUR PATH>/my-project/src/my_project/defs/schedules.py.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-schedules.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/commands/dg-scaffold-schedules.txt
@@ -1,3 +1,3 @@
 dg scaffold defs dagster.schedule schedules.py
 
-Creating a component at <YOUR PATH>/dagster-tutorial/src/dagster_tutorial/defs/schedules.py.
+Creating a component at <YOUR PATH>/<YOUR PROJECT>/src/<YOUR PROJECT>/defs/schedules.py.

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/assets.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/assets.txt
@@ -1,4 +1,4 @@
 src
-└── dagster_tutorial
+└── <your project>
     └── defs
         └── assets.py

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/assets.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/assets.txt
@@ -1,4 +1,4 @@
 src
-└── <your project>
+└── my_project
     └── defs
         └── assets.py

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/init-uv.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/init-uv.txt
@@ -2,7 +2,7 @@
 ├── pyproject.toml
 ├── README.md
 ├── src
-│   └── dagster_tutorial
+│   └── <your project>
 │       ├── __init__.py
 │       ├── definitions.py
 │       └── defs

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/init-uv.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/init-uv.txt
@@ -2,7 +2,7 @@
 ├── pyproject.toml
 ├── README.md
 ├── src
-│   └── <your project>
+│   └── my_project
 │       ├── __init__.py
 │       ├── definitions.py
 │       └── defs

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/resources.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/resources.txt
@@ -1,4 +1,4 @@
 src
-└── dagster_tutorial
+└── <your project>
     └── defs
         └── resources.py

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/resources.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/resources.txt
@@ -1,4 +1,4 @@
 src
-└── <your project>
+└── my_project
     └── defs
         └── resources.py

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/schedules.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/schedules.txt
@@ -1,4 +1,4 @@
 src
-└── <your project>
+└── my_project
     └── defs
         └── schedules.py

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/schedules.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/schedules.txt
@@ -1,4 +1,4 @@
 src
-└── dagster_tutorial
+└── <your project>
     └── defs
         └── schedules.py

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-0.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-0.txt
@@ -1,5 +1,5 @@
 src
-└── <your project>
+└── my_project
     ├── __init__.py
     ├── definitions.py
     └── defs

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-0.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-0.txt
@@ -1,5 +1,5 @@
 src
-└── dagster_tutorial
+└── <your project>
     ├── __init__.py
     ├── definitions.py
     └── defs

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-1.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-1.txt
@@ -1,5 +1,5 @@
 src
-└── <your project>
+└── my_project
     ├── __init__.py
     ├── definitions.py
     └── defs

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-1.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-1.txt
@@ -1,5 +1,5 @@
 src
-└── dagster_tutorial
+└── <your project>
     ├── __init__.py
     ├── definitions.py
     └── defs

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-5.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-5.txt
@@ -1,5 +1,5 @@
 src
-└── <your project>
+└── my_project
     ├── __init__.py
     ├── definitions.py
     └── defs

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-5.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-5.txt
@@ -1,5 +1,5 @@
 src
-└── dagster_tutorial
+└── <your project>
     ├── __init__.py
     ├── definitions.py
     └── defs

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-6a.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-6a.txt
@@ -1,5 +1,5 @@
 src
-└── dagster_tutorial
+└── <your project>
     ├── __init__.py
     ├── components   # NEW
     │   ├── __init__.py

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-6a.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-6a.txt
@@ -1,5 +1,5 @@
 src
-└── <your project>
+└── my_project
     ├── __init__.py
     ├── components   # NEW
     │   ├── __init__.py

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-6b.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-6b.txt
@@ -1,5 +1,5 @@
 src
-└── <your project>
+└── my_project
     ├── __init__.py
     ├── components
     │   ├── __init__.py

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-6b.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-6b.txt
@@ -1,5 +1,5 @@
 src
-└── dagster_tutorial
+└── <your project>
     ├── __init__.py
     ├── components
     │   ├── __init__.py

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-6c.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-6c.txt
@@ -1,5 +1,5 @@
 src
-└── <your project>
+└── my_project
     ├── __init__.py
     ├── components
     │   ├── __init__.py

--- a/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-6c.txt
+++ b/examples/docs_snippets/docs_snippets/guides/tutorials/dagster_tutorial/tree/step-6c.txt
@@ -1,5 +1,5 @@
 src
-└── dagster_tutorial
+└── <your project>
     ├── __init__.py
     ├── components
     │   ├── __init__.py


### PR DESCRIPTION
## Summary & Motivation

Updating the tutorial so that it doesn't assume you have the dagster-tutorial project template.

Replace:
```
src
└── dagster_tutorial
    └── defs
        └── assets.py
```
becomes:
```
src
└── <your project>
    └── defs
        └── assets.py
```

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
