### PR TITLE
[sbc] Update CLIs to allow selected by management type

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/defs_state.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/defs_state.py
@@ -1,10 +1,11 @@
 import asyncio
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Annotated, Literal, Optional
 
 import click
 from dagster_dg_core.utils import exit_with_error
+from dagster_shared.check import ImportFrom
 from dagster_shared.record import record, replace
 
 if TYPE_CHECKING:
@@ -12,20 +13,21 @@ if TYPE_CHECKING:
     from dagster.components.component.state_backed_component import StateBackedComponent
     from dagster.components.core.component_tree import ComponentTree
     from dagster_shared.serdes.objects.models import DefsStateInfo
+    from dagster_shared.serdes.objects.models.defs_state_info import DefsStateManagementType
 
 
 @record
 class ComponentStateRefreshStatus:
     status: Literal["refreshing", "done", "failed"]
+    management_type: Annotated[
+        "DefsStateManagementType",
+        ImportFrom("dagster_shared.serdes.objects.models.defs_state_info"),
+    ]
     error: Optional[Exception] = None
     # For updating: start_time tracks when it began
     # For completed: duration tracks final elapsed time
     start_time: float = 0.0
     duration: Optional[float] = None
-
-    @staticmethod
-    def default() -> "ComponentStateRefreshStatus":
-        return ComponentStateRefreshStatus(status="refreshing", start_time=time.time())
 
 
 def raise_component_state_refresh_errors(statuses: dict[str, ComponentStateRefreshStatus]) -> None:
