### PR TITLE
[components] Ensure TemplatedSqlComponents generate unique op names

### DIFF
--- a/python_modules/dagster/dagster/components/lib/sql_component/sql_component.py
+++ b/python_modules/dagster/dagster/components/lib/sql_component/sql_component.py
@@ -10,6 +10,7 @@ from dagster._annotations import preview, public
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.execution.context.asset_check_execution_context import AssetCheckExecutionContext
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._utils.security import non_secure_md5_hash_str
 from dagster.components.core.context import ComponentLoadContext
 from dagster.components.lib.executable_component.component import ExecutableComponent
 from dagster.components.lib.sql_component.sql_client import SQLClient
@@ -49,9 +50,17 @@ class SqlComponent(ExecutableComponent, ABC):
         """Execute the SQL content using the Snowflake resource."""
         self.connection.connect_and_execute(self.get_sql_content(context, component_load_context))
 
+    @abstractmethod
+    def get_unique_name(self) -> str:
+        """Get a unique name for the SQL component, if the user does not provide a name
+        to the execution config.
+        """
+        ...
+
     @property
     def op_spec(self) -> OpSpec:
-        return self.execution or OpSpec()
+        # generate a unique name from the hash of sql_template
+        return self.execution or OpSpec(name=self.get_unique_name())
 
     def invoke_execute_fn(
         self,
@@ -109,3 +118,11 @@ class TemplatedSqlComponent(SqlComponent):
 
         template = Template(template_str)
         return template.render(**(self.sql_template_vars or {}))
+
+    def get_unique_name(self) -> str:
+        template_str = (
+            self.sql_template.path if isinstance(self.sql_template, SqlFile) else self.sql_template
+        )
+        vars_str = str(sorted((self.sql_template_vars or {}).items()))
+        combined = f"{template_str}:{vars_str}"
+        return non_secure_md5_hash_str(combined.encode("utf-8"))[:8]

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
@@ -195,6 +195,12 @@ class RefreshExternalTableComponent(SqlComponent):
     ) -> str:
         return f"ALTER TABLE {self.table_name} REFRESH;"
 
+    def get_unique_name(self) -> str:
+        """Generate a unique name based on the table name."""
+        from dagster._utils.security import non_secure_md5_hash_str
+
+        return non_secure_md5_hash_str(self.table_name.encode("utf-8"))[:8]
+
 
 @mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)
 def test_custom_snowflake_sql_component(snowflake_connect):

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_sql_component.py
@@ -232,3 +232,78 @@ def test_custom_snowflake_sql_component(snowflake_connect):
         assert defs.resolve_asset_graph().get_all_asset_keys() == {
             AssetKey(["TESTDB", "TESTSCHEMA", "EXTERNAL_TABLE"])
         }
+
+
+@mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)
+def test_templated_sql_component_unique_node_names(snowflake_connect):
+    """Test that TemplatedSqlComponents with different template vars get unique node names."""
+    with create_defs_folder_sandbox() as sandbox:
+        # Create connection component
+        sandbox.scaffold_component(
+            component_cls=SnowflakeConnectionComponent,
+            defs_path="sql_connection_component",
+            defs_yaml_contents={
+                "type": "dagster_snowflake.SnowflakeConnectionComponent",
+                "attributes": {
+                    "account": "test_account",
+                    "user": "test_user",
+                    "password": "test_password",
+                    "database": "TESTDB",
+                    "schema": "TESTSCHEMA",
+                },
+            },
+        )
+
+        # Create first SQL component
+        sandbox.scaffold_component(
+            component_cls=TemplatedSqlComponent,
+            defs_path="sql_component_1",
+            defs_yaml_contents={
+                "type": "dagster.TemplatedSqlComponent",
+                "attributes": {
+                    "sql_template": "SELECT * FROM TABLE1 WHERE id = {{ id }}",
+                    "sql_template_vars": {"id": 1},
+                    "assets": [{"key": "TESTDB/TESTSCHEMA/TABLE1"}],
+                    "connection": "{{ load_component_at_path('sql_connection_component') }}",
+                },
+            },
+        )
+
+        # Create second SQL component with different template vars
+        sandbox.scaffold_component(
+            component_cls=TemplatedSqlComponent,
+            defs_path="sql_component_2",
+            defs_yaml_contents={
+                "type": "dagster.TemplatedSqlComponent",
+                "attributes": {
+                    "sql_template": "SELECT * FROM TABLE1 WHERE id = {{ id }}",
+                    "sql_template_vars": {"id": 2},
+                    "assets": [{"key": "TESTDB/TESTSCHEMA/TABLE2"}],
+                    "connection": "{{ load_component_at_path('sql_connection_component') }}",
+                },
+            },
+        )
+
+        with sandbox.build_all_defs() as defs:
+            # Get all asset definitions
+            asset_keys = defs.resolve_asset_graph().get_all_asset_keys()
+            assert asset_keys == {
+                AssetKey(["TESTDB", "TESTSCHEMA", "TABLE1"]),
+                AssetKey(["TESTDB", "TESTSCHEMA", "TABLE2"]),
+            }
+
+            # Verify each asset has a different node name
+            asset_def_1 = defs.get_assets_def(AssetKey(["TESTDB", "TESTSCHEMA", "TABLE1"]))
+            asset_def_2 = defs.get_assets_def(AssetKey(["TESTDB", "TESTSCHEMA", "TABLE2"]))
+
+            node_name_1 = asset_def_1.node_def.name
+            node_name_2 = asset_def_2.node_def.name
+
+            # Assert node names are unique
+            assert node_name_1 != node_name_2, (
+                "Components with same template but different vars should have different node names"
+            )
+
+            # Materialize all assets to ensure they execute correctly
+            result = materialize([asset_def_1, asset_def_2])
+            assert result.success


### PR DESCRIPTION
## Summary

If the user doesn't provide an

```yaml
attributes:
  execution:
    name: foo

```

to `TemplatedSqlComponent`, they use the default op name of `_assets_def`. This PR implements a default, unique name based on the hash of the template and template vars.

## Test Plan

New unit test.