### PR TITLE
Pass in a GrapheneRepository to bypass caching for workspace query

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -42,6 +42,10 @@ class RepositoryScopedBatchLoader:
         self._data: dict[RepositoryDataType, dict[str, list[Any]]] = {}
         self._limits: dict[RepositoryDataType, int] = {}
 
+    @property
+    def repository(self) -> RemoteRepository:
+        return self._repository
+
     def _get(self, data_type: RepositoryDataType, key: str, limit: int) -> Sequence[Any]:
         check.inst_param(data_type, "data_type", RepositoryDataType)
         check.str_param(key, "key")

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -354,10 +354,13 @@ class GrapheneRepository(graphene.ObjectType):
         ]
 
     def resolve_pipelines(self, graphene_info: ResolveInfo):
+        repo = self.get_repository(graphene_info)
+        batch_loader = self.get_batch_loader(graphene_info)
+
         return [
-            GraphenePipeline(pipeline)
+            GraphenePipeline(pipeline, batch_loader)
             for pipeline in sorted(
-                self.get_repository(graphene_info).get_all_jobs(),
+                repo.get_all_jobs(),
                 key=lambda pipeline: pipeline.name,
             )
         ]

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -326,6 +326,9 @@ class RemoteRepository:
             else self._asset_jobs.get(job_name, [])
         )
 
+    def get_asset_keys_in_job(self, job_name: str) -> Sequence[AssetKey]:
+        return [asset_snap.asset_key for asset_snap in self.get_asset_node_snaps(job_name)]
+
     @cached_property
     def _asset_snaps_by_key(self) -> Mapping[AssetKey, AssetNodeSnap]:
         mapping = {}

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -691,8 +691,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
             return []
 
         repository = location.get_repository(selector.repository_name)
-        snaps = repository.get_asset_node_snaps(job_name=selector.job_name)
-        return [snap.asset_key for snap in snaps]
+        return repository.get_asset_keys_in_job(job_name=selector.job_name)
 
     def get_assets_in_job(
         self,


### PR DESCRIPTION
## Summary & Motivation
- Keep cache behavior when you are doing a point query for a specific job
- In the workspace query where you are starting from a repo and generating every job, pass in the repo so that it can bypass cache when making calculations like isAssetJob

## How I Tested These Changes
BK