@@ -47,17 +49,27 @@ def raise_component_state_refresh_errors(statuses: dict[str, ComponentStateRefre
 
 
 def _get_components_to_refresh(
-    component_tree: "ComponentTree", defs_state_keys: Optional[set[str]]
+    component_tree: "ComponentTree",
+    defs_state_keys: Optional[set[str]],
+    management_types: set["DefsStateManagementType"],
 ) -> list["StateBackedComponent"]:
     from dagster.components.component.state_backed_component import StateBackedComponent
 
     state_backed_components = component_tree.get_all_components(of_type=StateBackedComponent)
-    if defs_state_keys is None:
-        return state_backed_components
 
     selected_components = [
         component
         for component in state_backed_components
+        if component.defs_state_config.type in management_types
+    ]
+
+    # Filter by defs state keys if specified
+    if defs_state_keys is None:
+        return selected_components
+
+    selected_components = [
+        component
+        for component in selected_components
         if component.defs_state_config.key in defs_state_keys
     ]
     missing_defs_keys = defs_state_keys - {
@@ -110,6 +122,7 @@ async def _refresh_state_for_components(
 def get_updated_defs_state_info_task_and_statuses(
     project_path: Path,
     defs_state_storage: "DefsStateStorage",
+    management_types: set["DefsStateManagementType"],
     defs_state_keys: Optional[set[str]] = None,
 ) -> tuple[asyncio.Task[Optional["DefsStateInfo"]], dict[str, ComponentStateRefreshStatus]]:
     """Creates an asyncio.Task that will refresh the defs state for all selected components within the specified project path.
@@ -122,7 +135,9 @@ def get_updated_defs_state_info_task_and_statuses(
 
     with disable_dagster_warnings():
         component_tree = ComponentTree.for_project(project_path)
-        components_to_refresh = _get_components_to_refresh(component_tree, defs_state_keys)
+        components_to_refresh = _get_components_to_refresh(
+            component_tree, defs_state_keys, management_types
+        )
 
     # in some cases, multiple components may share the same defs state key. in these cases, it is assumed that
     # the refresh_state method for each component of the same key will be identical, so we choose an arbitrary one
@@ -134,8 +149,12 @@ def get_updated_defs_state_info_task_and_statuses(
 
     # shared dictionary to be used for all subtasks
     statuses = {
-        key: ComponentStateRefreshStatus(status="refreshing", start_time=time.time())
-        for key in deduplicated_components.keys()
+        key: ComponentStateRefreshStatus(
+            status="refreshing",
+            management_type=component.defs_state_config.type,
+            start_time=time.time(),
+        )
+        for key, component in deduplicated_components.items()
     }
     refresh_task = asyncio.create_task(
         _refresh_state_for_components(
@@ -148,13 +167,14 @@ def get_updated_defs_state_info_task_and_statuses(
 async def get_updated_defs_state_info_and_statuses(
     project_path: Path,
     defs_state_storage: "DefsStateStorage",
+    management_types: set["DefsStateManagementType"],
     defs_state_keys: Optional[set[str]] = None,
 ) -> tuple[Optional["DefsStateInfo"], dict[str, ComponentStateRefreshStatus]]:
     """Refreshes the defs state for all selected components within the specified project path,
     and returns the updated defs state info and statuses.
     """
     task, statuses = get_updated_defs_state_info_task_and_statuses(
-        project_path, defs_state_storage, defs_state_keys
+        project_path, defs_state_storage, management_types, defs_state_keys
     )
     await task
     return task.result(), statuses

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import click
 from dagster_cloud_cli.types import SnapshotBaseDeploymentCondition
@@ -29,6 +29,9 @@ from dagster_dg_cli.cli.plus.deploy.deploy_session import (
     init_deploy_session,
 )
 from dagster_dg_cli.utils.plus.build import defs_state_storage_from_location_state, get_agent_type
+
+if TYPE_CHECKING:
+    from dagster_shared.serdes.objects.models.defs_state_info import DefsStateManagementType
 
 DEFAULT_STATEDIR_PATH = os.path.join(get_system_temp_directory(), "dg-build-state")
 
@@ -386,7 +389,12 @@ def build_and_push_command(
     )
 
 
-def refresh_defs_state_impl(ctx: click.Context, statedir: str, project_path: Path):
+def refresh_defs_state_impl(
+    ctx: click.Context,
+    statedir: str,
+    project_path: Path,
+    management_types: set["DefsStateManagementType"],
+):
     from dagster_cloud_cli.commands.ci import state
 
     state_store = state.FileStore(statedir=statedir)
@@ -395,7 +403,9 @@ def refresh_defs_state_impl(ctx: click.Context, statedir: str, project_path: Pat
     for location_state in locations:
         with defs_state_storage_from_location_state(ctx, location_state) as defs_state_storage:
             defs_state_info, statuses = asyncio.run(
-                get_updated_defs_state_info_and_statuses(project_path, defs_state_storage)
+                get_updated_defs_state_info_and_statuses(
+                    project_path, defs_state_storage, management_types=management_types
+                )
             )
             raise_component_state_refresh_errors(statuses)
         if defs_state_info is None:
@@ -412,19 +422,40 @@ def refresh_defs_state_impl(ctx: click.Context, statedir: str, project_path: Pat
 @dg_editable_dagster_options
 @dg_path_options
 @dg_global_options
+@click.option(
+    "--management-type",
+    multiple=True,
+    type=click.Choice(["LOCAL_FILESYSTEM", "VERSIONED_STATE_STORAGE"]),
+    help="Only refresh components with the specified management type. Can be specified multiple times to include multiple types. By default, refreshes only VERSIONED_STATE_STORAGE components.",
+)
 @cli_telemetry_wrapper
 def refresh_defs_state_command(
     target_path: Path,
+    management_type: tuple[str, ...],
     **global_options: object,
 ):
     """[Experimental] If using StateBackedComponents, this command will execute the `refresh_state` on each of them,
     and set the defs_state_info for each location.
     """
+    from dagster_shared.serdes.objects.models.defs_state_info import DefsStateManagementType
+
     ctx = click.get_current_context()
     cli_config = normalize_cli_config(global_options, ctx)
     # ensure that the command is executed in a project
     dg_context = DgContext.for_project_environment(target_path, cli_config)
-    refresh_defs_state_impl(ctx=ctx, statedir=_get_statedir(), project_path=dg_context.root_path)
+    management_types = (
+        {DefsStateManagementType(mt) for mt in management_type}
+        if management_type
+        else {
+            DefsStateManagementType.VERSIONED_STATE_STORAGE,
+        }
+    )
+    refresh_defs_state_impl(
+        ctx=ctx,
+        statedir=_get_statedir(),
+        project_path=dg_context.root_path,
+        management_types=management_types,
+    )
 
 
 @deploy_group.command(name="set-build-output", cls=DgClickCommand)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
@@ -49,6 +49,7 @@ from dagster_dg_cli.utils.yaml_template_generator import (
 
 if TYPE_CHECKING:
     from dagster._core.instance.instance import DagsterInstance
+    from dagster_shared.serdes.objects.models.defs_state_info import DefsStateManagementType
 
 DEFAULT_SCHEMA_FOLDER_NAME = ".dg"
 
@@ -421,11 +422,14 @@ def _get_display_text(statuses: dict[str, ComponentStateRefreshStatus], spinner_
 
 
 async def _refresh_defs_state_with_live_display(
-    project_path: Path, instance: "DagsterInstance", defs_state_keys: Optional[set[str]] = None
+    project_path: Path,
+    instance: "DagsterInstance",
+    management_types: set["DefsStateManagementType"],
+    defs_state_keys: Optional[set[str]] = None,
 ) -> None:
     defs_state_storage = check.not_none(instance.defs_state_storage)
     refresh_task, statuses = get_updated_defs_state_info_task_and_statuses(
-        project_path, defs_state_storage, defs_state_keys
+        project_path, defs_state_storage, management_types, defs_state_keys
     )
 
     # Thread-safe coordination variables
@@ -467,15 +471,23 @@ async def _refresh_defs_state_with_live_display(
     multiple=True,
     help="Only refresh state for specified defs state key. Can be specified multiple times.",
 )
+@click.option(
+    "--management-type",
+    multiple=True,
+    type=click.Choice(["LOCAL_FILESYSTEM", "VERSIONED_STATE_STORAGE"]),
+    help="Only refresh components with the specified management type. Can be specified multiple times to include multiple types. Defaults to all management types except for LEGACY_CODE_SERVER_SNAPSHOTS.",
+)
 @cli_telemetry_wrapper
 def refresh_defs_state(
     target_path: Path,
     defs_state_key: tuple[str, ...],
+    management_type: tuple[str, ...],
     **other_opts: object,
 ) -> None:
     """Refresh the defs state for the current project."""
     from dagster._cli.utils import get_possibly_temporary_instance_for_cli
     from dagster._core.instance.config import is_dagster_home_set
+    from dagster_shared.serdes.objects.models.defs_state_info import DefsStateManagementType
 
     # Check if DAGSTER_HOME is set before proceeding
     if not is_dagster_home_set():
@@ -494,6 +506,16 @@ def refresh_defs_state(
 
     with get_possibly_temporary_instance_for_cli("dg utils refresh-defs-state") as instance:
         defs_state_keys = set(defs_state_key) if defs_state_key else None
+        management_types = (
+            {DefsStateManagementType(mt) for mt in management_type}
+            if management_type
+            else {
+                DefsStateManagementType.LOCAL_FILESYSTEM,
+                DefsStateManagementType.VERSIONED_STATE_STORAGE,
+            }
+        )
         asyncio.run(
-            _refresh_defs_state_with_live_display(dg_context.root_path, instance, defs_state_keys)
+            _refresh_defs_state_with_live_display(
+                dg_context.root_path, instance, management_types, defs_state_keys
+            )
         )

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/sample_state_backed_component.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/sample_state_backed_component.py
@@ -3,24 +3,24 @@ from typing import Optional
 
 import dagster as dg
 from dagster.components.component.state_backed_component import StateBackedComponent
-from dagster.components.utils.defs_state import DefsStateConfig, DefsStateManagementType
+from dagster.components.utils.defs_state import (
+    DefsStateConfig,
+    DefsStateConfigArgs,
+    ResolvedDefsStateConfig,
+)
 
 
 class SampleStateBackedComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     fail_write: bool = False
     defs_state_key_id: Optional[str] = None
+    defs_state: ResolvedDefsStateConfig = DefsStateConfigArgs.versioned_state_storage()
 
     @property
     def defs_state_config(self) -> DefsStateConfig:
         default_key = self.__class__.__name__
         if self.defs_state_key_id is not None:
             default_key = f"{default_key}[{self.defs_state_key_id}]"
-
-        return DefsStateConfig(
-            key=default_key,
-            type=DefsStateManagementType.VERSIONED_STATE_STORAGE,
-            refresh_if_dev=True,
-        )
+        return DefsStateConfig.from_args(self.defs_state, default_key=default_key)
 
     def build_defs_from_state(
         self, context: dg.ComponentLoadContext, state_path: Optional[Path]

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/test_refresh_state_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/test_refresh_state_command.py
@@ -253,3 +253,173 @@ def test_refresh_state_command_with_duplicate_keys():
         key_count = result.output.count("SampleStateBackedComponent[shared]")
         # It should appear once in the status display, not twice
         assert key_count == 1, f"Expected key to appear once, but appeared {key_count} times"
+
+
+def test_refresh_state_command_with_management_type_filter():
+    """Test that refresh-defs-state filters by management type correctly."""
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(
+            runner, in_workspace=False, use_editable_dagster=True, uv_sync=True
+        ) as project_dir,
+        activate_venv(project_dir / ".venv"),
+        dg.instance_for_test(),
+    ):
+        state_storage = DefsStateStorage.get()
+        assert state_storage is not None
+
+        # Create a component with VERSIONED_STATE_STORAGE
+        versioned_component_dir = project_dir / "src/foo_bar/defs/versioned_component"
+        versioned_component_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(
+            Path(__file__).parent / "sample_state_backed_component.py",
+            versioned_component_dir / "local.py",
+        )
+        with (versioned_component_dir / "defs.yaml").open("w") as f:
+            yaml.dump(
+                {
+                    "type": ".local.SampleStateBackedComponent",
+                    "attributes": {
+                        "defs_state_key_id": "versioned",
+                        "defs_state": {"type": "VERSIONED_STATE_STORAGE"},
+                    },
+                },
+                f,
+            )
+
+        # Create a component with LOCAL_FILESYSTEM
+        local_component_dir = project_dir / "src/foo_bar/defs/local_component"
+        local_component_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(
+            Path(__file__).parent / "sample_state_backed_component.py",
+            local_component_dir / "local.py",
+        )
+        with (local_component_dir / "defs.yaml").open("w") as f:
+            yaml.dump(
+                {
+                    "type": ".local.SampleStateBackedComponent",
+                    "attributes": {
+                        "defs_state_key_id": "local",
+                        "defs_state": {"type": "LOCAL_FILESYSTEM"},
+                    },
+                },
+                f,
+            )
+
+        # Test 1: Filter by VERSIONED_STATE_STORAGE only
+        result = runner.invoke(
+            "utils", "refresh-defs-state", "--management-type", "VERSIONED_STATE_STORAGE"
+        )
+        assert_runner_result(result)
+
+        # Should only refresh the versioned component (check output not storage as storage is cumulative)
+        assert "SampleStateBackedComponent[versioned]" in result.output
+        # Should not show the local component
+        assert "SampleStateBackedComponent[local]" not in result.output
+
+        # Verify state storage has the versioned component
+        latest_state_info = state_storage.get_latest_defs_state_info()
+        assert latest_state_info is not None
+        assert "SampleStateBackedComponent[versioned]" in latest_state_info.info_mapping
+
+        # Test 2: Filter by LOCAL_FILESYSTEM only
+        result = runner.invoke(
+            "utils", "refresh-defs-state", "--management-type", "LOCAL_FILESYSTEM"
+        )
+        assert_runner_result(result)
+
+        # Should only refresh the local component (check output not storage as storage is cumulative)
+        assert "SampleStateBackedComponent[local]" in result.output
+        # Should not show the versioned component
+        assert "SampleStateBackedComponent[versioned]" not in result.output
+
+        # Verify state storage has the local component (state is cumulative, so it has both now)
+        latest_state_info = state_storage.get_latest_defs_state_info()
+        assert latest_state_info is not None
+        assert "SampleStateBackedComponent[local]" in latest_state_info.info_mapping
+
+        # Test 3: Refresh both by specifying both management types
+        result = runner.invoke(
+            "utils",
+            "refresh-defs-state",
+            "--management-type",
+            "VERSIONED_STATE_STORAGE",
+            "--management-type",
+            "LOCAL_FILESYSTEM",
+        )
+        assert_runner_result(result)
+
+        # Should refresh both components (check output shows both)
+        assert "SampleStateBackedComponent[versioned]" in result.output
+        assert "SampleStateBackedComponent[local]" in result.output
+
+        # Verify state storage has both components
+        latest_state_info = state_storage.get_latest_defs_state_info()
+        assert latest_state_info is not None
+        assert "SampleStateBackedComponent[versioned]" in latest_state_info.info_mapping
+        assert "SampleStateBackedComponent[local]" in latest_state_info.info_mapping
+
+
+def test_refresh_state_command_excludes_legacy_code_server_snapshots_by_default():
+    """Test that LEGACY_CODE_SERVER_SNAPSHOTS components are excluded by default."""
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(
+            runner, in_workspace=False, use_editable_dagster=True, uv_sync=True
+        ) as project_dir,
+        activate_venv(project_dir / ".venv"),
+        dg.instance_for_test(),
+    ):
+        state_storage = DefsStateStorage.get()
+        assert state_storage is not None
+
+        # Create a component with VERSIONED_STATE_STORAGE
+        versioned_component_dir = project_dir / "src/foo_bar/defs/versioned_component"
+        versioned_component_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(
+            Path(__file__).parent / "sample_state_backed_component.py",
+            versioned_component_dir / "local.py",
+        )
+        with (versioned_component_dir / "defs.yaml").open("w") as f:
+            yaml.dump(
+                {
+                    "type": ".local.SampleStateBackedComponent",
+                    "attributes": {
+                        "defs_state_key_id": "versioned",
+                        "defs_state": {"type": "VERSIONED_STATE_STORAGE"},
+                    },
+                },
+                f,
+            )
+
+        # Create a component with LEGACY_CODE_SERVER_SNAPSHOTS
+        legacy_component_dir = project_dir / "src/foo_bar/defs/legacy_component"
+        legacy_component_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(
+            Path(__file__).parent / "sample_state_backed_component.py",
+            legacy_component_dir / "local.py",
+        )
+        with (legacy_component_dir / "defs.yaml").open("w") as f:
+            yaml.dump(
+                {
+                    "type": ".local.SampleStateBackedComponent",
+                    "attributes": {
+                        "defs_state_key_id": "legacy",
+                        "defs_state": {"type": "LEGACY_CODE_SERVER_SNAPSHOTS"},
+                    },
+                },
+                f,
+            )
+
+        # Refresh without specifying management type
+        result = runner.invoke("utils", "refresh-defs-state")
+        assert_runner_result(result)
+
+        # Should only refresh the versioned component, not the legacy one
+        assert "SampleStateBackedComponent[versioned]" in result.output
+        assert "SampleStateBackedComponent[legacy]" not in result.output
+
+        # Verify state storage has only the versioned component
+        latest_state_info = state_storage.get_latest_defs_state_info()
+        assert latest_state_info is not None
+        assert latest_state_info.info_mapping.keys() == {"SampleStateBackedComponent[versioned]"}


### PR DESCRIPTION
## Summary & Motivation

It doesn't make sense to invoke `refresh-defs-state` on state that's stored in code server snapshots anyway, and if you're running this command inside the context of a docker image, it's almost always the case that you only want to update things that modify the local filesystem, and if you're running this within a github action, local file changes won't be reflected in the built image, and so you probably only want to do things that hit remote storage (hence that being the default if you're using `dg plus deploy refresh-defs-state`).

## How I Tested These Changes

## Changelog

NOCHANGELOG
