### PR TITLE
Check nodeNames instead of opName when filtering out ops from run config

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -94,7 +94,7 @@
   "AssetGroupAndLocationQuery": "584b27ecda9ff883e92f2d8858520a543ea0be07d39e1b4c0fc5d802231bb602",
   "ConfigPartitionForAssetJobQuery": "367eaeeb62b9e2339ab6c07a1e315310fd1a095b7ba7c8fa7a1e51282ca84796",
   "ConfigPartitionSelectionQuery": "54bfeba0e497a1ee185cf7d7fa251ce81cffdf97a3f234b5022f3c619e29ebd5",
-  "LaunchpadRootQuery": "527627287343c3a482b43445b66c55de58b667dadb36218161575caffbc78348",
+  "LaunchpadRootQuery": "e112792d378d703b308f66ef689e9379dddb8558e209aa2a3cb2675cc223d458",
   "PreviewConfigQuery": "d6d9fe33524d42b5159e04c018897ec90d991ebe6c2b46e5e5d736fc30f49c77",
   "ConfigForRunQuery": "3c4bb0f771599d50a7e4c05b683f8f7b4b3f0ab844b85501bb85527707a4982a",
   "OpSelectorQuery": "f1b601d74e6ffb2854418109f56c90bc7feb37cbabd9a4b60dd7075aa45fcadf",

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/LaunchpadAllowedRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/LaunchpadAllowedRoot.types.ts
@@ -18,6 +18,7 @@ export type LaunchpadRootQuery = {
         id: string;
         isJob: boolean;
         isAssetJob: boolean;
+        nodeNames: Array<string>;
         name: string;
         modes: Array<{__typename: 'Mode'; id: string; name: string; description: string | null}>;
         presets: Array<{
@@ -167,6 +168,7 @@ export type LaunchpadSessionPipelineFragment = {
   id: string;
   isJob: boolean;
   isAssetJob: boolean;
+  nodeNames: Array<string>;
   name: string;
   modes: Array<{__typename: 'Mode'; id: string; name: string; description: string | null}>;
   presets: Array<{
@@ -285,4 +287,4 @@ export type LaunchpadSessionModeNotFoundFragment = {
   message: string;
 };
 
-export const LaunchpadRootQueryVersion = '527627287343c3a482b43445b66c55de58b667dadb36218161575caffbc78348';
+export const LaunchpadRootQueryVersion = 'e112792d378d703b308f66ef689e9379dddb8558e209aa2a3cb2675cc223d458';


### PR DESCRIPTION
Summary:
Fixes an issue where a mismatch between these two fields could sometimes cause config to be incorrectly filtered out.

## Summary & Motivation

## How I Tested These Changes
Load this repo
```
import dagster as dg
from dagster._core.remote_representation.external_data import asset_node_snaps_from_repo


@dg.asset(deps=[dg.AssetKey("B")])
def A():
    return 1


@dg.asset(name="212313-dskflj_12321")
def goo():
    pass


@dg.multi_asset(
    outs={
        "foo": dg.AssetOut(is_required=False),
        "bar": dg.AssetOut(is_required=False),
    },
    internal_asset_deps={
        "foo": {dg.AssetKey("A")},
    },
    ins={
        "A": dg.AssetIn(key=dg.AssetKey("A")),
    },
    can_subset=True,
    config_schema={
        "my_field": dg.Field(
            str,
            default_value="default_value",
        ),
    },
)
def my_multi_asset(context: dg.AssetExecutionContext, A):
    if dg.AssetKey("foo") in context.selected_asset_keys:
        yield dg.Output(1, output_name="foo")
    if dg.AssetKey("bar") in context.selected_asset_keys:
        yield dg.Output(2, output_name="bar")


@dg.asset(deps=[dg.AssetKey("bar")])
def B():
    return 1


defs = dg.Definitions(assets=[my_multi_asset, A, B, goo])

graph = defs.resolve_asset_graph()

node_snaps = asset_node_snaps_from_repo(
    defs.get_repository_def(),
)

node_snap = next(n for n in node_snaps if n.asset_key == dg.AssetKey("foo"))

from dagster_shared.serdes.serdes import serialize_value

print(str(serialize_value(node_snap)))

print(node_snap.op_names)  # ['my_multi_asset_2']

job_def = defs.get_implicit_global_asset_job_def()

subset_job = job_def.get_subset(asset_selection={dg.AssetKey("foo")})

from dagster._core.snap import JobSnap

print(str(JobSnap.from_job_def(subset_job).node_names))
```

And see the correct ops being prefilled

Do the same thing with a graph asset with config set

