### PR TITLE
Fix dagster-airlift tests take 2

### DIFF
--- a/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/test_no_dagster_install.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/test_no_dagster_install.py
@@ -85,6 +85,8 @@ def test_in_airflow_package_implicit_requirements(temp_venv: Path):
             "apache-airflow",
             # https://github.com/apache/airflow/discussions/57769#discussioncomment-14861217
             "fastapi<0.118",
+            # https://github.com/apache/airflow/issues/57419
+            "structlog<25.5.0",
         ],
         check=True,
         capture_output=True,


### PR DESCRIPTION
Summary:
I fixed it in 3.9, then moved it to 3.10 and it promptly broke again.

BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
