### PR TITLE
[docs] use --group argument and add admonition to pip install -e docs

### DIFF
--- a/docs/docs/dagster-basics-tutorial/0-projects.md
+++ b/docs/docs/dagster-basics-tutorial/0-projects.md
@@ -4,7 +4,9 @@ description: The Dagster project
 sidebar_position: 10
 ---
 
-Dagster follows standard Python conventions, and most work in Dagster begins by creating a Python package called a [project](/guides/build/projects). This is where you’ll define your pipelines, as well as any dependencies within your project.
+import PipInstallEditable from '@site/docs/partials/_PipInstallEditable.md';
+
+Dagster follows standard Python conventions, and most work in Dagster begins by creating a Python package called a [project](/guides/build/projects). This is where you'll define your pipelines, as well as any dependencies within your project.
 
 To streamline project creation, Dagster provides the [`create-dagster` CLI](/api/clis/create-dagster), which quickly scaffolds a Python package containing a Dagster `Definitions` object. When you scaffold the project, the `Definitions` object will not contain any other Dagster objects.
 
@@ -81,9 +83,7 @@ To streamline project creation, Dagster provides the [`create-dagster` CLI](/api
 
       4. Install your project as an editable package:
 
-         ```shell
-         pip install --editable .
-         ```
+         <PipInstallEditable />
 
    </TabItem>
 </Tabs>

--- a/docs/docs/getting-started/quickstart-serverless.md
+++ b/docs/docs/getting-started/quickstart-serverless.md
@@ -5,6 +5,7 @@ description: Iterate on, test, and deploy your first Dagster+ Serverless pipelin
 ---
 
 import InstallUv from '@site/docs/partials/\_InstallUv.md';
+import PipInstallEditable from '@site/docs/partials/_PipInstallEditable.md';
 
 Welcome to Dagster+ Serverless! In this guide, we'll cover developing and testing your Dagster project locally, using branch deployments to safely test against production data, and finally, pushing your changes to production.
 
@@ -95,9 +96,7 @@ If you will be using `uv` as your package manager, follow the steps below to ins
 
       3. Install your project as an editable package:
 
-         ```shell
-         pip install --editable .
-         ```
+         <PipInstallEditable />
 
    </TabItem>
 </Tabs>

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -4,6 +4,8 @@ description: Learn how to set up a Dagster environment, create a project, define
 sidebar_label: Quickstart (Dagster+ Hybrid and OSS)
 ---
 
+import PipInstallEditable from '@site/docs/partials/_PipInstallEditable.md';
+
 Welcome to Dagster! In this guide, we'll cover:
 
 - Setting up a basic Dagster project using Dagster OSS for local development
@@ -110,9 +112,7 @@ For detailed instructions, see the [Installation guide](/getting-started/install
 
       5. Install your project as an editable package:
 
-         ```shell
-         pip install --editable .
-         ```
+         <PipInstallEditable />
 
    </TabItem>
 </Tabs>

--- a/docs/docs/partials/_PipInstallEditable.md
+++ b/docs/docs/partials/_PipInstallEditable.md
@@ -1,0 +1,9 @@
+```shell
+pip install --editable . --group dev
+```
+
+:::note
+
+The `--group` argument is only available in pip versions 25.1 and higher. If you have an older version of pip, you can upgrade it with `pip install --upgrade pip` or omit the `--group dev` flag.
+
+:::


### PR DESCRIPTION
## Summary & Motivation

I was going through the dagster tutorial today, and the commands to install the dev dependencies doesn't work for pip using our current pyproject.toml dependency-group of dev (basically, pip install --editable . doesn't work because it doesn't install dagster-webserver and dagster-dg-cli

I also created a partial for this since we use it in 3 places.

## How I Tested These Changes

`yarn start` + 👀  and buildkite

