### PR TITLE
[ui] Enable new navigation flag by default

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/DefaultFeatureFlags.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/DefaultFeatureFlags.oss.tsx
@@ -5,6 +5,7 @@ import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
  */
 export const DEFAULT_FEATURE_FLAG_VALUES: Partial<Record<FeatureFlag, boolean>> = {
   [FeatureFlag.flagAssetNodeFacets]: true,
+  [FeatureFlag.flagNavigationUpdate]: true,
 
   // Flags for tests
   [FeatureFlag.__TestFlagDefaultTrue]: true,

--- a/js_modules/dagster-ui/packages/ui-core/src/app/navigation/mainNavigationItems.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/navigation/mainNavigationItems.tsx
@@ -53,7 +53,7 @@ export const getTopGroups = (config: NavigationGroupConfig): NavigationGroup[] =
               icon={<Icon name="timeline" />}
               label="Overview"
               href="/overview"
-              isActive={(_, currentLocation) => currentLocation.pathname === '/overview'}
+              isActive={(_, currentLocation) => currentLocation.pathname.startsWith('/overview')}
             />
           ),
         },


### PR DESCRIPTION
## Summary & Motivation

Enable the new navigation flag by default ahead of 1.12.

Also fixed the "active" state for Overview paths.

## How I Tested These Changes

Load app, make sure that the flag value isn't set in localStorage. Reload the page, verify that the new navigation is enabled by default.

Verify that "Overview" is correctly highlighted.

Turn off the flag, verify that the old nav returns.

## Changelog

[ui] Enable the new navigation layout by default. For now, this can be turned off via User Settings.
