### PR TITLE
Don't include ignored nodes when generating run config for an implicit asset job

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
@@ -64,624 +64,7 @@
           },
           "type_param_keys": null
         },
-        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Bool",
-            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
-          ]
-        },
-        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Float",
-            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
-          ]
-        },
-        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "Int",
-            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
-          ]
-        },
-        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": null,
-          "given_name": null,
-          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SCALAR_UNION"
-          },
-          "scalar_kind": null,
-          "type_param_keys": [
-            "String",
-            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
-          ]
-        },
-        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "disabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "enabled",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.2571019f1a5201853d11032145ac3e534067f214": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "env",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.2571019f1a5201853d11032145ac3e534067f214",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Int"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Bool"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Float"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "json",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "pickle",
-              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "value",
-              "type_key": "Any"
-            }
-          ],
-          "given_name": null,
-          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.SELECTOR"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "[DEPRECATED]",
-              "is_required": false,
-              "name": "marker_to_close",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"enabled\": {}}",
-              "description": "Whether retries are enabled or not. By default, retries are enabled.",
-              "is_required": false,
-              "name": "retries",
-              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Determines when steps will be executed in relation to their upstream dependencies.",
-              "is_required": false,
-              "name": "step_dependency_config",
-              "type_key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"INFO\"",
-              "description": "The logger's threshold.",
-              "is_required": false,
-              "name": "log_level",
-              "type_key": "String"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "\"dagster\"",
-              "description": "The name of your logger.",
-              "is_required": false,
-              "name": "name",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
-              "description": "The default colored console logger.",
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": false,
-              "name": "base_dir",
-              "type_key": "StringSourceType"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.19f08340806258d3576e42405b375eda0ff33199": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
-              "description": "Configure how steps are executed within a run.",
-              "is_required": false,
-              "name": "execution",
-              "type_key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": "Configure how loggers emit messages within a run.",
-              "is_required": false,
-              "name": "loggers",
-              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_3_asset_3_check\": {}, \"asset_3_asset_3_other_check\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_with_automation_condition\": {}, \"asset_with_compute_storage_kinds\": {\"config\": {}}, \"asset_with_custom_automation_condition\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"concurrency_asset\": {}, \"concurrency_graph_asset\": {\"ops\": {\"concurrency_op_1\": {}, \"concurrency_op_2\": {}}}, \"concurrency_multi_asset\": {\"config\": {}}, \"downstream_asset\": {}, \"downstream_dynamic_partitioned_asset\": {}, \"downstream_static_partitioned_asset\": {}, \"downstream_time_partitioned_asset\": {}, \"downstream_weekly_partitioned_asset\": {}, \"dynamic_in_multipartitions_fail\": {}, \"dynamic_in_multipartitions_success\": {}, \"executable_asset\": {}, \"fail_partition_materialization\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"grouping_prefix__asset_with_prefix_1\": {}, \"grouping_prefix__asset_with_prefix_2\": {}, \"grouping_prefix__asset_with_prefix_3\": {}, \"grouping_prefix__asset_with_prefix_4\": {}, \"grouping_prefix__asset_with_prefix_5\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"hanging_partition_asset\": {}, \"integers_asset\": {}, \"middle_static_partitioned_asset_1\": {}, \"middle_static_partitioned_asset_2\": {}, \"multi_asset_with_kinds\": {\"config\": {}}, \"multi_run_backfill_policy_asset\": {}, \"multipartitions_1\": {}, \"multipartitions_2\": {}, \"multipartitions_fail\": {}, \"never_runs_asset\": {}, \"no_multipartitions_1\": {}, \"not_included_asset\": {}, \"observable_asset_same_version\": {}, \"output_then_hang_asset\": {}, \"owned_asset\": {}, \"owned_partitioned_asset\": {}, \"single_run_backfill_policy_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unowned_asset\": {}, \"unowned_partitioned_asset\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_daily_partitioned_asset\": {}, \"upstream_dynamic_partitioned_asset\": {}, \"upstream_static_partitioned_asset\": {}, \"upstream_time_partitioned_asset\": {}, \"yield_partition_materialization\": {}}",
-              "description": "Configure runtime parameters for ops or assets.",
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.644230186656cbf4a7bf5594a97caa6e85cded9d"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": "Configure how shared resources are implemented within a run.",
-              "is_required": true,
-              "name": "resources",
-              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.19f08340806258d3576e42405b375eda0ff33199",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.31ebade63b77a8095e9f78414e75445567b90463": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "concurrency_op_1",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            },
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "concurrency_op_2",
-              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.31ebade63b77a8095e9f78414e75445567b90463",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.35d3e42b53e66506c5867f04644849cd03763bc6": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}",
-              "description": null,
-              "is_required": false,
-              "name": "ops",
-              "type_key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.35d3e42b53e66506c5867f04644849cd03763bc6",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.44f2a71367507edd1b8e64f739222c4312b3691b": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": false,
-              "default_value_as_json_str": null,
-              "description": null,
-              "is_required": true,
-              "name": "path",
-              "type_key": "String"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
-          "__class__": "ConfigTypeSnap",
-          "description": null,
-          "enum_values": null,
-          "fields": [
-            {
-              "__class__": "ConfigFieldSnap",
-              "default_provided": true,
-              "default_value_as_json_str": "{}",
-              "description": null,
-              "is_required": false,
-              "name": "config",
-              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
-            }
-          ],
-          "given_name": null,
-          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
-          "kind": {
-            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
-          },
-          "scalar_kind": null,
-          "type_param_keys": null
-        },
-        "Shape.644230186656cbf4a7bf5594a97caa6e85cded9d": {
+        "Permissive.644230186656cbf4a7bf5594a97caa6e85cded9d": {
           "__class__": "ConfigTypeSnap",
           "description": null,
           "enum_values": null,
@@ -1372,7 +755,574 @@
             }
           ],
           "given_name": null,
