### PR TITLE
[sbc] Enable automatic refreshing of state in dev mode

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
@@ -169,6 +169,9 @@ class DefinitionsLoadContext:
         else:
             return self._pending_reconstruction_metadata[metadata_key]
 
+    def add_defs_state_info(self, key: str, version: str) -> None:
+        self._defs_state_info = DefsStateInfo.add_version(self._defs_state_info, key, version)
+
     @contextmanager
     def state_path(self, key: str, state_storage: DefsStateStorage) -> Iterator[Optional[Path]]:
         """Context manager that creates a temporary path to hold local state for a component."""

--- a/python_modules/dagster/dagster/components/utils/defs_state.py
+++ b/python_modules/dagster/dagster/components/utils/defs_state.py
@@ -16,6 +16,10 @@ class DefsStateConfig(Resolvable, Model):
             DefsStateManagementType.LEGACY_CODE_SERVER_SNAPSHOTS.value,
         ],
     )
+    refresh_if_dev: bool = Field(
+        default=True,
+        description="Whether to automatically refresh defs state when using `dagster dev` or the `dg` cli.",
+    )
 
     @classmethod
     def local_filesystem(cls) -> "DefsStateConfig":


### PR DESCRIPTION
## Summary & Motivation

dagster-dbt has `prepare_if_dev`. other state-based integrations automatically rebuild their state when the code server starts.

we want users of state-backed components to have a similarly pain-free way of having their state eagerly update while they're testing in local dev. this adds a new `refresh_if_dev` boolean to the `DefsStateConfig`, which defaults to `True`. This serves the same functional purpose as `prepare_if_dev` in dbt land, but is generalized for all state-backed components.

## How I Tested These Changes

unit

## Changelog

NOCHANGELOG
