### PR TITLE
[k8s] parameterize wait timeout in k8s pipe client

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -451,7 +451,7 @@ class PipesK8sClient(PipesClient, TreatAsResourceParam):
         base_pod_spec: Optional[Mapping[str, Any]] = None,
         ignore_containers: Optional[set] = None,
         enable_multi_container_logs: bool = False,
-        wait_pod_terminate_timeout: float = DEFAULT_WAIT_TIMEOUT,
+        pod_wait_timeout: float = DEFAULT_WAIT_TIMEOUT,
     ) -> PipesClientCompletedInvocation:
         """Publish a kubernetes pod and wait for it to complete, enriched with the pipes protocol.
 
@@ -487,8 +487,8 @@ class PipesK8sClient(PipesClient, TreatAsResourceParam):
             ignore_containers (Optional[Set]): Ignore certain containers from waiting for termination. Defaults to
                 None.
             enable_multi_container_logs (bool): Whether or not to enable multi-container log consumption.
-            wait_pod_terminate_timeout (float): How long to wait for the pod to terminate before raising an exception.
-                Defaults to DEFAULT_WAIT_TIMEOUT. Set to 0 to disable.
+            pod_wait_timeout (float): How long to wait for the pod to terminate before raising an exception.
+                Defaults to 24h. Set to 0 to disable.
 
         Returns:
             PipesClientCompletedInvocation: Wrapper containing results reported by the external
@@ -535,7 +535,7 @@ class PipesK8sClient(PipesClient, TreatAsResourceParam):
                         wait_for_state=WaitForPodState.Terminated,
                         ignore_containers=ignore_containers,
                         wait_time_between_attempts=self.poll_interval,
-                        wait_timeout=wait_pod_terminate_timeout,
+                        wait_timeout=pod_wait_timeout,
                     )
             finally:
                 client.core_api.delete_namespaced_pod(pod_name, namespace)


### PR DESCRIPTION
## Summary & Motivation
After setting timeouts in my k8s jobs spec, those aren't respected on the dagster wait side. So the k8s pipe client at this point will always kill jobs at 24hrs without a way to override or modify this behavior. Currently, I inherit the behavior of the underlying wait api. Debatably, this should be either be hard set to 0 or overridable and default to 0. The amount of toggles we have for workload timeouts is pretty confusing and this layer in dagster just adds to that confusion. I think everyone will agree that hard killing after 24hrs without notifying the user explicitly ahead of time or giving a way to override is pretty confusing especially to new users trying out pipes for the first time. 

The current behavior preserves the default behavior, but make it overridable.

## How I Tested These Changes
TBD. I want to first gather feedback on a what we'd like the default behavior to be. In fact, I think we should parameterize all Dagster based wait timeouts (launch_timeout, terminate_timeout, and poll_rate). Maybe parameterize it as a `TimeoutConfig` parameter.  

On our local deployment, I inherited and overrode the run method with an extra param. It seems to work well. 
## Changelog
  - Feature: parameterize k8s terminate wait timeout in K8sPipeClient

