### PR TITLE
kyle/DOC-1512 (docs card component update)

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -6,7 +6,7 @@ displayed_sidebar: 'docs'
 hide_table_of_contents: true
 ---
 
-import {Card, CardGroup} from '@site/src/components/Cards';
+import {Card} from '@site/src/components/Cards';
 import ThemedImage from '@theme/ThemedImage';
 
 # Welcome to Dagster
@@ -29,34 +29,17 @@ Dagster is a data orchestrator built for data engineers, with integrated lineage
 
 ## Get started
 
-<CardGroup cols={3}>
-  <Card title="Quickstart" href="/getting-started/quickstart" imagePath="./img/getting-started/icon-start.svg">
-    Build your first Dagster pipeline in our Quickstart tutorial.
-  </Card>
-  <Card title="Thinking in Assets" href="/guides/build/assets" imagePath="./img/getting-started/icon-assets.svg">
-    New to Dagster? Learn about how thinking in assets can help you manage your data better.
-  </Card>
-  <Card title="Dagster Plus" href="/deployment/dagster-plus" imagePath="./img/getting-started/icon-plus.svg">
-    Learn about Dagster Plus, our managed offering that includes a hosted Dagster instance and many more features.
-  </Card>
-</CardGroup>
+<div className="card-group cols-2">
+  <Card label="Quickstart" href="/getting-started/quickstart" logo="./img/getting-started/icon-start.svg" description="Build your first Dagster pipeline in our Quickstart tutorial." />
+  <Card label="Thinking in Assets" href="/guides/build/assets" logo="./img/getting-started/icon-assets.svg" description="New to Dagster? Learn about how thinking in assets can help you manage your data better." />
+  <Card label="Dagster Plus" href="/deployment/dagster-plus" logo="./img/getting-started/icon-plus.svg" description="Learn about Dagster Plus, our managed offering that includes a hosted Dagster instance and many more features." />
+</div>
 
 ## Join the Dagster community
 
-<CardGroup cols={4}>
-  <Card title="Slack" href="https://dagster.io/slack" imagePath="./img/getting-started/icon-slack.svg">
-    Join our Slack community to talk with other Dagster users, use our AI-powered chatbot, and get help with Dagster.
-  </Card>
-  <Card title="GitHub" href="https://github.com/dagster-io/dagster" imagePath="./img/getting-started/icon-github.svg">
-    Star our GitHub repository and follow our development through GitHub Discussions.
-  </Card>
-  <Card title="Youtube" href="https://www.youtube.com/@dagsterio" imagePath="./img/getting-started/icon-youtube.svg">
-    Watch our latest videos on YouTube.
-  </Card>
-  <Card
-    title="Dagster University"
-    href="https://courses.dagster.io"
-    imagePath="./img/getting-started/icon-education.svg">
-    Learn Dagster through interactive courses and hands-on tutorials.
-  </Card>
-</CardGroup>
+<div className="card-group cols-2">
+  <Card label="Slack" href="https://dagster.io/slack" logo="./img/getting-started/icon-slack.svg" description="Join our Slack community to talk with other Dagster users, use our AI-powered chatbot, and get help with Dagster." />
+  <Card label="GitHub" href="https://github.com/dagster-io/dagster" logo="./img/getting-started/icon-github.svg" description="Star our GitHub repository and follow our development through GitHub Discussions." />
+  <Card label="Youtube" href="https://www.youtube.com/@dagsterio" logo="./img/getting-started/icon-youtube.svg" description="Watch our latest videos on YouTube." />
+  <Card label="Dagster University" href="https://courses.dagster.io" logo="./img/getting-started/icon-education.svg" description="Learn Dagster through interactive courses and hands-on tutorials." />
+</div>

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -30,16 +30,51 @@ Dagster is a data orchestrator built for data engineers, with integrated lineage
 ## Get started
 
 <div className="card-group cols-2">
-  <Card label="Quickstart" href="/getting-started/quickstart" logo="./img/getting-started/icon-start.svg" description="Build your first Dagster pipeline in our Quickstart tutorial." />
-  <Card label="Thinking in Assets" href="/guides/build/assets" logo="./img/getting-started/icon-assets.svg" description="New to Dagster? Learn about how thinking in assets can help you manage your data better." />
-  <Card label="Dagster Plus" href="/deployment/dagster-plus" logo="./img/getting-started/icon-plus.svg" description="Learn about Dagster Plus, our managed offering that includes a hosted Dagster instance and many more features." />
+  <Card
+    label="Quickstart"
+    href="/getting-started/quickstart"
+    logo="./img/getting-started/icon-start.svg"
+    description="Build your first Dagster pipeline in our Quickstart tutorial."
+  />
+  <Card
+    label="Thinking in Assets"
+    href="/guides/build/assets"
+    logo="./img/getting-started/icon-assets.svg"
+    description="New to Dagster? Learn about how thinking in assets can help you manage your data better."
+  />
+  <Card
+    label="Dagster Plus"
+    href="/deployment/dagster-plus"
+    logo="./img/getting-started/icon-plus.svg"
+    description="Learn about Dagster Plus, our managed offering that includes a hosted Dagster instance and many more features."
+  />
 </div>
 
 ## Join the Dagster community
 
 <div className="card-group cols-2">
