### PR TITLE
[dagster-fivetran] Add state storage configuration option for FivetranAccountComponent

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_example
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_example
@@ -37,3 +37,6 @@ attributes:
     key: "example_string"
     key_prefix:
       - "example_string"
+  defs_state:
+    type: "example_string"
+    refresh_if_dev: true

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_schema
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_schema
@@ -72,3 +72,6 @@ attributes:  # Optional: Attributes details
     freshness_policy: <string>  # Optional: The freshness policy for the asset.
     key: <string>  # Optional: 
     key_prefix: <one of: string, array of string>  # Optional: Prefix the existing asset key with the provided value.
+  defs_state:  # Optional: Configuration for determining how state is stored and persisted for this component.  - `VERSIONED_STATE_STORAGE`: State is stored in your configured `defs_state_storage`. `dg utils refresh-defs-state` may be executed at any time to refresh the state.  - `LOCAL_FILESYSTEM`: State is stored on the local filesystem. `dg utils refresh-defs-state` must be executed while building the deployed container image in order for state to be accessible.  - `LEGACY_CODE_SERVER_SNAPSHOTS`: State is stored in memory in the code server. State is always automatically refreshed when the code server is loaded.
+    type: <one of: object (DefsStateManagementType), string>  # Required: The storage type for state required for loading this object's definitions.
+    refresh_if_dev: <one of: boolean, string>  # Optional:

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/components/workspace_component/component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/components/workspace_component/component.py
@@ -1,12 +1,16 @@
+from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from functools import cached_property
+from pathlib import Path
 from typing import Annotated, Callable, Optional, Union
 
 import dagster as dg
 import pydantic
 from dagster._annotations import public
 from dagster._utils.names import clean_name
+from dagster.components.component.state_backed_component import StateBackedComponent
 from dagster.components.resolved.base import resolve_fields
