### PR TITLE
Add basic validation to PEX build directory path

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/deps.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/deps.py
@@ -109,7 +109,7 @@ def collect_requirements(code_directory, python_interpreter: str) -> tuple[list[
 
     if not any(os.path.exists(os.path.join(code_directory, file)) for file in required_files):
         raise Exception(
-            f"Could not find a setup.py, requirements.txt, or pyproject.toml in build directory{os.path.abspath(code_directory)}."
+            f"Could not find a setup.py, requirements.txt, or pyproject.toml in build directory {os.path.abspath(code_directory)}."
         )
 
     # traverse all local packages and return the list of local packages and other requirements


### PR DESCRIPTION
Summary:
Instead of a cryptic 'no dagster dependency found' error if you point at a non-existant build folder or one without one of the needed files, raise a clear exception.

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
