### PR TITLE
[da] Fix issue with the `execution_failed` automation condition

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -612,6 +612,54 @@ class AssetGraphView(LoadingContext):
         )
         return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
 
+    async def _compute_execution_failed_unpartitioned(self, key: AssetKey) -> bool:
+        from dagster._core.event_api import AssetRecordsFilter
+        from dagster._core.storage.dagster_run import DagsterRunStatus, RunRecord
+        from dagster._core.storage.event_log.base import AssetRecord
+        from dagster._utils.storage import get_materialization_chunk_size
+
+        planned_materialization_info = (
+            self.instance.event_log_storage.get_latest_planned_materialization_info(key)
+        )
+        if not planned_materialization_info:
+            # has never been planned
+            return False
+
+        planned_storage_id = planned_materialization_info.storage_id
+        planned_run_id = planned_materialization_info.run_id
+        run = await RunRecord.gen(self, planned_run_id)
+
+        # note that if the run did fail, it's still possible that the materialization was successful,
+        # hence the extra code below this conditional
+        if not run or run.dagster_run.status != DagsterRunStatus.FAILURE:
+            # latest run did not fail
+            return False
+
+        # performance optimization: we will generally have this record cached, and in most cases
+        # the most recent materialization will map to the most recent planned run
+        asset_record = await AssetRecord.gen(self, key)
+        asset_entry = asset_record.asset_entry if asset_record else None
+        latest_materialization = asset_entry.last_materialization_record if asset_entry else None
+        if latest_materialization and latest_materialization.run_id == planned_run_id:
+            return False
+
+        # look for any materializations for the latest planned run for cases where
+        # the run failed but the materialization was successful
+        has_more = True
+        cursor = None
+        while has_more:
+            result = self.instance.fetch_materializations(
+                AssetRecordsFilter(asset_key=key, after_storage_id=planned_storage_id),
+                limit=get_materialization_chunk_size(),
+                cursor=cursor,
+            )
+            has_more, cursor = result.has_more, result.cursor
+            if any(record.run_id == planned_run_id for record in result.records):
+                return False
+
+        # could not find any materializations for the latest planned run
+        return True
+
     async def _compute_execution_failed_asset_subset(self, key: AssetKey) -> EntitySubset[AssetKey]:
         from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
@@ -623,8 +671,9 @@ class AssetGraphView(LoadingContext):
                 if cache_value
                 else self.get_empty_subset(key=key)
             )
-        value = self._queryer.get_failed_asset_subset(asset_key=key).value
-        return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
+        else:
+            value = await self._compute_execution_failed_unpartitioned(key)
+            return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
 
     async def _compute_missing_asset_subset(
         self, key: AssetKey, from_subset: EntitySubset

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime
@@ -874,6 +873,8 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         asset_key: AssetKey,
         after_cursor: int,
     ) -> Sequence["EventLogRecord"]:
+        from dagster._utils.storage import get_materialization_chunk_size
+
         has_more = True
         cursor = None
 
@@ -883,9 +884,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             result = self.instance.fetch_materializations(
                 AssetRecordsFilter(asset_key=asset_key, after_storage_id=after_cursor),
                 cursor=cursor,
-                limit=int(
-                    os.getenv("DAGSTER_FETCH_MATERIALIZATIONS_AFTER_CURSOR_CHUNK_SIZE", "1000")
-                ),
+                limit=get_materialization_chunk_size(),
             )
             cursor = result.cursor
             has_more = result.has_more

--- a/python_modules/dagster/dagster/_utils/storage.py
+++ b/python_modules/dagster/dagster/_utils/storage.py
@@ -1,0 +1,12 @@
+import os
+
+
+def get_materialization_chunk_size() -> int:
+    """Get the chunk size for fetching materializations after a cursor.
+
+    Returns:
+        int: The chunk size for materialization queries, configurable via
+        DAGSTER_FETCH_MATERIALIZATIONS_AFTER_CURSOR_CHUNK_SIZE environment variable.
+        Defaults to 1000.
+    """
+    return int(os.getenv("DAGSTER_FETCH_MATERIALIZATIONS_AFTER_CURSOR_CHUNK_SIZE", "1000"))

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_failed_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_failed_condition.py
@@ -2,6 +2,10 @@ import dagster as dg
 import pytest
 from dagster import AutomationCondition
 from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.events import AssetMaterializationPlannedData, StepMaterializationData
