### PR TITLE
[ui] Fix issue with supplying config to backfills that target asset checks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -389,7 +389,14 @@ const LaunchpadSession = (props: LaunchpadSessionProps) => {
         query: PREVIEW_CONFIG_QUERY,
         variables: {
           runConfigData: configYamlOrEmpty,
-          pipeline: pipelineSelector,
+          // for backfills (which have onSaveConfig set), asset checks are not explicitly
+          // selected, so we pass in null to align with the backfill daemon implementation
+          pipeline: props.onSaveConfig
+            ? {
+                ...pipelineSelector,
+                assetCheckSelection: null,
+              }
+            : pipelineSelector,
           mode: currentSession.mode || 'default',
         },
       });
@@ -418,6 +425,7 @@ const LaunchpadSession = (props: LaunchpadSessionProps) => {
       rootDefaultYaml,
       state.previewLoading,
       state.previewDefaultsToExpand,
+      props.onSaveConfig,
     ],
   );
 


### PR DESCRIPTION
## Summary & Motivation

Repro: attempt to launch a backfill for these assets and add run config.

```python
import dagster as dg


class MyConfig(dg.Config):
    foo: str


@dg.asset(
    check_specs=[
        dg.AssetCheckSpec(
            name="test_check",
            asset=dg.AssetKey("test_asset"),
            description="Test check",
        )
    ],
    partitions_def=dg.StaticPartitionsDefinition(["a", "b"]),
)
def test_asset(config: MyConfig):
    return dg.MaterializeResult(
        check_results=[
            dg.AssetCheckResult(
                check_name="test_check",
                metadata={"foo": config.foo},
                passed=True,
            )
        ]
    )


@dg.asset(
    deps=[test_asset],
    partitions_def=dg.StaticPartitionsDefinition(["a", "b", "c"]),
)
def test_asset_2(config: MyConfig): ...
```

## How I Tested These Changes

## Changelog

Fixed a bug that would cause errors when attempting to supply config to a backfill that targeted assets with checks.
