### PR TITLE
Add nodeNames to GraphenePipeline

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1317,6 +1317,7 @@ type Pipeline implements SolidContainer & IPipelineSnapshot {
   partition(partitionName: String!, selectedAssetKeys: [AssetKeyInput!]): PartitionTagsAndConfig
   hasLaunchExecutionPermission: Boolean!
   hasLaunchReexecutionPermission: Boolean!
+  nodeNames: [String!]!
 }
 
 type PartitionTagsAndConfig {
@@ -2444,6 +2445,7 @@ type Job implements SolidContainer & IPipelineSnapshot {
   partition(partitionName: String!, selectedAssetKeys: [AssetKeyInput!]): PartitionTagsAndConfig
   hasLaunchExecutionPermission: Boolean!
   hasLaunchReexecutionPermission: Boolean!
+  nodeNames: [String!]!
 }
 
 enum SensorType {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2400,6 +2400,7 @@ export type Job = IPipelineSnapshot &
     >;
     modes: Array<Mode>;
     name: Scalars['String']['output'];
+    nodeNames: Array<Scalars['String']['output']>;
     owners: Array<DefinitionOwner>;
     parentSnapshotId: Maybe<Scalars['String']['output']>;
     partition: Maybe<PartitionTagsAndConfig>;
@@ -3765,6 +3766,7 @@ export type Pipeline = IPipelineSnapshot &
     >;
     modes: Array<Mode>;
     name: Scalars['String']['output'];
+    nodeNames: Array<Scalars['String']['output']>;
     owners: Array<DefinitionOwner>;
     parentSnapshotId: Maybe<Scalars['String']['output']>;
     partition: Maybe<PartitionTagsAndConfig>;
@@ -10232,6 +10234,7 @@ export const buildJob = (
       overrides && overrides.hasOwnProperty('metadataEntries') ? overrides.metadataEntries! : [],
     modes: overrides && overrides.hasOwnProperty('modes') ? overrides.modes! : [],
     name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'rerum',
+    nodeNames: overrides && overrides.hasOwnProperty('nodeNames') ? overrides.nodeNames! : [],
     owners: overrides && overrides.hasOwnProperty('owners') ? overrides.owners! : [],
     parentSnapshotId:
       overrides && overrides.hasOwnProperty('parentSnapshotId')
@@ -12558,6 +12561,7 @@ export const buildPipeline = (
       overrides && overrides.hasOwnProperty('metadataEntries') ? overrides.metadataEntries! : [],
     modes: overrides && overrides.hasOwnProperty('modes') ? overrides.modes! : [],
     name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'veritatis',
+    nodeNames: overrides && overrides.hasOwnProperty('nodeNames') ? overrides.nodeNames! : [],
     owners: overrides && overrides.hasOwnProperty('owners') ? overrides.owners! : [],
     parentSnapshotId:
       overrides && overrides.hasOwnProperty('parentSnapshotId')

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -1200,6 +1200,7 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
     )
     hasLaunchExecutionPermission = graphene.NonNull(graphene.Boolean)
     hasLaunchReexecutionPermission = graphene.NonNull(graphene.Boolean)
+    nodeNames = non_null_list(graphene.String)
 
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         interfaces = (GrapheneSolidContainer, GrapheneIPipelineSnapshot)
@@ -1219,6 +1220,9 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
 
     def get_represented_job(self) -> RepresentedJob:
         return self._remote_job
+
+    def resolve_nodeNames(self, _graphene_info: ResolveInfo):
+        return self._remote_job.node_names
 
     def resolve_presets(self, _graphene_info: ResolveInfo):
         return [

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_misc.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_misc.py
@@ -163,6 +163,7 @@ def test_pipeline_or_error_by_name(graphql_context: WorkspaceRequestContext):
         pipelineOrError(params: $selector) {
             ... on Pipeline {
                 name
+                nodeNames
             }
         }
     }""",
@@ -172,6 +173,7 @@ def test_pipeline_or_error_by_name(graphql_context: WorkspaceRequestContext):
     assert not result.errors
     assert result.data
     assert result.data["pipelineOrError"]["name"] == "csv_hello_world_two"
+    assert result.data["pipelineOrError"]["nodeNames"] == ["sum_op"]
 
 
 def test_pipeline_or_error_by_name_not_found(graphql_context: WorkspaceRequestContext):


### PR DESCRIPTION
Summary:
This is a more accurate way to filter out incoming run config ops in the launchpad than GrapheneAssetNode.opNames.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
