### PR TITLE
Use a different key for the RemoteExecutionPlan loader

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -25,7 +25,6 @@ class JobSubsetSelector(IHaveNew):
     op_selection: Optional[Sequence[str]]
     asset_selection: Optional[AbstractSet[AssetKey]]
     asset_check_selection: Optional[AbstractSet[AssetCheckKey]]
-    run_config: Optional[Mapping[str, Any]]
 
     def __new__(
         cls,
@@ -35,7 +34,6 @@ class JobSubsetSelector(IHaveNew):
         op_selection: Optional[Sequence[str]],
         asset_selection: Optional[Iterable[AssetKey]] = None,
         asset_check_selection: Optional[Iterable[AssetCheckKey]] = None,
-        run_config: Optional[Mapping[str, Any]] = None,
     ):
         # coerce iterables to sets
         asset_selection = frozenset(asset_selection) if asset_selection else None
@@ -50,7 +48,6 @@ class JobSubsetSelector(IHaveNew):
             op_selection=op_selection,
             asset_selection=asset_selection,
             asset_check_selection=asset_check_selection,
-            run_config=run_config,
         )
 
     def to_graphql_input(self):

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -358,7 +358,6 @@ def submit_backfill_runs(
             job_name=partition_set.job_name,
             op_selection=None,
             asset_selection=backfill_job.asset_selection,
-            run_config=backfill_job.run_config,
         )
         remote_job = code_location.get_job(pipeline_selector)
     else:

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -4,9 +4,10 @@ from collections.abc import Iterable, Iterator, Mapping, Sequence, Set
 from datetime import datetime
 from functools import cached_property
 from threading import RLock
-from typing import TYPE_CHECKING, AbstractSet, Callable, Optional, Union  # noqa: UP035
+from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Optional, Union  # noqa: UP035
 
 from dagster_shared.error import DagsterError
+from dagster_shared.utils.hash import make_hashable
 
 import dagster._check as check
 from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot
@@ -77,6 +78,7 @@ from dagster._core.snap import ExecutionPlanSnapshot
 from dagster._core.snap.job_snapshot import JobSnap
 from dagster._core.storage.tags import EXTERNAL_JOB_SOURCE_TAG_KEY
 from dagster._core.utils import toposort
+from dagster._record import record
 from dagster._serdes import create_snapshot_id
 from dagster._utils.cached_method import cached_method
 from dagster._utils.schedules import schedule_execution_time_iterator
@@ -669,7 +671,17 @@ class RemoteJob(RepresentedJob, LoadableBy[JobSubsetSelector, "BaseWorkspaceRequ
         )
 
 
-class RemoteExecutionPlan(LoadableBy[JobSubsetSelector, "BaseWorkspaceRequestContext"]):
+@record
+class RemoteExecutionPlanSelector:
+    job_selector: JobSubsetSelector
+    run_config: Optional[Mapping[str, Any]]
+
+    @cached_method
+    def __hash__(self) -> int:
+        return hash(make_hashable(self))
+
+
+class RemoteExecutionPlan(LoadableBy[RemoteExecutionPlanSelector, "BaseWorkspaceRequestContext"]):
     """RemoteExecutionPlan is a object that represents an execution plan that
     was compiled in another process or persisted in an instance.
     """
@@ -695,21 +707,25 @@ class RemoteExecutionPlan(LoadableBy[JobSubsetSelector, "BaseWorkspaceRequestCon
 
     @classmethod
     async def _batch_load(
-        cls, keys: Iterable[JobSubsetSelector], context: "BaseWorkspaceRequestContext"
+        cls, keys: Iterable[RemoteExecutionPlanSelector], context: "BaseWorkspaceRequestContext"
     ) -> Iterable[Optional["RemoteExecutionPlan"]]:
-        remote_jobs = await RemoteJob.gen_many(context, keys)
-        remote_jobs_by_key = {key: job for key, job in zip(keys, remote_jobs)}
+        job_selectors = list({selector.job_selector for selector in keys})
+        remote_jobs = await RemoteJob.gen_many(context, job_selectors)
+        remote_jobs_by_selector_hash = {
+            hash(selector): job for selector, job in zip(job_selectors, remote_jobs)
+        }
+
         unique_keys = {key for key in keys}
 
         tasks = [
             context.gen_execution_plan(
-                check.not_none(remote_jobs_by_key[key]),
+                check.not_none(remote_jobs_by_selector_hash[hash(key.job_selector)]),
                 run_config=key.run_config or {},
                 step_keys_to_execute=None,
                 known_state=None,
             )
             for key in unique_keys
-            if remote_jobs_by_key[key] is not None
+            if remote_jobs_by_selector_hash[hash(key.job_selector)] is not None
         ]
 
         if tasks:
@@ -722,7 +738,7 @@ class RemoteExecutionPlan(LoadableBy[JobSubsetSelector, "BaseWorkspaceRequestCon
 
     @classmethod
     def _blocking_batch_load(
-        cls, keys: Iterable[JobSubsetSelector], context: "BaseWorkspaceRequestContext"
+        cls, keys: Iterable[RemoteExecutionPlanSelector], context: "BaseWorkspaceRequestContext"
     ) -> Iterable[Optional["RemoteExecutionPlan"]]:
         raise NotImplementedError
 

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_execution_plan.py
@@ -10,7 +10,10 @@ from dagster._api.snapshot_execution_plan import (
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.external import RemoteExecutionPlan
+from dagster._core.remote_representation.external import (
+    RemoteExecutionPlan,
+    RemoteExecutionPlanSelector,
+)
 from dagster._core.remote_representation.handle import JobHandle
 from dagster._core.snap.execution_plan_snapshot import ExecutionPlanSnapshot
 
@@ -89,10 +92,13 @@ async def test_execution_plan_loader(instance: DagsterInstance):
             await RemoteExecutionPlan.gen_many(
                 workspace,
                 [
-                    foo_selector,
-                    foo_selector,
-                    foo_selector_with_subset,
-                    bar_selector,
+                    RemoteExecutionPlanSelector(job_selector=job_selector, run_config={})
+                    for job_selector in [
+                        foo_selector,
+                        foo_selector,
+                        foo_selector_with_subset,
+                        bar_selector,
+                    ]
                 ],
             )
         )


### PR DESCRIPTION
Summary:
We didn't end up actually needing this in the change that I originally added it for, but I think it is still a good change for the future, since you don't need the run config to load a RemoteJob object. This in theory unblocks loading multiple execution plans for the same job with different run configs without having to refetch the same subset multiple times.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
