### PR TITLE
[docs] Clarify references to configuration

### DIFF
--- a/docs/docs/deployment/dagster-plus/hybrid/multiple.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/multiple.md
@@ -214,7 +214,7 @@ dagsterCloud:
 
 #### In Amazon ECS
 
-Modify your ECS Cloud Formation template to add the following configuration to the `dagster.yaml` file passed to the agent (the ECS agent configuration reference can be found [here](/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference.md#per-deployment-configuration)):
+Modify your ECS Cloud Formation template to add the following configuration to the `dagster.yaml` file passed to the agent (the ECS agent configuration reference can be found [here](/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference#per-deployment-configuration)):
 
 ```yaml
 # dagster.yaml

--- a/docs/docs/deployment/dagster-plus/hybrid/multiple.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/multiple.md
@@ -214,7 +214,7 @@ dagsterCloud:
 
 #### In Amazon ECS
 
-Modify your ECS Cloud Formation template to add the following configuration to the `dagster.yaml` file passed to the agent (the ECS agent configuration reference can be found [here](/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference.md)):
+Modify your ECS Cloud Formation template to add the following configuration to the `dagster.yaml` file passed to the agent (the ECS agent configuration reference can be found [here](/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference.md#per-deployment-configuration)):
 
 ```yaml
 # dagster.yaml

--- a/docs/docs/deployment/dagster-plus/hybrid/multiple.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/multiple.md
@@ -214,7 +214,7 @@ dagsterCloud:
 
 #### In Amazon ECS
 
-Modify your ECS Cloud Formation template to add the following configuration to the `config.yaml` passed to the agent:
+Modify your ECS Cloud Formation template to add the following configuration to the `dagster.yaml` file passed to the agent (the ECS agent configuration reference can be found [here](/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference.md)):
 
 ```yaml
 # config.yaml

--- a/docs/docs/deployment/dagster-plus/hybrid/multiple.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/multiple.md
@@ -217,7 +217,7 @@ dagsterCloud:
 Modify your ECS Cloud Formation template to add the following configuration to the `dagster.yaml` file passed to the agent (the ECS agent configuration reference can be found [here](/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference.md)):
 
 ```yaml
-# config.yaml
+# dagster.yaml
 agent_queues:
   # Continue to handle requests for code locations that aren't
   # assigned to a specific agent queue

--- a/docs/docs/guides/log-debug/logging/custom-logging.md
+++ b/docs/docs/guides/log-debug/logging/custom-logging.md
@@ -97,7 +97,7 @@ Here's an example of the output for reference, formatted for readability:
 
 ### Changing the logger configuration in the Dagster UI
 
-You can also change the logger configuration in the Dagster UI. This is useful if you want to change the logger configuration without changing the code, to use the custom logger on a manual asset materialization launch, or change the verbosity of the logs. Add the following lines to your `config.yaml`:
+You can also change the logger configuration in the Dagster UI. This is useful if you want to change the logger configuration without changing the code, to use the custom logger on a manual asset materialization launch, or change the verbosity of the logs. Add the following lines to your job's run config:
 
 ```yaml
 loggers:

--- a/docs/docs/guides/log-debug/logging/index.md
+++ b/docs/docs/guides/log-debug/logging/index.md
@@ -67,7 +67,7 @@ Windows / Azure users may need to enable the environment variable `PYTHONLEGACYW
 
 ## Configuring loggers
 
-Loggers can be configured when you run a job. For example, to filter all messages below `ERROR` out of the colored console logger, add the following lines to your `config.yaml`:
+Loggers can be configured when you run a job. For example, to filter all messages below `ERROR` out of the colored console logger for a job, add the following lines to the run config in the launchpad or `RunRequest`:
 
 <CodeExample path="docs_snippets/docs_snippets/concepts/logging/config.yaml" />
 


### PR DESCRIPTION
## Summary & Motivation
[This discussion](https://github.com/dagster-io/dagster/discussions/32238) pointed out a reference to `config.yaml`, which is not a standard named config file used in Dagster. I believe the author was referring to a `config.yaml` file that a separate example created to be used with CLI commands.

This change tries to clarify those references to indicate the users should be placing the documented configuration examples into their job's run config where appropriate. A cursory search of the docs for other `config.yaml` files found another location where it seemed that `config.yaml` was being used in place of `dagster.yaml`.

## How I Tested These Changes
I ran into an error when running `yarn start` to build the docs locally where it seems to not be able to find a few sidebar document ids:
```
- api/clis/cli
- api/clis/create-dagster
- api/clis/dg-cli/dg-cli-reference
```
So I haven't been able to test these changes locally unfortunately. I tried debugging the issue and these files certainly don't exist, so I don't quite understand how these references are working in the production docs site - I'm not familiar with yarn though, so any guidance here would be appreciated.
