### PR TITLE
[dagster-dbt] Fix bug with DbtProjectComponent in which user-provided template vars would not be accessible from the `cli_args` field.

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_dbt_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_dbt_component.py
@@ -265,8 +265,8 @@ def test_components_docs_dbt_project(
                   cli_args:
                     - build
                     - --vars:
-                      start_date: "{{ context.partition_time_window.start.strftime('%Y-%m-%d') }}"
-                      end_date: "{{ context.partition_time_window.end.strftime('%Y-%m-%d') }}"
+                      start_date: "{{ partition_time_window.start.strftime('%Y-%m-%d') }}"
+                      end_date: "{{ partition_time_window.end.strftime('%Y-%m-%d') }}"
                 post_processing:
                   assets:
                     - target: "*"


### PR DESCRIPTION
## Summary & Motivation

See title.

This is a bit of a tricky one because we can't really update the signature of `execute()` (it's user-visible and intended to be overridden by subclasses), so we need to find some other way of making the original resolution scope available at runtime.

There are basically two options:

- eagerly render template values beforehand, and in the case that we hit an error with a variable not existing, just leave it untouched
- global state (chosen)

The first option is

## How I Tested These Changes

## Changelog

[dagster-dbt] Fixed issue that made custom template vars unavailable when specifying them for the `cli_args:` field of the `DbtProjectComponent`.
