### PR TITLE
[dagster-dbt] Fix test_load_check_specs_exclude in dbt Cloud v2 test suite

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_specs.py
@@ -146,9 +146,9 @@ def test_load_check_specs_exclude(
     all_checks = load_dbt_cloud_check_specs(workspace=workspace, exclude="raw_customers+")
     all_checks_keys = [check.key for check in all_checks]
 
-    # 16 dbt tests
-    assert len(all_checks) == 16
-    assert len(all_checks_keys) == 16
+    # 15 dbt tests
+    assert len(all_checks) == 15
+    assert len(all_checks_keys) == 15
 
     # Sanity check outputs
     first_check_key = next(key for key in sorted(all_checks_keys))


### PR DESCRIPTION
## Summary & Motivation

Changes made in #32441 modify the number of asset checks in `test_load_check_specs_exclude` because of the updated condition `if child_unique_id not in selected_unique_ids or not child_unique_id.startswith("test")`.

## How I Tested These Changes

Updated test with BK

