### PR TITLE
add ENI to run tags for ECS tasks

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -35,6 +35,7 @@ from dagster._grpc.types import ExecuteRunArgs
 from dagster._serdes import ConfigurableClass
 from dagster._serdes.config_class import ConfigurableClassData
 from dagster._utils.backoff import backoff
+from dagster._utils.tags import get_boolean_tag_value
 from typing_extensions import Self
 
 from dagster_aws.ecs.container_context import (
@@ -80,8 +81,6 @@ TAGS_TO_EXCLUDE_FROM_PROPAGATION = {"dagster/op_selection", "dagster/solid_selec
 
 DEFAULT_REGISTER_TASK_DEFINITION_RETRIES = 5
 DEFAULT_RUN_TASK_RETRIES = 5
-
-ENI_TAGGING_ENABLED = os.getenv("DAGSTER_AWS_ENI_TAGGING_ENABLED", "false").lower() == "true"
 
 
 class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
@@ -894,7 +893,9 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
 
         t = tasks[0]
 
-        if ENI_TAGGING_ENABLED and not run.tags.get(f"{HIDDEN_TAG_PREFIX}eni_id"):
+        if get_boolean_tag_value(os.getenv("DAGSTER_AWS_ENI_TAGGING_ENABLED")) and not run.tags.get(
+            f"{HIDDEN_TAG_PREFIX}eni_id"
+        ):
             try:
                 self._add_eni_id_tags(run, t)
             except Exception:

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -13,7 +13,7 @@ from dagster._core.launcher import LaunchRunContext
 from dagster._core.launcher.base import WorkerStatus
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
 from dagster._core.storage.dagster_run import DagsterRunStatus
-from dagster._core.storage.tags import RUN_WORKER_ID_TAG
+from dagster._core.storage.tags import HIDDEN_TAG_PREFIX, RUN_WORKER_ID_TAG
 
 import dagster_aws
 from dagster_aws.ecs import EcsEventualConsistencyTimeout
@@ -1005,7 +1005,9 @@ def test_public_ip_assignment(ecs, ec2, instance, workspace, run, assign_public_
     assert bool(attributes.get("PublicIp")) == assign_public_ip
 
 
-def test_check_run_worker_health_adds_eni_tag(ecs, instance, workspace, run):
+def test_check_run_worker_health_adds_eni_tag(ecs, instance, workspace, run, monkeypatch):
+    monkeypatch.setenv("DAGSTER_AWS_ENI_TAGGING_ENABLED", "true")
+
     initial_tasks = ecs.list_tasks()["taskArns"]
 
     instance.launch_run(run.run_id, workspace)
@@ -1014,7 +1016,9 @@ def test_check_run_worker_health_adds_eni_tag(ecs, instance, workspace, run):
     task_arn = next(iter(set(tasks).difference(initial_tasks)))
     task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
 
-    assert not any(k.startswith("ecs/eni_id") for k in instance.get_run_by_id(run.run_id).tags)
+    assert not any(
+        k.startswith(f"{HIDDEN_TAG_PREFIX}eni_id") for k in instance.get_run_by_id(run.run_id).tags
+    )
 
     health = instance.run_launcher.check_run_worker_health(run)
     assert health.status == WorkerStatus.RUNNING
@@ -1024,7 +1028,7 @@ def test_check_run_worker_health_adds_eni_tag(ecs, instance, workspace, run):
     eni_id = details["networkInterfaceId"]
 
     run_tags = instance.get_run_by_id(run.run_id).tags
-    assert run_tags.get("ecs/eni_id") == eni_id
+    assert run_tags.get(f"{HIDDEN_TAG_PREFIX}eni_id") == eni_id
 
 
 def test_launcher_run_resources(


### PR DESCRIPTION
## Summary & Motivation

Whenever the worker health check runs, adds a tag with the AWS Network interface if it's not already attached.

## How I Tested These Changes

Tested locally and new test case added.

## Changelog

> Run worker health check will now tag runs with their associated eni ids.