+from dagster._core.storage.dagster_run import DagsterRunStatus
+from dagster._core.utils import make_new_run_id
+from dagster._time import get_current_timestamp
 
 from dagster_tests.declarative_automation_tests.scenario_utils.automation_condition_scenario import (
     AutomationConditionScenarioState,
@@ -11,6 +15,38 @@ from dagster_tests.declarative_automation_tests.scenario_utils.scenario_specs im
     one_asset,
     two_partitions_def,
 )
+
+
+def _materialization_planned_event(
+    asset_key: dg.AssetKey, job_name: str = "__job__"
+) -> dg.DagsterEvent:
+    return dg.DagsterEvent.build_asset_materialization_planned_event(
+        job_name, "step", AssetMaterializationPlannedData(asset_key=asset_key)
+    )
+
+
+def _materialization_event(asset_key: dg.AssetKey, job_name: str = "__job__") -> dg.DagsterEvent:
+    return dg.DagsterEvent(
+        event_type_value=dg.DagsterEventType.ASSET_MATERIALIZATION.value,
+        job_name=job_name,
+        event_specific_data=StepMaterializationData(
+            materialization=dg.AssetMaterialization(asset_key=asset_key)
+        ),
+        message="Materialized value.",
+    )
+
+
+def _add_event_to_run(instance: dg.DagsterInstance, run_id: str, event: dg.DagsterEvent) -> None:
+    instance.store_event(
+        dg.EventLogEntry(
+            error_info=None,
+            level="debug",
+            user_message="",
+            run_id=run_id,
+            timestamp=get_current_timestamp(),
+            dagster_event=event,
+        )
+    )
 
 
 @pytest.mark.asyncio
@@ -32,6 +68,59 @@ async def test_failed_unpartitioned() -> None:
     state = state.with_runs(run_request("A"))
     _, result = await state.evaluate("A")
     assert result.true_subset.size == 0
+
+
+def test_execution_failed_unpartitioned() -> None:
+    @dg.asset(automation_condition=dg.AutomationCondition.execution_failed())
+    def A(): ...
+
+    @dg.asset(deps=[A], automation_condition=dg.AutomationCondition.execution_failed())
+    def B():
+        raise Exception("blah")
+
+    defs = dg.Definitions(assets=[A, B])
+    instance = dg.DagsterInstance.ephemeral()
+    result = dg.evaluate_automation_conditions(defs=defs, instance=instance)
+    # no failures
+    assert result.total_requested == 0
+
+    # now execute a run where A succeeds and B fails
+    job_result = defs.resolve_implicit_global_asset_job_def().execute_in_process(
+        instance=instance, raise_on_error=False
+    )
+    assert not job_result.success
+
+    result = dg.evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    # only requested B
+    assert result.total_requested == 1
+
+    result = dg.evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    # still only requested B
+    assert result.total_requested == 1
+
+    # do some manual setup to force a failed run for A
+    run_id = make_new_run_id()
+    job_name = "job"
+    instance.add_run(
+        dg.DagsterRun(job_name=job_name, run_id=run_id, status=DagsterRunStatus.FAILURE)
+    )
+    # mark that there was a planned materialization for A
+    _add_event_to_run(instance, run_id, _materialization_planned_event(dg.AssetKey("A"), job_name))
+
+    # now both should be requested
+    result = dg.evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 2
+
+    # now add a materialization event to a different run for A, this should make no difference
+    other_run_id = make_new_run_id()
+    _add_event_to_run(instance, other_run_id, _materialization_event(dg.AssetKey("A"), job_name))
+    result = dg.evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 2
+
+    # now add a materialization event to the failed run for A, this shouls mean that A is no longer counted as failed
+    _add_event_to_run(instance, run_id, _materialization_event(dg.AssetKey("A"), job_name))
+    result = dg.evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary & Motivation

Previously, this would be true for an unpartitioned asset if the latest run for that asset failed, even if the asset successfully materialized within that run. This is different behavior from the partitioned asset implementation.

## How I Tested These Changes

unit

## Changelog

Fixed a bug with `AutomationCondition.execution_failed` that would cause it to be evaluated as `True` for an unpartitioned asset in cases where the latest run failed, but the asset itself materialized successfully before that failure.
