### PR TITLE
Remove no longer needed code that filtered out config for jobs with asset selection by op names

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
@@ -1,6 +1,3 @@
-import {useMemo} from 'react';
-import * as yaml from 'yaml';
-
 import {
   CONFIG_EDITOR_GENERATOR_PARTITION_SETS_FRAGMENT,
   CONFIG_EDITOR_GENERATOR_PIPELINE_FRAGMENT,
@@ -33,23 +30,6 @@ interface Props {
   onSaveConfig?: (config: LaunchpadConfig) => void;
 }
 
-const filterDefaultYamlForSubselection = (defaultYaml: string, opNames: Set<string>): string => {
-  const parsedYaml = yaml.parse(defaultYaml);
-
-  const opsConfig = parsedYaml['ops'];
-  if (opsConfig) {
-    const filteredOpKeys = Object.keys(opsConfig).filter((entry: any) => {
-      return opNames.has(entry);
-    });
-    const filteredOpsConfig = Object.fromEntries(
-      filteredOpKeys.map((key) => [key, opsConfig[key]]),
-    );
-    parsedYaml['ops'] = filteredOpsConfig;
-  }
-
-  return yaml.stringify(parsedYaml);
-};
-
 export const LaunchpadAllowedRoot = (props: Props) => {
   useTrackPageView();
 
@@ -79,20 +59,6 @@ export const LaunchpadAllowedRoot = (props: Props) => {
 
   const pipelineOrError = result?.data?.pipelineOrError;
   const partitionSetsOrError = result?.data?.partitionSetsOrError;
-
-  const runConfigSchemaOrError = result.data?.runConfigSchemaOrError;
-  const filteredRootDefaultYaml = useMemo(() => {
-    if (!runConfigSchemaOrError || runConfigSchemaOrError.__typename !== 'RunConfigSchema') {
-      return undefined;
-    }
-
-    const rootDefaultYaml = runConfigSchemaOrError.rootDefaultYaml;
-    const opNameList = sessionPresets?.assetSelection
-      ? sessionPresets.assetSelection.map((entry) => entry.opNames ?? []).flat()
-      : [];
-    const opNames = new Set(opNameList);
-    return filterDefaultYamlForSubselection(rootDefaultYaml, opNames);
-  }, [runConfigSchemaOrError, sessionPresets]);
 
   if (!pipelineOrError || !partitionSetsOrError) {
     return <LaunchpadSessionLoading />;
@@ -152,7 +118,11 @@ export const LaunchpadAllowedRoot = (props: Props) => {
         partitionSets={partitionSetsOrError}
         repoAddress={repoAddress}
         sessionPresets={sessionPresets || {}}
-        rootDefaultYaml={filteredRootDefaultYaml}
+        rootDefaultYaml={
+          result.data?.runConfigSchemaOrError.__typename === 'RunConfigSchema'
+            ? result.data.runConfigSchemaOrError.rootDefaultYaml
+            : undefined
+        }
         onSaveConfig={onSaveConfig}
         runConfigSchema={
           result.data?.runConfigSchemaOrError.__typename === 'RunConfigSchema'


### PR DESCRIPTION
Summary:
This was causing issues for asset jobs including graph assets. The only reason it wasn't casuing problems before https://github.com/dagster-io/dagster/commit/acc63a6518cf8f41e6a56991e45709a575ff7947 appears to have been some legacy fallback default yaml code involving modes and presets (!) that was kicking in: https://github.com/dagster-io/dagster/blob/c4494094cbdfa9d9e2e43426cb49de107e01e1a1/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx#L246-L288 - now that we are passing in an asset selection to this query, the preset is no longer returned so we can't rely on that fallback anymore. but we don't need this subsetting code anymore now that we are passing the asset selection down to the server, so we can just remove it. 

## How I Tested These Changes
View an asset job with a graph asset in it in the UI, config is now scaffolded correctly again

> Insert changelog entry or delete this section.
Fixed an issue introduced in the 1.11.14 release where default configuration for asset jobs involving graph assets was sometimes not populated correctly in the UI.