### PR TITLE
[dagster] Add `FreshnessResultCondition` AutomationCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -18,6 +18,7 @@ from dagster._core.asset_graph_view.serializable_entity_subset import Serializab
 from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey, EntityKey, T_EntityKey
 from dagster._core.definitions.assets.graph.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.freshness import FreshnessState
 from dagster._core.definitions.partitions.context import (
     PartitionLoadingContext,
     use_partition_loading_context,
@@ -557,6 +558,26 @@ class AssetGraphView(LoadingContext):
             else None
         )
         if resolved_status == status:
+            return self.get_full_subset(key=key)
+        else:
+            return self.get_empty_subset(key=key)
+
+    async def compute_subset_with_freshness_state(
+        self, key: AssetKey, state: FreshnessState
+    ) -> EntitySubset[AssetKey]:
+        from dagster._core.definitions.asset_health.asset_freshness_health import (
+            AssetFreshnessHealthState,
+        )
+
+        if not self.asset_graph.has(key) or self.asset_graph.get(key).freshness_policy is None:
+            if state == FreshnessState.NOT_APPLICABLE:
+                return self.get_full_subset(key=key)
+            else:
+                return self.get_empty_subset(key=key)
+
+        asset_freshness_health_state = await AssetFreshnessHealthState.compute_for_asset(key, self)
+
+        if asset_freshness_health_state.freshness_state == state:
             return self.get_full_subset(key=key)
         else:
             return self.get_empty_subset(key=key)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -28,6 +28,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     get_serializable_candidate_subset,
     get_serializable_true_subset,
 )
+from dagster._core.definitions.freshness import FreshnessState
 from dagster._core.definitions.partitions.subset import (
     AllPartitionsSubset,
     TimeWindowPartitionsSubset,
@@ -648,6 +649,36 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
             f"Invalid cron schedule: {cron_schedule}",
         )
         return CronTickPassedCondition(cron_schedule=cron_schedule, cron_timezone=cron_timezone)
