### PR TITLE
[dg] refactor `dg scaffold github-actions` and `dg scaffold build-artifacts` into `dg plus deploy configure`

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
@@ -23,6 +23,7 @@ from dagster_dg_cli.cli.defs_state import (
     raise_component_state_refresh_errors,
 )
 from dagster_dg_cli.cli.plus.constants import DgPlusAgentType, DgPlusDeploymentType
+from dagster_dg_cli.cli.plus.deploy.configure.commands import deploy_configure_group
 from dagster_dg_cli.cli.plus.deploy.deploy_session import (
     build_artifact,
     finish_deploy_session,
@@ -522,3 +523,7 @@ def finish_deploy_session_command(
     statedir = _get_statedir()
 
     finish_deploy_session(dg_context, statedir, location_names)
+
+
+# Register the configure subcommand group
+deploy_group.add_command(deploy_configure_group)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/__init__.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/__init__.py
@@ -1,0 +1,1 @@
+"""Deployment configuration scaffolding for Dagster Plus."""

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/commands.py
@@ -1,0 +1,388 @@
+"""Primary interface for deployment configuration scaffolding.
+
+This module provides the `dg scaffold deployment-config` command group with
+subcommands for serverless and hybrid deployments.
+"""
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+from dagster_dg_core.config import normalize_cli_config
+from dagster_dg_core.context import DgContext
+from dagster_dg_core.shared_options import dg_editable_dagster_options, dg_global_options
+from dagster_dg_core.utils import DgClickCommand, DgClickGroup, exit_with_error
+from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
+from dagster_shared.plus.config import DagsterPlusCliConfig
+
+from dagster_dg_cli.cli.plus.constants import DgPlusAgentPlatform, DgPlusAgentType
+from dagster_dg_cli.cli.plus.deploy.configure.configure_build_artifacts import (
+    configure_build_artifacts_impl,
+)
+from dagster_dg_cli.cli.plus.deploy.configure.configure_ci import configure_ci_impl
+from dagster_dg_cli.cli.plus.deploy.configure.utils import (
+    DeploymentScaffoldConfig,
+    GitProvider,
+    search_for_git_root,
+)
+from dagster_dg_cli.utils.plus.build import get_agent_type_and_platform_from_graphql
+from dagster_dg_cli.utils.plus.gql_client import DagsterPlusGraphQLClient
+
+
+def resolve_agent_type_and_platform(
+    agent_type: Optional[DgPlusAgentType],
+    agent_platform: Optional[DgPlusAgentPlatform],
+    plus_config: Optional[DagsterPlusCliConfig],
+) -> tuple[DgPlusAgentType, Optional[DgPlusAgentPlatform]]:
+    """Resolve agent type and platform from config or prompts (for deployment-config commands)."""
+    resolved_type = agent_type
+    resolved_platform = agent_platform
+
+    # Try to detect from Plus config via GraphQL
+    if resolved_type is None and plus_config:
+        gql_client = DagsterPlusGraphQLClient.from_config(plus_config)
+        detected_type, detected_platform = get_agent_type_and_platform_from_graphql(gql_client)
+        resolved_type = detected_type
+        if resolved_platform is None:
+            resolved_platform = detected_platform
+
+    # Prompt for agent type if still missing
+    if resolved_type is None:
+        resolved_type = DgPlusAgentType(
+            click.prompt(
+                "Deployment agent type",
+                type=click.Choice(["serverless", "hybrid"]),
+            ).upper()
+        )
+
+    # Prompt for platform if needed (only for hybrid)
+    if resolved_type == DgPlusAgentType.HYBRID and resolved_platform is None:
+        resolved_platform = DgPlusAgentPlatform(
+            click.prompt(
+                "Agent platform",
+                type=click.Choice(["k8s", "ecs", "docker"]),
+            ).upper()
+        )
+
+    return resolved_type, resolved_platform
+
+
+def resolve_organization(
+    organization: Optional[str],
+    plus_config: Optional[DagsterPlusCliConfig],
+    *,
+    show_detected_message: bool = True,
+) -> Optional[str]:
+    """Resolve organization name from config or prompt."""
+    if organization is not None:
+        return organization
+
+    if plus_config and plus_config.organization:
+        if show_detected_message:
+            click.echo(
+                f"Using organization name {plus_config.organization} from Dagster Plus config."
+            )
+        return plus_config.organization
+
+    return click.prompt("Dagster Plus organization name") or ""
+
+
+def resolve_deployment(
+    deployment: Optional[str],
+    plus_config: Optional[DagsterPlusCliConfig],
+    *,
+    show_detected_message: bool = True,
+) -> str:
+    """Resolve deployment name from config or prompt."""
+    if deployment is not None:
+        return deployment
+
+    if plus_config and plus_config.default_deployment:
+        if show_detected_message:
+            click.echo(
+                f"Using default deployment name {plus_config.default_deployment} from Dagster Plus config."
+            )
+        return plus_config.default_deployment
+
+    return click.prompt("Default deployment name", default="prod")
+
+
+def resolve_git_provider(
+    git_provider: Optional[GitProvider],
+    git_root: Optional[Path],
+) -> Optional[GitProvider]:
+    """Resolve git provider for CI/CD scaffolding (for deployment-config commands)."""
+    if git_provider is not None:
+        return git_provider
+
+    # Prompt for CI/CD configuration
+    if git_root is None:
+        should_scaffold_ci = click.confirm(
+            "Would you like to scaffold CI/CD configuration?", default=True
+        )
+        if should_scaffold_ci:
+            provider_choice = click.prompt(
+                "Git provider",
+                type=click.Choice(["github"]),  # Will add gitlab later
+                default="github",
+            )
+            return GitProvider(provider_choice)
+
+    return None
+
+
+def resolve_git_root(
+    git_root: Optional[Path],
+    git_provider: Optional[GitProvider],
+) -> Optional[Path]:
+    """Resolve git root path."""
+    if git_provider is None:
+        return None
+
+    if git_root is not None:
+        return git_root
+
+    resolved_git_root = search_for_git_root(Path.cwd())
+    if resolved_git_root is None:
+        exit_with_error(
+            "No git repository found. Must be run from a git repository, or "
+            "specify the path to the git root with `--git-root`."
+        )
+
+    return resolved_git_root
+
+
+def resolve_python_version(python_version: Optional[str]) -> str:
+    """Resolve Python version."""
+    return python_version or f"3.{sys.version_info.minor}"
+
+
+def _resolve_config_with_prompts(
+    agent_type: DgPlusAgentType,
+    agent_platform: Optional[DgPlusAgentPlatform],
+    organization: Optional[str],
+    deployment: Optional[str],
+    git_root: Optional[Path],
+    python_version: Optional[str],
+    skip_confirmation_prompt: bool,
+    use_editable_dagster: bool,
+    git_provider: Optional[GitProvider],
+    dg_context: DgContext,
+    cli_config,
+) -> DeploymentScaffoldConfig:
+    """Resolve all configuration for deployment-config commands, prompting for missing values.
+
+    This is used by the primary deployment-config commands (serverless/hybrid).
+    For legacy commands, use the specialized resolve functions below.
+    """
+    plus_config = DagsterPlusCliConfig.get() if DagsterPlusCliConfig.exists() else None
+
+    # Resolve agent type and platform
+    resolved_agent_type, resolved_agent_platform = resolve_agent_type_and_platform(
+        agent_type,
+        agent_platform,
+        plus_config,
+    )
+
+    # Resolve git provider
+    resolved_git_provider = resolve_git_provider(
+        git_provider,
+        git_root,
+    )
+
+    # Resolve organization and deployment (only needed if scaffolding CI/CD)
+    resolved_organization = None
+    resolved_deployment = deployment or "prod"
+    if resolved_git_provider is not None:
+        resolved_organization = resolve_organization(organization, plus_config)
+        resolved_deployment = resolve_deployment(deployment, plus_config)
+
+    # Resolve git root
+    resolved_git_root = resolve_git_root(git_root, resolved_git_provider)
+
+    # Resolve Python version
+    resolved_python_version = resolve_python_version(python_version)
+
+    return DeploymentScaffoldConfig(
+        dg_context=dg_context,
+        cli_config=cli_config,
+        plus_config=plus_config,
+        agent_type=resolved_agent_type,
+        agent_platform=resolved_agent_platform,
+        organization_name=resolved_organization,
+        deployment_name=resolved_deployment,
+        git_root=resolved_git_root,
+        python_version=resolved_python_version,
+        skip_confirmation_prompt=skip_confirmation_prompt,
+        git_provider=resolved_git_provider,
+        use_editable_dagster=use_editable_dagster,
+    )
+
+
+# ########################
+# ##### CLI COMMANDS
+# ########################
+
+
+@click.group(name="configure", cls=DgClickGroup)
+def deploy_configure_group():
+    """Scaffold deployment configuration files for Dagster Plus."""
+
+
+@click.command(name="serverless", cls=DgClickCommand)
+@click.option(
+    "--git-provider",
+    type=click.Choice(["github"]),
+    help="Git provider for CI/CD scaffolding (only github is supported currently)",
+)
+@click.option(
+    "--python-version",
+    type=click.Choice(["3.9", "3.10", "3.11", "3.12", "3.13"]),
+    help="Python version used to deploy the project",
+)
+@click.option(
+    "--organization",
+    help="Dagster Plus organization name",
+)
+@click.option(
+    "--deployment",
+    default="prod",
+    help="Deployment name",
+)
+@click.option(
+    "--git-root",
+    type=Path,
+    help="Path to the git repository root",
+)
+@click.option(
+    "-y",
+    "--yes",
+    "skip_confirmation_prompt",
+    is_flag=True,
+    help="Skip confirmation prompts",
+)
+@dg_editable_dagster_options
+@dg_global_options
+@cli_telemetry_wrapper
+def deploy_configure_serverless(
+    git_provider: Optional[str],
+    python_version: Optional[str],
+    organization: Optional[str],
+    deployment: Optional[str],
+    git_root: Optional[Path],
+    skip_confirmation_prompt: bool,
+    use_editable_dagster: Optional[str],
+    **global_options: object,
+) -> None:
+    """Scaffold deployment configuration for Dagster Plus Serverless.
+
+    This creates:
+    - Dockerfile and build.yaml for containerization
+    - GitHub Actions workflow (if --git-provider github is specified)
+    """
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+
+    config = _resolve_config_with_prompts(
+        agent_type=DgPlusAgentType.SERVERLESS,
+        agent_platform=None,  # Not needed for serverless
+        organization=organization,
+        deployment=deployment,
+        git_root=git_root,
+        python_version=python_version,
+        skip_confirmation_prompt=skip_confirmation_prompt,
+        use_editable_dagster=bool(use_editable_dagster),
+        git_provider=GitProvider(git_provider) if git_provider else None,
+        dg_context=dg_context,
+        cli_config=cli_config,
+    )
+
+    configure_build_artifacts_impl(config)
+    configure_ci_impl(config)
+
+
+@click.command(name="hybrid", cls=DgClickCommand)
+@click.option(
+    "--git-provider",
+    type=click.Choice(["github"]),
+    help="Git provider for CI/CD scaffolding (only github is supported currently)",
+)
+@click.option(
+    "--agent-platform",
+    type=click.Choice(["k8s", "ecs", "docker"]),
+    help="Agent platform (k8s, ecs, or docker)",
+)
+@click.option(
+    "--python-version",
+    type=click.Choice(["3.9", "3.10", "3.11", "3.12", "3.13"]),
+    help="Python version used to deploy the project",
+)
+@click.option(
+    "--organization",
+    help="Dagster Plus organization name",
+)
+@click.option(
+    "--deployment",
+    default="prod",
+    help="Deployment name",
+)
+@click.option(
+    "--git-root",
+    type=Path,
+    help="Path to the git repository root",
+)
+@click.option(
+    "-y",
+    "--yes",
+    "skip_confirmation_prompt",
+    is_flag=True,
+    help="Skip confirmation prompts",
+)
+@dg_editable_dagster_options
+@dg_global_options
+@cli_telemetry_wrapper
+def deploy_configure_hybrid(
+    git_provider: Optional[str],
+    agent_platform: Optional[str],
+    python_version: Optional[str],
+    organization: Optional[str],
+    deployment: Optional[str],
+    git_root: Optional[Path],
+    skip_confirmation_prompt: bool,
+    use_editable_dagster: Optional[str],
+    **global_options: object,
+) -> None:
+    """Scaffold deployment configuration for Dagster Plus Hybrid.
+
+    This creates:
+    - Dockerfile and build.yaml for containerization
+    - container_context.yaml with platform-specific config (k8s/ecs/docker)
+    - GitHub Actions workflow with Docker build steps (if --git-provider github is specified)
+    """
+    cli_config = normalize_cli_config(global_options, click.get_current_context())
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+
+    resolved_platform = DgPlusAgentPlatform(agent_platform.upper()) if agent_platform else None
+    resolved_git_provider = GitProvider(git_provider) if git_provider else None
+
+    config = _resolve_config_with_prompts(
+        agent_type=DgPlusAgentType.HYBRID,
+        agent_platform=resolved_platform,
+        organization=organization,
+        deployment=deployment,
+        git_root=git_root,
+        python_version=python_version,
+        skip_confirmation_prompt=skip_confirmation_prompt,
+        use_editable_dagster=bool(use_editable_dagster),
+        git_provider=resolved_git_provider,
+        dg_context=dg_context,
+        cli_config=cli_config,
+    )
+
+    configure_build_artifacts_impl(config)
+    configure_ci_impl(config)
+
+
+deploy_configure_group.add_command(deploy_configure_serverless)
+deploy_configure_group.add_command(deploy_configure_hybrid)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/configure_build_artifacts.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/configure_build_artifacts.py
@@ -1,0 +1,105 @@
+"""Implementation for configuring build artifacts (Dockerfiles, build configs, etc)."""
+
+import textwrap
+
+import click
+
+from dagster_dg_cli.cli.plus.deploy.configure.utils import (
+    DeploymentScaffoldConfig,
+    get_project_contexts,
+    get_scaffolded_container_context_yaml,
+)
+from dagster_dg_cli.utils.plus.build import create_deploy_dockerfile, get_dockerfile_path
+
+
+def configure_build_artifacts_impl(config: DeploymentScaffoldConfig) -> None:
+    """Core implementation for configuring build artifacts."""
+    import yaml
+
+    scaffolded_container_context_yaml = (
+        get_scaffolded_container_context_yaml(config.agent_platform)
+        if config.agent_platform
+        else None
+    )
+
+    if not config.dg_context.is_project:
+        click.echo("Scaffolding build artifacts for workspace...")
+
+        create = True
+        if config.dg_context.build_config_path.exists():
+            create = config.skip_confirmation_prompt or click.confirm(
+                f"Build config already exists at {config.dg_context.build_config_path}. Overwrite it?",
+            )
+        if create:
+            config.dg_context.build_config_path.write_text(yaml.dump({"registry": "..."}))
+            click.echo(f"Workspace build config created at {config.dg_context.build_config_path}.")
+
+        if scaffolded_container_context_yaml:
+            create = True
+            if config.dg_context.container_context_config_path.exists():
+                create = config.skip_confirmation_prompt or click.confirm(
+                    f"Container config already exists at {config.dg_context.container_context_config_path}. Overwrite it?",
+                )
+            if create:
+                config.dg_context.container_context_config_path.write_text(
+                    scaffolded_container_context_yaml
+                )
+                click.echo(
+                    f"Workspace container config created at {config.dg_context.container_context_config_path}."
+                )
+
+    project_contexts = get_project_contexts(config.dg_context, config.cli_config)
+    for project_context in project_contexts:
+        click.echo(f"Scaffolding build artifacts for {project_context.code_location_name}...")
+
+        create = True
+        if project_context.build_config_path.exists():
+            create = config.skip_confirmation_prompt or click.confirm(
+                f"Build config already exists at {project_context.build_config_path}. Overwrite it?",
+            )
+        if create:
+            project_context.build_config_path.write_text(
+                textwrap.dedent(
+                    """
+                    directory: .
+                    # Registry is specified in the build.yaml file at the root of the workspace,
+                    # but can be overridden here.
+                    # registry: '...'
+                    """
+                )
+                if config.dg_context.is_in_workspace
+                else textwrap.dedent(
+                    """
+                    directory: .
+                    registry: '...'
+                    """
+                )
+            )
+            click.echo(f"Project build config created at {project_context.build_config_path}.")
+
+        if scaffolded_container_context_yaml:
+            if project_context.container_context_config_path.exists():
+                create = config.skip_confirmation_prompt or click.confirm(
+                    f"Container config already exists at {project_context.container_context_config_path}. Overwrite it?",
+                )
+            if create:
+                project_context.container_context_config_path.write_text(
+                    scaffolded_container_context_yaml
+                )
+                click.echo(
+                    f"Project container config created at {project_context.container_context_config_path}."
+                )
+
+        dockerfile_path = get_dockerfile_path(project_context, workspace_context=config.dg_context)
+        create = True
+        if dockerfile_path.exists():
+            create = config.skip_confirmation_prompt or click.confirm(
+                f"A Dockerfile already exists at {dockerfile_path}. Overwrite it?",
+            )
+        if create:
+            create_deploy_dockerfile(
+                dockerfile_path,
+                config.python_version,
+                config.use_editable_dagster,
+            )
+            click.echo(f"Dockerfile created at {dockerfile_path}.")

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/configure_ci.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/configure_ci.py
@@ -1,0 +1,189 @@
+"""Implementation for scaffolding CI/CD workflows (GitHub Actions, GitLab CI, etc)."""
+
+import textwrap
+from typing import cast
+
+import click
+from dagster_dg_core.config import merge_build_configs
+from dagster_dg_core.utils import exit_with_error
+
+from dagster_dg_cli.cli.plus.constants import DgPlusAgentType
+from dagster_dg_cli.cli.plus.deploy.configure.utils import (
+    BUILD_LOCATION_FRAGMENT,
+    HYBRID_GITHUB_ACTION_FILE,
+    REGISTRY_INFOS,
+    SERVERLESS_GITHUB_ACTION_FILE,
+    DeploymentScaffoldConfig,
+    GitProvider,
+    get_cli_version_or_main,
+    get_git_web_url,
+    get_project_contexts,
+)
+from dagster_dg_cli.utils.plus.build import get_dockerfile_path
+
+
+def _get_build_fragment_for_locations(
+    config: DeploymentScaffoldConfig, registry_urls: list[str]
+) -> str:
+    """Generate the build fragment for GitHub Actions workflow."""
+    if config.git_root is None:
+        raise ValueError("Git root is required for generating build fragments")
+
+    project_contexts = get_project_contexts(config.dg_context, config.cli_config)
+
+    # TODO: when we cut over to dg deploy, we'll just use a single build call for the workspace
+    # rather than iterating over each project
+    output = []
+    for location_ctx, registry_url in zip(project_contexts, registry_urls):
+        output.append(
+            textwrap.indent(BUILD_LOCATION_FRAGMENT.read_text(), " " * 6)
+            .replace("TEMPLATE_LOCATION_NAME", location_ctx.code_location_name)
+            .replace(
+                "TEMPLATE_LOCATION_PATH", str(location_ctx.root_path.relative_to(config.git_root))
+            )
+            .replace("TEMPLATE_IMAGE_REGISTRY", registry_url)
+            .replace("TEMPLATE_DAGSTER_CLOUD_ACTION_VERSION", get_cli_version_or_main())
+        )
+    return "\n" + "\n".join(output)
+
+
+def _get_registry_fragment(registry_urls: list[str]) -> tuple[str, list[str]]:
+    """Generate registry login fragment and secrets hints for GitHub Actions."""
+    additional_secrets_hints = []
+    output = []
+    for registry_info in REGISTRY_INFOS:
+        fragment = registry_info.fragment.read_text()
+        matching_urls = [url for url in registry_urls if registry_info.match(url)]
+        if matching_urls:
+            if "TEMPLATE_IMAGE_REGISTRY" not in fragment:
+                output.append(fragment)
+            else:
+                for url in matching_urls:
+                    output.append(fragment.replace("TEMPLATE_IMAGE_REGISTRY", url))
+            additional_secrets_hints.extend(registry_info.secrets_hints)
+
+    return "\n".join(output), additional_secrets_hints
+
+
+def validate_registry_urls(config: DeploymentScaffoldConfig) -> list[str]:
+    """Validate that registry URLs are configured for all projects."""
+    project_contexts = get_project_contexts(config.dg_context, config.cli_config)
+
+    registry_urls = [
+        merge_build_configs(project.build_config, config.dg_context.build_config).get("registry")
+        for project in project_contexts
+    ]
+
+    for project, registry_url in zip(project_contexts, registry_urls):
+        if registry_url is None:
+            raise click.ClickException(
+                f"No registry URL found for project {project.code_location_name}. Please specify a registry URL in `build.yaml`."
+            )
+
+    return cast("list[str]", registry_urls)
+
+
+def validate_dockerfiles_exist(config: DeploymentScaffoldConfig) -> None:
+    """Validate that Dockerfiles exist for all projects."""
+    project_contexts = get_project_contexts(config.dg_context, config.cli_config)
+
+    for location_ctx in project_contexts:
+        dockerfile_path = get_dockerfile_path(location_ctx, config.dg_context)
+        if not dockerfile_path.exists():
+            raise click.ClickException(
+                f"Dockerfile not found at {dockerfile_path}. Please run `dg scaffold deployment-config` to create one."
+            )
+
+
+def configure_github_actions_impl(config: DeploymentScaffoldConfig) -> None:
+    """Core implementation for scaffolding GitHub Actions workflow."""
+    import typer
+
+    if config.git_root is None:
+        exit_with_error("Git root is required for scaffolding GitHub Actions workflow.")
+
+    workflows_dir = config.git_root / ".github" / "workflows"
+    workflows_dir.mkdir(parents=True, exist_ok=True)
+
+    if config.agent_type == DgPlusAgentType.SERVERLESS:
+        click.echo("Using serverless workflow template.")
+    else:
+        click.echo("Using hybrid workflow template.")
+
+    additional_secrets_hints = []
+
+    template = (
+        SERVERLESS_GITHUB_ACTION_FILE.read_text()
+        if config.agent_type == DgPlusAgentType.SERVERLESS
+        else HYBRID_GITHUB_ACTION_FILE.read_text()
+    )
+
+    template = (
+        template.replace(
+            "TEMPLATE_ORGANIZATION_NAME",
+            config.organization_name or "",
+        )
+        .replace(
+            "TEMPLATE_DEFAULT_DEPLOYMENT_NAME",
+            config.deployment_name,
+        )
+        .replace(
+            "TEMPLATE_PROJECT_DIR",
+            str(config.dg_context.root_path.relative_to(config.git_root)),
+        )
+        .replace(
+            "TEMPLATE_DAGSTER_CLOUD_ACTION_VERSION",
+            get_cli_version_or_main(),
+        )
+    )
+
+    registry_urls = None
+    if config.agent_type == DgPlusAgentType.HYBRID:
+        # Validate in the correct order: registry URLs first, then Dockerfiles
+        registry_urls = validate_registry_urls(config)
+        validate_dockerfiles_exist(config)
+
+        build_fragment = _get_build_fragment_for_locations(config, registry_urls)
+        template = template.replace("      # TEMPLATE_BUILD_LOCATION_FRAGMENT", build_fragment)
+
+        registry_fragment, additional_secrets_hints = _get_registry_fragment(registry_urls)
+        template = template.replace(
+            "# TEMPLATE_CONTAINER_REGISTRY_LOGIN_FRAGMENT",
+            textwrap.indent(
+                registry_fragment,
+                " " * 6,
+            ),
+        )
+
+    workflow_file = workflows_dir / "dagster-plus-deploy.yml"
+    workflow_file.write_text(template)
+
+    git_web_url = get_git_web_url(config.git_root) or ""
+    if git_web_url:
+        git_web_url = f"({git_web_url}/settings/secrets/actions) "
+    click.echo(
+        typer.style(
+            "\nGitHub Actions workflow created successfully. Commit and push your changes in order to deploy to Dagster Plus.\n",
+            fg=typer.colors.GREEN,
+        )
+        + f"\nYou will need to set up the following secrets in your GitHub repository using\nthe GitHub UI {git_web_url}or CLI (https://cli.github.com/):"
+        + typer.style(
+            f"\ndg plus create ci-api-token --description 'Used in {config.git_root.name} GitHub Actions' | gh secret set DAGSTER_CLOUD_API_TOKEN"
+            + "\n"
+            + "\n".join(additional_secrets_hints),
+            fg=typer.colors.YELLOW,
+        )
+    )
+
+
+def configure_ci_impl(config: DeploymentScaffoldConfig) -> None:
+    """Scaffold CI/CD workflow based on git provider."""
+    if config.git_provider == GitProvider.GITHUB:
+        configure_github_actions_impl(config)
+    elif config.git_provider == GitProvider.GITLAB:
+        raise NotImplementedError("GitLab CI scaffolding is not yet implemented")
+    elif config.git_provider is None:
+        # No CI/CD scaffolding requested
+        pass
+    else:
+        raise ValueError(f"Unsupported git provider: {config.git_provider}")

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/__init__.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/__init__.py
@@ -17,16 +17,7 @@ def scaffold_group():
 
 # Register all scaffold commands from submodules
 scaffold_group.add_command(scaffold_branch_command)
-scaffold_group.add_command(scaffold_build_artifacts_command)
+scaffold_group.add_command(scaffold_build_artifacts_command)  # Legacy shim
 scaffold_group.add_command(scaffold_component_command)
 scaffold_group.add_command(scaffold_defs_group)
-scaffold_group.add_command(scaffold_github_actions_command)
-
-__all__ = [
-    "scaffold_branch_command",
-    "scaffold_build_artifacts_command",
-    "scaffold_component_command",
-    "scaffold_defs_group",
-    "scaffold_github_actions_command",
-    "scaffold_group",
-]
+scaffold_group.add_command(scaffold_github_actions_command)  # Legacy shim

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/build_artifacts.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/build_artifacts.py
@@ -1,125 +1,75 @@
-import sys
-import textwrap
+"""Legacy command for scaffolding build artifacts.
+
+This command is maintained for backward compatibility.
+Consider using `dg plus deploy configure [serverless|hybrid]` instead.
+"""
+
 from pathlib import Path
 from typing import Optional
 
 import click
-from dagster_dg_core.config import DgRawCliConfig, normalize_cli_config
+from dagster_dg_core.config import normalize_cli_config
 from dagster_dg_core.context import DgContext
 from dagster_dg_core.shared_options import dg_editable_dagster_options, dg_global_options
 from dagster_dg_core.utils import DgClickCommand
 from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
 from dagster_shared.plus.config import DagsterPlusCliConfig
 
-from dagster_dg_cli.cli.plus.constants import DgPlusAgentPlatform
-from dagster_dg_cli.utils.plus.build import (
-    create_deploy_dockerfile,
-    get_agent_type_and_platform_from_graphql,
-    get_dockerfile_path,
+from dagster_dg_cli.cli.plus.constants import DgPlusAgentType
+from dagster_dg_cli.cli.plus.deploy.configure.commands import resolve_python_version
+from dagster_dg_cli.cli.plus.deploy.configure.configure_build_artifacts import (
+    configure_build_artifacts_impl,
 )
+from dagster_dg_cli.cli.plus.deploy.configure.utils import DeploymentScaffoldConfig
+from dagster_dg_cli.utils.plus.build import get_agent_type_and_platform_from_graphql
 from dagster_dg_cli.utils.plus.gql_client import DagsterPlusGraphQLClient
 
 
-def _get_scaffolded_container_context_yaml(agent_platform: DgPlusAgentPlatform) -> Optional[str]:
-    if agent_platform == DgPlusAgentPlatform.K8S:
-        return textwrap.dedent(
-            """
-            ### Uncomment to add configuration for k8s resources.
-            # k8s:
-            #   server_k8s_config: # Raw kubernetes config for code servers launched by the agent
-            #     pod_spec_config: # Config for the code server pod spec
-            #       node_selector:
-            #         disktype: standard
-            #     pod_template_spec_metadata: # Metadata for the code server pod
-            #       annotations:
-            #         mykey: myvalue
-            #     container_config: # Config for the main dagster container in the code server pod
-            #       resources:
-            #         limits:
-            #           cpu: 100m
-            #           memory: 128Mi
-            #   run_k8s_config: # Raw kubernetes config for runs launched by the agent
-            #     pod_spec_config: # Config for the run's PodSpec
-            #       node_selector:
-            #         disktype: ssd
-            #     container_config: # Config for the main dagster container in the run pod
-            #       resources:
-            #         limits:
-            #           cpu: 500m
-            #           memory: 1024Mi
-            #     pod_template_spec_metadata: # Metadata for the run pod
-            #       annotations:
-            #         mykey: myvalue
-            #     job_spec_config: # Config for the Kubernetes job for the run
-            #       ttl_seconds_after_finished: 7200
-            """
-        )
-    elif agent_platform == DgPlusAgentPlatform.ECS:
-        return textwrap.dedent(
-            """
-            ### Uncomment to add configuration for ECS resources.
-            # ecs:
-            #   env_vars:
-            #     - DATABASE_NAME=staging
-            #     - DATABASE_PASSWORD
-            #   secrets:
-            #     - name: 'MY_API_TOKEN'
-            #       valueFrom: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:token::'
-            #     - name: 'MY_PASSWORD'
-            #       valueFrom: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:FOO-AbCdEf:password::'
-            #   server_resources: # Resources for code servers launched by the agent for this location
-            #     cpu: "256"
-            #     memory: "512"
-            #   run_resources: # Resources for runs launched by the agent for this location
-            #     cpu: "4096"
-            #     memory: "16384"
-            #   execution_role_arn: arn:aws:iam::123456789012:role/MyECSExecutionRole
-            #   task_role_arn: arn:aws:iam::123456789012:role/MyECSTaskRole
-            #   mount_points:
-            #     - sourceVolume: myEfsVolume
-            #       containerPath: '/mount/efs'
-            #       readOnly: True
-            #   volumes:
-            #     - name: myEfsVolume
-            #       efsVolumeConfiguration:
-            #         fileSystemId: fs-1234
-            #         rootDirectory: /path/to/my/data
-            #   server_sidecar_containers:
-            #     - name: DatadogAgent
-            #       image: public.ecr.aws/datadog/agent:latest
-            #       environment:
-            #         - name: ECS_FARGATE
-            #           value: true
-            #   run_sidecar_containers:
-            #     - name: DatadogAgent
-            #       image: public.ecr.aws/datadog/agent:latest
-            #       environment:
-            #         - name: ECS_FARGATE
-            #           value: true
-            """
-        )
-    elif agent_platform == DgPlusAgentPlatform.DOCKER:
-        return textwrap.dedent(
-            """
-            ### Uncomment to add configuration for Docker resources.
-            # docker:
-            #   env_vars:
-            #     - DATABASE_NAME=staging
-            #     - DATABASE_PASSWORD
-            """
-        )
-    else:
-        return None
+def _resolve_config_for_build_artifacts(
+    python_version: Optional[str],
+    skip_confirmation_prompt: bool,
+    use_editable_dagster: bool,
+    dg_context: DgContext,
+    cli_config,
+) -> DeploymentScaffoldConfig:
+    """Resolve config for legacy build-artifacts command.
 
+    This command only scaffolds build artifacts (no CI/CD), and tries to detect
+    agent type/platform from Plus config but doesn't prompt if unavailable.
+    """
+    plus_config = DagsterPlusCliConfig.get() if DagsterPlusCliConfig.exists() else None
 
-def _get_project_contexts(dg_context: DgContext, cli_config: DgRawCliConfig) -> list[DgContext]:
-    if dg_context.is_in_workspace:
-        return [
-            dg_context.for_project_environment(project.path, cli_config)
-            for project in dg_context.project_specs
-        ]
-    else:
-        return [dg_context]
+    # Try to detect agent type and platform from Plus config
+    agent_type = None
+    agent_platform = None
+    if plus_config:
+        try:
+            gql_client = DagsterPlusGraphQLClient.from_config(plus_config)
+            agent_type, agent_platform = get_agent_type_and_platform_from_graphql(gql_client)
+        except Exception:
+            # If GraphQL fails, just proceed without it
+            pass
+
+    # Default to HYBRID if we couldn't detect it
+    if agent_type is None:
+        agent_type = DgPlusAgentType.HYBRID
+
+    resolved_python_version = resolve_python_version(python_version)
+
+    return DeploymentScaffoldConfig(
+        dg_context=dg_context,
+        cli_config=cli_config,
+        plus_config=plus_config,
+        agent_type=agent_type,
+        agent_platform=agent_platform,
+        organization_name=None,
+        deployment_name="prod",
+        git_root=None,
+        python_version=resolved_python_version,
+        skip_confirmation_prompt=skip_confirmation_prompt,
+        git_provider=None,
+        use_editable_dagster=use_editable_dagster,
+    )
 
 
 @click.command(name="build-artifacts", cls=DgClickCommand)
@@ -147,100 +97,21 @@ def scaffold_build_artifacts_command(
     skip_confirmation_prompt: bool,
     **global_options: object,
 ) -> None:
-    """Scaffolds a Dockerfile to build the given Dagster project or workspace."""
-    import yaml
+    """Scaffolds a Dockerfile to build the given Dagster project or workspace.
 
+    NOTE: This command is maintained for backward compatibility.
+    Consider using `dg plus deploy configure [serverless|hybrid]` instead for a complete
+    deployment setup including CI/CD configuration.
+    """
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
 
-    plus_config = DagsterPlusCliConfig.get() if DagsterPlusCliConfig.exists() else None
+    config = _resolve_config_for_build_artifacts(
+        python_version=python_version,
+        skip_confirmation_prompt=skip_confirmation_prompt,
+        use_editable_dagster=bool(use_editable_dagster),
+        dg_context=dg_context,
+        cli_config=cli_config,
+    )
 
-    if plus_config:
-        gql_client = DagsterPlusGraphQLClient.from_config(plus_config)
-        _, agent_platform = get_agent_type_and_platform_from_graphql(gql_client)
-    else:
-        agent_platform = DgPlusAgentPlatform.UNKNOWN
-
-    scaffolded_container_context_yaml = _get_scaffolded_container_context_yaml(agent_platform)
-
-    if not dg_context.is_project:
-        click.echo("Scaffolding build artifacts for workspace...")
-
-        create = True
-        if dg_context.build_config_path.exists():
-            create = skip_confirmation_prompt or click.confirm(
-                f"Build config already exists at {dg_context.build_config_path}. Overwrite it?",
-            )
-        if create:
-            dg_context.build_config_path.write_text(yaml.dump({"registry": "..."}))
-            click.echo(f"Workspace build config created at {dg_context.build_config_path}.")
-
-        if scaffolded_container_context_yaml:
-            create = True
-            if dg_context.container_context_config_path.exists():
-                create = skip_confirmation_prompt or click.confirm(
-                    f"Container config already exists at {dg_context.container_context_config_path}. Overwrite it?",
-                )
-            if create:
-                dg_context.container_context_config_path.write_text(
-                    scaffolded_container_context_yaml
-                )
-                click.echo(
-                    f"Workspace container config created at {dg_context.container_context_config_path}."
-                )
-
-    project_contexts = _get_project_contexts(dg_context, cli_config)
-    for project_context in project_contexts:
-        click.echo(f"Scaffolding build artifacts for {project_context.code_location_name}...")
-
-        create = True
-        if project_context.build_config_path.exists():
-            create = skip_confirmation_prompt or click.confirm(
-                f"Build config already exists at {project_context.build_config_path}. Overwrite it?",
-            )
-        if create:
-            project_context.build_config_path.write_text(
-                textwrap.dedent(
-                    """
-                    directory: .
-                    # Registry is specified in the build.yaml file at the root of the workspace,
-                    # but can be overridden here.
-                    # registry: '...'
-                    """
-                )
-                if dg_context.is_in_workspace
-                else textwrap.dedent(
-                    """
-                    directory: .
-                    registry: '...'
-                    """
-                )
-            )
-            click.echo(f"Project build config created at {project_context.build_config_path}.")
-
-        if scaffolded_container_context_yaml:
-            if project_context.container_context_config_path.exists():
-                create = skip_confirmation_prompt or click.confirm(
-                    f"Container config already exists at {project_context.container_context_config_path}. Overwrite it?",
-                )
-            if create:
-                project_context.container_context_config_path.write_text(
-                    scaffolded_container_context_yaml
-                )
-                click.echo(
-                    f"Project container config created at {project_context.container_context_config_path}."
-                )
-
-        dockerfile_path = get_dockerfile_path(project_context, workspace_context=dg_context)
-        create = True
-        if dockerfile_path.exists():
-            create = skip_confirmation_prompt or click.confirm(
-                f"A Dockerfile already exists at {dockerfile_path}. Overwrite it?",
-            )
-        if create:
-            create_deploy_dockerfile(
-                dockerfile_path,
-                python_version or f"3.{sys.version_info.minor}",
-                bool(use_editable_dagster),
-            )
-            click.echo(f"Dockerfile created at {dockerfile_path}.")
+    configure_build_artifacts_impl(config)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/github_actions.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/github_actions.py
@@ -1,153 +1,88 @@
-import subprocess
-import textwrap
-from collections.abc import Callable
+"""Legacy command for scaffolding GitHub Actions workflow.
+
+This command is maintained for backward compatibility.
+Consider using `dg plus deploy configure [serverless|hybrid] --git-provider github` instead.
+"""
+
 from pathlib import Path
-from typing import NamedTuple, Optional, cast
+from typing import Optional
 
 import click
-from dagster_dg_core.config import DgRawCliConfig, normalize_cli_config
+from dagster_dg_core.config import normalize_cli_config
 from dagster_dg_core.context import DgContext
 from dagster_dg_core.shared_options import dg_global_options
-from dagster_dg_core.utils import DgClickCommand, exit_with_error
+from dagster_dg_core.utils import DgClickCommand
 from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
-from dagster_shared.plus.config import DagsterPlusCliConfig
 
 from dagster_dg_cli.cli.plus.constants import DgPlusAgentType
-from dagster_dg_cli.utils.plus.build import get_agent_type, get_dockerfile_path, merge_build_configs
+from dagster_dg_cli.cli.plus.deploy.configure.commands import (
+    resolve_deployment,
+    resolve_git_root,
+    resolve_organization,
+    resolve_python_version,
+)
+from dagster_dg_cli.cli.plus.deploy.configure.configure_ci import configure_ci_impl
+from dagster_dg_cli.cli.plus.deploy.configure.utils import DeploymentScaffoldConfig, GitProvider
+from dagster_dg_cli.utils.plus.build import get_agent_type_and_platform_from_graphql
+from dagster_dg_cli.utils.plus.gql_client import DagsterPlusGraphQLClient
 
 
-def get_cli_version_or_main() -> str:
-    from dagster_dg_cli.version import __version__ as cli_version
+def _resolve_config_for_github_actions(
+    git_root: Optional[Path],
+    dg_context: DgContext,
+    cli_config,
+) -> DeploymentScaffoldConfig:
+    """Resolve config for legacy github-actions command.
 
-    return "main" if cli_version.endswith("+dev") else f"v{cli_version}"
+    This command prompts in the legacy order: org, deployment, agent type (no platform).
+    """
+    from dagster_shared.plus.config import DagsterPlusCliConfig
 
+    plus_config = DagsterPlusCliConfig.get() if DagsterPlusCliConfig.exists() else None
 
-def search_for_git_root(path: Path) -> Optional[Path]:
-    if path.joinpath(".git").exists():
-        return path
-    elif path.parent == path:
-        return None
-    else:
-        return search_for_git_root(path.parent)
+    # Prompt for org and deployment FIRST (legacy order)
+    resolved_organization = resolve_organization(None, plus_config)
+    resolved_deployment = resolve_deployment(None, plus_config)
 
+    # Try to detect agent type and platform from Plus config
+    agent_type = None
+    agent_platform = None
+    if plus_config:
+        try:
+            gql_client = DagsterPlusGraphQLClient.from_config(plus_config)
+            agent_type, agent_platform = get_agent_type_and_platform_from_graphql(gql_client)
+        except Exception:
+            pass
 
-def _get_project_contexts(dg_context: DgContext, cli_config: DgRawCliConfig) -> list[DgContext]:
-    if dg_context.is_in_workspace:
-        return [
-            dg_context.for_project_environment(project.path, cli_config)
-            for project in dg_context.project_specs
-        ]
-    else:
-        return [dg_context]
-
-
-def _get_git_web_url(git_root: Path) -> Optional[str]:
-    from dagster_cloud_cli.core.pex_builder.code_location import get_local_repo_name
-
-    try:
-        local_repo_name = get_local_repo_name(str(git_root))
-        return f"https://github.com/{local_repo_name}"
-    except subprocess.CalledProcessError:
-        return None
-
-
-# Template file paths
-TEMPLATES_DIR = Path(__file__).parent.parent.parent / "templates"
-SERVERLESS_GITHUB_ACTION_FILE = TEMPLATES_DIR / "serverless-github-action.yaml"
-HYBRID_GITHUB_ACTION_FILE = TEMPLATES_DIR / "hybrid-github-action.yaml"
-
-BUILD_LOCATION_FRAGMENT = TEMPLATES_DIR / "build-location-fragment.yaml"
-
-
-class ContainerRegistryInfo(NamedTuple):
-    name: str
-    match: Callable[[str], bool]
-    fragment: Path
-    secrets_hints: list[str]
-
-
-REGISTRY_INFOS = [
-    ContainerRegistryInfo(
-        name="ECR",
-        match=lambda url: "ecr" in url,
-        fragment=TEMPLATES_DIR / "registry_fragments" / "ecr-login-fragment.yaml",
-        secrets_hints=[
-            'gh secret set AWS_ACCESS_KEY_ID --body "(your AWS access key ID)"',
-            'gh secret set AWS_SECRET_ACCESS_KEY --body "(your AWS secret access key)"',
-            'gh secret set AWS_REGION --body "(your AWS region)"',
-        ],
-    ),
-    ContainerRegistryInfo(
-        name="DockerHub",
-        match=lambda url: "docker.io" in url,
-        fragment=TEMPLATES_DIR / "registry_fragments" / "dockerhub-login-fragment.yaml",
-        secrets_hints=[
-            'gh secret set DOCKERHUB_USERNAME --body "(your DockerHub username)"',
-            'gh secret set DOCKERHUB_TOKEN --body "(your DockerHub token)"',
-        ],
-    ),
-    ContainerRegistryInfo(
-        name="GitHub Container Registry",
-        match=lambda url: "ghcr.io" in url,
-        fragment=TEMPLATES_DIR
-        / "registry_fragments"
-        / "github-container-registry-login-fragment.yaml",
-        secrets_hints=[],
-    ),
-    ContainerRegistryInfo(
-        name="Azure Container Registry",
-        match=lambda url: "azurecr.io" in url,
-        fragment=TEMPLATES_DIR
-        / "registry_fragments"
-        / "azure-container-registry-login-fragment.yaml",
-        secrets_hints=[
-            'gh secret set AZURE_CLIENT_ID --body "(your Azure client ID)"',
-            'gh secret set AZURE_CLIENT_SECRET --body "(your Azure client secret)"',
-        ],
-    ),
-    ContainerRegistryInfo(
-        name="Google Container Registry",
-        match=lambda url: "gcr.io" in url,
-        fragment=TEMPLATES_DIR / "registry_fragments" / "gcr-login-fragment.yaml",
-        secrets_hints=[
-            'gh secret set GCR_JSON_KEY --body "(your GCR JSON key)"',
-        ],
-    ),
-]
-
-
-def _get_build_fragment_for_locations(
-    location_ctxs: list[DgContext], git_root: Path, registry_urls: list[str]
-) -> str:
-    # TODO: when we cut over to dg deploy, we'll just use a single build call for the workspace
-    # rather than iterating over each project
-    output = []
-    for location_ctx, registry_url in zip(location_ctxs, registry_urls):
-        output.append(
-            textwrap.indent(BUILD_LOCATION_FRAGMENT.read_text(), " " * 6)
-            .replace("TEMPLATE_LOCATION_NAME", location_ctx.code_location_name)
-            .replace("TEMPLATE_LOCATION_PATH", str(location_ctx.root_path.relative_to(git_root)))
-            .replace("TEMPLATE_IMAGE_REGISTRY", registry_url)
-            .replace("TEMPLATE_DAGSTER_CLOUD_ACTION_VERSION", get_cli_version_or_main())
+    # Prompt for agent type if not detected
+    if agent_type is None:
+        agent_type = DgPlusAgentType(
+            click.prompt(
+                "Deployment agent type",
+                type=click.Choice(["serverless", "hybrid"]),
+            ).upper()
         )
-    return "\n" + "\n".join(output)
 
+    # Resolve git root
+    resolved_git_root = resolve_git_root(git_root, GitProvider.GITHUB)
 
-def _get_registry_fragment(registry_urls: list[str]) -> tuple[str, list[str]]:
-    additional_secrets_hints = []
-    output = []
-    for registry_info in REGISTRY_INFOS:
-        fragment = registry_info.fragment.read_text()
-        matching_urls = [url for url in registry_urls if registry_info.match(url)]
-        if matching_urls:
-            if "TEMPLATE_IMAGE_REGISTRY" not in fragment:
-                output.append(fragment)
-            else:
-                for url in matching_urls:
-                    output.append(fragment.replace("TEMPLATE_IMAGE_REGISTRY", url))
-            additional_secrets_hints.extend(registry_info.secrets_hints)
+    # Use default Python version
+    resolved_python_version = resolve_python_version(None)
 
-    return "\n".join(output), additional_secrets_hints
+    return DeploymentScaffoldConfig(
+        dg_context=dg_context,
+        cli_config=cli_config,
+        plus_config=plus_config,
+        agent_type=agent_type,
+        agent_platform=agent_platform,  # May be None - legacy didn't require platform
+        organization_name=resolved_organization,
+        deployment_name=resolved_deployment,
+        git_root=resolved_git_root,
+        python_version=resolved_python_version,
+        skip_confirmation_prompt=False,
+        git_provider=GitProvider.GITHUB,
+        use_editable_dagster=False,
+    )
 
 
 @click.command(
@@ -162,121 +97,18 @@ def scaffold_github_actions_command(git_root: Optional[Path], **global_options: 
     """Scaffold a GitHub Actions workflow for a Dagster project.
 
     This command will create a GitHub Actions workflow in the `.github/workflows` directory.
+
+    NOTE: This command is maintained for backward compatibility.
+    Consider using `dg plus deploy configure [serverless|hybrid] --git-provider github`
+    instead for a complete deployment setup.
     """
-    import typer
-
-    git_root = git_root or search_for_git_root(Path.cwd())
-    if git_root is None:
-        exit_with_error(
-            "No git repository found. `dg scaffold github-actions` must be run from a git repository, or "
-            "specify the path to the git root with `--git-root`."
-        )
-
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
 
-    plus_config = DagsterPlusCliConfig.get() if DagsterPlusCliConfig.exists() else None
-
-    workflows_dir = git_root / ".github" / "workflows"
-    workflows_dir.mkdir(parents=True, exist_ok=True)
-
-    if plus_config and plus_config.organization:
-        organization_name = plus_config.organization
-        click.echo(f"Using organization name {organization_name} from Dagster Plus config.")
-    else:
-        organization_name = click.prompt("Dagster Plus organization name") or ""
-
-    if plus_config and plus_config.default_deployment:
-        deployment_name = plus_config.default_deployment
-        click.echo(f"Using default deployment name {deployment_name} from Dagster Plus config.")
-    else:
-        deployment_name = click.prompt("Default deployment name", default="prod")
-
-    agent_type = get_agent_type(plus_config)
-    if agent_type == DgPlusAgentType.SERVERLESS:
-        click.echo("Using serverless workflow template.")
-    else:
-        click.echo("Using hybrid workflow template.")
-
-    additional_secrets_hints = []
-
-    template = (
-        SERVERLESS_GITHUB_ACTION_FILE.read_text()
-        if agent_type == DgPlusAgentType.SERVERLESS
-        else HYBRID_GITHUB_ACTION_FILE.read_text()
+    config = _resolve_config_for_github_actions(
+        git_root=git_root,
+        dg_context=dg_context,
+        cli_config=cli_config,
     )
 
-    template = (
-        template.replace(
-            "TEMPLATE_ORGANIZATION_NAME",
-            organization_name,
-        )
-        .replace(
-            "TEMPLATE_DEFAULT_DEPLOYMENT_NAME",
-            deployment_name,
-        )
-        .replace(
-            "TEMPLATE_PROJECT_DIR",
-            str(dg_context.root_path.relative_to(git_root)),
-        )
-        .replace(
-            "TEMPLATE_DAGSTER_CLOUD_ACTION_VERSION",
-            get_cli_version_or_main(),
-        )
-    )
-
-    registry_urls = None
-    if agent_type == DgPlusAgentType.HYBRID:
-        project_contexts = _get_project_contexts(dg_context, cli_config)
-
-        registry_urls = [
-            merge_build_configs(project.build_config, dg_context.build_config).get("registry")
-            for project in project_contexts
-        ]
-        for project, registry_url in zip(project_contexts, registry_urls):
-            if registry_url is None:
-                raise click.ClickException(
-                    f"No registry URL found for project {project.code_location_name}. Please specify a registry URL in `build.yaml`."
-                )
-        registry_urls = cast("list[str]", registry_urls)
-
-        for location_ctx in project_contexts:
-            dockerfile_path = get_dockerfile_path(location_ctx, dg_context)
-            if not dockerfile_path.exists():
-                raise click.ClickException(
-                    f"Dockerfile not found at {dockerfile_path}. Please run `dg scaffold build-artifacts` in {location_ctx.root_path} to create one."
-                )
-
-        build_fragment = _get_build_fragment_for_locations(
-            project_contexts, git_root, registry_urls
-        )
-        template = template.replace("      # TEMPLATE_BUILD_LOCATION_FRAGMENT", build_fragment)
-
-        registry_fragment, additional_secrets_hints = _get_registry_fragment(registry_urls)
-        template = template.replace(
-            "# TEMPLATE_CONTAINER_REGISTRY_LOGIN_FRAGMENT",
-            textwrap.indent(
-                registry_fragment,
-                " " * 6,
-            ),
-        )
-
-    workflow_file = workflows_dir / "dagster-plus-deploy.yml"
-    workflow_file.write_text(template)
-
-    git_web_url = _get_git_web_url(git_root) or ""
-    if git_web_url:
-        git_web_url = f"({git_web_url}/settings/secrets/actions) "
-    click.echo(
-        typer.style(
-            "\nGitHub Actions workflow created successfully. Commit and push your changes in order to deploy to Dagster Plus.\n",
-            fg=typer.colors.GREEN,
-        )
-        + f"\nYou will need to set up the following secrets in your GitHub repository using\nthe GitHub UI {git_web_url}or CLI (https://cli.github.com/):"
-        + typer.style(
-            f"\ndg plus create ci-api-token --description 'Used in {git_root.name} GitHub Actions' | gh secret set DAGSTER_CLOUD_API_TOKEN"
-            + "\n"
-            + "\n".join(additional_secrets_hints),
-            fg=typer.colors.YELLOW,
-        )
-    )
+    configure_ci_impl(config)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/plus_tests/test_scaffold_plus_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/plus_tests/test_scaffold_plus_commands.py
@@ -19,7 +19,7 @@ from dagster_test.dg_utils.utils import (
 )
 
 from dagster_dg_cli.cli.plus.constants import DgPlusAgentPlatform
-from dagster_dg_cli.cli.scaffold.github_actions import REGISTRY_INFOS
+from dagster_dg_cli.cli.plus.deploy.configure.utils import REGISTRY_INFOS
 from dagster_dg_cli.utils.plus import gql
 from dagster_dg_cli_tests.cli_tests.plus_tests.utils import (
     PYTHON_VERSION,


### PR DESCRIPTION
## Summary & Motivation

As title. Creates a single entrypoint for getting an existing project ready for deployment.

Also allows all parameterization to be (optionally) done via command line flags to help with automation from external tools / workflows.

Structurally, this introduces a single entrypoint where parameters can be passed in optionally. if parameters are not passed in, we try to pull them from the environment (e.g. reading config files). if we are not able to pull them from the environment, we prompt the user for them.

This setup allows us to present a user-friendly prompt-based workflow, while also enabling tools to just inject the parameters directly.

The existing github-actions and build-artifacts commands can then just invoke this same command for backcompat.

Also sets us up nicely for adding gitlab support (this is factored in a way that we just pass in a git_provider param so we can always add more there).

## How I Tested These Changes

## Changelog

Added a new `dg plus deploy configure` CLI group that generates all the files necessary to get an existing project ready for deployment via Dagster+.
