### PR TITLE
use has_permission_for_definition instead of has_permission_for_selector in asset queries

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -70,6 +70,7 @@ from dagster_graphql.implementation.fetch_assets import (
 from dagster_graphql.implementation.fetch_partition_subsets import (
     regenerate_and_check_partition_subsets,
 )
+from dagster_graphql.implementation.utils import has_permission_for_definition
 from dagster_graphql.schema import external
 from dagster_graphql.schema.asset_checks import (
     AssetChecksOrErrorUnion,
@@ -566,24 +567,24 @@ class GrapheneAssetNode(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
     ) -> bool:
-        return graphene_info.context.has_permission_for_selector(
-            Permissions.LAUNCH_PIPELINE_EXECUTION, self._asset_node_snap.asset_key
+        return has_permission_for_definition(
+            graphene_info, Permissions.LAUNCH_PIPELINE_EXECUTION, self._remote_node
         )
 
     def resolve_hasWipePermission(
         self,
         graphene_info: ResolveInfo,
     ) -> bool:
-        return graphene_info.context.has_permission_for_selector(
-            Permissions.WIPE_ASSETS, self._asset_node_snap.asset_key
+        return has_permission_for_definition(
+            graphene_info, Permissions.WIPE_ASSETS, self._remote_node
         )
 
     def resolve_hasReportRunlessAssetEventPermission(
         self,
         graphene_info: ResolveInfo,
     ) -> bool:
-        return graphene_info.context.has_permission_for_location(
-            Permissions.REPORT_RUNLESS_ASSET_EVENTS, self._repository_selector.location_name
+        return has_permission_for_definition(
+            graphene_info, Permissions.REPORT_RUNLESS_ASSET_EVENTS, self._remote_node
         )
 
     def resolve_assetMaterializationUsedData(


### PR DESCRIPTION
Summary:
This is faster when you already have the remote node loaded, which we do here.

However, one thing we need to verify is how the frontend combines the results of these permissions for different repositories. This is one where you really only want to check it for the materialiable one if it is present I think?

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
