### PR TITLE
Support adding input context with multiple partition keys.

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -486,15 +486,18 @@ class InputContext:
         if self.has_asset_key:
             check.opt_str_param(description, "description")
 
-            observation = AssetObservation(
-                asset_key=self.asset_key,
-                description=description,
-                partition=self.asset_partition_key if self.has_asset_partitions else None,
-                metadata=metadata,
-            )
-            self._observations.append(observation)
-            if self._step_context:
-                self._events.append(DagsterEvent.asset_observation(self._step_context, observation))
+            # Append one observation per asset partition key, or only one without a partition key if there are none.
+            for partition_key in (self.asset_partition_keys or [None]):
+                observation = AssetObservation(
+                    asset_key=self.asset_key,
+                    description=description,
+                    partition=partition_key,
+                    metadata=metadata,
+                )
+
+                self._observations.append(observation)
+                if self._step_context:
+                    self._events.append(DagsterEvent.asset_observation(self._step_context, observation))
 
     def get_observations(
         self,


### PR DESCRIPTION
## Summary & Motivation

I have an upstream asset with partitions in one set, and a downstream asset with partitions in a totally distinct set. The downstream asset uses `AllPartitionMapping` to aggregate all the upstream partitions into one input item that gets loaded and processed out according to the downstream partition scheme.

I am also using an IO manager that invokes `InputContext.add_input_metadata` which began throwing errors when more than one partition was being loaded (i.e., because of `AllPartitionMapping`).

```
dagster_shared.check.functions.CheckError: Failure condition: Tried to access partition key for asset 'AssetKey(['nexus_lens', 'cohorts'])', but the number of input partitions != 1: 'DefaultPartitionsSubset(subset={redacted})'.

Stack Trace:
  File "/Users/michel/Library/Caches/pypoetry/virtualenvs/nexus-lens-Eb6fXjgf-py3.12/lib/python3.12/site-packages/dagster/_core/execution/plan/utils.py", line 57, in op_execution_error_boundary
    yield
  File "/Users/michel/Library/Caches/pypoetry/virtualenvs/nexus-lens-Eb6fXjgf-py3.12/lib/python3.12/site-packages/dagster/_core/execution/plan/inputs.py", line 619, in _load_input_with_input_manager
    value = input_manager.load_input(context)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/michel/Library/Caches/pypoetry/virtualenvs/nexus-lens-Eb6fXjgf-py3.12/lib/python3.12/site-packages/lib_dagster/iceberg/io_manager.py", line 574, in load_input
    context.add_input_metadata(self._metadata(table_snapshot, engine))
  File "/Users/michel/Library/Caches/pypoetry/virtualenvs/nexus-lens-Eb6fXjgf-py3.12/lib/python3.12/site-packages/dagster/_core/execution/context/input.py", line 492, in add_input_metadata
    partition=self.asset_partition_key if self.has_asset_partitions else None,
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/michel/Library/Caches/pypoetry/virtualenvs/nexus-lens-Eb6fXjgf-py3.12/lib/python3.12/site-packages/dagster/_core/execution/context/input.py", line 355, in asset_partition_key
    check.failed(
  File "/Users/michel/Library/Caches/pypoetry/virtualenvs/nexus-lens-Eb6fXjgf-py3.12/lib/python3.12/site-packages/dagster_shared/check/functions.py", line 1712, in failed
    raise CheckError(f"Failure condition: {desc}")
```

This is because `InputContext.add_input_metadata` assumes the upstream asset is only being observed for a single partition. This PR changes that function to instead observe the function once _per_ partition. And in the event that there are no partitions, it observes the asset still once only.

## How I Tested These Changes

Initially I manually modified the library code and ran my asset locally with success. Then, I added unit tests. I tried running the suite locally on my machine using `make dev_install` but it exploded `Too many open files (os error 24)`. Here I go hoping CI runs OK :)