### PR TITLE
pass in asset keys in event log storage tests that fetch last materialization/observation

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -3325,7 +3325,7 @@ class TestEventLogStorage:
             )
             # get the storage id of the materialization we just stored
             return storage.get_event_records(
-                dg.EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION),
+                dg.EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION, asset_key=asset_key),
                 limit=1,
                 ascending=False,
             )[0].storage_id
@@ -3406,7 +3406,7 @@ class TestEventLogStorage:
             )
             # get the storage id of the materialization we just stored
             return storage.get_event_records(
-                dg.EventRecordsFilter(dagster_event_type),
+                dg.EventRecordsFilter(dagster_event_type, asset_key=asset_key),
                 limit=1,
                 ascending=False,
             )[0].storage_id
@@ -3561,7 +3561,7 @@ class TestEventLogStorage:
             )
             # get the storage id of the materialization we just stored
             return storage.get_event_records(
-                dg.EventRecordsFilter(dagster_event_type),
+                dg.EventRecordsFilter(dagster_event_type, asset_key=asset_key),
                 limit=1,
                 ascending=False,
             )[0].storage_id


### PR DESCRIPTION
Summary:
This helps with tests that immediately archive the event log

BK

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
