### PR TITLE
[docs] attempt fix of objects.inv API references

### DIFF
--- a/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/builders/mdx.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/builders/mdx.py
@@ -61,7 +61,12 @@ class MdxBuilder(Builder):
                 pass
 
     def get_target_uri(self, docname: str, typ: str | None = None) -> str:
-        return self.link_transform(docname)
+        # Transform the docname to match the actual documentation URL structure
+        # Remove 'sections/api/apidocs/' prefix if present
+        transformed = docname
+        if transformed.startswith("sections/api/apidocs/"):
+            transformed = transformed.replace("sections/api/apidocs/", "api/", 1)
+        return self.link_transform(transformed)
 
     def prepare_writing(self, docnames: set[str]) -> None:
         self.writer = MdxWriter(self)

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -43,6 +43,9 @@ project = "Dagster"
 copyright = "2019, Dagster Labs, Inc"  # noqa: A001
 author = "Dagster Labs"
 
+# Base URL for the documentation site - used for generating correct inventory URIs
+html_baseurl = "https://docs.dagster.io/"
+
 # -- General configuration ---------------------------------------------------
 
 # NOTE: `sphinx.ext.*` extensions are built-in to sphinx-- all others are supplied by other


### PR DESCRIPTION
## Summary & Motivation

Closes #32228

Changes made:

1. Created a custom Sphinx extension (docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py:174-239) that hooks into the env-updated event to transform inventory URIs before they're written to objects.inv.
2. Added the base URL configuration to docs/sphinx/conf.py:47 to ensure proper URL resolution.
3. Copied the fixed objects.inv to docs/static/ where the build process expects it.

Result:
- Old (broken): https://docs.dagster.io/api#dagster.InitExecutorContext
- New (fixed): https://docs.dagster.io/api/dagster/internals#dagster.InitExecutorContext

## How I Tested These Changes


```
curl -O https://colton-fix-objects-inv.archive.dagster-docs.io/objects.inv

uvx sphobjinv convert json objects.inv
```

```
  "1044": {
    "name": "dagster._core.executor.init.InitExecutorContext",
    "domain": "py",
    "role": "class",
    "priority": "-1",
    "uri": "api/dagster/internals/#dagster.InitExecutorContext",
    "dispname": "-"
  },
```

## Changelog

- [docs] fix broken API doc references in `objects.inv`
