### PR TITLE
[core] Handle invalid UTF-8 in stderr logs (rebased)

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/compute_logs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/compute_logs.py
@@ -5,10 +5,20 @@ from dagster_graphql.schema.util import non_null_list
 
 
 def from_captured_log_data(log_data: CapturedLogData):
+    """Convert CapturedLogData to GrapheneCapturedLogs.
+
+    Uses 'replace' error handling for UTF-8 decoding to gracefully handle:
+    - Binary data in log files
+    - Invalid UTF-8 sequences
+    - Partial multi-byte UTF-8 characters at chunk boundaries
+    - Non-UTF-8 encoded text
+
+    Invalid bytes are replaced with � (U+FFFD) to ensure logs are always viewable.
+    """
     return GrapheneCapturedLogs(
         logKey=log_data.log_key,
-        stdout=log_data.stdout.decode("utf-8") if log_data.stdout else None,
-        stderr=log_data.stderr.decode("utf-8") if log_data.stderr else None,
+        stdout=log_data.stdout.decode("utf-8", errors="replace") if log_data.stdout else None,
+        stderr=log_data.stderr.decode("utf-8", errors="replace") if log_data.stderr else None,
         cursor=log_data.cursor,
     )
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_captured_logs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_captured_logs.py
@@ -112,3 +112,103 @@ class TestCapturedLogs(ExecutingGraphQLContextTestMatrix):
         assert result.data["runOrError"]["__typename"] == "Run"
         events = result.data["runOrError"]["eventConnection"]["events"]
         assert len(events) > 0
