### PR TITLE
easy: add per-asset permissions ui for wipe mutations

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -48,6 +48,7 @@
   "FreshnessEvaluationEnabledQuery": "db79450d1d49690ab8e4b843490dbb3b83b7349c2334c619e80e597089cc9d57",
   "FreshnessStatusQuery": "3bb87b020443a031d2b0786e007d175d474896b5ad8b7b06f6f9c4de51b21594",
   "AssetRecordsQuery": "1778f6a11acc440983fcf6b6156518b3113c7fa29127130bb30a3e0140807575",
+  "AssetPermissionsQuery": "ff8b09ce270b20e67a0b552f66238f6705e12b79fdbff05b24a8dc3dcbf53ef0",
   "GetAutoMaterializePausedQuery": "50f74183f54031274136ab855701d01f26642a6d958d7452ae13aa6c40ca349d",
   "SetAutoMaterializePausedMutation": "144afc0d6f43dfa6d437c0e7f621e4f19ffb48c7f75669d2e3d742c115aa7b4b",
   "AssetOverviewMetadataEventsQuery": "114f8107c50306b1a96275b011beacf8b6422c88e387f479da4d0a45c4a08cca",

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useAssetPermissions.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useAssetPermissions.types.ts
@@ -1,0 +1,22 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type AssetPermissionsQueryVariables = Types.Exact<{
+  assetKey: Types.AssetKeyInput;
+}>;
+
+export type AssetPermissionsQuery = {
+  __typename: 'Query';
+  assetNodeOrError:
+    | {
+        __typename: 'AssetNode';
+        id: string;
+        hasMaterializePermission: boolean;
+        hasWipePermission: boolean;
+        hasReportRunlessAssetEventPermission: boolean;
+      }
+    | {__typename: 'AssetNotFoundError'};
+};
+
+export const AssetPermissionsQueryVersion = 'ff8b09ce270b20e67a0b552f66238f6705e12b79fdbff05b24a8dc3dcbf53ef0';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetPermissions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetPermissions.tsx
@@ -1,0 +1,59 @@
+import {useMemo} from 'react';
+
+import {gql, useQuery} from '../apollo-client';
+import {usePermissionsForLocation} from '../app/Permissions';
+import {AssetKeyInput} from '../graphql/types';
+import {
+  AssetPermissionsQuery,
+  AssetPermissionsQueryVariables,
+} from './types/useAssetPermissions.types';
+
+export const useAssetPermissions = (assetKey: AssetKeyInput, locationName: string) => {
+  const {permissions: locationPermissions, loading: locationLoading} =
+    usePermissionsForLocation(locationName);
+
+  const {data, loading} = useQuery<AssetPermissionsQuery, AssetPermissionsQueryVariables>(
+    ASSET_PERMISSIONS_QUERY,
+    {
+      variables: {assetKey},
+    },
+  );
+
+  const {canLaunchPipelineExecution, canWipeAssets, canReportRunlessAssetEvents} =
+    locationPermissions;
+  const fallbackPermissions = useMemo(() => {
+    return {canLaunchPipelineExecution, canWipeAssets, canReportRunlessAssetEvents};
+  }, [canLaunchPipelineExecution, canWipeAssets, canReportRunlessAssetEvents]);
+
+  return useMemo(() => {
+    if (data?.assetNodeOrError.__typename === 'AssetNode') {
+      return {
+        hasMaterializePermission: data.assetNodeOrError.hasMaterializePermission,
+        hasWipePermission: data.assetNodeOrError.hasWipePermission,
+        hasReportRunlessAssetEventPermission:
+          data.assetNodeOrError.hasReportRunlessAssetEventPermission,
+        loading,
+      };
+    }
+
+    return {
+      hasMaterializePermission: fallbackPermissions.canLaunchPipelineExecution,
+      hasWipePermission: fallbackPermissions.canWipeAssets,
+      hasReportRunlessAssetEventPermission: fallbackPermissions.canReportRunlessAssetEvents,
+      loading: loading || locationLoading,
+    };
+  }, [data, loading, locationLoading, fallbackPermissions]);
+};
+
+export const ASSET_PERMISSIONS_QUERY = gql`
+  query AssetPermissionsQuery($assetKey: AssetKeyInput!) {
+    assetNodeOrError(assetKey: $assetKey) {
+      ... on AssetNode {
+        id
+        hasMaterializePermission
+        hasWipePermission
+        hasReportRunlessAssetEventPermission
+      }
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useDeleteDynamicPartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useDeleteDynamicPartitionsDialog.tsx
@@ -2,8 +2,8 @@ import {Colors, Icon, MenuItem} from '@dagster-io/ui-components';
 import {useContext, useState} from 'react';
 
 import {DeleteDynamicPartitionsDialog} from './DeleteDynamicPartitionsDialog';
+import {useAssetPermissions} from './useAssetPermissions';
 import {CloudOSSContext} from '../app/CloudOSSContext';
-import {usePermissionsForLocation} from '../app/Permissions';
 import {AssetKeyInput, PartitionDefinitionType} from '../graphql/types';
 import {RepoAddress} from '../workspace/types';
 
@@ -22,9 +22,6 @@ export function useDeleteDynamicPartitionsDialog(
   refresh?: () => void,
 ) {
   const [showing, setShowing] = useState(false);
-  const {
-    permissions: {canWipeAssets},
-  } = usePermissionsForLocation(opts ? opts.repoAddress.location : null);
 
   const {
     featureContext: {canSeeWipeMaterializationAction},
@@ -32,6 +29,11 @@ export function useDeleteDynamicPartitionsDialog(
 
   const dynamicDimension = opts?.definition.partitionDefinition?.dimensionTypes?.find(
     (d) => d.type === PartitionDefinitionType.DYNAMIC,
+  );
+
+  const {hasWipePermission} = useAssetPermissions(
+    opts?.assetKey || {path: []},
+    opts?.repoAddress.location || '',
   );
 
   if (
@@ -61,7 +63,7 @@ export function useDeleteDynamicPartitionsDialog(
         key="delete"
         text="Delete partitions"
         icon={<Icon name="delete" color={Colors.accentRed()} />}
-        disabled={!canWipeAssets}
+        disabled={!hasWipePermission}
         intent="danger"
         onClick={() => setShowing(true)}
       />,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useWipeDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useWipeDialog.tsx
@@ -2,8 +2,8 @@ import {Colors, Icon, MenuDivider, MenuItem} from '@dagster-io/ui-components';
 import {useContext, useState} from 'react';
 import {AssetWipeDialog} from 'shared/assets/AssetWipeDialog.oss';
 
+import {useAssetPermissions} from './useAssetPermissions';
 import {CloudOSSContext} from '../app/CloudOSSContext';
-import {usePermissionsForLocation} from '../app/Permissions';
 import {AssetKeyInput} from '../graphql/types';
 
 export function useWipeDialog(
@@ -11,13 +11,15 @@ export function useWipeDialog(
   refresh?: () => void,
 ) {
   const [showing, setShowing] = useState(false);
-  const {
-    permissions: {canWipeAssets},
-  } = usePermissionsForLocation(opts && opts.repository ? opts.repository.location.name : null);
 
   const {
     featureContext: {canSeeWipeMaterializationAction},
   } = useContext(CloudOSSContext);
+
+  const {hasWipePermission} = useAssetPermissions(
+    opts?.assetKey || {path: []},
+    opts?.repository?.location.name || '',
+  );
 
   return {
     element: (
@@ -36,7 +38,7 @@ export function useWipeDialog(
               key="wipe"
               text="Wipe materializations"
               icon={<Icon name="delete" color={Colors.accentRed()} />}
-              disabled={!canWipeAssets}
+              disabled={!hasWipePermission}
               intent="danger"
               onClick={() => setShowing(true)}
             />,


### PR DESCRIPTION
## Summary & Motivation
This is a recommit of  #32634, which was reverted to avoid cross-push backcompat issues (allowing the graphql fields to be deployed first).

* adds a react hook to check asset wipe permissions

## How I Tested These Changes
BK