+
+    @public
+    @staticmethod
+    def freshness_passed() -> "BuiltinAutomationCondition[AssetKey]":
+        """Returns an AutomationCondition that is true if the target's freshness is PASS."""
+        from dagster._core.definitions.declarative_automation.operands import (
+            FreshnessResultCondition,
+        )
+
+        return FreshnessResultCondition(state=FreshnessState.PASS).with_label("freshness_passed")
+
+    @public
+    @staticmethod
+    def freshness_warned() -> "BuiltinAutomationCondition[AssetKey]":
+        """Returns an AutomationCondition that is true if the target's freshness is WARN."""
+        from dagster._core.definitions.declarative_automation.operands import (
+            FreshnessResultCondition,
+        )
+
+        return FreshnessResultCondition(state=FreshnessState.WARN).with_label("freshness_warned")
+
+    @public
+    @staticmethod
+    def freshness_failed() -> "BuiltinAutomationCondition[AssetKey]":
+        """Returns an AutomationCondition that is true if the target's freshness is FAIL."""
+        from dagster._core.definitions.declarative_automation.operands import (
+            FreshnessResultCondition,
+        )
+
+        return FreshnessResultCondition(state=FreshnessState.FAIL).with_label("freshness_failed")
 
     @public
     @staticmethod

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/__init__.py
@@ -4,6 +4,7 @@ from dagster._core.definitions.declarative_automation.operands.operands import (
     CodeVersionChangedCondition as CodeVersionChangedCondition,
     CronTickPassedCondition as CronTickPassedCondition,
     ExecutionFailedAutomationCondition as ExecutionFailedAutomationCondition,
+    FreshnessResultCondition as FreshnessResultCondition,
     InitialEvaluationCondition as InitialEvaluationCondition,
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
     MissingAutomationCondition as MissingAutomationCondition,

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_freshness_result_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_freshness_result_condition.py
@@ -1,0 +1,170 @@
+from collections.abc import Sequence
+from datetime import timedelta
+
+import dagster as dg
+import pytest
+from dagster import AssetKey, AutomationCondition, DagsterInstance
+from dagster._core.definitions.freshness import (
+    FreshnessPolicy,
+    FreshnessState,
+    FreshnessStateChange,
+)
+from dagster._time import get_current_timestamp
+from dagster_shared.check import ParameterCheckError
+
+
+class TestFreshnessResultCondition:
+    instance: DagsterInstance
+    __state_cache: dict[AssetKey, FreshnessState]
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        self.instance = DagsterInstance.ephemeral()
+        self.__state_cache = {}
+        yield
+        self.instance = None  # pyright: ignore[reportAttributeAccessIssue]
+        self.__state_cache = {}
+
+    def report_freshness_state(self, key: AssetKey, state: FreshnessState) -> None:
+        self.instance.report_runless_asset_event(
+            asset_event=FreshnessStateChange(
+                key=key,
+                previous_state=self.__state_cache.get(key, FreshnessState.UNKNOWN),
+                new_state=state,
+                state_change_timestamp=get_current_timestamp(),
+            )
+        )
+        self.__state_cache[key] = state
+
+    @pytest.mark.parametrize(
+        ["automation_condition", "synth_events", "expected_requested"],
+        [
+            pytest.param(
+                automation_condition,
+                synth_events,
+                expected_requested,
+                id=f"{automation_condition.name}-{[e.value for e in synth_events]}-{expected_requested}",
+            )
+            for automation_condition, synth_events, expected_requested in [
+                (AutomationCondition.freshness_passed(), [FreshnessState.PASS], 1),
+                (AutomationCondition.freshness_passed(), [FreshnessState.WARN], 0),
+                (AutomationCondition.freshness_passed(), [FreshnessState.FAIL], 0),
+                (AutomationCondition.freshness_passed(), [FreshnessState.UNKNOWN], 0),
+                (AutomationCondition.freshness_passed(), [FreshnessState.NOT_APPLICABLE], 0),
+                (
+                    AutomationCondition.freshness_passed(),
+                    [FreshnessState.NOT_APPLICABLE, FreshnessState.UNKNOWN, FreshnessState.PASS],
+                    1,
+                ),
+                (
+                    AutomationCondition.freshness_passed(),
+                    [FreshnessState.PASS, FreshnessState.FAIL, FreshnessState.PASS],
+                    1,
+                ),
+                (
+                    AutomationCondition.freshness_passed(),
+                    [FreshnessState.PASS, FreshnessState.WARN, FreshnessState.FAIL],
+                    0,
+                ),
+                (AutomationCondition.freshness_passed(), [FreshnessState.NOT_APPLICABLE], 0),
+                (AutomationCondition.freshness_warned(), [FreshnessState.PASS], 0),
+                (AutomationCondition.freshness_warned(), [FreshnessState.WARN], 1),
+                (AutomationCondition.freshness_warned(), [FreshnessState.FAIL], 0),
+                (AutomationCondition.freshness_warned(), [FreshnessState.UNKNOWN], 0),
+                (AutomationCondition.freshness_warned(), [FreshnessState.NOT_APPLICABLE], 0),
+                (
+                    AutomationCondition.freshness_warned(),
+                    [FreshnessState.NOT_APPLICABLE, FreshnessState.UNKNOWN, FreshnessState.WARN],
+                    1,
+                ),
+                (
+                    AutomationCondition.freshness_warned(),
+                    [FreshnessState.PASS, FreshnessState.FAIL, FreshnessState.WARN],
+                    1,
+                ),
+                (
+                    AutomationCondition.freshness_warned(),
+                    [FreshnessState.PASS, FreshnessState.WARN, FreshnessState.FAIL],
+                    0,
+                ),
+                (AutomationCondition.freshness_failed(), [FreshnessState.PASS], 0),
+                (AutomationCondition.freshness_failed(), [FreshnessState.WARN], 0),
+                (AutomationCondition.freshness_failed(), [FreshnessState.FAIL], 1),
+                (AutomationCondition.freshness_failed(), [FreshnessState.UNKNOWN], 0),
+                (AutomationCondition.freshness_failed(), [FreshnessState.NOT_APPLICABLE], 0),
+                (
+                    AutomationCondition.freshness_failed(),
+                    [FreshnessState.NOT_APPLICABLE, FreshnessState.UNKNOWN, FreshnessState.FAIL],
+                    1,
+                ),
+                (
+                    AutomationCondition.freshness_failed(),
+                    [FreshnessState.FAIL, FreshnessState.WARN, FreshnessState.FAIL],
+                    1,
+                ),
+                (
+                    AutomationCondition.freshness_failed(),
+                    [FreshnessState.WARN, FreshnessState.FAIL, FreshnessState.PASS],
+                    0,
+                ),
+            ]
+        ],
+    )
+    def test_freshness_status_condition(
+        self,
+        automation_condition: AutomationCondition,
+        synth_events: Sequence[FreshnessState],
+        expected_requested: int,
+    ) -> None:
+        @dg.asset(
+            freshness_policy=FreshnessPolicy.time_window(
+                fail_window=timedelta(seconds=1, minutes=2, hours=3)
+            ),
+            automation_condition=automation_condition,
+        )
+        def _asset() -> None: ...
+
+        # no change events - should not request
+        result = dg.evaluate_automation_conditions(defs=[_asset], instance=self.instance)
+        assert result.total_requested == 0
+
+        for state in synth_events:
+            self.report_freshness_state(_asset.key, state)
+
+        # should request based on the last event
+        result = dg.evaluate_automation_conditions(defs=[_asset], instance=self.instance)
+        assert result.total_requested == expected_requested
+
+        # should not change if we re-evaluate
+        result = dg.evaluate_automation_conditions(defs=[_asset], instance=self.instance)
+        assert result.total_requested == expected_requested
+
+    @pytest.mark.parametrize(
+        "automation_condition",
+        [
+            AutomationCondition.freshness_passed(),
+            AutomationCondition.freshness_warned(),
+            AutomationCondition.freshness_failed(),
+        ],
+        ids=["freshness_passed", "freshness_warned", "freshness_failed"],
+    )
+    def test_freshness_result_condition_no_freshness_policy(
+        self, automation_condition: AutomationCondition
+    ) -> None:
+        @dg.asset(
+            freshness_policy=None,
+            automation_condition=automation_condition,
+        )
+        def _asset() -> None: ...
+
+        # no freshness policy - should not request
+        result = dg.evaluate_automation_conditions(defs=[_asset], instance=self.instance)
+        assert result.total_requested == 0
+
+    def test_freshness_result_condition_invalid_state_param(self) -> None:
+        with pytest.raises(ParameterCheckError):
+            from dagster._core.definitions.declarative_automation.operands import (
+                FreshnessResultCondition,
+            )
+
+            FreshnessResultCondition(state="Fresh")  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
## Summary & Motivation

Add a AutomationCondition for evaluating Freshness State of an asset

## How I Tested These Changes

Test suite added - please let me know if I'm missing any edge cases

## Changelog

> [dagster] New AutomationConditions for checking asset freshness - `dg.AutomationCondition.freshness_passed()`, `dg.AutomationCondition.freshness_warned()` and `dg.AutomationCondition.freshness_failed()`.
