### PR TITLE
[da] Update `evaluation_id` threading

### DIFF
--- a/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
+++ b/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
@@ -93,6 +93,7 @@ def test_auto_materialize_perf(scenario: PerfScenario):
             asset_graph=asset_graph,
             emit_backfills=False,
             cursor=AssetDaemonCursor.empty(),
+            evaluation_id=1,
         ).evaluate()
 
         end = time.time()

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -69,7 +69,8 @@ class AssetDaemonCursor:
     """State that's stored between daemon evaluations.
 
     Args:
-        evaluation_id (int): The ID of the evaluation that produced this cursor.
+        evaluation_id (int): (DEPRECATED) The ID of the evaluation that produced this cursor.
+            This is no longer used as the source of truth for the evaluation id.
         previous_evaluation_state (Sequence[AutomationConditionEvaluationState]): (DEPRECATED) The
             evaluation info recorded for each asset on the previous tick.
         previous_cursors (Sequence[AutomationConditionCursor]): The cursor objects for each asset

--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -71,6 +71,7 @@ class AutomationTickEvaluationContext:
             cursor=cursor,
             evaluation_time=evaluation_time,
             logger=logger,
+            evaluation_id=self._evaluation_id,
         )
         self._materialize_run_tags = materialize_run_tags
         self._observe_run_tags = observe_run_tags

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -34,6 +34,7 @@ class AutomationConditionEvaluator:
         asset_graph: BaseAssetGraph,
         cursor: AssetDaemonCursor,
         emit_backfills: bool,
+        evaluation_id: int,
         default_condition: Optional[AutomationCondition] = None,
         evaluation_time: Optional[datetime.datetime] = None,
         logger: logging.Logger = logging.getLogger("dagster.automation"),
@@ -68,6 +69,7 @@ class AutomationConditionEvaluator:
         self.legacy_data_time_resolver = CachingDataTimeResolver(self.instance_queryer)
 
         self.request_subsets_by_key: dict[EntityKey, EntitySubset] = {}
+        self.evaluation_id = evaluation_id
 
     @property
     def instance_queryer(self) -> "CachingInstanceQueryer":

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
@@ -147,6 +147,7 @@ def evaluate_automation_conditions(
         emit_backfills=False,
         logger=logging.getLogger("dagster.automation_condition_tester"),
         cursor=cursor,
+        evaluation_id=cursor.evaluation_id,
     )
     results, requested_subsets = evaluator.evaluate()
     with partition_loading_context(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -49,6 +49,7 @@ def _has_legacy_condition(condition: AutomationCondition):
 
 @dataclass(frozen=True)
 class AutomationContext(Generic[T_EntityKey]):
+    evaluation_id: int
     condition: AutomationCondition
     condition_unique_ids: Sequence[str]
     candidate_subset: EntitySubset[T_EntityKey]
@@ -82,6 +83,7 @@ class AutomationContext(Generic[T_EntityKey]):
             asset_graph_view=asset_graph_view,
             request_subsets_by_key=evaluator.request_subsets_by_key,
             parent_context=None,
+            evaluation_id=evaluator.evaluation_id,
             _cursor=evaluator.cursor.get_previous_condition_cursor(key),
             _full_cursor=evaluator.cursor,
             _legacy_context=LegacyRuleEvaluationContext.create(key, evaluator)
@@ -109,6 +111,7 @@ class AutomationContext(Generic[T_EntityKey]):
             asset_graph_view=self.asset_graph_view,
             request_subsets_by_key=self.request_subsets_by_key,
             parent_context=self,
+            evaluation_id=self.evaluation_id,
             _cursor=self._cursor,
             _full_cursor=self._full_cursor,
             _legacy_context=self._legacy_context.for_child(
@@ -223,13 +226,6 @@ class AutomationContext(Generic[T_EntityKey]):
     def previous_temporal_context(self) -> Optional[TemporalContext]:
         """The `temporal_context` value used on the previous tick's evaluation."""
         return self._cursor.temporal_context if self._cursor else None
-
-    @property
-    def evaluation_id(self) -> int:
-        """Returns the current evaluation ID. This ID is incremented for each tick
-        and is global across all conditions.
-        """
-        return self._full_cursor.evaluation_id
 
     @property
     def legacy_context(self) -> LegacyRuleEvaluationContext:

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
@@ -81,15 +81,17 @@ class AutomationConditionScenarioState(ScenarioState):
         ).asset_graph
 
         with freeze_time(self.current_time):
+            cursor = AssetDaemonCursor.empty().with_updates(
+                0, 0, [], [self.condition_cursor] if self.condition_cursor else [], asset_graph
+            )
             evaluator = AutomationConditionEvaluator(
                 asset_graph=asset_graph,
                 instance=self.instance,
                 entity_keys=asset_graph.get_all_asset_keys(),
-                cursor=AssetDaemonCursor.empty().with_updates(
-                    0, 0, [], [self.condition_cursor] if self.condition_cursor else [], asset_graph
-                ),
+                cursor=cursor,
                 logger=self.logger,
                 emit_backfills=False,
+                evaluation_id=cursor.evaluation_id,
             )
             evaluator.request_subsets_by_key = self._get_request_subsets_by_key(
                 evaluator.asset_graph_view


### PR DESCRIPTION
## Summary & Motivation

We no longer use the `evaluation_id` that's set on the AssetDaemonCursor for anything, instead opting for getting the evaluation id from the database when we generate a new tick. This means that code that was trying to access this during AutomationCondition evaluation would get an incorrect value (this was just the SinceCondition metadata, so it didn't impact anything functional).

## How I Tested These Changes

## Changelog

NOCHANGELOG
