### PR TITLE
[ui] Show legacy freshness policy tag on asset overview sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AutomationDetailsSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AutomationDetailsSection.tsx
@@ -1,4 +1,4 @@
-import {Body, Box} from '@dagster-io/ui-components';
+import {Body, Box, Popover, Tag} from '@dagster-io/ui-components';
 import React, {useMemo} from 'react';
 
 import {insitigatorsByType} from '../AssetNodeInstigatorTag';
@@ -69,7 +69,35 @@ export const AutomationDetailsSection = ({
       label: 'Freshness policy',
       children: assetNode ? (
         assetNode?.freshnessPolicy && (
-          <Body>{freshnessPolicyDescription(assetNode.freshnessPolicy)}</Body>
+          <Box flex={{direction: 'column', gap: 12}}>
+            <Popover
+              placement="top"
+              interactionKind="hover"
+              content={
+                <Body>
+                  <Box padding={{vertical: 12, horizontal: 16}} style={{maxWidth: '300px'}}>
+                    This is a legacy freshness policy, and will not appear in observability
+                    features.{' '}
+                    <a
+                      href="https://docs.dagster.io/guides/observe/asset-freshness-policies"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn how to upgrade
+                    </a>{' '}
+                    to use the new freshness policy API.
+                  </Box>
+                </Body>
+              }
+            >
+              <Tag intent="warning" icon="freshness">
+                Legacy freshness policy
+              </Tag>
+            </Popover>
+            <div>
+              <Body>{freshnessPolicyDescription(assetNode.freshnessPolicy)}</Body>
+            </div>
+          </Box>
         )
       ) : (
         <SectionSkeleton />


### PR DESCRIPTION
## Summary & Motivation

Users have been confused by legacy freshness policies appearing in the asset overview sidebar but not in asset health features.

Mark these freshness policies as clearly being legacy, with added details and a link to docs, to hopefully help alleviate that confusion.

<img width="290" height="108" alt="Screenshot 2025-10-29 at 16 15 11" src="https://github.com/user-attachments/assets/f7883645-12f7-4331-920b-d981af96a6b0" />
<img width="325" height="161" alt="Screenshot 2025-10-29 at 16 15 17" src="https://github.com/user-attachments/assets/d84e0817-8132-4139-802f-cd5d9d1f79f2" />

## How I Tested These Changes

Force freshness policy section to appear in sidebar, verify that tag and tooltip render correctly.

## Changelog

[ui] In asset sidebar, clearly indicate when a freshness policy is a legacy policy.