### PR TITLE
Fix a few bugs in the doc for Dagster+ hybrid deployment to k8s

### DIFF
--- a/docs/docs/deployment/dagster-plus/hybrid/kubernetes/setup.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/kubernetes/setup.md
@@ -148,18 +148,20 @@ For cloud-based Kubernetes deployments such as AWS EKS, AKS, or GCP, you don't n
 First create the secret. This step will vary based on the registry you use, but for DockerHub:
 
 ```
-kubectl create secret docker-registry regCred \
+kubectl create secret docker-registry regcred \
   --docker-server=DOCKER_REGISTRY_SERVER \
   --docker-username=DOCKER_USER \
   --docker-password=DOCKER_PASSWORD \
-  --docker-email=DOCKER_EMAIL
+  --docker-email=DOCKER_EMAIL \
+  --namespace dagster-cloud
 ```
 
 Use Helm to configure the agent with the secret:
 
 ```yaml file=values.yaml
 # values.yaml
-imagePullSecrets: [regCred]
+imagePullSecrets: 
+  - name: regcred
 ```
 
 ```shell


### PR DESCRIPTION
## Summary & Motivation
Fix bugs in the doc during the process of our Dagster+ hybrid deployment

## How I Tested These Changes
We tested in our own Dagster+ deployment to our own k8s cluster

## Changelog
Corrected a few bugs in the doc 
- The secret name `regCred` should be all lower case, otherwise `kubectl` will complain
- Updated the `imagePullSecrets` format in `values.yaml` to the correct format
- Added missing `namespace` parameter
