### PR TITLE
[sbc] Update `type:` to `management_type:`

### DIFF
--- a/python_modules/dagster/dagster/components/component/state_backed_component.py
+++ b/python_modules/dagster/dagster/components/component/state_backed_component.py
@@ -99,16 +99,22 @@ class StateBackedComponent(Component):
         key = self.defs_state_config.key
         state_storage = DefsStateStorage.get()
 
-        if self.defs_state_config.type == DefsStateManagementType.VERSIONED_STATE_STORAGE:
+        if (
+            self.defs_state_config.management_type
+            == DefsStateManagementType.VERSIONED_STATE_STORAGE
+        ):
             if state_storage is None:
                 raise DagsterInvalidInvocationError(
-                    f"Attempted to refresh state for key {key} with management type {self.defs_state_config.type} "
+                    f"Attempted to refresh state for key {key} with management type {self.defs_state_config.management_type} "
                     "without a StateStorage in context. This is likely the result of an internal framework error."
                 )
             return await self._store_versioned_state_storage_state(key, state_storage)
-        elif self.defs_state_config.type == DefsStateManagementType.LOCAL_FILESYSTEM:
+        elif self.defs_state_config.management_type == DefsStateManagementType.LOCAL_FILESYSTEM:
             return await self._store_local_filesystem_state(key, state_storage, project_root)
