### PR TITLE
fix missing asset check selection in automatic run retries

### DIFF
--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -171,6 +171,11 @@ def retry_run(
             asset_selection=(
                 None if failed_run.asset_selection is None else list(failed_run.asset_selection)
             ),
+            asset_check_selection=(
+                None
+                if failed_run.asset_check_selection is None
+                else list(failed_run.asset_check_selection)
+            ),
         )
     )
 


### PR DESCRIPTION
Summary:
Previously we were not selecting the correct job if the run targeted a subset of assets.

## How I Tested These Changes

New test case that was failing before

## Changelog

Fixed an issue where automatic run retries of runs that only targeted asset checks would sometimes fail with a DagsterInvalidConfigError.