### PR TITLE
[ui] Fix top nav behavior for opted-out Plus users

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppLayout.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppLayout.tsx
@@ -1,8 +1,11 @@
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
+import {AppTopNav} from './AppTopNav/AppTopNav';
 import {AppWithNewLayout} from './AppWithNewLayout';
 import {AppWithOldLayout} from './AppWithOldLayout';
 import {featureEnabled} from './Flags';
+import {HelpMenu} from './HelpMenu';
+import {UserSettingsButton} from './UserSettingsButton';
 
 interface Props {
   children: React.ReactNode;
@@ -12,5 +15,17 @@ export const AppLayout = ({children}: Props) => {
   if (newLayout) {
     return <AppWithNewLayout>{children}</AppWithNewLayout>;
   }
-  return <AppWithOldLayout>{children}</AppWithOldLayout>;
+
+  return (
+    <AppWithOldLayout
+      top={
+        <AppTopNav allowGlobalReload>
+          <HelpMenu showContactSales={false} />
+          <UserSettingsButton />
+        </AppTopNav>
+      }
+    >
+      {children}
+    </AppWithOldLayout>
+  );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppWithOldLayout.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppWithOldLayout.tsx
@@ -1,20 +1,18 @@
 import clsx from 'clsx';
 import {CSSProperties, useCallback, useContext} from 'react';
 
-import {AppTopNav} from './AppTopNav/AppTopNav';
 import {useFullScreen} from './AppTopNav/AppTopNavContext';
-import {HelpMenu} from './HelpMenu';
 import {LayoutContext} from './LayoutProvider';
-import {UserSettingsButton} from './UserSettingsButton';
 import {LEFT_NAV_WIDTH, LeftNav} from '../nav/LeftNav';
 import styles from './css/App.module.css';
 
 interface Props {
   banner?: React.ReactNode;
   children: React.ReactNode;
+  top?: React.ReactNode;
 }
 
-export const AppWithOldLayout = ({banner, children}: Props) => {
+export const AppWithOldLayout = ({banner, children, top}: Props) => {
   const {nav} = useContext(LayoutContext);
 
   const onClickMain = useCallback(() => {
@@ -27,10 +25,7 @@ export const AppWithOldLayout = ({banner, children}: Props) => {
 
   return (
     <>
-      <AppTopNav allowGlobalReload>
-        <HelpMenu showContactSales={false} />
-        <UserSettingsButton />
-      </AppTopNav>
+      {top}
       <div
         className={clsx(styles.container, isFullScreen ? styles.fullScreen : null)}
         style={{'--left-nav-width': `${LEFT_NAV_WIDTH}px`} as CSSProperties}


### PR DESCRIPTION
## Summary & Motivation

Dagster+ users who have opted out of Observe are seeing the top nav render twice. Fix this.

## How I Tested These Changes

Test OSS app with the new nav flag on and off. Verify correct rendering and behavior.

View Plus app with new nav flag on and off. Verify correct rendering and behavior. Also tested Org Settings.

## Changelog

[ui] Fix top nav rendering for Plus users.