### PR TITLE
Show a clearer exception when a particular asset job cannot resolve during definitions load

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -123,12 +123,17 @@ def _resolve_unresolved_job_def_lambda(
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]],
 ) -> Callable[[], JobDefinition]:
     def resolve_unresolved_job_def() -> JobDefinition:
-        job_def = unresolved_job_def.resolve(
-            asset_graph=asset_graph,
-            default_executor_def=default_executor_def,
-            resource_defs=top_level_resources,
-        )
-        return _process_resolved_job(job_def, default_executor_def, default_logger_defs)
+        try:
+            job_def = unresolved_job_def.resolve(
+                asset_graph=asset_graph,
+                default_executor_def=default_executor_def,
+                resource_defs=top_level_resources,
+            )
+            return _process_resolved_job(job_def, default_executor_def, default_logger_defs)
+        except Exception as e:
+            raise DagsterInvalidDefinitionError(
+                f"Failed to resolve asset job {unresolved_job_def.name}"
+            ) from e
 
     return resolve_unresolved_job_def
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
@@ -847,7 +847,7 @@ def test_multi_asset_check() -> None:
         == 1
     )
 
-    with pytest.raises(dg.DagsterInvalidSubsetError):
+    with pytest.raises(dg.DagsterInvalidDefinitionError):
         execute_assets_and_checks(
             asset_checks=[checks],
             instance=instance,


### PR DESCRIPTION
## Summary & Motivation


This fixes an issue where a particular asset job can't resolve (e.g. due to not targeting any assets) and the resulting error gives no clue about which job actually caused the problem.

## How I Tested These Changes

New test case

## Changelog

Asset jobs that are unable to resolve their asset selection (for example, due to targeting an empty set of asset keys) will now raise a clearer exception at definition load time explaining which job failed to resolve its asset selection.