### PR TITLE
[dagster-dbt] Add get_resource_props method

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -225,6 +225,34 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
     def _base_translator(self) -> "DagsterDbtTranslator":
         return DagsterDbtTranslator(self.translation_settings)
 
+    def get_resource_props(self, manifest: Mapping[str, Any], unique_id: str) -> Mapping[str, Any]:
+        """Given a parsed manifest and a dbt unique_id, returns the dictionary of properties
+        for the corresponding dbt resource (e.g. model, seed, snapshot, source) as defined
+        in your dbt project. This can be used as a convenience method when overriding the
+        `get_asset_spec` method.
+
+        Args:
+            manifest (Mapping[str, Any]): The parsed manifest of the dbt project.
+            unique_id (str): The unique_id of the dbt resource.
+
+        Returns:
+            Mapping[str, Any]: The dictionary of properties for the corresponding dbt resource.
+
+        Examples:
+            .. code-block:: python
+
+                class CustomDbtProjectComponent(DbtProjectComponent):
+
+                    def get_asset_spec(self, manifest: Mapping[str, Any], unique_id: str, project: Optional[DbtProject]) -> dg.AssetSpec:
+                        base_spec = super().get_asset_spec(manifest, unique_id, project)
+                        resource_props = self.get_resource_props(manifest, unique_id)
+                        if resource_props["meta"].get("use_custom_group"):
+                            return base_spec.replace_attributes(group_name="custom_group")
+                        else:
+                            return base_spec
+        """
+        return get_node(manifest, unique_id)
+
     def get_asset_spec(
         self, manifest: Mapping[str, Any], unique_id: str, project: Optional[DbtProject]
     ) -> dg.AssetSpec:


### PR DESCRIPTION
## Summary & Motivation

The get_asset_spec pattern is generally way better for users than the old-style pattern where we would have a bunch of different `get_x` methods, but one consequence is that the method signature for get_asset_spec in dagster-dbt only has higher level objects, rather than the simpler resource_props dictionary. In order to get that, it's not actually trivial (not just indexing into the manifest dictioanry), and so rather than  forcing users to do that themselves or exporting the get_node() method to the top-level of dagster-dbt, it felt cleaner to make this a method  on the relevant classes.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
