### PR TITLE
[ui] Automations: Show description for sensors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/automation/ObserveAutomationScheduleRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/ObserveAutomationScheduleRow.tsx
@@ -174,7 +174,7 @@ export const ObserveAutomationScheduleRow = forwardRef(
                 <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>{name}</Box>
                 {scheduleData?.description ? (
                   <Tooltip
-                    content={<div style={{width: 320}}>{scheduleData.description}</div>}
+                    content={<div style={{maxWidth: 320}}>{scheduleData.description}</div>}
                     placement="top"
                   >
                     <Icon name="info" color={Colors.textLight()} />

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/ObserveAutomationSensorRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/ObserveAutomationSensorRow.tsx
@@ -94,8 +94,13 @@ export const ObserveAutomationSensorRow = forwardRef(
 
     const tick = sensorData?.sensorState.ticks[0];
 
-    const sensorType = sensorData?.sensorType;
-    const sensorInfo = sensorType ? SENSOR_TYPE_META[sensorType] : null;
+    const sensorDescription = useMemo(() => {
+      if (sensorData?.description) {
+        return sensorData.description;
+      }
+      const sensorType = sensorData?.sensorType;
+      return sensorType ? SENSOR_TYPE_META[sensorType].description : null;
+    }, [sensorData]);
 
     const right = () => {
       if (sensorQueryResult.loading && !sensorQueryResult.data) {
@@ -167,9 +172,9 @@ export const ObserveAutomationSensorRow = forwardRef(
             <Box flex={{direction: 'column', gap: 4}}>
               <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
                 {name}
-                {sensorInfo?.description ? (
+                {sensorDescription ? (
                   <Tooltip
-                    content={<div style={{width: 320}}>{sensorInfo.description}</div>}
+                    content={<div style={{maxWidth: 320}}>{sensorDescription}</div>}
                     placement="top"
                   >
                     <Icon name="info" color={Colors.textLight()} />


### PR DESCRIPTION
## Summary & Motivation

Our automation list currently ignores sensor descriptions in favor of a few canned descriptions for particular sensor types, or none at all.

Instead, if a description is avaiable on the sensor, show it. Otherwise fall back to the canned description, or none.

Also fix the tooltip content width to use max-width.

## How I Tested These Changes

View automation list, verify that sensors that have descriptions correctly show them in their tooltips.

## Changelog

[ui] Fix sensor descriptions in the automation list.
