### PR TITLE
[sbc] No longer error if DAGSTER_HOME is not set

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
@@ -491,14 +491,18 @@ def refresh_defs_state(
 
     # Check if DAGSTER_HOME is set before proceeding
     if not is_dagster_home_set():
-        raise click.UsageError(
-            "DAGSTER_HOME is not set, which means defs state cannot be stored in a persistent location, "
-            "please set it to use this command.\n"
-            "You can resolve this error by exporting the environment variable. "
-            "For example, you can run the following command in your shell or "
-            "include it in your shell configuration file:\n"
-            '\texport DAGSTER_HOME="~/dagster_home"'
-            "\n\n"
+        # emit warning
+        click.echo(
+            click.style(
+                "DAGSTER_HOME is not set, which means defs state for VERSIONED_STATE_STORAGE components "
+                "cannot be stored in a persistent location. \n"
+                "You can resolve this warning by exporting the environment variable. "
+                "For example, you can run the following command in your shell or "
+                "include it in your shell configuration file:\n"
+                '\texport DAGSTER_HOME="~/dagster_home"'
+                "\n\n",
+                fg="yellow",
+            )
         )
 
     cli_config = normalize_cli_config(other_opts, click.get_current_context())

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/test_refresh_state_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/test_refresh_state_command.py
@@ -179,15 +179,17 @@ def test_refresh_state_command_dagster_home_not_set():
             runner, in_workspace=False, use_editable_dagster=True, uv_sync=True
         ) as project_dir,
         activate_venv(project_dir / ".venv"),
-        environ({"DAGSTER_HOME": None}),  # pyright: ignore[reportArgumentType]  # Temporarily unset DAGSTER_HOME
+        environ({"DAGSTER_HOME": None}),  # pyright: ignore[reportArgumentType] # Temporarily unset DAGSTER_HOME
     ):
+        # no components to refresh, so command should succeed
         result = runner.invoke("utils", "refresh-defs-state")
-        assert result.exit_code == 2  # Click.UsageError raises SystemExit(2)
+        assert_runner_result(result)
+
+        # check that the warning is emitted
         assert (
-            "DAGSTER_HOME is not set, which means defs state cannot be stored in a persistent location"
+            "DAGSTER_HOME is not set, which means defs state for VERSIONED_STATE_STORAGE components "
             in result.output
         )
-        assert "please set it to use this command" in result.output
         assert "export DAGSTER_HOME" in result.output
 
 


### PR DESCRIPTION
## Summary & Motivation

LOCAL_FILESYSTEM components do not require a real instance in order to update their state, so just warn instead of error

## How I Tested These Changes

## Changelog

NOCHANGELOG