+from dagster.components.utils.defs_state import DefsStateConfig, ResolvedDefsStateConfig
 from dagster.components.utils.translation import (
     ComponentTranslator,
     TranslationFn,
@@ -14,8 +18,8 @@ from dagster.components.utils.translation import (
     create_component_translator_cls,
 )
 from dagster_shared import check
+from dagster_shared.serdes.serdes import deserialize_value
 
-from dagster_fivetran.asset_decorator import fivetran_assets
 from dagster_fivetran.components.workspace_component.scaffolder import (
     FivetranAccountComponentScaffolder,
 )
@@ -25,7 +29,9 @@ from dagster_fivetran.translator import (
     FivetranConnector,
     FivetranConnectorTableProps,
     FivetranMetadataSet,
+    FivetranWorkspaceData,
 )
+from dagster_fivetran.utils import DAGSTER_FIVETRAN_TRANSLATOR_METADATA_KEY
 
 
 class FivetranWorkspaceModel(pydantic.BaseModel):
@@ -68,7 +74,7 @@ def resolve_connector_selector(
 
 @public
 @dg.scaffold_with(FivetranAccountComponentScaffolder)
-class FivetranAccountComponent(dg.Component, dg.Model, dg.Resolvable):
+class FivetranAccountComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     """Loads Fivetran connectors from a given Fivetran instance as Dagster assets.
     Materializing these assets will trigger a sync of the Fivetran connector, enabling
     you to schedule Fivetran syncs using Dagster.
@@ -100,6 +106,10 @@ class FivetranAccountComponent(dg.Component, dg.Model, dg.Resolvable):
         default=None,
         description="Function used to translate Fivetran connector table properties into Dagster asset specs.",
     )
+    defs_state: ResolvedDefsStateConfig = DefsStateConfig.legacy_code_server_snapshots()
+
+    def get_defs_state_key(self) -> str:
+        return f"{self.__class__.__name__}[{self.workspace_resource.account_id}]"
 
     @cached_property
     def workspace_resource(self) -> FivetranWorkspace:
@@ -113,6 +123,10 @@ class FivetranAccountComponent(dg.Component, dg.Model, dg.Resolvable):
     def _base_translator(self) -> DagsterFivetranTranslator:
         return DagsterFivetranTranslator()
 
+    @property
+    def defs_state_config(self) -> DefsStateConfig:
+        return self.defs_state
+
     def get_asset_spec(self, props: FivetranConnectorTableProps) -> dg.AssetSpec:
         return self._base_translator.get_asset_spec(props)
 
@@ -121,36 +135,50 @@ class FivetranAccountComponent(dg.Component, dg.Model, dg.Resolvable):
     ) -> Iterable[Union[dg.AssetMaterialization, dg.MaterializeResult]]:
         yield from fivetran.sync_and_poll(context=context)
 
-    def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
+    def _load_asset_specs(self, state: FivetranWorkspaceData) -> Sequence[dg.AssetSpec]:
         connector_selector_fn = self.connector_selector or (lambda connector: bool(connector))
-        all_asset_specs = self.workspace_resource.load_asset_specs(
-            dagster_fivetran_translator=self.translator,
-            connector_selector_fn=connector_selector_fn,
-        )
-
-        connectors = {
-            (
-                check.not_none(FivetranMetadataSet.extract(spec.metadata).connector_id),
-                check.not_none(FivetranMetadataSet.extract(spec.metadata).connector_name),
+        return [
+            self.translator.get_asset_spec(props).merge_attributes(
+                metadata={DAGSTER_FIVETRAN_TRANSLATOR_METADATA_KEY: self.translator}
             )
-            for spec in all_asset_specs
-        }
+            for props in state.to_workspace_data_selection(
+                connector_selector_fn=connector_selector_fn
+            ).to_fivetran_connector_table_props_data()
+        ]
 
-        assets = []
-        for connector_id, connector_name in connectors:
+    def _get_fivetran_assets_def(
+        self, connector_name: str, specs: Sequence[dg.AssetSpec]
+    ) -> dg.AssetsDefinition:
+        @dg.multi_asset(name=f"fivetran_{clean_name(connector_name)}", can_subset=True, specs=specs)
+        def _asset(context: dg.AssetExecutionContext):
+            yield from self.execute(context=context, fivetran=self.workspace)
 
-            @fivetran_assets(
-                connector_id=connector_id,
-                workspace=self.workspace_resource,
-                name=f"fivetran_{clean_name(connector_name)}",
-                dagster_fivetran_translator=self.translator,
-                connector_selector_fn=connector_selector_fn,
+        return _asset
+
+    async def write_state_to_path(self, state_path: Path) -> None:
+        state = self.workspace_resource.fetch_fivetran_workspace_data()
+        state_path.write_text(dg.serialize_value(state))
+
+    def build_defs_from_state(
+        self, context: dg.ComponentLoadContext, state_path: Optional[Path]
+    ) -> dg.Definitions:
+        if state_path is None:
+            return dg.Definitions()
+        state = deserialize_value(state_path.read_text(), FivetranWorkspaceData)
+
+        # group specs by their connector names
+        specs_by_connector_name = defaultdict(list)
+        for spec in self._load_asset_specs(state):
+            connector_name = check.not_none(
+                FivetranMetadataSet.extract(spec.metadata).connector_name
             )
-            def _asset(context: dg.AssetExecutionContext):
-                yield from self.execute(context=context, fivetran=self.workspace_resource)
+            specs_by_connector_name[connector_name].append(spec)
 
-            assets.append(_asset)
-
+        # create one assets definition per connector
+        assets = [
+            self._get_fivetran_assets_def(connector_name, specs)
+            for connector_name, specs in specs_by_connector_name.items()
+        ]
         return dg.Definitions(assets=assets)
 
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/conftest.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 
 import pytest
 import responses
+from dagster._core.test_utils import instance_for_test
+from dagster._utils.test.definitions import scoped_definitions_load_context
 from dagster_fivetran.resources import (
     FIVETRAN_API_BASE,
     FIVETRAN_API_VERSION,
@@ -532,7 +534,11 @@ def group_id_fixture() -> str:
 def fetch_workspace_data_api_mocks_fixture(
     connector_id: str, destination_id: str, group_id: str
 ) -> Iterator[responses.RequestsMock]:
-    with responses.RequestsMock() as response:
+    with (
+        responses.RequestsMock() as response,
+        instance_for_test(),
+        scoped_definitions_load_context(),
+    ):
         response.add(
             method=responses.GET,
             url=f"{FIVETRAN_API_BASE}/{FIVETRAN_API_VERSION}/groups",

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
@@ -10,6 +11,7 @@ from dagster import AssetKey
 from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils.env import environ
+from dagster._utils.test.definitions import scoped_definitions_load_context
 from dagster.components.core.component_tree import ComponentTree
 from dagster.components.testing.test_cases import TestTranslation
 from dagster.components.testing.utils import create_defs_folder_sandbox
@@ -88,6 +90,47 @@ def test_basic_component_load(
             AssetKey(["schema_name_in_destination_2", "table_name_in_destination_1_extra"]),
             AssetKey(["schema_name_in_destination_2", "table_name_in_destination_2_extra"]),
         }
+
+
+@pytest.mark.parametrize(
+    "defs_state_type",
+    ["LOCAL_FILESYSTEM", "VERSIONED_STATE_STORAGE"],
+)
+def test_component_load_with_defs_state(
+    fetch_workspace_data_multiple_connectors_mocks: responses.RequestsMock,
+    defs_state_type: str,
+) -> None:
+    with (
+        environ(
+            {
+                "FIVETRAN_API_KEY": TEST_API_KEY,
+                "FIVETRAN_API_SECRET": TEST_API_SECRET,
+                "FIVETRAN_ACCOUNT_ID": TEST_ACCOUNT_ID,
+            }
+        ),
+        create_defs_folder_sandbox() as sandbox,
+    ):
+        defs_path = sandbox.scaffold_component(
+            component_cls=FivetranAccountComponent,
+            defs_yaml_contents=deep_merge_dicts(
+                BASIC_FIVETRAN_COMPONENT_BODY,
+                {"attributes": {"defs_state": {"type": defs_state_type}}},
+            ),
+        )
+        with (
+            sandbox.load_component_and_build_defs(defs_path=defs_path) as (component, defs),
+        ):
+            # first load, nothing there
+            assert len(defs.resolve_asset_graph().get_all_asset_keys()) == 0
+            assert isinstance(component, FivetranAccountComponent)
+            asyncio.run(component.refresh_state())
+
+        with (
+            scoped_definitions_load_context(),
+            sandbox.load_component_and_build_defs(defs_path=defs_path) as (component, defs),
+        ):
+            # second load, should now have assets
+            assert len(defs.resolve_asset_graph().get_all_asset_keys()) == 8
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary & Motivation

This adds a transparent way for users to opt into the more principled state handling APIs provided by the new StateBackedComponents framework.

All StateBackedComponents now have a `defs_state_config` property, which will almost always be populated via a `defs_state` resolvable field on the model (although could in theory be populated some other way for highly-specialized use cases).

In order for this to work, I did end up needing to abandon the use of the `@fivetran_assets` decorator within the body of the component. There's just no realistic way for this to work now that we need to have fine-grained control over how the specs are produced. To be more specific, the decorator currently always invokes `workspace.load_asset_specs()` in order to get the specific set of AssetSpecs that should map to a given connector. Buried within that method call, we end up invoking FivetranWorkspaceDefsLoader.build_defs(), which is highly opinionated about the key that is used within the reconstruction metadata. In order for this to work now that StateBackedComponents are taking responsibility for the state handling process, we would need to thread through the state directly into workspace.load_asset_specs(). But even that doesn't work great -- beyond polluting a public API, we'd need to handle both cases of:

- state is passed through externally (state-backed components)
- state is not passed through (current-day)

To do this, it's not enough to just have an `Optional[TState]` argument on `build_defs()`, because we need to handle the case where state backed components are managing state for the user but there's not yet any state available. If you're using REMOTE / LOCAL storage, we don't want to then hit the fivetran API in these cases, so we need something more than a `None` value to distinguish between the cases.

I think the simplicity in this implementation is well worth the mild risk of divergence (i.e. if we decide to change anything about the `@fivetran_assets` decorator, that will not automatically be reflected in the component). 


## How I Tested These Changes

## Changelog

NOCHANGELOG
