### PR TITLE
remove deepeval from automation requirements

### DIFF
--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -32,7 +32,6 @@ setup(
         "virtualenv>=20.27.0",
         "urllib3",
         "watchdog",
-        "deepeval",
     ],
     extras_require={
         "buildkite": [


### PR DESCRIPTION
they pushed a bad version and you only need it to run cli that is unlikely used by anyone

## How I Tested These Changes

bk