-          "key": "Shape.644230186656cbf4a7bf5594a97caa6e85cded9d",
+          "key": "Permissive.644230186656cbf4a7bf5594a97caa6e85cded9d",
+          "kind": {
+            "__enum__": "ConfigTypeKind.PERMISSIVE_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Bool-Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Bool",
+            "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59"
+          ]
+        },
+        "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Float-Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Float",
+            "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3"
+          ]
+        },
+        "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.Int-Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "Int",
+            "Selector.a9799b971d12ace70a2d8803c883c863417d0725"
+          ]
+        },
+        "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": null,
+          "given_name": null,
+          "key": "ScalarUnion.String-Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SCALAR_UNION"
+          },
+          "scalar_kind": null,
+          "type_param_keys": [
+            "String",
+            "Selector.e04723c9d9937e3ab21206435b22247cfbe58269"
+          ]
+        },
+        "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "disabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "enabled",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.2571019f1a5201853d11032145ac3e534067f214": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "env",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.2571019f1a5201853d11032145ac3e534067f214",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.a9799b971d12ace70a2d8803c883c863417d0725": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Int"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.a9799b971d12ace70a2d8803c883c863417d0725",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Bool"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.be5d518b39e86a43c5f2eecaf538c1f6c7711b59",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Float"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.d00a37e3807d37c9f69cc62997c4a5f4a176e5c3",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.e04723c9d9937e3ab21206435b22247cfbe58269": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.e04723c9d9937e3ab21206435b22247cfbe58269",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "json",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "pickle",
+              "type_key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "value",
+              "type_key": "Any"
+            }
+          ],
+          "given_name": null,
+          "key": "Selector.f2fe6dfdc60a1947a8f8e7cd377a012b47065bc4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.SELECTOR"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "[DEPRECATED]",
+              "is_required": false,
+              "name": "marker_to_close",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"enabled\": {}}",
+              "description": "Whether retries are enabled or not. By default, retries are enabled.",
+              "is_required": false,
+              "name": "retries",
+              "type_key": "Selector.1bfb167aea90780aa679597800c71bd8c65ed0b2"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Determines when steps will be executed in relation to their upstream dependencies.",
+              "is_required": false,
+              "name": "step_dependency_config",
+              "type_key": "Shape.c1b51cfcee4bafa04a39110cb65b6e600e4d98d3"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.01b2c92ded97d2dd2ca2591c9ca93d8abac33ee4",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.081354663b9d4b8fbfd1cb8e358763912953913f": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"INFO\"",
+              "description": "The logger's threshold.",
+              "is_required": false,
+              "name": "log_level",
+              "type_key": "String"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "\"dagster\"",
+              "description": "The name of your logger.",
+              "is_required": false,
+              "name": "name",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"log_level\": \"INFO\", \"name\": \"dagster\"}",
+              "description": "The default colored console logger.",
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.081354663b9d4b8fbfd1cb8e358763912953913f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.0fe8353d6b542accfad9becbdbaeb92f649ebb9a",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": false,
+              "name": "base_dir",
+              "type_key": "StringSourceType"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.31ebade63b77a8095e9f78414e75445567b90463": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "concurrency_op_1",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "concurrency_op_2",
+              "type_key": "Shape.743e47901855cb245064dd633e217bfcb49a11a7"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.31ebade63b77a8095e9f78414e75445567b90463",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.35d3e42b53e66506c5867f04644849cd03763bc6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}",
+              "description": null,
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Shape.811a60b4c43530c3d6100304f377dbd2d3045291"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.35d3e42b53e66506c5867f04644849cd03763bc6",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.44f2a71367507edd1b8e64f739222c4312b3691b": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.18b2faaf1efd505374f7f25fcb61ed59bd5be851"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.44f2a71367507edd1b8e64f739222c4312b3691b",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": null,
+              "is_required": true,
+              "name": "path",
+              "type_key": "String"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.4b53b73df342381d0d05c5f36183dc99cb9676e2",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.62edccaf30696e25335ae92685bdc41e204e30e6": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": null,
+              "is_required": false,
+              "name": "config",
+              "type_key": "Shape.da39a3ee5e6b4b0d3255bfef95601890afd80709"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.62edccaf30696e25335ae92685bdc41e204e30e6",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -1501,6 +1451,56 @@
           ],
           "given_name": null,
           "key": "Shape.9a3a315bff2146cca750edbec49c6b4b4d0ce58e",
