### PR TITLE
Fix user-deployments readiness probe template

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -145,7 +145,8 @@ spec:
               {{- toYaml $deployment.readinessProbe.failureThreshold | nindent 14 }}
             {{- end }}
           {{- else}}
-          readinessProbe: {{ $deployment.readinessProbe | toYaml | nindent 12 }}
+          {{- $readinessProbe := omit $deployment.readinessProbe "enabled" }}
+          readinessProbe: {{ $readinessProbe | toYaml | nindent 12 }}
           {{- end }}
         {{- end }}
         {{- if $deployment.livenessProbe }}


### PR DESCRIPTION
## Summary & Motivation

Currently, overriding the readiness probe exec command in the dagster-user-deployments helm chart will throw a validation error on helm lint or helm template, like:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
dagster-user-deployments:
- at '/deployments/1/readinessProbe': 'anyOf' failed
  - at '/deployments/1/readinessProbe': missing property 'enabled'
  - at '/deployments/1/readinessProbe': got object, want null
 ```

This is because the `UserDeployment` schema model overrides the readiness probe field with a field that includes an `enabled` field. This forces users to include the enabled field if using schema validation, which creates a second problem.

When a user sets `enabled: true`, syncing helm state with a tool like ArgoCD results in errors because the enabled field is included as part of the probe, though it is not supported:

```
error validating data: ValidationError(Deployment.spec.template.spec.containers[0].readinessProbe): unknown field "enabled" in io.k8s.api.core.v1.Probe
```

The solution is to follow the pattern already present in the `startupProbe`, omitting the enabled field during templating.

## How I Tested These Changes

I tested by templating the chart with various readiness probe configurations, including disabling, enabling, and overriding the exec command.

