### PR TITLE
Bandaid fix for `get_smallest_cron_interval` negative time intervals

### DIFF
--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -937,6 +937,12 @@ def get_smallest_cron_interval(
                 # We've encountered a genuine zero interval (which shouldn't happen)
                 raise Exception("Encountered a genuine zero interval")
 
+            if interval < datetime.timedelta(seconds=0):
+                # This happens when the sampling encounters a daylight savings transition where the clocks roll back
+                # Just skip this interval and continue sampling
+                prev_tick = current_tick
+                continue
+
             # Update minimum interval
             if min_interval is None or interval < min_interval:
                 min_interval = interval


### PR DESCRIPTION
## Summary & Motivation
Temporary fix for `get_smallest_cron_interval` returning negative time interval when running over a DST fall back transition.

This should be good enough for now to get the build green again. The more permanent fix is to remove the sampling based algorithm in favor of a deterministic approach, being worked on in https://app.graphite.dev/github/pr/dagster-io/dagster/32626/Improve-%60get_smallest_cron_interval%60

## How I Tested These Changes
bk

## Changelog

> Insert changelog entry or delete this section.
