### PR TITLE
[ui] Modify next config to stop rewriting next-env.d.ts

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/.eslintrc.js
+++ b/js_modules/dagster-ui/packages/app-oss/.eslintrc.js
@@ -1,3 +1,4 @@
 module.exports = {
   extends: ['@dagster-io/eslint-config'],
+  ignorePatterns: ['next-env.d.ts'],
 };

--- a/js_modules/dagster-ui/packages/app-oss/next-env.d.ts
+++ b/js_modules/dagster-ui/packages/app-oss/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/js_modules/dagster-ui/packages/app-oss/next.config.js
+++ b/js_modules/dagster-ui/packages/app-oss/next.config.js
@@ -60,7 +60,6 @@ const nextConfig = {
   compiler: {
     styledComponents: true,
   },
-  distDir: 'build',
   assetPrefix: 'BUILDTIME_ASSETPREFIX_REPLACE_ME',
 };
 
@@ -88,5 +87,10 @@ module.exports = (phase) => {
       },
     };
   }
-  return nextConfig;
+
+  // The prod build outputs to `build`. The post-build script copies from there.
+  return {
+    ...nextConfig,
+    distDir: 'build',
+  };
 };

--- a/js_modules/dagster-ui/packages/app-oss/tsconfig.json
+++ b/js_modules/dagster-ui/packages/app-oss/tsconfig.json
@@ -29,6 +29,6 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "incremental": true
   },
-  "include": ["src", "custom-next-env.d.ts"],
-  "exclude": ["node_modules", "next-env.d.ts"]
+  "include": ["src", "typings.d.ts", "next-env.d.ts"],
+  "exclude": ["node_modules"]
 }

--- a/js_modules/dagster-ui/packages/app-oss/typings.d.ts
+++ b/js_modules/dagster-ui/packages/app-oss/typings.d.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-default-export */
-/// <reference types="next" />
 
 type StaticImageData = {
   src: string;


### PR DESCRIPTION
## Summary & Motivation

Stop thrashing the `next-env.d.ts` file whenever someone runs `yarn build` or `yarn dev`. This is the OSS version of https://github.com/dagster-io/internal/pull/18220.

- Only use the `build` distDir on prod builds. We don't need this to be the build output for dev. This should stop the next build from adding a `build/...` path to `next-env.d.ts`.
- Add `next-env.d.ts` to the list of includes for tsconfig, rename the custom env file to `typings.d.ts`.

## How I Tested These Changes

`yarn ts`

Run next dev build and `yarn build` for prod build. Verify that neither of them modify the `next-env.d.ts` anymore.