### PR TITLE
Store the project_dir in the statefile in dagster-cloud ci init, and use it when determining the build directory path

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/ci/__init__.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/ci/__init__.py
@@ -517,6 +517,7 @@ def init_impl(
             ),
             build_output=None,
             status_url=status_url,
+            project_dir=project_dir,
         )
         location_state.add_status_change(state.LocationStatus.pending, "initialized")
         state_store.save(location_state)
@@ -728,6 +729,7 @@ def build_impl(
         ui.print(f"- {name}")
 
     for name, location_state in locations.items():
+        project_dir = location_state.project_dir
         try:
             configured_build_directory = (
                 location_state.build.build_config.directory
@@ -749,6 +751,9 @@ def build_impl(
                 location_build_dir = build_directory
             else:
                 location_build_dir = "."
+
+            if project_dir and not os.path.isabs(location_build_dir):
+                location_build_dir = str(pathlib.Path(project_dir) / location_build_dir)
 
             url = location_state.url
             api_token = get_user_token() or ""

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/ci/state.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/ci/state.py
@@ -57,6 +57,7 @@ class LocationState(BaseModel, extra=Extra.forbid):
     defs_state_info: Optional[DefsStateInfo] = None
     status_url: Optional[str]  # link to cicd run url when building and dagster cloud url when done
     history: list[StatusChange] = []
+    project_dir: Optional[str] = None
 
     def add_status_change(self, status: LocationStatus, log: str):
         self.history.append(

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/test_ci_commands.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/test_ci_commands.py
@@ -132,6 +132,7 @@ def test_ci_init_local_branch_deployment(monkeypatch, mocker, empty_config) -> N
                 "history": [{"log": "initialized", "status": "pending", "timestamp": "-"}],
                 "status_url": "http://github/run-url",
                 "defs_state_info": None,
+                "project_dir": f"{project_dir}",
             }
 
 
@@ -188,6 +189,7 @@ def test_ci_init(monkeypatch, mocker, empty_config) -> None:
                 "history": [{"log": "initialized", "status": "pending", "timestamp": "-"}],
                 "status_url": "http://github/run-url",
                 "defs_state_info": None,
+                "project_dir": f"{project_dir}",
             }
 
             location_auto = locations[3]
@@ -240,28 +242,33 @@ def deployment_name(request):
 
 
 @pytest.fixture
-def initialized_runner(deployment_name, monkeypatch):
+def project_dir():
+    with tempfile.TemporaryDirectory():
+        with with_dagster_yaml(DAGSTER_CLOUD_YAML) as the_project_dir:
+            yield the_project_dir
+
+
+@pytest.fixture
+def initialized_runner(deployment_name, monkeypatch, project_dir):
     monkeypatch.setenv("DAGSTER_CLOUD_ORGANIZATION", "some-org")
     monkeypatch.setenv("DAGSTER_CLOUD_API_TOKEN", "some-org:some-token")
-    with tempfile.TemporaryDirectory():
-        with with_dagster_yaml(DAGSTER_CLOUD_YAML) as project_dir:
-            statedir = os.path.join(project_dir, "tmp")
-            monkeypatch.setenv("DAGSTER_BUILD_STATEDIR", statedir)
+    statedir = os.path.join(project_dir, "tmp")
+    monkeypatch.setenv("DAGSTER_BUILD_STATEDIR", statedir)
 
-            runner = CliRunner()
+    runner = CliRunner()
 
-            result = runner.invoke(
-                app,
-                [
-                    "ci",
-                    "init",
-                    f"--project-dir={project_dir}",
-                    f"--deployment={deployment_name}",
-                    "--commit-hash=hash-4354",
-                ],
-            )
-            assert not result.exit_code, result.output
-            yield runner
+    result = runner.invoke(
+        app,
+        [
+            "ci",
+            "init",
+            f"--project-dir={project_dir}",
+            f"--deployment={deployment_name}",
+            "--commit-hash=hash-4354",
+        ],
+    )
+    assert not result.exit_code, result.output
+    yield runner
 
 
 @pytest.fixture
@@ -316,7 +323,7 @@ def test_ci_selection(initialized_runner: CliRunner) -> None:
 
 
 def test_ci_build_docker(
-    mocker, monkeypatch, deployment_name: str, initialized_runner: CliRunner
+    mocker, monkeypatch, deployment_name: str, initialized_runner: CliRunner, project_dir: str
 ) -> None:
     assert len(get_locations(initialized_runner)) == 4
 
@@ -339,7 +346,7 @@ def test_ci_build_docker(
 
     (b_build_dir, b_tag, b_registry_info), b_kwargs = build_image.call_args_list[0]
     (b_upload_tag, b_upload_registry_info), _ = upload_image.call_args_list[0]
-    assert b_build_dir == "."
+    assert b_build_dir == project_dir
     assert b_tag.startswith(f"{deployment_name}-b")
     assert b_registry_info["registry_url"] == "example.com/image-registry"
     assert b_kwargs["base_image"] == "python:3.11-slim"
@@ -349,7 +356,7 @@ def test_ci_build_docker(
 
     (c_build_dir, c_tag, c_registry_info), b_kwargs = build_image.call_args_list[1]
     assert c_tag.startswith(f"{deployment_name}-c")
-    assert c_build_dir == "subdir"
+    assert c_build_dir == os.path.join(project_dir, "subdir")
 
     # test overriding some defaults
     build_image.reset_mock()
@@ -367,7 +374,7 @@ def test_ci_build_docker(
     assert not result.exit_code, result.output
 
     (b_build_dir, b_tag, b_registry_info), b_kwargs = build_image.call_args_list[0]
-    assert b_build_dir == "."
+    assert b_build_dir == project_dir
     assert b_registry_info["registry_url"] == "example.com/image-registry"
     assert b_kwargs["base_image"] == "custom-base-image"
     assert b_kwargs["env_vars"] == ["A=1", "B=2"]


### PR DESCRIPTION
## Summary & Motivation

In most of our examples, the project_dir is just the current folder and the dagster_cloud.yaml file is at the root. But you might also do something in your CI/CD like clone a repo with a dagster_cloud.yaml in it into a subfolder and try to init it using the project_dir argument to ci init. Unfortuntately, that does not work very well - the ci build command will still look for a [setup.py](http://setup.py) at the current folder and be unable to find it. And if you try to fix it by changing your dagster_cloud.yaml file, the path has to be relative to the cwd rather than the project_dir.

This fixes that by saving the project_dir at ci init time and incorporating it into the build folder. Relative paths in the dagster_cloud.yaml are assumed to be relative to the project_dir (which was already the case in the more common case when the project dir was the same as the current directory).

Fixed an issue where setting a custom project_dir in a serverless github action resulted in the 'daggster-cloud ci build' step being unable to find the correct path.

## How I Tested These Changes

New tests, run ci init and ci build locally