### PR TITLE
Allow `config_schema` to be configured in `OpSpec`

### DIFF
--- a/python_modules/dagster/dagster/components/lib/executable_component/component.py
+++ b/python_modules/dagster/dagster/components/lib/executable_component/component.py
@@ -92,6 +92,7 @@ class ExecutableComponent(Component, Resolvable, Model, ABC):
                 pool=self.op_spec.pool,
                 config_schema=self.config_fields,
             )
+            @self.op_spec.apply_config_schema
             def _assets_def(context: AssetExecutionContext, **kwargs):
                 return to_iterable(
                     self.invoke_execute_fn(context, component_load_context=component_load_context),
@@ -110,6 +111,7 @@ class ExecutableComponent(Component, Resolvable, Model, ABC):
                 pool=self.op_spec.pool,
                 config_schema=self.config_fields,
             )
+            @self.op_spec.apply_config_schema
             def _asset_check_def(context: AssetCheckExecutionContext, **kwargs):
                 return to_iterable(
                     self.invoke_execute_fn(context, component_load_context=component_load_context),

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/components/databricks_asset_bundle/component.py
@@ -257,18 +257,20 @@ class DatabricksAssetBundleComponent(Component, Resolvable):
 
         databricks_assets = []
         for task_key, asset_specs in self.asset_specs_by_task_key.items():
+            op = self.op or OpSpec(
+                name=f"databricks_{task_key}_multi_asset_{component_defs_path_as_python_str}"
+            )
 
             @multi_asset(
-                name=self.op.name
-                if self.op and self.op.name
-                else f"databricks_{task_key}_multi_asset_{component_defs_path_as_python_str}",
+                name=op.name,
                 specs=asset_specs,
                 can_subset=False,
-                op_tags=self.op.tags if self.op else None,
-                description=self.op.description if self.op else None,
-                pool=self.op.pool if self.op else None,
-                backfill_policy=self.op.backfill_policy if self.op else None,
+                op_tags=op.tags,
+                description=op.description,
+                pool=op.pool,
+                backfill_policy=op.backfill_policy,
             )
+            @op.apply_config_schema
             def _databricks_task_multi_asset(
                 context: AssetExecutionContext,
                 databricks: DatabricksWorkspace,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -332,17 +332,19 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
         project = self._project_manager.get_project(state_path)
 
         res_ctx = context.resolution_context
+        op = self.op or OpSpec(name=project.name)
 
         @dbt_assets(
             manifest=project.manifest_path,
             project=project,
-            name=self.op.name if self.op else project.name,
-            op_tags=self.op.tags if self.op else None,
+            name=op.name,
+            op_tags=op.tags,
             dagster_dbt_translator=self.translator,
             select=self.select,
             exclude=self.exclude,
-            backfill_policy=self.op.backfill_policy if self.op else None,
+            backfill_policy=op.backfill_policy,
         )
+        @op.apply_config_schema
         def _fn(context: dg.AssetExecutionContext):
             with _set_resolution_context(res_ctx):
                 yield from self.execute(context=context, dbt=DbtCliResource(project))

--- a/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
+++ b/python_modules/libraries/dagster-sling/dagster_sling/components/sling_replication_collection/component.py
@@ -182,16 +182,17 @@ class SlingReplicationCollectionComponent(Component, Resolvable):
     def build_asset(
         self, context: ComponentLoadContext, replication_spec_model: SlingReplicationSpecModel
     ) -> AssetsDefinition:
-        op_spec = replication_spec_model.op or OpSpec()
+        op_spec = replication_spec_model.op or OpSpec(name=Path(replication_spec_model.path).stem)
         translator = SlingComponentTranslator(self, replication_spec_model, context.path)
 
         @sling_assets(
-            name=op_spec.name or Path(replication_spec_model.path).stem,
+            name=op_spec.name,
             op_tags=op_spec.tags,
             replication_config=context.path / replication_spec_model.path,
             dagster_sling_translator=translator,
             backfill_policy=op_spec.backfill_policy,
         )
+        @op_spec.apply_config_schema
         def _asset(context: AssetExecutionContext):
             yield from self.execute(
                 context=context,


### PR DESCRIPTION
## Summary & Motivation

Right now, any integration we have that invokes one of our custom asset decorators internally is incapable of having its config schema set. The code issue here is that pythonic config doesn't really play nicely with asset factories, as it requires config arguments to be set directly in the function signature, which the user doesn't really have access to in these component factories.

This uses a pretty nasty hack under the hood to enable this, but realistically the future of this framework kinda requires a better computation construction API (ahem: https://github.com/dagster-io/dagster/pull/31151).

Main goal here is to let users of (e.g.) the dbt project component to customize configuration, which has otherwise been impossible.

## How I Tested These Changes

## Changelog

You can now configure a `config_schema` when using `OpSpec` in your components. If you're building your own components, you'll need to apply `@self.op_spec.apply_config_schema` to your core execution function for users of your component to take advantage of this.
