### PR TITLE
default dst_safe_strptime lru cache value to 8192

### DIFF
--- a/python_modules/dagster/dagster/_time/__init__.py
+++ b/python_modules/dagster/dagster/_time/__init__.py
@@ -180,7 +180,7 @@ def dst_safe_strftime(dt: datetime, tz: str, fmt: str, cron_schedule: str) -> st
     return dt.strftime(fmt)
 
 
-lru_cache_size = int(os.getenv("DAGSTER_DST_SAFE_STRPTIME_LRU_CACHE_SIZE", "0"))
+lru_cache_size = int(os.getenv("DAGSTER_DST_SAFE_STRPTIME_LRU_CACHE_SIZE", "8192"))
 
 
 def dst_safe_strptime(date_string: str, tz: str, fmt: str) -> datetime:


### PR DESCRIPTION
Summary:
A quick benchmark suggests that this cache uses about 2.5 MB when full, and we have evidence that it helps substantially with thread contention when lots of threads are doing partition work at once. Can be tuned down to 0 if one would prefer to optimize for memory.