+          "kind": {
+            "__enum__": "ConfigTypeKind.STRICT_SHAPE"
+          },
+          "scalar_kind": null,
+          "type_param_keys": null
+        },
+        "Shape.9cb06b2df968d56ffd602d11c5dc54be42b37d41": {
+          "__class__": "ConfigTypeSnap",
+          "description": null,
+          "enum_values": null,
+          "fields": [
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"config\": {\"retries\": {\"enabled\": {}}}}",
+              "description": "Configure how steps are executed within a run.",
+              "is_required": false,
+              "name": "execution",
+              "type_key": "Shape.f07ed19fc888e3245c2ca562556397f72651e11e"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{}",
+              "description": "Configure how loggers emit messages within a run.",
+              "is_required": false,
+              "name": "loggers",
+              "type_key": "Shape.e895d95ee6d0eff1b884c76f44a2ab7089f0c49b"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": true,
+              "default_value_as_json_str": "{\"asset_1\": {}, \"asset_1_my_check\": {}, \"asset_2\": {}, \"asset_3\": {}, \"asset_3_asset_3_check\": {}, \"asset_3_asset_3_other_check\": {}, \"asset_one\": {}, \"asset_two\": {}, \"asset_with_automation_condition\": {}, \"asset_with_compute_storage_kinds\": {\"config\": {}}, \"asset_with_custom_automation_condition\": {}, \"asset_yields_observation\": {}, \"bar\": {}, \"baz\": {}, \"check_in_op_asset\": {}, \"concurrency_asset\": {}, \"concurrency_graph_asset\": {\"ops\": {\"concurrency_op_1\": {}, \"concurrency_op_2\": {}}}, \"concurrency_multi_asset\": {\"config\": {}}, \"downstream_asset\": {}, \"downstream_dynamic_partitioned_asset\": {}, \"downstream_static_partitioned_asset\": {}, \"downstream_time_partitioned_asset\": {}, \"downstream_weekly_partitioned_asset\": {}, \"dynamic_in_multipartitions_fail\": {}, \"dynamic_in_multipartitions_success\": {}, \"executable_asset\": {}, \"fail_partition_materialization\": {}, \"first_asset\": {}, \"foo\": {}, \"foo_bar\": {}, \"fresh_diamond_bottom\": {}, \"fresh_diamond_left\": {}, \"fresh_diamond_right\": {}, \"fresh_diamond_top\": {}, \"grouped_asset_1\": {}, \"grouped_asset_2\": {}, \"grouped_asset_4\": {}, \"grouping_prefix__asset_with_prefix_1\": {}, \"grouping_prefix__asset_with_prefix_2\": {}, \"grouping_prefix__asset_with_prefix_3\": {}, \"grouping_prefix__asset_with_prefix_4\": {}, \"grouping_prefix__asset_with_prefix_5\": {}, \"hanging_asset\": {}, \"hanging_graph\": {\"ops\": {\"hanging_op\": {}, \"my_op\": {}, \"never_runs_op\": {}}}, \"hanging_partition_asset\": {}, \"integers_asset\": {}, \"middle_static_partitioned_asset_1\": {}, \"middle_static_partitioned_asset_2\": {}, \"multi_asset_with_kinds\": {\"config\": {}}, \"multi_run_backfill_policy_asset\": {}, \"multipartitions_1\": {}, \"multipartitions_2\": {}, \"multipartitions_fail\": {}, \"never_runs_asset\": {}, \"no_multipartitions_1\": {}, \"not_included_asset\": {}, \"observable_asset_same_version\": {}, \"output_then_hang_asset\": {}, \"owned_asset\": {}, \"owned_partitioned_asset\": {}, \"single_run_backfill_policy_asset\": {}, \"subsettable_checked_multi_asset\": {\"config\": {}}, \"typed_asset\": {}, \"typed_multi_asset\": {\"config\": {}}, \"unconnected\": {}, \"ungrouped_asset_3\": {}, \"ungrouped_asset_5\": {}, \"unowned_asset\": {}, \"unowned_partitioned_asset\": {}, \"unpartitioned_upstream_of_partitioned\": {}, \"untyped_asset\": {}, \"upstream_daily_partitioned_asset\": {}, \"upstream_dynamic_partitioned_asset\": {}, \"upstream_static_partitioned_asset\": {}, \"upstream_time_partitioned_asset\": {}, \"yield_partition_materialization\": {}}",
+              "description": "Configure runtime parameters for ops or assets.",
+              "is_required": false,
+              "name": "ops",
+              "type_key": "Permissive.644230186656cbf4a7bf5594a97caa6e85cded9d"
+            },
+            {
+              "__class__": "ConfigFieldSnap",
+              "default_provided": false,
+              "default_value_as_json_str": null,
+              "description": "Configure how shared resources are implemented within a run.",
+              "is_required": true,
+              "name": "resources",
+              "type_key": "Shape.7493b137e48f8d4b013bce61e92617ff1bc51f7f"
+            }
+          ],
+          "given_name": null,
+          "key": "Shape.9cb06b2df968d56ffd602d11c5dc54be42b37d41",
           "kind": {
             "__enum__": "ConfigTypeKind.STRICT_SHAPE"
           },
