### PR TITLE
[ui] Fix missing backfill dialog bug

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -212,6 +212,16 @@ export const ASSET_DAILY = buildAssetNode({
   }),
 });
 
+export const PARTITIONED_ASSET_WITH_REQUIRED_CONFIG = buildAssetNode({
+  ...ASSET_DAILY,
+  id: 'test.py.repo.["partitioned_asset_with_required_config"]',
+  opNames: ['partitioned_asset_with_required_config'],
+  assetKey: buildAssetKey({
+    path: ['partitioned_asset_with_required_config'],
+  }),
+  configField: {...BASE_CONFIG_TYPE_FIELD, isRequired: true},
+});
+
 export const ASSET_WEEKLY = buildAssetNode({
   __typename: 'AssetNode',
   id: 'test.py.repo.["asset_weekly"]',
@@ -363,6 +373,36 @@ export const ASSET_DAILY_PARTITION_KEYS_MISSING = without(
     generateDailyTimePartitions(new Date(r.startTime * 1000 - 1), new Date(r.endTime * 1000 - 1)),
   ),
 );
+
+export const PartitionHealthPartitionedAssetWithRequiredConfigMock: MockedResponse<PartitionHealthQuery> =
+  {
+    request: {
+      query: PARTITION_HEALTH_QUERY,
+      variables: {
+        assetKey: {
+          path: ['partitioned_asset_with_required_config'],
+        },
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Query',
+        assetNodeOrError: buildAssetNode({
+          id: 'test.py.repo.["partitioned_asset_with_required_config"]',
+          partitionKeysByDimension: [
+            buildDimensionPartitionKeys({
+              name: 'default',
+              partitionKeys: ASSET_DAILY_PARTITION_KEYS,
+              type: PartitionDefinitionType.TIME_WINDOW,
+            }),
+          ],
+          assetPartitionStatuses: buildTimePartitionStatuses({
+            ranges: PartitionHealthAssetDailyMaterializedRanges,
+          }),
+        }),
+      },
+    },
+  };
 
 export const PartitionHealthAssetWeeklyMock: MockedResponse<PartitionHealthQuery> = {
   request: {
@@ -611,6 +651,7 @@ export const LOADER_RESULTS = [
   ASSET_WEEKLY_ROOT,
   UNPARTITIONED_ASSET,
   UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG,
+  PARTITIONED_ASSET_WITH_REQUIRED_CONFIG,
   UNPARTITIONED_ASSET_OTHER_REPO,
   MULTI_ASSET_OUT_1,
   MULTI_ASSET_OUT_2,
@@ -621,6 +662,7 @@ export const PartitionHealthAssetMocks = [
   PartitionHealthAssetWeeklyRootMock,
   PartitionHealthAssetWeeklyMock,
   PartitionHealthAssetDailyMock,
+  PartitionHealthPartitionedAssetWithRequiredConfigMock,
 ];
 
 export function buildLaunchAssetLoaderMock(

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -31,6 +31,7 @@ import {
   LaunchAssetLoaderResourceMyAssetJobMock,
   MULTI_ASSET_OUT_1,
   MULTI_ASSET_OUT_2,
+  PARTITIONED_ASSET_WITH_REQUIRED_CONFIG,
   PartitionHealthAssetMocks,
   UNPARTITIONED_ASSET,
   UNPARTITIONED_ASSET_OTHER_REPO,
@@ -324,6 +325,18 @@ describe('LaunchAssetExecutionButton', () => {
       renderButton({scope: {all: [ASSET_DAILY]}});
       await clickMaterializeButton();
       await screen.findByTestId('choose-partitions-dialog');
+    });
+
+    it('should show the partition dialog even if asset has required config', async () => {
+      // Regression test for #32043: partitioned assets with config should use backfill flow, not launchpad
+      renderButton({
+        scope: {all: [PARTITIONED_ASSET_WITH_REQUIRED_CONFIG]},
+        preferredJobName: undefined,
+      });
+      await clickMaterializeButton();
+      await screen.findByTestId('choose-partitions-dialog');
+      // Should NOT show launchpad
+      expect(screen.queryByText('Launchpad (configure assets)')).not.toBeInTheDocument();
     });
 
     it('should launch single runs using the job in context if specified', async () => {


### PR DESCRIPTION
## Summary & Motivation

Fixed a bug where partitioned assets with required config would incorrectly show the launchpad instead of the backfill flow. The code now ensures that all partitioned assets use the backfill flow regardless of their config requirements, which is the correct behavior. The launchpad is accessible from the backfill dialog.

## How I Tested These Changes

Added a new test fixture `PARTITIONED_ASSET_WITH_REQUIRED_CONFIG` and a corresponding test case that verifies partitioned assets with required config properly show the partition dialog instead of the launchpad.

## Changelog

[ui] Fixed a bug where partitioned assets with required config would incorrectly show the launchpad instead of the backfill flow.