### PR TITLE
Fix #32574: Handle callable objects with custom __signature__ in get_type_hints

### DIFF
--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -15,6 +15,7 @@ from typing import (  # noqa: UP035
     cast,
     get_type_hints as typing_get_type_hints,
 )
+from unittest.mock import Mock
 
 from typing_extensions import Concatenate, ParamSpec, TypeAlias, TypeGuard
 
@@ -66,17 +67,41 @@ def get_function_params(fn: Callable[..., Any]) -> Sequence[Parameter]:
 
 
 def get_type_hints(fn: Callable[..., Any]) -> Mapping[str, Any]:
+    """Wrapper around typing.get_type_hints that handles functools.partial,
+    objects with __signature__, callable instances, and Mock objects gracefully.
+    """
+    original_fn = fn
+
+    # process functiontools.partial
     if isinstance(fn, functools.partial):
         target = fn.func
-    elif inspect.isfunction(fn):
-        target = fn
-    elif hasattr(fn, "__call__"):
-        target = fn.__call__  # pyright: ignore[reportFunctionMemberAccess]
     else:
-        check.failed(f"Unhandled Callable object {fn}")
+        target = fn
 
+    # handle __signature__ - Highest priority
+    if hasattr(fn, "__signature__"):
+        sig = fn.__signature__
+        hints = {}
+        for param_name, param in sig.parameters.items():
+            if param.annotation != inspect.Parameter.empty:
+                hints[param_name] = param.annotation
+        if sig.return_annotation != inspect.Signature.empty:
+            hints["return"] = sig.return_annotation
+        return hints
+    # handle Mock objects
+    elif isinstance(fn, Mock) and hasattr(fn, "__call__"):
+        target_for_hints = fn.__call__
+    # handle regular functions
+    elif inspect.isfunction(target):
+        target_for_hints = target
+    # handle other callable objects (like class instances without __signature__)
+    elif hasattr(target, "__call__"):
+        # no __signature__, only __call__ exists, __call__ have to be used
+        target_for_hints = target.__call__
+    else:
+        check.failed(f"Unhandled Callable object {original_fn}")
     try:
-        return typing_get_type_hints(target, include_extras=True)
+        return typing_get_type_hints(target_for_hints, include_extras=True)
     except NameError as e:
         match = re.search(r"'(\w+)'", str(e))
         assert match
@@ -89,6 +114,12 @@ def get_type_hints(fn: Callable[..., Any]) -> Mapping[str, Any]:
             " annotations`, all annotations in that module are stored as strings. Suggested"
             " solutions include: (1) convert the annotation to a non-string annotation; (2) move"
             " the type referenced by the annotation out of local scope or a `TYPE_CHECKING` block."
+        )
+    except TypeError as e:
+        func_name = getattr(original_fn, "__name__", str(original_fn))
+        raise DagsterInvalidDefinitionError(
+            f"Failed to get type hints for {func_name}. This can happen with certain callable"
+            f" objects that don't support introspection well. Original error: {e}"
         )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
@@ -1,3 +1,4 @@
+import inspect
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import cast
@@ -1891,3 +1892,45 @@ def test_run_status_sensor_eval_tick_testing() -> None:
 
     # assert the expected response amongst sensors
     assert requested_jobs == {"job_1", "job_2"}
+
+
+def test_sensor_invocation_resources_callable_with_custom_signature() -> None:
+    """Test that callable objects with __signature__ attribute are handled correctly."""
+
+    class MyResource(dg.ConfigurableResource):
+        a_str: str
+
+    # Define the signature we want to use
+    def custom_signature(my_resource: MyResource) -> dg.RunRequest:
+        pass
+
+    class FooWithSignature:
+        def __init__(self):
+            # Set custom signature on the instance
+            self.__signature__ = inspect.signature(custom_signature)
+
+        def __call__(self, **kwargs):
+            # __call__ has generic signature, but __signature__ overrides it
+            return dg.RunRequest(
+                run_key=None, run_config={"foo": kwargs["my_resource"].a_str}, tags={}
+            )
+
+    weird_sensor = dg.SensorDefinition(
+        name="weird_with_sig",
+        evaluation_fn=FooWithSignature(),
+    )
+
+    # Should recognize my_resource as a resource parameter from __signature__
+    with pytest.raises(
+        dg.DagsterInvalidDefinitionError,
+        match=(
+            "Resource with key 'my_resource' required by sensor 'weird_with_sig' was not provided."
+        ),
+    ):
+        weird_sensor()
+
+    # Should work when resource is provided
+    assert cast(
+        "dg.RunRequest",
+        weird_sensor(dg.build_sensor_context(resources={"my_resource": MyResource(a_str="bar")})),
+    ).run_config == {"foo": "bar"}


### PR DESCRIPTION
## Summary
Fixes #32574

This PR fixes an issue where `get_type_hints()` incorrectly handled callable objects with custom `__signature__` attributes. Previously, these objects would fail with a `TypeError` because `typing.get_type_hints()` cannot introspect arbitrary callable instances.

## Problem
When a callable object defines a custom `__signature__` attribute, the existing implementation would pass the callable instance itself to `typing.get_type_hints()`.

This broke use cases where wrappers need to preserve type information from wrapped functions by setting `__signature__`.

## Solution
Modified `get_type_hints()` in `decorator_utils.py` to:
1. Check for `__signature__` attribute first (highest priority).
2. Extract type hints directly from the signature object instead of calling `typing.get_type_hints()`.
3. Properly handle parameters and return annotations from the signature.

## Changes
- Modified `python_modules/dagster/dagster/_core/decorator_utils.py`:
  - Updated `get_type_hints()` to extract annotations directly from `__signature__` when present
- Added test in `python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py`:
  - `test_sensor_invocation_resources_callable_with_custom_signature()`

## Testing
- New test `test_sensor_invocation_resources_callable_with_custom_signature` passes
- All existing `test_sensor_invocation.py` tests pass
- Verified backward compatibility with existing callable object handling
<img width="392" height="110" alt="Screenshot 2025-10-27 at 6 10 03 PM" src="https://github.com/user-attachments/assets/81aab7b4-3f90-484b-b307-5b5bab6c7fe1" />


