### PR TITLE
Include ChunkedEncodingError in the set of exceptions that the graphql client retries on

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/graphql_client.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/graphql_client.py
@@ -10,6 +10,7 @@ import requests
 from dagster_shared import check
 from requests.adapters import HTTPAdapter
 from requests.exceptions import (
+    ChunkedEncodingError,
     ConnectionError as RequestsConnectionError,
     HTTPError,
     ReadTimeout as RequestsReadTimeout,
@@ -148,17 +149,17 @@ def _retry_loop(
     while True:
         try:
             return execute_retry()
-        except (HTTPError, RequestsConnectionError, RequestsReadTimeout) as e:
+        except (HTTPError, RequestsConnectionError, RequestsReadTimeout, ChunkedEncodingError) as e:
             retryable_error = False
             if isinstance(e, HTTPError):
                 retryable_error = e.response.status_code in RETRY_STATUS_CODES
                 error_msg = e.response.status_code
                 requested_sleep_time = _get_retry_after_sleep_time(e.response.headers)
-            elif isinstance(e, RequestsReadTimeout):
-                retryable_error = retry_on_read_timeout
+            elif isinstance(e, RequestsConnectionError):
+                retryable_error = True
                 error_msg = str(e)
             else:
-                retryable_error = True
+                retryable_error = retry_on_read_timeout
                 error_msg = str(e)
 
             error_msg_set.add(error_msg)


### PR DESCRIPTION
## Summary & Motivation
In appears in certain rare situations / network configurations its possible for a hybrid agent to encounter this network error. We should retry on these like other requests errors. Maybe there is some base class we should be catching here instead?

## Test Plan:
BK

##
[dagster-cloud] The Dagster+ Agent will now retry network requests that receive a ChunkedEncodingError.