### PR TITLE
Key job snapshots by name when possible when loading RemoteJobs

### DIFF
--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -109,6 +109,15 @@ def bar_job():
     fail_subset(one())
 
 
+@dg.job(name="bar")
+def other_bar_job():
+    @dg.op
+    def hello():
+        pass
+
+    hello()
+
+
 @dg.schedule(job_name="baz", cron_schedule="* * * * *")
 def partitioned_run_request_schedule():
     return dg.RunRequest(partition_key="a")
@@ -215,6 +224,6 @@ def bar_repo():
     }
 
 
-@dg.repository  # pyright: ignore[reportArgumentType]
+@dg.repository
 def other_repo():
-    return {"jobs": {"other_foo": define_other_foo_job}}
+    return {"jobs": {"other_foo": define_other_foo_job, "bar": other_bar_job}}

--- a/python_modules/dagster/dagster_tests/api_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/api_tests/utils.py
@@ -31,7 +31,7 @@ def get_bar_workspace(instance: DagsterInstance) -> Iterator[WorkspaceRequestCon
 def get_workspace(
     instance: DagsterInstance,
     python_file: str,
-    attribute: str,
+    attribute: Optional[str],
     location_name: str,
 ) -> Iterator[WorkspaceRequestContext]:
     with WorkspaceProcessContext(


### PR DESCRIPTION
## Summary & Motivation

This guards us better against snapshot ID instability/non-determinism in the case where the snapshots are sitting in memory already anyway.

## How I Tested These Changes

New test case

## Changelog

Fixed an issue introduced in dagster 1.11.16 where repositories using custom RepositoryData subclasses would sometimes raise an error when viewing jobs in the Dagster UI.