-        elif self.defs_state_config.type == DefsStateManagementType.LEGACY_CODE_SERVER_SNAPSHOTS:
+        elif (
+            self.defs_state_config.management_type
+            == DefsStateManagementType.LEGACY_CODE_SERVER_SNAPSHOTS
+        ):
             check.invariant(
                 DefinitionsLoadContext.get().load_type == DefinitionsLoadType.INITIALIZATION,
                 "Attempted to refresh `LEGACY_CODE_SERVER_SNAPSHOTS` state explicitly, but this can only happen during code server startup.",
@@ -116,7 +122,7 @@ class StateBackedComponent(Component):
             return await self._store_code_server_state(key, state_storage)
         else:
             raise DagsterInvalidInvocationError(
-                f"Invalid state storage location: {self.defs_state_config.type}"
+                f"Invalid state storage location: {self.defs_state_config.management_type}"
             )
 
     def build_defs(self, context: ComponentLoadContext) -> Definitions:
@@ -128,7 +134,7 @@ class StateBackedComponent(Component):
             if (
                 # for code server state management, we always refresh the state
                 (
-                    self.defs_state_config.type
+                    self.defs_state_config.management_type
                     == DefsStateManagementType.LEGACY_CODE_SERVER_SNAPSHOTS
                 )
                 or

--- a/python_modules/dagster/dagster/components/utils/defs_state.py
+++ b/python_modules/dagster/dagster/components/utils/defs_state.py
@@ -11,7 +11,7 @@ class DefsStateConfigArgs(Model):
     key: Optional[str] = Field(
         default=None, description="The key for the state. This must be unique per deployment."
     )
-    type: DefsStateManagementType = Field(
+    management_type: DefsStateManagementType = Field(
         description="The storage type for state required for loading this object's definitions."
         "  - `LOCAL_FILESYSTEM`: State is stored on the local filesystem. `dg utils refresh-defs-state` must be executed while building the deployed container image in order for state to be accessible."
         "  - `VERSIONED_STATE_STORAGE`: State is stored in your configured `defs_state_storage`. `dg utils refresh-defs-state` may be executed at any time to refresh the state."
@@ -29,28 +29,28 @@ class DefsStateConfigArgs(Model):
 
     @classmethod
     def local_filesystem(cls) -> "DefsStateConfigArgs":
-        return cls(type=DefsStateManagementType.LOCAL_FILESYSTEM)
+        return cls(management_type=DefsStateManagementType.LOCAL_FILESYSTEM)
 
     @classmethod
     def versioned_state_storage(cls) -> "DefsStateConfigArgs":
-        return cls(type=DefsStateManagementType.VERSIONED_STATE_STORAGE)
+        return cls(management_type=DefsStateManagementType.VERSIONED_STATE_STORAGE)
 
     @classmethod
     def legacy_code_server_snapshots(cls) -> "DefsStateConfigArgs":
-        return cls(type=DefsStateManagementType.LEGACY_CODE_SERVER_SNAPSHOTS)
+        return cls(management_type=DefsStateManagementType.LEGACY_CODE_SERVER_SNAPSHOTS)
 
 
 @record
 class DefsStateConfig:
     key: str
-    type: DefsStateManagementType
+    management_type: DefsStateManagementType
     refresh_if_dev: bool
 
     @classmethod
     def from_args(cls, args: DefsStateConfigArgs, default_key: str) -> "DefsStateConfig":
         return cls(
             key=args.key or default_key,
-            type=args.type,
+            management_type=args.management_type,
             refresh_if_dev=args.refresh_if_dev,
         )
 

--- a/python_modules/dagster/dagster_tests/components_tests/state_backed_component_tests/test_state_backed_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/state_backed_component_tests/test_state_backed_component.py
@@ -108,7 +108,10 @@ def test_simple_state_backed_component(
             defs_yaml_contents={
                 "type": "dagster_tests.components_tests.state_backed_component_tests.test_state_backed_component.MyStateBackedComponent",
                 "attributes": {
-                    "defs_state": {"type": storage_location.value, **({"key": key} if key else {})}
+                    "defs_state": {
+                        "management_type": storage_location.value,
+                        **({"key": key} if key else {}),
+                    }
                 },
             },
             defs_path="foo",
@@ -193,7 +196,7 @@ def test_code_server_state_backed_component(instance_available: bool) -> None:
                 "type": "dagster_tests.components_tests.state_backed_component_tests.test_state_backed_component.MyStateBackedComponent",
                 "attributes": {
                     "defs_state": {
-                        "type": DefsStateManagementType.LEGACY_CODE_SERVER_SNAPSHOTS.value
+                        "management_type": DefsStateManagementType.LEGACY_CODE_SERVER_SNAPSHOTS.value
                     }
                 },
             },
@@ -250,7 +253,7 @@ def test_local_filesystem_state_backed_component(instance_available: bool) -> No
                 "type": "dagster_tests.components_tests.state_backed_component_tests.test_state_backed_component.MyStateBackedComponent",
                 "attributes": {
                     "defs_state": {
-                        "type": DefsStateManagementType.LOCAL_FILESYSTEM.value,
+                        "management_type": DefsStateManagementType.LOCAL_FILESYSTEM.value,
                     }
                 },
             },
@@ -311,7 +314,7 @@ def test_dev_mode_state_backed_component(storage_location: DefsStateManagementTy
             component_cls=MyStateBackedComponent,
             defs_yaml_contents={
                 "type": "dagster_tests.components_tests.state_backed_component_tests.test_state_backed_component.MyStateBackedComponent",
-                "attributes": {"defs_state": {"type": storage_location.value}},
+                "attributes": {"defs_state": {"management_type": storage_location.value}},
             },
             defs_path="foo",
         )
@@ -427,7 +430,7 @@ def test_state_backed_component_migration_from_versioned_to_local_storage() -> N
                 "type": "dagster_tests.components_tests.state_backed_component_tests.test_state_backed_component.MyStateBackedComponent",
                 "attributes": {
                     "defs_state": {
-                        "type": DefsStateManagementType.VERSIONED_STATE_STORAGE.value,
+                        "management_type": DefsStateManagementType.VERSIONED_STATE_STORAGE.value,
                     }
                 },
             },
@@ -466,7 +469,7 @@ def test_state_backed_component_migration_from_versioned_to_local_storage() -> N
                 "type": "dagster_tests.components_tests.state_backed_component_tests.test_state_backed_component.MyStateBackedComponent",
                 "attributes": {
                     "defs_state": {
-                        "type": DefsStateManagementType.LOCAL_FILESYSTEM.value,
+                        "management_type": DefsStateManagementType.LOCAL_FILESYSTEM.value,
                     }
                 },
             },

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/state_versions/sample_state_backed_component.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/state_versions/sample_state_backed_component.py
@@ -25,7 +25,7 @@ class SampleStateBackedComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     def defs_state_config(self) -> DefsStateConfig:
         return DefsStateConfig(
             key=self.__class__.__name__,
-            type=DefsStateManagementType.VERSIONED_STATE_STORAGE,
+            management_type=DefsStateManagementType.VERSIONED_STATE_STORAGE,
             refresh_if_dev=True,
         )
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_component.py
@@ -229,7 +229,7 @@ def test_component_load_with_defs_state(
             component_cls=AirbyteWorkspaceComponent,
             defs_yaml_contents=deep_merge_dicts(
                 BASIC_AIRBYTE_OSS_COMPONENT_BODY,
-                {"attributes": {"defs_state": {"type": defs_state_type}}},
+                {"attributes": {"defs_state": {"management_type": defs_state_type}}},
             ),
         )
         with (

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -213,7 +213,7 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
     def defs_state_config(self) -> DefsStateConfig:
         return DefsStateConfig(
             key=f"{self.__class__.__name__}[{self.project.name}]",
-            type=DefsStateManagementType.LOCAL_FILESYSTEM,
+            management_type=DefsStateManagementType.LOCAL_FILESYSTEM,
             refresh_if_dev=self.prepare_if_dev,
         )
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/defs_state.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/defs_state.py
@@ -60,7 +60,7 @@ def _get_components_to_refresh(
     selected_components = [
         component
         for component in state_backed_components
-        if component.defs_state_config.type in management_types
+        if component.defs_state_config.management_type in management_types
     ]
 
     # Filter by defs state keys if specified
@@ -157,7 +157,7 @@ def get_updated_defs_state_info_task_and_statuses(
     statuses = {
         key: ComponentStateRefreshStatus(
             status="refreshing",
-            management_type=component.defs_state_config.type,
+            management_type=component.defs_state_config.management_type,
             start_time=time.time(),
         )
         for key, component in deduplicated_components.items()

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/test_refresh_state_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/defs_state_tests/test_refresh_state_command.py
@@ -283,7 +283,7 @@ def test_refresh_state_command_with_management_type_filter():
                     "type": ".local.SampleStateBackedComponent",
                     "attributes": {
                         "defs_state_key_id": "versioned",
-                        "defs_state": {"type": "VERSIONED_STATE_STORAGE"},
+                        "defs_state": {"management_type": "VERSIONED_STATE_STORAGE"},
                     },
                 },
                 f,
@@ -302,7 +302,7 @@ def test_refresh_state_command_with_management_type_filter():
                     "type": ".local.SampleStateBackedComponent",
                     "attributes": {
                         "defs_state_key_id": "local",
-                        "defs_state": {"type": "LOCAL_FILESYSTEM"},
+                        "defs_state": {"management_type": "LOCAL_FILESYSTEM"},
                     },
                 },
                 f,
@@ -388,7 +388,7 @@ def test_refresh_state_command_excludes_legacy_code_server_snapshots_by_default(
                     "type": ".local.SampleStateBackedComponent",
                     "attributes": {
                         "defs_state_key_id": "versioned",
-                        "defs_state": {"type": "VERSIONED_STATE_STORAGE"},
+                        "defs_state": {"management_type": "VERSIONED_STATE_STORAGE"},
                     },
                 },
                 f,
@@ -407,7 +407,7 @@ def test_refresh_state_command_excludes_legacy_code_server_snapshots_by_default(
                     "type": ".local.SampleStateBackedComponent",
                     "attributes": {
                         "defs_state_key_id": "legacy",
-                        "defs_state": {"type": "LEGACY_CODE_SERVER_SNAPSHOTS"},
+                        "defs_state": {"management_type": "LEGACY_CODE_SERVER_SNAPSHOTS"},
                     },
                 },
                 f,

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_example
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_example
@@ -39,5 +39,5 @@ attributes:
       - "example_string"
   defs_state:
     key: "example_string"
-    type: "example_string"
+    management_type: "example_string"
     refresh_if_dev: true

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_schema
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_schema
@@ -74,5 +74,5 @@ attributes:  # Optional: Attributes details
     key_prefix: <one of: string, array of string>  # Optional: Prefix the existing asset key with the provided value.
   defs_state:  # Optional: Configuration for determining how state is stored and persisted for this component.
     key: <string>  # Optional: The key for the state. This must be unique per deployment.
-    type: <string>  # Required: 
+    management_type: <string>  # Required: 
     refresh_if_dev: <boolean>  # Optional: Whether to automatically refresh defs state when using `dagster dev` or the `dg` cli.

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_component.py
@@ -114,7 +114,7 @@ def test_component_load_with_defs_state(
             component_cls=FivetranAccountComponent,
             defs_yaml_contents=deep_merge_dicts(
                 BASIC_FIVETRAN_COMPONENT_BODY,
-                {"attributes": {"defs_state": {"type": defs_state_type}}},
+                {"attributes": {"defs_state": {"management_type": defs_state_type}}},
             ),
         )
         with (

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_component.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_component.py
@@ -55,7 +55,7 @@ def test_component_load_with_defs_state(
 ) -> None:
     """Test component loading with defs state."""
     body = copy.deepcopy(BASIC_LOOKER_COMPONENT_BODY)
-    body["attributes"]["defs_state"] = {"type": defs_state_type}
+    body["attributes"]["defs_state"] = {"management_type": defs_state_type}
 
     with create_defs_folder_sandbox() as sandbox:
         defs_path = sandbox.scaffold_component(
@@ -94,7 +94,7 @@ class TestLookerTranslation(TestTranslation):
     ) -> None:
         body = copy.deepcopy(BASIC_LOOKER_COMPONENT_BODY)
         body["attributes"]["translation"] = attributes
-        body["attributes"]["defs_state"] = {"type": "LOCAL_FILESYSTEM"}
+        body["attributes"]["defs_state"] = {"management_type": "LOCAL_FILESYSTEM"}
 
         with create_defs_folder_sandbox() as sandbox:
             defs_path = sandbox.scaffold_component(

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_components.py
@@ -360,7 +360,7 @@ def test_component_load_with_defs_state(
                         "workspace_id": workspace_id,
                     },
                     "use_workspace_scan": False,
-                    "defs_state": {"type": defs_state_type},
+                    "defs_state": {"management_type": defs_state_type},
                 },
             },
         )

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_components.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_components.py
@@ -273,7 +273,7 @@ def test_component_load_with_defs_state(
                         "client_id": uuid.uuid4().hex,
                         "client_secret": uuid.uuid4().hex,
                     },
-                    "defs_state": {"type": defs_state_type},
+                    "defs_state": {"management_type": defs_state_type},
                 },
             },
         )

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_component.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_component.py
@@ -59,7 +59,7 @@ def test_component_load_with_defs_state(
 ) -> None:
     """Test component loading with defs state."""
     body = copy.deepcopy(BASIC_TABLEAU_COMPONENT_BODY)
-    body["attributes"]["defs_state"] = {"type": defs_state_type}
+    body["attributes"]["defs_state"] = {"management_type": defs_state_type}
 
     with (
         instance_for_test(),
@@ -105,7 +105,7 @@ class TestTableauTranslation(TestTranslation):
     ) -> None:
         body = copy.deepcopy(BASIC_TABLEAU_COMPONENT_BODY)
         body["attributes"]["translation"] = attributes
-        body["attributes"]["defs_state"] = {"type": "LOCAL_FILESYSTEM"}
+        body["attributes"]["defs_state"] = {"management_type": "LOCAL_FILESYSTEM"}
 
         with (
             instance_for_test(),


### PR DESCRIPTION
## Summary & Motivation

This is more explicit and also follows the pattern of the `key` attribute (where it's a "defs state key" in other parts of the product, and we omit the "defs state" part as it's in the "defs state config". 

## How I Tested These Changes

## Changelog

NOCHANGELOG
