### PR TITLE
Use correct default `day_offset` of 1 when defining a `TimeWindowPartition` with monthly schedule

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window.py
@@ -149,7 +149,7 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
                 schedule_type=schedule_type,
                 minute_offset=minute_offset or 0,
                 hour_offset=hour_offset or 0,
-                day_offset=day_offset or 0,
+                day_offset=day_offset or None,
             )
 
         if not is_valid_cron_schedule(cron_schedule):

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -877,6 +877,19 @@ def test_start_not_aligned():
     )
 
 
+def test_time_window_partition_default_month_offset():
+    """Test that we can define a time window partition on a monthly schedule with the default minute, hour and day offsets."""
+    my_date = datetime.strptime("2021-05-01", DATE_FORMAT)
+    partitions_def = TimeWindowPartitionsDefinition(
+        schedule_type=ScheduleType.MONTHLY,
+        start=my_date,
+        fmt="%Y-%m-%d",
+    )
+    assert partitions_def.day_offset == 1
+    assert partitions_def.hour_offset == 0
+    assert partitions_def.minute_offset == 0
+
+
 @pytest.mark.parametrize(
     "case_str",
     [


### PR DESCRIPTION
## Summary & Motivation
Previously, defining a time window partition with a monthly schedule and no provided offset would fail since `TimeWindowPartitionsDefinition` constructor was passing 0 as the default day offset value. In cron format, days of months start at 1, not 0.

```python
partition_def = TimeWindowPartitionsDefinition(
  schedule_type=ScheduleType.MONTHLY,
  start=datetime.now(),
  fmt="%Y-%m-%d",
)

# fails with error:
# Found invalid cron schedule '0 0 0 * *'
```

This PR simply propagates the constructor default `None` instead of `0` through to `cron_schedule_from_schedule_type_and_offsets` which correctly sets the default day offset to 1.

This lets users define a `TimeWindowPartitionDefinition` with monthly schedule type without manually setting `day_offset=1`.

## How I Tested These Changes
Added a unit test that tries to define a time window partition this way

## Changelog

Fix a bug where `TimeWindowPartitionsDefinition` could not be instantiated with a monthly schedule and the default day offset