### PR TITLE
[sbc] Move state management under project root

### DIFF
--- a/python_modules/dagster/dagster/components/core/component_tree.py
+++ b/python_modules/dagster/dagster/components/core/component_tree.py
@@ -136,6 +136,9 @@ class ComponentTree(IHaveNew):
                 f"Could not find config file (pyproject.toml/dg.toml) in {path_within_project} or any parent of."
             )
 
+        project_root = root_config_path.parent
+
+        # Use shared utility to get defs module configuration
         toml_config = load_toml_as_dict(root_config_path)
 
         if root_config_path and root_config_path.stem == "dg":
@@ -155,7 +158,7 @@ class ComponentTree(IHaveNew):
 
         return cls(
             defs_module=defs_module,
-            project_root=root_config_path.parent,
+            project_root=project_root,
         )
 
     @property

--- a/python_modules/dagster/dagster/components/testing/utils.py
+++ b/python_modules/dagster/dagster/components/testing/utils.py
@@ -8,7 +8,6 @@ import sys
 import textwrap
 from pathlib import Path
 from typing import Callable
-from unittest.mock import patch
 
 import yaml
 from dagster_shared import check
@@ -315,18 +314,18 @@ def create_defs_folder_sandbox(
     """
     project_name = project_name or random_importable_name()
 
-    with (
-        tempfile.TemporaryDirectory() as project_root_str,
-        patch(
-            "dagster_shared.serdes.objects.models.defs_state_info._global_state_dir",
-        ) as mock_global_state_dir,
-    ):
+    with tempfile.TemporaryDirectory() as project_root_str:
         project_root = Path(project_root_str)
         defs_folder_path = project_root / "src" / project_name / "defs"
         defs_folder_path.mkdir(parents=True, exist_ok=True)
 
-        # make sure that local state is not persisted across test runs
-        mock_global_state_dir.return_value = project_root / ".mock_global_state"
+        dg_toml_path = project_root / "dg.toml"
+        dg_toml_path.write_text(
+            textwrap.dedent(f"""
+                [project]
+                root_module = "{project_name}"
+            """)
+        )
 
         yield DefsFolderSandbox(
             project_root=project_root,

--- a/python_modules/dagster/dagster/components/utils/project_paths.py
+++ b/python_modules/dagster/dagster/components/utils/project_paths.py
@@ -1,0 +1,130 @@
+"""Utilities for discovering project paths."""
+
+import importlib
+import re
+from functools import cache
+from pathlib import Path
+
+from dagster_shared import check
+from dagster_shared.utils.config import (
+    discover_config_file,
+    get_canonical_defs_module_name,
+    load_toml_as_dict,
+)
+
+from dagster._core.errors import DagsterError
+
+_LOCAL_DEFS_STATE_DIR = ".local_defs_state"
+
+
+@cache
+def get_defs_module_path_for_project(project_root: Path) -> Path:
+    """Get the defs module path for a project by discovering and parsing its config.
+
+    Args:
+        project_root: The root directory of the project.
+
+    Returns:
+        The filesystem path to the defs module directory.
+
+    Raises:
+        DagsterError: If no config file is found or the config is invalid.
+    """
+    # Discover the config file from the project root
+    config_file = discover_config_file(project_root)
+    if not config_file:
+        raise DagsterError(f"Could not find dg.toml or pyproject.toml in {project_root}")
+
+    # Load the config to get the root_module and defs_module
+    config_dict = load_toml_as_dict(config_file)
+
+    # Check if it's a nested config (pyproject.toml) or root (dg.toml)
+    if config_file.name == "dg.toml":
+        project_config = config_dict.get("project", {})
+    else:
+        project_config = config_dict.get("tool", {}).get("dg", {}).get("project", {})
+
+    root_module = project_config.get("root_module")
+    defs_module_name = project_config.get("defs_module")
+
+    check.invariant(
+        defs_module_name or root_module,
+        f"Either defs_module or root_module must be set in the project config {config_file}",
+    )
+
+    defs_module_name = get_canonical_defs_module_name(defs_module_name, root_module)
+
+    # Import the module to get its filesystem path
+    defs_module = importlib.import_module(defs_module_name)
+
+    # Get the module path, handling both __file__ and __path__ attributes
+    if defs_module.__file__:
+        # Get the directory path (handle both __init__.py and direct module files)
+        defs_module_path = Path(defs_module.__file__).parent
+    elif hasattr(defs_module, "__path__") and defs_module.__path__:
+        defs_module_path = Path(defs_module.__path__[0])
+    else:
+        raise DagsterError(f"Could not determine path for module {defs_module_name}")
+
+    return defs_module_path
+
+
+def get_local_defs_state_dir(project_root: Path) -> Path:
+    """Get the local state directory for the project.
+
+    This discovers the defs module path from the project configuration and creates
+    a project-local subdirectory within it for storing component state.
+
+    Args:
+        project_root: The root directory of the project.
+
+    Returns:
+        The path to the state directory.
+    """
+    defs_module_path = get_defs_module_path_for_project(project_root)
+
+    local_state_dir = defs_module_path / _LOCAL_DEFS_STATE_DIR
+    local_state_dir.mkdir(parents=True, exist_ok=True)
+
+    # create .gitignore if it doesn't exist to ensure that this directory is ignored by git
+    gitignore_path = local_state_dir / ".gitignore"
+    if not gitignore_path.exists():
+        gitignore_path.write_text("\n".join(["*", "*/", ".*"]))
+
+    return local_state_dir
+
+
+def get_local_state_dir(key: str, project_root: Path) -> Path:
+    """Get the local state directory for a specific component state key.
+
+    Args:
+        key: The defs state key for the component.
+        project_root: The root directory of the project.
+
+    Returns:
+        The path to the state directory for this key.
+    """
+    sanitized_key = re.sub(r"[^A-Za-z0-9._-]", "__", key)
+    state_dir = get_local_defs_state_dir(project_root) / sanitized_key
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir
+
+
+def get_local_state_path(key: str, project_root: Path) -> Path:
+    """Get the local state file path for a specific component state key.
+
+    Args:
+        key: The defs state key for the component.
+        project_root: The root directory of the project.
+
+    Returns:
+        The path to the state file for this key.
+    """
+    return get_local_state_dir(key, project_root) / "state"
+
+
+def get_code_server_metadata_key(key: str) -> str:
+    """Returns a key for storing defs state in the code server reconstruction metadata.
+    Avoids using the original key directly to avoid potential collisions.
+    """
+    return f"defs-state-[{key}]"

--- a/python_modules/dagster/dagster_tests/components_tests/state_backed_component_tests/test_state_backed_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/state_backed_component_tests/test_state_backed_component.py
@@ -21,11 +21,11 @@ from dagster.components.utils.defs_state import (
     DefsStateConfigArgs,
     ResolvedDefsStateConfig,
 )
+from dagster.components.utils.project_paths import get_code_server_metadata_key
 from dagster_shared.serdes.objects.models.defs_state_info import (
     CODE_SERVER_STATE_VERSION,
     LOCAL_STATE_VERSION,
     DefsStateManagementType,
-    get_code_server_metadata_key,
 )
 
 
@@ -64,9 +64,11 @@ class MyStateBackedComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             json.dump({"value": f"bar_{random.randint(1000, 9999)}"}, f)
 
     def _get_state_refresh_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
+        project_root = context.project_root
+
         @dg.op
         def refresh_state_op():
-            asyncio.run(self.refresh_state())
+            asyncio.run(self.refresh_state(project_root))
 
         @dg.job(name=f"state_refresh_job_{context.component_path.file_path.stem}")
         def state_refresh_job():

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
@@ -239,7 +239,7 @@ def test_component_load_with_defs_state(
             # first load, nothing there
             assert len(defs.resolve_asset_graph().get_all_asset_keys()) == 0
             assert isinstance(component, AirbyteWorkspaceComponent)
-            asyncio.run(component.refresh_state())
+            asyncio.run(component.refresh_state(sandbox.project_root))
 
         with (
             scoped_definitions_load_context(),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -5,6 +5,7 @@ from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
+from unittest.mock import patch
 
 import dagster as dg
 import pytest
@@ -60,7 +61,16 @@ JAFFLE_SHOP_KEYS = {
 
 @pytest.fixture(autouse=True)
 def _setup() -> Iterator:
-    with instance_for_test() as instance, scoped_definitions_load_context():
+    with (
+        instance_for_test() as instance,
+        scoped_definitions_load_context(),
+        # this file doesn't use `create_defs_folder_sandbox` so we need to mock out the local_state_dir
+        tempfile.TemporaryDirectory() as temp_dir,
+        patch(
+            "dagster.components.utils.project_paths.get_local_defs_state_dir",
+            return_value=Path(temp_dir),
+        ),
+    ):
         yield instance
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_templated_custom_keys_dbt_project.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from dagster import AssetKey
@@ -48,7 +49,16 @@ JAFFLE_SHOP_KEYS_WITH_PREFIX = {
 
 @pytest.fixture(autouse=True)
 def _setup() -> Iterator:
-    with instance_for_test() as instance, scoped_definitions_load_context():
+    with (
+        instance_for_test() as instance,
+        scoped_definitions_load_context(),
+        # this file doesn't use `create_defs_folder_sandbox` so we need to mock out the local_state_dir
+        tempfile.TemporaryDirectory() as temp_dir,
+        patch(
+            "dagster.components.utils.project_paths.get_local_defs_state_dir",
+            return_value=Path(temp_dir),
+        ),
+    ):
         yield instance
 
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -123,7 +123,7 @@ def test_component_load_with_defs_state(
             # first load, nothing there
             assert len(defs.resolve_asset_graph().get_all_asset_keys()) == 0
             assert isinstance(component, FivetranAccountComponent)
-            asyncio.run(component.refresh_state())
+            asyncio.run(component.refresh_state(sandbox.project_root))
 
         with (
             scoped_definitions_load_context(),

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
@@ -371,7 +371,7 @@ def test_component_load_with_defs_state(
             # First load, nothing there
             assert len(defs.resolve_asset_graph().get_all_asset_keys()) == 0
             assert isinstance(component, PowerBIWorkspaceComponent)
-            asyncio.run(component.refresh_state())
+            asyncio.run(component.refresh_state(sandbox.project_root))
 
         with (
             scoped_definitions_load_context(),

--- a/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/models/defs_state_info.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/serdes/objects/models/defs_state_info.py
@@ -1,37 +1,13 @@
 import time
 from collections.abc import Mapping
 from enum import Enum
-from pathlib import Path
 from typing import Any, Optional
-
-from platformdirs import user_data_dir
 
 from dagster_shared.dagster_model import DagsterModel
 from dagster_shared.serdes import whitelist_for_serdes
 
 LOCAL_STATE_VERSION = "__local__"
 CODE_SERVER_STATE_VERSION = "__code_server__"
-
-
-def _global_state_dir() -> Path:
-    return Path(user_data_dir("dagster", appauthor=False)).resolve()
-
-
-def get_local_state_dir(key: str) -> Path:
-    state_dir = _global_state_dir() / key
-    state_dir.mkdir(parents=True, exist_ok=True)
-    return state_dir
-
-
-def get_local_state_path(key: str) -> Path:
-    return get_local_state_dir(key) / "state"
-
-
-def get_code_server_metadata_key(key: str) -> str:
-    """Returns a key for storing defs state in the code server reconstruction metadata. Avoids using the
-    original key directly to avoid potential collisions.
-    """
-    return f"defs-state-[{key}]"
 
 
 class DefsStateManagementType(Enum):


### PR DESCRIPTION
## Summary & Motivation

For local filesystem state storage, it's desirable to have the local state stored in a path that's relative to the project root instead of a user data dir, specifically for PEX-deployed projects which require data to be in the python package files. Instead of making that a bespoke aspect of the deploy process, we can just store this in an accessible place from the start.

## How I Tested These Changes

## Changelog

NOCHANGELOG
