### PR TITLE
FE-846: Don’t scaffold default config of optional resources in launchpad

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
@@ -1,5 +1,4 @@
 import {useMemo} from 'react';
-import * as yaml from 'yaml';
 
 import {
   CONFIG_EDITOR_GENERATOR_PARTITION_SETS_FRAGMENT,
@@ -11,6 +10,7 @@ import {LaunchpadSessionLoading} from './LaunchpadSessionLoading';
 import {LaunchpadTransientSessionContainer} from './LaunchpadTransientSessionContainer';
 import {LaunchpadType} from './types';
 import {gql, useQuery} from '../apollo-client';
+import {filterDefaultYamlForSubselection} from './configFiltering';
 import {LaunchpadRootQuery, LaunchpadRootQueryVariables} from './types/LaunchpadAllowedRoot.types';
 import {IExecutionSession} from '../app/ExecutionSessionStorage';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
@@ -32,23 +32,6 @@ interface Props {
   sessionPresets?: Partial<IExecutionSession>;
   onSaveConfig?: (config: LaunchpadConfig) => void;
 }
-
-const filterDefaultYamlForSubselection = (defaultYaml: string, opNames: Set<string>): string => {
-  const parsedYaml = yaml.parse(defaultYaml);
-
-  const opsConfig = parsedYaml['ops'];
-  if (opsConfig) {
-    const filteredOpKeys = Object.keys(opsConfig).filter((entry) => {
-      return opNames.has(entry);
-    });
-    const filteredOpsConfig = Object.fromEntries(
-      filteredOpKeys.map((key) => [key, opsConfig[key]]),
-    );
-    parsedYaml['ops'] = filteredOpsConfig;
-  }
-
-  return yaml.stringify(parsedYaml);
-};
 
 export const LaunchpadAllowedRoot = (props: Props) => {
   useTrackPageView();

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadStoredSessionsContainer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadStoredSessionsContainer.tsx
@@ -1,5 +1,8 @@
+import {useMemo} from 'react';
+
 import LaunchpadSession from './LaunchpadSession';
 import {LaunchpadTabs} from './LaunchpadTabs';
+import {filterDefaultYamlOptionalResources} from './configFiltering';
 import {LaunchpadType} from './types';
 import {
   LaunchpadSessionPartitionSetsFragment,
@@ -31,10 +34,19 @@ export const LaunchpadStoredSessionsContainer = (props: Props) => {
     props;
 
   const {flagDisableAutoLoadDefaults} = useFeatureFlags();
+
+  const initialConfigYaml = useMemo(
+    () =>
+      rootDefaultYaml && runConfigSchema
+        ? filterDefaultYamlOptionalResources(rootDefaultYaml, runConfigSchema)
+        : rootDefaultYaml,
+    [rootDefaultYaml, runConfigSchema],
+  );
+
   const initialDataForMode = useInitialDataForMode(
     pipeline,
     partitionSets,
-    rootDefaultYaml,
+    initialConfigYaml,
     !flagDisableAutoLoadDefaults,
   );
   const [data, onSave] = useExecutionSessionStorage(repoAddress, pipeline.name, initialDataForMode);

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTransientSessionContainer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTransientSessionContainer.tsx
@@ -1,6 +1,7 @@
-import {useState} from 'react';
+import {useMemo, useState} from 'react';
 
 import LaunchpadSession, {LaunchpadConfig} from './LaunchpadSession';
+import {filterDefaultYamlOptionalResources} from './configFiltering';
 import {LaunchpadType} from './types';
 import {
   LaunchpadSessionPartitionSetsFragment,
@@ -41,10 +42,19 @@ export const LaunchpadTransientSessionContainer = (props: Props) => {
   } = props;
 
   const {flagDisableAutoLoadDefaults} = useFeatureFlags();
+
+  const initialConfigYaml = useMemo(
+    () =>
+      rootDefaultYaml && runConfigSchema
+        ? filterDefaultYamlOptionalResources(rootDefaultYaml, runConfigSchema)
+        : rootDefaultYaml,
+    [rootDefaultYaml, runConfigSchema],
+  );
+
   const initialData = useInitialDataForMode(
     pipeline,
     partitionSets,
-    rootDefaultYaml,
+    initialConfigYaml,
     !flagDisableAutoLoadDefaults,
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/__tests__/configFiltering.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/__tests__/configFiltering.test.ts
@@ -1,0 +1,286 @@
+import {
+  buildCompositeConfigType,
+  buildConfigTypeField,
+  buildPipelineNotFoundError,
+  buildRunConfigSchema,
+} from '../../graphql/types';
+import {
+  filterDefaultYamlForSubselection,
+  filterDefaultYamlOptionalResources,
+} from '../configFiltering';
+import {LaunchpadRootQuery} from '../types/LaunchpadAllowedRoot.types';
+
+describe('filterDefaultYamlForSubselection', () => {
+  it('filters ops config based on provided op names', () => {
+    const yamlInput = `
+ops:
+  op1:
+    config:
+      value: 1
+  op2:
+    config:
+      value: 2
+  op3:
+    config:
+      value: 3
+resources:
+  db: {}
+`;
+
+    const opNames = new Set(['op1', 'op3']);
+    const result = filterDefaultYamlForSubselection(yamlInput, opNames);
+
+    expect(result).toContain('op1');
+    expect(result).toContain('op3');
+    expect(result).not.toContain('op2');
+    expect(result).toContain('resources');
+    expect(result).toContain('db');
+  });
+
+  it('handles empty op names set', () => {
+    const yamlInput = `
+ops:
+  op1:
+    config:
+      value: 1
+  op2:
+    config:
+      value: 2
+`;
+
+    const opNames = new Set<string>();
+    const result = filterDefaultYamlForSubselection(yamlInput, opNames);
+
+    expect(result).toContain('ops: {}');
+  });
+
+  it('handles yaml without ops section', () => {
+    const yamlInput = `
+resources:
+  db: {}
+execution:
+  multiprocess: {}
+`;
+
+    const opNames = new Set(['op1']);
+    const result = filterDefaultYamlForSubselection(yamlInput, opNames);
+
+    expect(result).toContain('resources');
+    expect(result).toContain('execution');
+    expect(result).not.toContain('ops');
+  });
+
+  it('handles empty yaml', () => {
+    const yamlInput = '{}';
+    const opNames = new Set(['op1']);
+    const result = filterDefaultYamlForSubselection(yamlInput, opNames);
+
+    expect(result.trim()).toBe('{}');
+  });
+});
+
+describe('filterDefaultYamlOptionalResources', () => {
+  const createMockRunConfigSchema = (
+    resourceFields: Array<{name: string; isRequired: boolean}>,
+  ): LaunchpadRootQuery['runConfigSchemaOrError'] =>
+    buildRunConfigSchema({
+      rootDefaultYaml: '',
+      rootConfigType: buildCompositeConfigType({
+        key: 'root-key',
+      }),
+      allConfigTypes: [
+        buildCompositeConfigType({
+          key: 'root-key',
+          description: null,
+          isSelector: false,
+          typeParamKeys: [],
+          fields: [
+            buildConfigTypeField({
+              name: 'resources',
+              description: null,
+              isRequired: false,
+              configTypeKey: 'resources-key',
+              defaultValueAsJson: null,
+            }),
+          ],
+        }),
+        buildCompositeConfigType({
+          key: 'resources-key',
+          description: null,
+          isSelector: false,
+          typeParamKeys: [],
+          fields: resourceFields.map((field) =>
+            buildConfigTypeField({
+              name: field.name,
+              description: null,
+              isRequired: field.isRequired,
+              configTypeKey: 'String',
+              defaultValueAsJson: null,
+            }),
+          ),
+        }),
+      ],
+    });
+
+  it('removes optional resources and keeps required ones', () => {
+    const yamlInput = `
+resources:
+  required_db:
+    host: localhost
+  optional_cache:
+    ttl: 300
+  another_optional:
+    setting: value
+ops:
+  my_op: {}
+`;
+
+    const schema = createMockRunConfigSchema([
+      {name: 'required_db', isRequired: true},
+      {name: 'optional_cache', isRequired: false},
+      {name: 'another_optional', isRequired: false},
+    ]);
+
+    const result = filterDefaultYamlOptionalResources(yamlInput, schema);
+
+    expect(result).toContain('required_db');
+    expect(result).not.toContain('optional_cache');
+    expect(result).not.toContain('another_optional');
+    expect(result).toContain('ops');
+  });
+
+  it('removes entire resources section when no required resources exist', () => {
+    const yamlInput = `
+resources:
+  optional_cache:
+    ttl: 300
+  another_optional:
+    setting: value
+ops:
+  my_op: {}
+`;
+
+    const schema = createMockRunConfigSchema([
+      {name: 'optional_cache', isRequired: false},
+      {name: 'another_optional', isRequired: false},
+    ]);
+
+    const result = filterDefaultYamlOptionalResources(yamlInput, schema);
+
+    expect(result).not.toContain('resources');
+    expect(result).not.toContain('optional_cache');
+    expect(result).not.toContain('another_optional');
+    expect(result).toContain('ops');
+  });
+
+  it('handles yaml without resources section', () => {
+    const yamlInput = `
+ops:
+  my_op: {}
+execution:
+  multiprocess: {}
+`;
+
+    const schema = createMockRunConfigSchema([{name: 'some_resource', isRequired: false}]);
+
+    const result = filterDefaultYamlOptionalResources(yamlInput, schema);
+
+    expect(result).toBe(yamlInput);
+  });
+
+  it('returns original yaml when schema is invalid', () => {
+    const yamlInput = `
+resources:
+  some_resource: {}
+`;
+
+    const invalidSchema: LaunchpadRootQuery['runConfigSchemaOrError'] = buildPipelineNotFoundError({
+      message: 'Pipeline not found',
+    });
+
+    const result = filterDefaultYamlOptionalResources(yamlInput, invalidSchema);
+
+    expect(result).toBe(yamlInput);
+  });
+
+  it('returns original yaml when root config type is not found', () => {
+    const yamlInput = `
+resources:
+  some_resource: {}
+`;
+
+    const schema: LaunchpadRootQuery['runConfigSchemaOrError'] = buildRunConfigSchema({
+      rootDefaultYaml: '',
+      rootConfigType: buildCompositeConfigType({
+        key: 'root-key',
+      }),
+      allConfigTypes: [
+        // Empty array - root config type not found
+      ],
+    });
+
+    const result = filterDefaultYamlOptionalResources(yamlInput, schema);
+
+    expect(result).toBe(yamlInput);
+  });
+
+  it('returns original yaml when resources field is not found in root config', () => {
+    const yamlInput = `
+resources:
+  some_resource: {}
+`;
+
+    const schema: LaunchpadRootQuery['runConfigSchemaOrError'] = buildRunConfigSchema({
+      rootDefaultYaml: '',
+      rootConfigType: buildCompositeConfigType({
+        key: 'root-key',
+      }),
+      allConfigTypes: [
+        buildCompositeConfigType({
+          key: 'root-key',
+          description: null,
+          isSelector: false,
+          typeParamKeys: [],
+          fields: [
+            // No resources field
+            buildConfigTypeField({
+              name: 'ops',
+              description: null,
+              isRequired: true,
+              configTypeKey: 'ops-key',
+              defaultValueAsJson: null,
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const result = filterDefaultYamlOptionalResources(yamlInput, schema);
+
+    expect(result).toBe(yamlInput);
+  });
+
+  it('handles all resources being required', () => {
+    const yamlInput = `
+resources:
+  required_db:
+    host: localhost
+  required_cache:
+    ttl: 300
+ops:
+  my_op: {}
+`;
+
+    const schema = createMockRunConfigSchema([
+      {name: 'required_db', isRequired: true},
+      {name: 'required_cache', isRequired: true},
+    ]);
+
+    const result = filterDefaultYamlOptionalResources(yamlInput, schema);
+
+    expect(result).toContain('required_db');
+    expect(result).toContain('required_cache');
+    expect(result).toContain('resources');
+    expect(result).toContain('ops');
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/configFiltering.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/configFiltering.ts
@@ -1,0 +1,66 @@
+import * as yaml from 'yaml';
+
+import {LaunchpadRootQuery} from './types/LaunchpadAllowedRoot.types';
+
+export const filterDefaultYamlForSubselection = (
+  defaultYaml: string,
+  opNames: Set<string>,
+): string => {
+  const parsedYaml = yaml.parse(defaultYaml);
+
+  const opsConfig = parsedYaml['ops'];
+  if (opsConfig) {
+    const filteredOpKeys = Object.keys(opsConfig).filter((entry) => {
+      return opNames.has(entry);
+    });
+    const filteredOpsConfig = Object.fromEntries(
+      filteredOpKeys.map((key) => [key, opsConfig[key]]),
+    );
+    parsedYaml['ops'] = filteredOpsConfig;
+  }
+
+  return yaml.stringify(parsedYaml);
+};
+
+export const filterDefaultYamlOptionalResources = (
+  defaultYaml: string,
+  runConfigSchema: LaunchpadRootQuery['runConfigSchemaOrError'],
+): string => {
+  if (!runConfigSchema || runConfigSchema.__typename !== 'RunConfigSchema') {
+    return defaultYaml;
+  }
+
+  const parsedYaml = yaml.parse(defaultYaml);
+
+  // Find the root config type to get the structure
+  const rootConfigType = runConfigSchema.allConfigTypes.find(
+    (type) => type.key === runConfigSchema.rootConfigType.key,
+  );
+  if (!rootConfigType || rootConfigType.__typename !== 'CompositeConfigType') {
+    return defaultYaml;
+  }
+
+  const resourcesField = rootConfigType.fields.find((field) => field.name === 'resources');
+  if (!resourcesField || !parsedYaml.resources) {
+    return defaultYaml;
+  }
+  const resourcesConfigType = runConfigSchema.allConfigTypes.find(
+    (type) => type.key === resourcesField.configTypeKey,
+  );
+
+  if (!resourcesConfigType || resourcesConfigType.__typename !== 'CompositeConfigType') {
+    return defaultYaml;
+  }
+  const optionalResources = resourcesConfigType.fields
+    .filter((field) => !field.isRequired)
+    .map((field) => field.name);
+
+  for (const resourceKey of optionalResources) {
+    delete parsedYaml.resources[resourceKey];
+  }
+  if (Object.keys(parsedYaml.resources).length === 0) {
+    delete parsedYaml.resources;
+  }
+
+  return yaml.stringify(parsedYaml);
+};


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/FE-846/hide-resources-from-default-yaml-in-launchpad

## How I Tested These Changes

- Shift-click Materialize on assets where optional resources are present, see that optional resources are no longer scaffolded
- View a job launchpad, see that optional resources are no longer scaffolded.
- Make sure "Scaffold all default config" still adds the config that was omitted

## Changelog

[ui] The launchpad no longer prefills with the config of optional resources. To scaffold optional resource config, click the "Scaffold all default config" button.