### PR TITLE
Add new get_execution_plan_snapshot_without_job_snapshot_id to allow fetching remotejob and remoteexecutionplan in parallel

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -658,7 +658,9 @@ class RemoteJob(RepresentedJob, LoadableBy[JobSubsetSelector, "BaseWorkspaceRequ
         return self.tags.get(EXTERNAL_JOB_SOURCE_TAG_KEY)
 
     def get_subset_selector(
-        self, asset_selection: Set[AssetKey], asset_check_selection: Set[AssetCheckKey]
+        self,
+        asset_selection: Optional[Set[AssetKey]],
+        asset_check_selection: Optional[Set[AssetCheckKey]],
     ) -> JobSubsetSelector:
         """Returns a JobSubsetSelector to select a subset of this RemoteJob."""
         return JobSubsetSelector(


### PR DESCRIPTION
Summary:
End goal here is to make the two grpc calls that are needed to launch a job in parallel instead of serially. Right now we fetch a remotejob over grpc just to generate a job snapshot ID that we don't actually use in execution plan creation.

No actual speedup yet in practice, but the next change would fetch the remote job and execution plan snapshot in two grpc calls in parallel, then construct the final remoteexecutionplan using the snapshot ID from the remote job from the first call, and the execution plan snapshot from the second call.

## How I Tested These Changes
BK
