### PR TITLE
Fix: Preserve and apply default_factory for dataclasses and Pydantic models in resolvable 

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -17,7 +17,12 @@ from typing import (
 )
 
 import yaml
-from dagster_shared.record import get_record_annotations, get_record_defaults, is_record, record
+from dagster_shared.record import (
+    get_record_annotations,
+    get_record_defaults,
+    is_record,
+    record,
+)
 from dagster_shared.utils import safe_is_subclass
 from dagster_shared.yaml_utils import try_parse_yaml_with_source_position
 from pydantic import BaseModel, PydanticSchemaGenerationError, create_model
@@ -29,6 +34,13 @@ from dagster._utils.pydantic_yaml import _parse_and_populate_model_with_annotate
 from dagster.components.resolved.context import ResolutionContext
 from dagster.components.resolved.errors import ResolutionException
 from dagster.components.resolved.model import Model, Resolver
+
+
+try:
+    # this type only exists in python 3.10+
+    from types import UnionType  # type: ignore
+except ImportError:
+    UnionType = Union
 
 
 class _TypeContainer(Enum):
@@ -193,7 +205,9 @@ def derive_model_type(
 
             # Prefer a default_factory present (from pydantic field_info or from Annotation info (for dataclasses))
             factory = (
-                annotation_info.field_info.default_factory if annotation_info.field_info else None
+                annotation_info.field_info.default_factory
+                if annotation_info.field_info
+                else None
             ) or annotation_info.default_factory
 
             if annotation_info.has_default:
@@ -205,7 +219,8 @@ def derive_model_type(
 
                 default_value = (
                     annotation_info.default
-                    if type(annotation_info.default) in {int, float, str, bool, type(None)}
+                    if type(annotation_info.default)
+                    in {int, float, str, bool, type(None)}
                     else _Unset
                 )
                 # We want the derived Pydantic model to materialize a value even if the user omits the field
@@ -245,7 +260,9 @@ def derive_model_type(
                 **model_fields,
             )
         except PydanticSchemaGenerationError as e:
-            raise ResolutionException(f"Unable to derive Model for {target_type}") from e
+            raise ResolutionException(
+                f"Unable to derive Model for {target_type}"
+            ) from e
 
     return _DERIVED_MODEL_REGISTRY[target_type]
 
@@ -274,14 +291,18 @@ def _is_implicitly_resolved_type(annotation):
     ):
         return True
 
-    if origin is Literal and all(_is_implicitly_resolved_type(type(arg)) for arg in args):
+    if origin is Literal and all(
+        _is_implicitly_resolved_type(type(arg)) for arg in args
+    ):
         return True
 
     return False
 
 
 def _is_resolvable_type(annotation):
-    return _is_implicitly_resolved_type(annotation) or safe_is_subclass(annotation, Resolvable)
+    return _is_implicitly_resolved_type(annotation) or safe_is_subclass(
+        annotation, Resolvable
+    )
 
 
 @record
@@ -403,7 +424,10 @@ def resolve_fields(
         fname
         for fname, info in _get_annotations(resolved_cls).items()
         if (
-            (info.field_info is not None and info.field_info.default_factory is not None)
+            (
+                info.field_info is not None
+                and info.field_info.default_factory is not None
+            )
             or (getattr(info, "default_factory", None) is not None)
         )
     }
@@ -415,7 +439,9 @@ def resolve_fields(
         model_field_name = resolver.model_field_name or field_name
 
         # include if explicity set Or it had a default_factory
-        should_include = (model_field_name in dumped) or (field_name in fields_with_factory)
+        should_include = (model_field_name in dumped) or (
+            field_name in fields_with_factory
+        )
         if not should_include:
             continue
 
@@ -423,7 +449,9 @@ def resolve_fields(
         if value == _Unset:
             continue
 
-        out[field_name] = resolver.execute(context=context, model=model, field_name=field_name)
+        out[field_name] = resolver.execute(
+            context=context, model=model, field_name=field_name
+        )
     return {alias_name_by_field_name[k]: v for k, v in out.items()}
 
 
@@ -575,7 +603,10 @@ def _zero_arg_callable(fn: Any) -> bool:
         # If any parameter (positional or keyword-only) is required (no default),
         # then the callable is not a zero-arg callable.
         for p in sig.parameters.values():
-            if p.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            if p.kind in (
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            ):
                 # *args/**kwargs don't introduce required positional params by themselves
                 continue
             if p.default is inspect.Parameter.empty and p.kind in (
@@ -602,7 +633,11 @@ def _resolve_at_path(
     container = container_path[0]
     inner_path = container_path[1:]
     if container is _TypeContainer.OPTIONAL:
-        return _resolve_at_path(context, value, inner_path, resolver) if value is not None else None
+        return (
+            _resolve_at_path(context, value, inner_path, resolver)
+            if value is not None
+            else None
+        )
     elif container is _TypeContainer.SEQUENCE:
         return [
             _resolve_at_path(context.at_path(idx), i, inner_path, resolver)

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
+
 from typing import Annotated, Any, Literal, NamedTuple, Optional, Union
 
 import dagster as dg
@@ -10,6 +11,12 @@ from dagster.components.resolved.errors import ResolutionException
 from dagster.components.resolved.model import Resolver
 from dagster_shared.record import record
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+
+try:
+    from typing import TypeAlias
+except Exception:
+    from typing_extensions import TypeAlias
 
 
 def test_basic():
@@ -601,7 +608,9 @@ def test_plain_named_tuple():
         thing: OuterWrapper
 
     # or indirectly
-    with pytest.raises(ResolutionException, match="Wrapper includes incompatible field\n  nt:"):
+    with pytest.raises(
+        ResolutionException, match="Wrapper includes incompatible field\n  nt:"
+    ):
         Outer.model()
 
 
@@ -637,7 +646,9 @@ class Foo:
     name: str
 
 
-ResolvedFoo: TypeAlias = Annotated[Foo, dg.Resolver(lambda _, v: Foo(name=v), model_field_type=str)]
+ResolvedFoo: TypeAlias = Annotated[
+    Foo, dg.Resolver(lambda _, v: Foo(name=v), model_field_type=str)
+]
 
 
 def test_containers():
@@ -738,4 +749,6 @@ def test_dicts():
         thing: dict[int, Inner]
 
     with pytest.raises(ResolutionException, match="dict key type must be str"):
-        BadHasDict.resolve_from_dict({"thing": {"a": {"name": "a", "value": {"key": "a"}}}})
+        BadHasDict.resolve_from_dict(
+            {"thing": {"a": {"name": "a", "value": {"key": "a"}}}}
+        )


### PR DESCRIPTION
## Summary & Motivation
Fixes #31937 

This PR fixes an issue where fields assigned with default_factory (ex. Field(default_factory=dict) or Field(default_factory=list)) lost their factory information when a resolvable class was resolved from YAML or directly from a Pydantic model. This issue was filed through CodeDay as a GitHub issue, **'[components] default_factory cannot be used under certain conditions '.**

### Background
Previously, `derive_model_type()` in `base.py` would assign all non-primitive defaults with `_Unset`, including the valid `default_factory` callables.  This caused the omitted YAML fields like dict or list to not materialize at the final object instantiation. 

### The fix
This fix ensures that `AnnotationInfo` holds information for `default_factory` for dataclasses and Pydantic models. Now, `derive_model_type()` has an updated if-statement that appends the `default_factory` information to field_infos if it is valid.  `resolve_fields` now checks if there are any `default_factory` set and handles them correctly.  `def _zero_arg_callable(fn: Any)` was added to check whether `default_factory` inserted contains no arguments. 


## How I Tested These Changes

- Added test for dataclasses and Pydantic models in `test_resolved.py`  under `def test_default_factory_dict()` (line 350-380).
- Verified that omitted YAML fields actually receive the intended `default_factory` set. class `DefaultFactoryDictTestComponent(dg.Component, dg.Model, dg.Resolvable)` (371-380), creates a test case very similar to the one given in the GitHub issue that checks for the model creation and field creation with an empty dict. 
- Ran all the test cases included in the file `test_resolved.py` to ensure previous behavior was not affected.

## Changelog

### Changes in base.py -> python_modules\dagster\dagster\components\resolved\base.py
- Added `default_factory` field to `AnnotationInfo`.
- `_get_annotations()` now captures factories for dataclasses and Pydantic models.
- `derive_model_type()` now uses `(Field(default_factory=...)` when applicable.
- `resolve_fields()` now includes the `default_factory` fields even when hidden by `exclude_unset=True`.
- Added `_zero_arg_callable()` as helper to ensure `default_factories` passed contained no arguments and were valid
### Changes in -> python_modules\dagster\dagster_tests\components_tests\resolution_tests\test_resolved.py
- Test cases were added to `test_resolved.py` in `def test_default_factory_dict():` as described above to test dataclass instantiation with `default_factory` as well as Pydantic Models with `default_factory`. 
