### PR TITLE
Update gitignore to ignore claude local files anywhere in repo (not just root)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@ __pycache__/
 *$py.class
 
 # Claude context file
-CLAUDE.local.md
-.claude/settings.local.json
+**/CLAUDE.local.md
+**/.claude/settings.local.json
 # C extensions
 *.so
 


### PR DESCRIPTION
## Summary & Motivation

Now if you run claude outside the repo root and generate local settings, git won't try to add them.