### PR TITLE
Fix broken tests

### DIFF
--- a/python_modules/automation/setup.py
+++ b/python_modules/automation/setup.py
@@ -32,7 +32,7 @@ setup(
         "virtualenv>=20.27.0",
         "urllib3",
         "watchdog",
-        "deepeval!=3.6.5",
+        "deepeval!=3.6.5,!=3.6.8,!=3.6.9",
     ],
     extras_require={
         "buildkite": [

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/util.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/util.py
@@ -14,7 +14,7 @@ from dagster_cloud_cli.core.pex_builder.platforms import COMPLETE_PLATFORMS
 from dagster_cloud_cli.utils import DEFAULT_PYTHON_VERSION
 
 TARGET_PYTHON_VERSIONS = [
-    version.Version(python_version) for python_version in ["3.9", "3.10", "3.11", "3.12"]
+    version.Version(python_version) for python_version in ["3.9", "3.10", "3.11", "3.12", "3.13"]
 ]
 
 


### PR DESCRIPTION
## Summary & Motivation

A test was failing when run on python 3.13 because it wasn't listed as an available version. The code setting the list of available versions is very old and didn't reflect the fact that we do in fact support 3.13 now.

## How I Tested These Changes

## Changelog

NOCHANGELOG
