### PR TITLE
[dagster-dbt][dagster-sling] Remove legacy freshness policy from translator

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -18,7 +18,6 @@ from dagster import (
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
     DefaultScheduleStatus,
-    LegacyFreshnessPolicy,
     OpExecutionContext,
     RunConfig,
     ScheduleDefinition,
@@ -604,25 +603,6 @@ def default_owners_from_dbt_resource_props(
         return None
 
     return [owner] if isinstance(owner, str) else owner
-
-
-def default_freshness_policy_fn(
-    dbt_resource_props: Mapping[str, Any],
-) -> Optional[LegacyFreshnessPolicy]:
-    dagster_metadata = dbt_resource_props.get("meta", {}).get("dagster", {})
-    freshness_policy_config = dagster_metadata.get("freshness_policy", {})
-
-    freshness_policy = (
-        LegacyFreshnessPolicy(
-            maximum_lag_minutes=float(freshness_policy_config["maximum_lag_minutes"]),
-            cron_schedule=freshness_policy_config.get("cron_schedule"),
-            cron_schedule_timezone=freshness_policy_config.get("cron_schedule_timezone"),
-        )
-        if freshness_policy_config
-        else None
-    )
-
-    return freshness_policy
 
 
 def default_auto_materialize_policy_fn(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -12,7 +12,6 @@ from dagster import (
     AutoMaterializePolicy,
     AutomationCondition,
     DagsterInvalidDefinitionError,
-    LegacyFreshnessPolicy,
     PartitionMapping,
 )
 from dagster._annotations import beta, public
@@ -36,7 +35,6 @@ from dagster_dbt.asset_utils import (
     default_auto_materialize_policy_fn,
     default_code_version_fn,
     default_description_fn,
-    default_freshness_policy_fn,
     default_group_from_dbt_resource_props,
     default_metadata_from_dbt_resource_props,
     default_owners_from_dbt_resource_props,
@@ -158,7 +156,6 @@ class DagsterDbtTranslator:
             group_name=self.get_group_name(resource_props),
             code_version=self.get_code_version(resource_props),
             automation_condition=self.get_automation_condition(resource_props),
-            legacy_freshness_policy=self.get_freshness_policy(resource_props),
             owners=self.get_owners(owners_resource_props),
             tags=self.get_tags(resource_props),
             kinds={"dbt", manifest.get("metadata", {}).get("adapter_type", "dbt")},
@@ -492,60 +489,6 @@ class DagsterDbtTranslator:
                         return ["user@owner.com", "team:team@owner.com"]
         """
         return default_owners_from_dbt_resource_props(dbt_resource_props)
-
-    @public
-    @beta(emit_runtime_warning=False)
-    def get_freshness_policy(
-        self, dbt_resource_props: Mapping[str, Any]
-    ) -> Optional[LegacyFreshnessPolicy]:
-        """A function that takes a dictionary representing properties of a dbt resource, and
-        returns the Dagster :py:class:`dagster.FreshnessPolicy` for that resource.
-
-        Note that a dbt resource is unrelated to Dagster's resource concept, and simply represents
-        a model, seed, snapshot or source in a given dbt project. You can learn more about dbt
-        resources and the properties available in this dictionary here:
-        https://docs.getdbt.com/reference/artifacts/manifest-json#resource-details
-
-        This method can be overridden to provide a custom freshness policy for a dbt resource.
-
-        Args:
-            dbt_resource_props (Mapping[str, Any]): A dictionary representing the dbt resource.
-
-        Returns:
-            Optional[FreshnessPolicy]: A Dagster freshness policy.
-
-        Examples:
-            Set a custom freshness policy for all dbt resources:
-
-            .. code-block:: python
-
-                from typing import Any, Mapping
-
-                from dagster_dbt import DagsterDbtTranslator
-
-
-                class CustomDagsterDbtTranslator(DagsterDbtTranslator):
-                    def get_freshness_policy(self, dbt_resource_props: Mapping[str, Any]) -> Optional[FreshnessPolicy]:
-                        return FreshnessPolicy(maximum_lag_minutes=60)
-
-            Set a custom freshness policy for dbt resources with a specific tag:
-
-            .. code-block:: python
-
-                from typing import Any, Mapping
-
-                from dagster_dbt import DagsterDbtTranslator
-
-
-                class CustomDagsterDbtTranslator(DagsterDbtTranslator):
-                    def get_freshness_policy(self, dbt_resource_props: Mapping[str, Any]) -> Optional[FreshnessPolicy]:
-                        freshness_policy = None
-                        if "my_custom_tag" in dbt_resource_props.get("tags", []):
-                            freshness_policy = FreshnessPolicy(maximum_lag_minutes=60)
-
-                        return freshness_policy
-        """
-        return default_freshness_policy_fn(dbt_resource_props)
 
     @public
     @beta(emit_runtime_warning=False)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -8,7 +8,6 @@ from dagster import (
     AssetKey,
     AssetSelection,
     AutoMaterializePolicy,
-    LegacyFreshnessPolicy,
     MetadataValue,
     asset,
     define_asset_job,
@@ -449,31 +448,6 @@ def test_node_info_to_asset_key(dbt_cloud, dbt_cloud_service):
 
 
 @responses.activate
-def test_custom_freshness_policy(dbt_cloud, dbt_cloud_service):
-    _add_dbt_cloud_job_responses(
-        dbt_cloud_service=dbt_cloud_service,
-        dbt_commands=["dbt build"],
-    )
-
-    dbt_cloud_cacheable_assets = load_assets_from_dbt_cloud_job(
-        dbt_cloud=dbt_cloud,
-        job_id=DBT_CLOUD_JOB_ID,
-        node_info_to_freshness_policy_fn=lambda node_info: LegacyFreshnessPolicy(
-            maximum_lag_minutes=len(node_info["name"])
-        ),
-    )
-    dbt_assets_definition_cacheable_data = dbt_cloud_cacheable_assets.compute_cacheable_data()
-    dbt_cloud_assets = dbt_cloud_cacheable_assets.build_definitions(
-        dbt_assets_definition_cacheable_data
-    )
-
-    assert dbt_cloud_assets[0].legacy_freshness_policies_by_key == {
-        key: LegacyFreshnessPolicy(maximum_lag_minutes=len(key.path[-1]))
-        for key in dbt_cloud_assets[0].keys
-    }
-
-
-@responses.activate
 def test_custom_auto_materialize_policy(dbt_cloud, dbt_cloud_service):
     _add_dbt_cloud_job_responses(
         dbt_cloud_service=dbt_cloud_service,
@@ -508,8 +482,6 @@ def test_partitions(mocker, dbt_cloud, dbt_cloud_service):
         job_id=DBT_CLOUD_JOB_ID,
         partitions_def=partition_def,
         partition_key_to_vars_fn=lambda partition_key: {"run_date": partition_key},
-        # FreshnessPolicies not currently supported for partitioned assets
-        node_info_to_freshness_policy_fn=lambda _: None,
     )
 
     mock_run_job_and_poll = mocker.patch(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -15,7 +15,6 @@ from dagster import (
     Definitions,
     DependencyDefinition,
     Jitter,
-    LegacyFreshnessPolicy,
     NodeInvocation,
     OpDefinition,
     PartitionMapping,
@@ -347,16 +346,10 @@ def test_backfill_policy(
     backfill_policy: BackfillPolicy,
     expected_backfill_policy: BackfillPolicy,
 ) -> None:
-    class CustomDagsterDbtTranslator(DagsterDbtTranslator):
-        def get_freshness_policy(self, _: Mapping[str, Any]) -> Optional[LegacyFreshnessPolicy]:  # pyright: ignore[reportIncompatibleMethodOverride]
-            # Disable freshness policies when using static partitions
-            return None
-
     @dbt_assets(
         manifest=test_jaffle_shop_manifest,
         partitions_def=partitions_def,
         backfill_policy=backfill_policy,
-        dagster_dbt_translator=CustomDagsterDbtTranslator(),
     )
     def my_dbt_assets(): ...
 
@@ -757,31 +750,6 @@ def test_all_assets_have_a_distinct_code_version(test_jaffle_shop_manifest: dict
     assert len(code_versions) == len(set(code_versions))
 
 
-def test_with_freshness_policy_replacements(test_jaffle_shop_manifest: dict[str, Any]) -> None:
-    expected_freshness_policy = LegacyFreshnessPolicy(maximum_lag_minutes=60)
-
-    class CustomDagsterDbtTranslator(DagsterDbtTranslator):
-        def get_freshness_policy(self, _: Mapping[str, Any]) -> Optional[LegacyFreshnessPolicy]:  # pyright: ignore[reportIncompatibleMethodOverride]
-            return expected_freshness_policy
-
-    expected_specs_by_key = {
-        spec.key: spec
-        for spec in build_dbt_asset_specs(
-            manifest=test_jaffle_shop_manifest,
-            dagster_dbt_translator=CustomDagsterDbtTranslator(),
-        )
-    }
-
-    @dbt_assets(
-        manifest=test_jaffle_shop_manifest, dagster_dbt_translator=CustomDagsterDbtTranslator()
-    )
-    def my_dbt_assets(): ...
-
-    for asset_key, freshness_policy in my_dbt_assets.legacy_freshness_policies_by_key.items():
-        assert freshness_policy == expected_freshness_policy
-        assert expected_specs_by_key[asset_key].legacy_freshness_policy == expected_freshness_policy
-
-
 def test_with_auto_materialize_policy_replacements(
     test_jaffle_shop_manifest: dict[str, Any],
 ) -> None:
@@ -891,25 +859,6 @@ def test_dbt_meta_auto_materialize_policy(test_meta_config_manifest: dict[str, A
             expected_specs_by_key[asset_key].auto_materialize_policy
             == expected_auto_materialize_policy
         )
-
-
-def test_dbt_meta_freshness_policy(test_meta_config_manifest: dict[str, Any]) -> None:
-    expected_freshness_policy = LegacyFreshnessPolicy(
-        maximum_lag_minutes=60.0, cron_schedule="* * * * *"
-    )
-    expected_specs_by_key = {
-        spec.key: spec for spec in build_dbt_asset_specs(manifest=test_meta_config_manifest)
-    }
-
-    @dbt_assets(manifest=test_meta_config_manifest)
-    def my_dbt_assets(): ...
-
-    freshness_policies = my_dbt_assets.legacy_freshness_policies_by_key.items()
-    assert freshness_policies
-
-    for asset_key, freshness_policy in freshness_policies:
-        assert freshness_policy == expected_freshness_policy
-        assert expected_specs_by_key[asset_key].legacy_freshness_policy == expected_freshness_policy
 
 
 def test_dbt_meta_asset_key(test_meta_config_manifest: dict[str, Any]) -> None:

--- a/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/dagster_sling_translator.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
-from dagster import AssetKey, AssetSpec, AutoMaterializePolicy, LegacyFreshnessPolicy, MetadataValue
+from dagster import AssetKey, AssetSpec, AutoMaterializePolicy, MetadataValue
 from dagster._annotations import public, superseded
 from dagster._utils.names import clean_name_lower_with_dots
 from dagster._utils.warnings import supersession_warning
@@ -41,9 +41,6 @@ class DagsterSlingTranslator:
             ),
             group_name=self._resolve_back_compat_method(
                 "get_group_name", self._default_group_name_fn, stream_definition
-            ),
-            legacy_freshness_policy=self._resolve_back_compat_method(
-                "get_freshness_policy", self._default_freshness_policy_fn, stream_definition
             ),
             auto_materialize_policy=self._resolve_back_compat_method(
                 "get_auto_materialize_policy",
@@ -464,58 +461,6 @@ class DagsterSlingTranslator:
         config = stream_definition.get("config", {}) or {}
         meta = config.get("meta", {})
         return meta.get("dagster", {}).get("group")
-
-    @superseded(
-        additional_warn_text="Use `DagsterSlingTranslator.get_asset_spec(...).freshness_policy` instead.",
-    )
-    @public
-    def get_freshness_policy(
-        self, stream_definition: Mapping[str, Any]
-    ) -> Optional[LegacyFreshnessPolicy]:
-        """Retrieves the freshness policy for a given stream definition.
-
-        This method checks the provided stream definition for a specific configuration
-        indicating a freshness policy. If the configuration is found, it constructs and
-        returns a FreshnessPolicy object based on the provided parameters. Otherwise,
-        it returns None.
-
-        Parameters:
-            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition,
-            which includes configuration details.
-
-        Returns:
-            Optional[FreshnessPolicy]: A FreshnessPolicy object if the configuration is found,
-            otherwise None.
-        """
-        return self._default_freshness_policy_fn(stream_definition)
-
-    def _default_freshness_policy_fn(
-        self, stream_definition: Mapping[str, Any]
-    ) -> Optional[LegacyFreshnessPolicy]:
-        """Retrieves the freshness policy for a given stream definition.
-
-        This method checks the provided stream definition for a specific configuration
-        indicating a freshness policy. If the configuration is found, it constructs and
-        returns a FreshnessPolicy object based on the provided parameters. Otherwise,
-        it returns None.
-
-        Parameters:
-            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition,
-            which includes configuration details.
-
-        Returns:
-            Optional[FreshnessPolicy]: A FreshnessPolicy object if the configuration is found,
-            otherwise None.
-        """
-        config = stream_definition.get("config", {}) or {}
-        meta = config.get("meta", {})
-        freshness_policy_config = meta.get("dagster", {}).get("freshness_policy")
-        if freshness_policy_config:
-            return LegacyFreshnessPolicy(
-                maximum_lag_minutes=float(freshness_policy_config["maximum_lag_minutes"]),
-                cron_schedule=freshness_policy_config.get("cron_schedule"),
-                cron_schedule_timezone=freshness_policy_config.get("cron_schedule_timezone"),
-            )
 
     @superseded(
         additional_warn_text="Use `DagsterSlingTranslator.get_asset_spec(...).auto_materialize_policy` instead.",

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_asset_decorator.py
@@ -12,7 +12,6 @@ from dagster import (
     AssetSpec,
     Config,
     JsonMetadataValue,
-    LegacyFreshnessPolicy,
     file_relative_path,
 )
 from dagster._core.definitions.materialize import materialize
@@ -209,12 +208,6 @@ def test_base_with_meta_config_translator():
         AssetKey(["target", "departments"]): "group_2",
     }
 
-    assert my_sling_assets.legacy_freshness_policies_by_key == {
-        AssetKey(["target", "departments"]): LegacyFreshnessPolicy(
-            maximum_lag_minutes=0.0, cron_schedule="5 4 * * *", cron_schedule_timezone="UTC"
-        )
-    }
-
     assert (
         AssetKey(["target", "public", "transactions"])
         in my_sling_assets.auto_materialize_policies_by_key
@@ -275,9 +268,6 @@ def test_base_with_custom_tags_translator_legacy() -> None:
 
         def get_group_name(self, stream_definition):
             return super().get_group_name(stream_definition)
-
-        def get_freshness_policy(self, stream_definition):
-            return super().get_freshness_policy(stream_definition)
 
         def get_auto_materialize_policy(self, stream_definition):
             return super().get_auto_materialize_policy(stream_definition)

--- a/python_modules/libraries/dagster-sling/dagster_sling_tests/test_dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling_tests/test_dagster_sling_translator.py
@@ -1,5 +1,5 @@
 import pytest
-from dagster import AssetKey, AutoMaterializePolicy, JsonMetadataValue, LegacyFreshnessPolicy
+from dagster import AssetKey, AutoMaterializePolicy, JsonMetadataValue
 from dagster_sling.dagster_sling_translator import DagsterSlingTranslator
 
 
@@ -116,24 +116,6 @@ def test_metadata_from_get_asset_spec(stream, expected):
 def test_group_name_from_get_asset_spec(stream, expected):
     translator = DagsterSlingTranslator()
     assert translator.get_asset_spec(stream).group_name == expected
-
-
-@pytest.mark.parametrize(
-    "stream,expected",
-    [
-        ({"name": "foo"}, None),
-        (
-            {
-                "name": "foo",
-                "config": {"meta": {"dagster": {"freshness_policy": {"maximum_lag_minutes": 5}}}},
-            },
-            LegacyFreshnessPolicy(maximum_lag_minutes=5),
-        ),
-    ],
-)
-def test_freshness_policy_from_get_asset_spec(stream, expected):
-    translator = DagsterSlingTranslator()
-    assert translator.get_asset_spec(stream).legacy_freshness_policy == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary & Motivation

As title. This functionality has been deprecated for many releases so we should stop parsing this out automatically.

Should be merged in with the 1.12.0 release.

## How I Tested These Changes

## Changelog

[dagster-dbt] The `DagsterDbtTranslator` no longer has a `get_freshness_policy` method, nor does it automatically parse the legacy / deprecated `LegacyFreshnessPolicy` objects from dbt model configuration. [dagster-sling] The `DagsterSlingTranslator` no longer has a `get_freshness_policy` method, nor does it automatically parse the legacy / deprecated `LegacyFreshnessPolicy` objects from sling configuration.