-  <Card label="Slack" href="https://dagster.io/slack" logo="./img/getting-started/icon-slack.svg" description="Join our Slack community to talk with other Dagster users, use our AI-powered chatbot, and get help with Dagster." />
-  <Card label="GitHub" href="https://github.com/dagster-io/dagster" logo="./img/getting-started/icon-github.svg" description="Star our GitHub repository and follow our development through GitHub Discussions." />
-  <Card label="Youtube" href="https://www.youtube.com/@dagsterio" logo="./img/getting-started/icon-youtube.svg" description="Watch our latest videos on YouTube." />
-  <Card label="Dagster University" href="https://courses.dagster.io" logo="./img/getting-started/icon-education.svg" description="Learn Dagster through interactive courses and hands-on tutorials." />
+  <Card
+    label="Slack"
+    href="https://dagster.io/slack"
+    logo="./img/getting-started/icon-slack.svg"
+    description="Join our Slack community to talk with other Dagster users, use our AI-powered chatbot, and get help with Dagster."
+  />
+  <Card
+    label="GitHub"
+    href="https://github.com/dagster-io/dagster"
+    logo="./img/getting-started/icon-github.svg"
+    description="Star our GitHub repository and follow our development through GitHub Discussions."
+  />
+  <Card
+    label="Youtube"
+    href="https://www.youtube.com/@dagsterio"
+    logo="./img/getting-started/icon-youtube.svg"
+    description="Watch our latest videos on YouTube."
+  />
+  <Card
+    label="Dagster University"
+    href="https://courses.dagster.io"
+    logo="./img/getting-started/icon-education.svg"
+    description="Learn Dagster through interactive courses and hands-on tutorials."
+  />
 </div>

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -66,7 +66,7 @@ Dagster is a data orchestrator built for data engineers, with integrated lineage
     description="Star our GitHub repository and follow our development through GitHub Discussions."
   />
   <Card
-    label="Youtube"
+    label="YouTube"
     href="https://www.youtube.com/@dagsterio"
     logo="./img/getting-started/icon-youtube.svg"
     description="Watch our latest videos on YouTube."

--- a/docs/src/components/Cards.tsx
+++ b/docs/src/components/Cards.tsx
@@ -1,40 +1,26 @@
-import React from 'react';
-import Link from '@docusaurus/Link';
-import Heading from '@theme/Heading';
+import React, {type ReactNode} from 'react';
+import type {PropSidebarItemLink} from '@docusaurus/plugin-content-docs';
+import DocCard from '@theme/DocCard';
+
 interface CardProps {
-  title: string;
-  imagePath?: string;
+  label: string;
   href: string;
-  children: React.ReactNode;
+  description?: string;
+  logo?: string;
+  community?: boolean;
 }
 
-const Card: React.FC<CardProps> = ({title, imagePath, href, children}) => (
-  <Link to={href} className="card">
-    {imagePath && (
-      <img
-        style={{
-          marginBottom: '6px',
-          background: 'var(--theme-color-background-default)',
-          transition: 'background 0.5s',
-        }}
-        src={`${imagePath}`}
-        alt={title}
-        width="56"
-        height="56"
-      />
-    )}
-    <Heading as="h3">{title}</Heading>
-    <p>{children}</p>
-  </Link>
-);
+const Card: React.FC<CardProps> = ({label, href, description, logo, community}) => {
+  const item: PropSidebarItemLink = {
+    type: 'link',
+    label,
+    href,
+    description,
+    docId: undefined,
+    customProps: {logo, community},
+  };
 
-interface CardGroupProps {
-  cols: number;
-  children: React.ReactNode;
-}
+  return <DocCard item={item} />;
+};
 
-const CardGroup: React.FC<CardGroupProps> = ({cols, children}) => (
-  <div className={`card-group cols-${cols}`}>{children}</div>
-);
-
-export {Card, CardGroup};
+export {Card};

