### PR TITLE
[sbc] Sanitize path key

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
@@ -225,13 +225,13 @@ class DefinitionsLoadContext:
                 return
             # grab state for storage
             with tempfile.TemporaryDirectory() as temp_dir:
-                state_path = Path(temp_dir) / key
+                state_path = Path(temp_dir) / "state"
                 state_storage.download_state_to_path(key, key_info.version, state_path)
                 yield state_path
         elif config.type == DefsStateManagementType.LEGACY_CODE_SERVER_SNAPSHOTS:
             # state is stored in the reconstruction metadata
             with tempfile.TemporaryDirectory() as temp_dir:
-                state_path = Path(temp_dir) / key
+                state_path = Path(temp_dir) / "state"
                 state = self._get_defs_state_from_reconstruction_metadata(key)
                 state_path.write_text(state)
                 yield state_path

--- a/python_modules/dagster/dagster/_core/storage/defs_state/base.py
+++ b/python_modules/dagster/dagster/_core/storage/defs_state/base.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -96,6 +97,9 @@ class DefsStateStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
             version (str): The version of the state to persist.
         """
         raise NotImplementedError()
+
+    def _sanitize_key(self, key: str) -> str:
+        return re.sub(r"[^A-Za-z0-9._-]", "__", key)
 
     def _get_version_key(self, key: str) -> str:
         """Returns a storage key under which the latest version of a given key's state is stored."""

--- a/python_modules/dagster/dagster/_core/storage/defs_state/blob_storage_state_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/defs_state/blob_storage_state_storage.py
@@ -58,7 +58,7 @@ class BlobStorageStateStorage(DefsStateStorage, ConfigurableClass):
         )
 
     def _get_state_path(self, key: str, version: str) -> "UPath":
-        return self._base_path / key / version
+        return self._base_path / self._sanitize_key(key) / version
 
     def download_state_to_path(self, key: str, version: str, path: Path) -> None:
         remote_path = self._get_state_path(key, version)

--- a/python_modules/dagster/dagster/components/component/state_backed_component.py
+++ b/python_modules/dagster/dagster/components/component/state_backed_component.py
@@ -61,7 +61,7 @@ class StateBackedComponent(Component):
             "Attempted to store LEGACY_CODE_SERVER_SNAPSHOTS state outside of the initialization phase.",
         )
         with tempfile.TemporaryDirectory() as temp_dir:
-            state_path = Path(temp_dir) / key
+            state_path = Path(temp_dir) / "state"
             await self._write_state_to_path_async(state_path)
             load_context.add_code_server_defs_state_info(key, state_path.read_text())
             state_storage.set_latest_version(key, CODE_SERVER_STATE_VERSION)
@@ -81,7 +81,7 @@ class StateBackedComponent(Component):
     ) -> str:
         with tempfile.TemporaryDirectory() as temp_dir:
             version = str(uuid4())
-            state_path = Path(temp_dir) / key
+            state_path = Path(temp_dir) / "state"
             await self._write_state_to_path_async(state_path)
             state_storage.upload_state_from_path(key, version=version, path=state_path)
             return version

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/defs_state_storage.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/defs_state_storage.py
@@ -79,7 +79,7 @@ class DagsterPlusCliDefsStateStorage(DefsStateStorage[T_DagsterInstance]):
         return self.graphql_client.execute(query, variables=variables)
 
     def _get_artifact_key(self, key: str, version: str) -> str:
-        return f"__state__/{key}/{version}"
+        return f"__state__/{self._sanitize_key(key)}/{version}"
 
     def download_state_to_path(self, key: str, version: str, path: Path) -> None:
         download_artifact(


### PR DESCRIPTION
## Summary & Motivation

This prevents issues that can arise if the key contains weird characters. The worst offender here is a key of the form `FooComponent[https://foo.com]`, in which that gets converted to the file path `path/to/FooComponent[https:/foo.com]` (note that `FooComponent[https:` is a directory).

This vaguely kinda doesn't cause issues, but is really ugly and it's easier to change it now than later.

## How I Tested These Changes

## Changelog

NOCHANGELOG
