### PR TITLE
Migrate SqlComponent to Pydantic v2 model_config pattern

### DIFF
--- a/python_modules/dagster/dagster/components/lib/sql_component/sql_component.py
+++ b/python_modules/dagster/dagster/components/lib/sql_component/sql_component.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Annotated, Any, Optional, Union
 
 from dagster_shared import check
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from dagster._annotations import preview, public
 from dagster._core.definitions.result import MaterializeResult
@@ -24,9 +24,8 @@ class SqlComponent(ExecutableComponent, ABC):
     implement instructions on where to load the SQL content from.
     """
 
-    class Config:
-        # Necessary to allow connection to be a SQLClient, which is an ABC
-        arbitrary_types_allowed = True
+    # Necessary to allow connection to be a SQLClient, which is an ABC
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     connection: Annotated[
         Annotated[


### PR DESCRIPTION
## Summary & Motivation
Dagster components use class-based config which is deprecated in Pydantic v2.
Instead of having a filterwarning in our project let's do a contribution.
This follows the official Pydantic v2 migration guide and eliminates the deprecation warning when running pytest.

This tackle : https://github.com/dagster-io/dagster/issues/18296

## How I Tested These Changes
Running the whole test suite

## Changelog
Migrate SqlComponent to Pydantic v2 model_config pattern
