### PR TITLE
make streamline timestamps default to None

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_check_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_check_health.py
@@ -25,9 +25,9 @@ class AssetCheckHealthState(LoadableBy[AssetKey]):
     failing_checks: set[AssetCheckKey]
     warning_checks: set[AssetCheckKey]
     all_checks: set[AssetCheckKey]
-    latest_passing_check_timestamp: Optional[float]
-    latest_failing_check_timestamp: Optional[float]
-    latest_warning_check_timestamp: Optional[float]
+    latest_passing_check_timestamp: Optional[float] = None
+    latest_failing_check_timestamp: Optional[float] = None
+    latest_warning_check_timestamp: Optional[float] = None
 
     @classmethod
     def default(cls) -> "AssetCheckHealthState":

--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_freshness_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_freshness_health.py
@@ -24,7 +24,7 @@ class AssetFreshnessHealthState(LoadableBy[AssetKey]):
     """Maintains the latest freshness state for the asset."""
 
     freshness_state: FreshnessState
-    updated_timestamp: Optional[float]
+    updated_timestamp: Optional[float] = None
 
     @property
     def health_status(self) -> AssetHealthStatus:

--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
@@ -35,7 +35,7 @@ class MinimalAssetMaterializationHealthState(LoadableBy[AssetKey]):
     num_failed_partitions: int
     num_currently_materialized_partitions: int
     partitions_snap: Optional[PartitionsSnap]
-    latest_failed_to_materialize_timestamp: Optional[float]
+    latest_failed_to_materialize_timestamp: Optional[float] = None
 
     @property
     def health_status(self) -> AssetHealthStatus:


### PR DESCRIPTION
Need these to have defaults, because otherwise we can't deserialize the already stored values