--- a/docs/src/styles/custom.scss
+++ b/docs/src/styles/custom.scss
@@ -595,7 +595,7 @@ dd code {
 /* Card and CardGroup styles */
 .card-group {
   display: grid;
-  gap: 1rem;
+  gap: var(--card-group-gap, 1rem);
   margin-bottom: 2rem;
   &.cols-2 {
     grid-template-columns: repeat(2, 1fr);
@@ -614,9 +614,6 @@ dd code {
     @media (max-width: 768px) {
       grid-template-columns: 1fr;
     }
-  }
-  &.gap-lg {
-    gap: 2rem;
   }
 }
 

--- a/docs/src/styles/custom.scss
+++ b/docs/src/styles/custom.scss
@@ -615,6 +615,9 @@ dd code {
       grid-template-columns: 1fr;
     }
   }
+  &.gap-lg {
+    gap: 2rem;
+  }
 }
 
 .card {

--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -64,7 +64,7 @@ function CardLayout({
   const logo: string | null = (item?.customProps?.logo as string) || null;
   const community: boolean = (item?.customProps?.community as boolean) || false;
   const categoryItemsPlural = useCategoryItemsPlural();
-  const doc = useDocById(item.type === 'link' ? item.docId ?? undefined : undefined);
+  const doc = useDocById(item.type === 'link' ? (item.docId ?? undefined) : undefined);
   const logoUrl = useBaseUrl(logo || '');
 
   let href, description;
@@ -79,7 +79,6 @@ function CardLayout({
     href = item.href;
     description = item.description ?? doc?.description;
   }
-
 
   const LinkComponent = Link as any; //Type assertion to bypass linting error
 

--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -49,7 +49,8 @@ function CardLayout({
     description = item.description ?? categoryItemsPlural(item.items.length);
   } else {
     href = item.href;
-    description = item.description;
+    const doc = useDocById(item.docId ?? undefined);
+    description = item.description ?? doc?.description;
   }
 
   const LinkComponent = Link as any; //Type assertion to bypass linting error
@@ -67,14 +68,12 @@ function CardLayout({
             />
         )}
         <div>
-          <div style={{display: 'flex', flexDirection: 'row'}}>
+          <div className={styles.cardTitleWrapper}>
             <Heading as="h2" className={styles.cardTitle} title={title}>
               {title}
             </Heading>
             {community && (
-              <span style={{marginLeft: 'auto'}}>
-                <div className={styles.cardTags}>Community</div>
-              </span>
+              <span className={styles.cardTags}>Community</span>
             )}
           </div>
           {description && (

--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -33,22 +33,20 @@ function useCategoryItemsPlural() {
     );
 }
 
-
 function ExternalLinkIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
-    <svg 
-      width="16" 
-      height="16" 
-      viewBox="0 0 20 20" 
-      fill="none" 
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 20 20"
+      fill="none"
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden="true"
-      {...props}
-    >
-      <path 
-        fillRule="evenodd" 
-        clipRule="evenodd" 
-        d="M15.5 12.25V15.25C15.5 15.3881 15.3881 15.5 15.25 15.5H4.75C4.61193 15.5 4.5 15.3881 4.5 15.25V4.75C4.5 4.61193 4.61193 4.5 4.75 4.5H7.75H8.5V3H7.75H4.75C3.7835 3 3 3.7835 3 4.75V15.25C3 16.2165 3.7835 17 4.75 17H15.25C16.2165 17 17 16.2165 17 15.25V12.25V11.5H15.5V12.25ZM11 3H11.75H16.2495C16.6637 3 16.9995 3.33579 16.9995 3.75V8.25V9H15.4995V8.25V5.56066L10.5303 10.5298L10 11.0601L8.93934 9.99945L9.46967 9.46912L14.4388 4.5H11.75H11V3Z" 
+      {...props}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M15.5 12.25V15.25C15.5 15.3881 15.3881 15.5 15.25 15.5H4.75C4.61193 15.5 4.5 15.3881 4.5 15.25V4.75C4.5 4.61193 4.61193 4.5 4.75 4.5H7.75H8.5V3H7.75H4.75C3.7835 3 3 3.7835 3 4.75V15.25C3 16.2165 3.7835 17 4.75 17H15.25C16.2165 17 17 16.2165 17 15.25V12.25V11.5H15.5V12.25ZM11 3H11.75H16.2495C16.6637 3 16.9995 3.33579 16.9995 3.75V8.25V9H15.4995V8.25V5.56066L10.5303 10.5298L10 11.0601L8.93934 9.99945L9.46967 9.46912L14.4388 4.5H11.75H11V3Z"
         fill="currentColor"
       />
     </svg>
@@ -78,33 +76,22 @@ function CardLayout({
   const LinkComponent = Link as any; //Type assertion to bypass linting error
 
   return (
-    <LinkComponent
-      href={href}
-      {...props}
-      className={clsx('card', styles.cardContainer)}
-    >
-      {logo && (
-            <img
-              className={styles.cardLogo}
-              src={useBaseUrl(logo)}
-            />
-        )}
-        <div>
-          <div className={styles.cardTitleWrapper}>
-            <Heading as="h2" className={styles.cardTitle} title={title}>
-              {title}
-            </Heading>
-            {!isInternalUrl(href) && <ExternalLinkIcon />}
-            {community && (
-              <span className={styles.cardTags}>Community</span>
-            )}
-          </div>
-          {description && (
-            <p className={styles.cardDescription} title={description}>
-              {description}
-            </p>
-          )}
+    <LinkComponent href={href} {...props} className={clsx('card', styles.cardContainer)}>
+      {logo && <img className={styles.cardLogo} src={useBaseUrl(logo)} />}
+      <div>
+        <div className={styles.cardTitleWrapper}>
+          <Heading as="h2" className={styles.cardTitle} title={title}>
+            {title}
+          </Heading>
+          {!isInternalUrl(href) && <ExternalLinkIcon />}
+          {community && <span className={styles.cardTags}>Community</span>}
         </div>
+        {description && (
+          <p className={styles.cardDescription} title={description}>
+            {description}
+          </p>
+        )}
+      </div>
     </LinkComponent>
   );
 }

--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -52,28 +52,19 @@ function CardLayout({
     description = item.description;
   }
 
-  const LinkComponent = Link as any; // ← Type assertion to bypass the error
+  const LinkComponent = Link as any; //Type assertion to bypass linting error
 
   return (
     <LinkComponent
       href={href}
       {...props}
-      className={clsx('card padding--lg', styles.cardContainer)}
-      style={{height: '100%'}}>
-      <div style={{display: 'flex', flexDirection: 'row', gap: '12px'}} className="cardContainer">
-        {logo && (
-          <div style={{flex: '0 0 64px'}}>
+      className={clsx('card', styles.cardContainer)}
+    >
+      {logo && (
             <img
+              className={styles.cardLogo}
               src={useBaseUrl(logo)}
-              style={{
-                display: 'block',
-                width: '64px',
-                height: '64px',
-                background: 'var(--dagster-white)',
-                padding: '4px',
-              }}
             />
-          </div>
         )}
         <div>
           <div style={{display: 'flex', flexDirection: 'row'}}>
@@ -92,7 +83,6 @@ function CardLayout({
             </p>
           )}
         </div>
-      </div>
     </LinkComponent>
   );
 }

--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -55,35 +55,37 @@ function ExternalLinkIcon(props: React.SVGProps<SVGSVGElement>) {
 
 function CardLayout({
   item,
-  ...props
+  className,
 }: {
   item: PropSidebarItemCategory | PropSidebarItemLink;
-} & React.ComponentPropsWithoutRef<'a'>): ReactNode {
+  className?: string;
+}): ReactNode {
   const label = item.label;
   const logo: string | null = (item?.customProps?.logo as string) || null;
   const community: boolean = (item?.customProps?.community as boolean) || false;
-  let href, description;
   const categoryItemsPlural = useCategoryItemsPlural();
+  const doc = useDocById(item.type === 'link' ? item.docId ?? undefined : undefined);
+  const logoUrl = useBaseUrl(logo || '');
 
-if (item.type === 'category') {
-  href = findFirstSidebarItemLink(item);
-  // Add safety check to handle cases where a category might not have a valid link
-  if (href === undefined) {
-    href = null; // or another appropriate fallback
+  let href, description;
+  if (item.type === 'category') {
+    href = findFirstSidebarItemLink(item);
+    // Add safety check to handle cases where a category might not have a valid link
+    if (href === undefined) {
+      href = null; // or another appropriate fallback
+    }
+    description = item.description ?? categoryItemsPlural(item.items.length);
+  } else {
+    href = item.href;
+    description = item.description ?? doc?.description;
   }
-  description = item.description ?? categoryItemsPlural(item.items.length);
-} else {
-  href = item.href;
-  const doc = useDocById(item.docId ?? undefined);
-  description = item.description ?? doc?.description;
-}
 
 
   const LinkComponent = Link as any; //Type assertion to bypass linting error
 
   return (
-    <LinkComponent href={href} {...props} className={clsx('card', styles.cardContainer)}>
-      {logo && <img className={styles.cardLogo} src={useBaseUrl(logo)} />}
+    <LinkComponent href={href} className={clsx('card', styles.cardContainer, className)}>
+      {logo && <img className={styles.cardLogo} src={logoUrl} />}
       <div>
         <div className={styles.cardTitleWrapper}>
           <Heading as="h2" className={styles.cardTitle} title={label}>

--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -77,17 +77,17 @@ function CardLayout({
         )}
         <div>
           <div style={{display: 'flex', flexDirection: 'row'}}>
-            <Heading as="h2" className={clsx('', styles.cardTitle)} title={title}>
+            <Heading as="h2" className={styles.cardTitle} title={title}>
               {title}
             </Heading>
             {community && (
               <span style={{marginLeft: 'auto'}}>
-                <div className={clsx(styles.cardTags)}>Community</div>
+                <div className={styles.cardTags}>Community</div>
               </span>
             )}
           </div>
           {description && (
-            <p className={clsx(styles.cardDescription)} title={description}>
+            <p className={styles.cardDescription} title={description}>
               {description}
             </p>
           )}

--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -33,6 +33,28 @@ function useCategoryItemsPlural() {
     );
 }
 
+
+function ExternalLinkIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg 
+      width="16" 
+      height="16" 
+      viewBox="0 0 20 20" 
+      fill="none" 
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      {...props}
+    >
+      <path 
+        fillRule="evenodd" 
+        clipRule="evenodd" 
+        d="M15.5 12.25V15.25C15.5 15.3881 15.3881 15.5 15.25 15.5H4.75C4.61193 15.5 4.5 15.3881 4.5 15.25V4.75C4.5 4.61193 4.61193 4.5 4.75 4.5H7.75H8.5V3H7.75H4.75C3.7835 3 3 3.7835 3 4.75V15.25C3 16.2165 3.7835 17 4.75 17H15.25C16.2165 17 17 16.2165 17 15.25V12.25V11.5H15.5V12.25ZM11 3H11.75H16.2495C16.6637 3 16.9995 3.33579 16.9995 3.75V8.25V9H15.4995V8.25V5.56066L10.5303 10.5298L10 11.0601L8.93934 9.99945L9.46967 9.46912L14.4388 4.5H11.75H11V3Z" 
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
 function CardLayout({
   item,
   ...props
@@ -72,6 +94,7 @@ function CardLayout({
             <Heading as="h2" className={styles.cardTitle} title={title}>
               {title}
             </Heading>
+            {!isInternalUrl(href) && <ExternalLinkIcon />}
             {community && (
               <span className={styles.cardTags}>Community</span>
             )}

--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -64,14 +64,20 @@ function CardLayout({
   const community: boolean = (item?.customProps?.community as boolean) || false;
   let href, description;
   const categoryItemsPlural = useCategoryItemsPlural();
-  if (item.type === 'category') {
-    href = findFirstSidebarItemLink(item);
-    description = item.description ?? categoryItemsPlural(item.items.length);
-  } else {
-    href = item.href;
-    const doc = useDocById(item.docId ?? undefined);
-    description = item.description ?? doc?.description;
+
+if (item.type === 'category') {
+  href = findFirstSidebarItemLink(item);
+  // Add safety check to handle cases where a category might not have a valid link
+  if (href === undefined) {
+    href = null; // or another appropriate fallback
   }
+  description = item.description ?? categoryItemsPlural(item.items.length);
+} else {
+  href = item.href;
+  const doc = useDocById(item.docId ?? undefined);
+  description = item.description ?? doc?.description;
+}
+
 
   const LinkComponent = Link as any; //Type assertion to bypass linting error
 

--- a/docs/src/theme/DocCard/index.tsx
+++ b/docs/src/theme/DocCard/index.tsx
@@ -59,7 +59,7 @@ function CardLayout({
 }: {
   item: PropSidebarItemCategory | PropSidebarItemLink;
 } & React.ComponentPropsWithoutRef<'a'>): ReactNode {
-  const title = item.label;
+  const label = item.label;
   const logo: string | null = (item?.customProps?.logo as string) || null;
   const community: boolean = (item?.customProps?.community as boolean) || false;
   let href, description;
@@ -80,8 +80,8 @@ function CardLayout({
       {logo && <img className={styles.cardLogo} src={useBaseUrl(logo)} />}
       <div>
         <div className={styles.cardTitleWrapper}>
-          <Heading as="h2" className={styles.cardTitle} title={title}>
-            {title}
+          <Heading as="h2" className={styles.cardTitle} title={label}>
+            {label}
           </Heading>
           {!isInternalUrl(href) && <ExternalLinkIcon />}
           {community && <span className={styles.cardTags}>Community</span>}

--- a/docs/src/theme/DocCard/styles.module.css
+++ b/docs/src/theme/DocCard/styles.module.css
@@ -11,7 +11,9 @@
 
   display: flex;
   flex-direction: row;
-  gap: .75rem
+  align-items: stretch;
+  gap: .75rem;
+  height: 100%;
 }
 
 .cardContainer:hover {
@@ -60,9 +62,16 @@
 }
 
 .cardLogo {
-  display: block;
   width: 4rem;
   height: 4rem;
   background: var(--dagster-white);
   padding: .25rem;
+  flex-shrink: 0;
+}
+
+.cardTitleWrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: start;
+  gap: 12px;
 }

--- a/docs/src/theme/DocCard/styles.module.css
+++ b/docs/src/theme/DocCard/styles.module.css
@@ -1,3 +1,5 @@
+/* TODO: Refactor with scss to simplify/match other docs styling, merge with card styling in custom.scss */
+
 .cardContainer {
   --ifm-link-color: var(--ifm-color-emphasis-800);
   --ifm-link-hover-color: var(--ifm-color-emphasis-700);
@@ -12,6 +14,7 @@
   gap: .75rem;
   height: 100%;
   border-radius: 8px;
+  justify-self: stretch;
 }
 
 .cardContainer:hover {
@@ -25,7 +28,8 @@
 .cardTitle {
   font-size: 1rem;
   font-weight: 500;
-  margin-bottom: 0.5rem;
+  margin: 0 !important;
+  padding: 0 !important;
   padding-top: 0.2rem;
   line-height: 1.25rem;
 }
@@ -50,7 +54,7 @@
 .cardDescription {
   font-size: 0.875rem !important;
   font-weight: 400 !important;
-  line-height: 1rem !important;
+  line-height: 1.25rem !important;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   line-clamp: 3;
@@ -71,6 +75,11 @@
 .cardTitleWrapper {
   display: flex;
   flex-direction: row;
-  align-items: start;
-  gap: 12px;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.cardTitleWrapper .cardTags {
+  margin-left: 8px;
 }

--- a/docs/src/theme/DocCard/styles.module.css
+++ b/docs/src/theme/DocCard/styles.module.css
@@ -8,6 +8,10 @@
   transition: all var(--ifm-transition-fast) ease;
   transition-property: border, box-shadow;
   padding: 1rem !important;
+
+  display: flex;
+  flex-direction: row;
+  gap: .75rem
 }
 
 .cardContainer:hover {
@@ -53,4 +57,12 @@
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+.cardLogo {
+  display: block;
+  width: 4rem;
+  height: 4rem;
+  background: var(--dagster-white);
+  padding: .25rem;
 }

--- a/docs/src/theme/DocCard/styles.module.css
+++ b/docs/src/theme/DocCard/styles.module.css
@@ -71,7 +71,7 @@
   align-items: center;
   gap: 4px;
   margin-bottom: 4px;
-  padding-top: .25rem;
+  padding-top: 0.25rem;
 }
 
 .cardTitleWrapper .cardTags {

--- a/docs/src/theme/DocCard/styles.module.css
+++ b/docs/src/theme/DocCard/styles.module.css
@@ -1,24 +1,18 @@
 /* TODO: Refactor with scss to simplify/match other docs styling, merge with card styling in custom.scss */
+/* TODO: This duplicates/conflicts with .card styles set in custom.scss. Try to create a more cohesive card styling system */
 
 .cardContainer {
   --ifm-link-color: var(--ifm-color-emphasis-800);
   --ifm-link-hover-color: var(--ifm-color-emphasis-700);
   --ifm-link-hover-decoration: none;
-  border: 1px solid var(--theme-color-keyline);
   transition: all var(--ifm-transition-fast) ease;
-  transition-property: border, box-shadow;
   padding: 1rem !important;
   display: flex;
   flex-direction: row;
   align-items: flex-start;
   gap: 0.75rem;
   height: 100%;
-  border-radius: 8px;
   justify-self: stretch;
-}
-
-.cardContainer:hover {
-  box-shadow: 0 0 8px 0 var(--dagster-blue-translucent-30);
 }
 
 .cardContainer *:last-child {

--- a/docs/src/theme/DocCard/styles.module.css
+++ b/docs/src/theme/DocCard/styles.module.css
@@ -44,12 +44,13 @@
 }
 
 .cardTags {
-  padding-left: 8px;
-  padding-right: 8px;
-  background: var(--theme-color-background-blue);
-  border-radius: 16px;
-  font-size: 0.8rem;
+  padding: 4px 8px;
+  background: var(--theme-color-background-gray);
+  border-radius: 8px;
+  font-size: 12px;
+  line-height: 16px;
   font-weight: 400;
+  color: var(--theme-color-text-light);
 }
 
 .cardDescription {

--- a/docs/src/theme/DocCard/styles.module.css
+++ b/docs/src/theme/DocCard/styles.module.css
@@ -2,31 +2,24 @@
   --ifm-link-color: var(--ifm-color-emphasis-800);
   --ifm-link-hover-color: var(--ifm-color-emphasis-700);
   --ifm-link-hover-decoration: none;
-
-  box-shadow: 0 1.5px 3px 0 rgb(0 0 0 / 15%);
-  border: 1px solid var(--ifm-color-emphasis-200);
+  border: 1px solid var(--theme-color-keyline);
   transition: all var(--ifm-transition-fast) ease;
   transition-property: border, box-shadow;
   padding: 1rem !important;
-
   display: flex;
   flex-direction: row;
-  align-items: stretch;
+  align-items: flex-start;
   gap: .75rem;
   height: 100%;
+  border-radius: 8px;
 }
 
 .cardContainer:hover {
-  border-color: var(--ifm-color-primary);
-  box-shadow: 0 3px 6px 0 rgb(0 0 0 / 20%);
+  box-shadow: 0 0 8px 0 var(--dagster-blue-translucent-30);
 }
 
 .cardContainer *:last-child {
   margin-bottom: 0;
-}
-
-.cardTitleContainer {
-  display: flex;
 }
 
 .cardTitle {
@@ -34,6 +27,7 @@
   font-weight: 500;
   margin-bottom: 0.5rem;
   padding-top: 0.2rem;
+  line-height: 1.25rem;
 }
 
 .cardSubtitle {
@@ -47,19 +41,22 @@
   padding: 4px 8px;
   background: var(--theme-color-background-gray);
   border-radius: 8px;
-  font-size: 12px;
-  line-height: 16px;
+  font-size: .75rem;
+  line-height: 1rem;
   font-weight: 400;
   color: var(--theme-color-text-light);
 }
 
 .cardDescription {
-  font-size: 0.8rem !important;
+  font-size: 0.875rem !important;
   font-weight: 400 !important;
+  line-height: 1rem !important;
   display: -webkit-box;
   -webkit-line-clamp: 3;
+  line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  color: var(--theme-color-text-light);
 }
 
 .cardLogo {
@@ -68,6 +65,7 @@
   background: var(--dagster-white);
   padding: .25rem;
   flex-shrink: 0;
+  border-radius: 4px !important;
 }
 
 .cardTitleWrapper {

--- a/docs/src/theme/DocCard/styles.module.css
+++ b/docs/src/theme/DocCard/styles.module.css
@@ -11,7 +11,7 @@
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-  gap: .75rem;
+  gap: 0.75rem;
   height: 100%;
   border-radius: 8px;
   justify-self: stretch;
@@ -45,7 +45,7 @@
   padding: 4px 8px;
   background: var(--theme-color-background-gray);
   border-radius: 8px;
-  font-size: .75rem;
+  font-size: 0.75rem;
   line-height: 1rem;
   font-weight: 400;
   color: var(--theme-color-text-light);
@@ -67,7 +67,7 @@
   width: 4rem;
   height: 4rem;
   background: var(--dagster-white);
-  padding: .25rem;
+  padding: 0.25rem;
   flex-shrink: 0;
   border-radius: 4px !important;
 }

--- a/docs/src/theme/DocCard/styles.module.css
+++ b/docs/src/theme/DocCard/styles.module.css
@@ -23,8 +23,7 @@
   font-size: 1rem;
   font-weight: 500;
   margin: 0 !important;
-  padding: 0 !important;
-  padding-top: 0.2rem;
+  padding: 0px !important;
   line-height: 1.25rem;
 }
 
@@ -72,6 +71,7 @@
   align-items: center;
   gap: 4px;
   margin-bottom: 4px;
+  padding-top: .25rem;
 }
 
 .cardTitleWrapper .cardTags {

--- a/docs/src/theme/DocCard/styles.module.css
+++ b/docs/src/theme/DocCard/styles.module.css
@@ -71,7 +71,7 @@
   align-items: center;
   gap: 4px;
   margin-bottom: 4px;
-  padding-top: 0.25rem;
+  padding: 0.125rem 0rem;
 }
 
 .cardTitleWrapper .cardTags {

--- a/docs/src/theme/DocCardList/index.tsx
+++ b/docs/src/theme/DocCardList/index.tsx
@@ -30,9 +30,7 @@ export default function DocCardList(props: Props): ReactNode {
         {() => {
           return filteredItems
             .filter((item) => item.href !== window.location.pathname)
-            .map((item, index) => (
-              <DocCard item={item} />
-            ));
+            .map((item, index) => <DocCard key={index} item={item} />);
         }}
       </BrowserOnly>
     </section>

--- a/docs/src/theme/DocCardList/index.tsx
+++ b/docs/src/theme/DocCardList/index.tsx
@@ -25,7 +25,7 @@ export default function DocCardList(props: Props): ReactNode {
   // https://github.com/facebook/docusaurus/blob/67924ca9795c4cd0399c752b4345f515bcedcaf6/website/docs/advanced/ssg.mdx#browseronly-browseronly
 
   return (
-    <section className={clsx('card-group cols-2 gap-lg', className)}>
+    <section className={clsx('card-group cols-2 gap-lg', className)} style={{['--card-group-gap' as any]: '2rem'}}>
       <BrowserOnly>
         {() => {
           return filteredItems

--- a/docs/src/theme/DocCardList/index.tsx
+++ b/docs/src/theme/DocCardList/index.tsx
@@ -25,7 +25,7 @@ export default function DocCardList(props: Props): ReactNode {
   // https://github.com/facebook/docusaurus/blob/67924ca9795c4cd0399c752b4345f515bcedcaf6/website/docs/advanced/ssg.mdx#browseronly-browseronly
 
   return (
-    <section className={clsx('card-group cols-2 gap-lg', className)} style={{['--card-group-gap' as any]: '2rem'}}>
+    <section className={clsx('card-group cols-2', className)} style={{['--card-group-gap' as any]: '2rem'}}>
       <BrowserOnly>
         {() => {
           return filteredItems

--- a/docs/src/theme/DocCardList/index.tsx
+++ b/docs/src/theme/DocCardList/index.tsx
@@ -25,15 +25,13 @@ export default function DocCardList(props: Props): ReactNode {
   // https://github.com/facebook/docusaurus/blob/67924ca9795c4cd0399c752b4345f515bcedcaf6/website/docs/advanced/ssg.mdx#browseronly-browseronly
 
   return (
-    <section className={clsx('row', className)}>
+    <section className={clsx('card-group cols-2 gap-lg', className)}>
       <BrowserOnly>
         {() => {
           return filteredItems
             .filter((item) => item.href !== window.location.pathname)
             .map((item, index) => (
-              <article key={index} className="col col--6 margin-bottom--lg">
-                <DocCard item={item} />
-              </article>
+              <DocCard item={item} />
             ));
         }}
       </BrowserOnly>


### PR DESCRIPTION
## Summary & Motivation

We had two separate card components being used in the intro page and in content hub pages around the site. I refactored so that manually-authored and automatically generated cards consume the same DocCard component and made some light styling updates, also added the external link icon to show conditionally where needed.

## How I Tested These Changes

Tested by starting the docs server with yarn start and manually clicking through cards to verify rendering and navigation, then ran yarn build, yarn test, and yarn format_check to ensure no build errors, test failures, or formatting issues.

## Before and after screenshots

### Before

<img width="1577" height="939" alt="Screenshot 2025-10-14 at 12 08 07 PM" src="https://github.com/user-attachments/assets/be8cd5e8-76e9-4ad9-9258-ecf4596d4505" />

<img width="1578" height="942" alt="Screenshot 2025-10-14 at 12 15 23 PM" src="https://github.com/user-attachments/assets/a3b4c2d8-6ed3-4a92-8b4f-6ba7417f3064" />

### After 


<img width="1582" height="937" alt="Screenshot 2025-10-14 at 12 16 02 PM" src="https://github.com/user-attachments/assets/ffc4a8a6-81af-433f-b0c0-75bc3c843a16" />

^ Minimal changes to "DocCard" visuals - some light cleanup to text styles and border radiuses. 

<img width="1569" height="937" alt="Screenshot 2025-10-14 at 12 17 03 PM" src="https://github.com/user-attachments/assets/b86103a1-4a37-45c4-a6ac-ed590bb4a2be" />

^ "Card" component (only used on homepage) consumes same DocCard component as above but allows user to manually pass in props like "title=" "href=". No reason to use a visually distinct doc card here.
