### PR TITLE
[ui] Handle asset trend pez for >5 events

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
@@ -12,8 +12,8 @@ interface Props {
 }
 
 export const AssetRecentUpdatesTrend = React.memo(({latestInfo, events}: Props) => {
-  const items = latestInfo ? [latestInfo, ...events] : [...events];
-  const emptyItems = new Array(5 - items.length).fill(null);
+  const items = latestInfo ? [latestInfo, ...events.slice(0, 4)] : events.slice(0, 5);
+  const emptyItems = new Array(Math.max(5 - items.length, 0)).fill(null);
   const allItems = [...items, ...emptyItems].reverse();
 
   const states = allItems.map((event, index) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetRecentUpdatesTrend.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetRecentUpdatesTrend.test.tsx
@@ -1,0 +1,123 @@
+import {render, screen} from '@testing-library/react';
+
+import {
+  RunStatus,
+  buildAssetLatestInfo,
+  buildFailedToMaterializeEvent,
+  buildMaterializationEvent,
+  buildObservationEvent,
+  buildRun,
+} from '../../graphql/types';
+import {AssetRecentUpdatesTrend} from '../AssetRecentUpdatesTrend';
+
+jest.mock('../../ui/PezItem', () => ({
+  ...jest.requireActual('../../ui/PezItem'),
+  PezItem: ({color}: {color: string}) => <div style={{backgroundColor: color}}>pez {color}</div>,
+}));
+
+describe('AssetRecentUpdatesTrend', () => {
+  it('should render for empty events list', async () => {
+    render(<AssetRecentUpdatesTrend events={[]} />);
+    const allPez = await screen.findAllByText(/pez/i);
+    expect(allPez).toHaveLength(5);
+    const allGray = await screen.findAllByText(/var\(--color-background-disabled\)/i);
+    expect(allGray).toHaveLength(5);
+  });
+
+  it('should render for events list', async () => {
+    const events = Array.from({length: 5}, (_, i) => {
+      return buildMaterializationEvent({
+        runId: `1-${i}`,
+        timestamp: `${1000000 + i}`,
+      });
+    });
+    render(<AssetRecentUpdatesTrend events={events} />);
+    const allPez = await screen.findAllByText(/pez/i);
+    expect(allPez).toHaveLength(5);
+    const allGreen = await screen.findAllByText(/var\(--color-accent-green\)/i);
+    expect(allGreen).toHaveLength(5);
+  });
+
+  it('should render for short events list', async () => {
+    const events = Array.from({length: 2}, (_, i) => {
+      return buildMaterializationEvent({
+        runId: `1-${i}`,
+        timestamp: `${1000000 + i}`,
+      });
+    });
+    render(<AssetRecentUpdatesTrend events={events} />);
+    const allPez = await screen.findAllByText(/pez/i);
+    expect(allPez).toHaveLength(5);
+    expect(allPez[0]).toHaveTextContent('pez var(--color-background-disabled)');
+    expect(allPez[1]).toHaveTextContent('pez var(--color-background-disabled)');
+    expect(allPez[2]).toHaveTextContent('pez var(--color-background-disabled)');
+    expect(allPez[3]).toHaveTextContent('pez var(--color-accent-green)');
+    expect(allPez[4]).toHaveTextContent('pez var(--color-accent-green)');
+  });
+
+  it('should handle cases where more than 5 events are provided', async () => {
+    const events = Array.from({length: 10}, (_, i) => {
+      return buildMaterializationEvent({
+        runId: `1-${i}`,
+        timestamp: `${1000000 + i}`,
+      });
+    });
+    render(<AssetRecentUpdatesTrend events={events} />);
+    const allPez = await screen.findAllByText(/pez/i);
+    expect(allPez).toHaveLength(5);
+    const allGreen = await screen.findAllByText(/var\(--color-accent-green\)/i);
+    expect(allGreen).toHaveLength(5);
+  });
+
+  it('should handle latest info', async () => {
+    const events = Array.from({length: 5}, (_, i) => {
+      return buildMaterializationEvent({
+        runId: `1-${i}`,
+        timestamp: `${1000000 + i}`,
+      });
+    });
+    const latestInfo = buildAssetLatestInfo({
+      latestRun: buildRun({
+        id: '1',
+        status: RunStatus.SUCCESS,
+        startTime: 1000000,
+      }),
+    });
+    render(<AssetRecentUpdatesTrend latestInfo={latestInfo} events={events} />);
+    const allPez = await screen.findAllByText(/pez/i);
+    expect(allPez).toHaveLength(5);
+    expect(allPez[0]).toHaveTextContent('pez var(--color-accent-green)');
+    expect(allPez[1]).toHaveTextContent('pez var(--color-accent-green)');
+    expect(allPez[2]).toHaveTextContent('pez var(--color-accent-green)');
+    expect(allPez[3]).toHaveTextContent('pez var(--color-accent-green)');
+    expect(allPez[4]).toHaveTextContent('pez var(--color-accent-blue)');
+  });
+
+  it('should handle failed to materialize event', async () => {
+    const events = Array.from({length: 5}, (_, i) => {
+      return buildFailedToMaterializeEvent({
+        runId: `1-${i}`,
+        timestamp: `${1000000 + i}`,
+      });
+    });
+    render(<AssetRecentUpdatesTrend events={events} />);
+    const allPez = await screen.findAllByText(/pez/i);
+    expect(allPez).toHaveLength(5);
+    const allRed = await screen.findAllByText(/var\(--color-accent-red\)/i);
+    expect(allRed).toHaveLength(5);
+  });
+
+  it('should handle observation event', async () => {
+    const events = Array.from({length: 5}, (_, i) => {
+      return buildObservationEvent({
+        runId: `1-${i}`,
+        timestamp: `${1000000 + i}`,
+      });
+    });
+    render(<AssetRecentUpdatesTrend events={events} />);
+    const allPez = await screen.findAllByText(/pez/i);
+    expect(allPez).toHaveLength(5);
+    const allGreen = await screen.findAllByText(/var\(--color-accent-green\)/i);
+    expect(allGreen).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary & Motivation

When providing more than 5 events to `AssetRecentUpdatesTrend`, we end up with an invalid array length on the array constructed for empty items.

Resolve this by:

- Only using five events (or four, if latest info is provided) from the provided `events` array
- Use a `Math.max` to guard against negative array lengths. This shouldn't be strictly necessary now, since the `events` prop is being sliced, but it shouldn't hurt.

Added a test as well.

## How I Tested These Changes

`yarn jest AssetRecentUpdatesTrend`

Load an asset catalog list that is known to show errors, verify that it no longer does.