@@ -2852,7 +2852,7 @@
             "name": "io_manager"
           }
         ],
-        "root_config_key": "Shape.19f08340806258d3576e42405b375eda0ff33199"
+        "root_config_key": "Shape.9cb06b2df968d56ffd602d11c5dc54be42b37d41"
       }
     ],
     "name": "__ASSET_JOB",
@@ -41339,7 +41339,7 @@
   'a42b76205f669056b37fd68ef75743cbb470f27e'
 # ---
 # name: test_all_snapshot_ids[1]
-  'add137417ecdf718c8ca4df764a5161f4fc50789'
+  '354b09f2adad70fde8011d713fab1e0edc2e7e28'
 # ---
 # name: test_all_snapshot_ids[20]
   '''

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -1439,12 +1439,13 @@ def _create_run_config_schema(
         define_run_config_schema_type,
     )
     from dagster._core.definitions.run_config_schema import RunConfigSchema
+    from dagster._core.remote_representation.code_location import is_implicit_asset_job_name
 
-    # When executing with a subset job, include the missing nodes
+    # When executing with a subset job that is not an implicit asset job, include the missing nodes
     # from the original job as ignored to allow execution with
     # run config that is valid for the original
     ignored_nodes: Sequence[Node] = []
-    if job_def.is_subset:
+    if job_def.is_subset and not is_implicit_asset_job_name(job_def.name):
         if isinstance(job_def.graph, SubselectedGraphDefinition):  # op selection provided
             ignored_nodes = job_def.graph.get_top_level_omitted_nodes()
         elif job_def.asset_selection_data:

--- a/python_modules/dagster/dagster/_core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/_core/system_config/composite_descent.py
@@ -10,7 +10,7 @@ from dagster._core.definitions.dependency import GraphNode, Node, NodeHandle, Op
 from dagster._core.definitions.graph_definition import GraphDefinition, SubselectedGraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.resource_definition import ResourceDefinition
-from dagster._core.definitions.run_config import define_node_shape
+from dagster._core.definitions.run_config import define_node_config
 from dagster._core.errors import (
     DagsterConfigMappingFunctionError,
     DagsterInvalidConfigError,
@@ -217,7 +217,7 @@ def _apply_top_level_config_mapping(
         # Dynamically construct the type that the output of the config mapping function will
         # be evaluated against
 
-        type_to_evaluate_against = define_node_shape(
+        type_to_evaluate_against = define_node_config(
             nodes=graph_def.nodes,
             ignored_nodes=None,
             dependency_structure=graph_def.dependency_structure,
@@ -284,7 +284,7 @@ def _apply_config_mapping(
         else None
     )
 
-    type_to_evaluate_against = define_node_shape(
+    type_to_evaluate_against = define_node_config(
         nodes=graph_def.nodes,
         ignored_nodes=ignored_nodes,
         dependency_structure=graph_def.dependency_structure,

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -1,12 +1,14 @@
 import re
+from typing import cast
 
 import dagster as dg
 from dagster import Any, Int
 from dagster._config import ConfigTypeKind, process_config
 from dagster._config.config_type import ConfigType
+from dagster._config.field_utils import Permissive, Shape
 from dagster._core.definitions import create_run_config_schema
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.run_config import RunConfigSchemaCreationData, define_node_shape
+from dagster._core.definitions.run_config import RunConfigSchemaCreationData, define_node_config
 from dagster._core.system_config.objects import OpConfig, ResolvedRunConfig, ResourceConfig
 
 
@@ -255,7 +257,7 @@ def test_whole_environment():
 
 def test_op_config_error():
     job_def = define_test_solids_config_pipeline()
-    solid_dict_type = define_node_shape(
+    solid_dict_type = define_node_config(
         nodes=job_def.nodes,
         ignored_nodes=None,
         dependency_structure=job_def.dependency_structure,
@@ -405,6 +407,65 @@ def test_required_op_with_required_subfield():
 
     res = process_config(env_type, {})
     assert not res.success
+
+
+def test_implicit_asset_job_subset_config():
+    @dg.asset(config_schema={"foo": int})
+    def asset():
+        return 1
+
+    @dg.asset(config_schema={"bar": int})
+    def asset2():
+        return 2
+
+    @dg.asset
+    def asset3():
+        return 3
+
+    @dg.asset
+    def asset_without_config():
+        return 3
+
+    defs = dg.Definitions(
+        assets=[asset, asset2, asset3, asset_without_config],
+        jobs=[
+            dg.define_asset_job(
+                "explicit_asset_job", selection=["asset", "asset2", "asset_without_config"]
+            )
+        ],
+    )
+
+    explicit_asset_job = defs.resolve_job_def("explicit_asset_job")
+    explicit_asset_job_subset = explicit_asset_job.get_subset(
+        asset_selection={dg.AssetKey(["asset"])}
+    )
+
+    implicit_asset_job_subset = defs.resolve_implicit_global_asset_job_def().get_subset(
+        asset_selection={dg.AssetKey(["asset"]), dg.AssetKey(["asset2"])}
+    )
+
+    # implicit asset job subset only reference the specific assets in the subset
+    implicit_subset_env_type = create_run_config_schema_type(implicit_asset_job_subset)
+    assert isinstance(implicit_subset_env_type, Shape)
+    assert isinstance(implicit_subset_env_type.fields["ops"].config_type, Permissive)
+    permissive = cast("Permissive", implicit_subset_env_type.fields["ops"].config_type)
+    assert permissive.fields.keys() == {
+        "asset",
+        "asset2",
+    }
+
+    # despite having an asset_selection of just one asset, the subset job still includes the other assets
+    # in the job are not in the selection, since the job is an explicitly defined subset
+    explicit_subset_env_type = create_run_config_schema_type(explicit_asset_job_subset)
+    assert isinstance(explicit_subset_env_type, Shape)
+    assert isinstance(explicit_subset_env_type.fields["ops"].config_type, Shape)
+    shape = cast("Shape", explicit_subset_env_type.fields["ops"].config_type)
+
+    assert shape.fields.keys() == {
+        "asset",
+        "asset2",
+        "asset_without_config",
+    }
 
 
 def test_optional_op_with_optional_subfield():

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -267,7 +267,7 @@ def test_snapshot_id(
     assert len(set(results)) == 1
 
     # this should only update if the dbt project or asset producing code changes
-    assert results[0] == "48b79ea46a9a3ef9f80407d94f75c80431c5159c"
+    assert results[0] == "3d21d8fcd9e98b37154bd6db66324c985153853d"
 
 
 @pytest.mark.parametrize("name", [None, "custom"])


### PR DESCRIPTION
Summary:
This feature was intended to ensure that if you subset a job you can still pass in the original run config and have the unrelated fields still work. That logic does not apply to implicit asset job and just bloats the schema with information about every asset.

This required changing the launching backfills with config logic to only include the config for the relevant ops.