+
+    def test_captured_logs_with_invalid_utf8(self, graphql_context):
+        """Test that captured logs handle invalid UTF-8 sequences gracefully.
+
+        This test verifies the fix for issue #32251 where invalid UTF-8 bytes
+        in stderr would cause GraphQL query failures.
+        """
+        import os
+
+        # Create a unique log key for this test
+        log_key = ["test_invalid_utf8", "compute_logs", "test_step"]
+
+        # Write binary data with invalid UTF-8 to stderr
+        compute_log_manager = graphql_context.instance.compute_log_manager
+        stderr_path = compute_log_manager.get_captured_local_path(log_key, "err")
+
+        # Ensure directory exists
+        os.makedirs(os.path.dirname(stderr_path), exist_ok=True)
+
+        # Write test data with invalid UTF-8 sequences
+        with open(stderr_path, "wb") as f:
+            f.write(b"Valid text before\n")
+            f.write(b"\xff\xfe")  # Invalid UTF-8 sequence
+            f.write(b"\nValid text after\n")
+
+        try:
+            # Query should not raise an exception
+            result = execute_dagster_graphql(
+                graphql_context,
+                CAPTURED_LOGS_QUERY,
+                variables={"logKey": log_key},
+            )
+
+            # Verify we got a result (not an error)
+            assert result.data is not None
+            assert result.data["capturedLogs"] is not None
+
+            # Stderr should contain the replacement character (�)
+            stderr = result.data["capturedLogs"]["stderr"]
+            assert stderr is not None
+            assert "Valid text before" in stderr
+            assert "Valid text after" in stderr
+            # The invalid bytes should be replaced with replacement character
+            assert "\ufffd" in stderr or "�" in stderr
+
+        finally:
+            # Cleanup test file
+            if os.path.exists(stderr_path):
+                os.remove(stderr_path)
+
+    def test_captured_logs_subscription_with_invalid_utf8(self, graphql_context):
+        """Test that captured logs subscription handles invalid UTF-8 gracefully.
+
+        This test verifies the fix works for GraphQL subscriptions as well as queries.
+        """
+        import os
+
+        # Create a unique log key for this test
+        log_key = ["test_invalid_utf8_sub", "compute_logs", "test_step"]
+
+        # Write binary data with invalid UTF-8 to stderr
+        compute_log_manager = graphql_context.instance.compute_log_manager
+        stderr_path = compute_log_manager.get_captured_local_path(log_key, "err")
+
+        # Ensure directory exists
+        os.makedirs(os.path.dirname(stderr_path), exist_ok=True)
+
+        # Write test data simulating partial multi-byte UTF-8 at chunk boundary
+        with open(stderr_path, "wb") as f:
+            # Write valid text
+            f.write(b"Subscription test\n")
+            # Add invalid UTF-8 (partial 4-byte sequence)
+            f.write(b"\xf0\x9f")  # First 2 bytes of 4-byte emoji, incomplete
+            f.write(b"\nMore text\n")
+
+        try:
+            # Subscription should not raise an exception
+            results = execute_dagster_graphql_subscription(
+                graphql_context,
+                CAPTURED_LOGS_SUBSCRIPTION,
+                variables={"logKey": log_key},
+            )
+
+            # Verify we got results
+            assert len(results) > 0
+
+            # First result should contain data
+            assert results[0].data is not None
+            assert results[0].data["capturedLogs"] is not None
+
+            # Stderr should be readable
+            stderr = results[0].data["capturedLogs"]["stderr"]
+            assert stderr is not None
+            assert "Subscription test" in stderr
+            assert "More text" in stderr
+
+        finally:
+            # Cleanup test file
+            if os.path.exists(stderr_path):
+                os.remove(stderr_path)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/schema/test_compute_logs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/schema/test_compute_logs.py
@@ -1,0 +1,98 @@
+"""Unit tests for compute log GraphQL schema utilities."""
+
+from dagster._core.storage.compute_log_manager import CapturedLogData
+from dagster_graphql.schema.logs.compute_logs import from_captured_log_data
+
+
+def test_from_captured_log_data_with_valid_utf8():
+    """Test that valid UTF-8 is decoded correctly."""
+    log_data = CapturedLogData(
+        log_key=["test", "key"],
+        stdout=b"Hello stdout\n",
+        stderr=b"Hello stderr\n",
+        cursor="0",
+    )
+
+    result = from_captured_log_data(log_data)
+
+    assert result.stdout == "Hello stdout\n"
+    assert result.stderr == "Hello stderr\n"
+    assert result.cursor == "0"
+    assert result.logKey == ["test", "key"]
+
+
+def test_from_captured_log_data_with_invalid_utf8_in_stderr():
+    """Test that invalid UTF-8 bytes in stderr are replaced gracefully.
+
+    This test verifies the fix for issue #32251 where invalid UTF-8 bytes
+    would cause GraphQL query failures.
+    """
+    log_data = CapturedLogData(
+        log_key=["test", "key"],
+        stdout=b"Valid stdout\n",
+        stderr=b"Valid before\n\xff\xfe\nValid after\n",  # Invalid UTF-8 sequence
+        cursor="0",
+    )
+
+    result = from_captured_log_data(log_data)
+
+    assert result.stdout == "Valid stdout\n"
+    assert result.stderr is not None
+    assert "Valid before" in result.stderr
+    assert "Valid after" in result.stderr
+    # Invalid bytes should be replaced with replacement character
+    assert "\ufffd" in result.stderr
+
+
+def test_from_captured_log_data_with_invalid_utf8_in_stdout():
+    """Test that invalid UTF-8 bytes in stdout are replaced gracefully."""
+    log_data = CapturedLogData(
+        log_key=["test", "key"],
+        stdout=b"Valid text\n\xf0\x9f\nMore text\n",  # Partial multi-byte UTF-8
+        stderr=b"Valid stderr\n",
+        cursor="0",
+    )
+
+    result = from_captured_log_data(log_data)
+
+    assert result.stdout is not None
+    assert "Valid text" in result.stdout
+    assert "More text" in result.stdout
+    # Partial multi-byte sequence should be replaced
+    assert "\ufffd" in result.stdout
+    assert result.stderr == "Valid stderr\n"
+
+
+def test_from_captured_log_data_with_none_logs():
+    """Test that None values for stdout/stderr are handled correctly."""
+    log_data = CapturedLogData(
+        log_key=["test", "key"],
+        stdout=None,
+        stderr=None,
+        cursor="0",
+    )
+
+    result = from_captured_log_data(log_data)
+
+    assert result.stdout is None
+    assert result.stderr is None
+    assert result.cursor == "0"
+    assert result.logKey == ["test", "key"]
+
+
+def test_from_captured_log_data_with_binary_data():
+    """Test that completely binary (non-text) data is handled."""
+    log_data = CapturedLogData(
+        log_key=["test", "key"],
+        stdout=b"\x00\x01\x02\x03\x04",  # Pure binary
+        stderr=b"Text with\x00null bytes",
+        cursor="0",
+    )
+
+    result = from_captured_log_data(log_data)
+
+    # Should not raise an exception
+    assert result.stdout is not None
+    assert result.stderr is not None
+    # Binary data should be replaced with replacement characters
+    assert "\ufffd" in result.stdout or "\x00" in result.stdout


### PR DESCRIPTION
## Summary & Motivation

Rebase of https://github.com/dagster-io/dagster/pull/32346 on `master`.

Created a separate PR to run the full test suite.

## How I Tested These Changes

## Changelog

* Fixed GraphQL exception when viewing compute logs containing invalid UTF-8 sequences or binary data. Invalid bytes are now replaced with the Unicode replacement character (�) instead of causing query failures.
