### PR TITLE
replace streaming grpc repository gets with regular gets

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
@@ -38,7 +38,7 @@ def test_can_reload_on_remote_repository_error():
                 # note it where the function is *used* that needs to mocked, not
                 # where it is defined.
                 # see https://docs.python.org/3/library/unittest.mock.html#where-to-patch
-                "dagster._api.snapshot_repository.sync_get_streaming_external_repositories_data_grpc"
+                "dagster._api.snapshot_repository.sync_get_external_repositories_data_grpc"
             ) as remote_repository_mock:
                 remote_repository_mock.side_effect = Exception("get_remote_repo_failure")
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
@@ -297,7 +297,7 @@ class TestReloadRepositoriesOutOfProcess(OutOfProcessTestSuite):
                 # note it where the function is *used* that needs to mocked, not
                 # where it is defined.
                 # see https://docs.python.org/3/library/unittest.mock.html#where-to-patch
-                "dagster._api.snapshot_repository.sync_get_streaming_external_repositories_data_grpc"
+                "dagster._api.snapshot_repository.sync_get_external_repositories_data_grpc"
             ) as remote_repository_mock:
 
                 @repository

--- a/python_modules/dagster/dagster/_api/snapshot_repository.py
+++ b/python_modules/dagster/dagster/_api/snapshot_repository.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from dagster._grpc.client import DagsterGrpcClient
 
 
-def sync_get_streaming_external_repositories_data_grpc(
+def sync_get_external_repositories_data_grpc(
     api_client: "DagsterGrpcClient", code_location: "CodeLocation"
 ) -> Mapping[str, RepositorySnap]:
     from dagster._core.remote_origin import RemoteRepositoryOrigin
@@ -21,21 +21,12 @@ def sync_get_streaming_external_repositories_data_grpc(
 
     repo_datas = {}
     for repository_name in code_location.repository_names:  # type: ignore
-        external_repository_chunks = list(
-            api_client.streaming_external_repository(
+        result = deserialize_value(
+            api_client.external_repository(
                 remote_repository_origin=RemoteRepositoryOrigin(
                     code_location.origin,
                     repository_name,
                 )
-            )
-        )
-
-        result = deserialize_value(
-            "".join(
-                [
-                    chunk["serialized_external_repository_chunk"]
-                    for chunk in external_repository_chunks
-                ]
             ),
             (RepositorySnap, RepositoryErrorSnap),
         )
@@ -47,7 +38,7 @@ def sync_get_streaming_external_repositories_data_grpc(
     return repo_datas
 
 
-async def gen_streaming_external_repositories_data_grpc(
+async def gen_external_repositories_data_grpc(
     api_client: "DagsterGrpcClient", code_location: "CodeLocation"
 ) -> Mapping[str, RepositorySnap]:
     from dagster._core.remote_origin import RemoteRepositoryOrigin
@@ -57,22 +48,12 @@ async def gen_streaming_external_repositories_data_grpc(
 
     repo_datas = {}
     for repository_name in code_location.repository_names:  # type: ignore
-        external_repository_chunks = [
-            chunk
-            async for chunk in api_client.gen_streaming_external_repository(
+        result = deserialize_value(
+            await api_client.gen_external_repository(
                 remote_repository_origin=RemoteRepositoryOrigin(
                     code_location.origin,
                     repository_name,
                 )
-            )
-        ]
-
-        result = deserialize_value(
-            "".join(
-                [
-                    chunk["serialized_external_repository_chunk"]
-                    for chunk in external_repository_chunks
-                ]
             ),
             (RepositorySnap, RepositoryErrorSnap),
         )

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -648,9 +648,7 @@ class GrpcServerCodeLocation(CodeLocation):
     ):
         from dagster._api.get_server_id import sync_get_server_id
         from dagster._api.list_repositories import sync_list_repositories_grpc
-        from dagster._api.snapshot_repository import (
-            sync_get_streaming_external_repositories_data_grpc,
-        )
+        from dagster._api.snapshot_repository import sync_get_external_repositories_data_grpc
         from dagster._grpc.client import DagsterGrpcClient, client_heartbeat_thread
 
         self._origin = check.inst_param(origin, "origin", CodeLocationOrigin)
@@ -729,7 +727,7 @@ class GrpcServerCodeLocation(CodeLocation):
 
             self._container_context = list_repositories_response.container_context
 
-            self._repository_snaps = sync_get_streaming_external_repositories_data_grpc(
+            self._repository_snaps = sync_get_external_repositories_data_grpc(
                 self.client,
                 self,
             )

--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -430,6 +430,7 @@ class DagsterGrpcClient:
         self,
         remote_repository_origin: RemoteRepositoryOrigin,
         defer_snapshots: bool = False,
+        timeout=DEFAULT_REPOSITORY_GRPC_TIMEOUT,
     ) -> str:
         check.inst_param(
             remote_repository_origin,
@@ -443,6 +444,30 @@ class DagsterGrpcClient:
             # rename this param name
             serialized_repository_python_origin=serialize_value(remote_repository_origin),
             defer_snapshots=defer_snapshots,
+            timeout=timeout,
+        )
+
+        return res.serialized_external_repository_data
+
+    async def gen_external_repository(
+        self,
+        remote_repository_origin: RemoteRepositoryOrigin,
+        defer_snapshots: bool = False,
+        timeout=DEFAULT_REPOSITORY_GRPC_TIMEOUT,
+    ) -> str:
+        check.inst_param(
+            remote_repository_origin,
+            "remote_repository_origin",
+            RemoteRepositoryOrigin,
+        )
+
+        res = await self._gen_query(
+            "ExternalRepository",
+            dagster_api_pb2.ExternalRepositoryRequest,
+            # rename this param name
+            serialized_repository_python_origin=serialize_value(remote_repository_origin),
+            defer_snapshots=defer_snapshots,
+            timeout=timeout,
         )
 
         return res.serialized_external_repository_data
@@ -466,25 +491,6 @@ class DagsterGrpcClient:
             job_name=job_name,
             timeout=timeout,
         )
-
-    def streaming_external_repository(
-        self,
-        remote_repository_origin: RemoteRepositoryOrigin,
-        defer_snapshots: bool = False,
-        timeout=DEFAULT_REPOSITORY_GRPC_TIMEOUT,
-    ) -> Iterator[dict]:
-        for res in self._streaming_query(
-            "StreamingExternalRepository",
-            dagster_api_pb2.ExternalRepositoryRequest,
-            # Rename parameter
-            serialized_repository_python_origin=serialize_value(remote_repository_origin),
-            defer_snapshots=defer_snapshots,
-            timeout=timeout,
-        ):
-            yield {
-                "sequence_number": res.sequence_number,
-                "serialized_external_repository_chunk": res.serialized_external_repository_chunk,
-            }
 
     async def gen_streaming_external_repository(
         self,

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -299,7 +299,9 @@ class DagsterProxyApiServicer(DagsterApiServicer):
         return self._query("ExternalPipelineSubsetSnapshot", request, context)
 
     def ExternalRepository(self, request, context):
-        return self._query("ExternalRepository", request, context)
+        return self._query(
+            "ExternalRepository", request, context, timeout=DEFAULT_REPOSITORY_GRPC_TIMEOUT
+        )
 
     def ExternalJob(self, request, context):
         return self._query("ExternalJob", request, context)

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -6,8 +6,8 @@ import dagster as dg
 import pytest
 from dagster import job
 from dagster._api.snapshot_repository import (
-    gen_streaming_external_repositories_data_grpc,
-    sync_get_streaming_external_repositories_data_grpc,
+    gen_external_repositories_data_grpc,
+    sync_get_external_repositories_data_grpc,
 )
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.instance import DagsterInstance
@@ -35,7 +35,7 @@ from dagster_tests.api_tests.utils import get_bar_repo_code_location
 
 def test_streaming_external_repositories_api_grpc(instance):
     with get_bar_repo_code_location(instance) as code_location:
-        repository_snaps = sync_get_streaming_external_repositories_data_grpc(
+        repository_snaps = sync_get_external_repositories_data_grpc(
             code_location.client, code_location
         )
 
@@ -51,7 +51,7 @@ def test_streaming_external_repositories_api_grpc(instance):
         }
 
         async_repository_snaps = asyncio.run(
-            gen_streaming_external_repositories_data_grpc(code_location.client, code_location)
+            gen_external_repositories_data_grpc(code_location.client, code_location)
         )
 
         assert async_repository_snaps == repository_snaps
@@ -66,15 +66,13 @@ def test_streaming_external_repositories_error(instance):
             DagsterUserCodeProcessError,
             match='Could not find a repository called "does_not_exist"',
         ):
-            sync_get_streaming_external_repositories_data_grpc(code_location.client, code_location)
+            sync_get_external_repositories_data_grpc(code_location.client, code_location)
 
         with pytest.raises(
             DagsterUserCodeProcessError,
             match='Could not find a repository called "does_not_exist"',
         ):
-            asyncio.run(
-                gen_streaming_external_repositories_data_grpc(code_location.client, code_location)
-            )
+            asyncio.run(gen_external_repositories_data_grpc(code_location.client, code_location))
 
 
 @dg.op
@@ -117,7 +115,7 @@ def test_giant_external_repository_streaming_grpc():
     with dg.instance_for_test() as instance:
         with get_giant_repo_grpc_code_location(instance) as code_location:
             # Using streaming allows the giant repo to load
-            repository_snaps = sync_get_streaming_external_repositories_data_grpc(
+            repository_snaps = sync_get_external_repositories_data_grpc(
                 code_location.client, code_location
             )
 


### PR DESCRIPTION
## Summary & Motivation


These were originally made streaming in a misguided attempt to work around byte size limits. There is no reason for the call to be streaming and some circumstantial evidence that it being streaming may be causing problems. This PR makes it synchronous, making sure that the higher timeout is kept.

## How I Tested These Changes

BK