### PR TITLE
Support all sequences in the method `AssetKey.with_prefix`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_key.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_key.py
@@ -195,7 +195,7 @@ def check_opt_coercible_to_asset_key_prefix_param(
 def key_prefix_from_coercible(key_prefix: CoercibleToAssetKeyPrefix) -> Sequence[str]:
     if isinstance(key_prefix, str):
         return [key_prefix]
-    elif isinstance(key_prefix, list):
+    elif isinstance(key_prefix, Sequence):
         return key_prefix
     else:
         check.failed(f"Unexpected type for key_prefix: {type(key_prefix)}")

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_key.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_key.py
@@ -1,6 +1,14 @@
 import dagster as dg
 import pytest
 from dagster import AssetKey
+from dagster._core.definitions.asset_key import key_prefix_from_coercible
+
+
+def test_key_prefix_from_coercible():
+    assert key_prefix_from_coercible("foo") == ["foo"]
+    assert key_prefix_from_coercible(["foo"]) == ["foo"]
+    assert key_prefix_from_coercible(("foo",)) == ("foo",)
+
 
 # While it's not trivial to achieve, slashes can ponentially sneak into asset keys
 # inside definitions. These tests pin the current behavior around getting forward


### PR DESCRIPTION
## Summary & Motivation

Even though `AssetKey.with_prefix`'s signature supports all sequences, the implementation doesn't. This PR resolves this discrepancy.

## How I Tested These Changes

Added a test.

## Changelog

> Support all sequences in the method `AssetKey.with_prefix`.