### PR TITLE
[dagster-dbt] pass dbt_project to get_asset_spec to fix code links

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -168,7 +168,9 @@ def get_asset_keys_by_output_name_for_source(
         raise KeyError(f"Could not find a dbt source with name: {source_name}")
 
     return {
-        dagster_name_fn(value): dagster_dbt_translator.get_asset_spec(manifest, unique_id, None).key
+        dagster_name_fn(value): dagster_dbt_translator.get_asset_spec(
+            manifest, unique_id, dbt_project
+        ).key
         for unique_id, value in matching.items()
     }
 


### PR DESCRIPTION
Based off of a user report that enable_code_references wasn't working for dbt assets. They pointed to this line as resulting in an exception here https://github.com/dagster-io/dagster/blob/6e1ebc1d7c36b75a136244584304233b59868c1a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py#L179

I'm not sure what the consequences of passing the project here are. Is there a reason it wasn't being passed?



## Changelog 

[dagster-dbt] Fixed a bug where setting `enable_code_references`​ failed for dbt assets.