### PR TITLE
Fix Dask parquet filter predicates conversion from YAML

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/data_frame.py
@@ -488,12 +488,26 @@ def dataframe_loader(_context, config):
     read_args = [read_options.pop("path")] if read_meta.get("is_path_based", False) else []
     read_kwargs = read_options
 
+    if "filters" in read_kwargs:
+        # Ops are configured in YAML, but YAML has no concept of a Python tuple. Dask is no longer lenient
+        # of the innermost list of a filter being a python list, and these must be converted to tuples.
+        read_kwargs["filters"] = _innermost_list2tuple(read_kwargs["filters"])
+
     # Read the dataframe and apply any utility functions
     df = read_function(*read_args, **read_kwargs)
     df = apply_utilities_to_df(df, config)
     df = df.persist()
 
     return df
+
+
+def _innermost_list2tuple(data):
+    def converted(x):
+        if not any(isinstance(a, list) for a in x):
+            return tuple(x)
+        return [converted(d) if isinstance(d, list) else d for d in x]
+
+    return [converted(d) for d in data]
 
 
 def df_type_check(_, value):

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_data_frame.py
@@ -4,7 +4,7 @@ from dagster import file_relative_path, op
 from dagster._core.definitions.input import In
 from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_dask import DataFrame
-from dagster_dask.data_frame import DataFrameReadTypes
+from dagster_dask.data_frame import DataFrameReadTypes, _innermost_list2tuple
 from dagster_dask.utils import DataFrameUtilities
 from dask.dataframe.utils import assert_eq
 
@@ -51,3 +51,87 @@ def test_dataframe_loader_config_keys_dont_overlap():
     read_keys = set(DataFrameReadTypes.keys())
 
     assert len(config_keys.intersection(read_keys)) == 0
+
+
+def test_innermost_list2tuple():
+    """Test that _innermost_list2tuple correctly converts filter predicates from lists to tuples.
+
+    Parquet filters should be of the form:
+    - List[Tuple[str, str, Any]] for simple filters (AND conditions)
+    - List[List[Tuple[str, str, Any]]] for compound filters (OR conditions)
+
+    YAML config converts everything to lists, so we need to convert the innermost
+    list wrapping the predicate triple to a tuple.
+    """
+    # Test simple filter with single predicate
+    input_filter = [["column", "==", "value"]]
+    expected = [("column", "==", "value")]
+    assert _innermost_list2tuple(input_filter) == expected
+
+    # Test multiple simple predicates (AND condition)
+    input_filter = [["column1", "==", "value1"], ["column2", ">", 100]]
+    expected = [("column1", "==", "value1"), ("column2", ">", 100)]
+    assert _innermost_list2tuple(input_filter) == expected
+
+    # Test compound filter with multiple predicates (OR condition)
+    input_filter = [[["column1", "==", "value1"]], [["column2", ">", 100]]]
+    expected = [[("column1", "==", "value1")], [("column2", ">", 100)]]
+    assert _innermost_list2tuple(input_filter) == expected
+
+    # Test multiple predicates in same OR group (AND within OR)
+    input_filter = [[["column1", "==", "value1"], ["column2", ">", 100]]]
+    expected = [[("column1", "==", "value1"), ("column2", ">", 100)]]
+    assert _innermost_list2tuple(input_filter) == expected
+
+    # Test complex nested structure (OR of ANDs)
+    input_filter = [
+        [["col1", "==", "a"], ["col2", "<", 10]],
+        [["col3", "!=", "b"]],
+    ]
+    expected = [
+        [("col1", "==", "a"), ("col2", "<", 10)],
+        [("col3", "!=", "b")],
+    ]
+    assert _innermost_list2tuple(input_filter) == expected
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        # Simple filter as it would come from YAML
+        pytest.param([["num1", ">", 1]], id="simple_filter"),
+        # Compound filter (OR condition) as it would come from YAML
+        pytest.param([[["num1", ">", 1]], [["num2", "<", 5]]], id="compound_filter"),
+    ],
+)
+def test_dataframe_parquet_with_filters(filters):
+    """Test that parquet files can be read with filters specified in YAML format.
+
+    This ensures that the filter conversion from lists to tuples works correctly
+    in the actual dataframe loading process.
+    """
+
+    @op(ins={"input_df": In(DataFrame)})
+    def return_df(_, input_df):
+        return input_df
+
+    file_name = file_relative_path(__file__, "num.parquet")
+
+    # This should not raise an error about "too many values to unpack"
+    read_result = wrap_op_in_graph_and_execute(
+        return_df,
+        run_config={
+            "ops": {
+                "return_df": {
+                    "inputs": {
+                        "input_df": {"read": {"parquet": {"path": file_name, "filters": filters}}}
+                    }
+                }
+            }
+        },
+        do_input_mapping=False,
+    )
+    assert read_result.success
+    # Verify we got a DataFrame back
+    result_df = read_result.output_value()
+    assert isinstance(result_df, dd.DataFrame)


### PR DESCRIPTION
## Summary

Refresh of outdated community PR: https://github.com/dagster-io/dagster/pull/9081

---

Fixes an issue where Dask parquet filters configured in YAML would fail with `ValueError: too many values to unpack (expected 3)` when using Dask version 2022.4.2 or later.

### Changes

- Fixed bug in `_innermost_list2tuple()` where non-list elements (strings, numbers) were incorrectly being converted to tuples of characters/digits
- Added comprehensive unit tests for the conversion function
- Added integration tests demonstrating the fix works with actual parquet file reading

## Test Plan

All new tests pass:
- `test_innermost_list2tuple`: Unit tests for the conversion function
- `test_dataframe_parquet_with_filters`: Integration tests with actual parquet files

## Changelog

* Fixes an issue where Dask parquet filters configured in YAML would fail with `ValueError: too many values to unpack (expected 3)` when using Dask version 2022.4.2