### PR TITLE
[Freshness Policy GA] api docs

### DIFF
--- a/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
@@ -589,6 +589,8 @@ class MdxTranslator(SphinxTranslator):
     depart_sidebar = depart_topic
 
     def visit_rubric(self, node: Element) -> None:
+        # Add blank line before rubrics to separate sections (e.g., between Returns and Examples)
+        self.add_text(self.nl)
         self.new_state(0)
 
     def depart_rubric(self, node: Element) -> None:

--- a/docs/sphinx/sections/api/apidocs/dagster/assets.rst
+++ b/docs/sphinx/sections/api/apidocs/dagster/assets.rst
@@ -89,6 +89,17 @@ Refer to the `Asset observation <https://docs.dagster.io/guides/build/assets/met
 
 .. autoclass:: AssetObservation
 
+Freshness policies
+------------------
+
+Freshness policies allow you to define freshness expectations for your assets and track their freshness state over time.
+
+.. autoclass:: FreshnessPolicy
+
+.. automethod:: FreshnessPolicy.time_window
+
+.. automethod:: FreshnessPolicy.cron
+
 Declarative Automation
 ---------------------------------------
 

--- a/python_modules/dagster/dagster/_core/definitions/assets/definition/assets_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/definition/assets_definition.py
@@ -511,9 +511,9 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
                 tags to be associated with each of the output assets for this node. Keys are the names
                 of outputs, and values are dictionaries of tags to be associated with the related
                 asset.
-            legacy_freshness_policies_by_output_name (Optional[Mapping[str, Optional[FreshnessPolicy]]]): Defines a
-                FreshnessPolicy to be associated with some or all of the output assets for this node.
-                Keys are the names of the outputs, and values are the FreshnessPolicies to be attached
+            legacy_freshness_policies_by_output_name (Optional[Mapping[str, Optional[LegacyFreshnessPolicy]]]): Defines a
+                LegacyFreshnessPolicy to be associated with some or all of the output assets for this node.
+                Keys are the names of the outputs, and values are the LegacyFreshnessPolicies to be attached
                 to the associated asset.
             automation_conditions_by_output_name (Optional[Mapping[str, Optional[AutomationCondition]]]): Defines an
                 AutomationCondition to be associated with some or all of the output assets for this node.

--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -10,6 +10,7 @@ from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.loader import LoadableBy, LoadingContext
 from dagster._record import IHaveNew, record, record_custom
 from dagster._serdes import deserialize_value, whitelist_for_serdes
+from dagster._symbol_annotations.public import public
 from dagster._time import datetime_from_timestamp, get_timezone
 from dagster._utils import check
 from dagster._utils.schedules import get_smallest_cron_interval, is_valid_cron_string
@@ -48,6 +49,7 @@ class FreshnessStateChange:
 INTERNAL_FRESHNESS_POLICY_METADATA_KEY = "dagster/internal_freshness_policy"
 
 
+@public
 class FreshnessPolicy(ABC):
     """Base class for all freshness policies.
 
@@ -76,6 +78,7 @@ class FreshnessPolicy(ABC):
         return deserialize_value(serialized_policy.value, cls)  # pyright: ignore
 
     @staticmethod
+    @public
     def time_window(
         fail_window: timedelta, warn_window: Optional[timedelta] = None
     ) -> "TimeWindowFreshnessPolicy":
@@ -105,6 +108,7 @@ class FreshnessPolicy(ABC):
         return TimeWindowFreshnessPolicy.from_timedeltas(fail_window, warn_window)
 
     @staticmethod
+    @public
     def cron(
         deadline_cron: str, lower_bound_delta: timedelta, timezone: str = "UTC"
     ) -> "CronFreshnessPolicy":

--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -136,7 +136,7 @@ class FreshnessPolicy(ABC):
 
             - If the asset is materialized at 9:30 AM, the asset is passing its freshness policy, and will have a freshness state of ``PASS``. The asset will continue to pass the freshness policy until at least the deadline next day (10AM).
             - If the asset is materialized at 9:59 AM, the asset is passing its freshness policy, and will have a freshness state of ``PASS``. The asset will continue to pass the freshness policy until at least the deadline next day (10AM).
-            - If the asset is not materialized by 10:00 AM, the asset is failing its freshness policy, and will have a freshness sate of ``FAIL``. The asset will continue to fail the freshness policy until it is materialized again.
+            - If the asset is not materialized by 10:00 AM, the asset is failing its freshness policy, and will have a freshness state of ``FAIL``. The asset will continue to fail the freshness policy until it is materialized again.
             - If the asset is then materialized at 10:30AM, it will pass the freshness policy again until at least the deadline the next day (10AM).
 
             Keep in mind that the policy will always look at the last completed cron tick.

--- a/python_modules/dagster/dagster/_core/definitions/freshness.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness.py
@@ -78,7 +78,6 @@ class FreshnessPolicy(ABC):
         return deserialize_value(serialized_policy.value, cls)  # pyright: ignore
 
     @staticmethod
-    @public
     def time_window(
         fail_window: timedelta, warn_window: Optional[timedelta] = None
     ) -> "TimeWindowFreshnessPolicy":
@@ -108,7 +107,6 @@ class FreshnessPolicy(ABC):
         return TimeWindowFreshnessPolicy.from_timedeltas(fail_window, warn_window)
 
     @staticmethod
-    @public
     def cron(
         deadline_cron: str, lower_bound_delta: timedelta, timezone: str = "UTC"
     ) -> "CronFreshnessPolicy":


### PR DESCRIPTION
## Summary & Motivation
- Adds API docs for `FreshnessPolicy`
- Adds `@public` annotation to `FreshnessPolicy` class
- Moves docstrings from freshness subclasses to their corresponding static constructors
- Fixes a small bug in mdx generator that did not render newlines correctly in the api docs

## How I Tested These Changes
local docs site

## Changelog

> Insert changelog entry or delete this section.
