### PR TITLE
[sbc] Update scaffolded github action to use `dg plus deploy refresh-defs-state`

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
@@ -426,7 +426,7 @@ def refresh_defs_state_impl(
     "--management-type",
     multiple=True,
     type=click.Choice(["LOCAL_FILESYSTEM", "VERSIONED_STATE_STORAGE"]),
-    help="Only refresh components with the specified management type. Can be specified multiple times to include multiple types. By default, refreshes only VERSIONED_STATE_STORAGE components.",
+    help="Only refresh components with the specified management type. Can be specified multiple times to include multiple types. By default, refreshes VERSIONED_STATE_STORAGE and LOCAL_FILESYSTEM components.",
 )
 @cli_telemetry_wrapper
 def refresh_defs_state_command(
@@ -448,6 +448,7 @@ def refresh_defs_state_command(
         if management_type
         else {
             DefsStateManagementType.VERSIONED_STATE_STORAGE,
+            DefsStateManagementType.LOCAL_FILESYSTEM,
         }
     )
     refresh_defs_state_impl(

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/hybrid-github-action.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/hybrid-github-action.yaml
@@ -47,6 +47,27 @@ jobs:
           # the base deployment for the branch deployment.
           deployment: "TEMPLATE_DEFAULT_DEPLOYMENT_NAME"
 
+      # Ensure the correct Python version is installed
+      - name: Set up Python ${{ env.PYTHON_VERSION }} for target
+        id: setup-python-version
+        if: steps.prerun.outputs.result != 'skip'
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        if: steps.prerun.outputs.result != 'skip'
+        run: ${{ steps.setup-python-version.outputs.python-path }} -m pip install uv
+        shell: bash
+
+      # Refresh state for any StateBackedComponents in the project
+      - name: Refresh defs state
+        if: steps.prerun.outputs.result != 'skip'
+        run: |
+          cd ${{ env.DAGSTER_PROJECT_DIR }}
+          ${{ steps.setup-python-version.outputs.python-path }} -m uv run dg plus deploy refresh-defs-state
+        shell: bash
+
       # Any value can be used as the docker image tag. It is recommended to use a unique value
       # for each build so that multiple builds do not overwrite each other.
       - name: Generate docker image tag

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-github-action.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-github-action.yaml
@@ -45,15 +45,28 @@ jobs:
           # the base deployment for the branch deployment.
           deployment: "TEMPLATE_DEFAULT_DEPLOYMENT_NAME"
 
-      # If using fast build, build the PEX
-      # First ensure the correct Python version is installed
+      # Ensure the correct Python version is installed
       - name: Set up Python ${{ env.PYTHON_VERSION }} for target
         id: setup-python-version
-        if: steps.prerun.outputs.result == 'pex-deploy'
+        if: steps.prerun.outputs.result != 'skip'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Install uv
+        if: steps.prerun.outputs.result != 'skip'
+        run: ${{ steps.setup-python-version.outputs.python-path }} -m pip install uv
+        shell: bash
+
+      # Refresh state for any StateBackedComponents in the project
+      - name: Refresh defs state
+        if: steps.prerun.outputs.result != 'skip'
+        run: |
+          cd ${{ env.DAGSTER_PROJECT_DIR }}
+          ${{ steps.setup-python-version.outputs.python-path }} -m uv run dg plus deploy refresh-defs-state
+        shell: bash
+
+      # If using fast build, build the PEX
       - name: Install setuptools
         if: steps.prerun.outputs.result == 'pex-deploy'
         run: ${{ steps.setup-python-version.outputs.python-path }} -m pip install setuptools


### PR DESCRIPTION
## Summary & Motivation

Updates the scaffold templates to include commands to refresh defs state. In the process of this, I realized our existing docs were way too complicated because there's really not much use case for doing any def refreshing inside your Dockerfile (you can just do it outside and the copy the state inside). This was a relic of an earlier setup where state was not written to a directory that was accessible in this way.

So updated the docs accordingly

## How I Tested These Changes

Manually in internal.

## Changelog

The github actions scaffolded by `dg scaffold github-actions` now include commands to refresh state for `StateBackedComponents`.
