### PR TITLE
Make DagsterInstance.get() calls within a sensor or schedule body return the SensorExecutionContext instance object instead of trying to create one from scratch

### DIFF
--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedule_examples.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/schedules/schedule_examples.py
@@ -9,11 +9,11 @@ import dagster as dg
 
 
 def test_configurable_job_schedule():
-    context = dg.build_schedule_context(
+    with dg.build_schedule_context(
         scheduled_execution_time=datetime.datetime(2020, 1, 1)
-    )
-    run_request = dg.configurable_job_schedule(context)
-    assert dg.validate_run_config(configurable_job, run_request.run_config)
+    ) as context:
+        run_request = dg.configurable_job_schedule(context)
+        assert dg.validate_run_config(configurable_job, run_request.run_config)
 
 
 # end_test_cron_schedule_context

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/asset_sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/asset_sensors.py
@@ -44,17 +44,16 @@ def test_my_asset_sensor():
         return 1
 
     instance = DagsterInstance.ephemeral()
-    ctx = build_sensor_context(instance)
+    with build_sensor_context(instance) as ctx:
+        result = list(my_asset_sensor(ctx))
+        assert len(result) == 1
+        assert isinstance(result[0], SkipReason)
 
-    result = list(my_asset_sensor(ctx))
-    assert len(result) == 1
-    assert isinstance(result[0], SkipReason)
+        materialize([my_table], instance=instance)
 
-    materialize([my_table], instance=instance)
-
-    result = list(my_asset_sensor(ctx))
-    assert len(result) == 1
-    assert isinstance(result[0], RunRequest)
+        result = list(my_asset_sensor(ctx))
+        assert len(result) == 1
+        assert isinstance(result[0], RunRequest)
 
 
 # end_asset_sensor_test_marker

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -138,9 +138,9 @@ from dagster import build_sensor_context
 
 
 def test_my_directory_sensor_cursor():
-    context = build_sensor_context(cursor="0")
-    for run_request in my_directory_sensor_cursor(context):
-        assert validate_run_config(log_file_job, run_request.run_config)
+    with build_sensor_context(cursor="0") as context:
+        for run_request in my_directory_sensor_cursor(context):
+            assert validate_run_config(log_file_job, run_request.run_config)
 
 
 # end_sensor_testing_with_context

--- a/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
@@ -803,9 +803,9 @@ def new_resource_on_sensor() -> None:
             def fetch_users(self) -> list[str]:
                 return ["1", "2", "3"]
 
-        context = dg.build_sensor_context()
-        run_requests = process_new_users_sensor(context, users_api=FakeUsersAPI())
-        assert len(run_requests) == 3
+        with dg.build_sensor_context() as context:
+            run_requests = process_new_users_sensor(context, users_api=FakeUsersAPI())
+            assert len(run_requests) == 3
 
         # end_test_resource_on_sensor
 
@@ -852,15 +852,15 @@ def new_resource_on_schedule() -> None:
     import dagster as dg
 
     def test_process_data_schedule():
-        context = dg.build_schedule_context(
+        with dg.build_schedule_context(
             scheduled_execution_time=datetime.datetime(2020, 1, 1)
-        )
-        run_request = process_data_schedule(
-            context, date_formatter=DateFormatter(format="%Y-%m-%d")
-        )
-        assert (
-            run_request.run_config["ops"]["fetch_data"]["config"]["date"]
-            == "2020-01-01"
-        )
+        ) as context:
+            run_request = process_data_schedule(
+                context, date_formatter=DateFormatter(format="%Y-%m-%d")
+            )
+            assert (
+                run_request.run_config["ops"]["fetch_data"]["config"]["date"]
+                == "2020-01-01"
+            )
 
     # end_test_resource_on_schedule

--- a/python_modules/dagster/dagster/_core/instance/context.py
+++ b/python_modules/dagster/dagster/_core/instance/context.py
@@ -1,0 +1,38 @@
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DagsterInstance
+
+
+class DagsterInstanceContext(ABC):
+    @property
+    @abstractmethod
+    def instance(self) -> "DagsterInstance": ...
+
+    @abstractmethod
+    def create_instance(self) -> Optional["DagsterInstance"]: ...
+
+
+_current_ctx: ContextVar[Optional[DagsterInstanceContext]] = ContextVar(
+    "current_dagster_instance_context", default=None
+)
+
+
+@contextmanager
+def set_dagster_instance_context(
+    new_ctx: DagsterInstanceContext,
+) -> Iterator[DagsterInstanceContext]:
+    token = _current_ctx.set(new_ctx)
+
+    try:
+        yield new_ctx
+    finally:
+        _current_ctx.reset(token)
+
+
+def get_dagster_instance_context() -> Optional[DagsterInstanceContext]:
+    return _current_ctx.get()

--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -268,7 +268,14 @@ class DagsterInstance(
         Returns:
             DagsterInstance: The current DagsterInstance.
         """
+        from dagster._core.instance.context import get_dagster_instance_context
         from dagster._core.instance.factory import create_instance_from_dagster_home
+
+        current_context = get_dagster_instance_context()
+        if current_context:
+            created_instance = current_context.create_instance()
+            if created_instance:
+                return created_instance
 
         return create_instance_from_dagster_home()
 


### PR DESCRIPTION
## Summary & Motivation
Intended to address a situation where you write a sensor that calls DagsterInstance.get() in its body (instead of using context.instance) and it works great locally but then fails when deployed to k8s or Dagster+. Store the current instance that you should use in a contextvar and access that.

It creates a new instance rather than using the stored instance, to make sure that the lifecycle of the instance is managed in the exact same way as if you had called DagsterInstance.get() (which would probably be better named DagsterInstance.create())

## How I Tested These Changes
New test cases

## Changelog
Fixed an issue where calling `DagsterInstance.get()` instead of `context.instance` in the body of a schedule or sensor function would work when running `dagster dev` locally but fail with an error when the schedule or sensor was deployed to kubernetes or Dagster+.