### PR TITLE
Don't change the working directory during PEX builds

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/source.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/source.py
@@ -47,38 +47,33 @@ def build_source_pex(
 
 
 def _build_local_package(local_dir: str, build_dir: str, python_interpreter: str):
-    curdir = os.curdir
-    os.chdir(local_dir)
-    try:
-        if os.path.exists("setup.py"):
-            ui.print(f"Building package at {local_dir!r} using {python_interpreter} setup.py build")
-            command = [
-                python_interpreter,
-                "setup.py",
-                "build",
-                "--build-lib",
-                build_dir,
-            ]
-            subprocess.run(command, check=True)
-        elif os.path.exists("pyproject.toml"):
-            ui.print(f"Building package at {local_dir!r} using {python_interpreter} -m pip install")
-            # Use pip install with --target to build and install the package to the build directory
-            # This handles pyproject.toml files properly using modern Python build standards
-            command = [
-                python_interpreter,
-                "-m",
-                "pip",
-                "install",
-                "--target",
-                build_dir,
-                "--no-deps",  # Don't install dependencies, just the package itself
-                ".",
-            ]
-            subprocess.run(command, check=True)
-        else:
-            ui.warn(f"No setup.py or pyproject.toml found in {local_dir!r} - will not build.")
-    finally:
-        os.chdir(curdir)
+    if os.path.exists(os.path.join(local_dir, "setup.py")):
+        ui.print(f"Building package at {local_dir!r} using {python_interpreter} setup.py build")
+        command = [
+            python_interpreter,
+            "setup.py",
+            "build",
+            "--build-lib",
+            build_dir,
+        ]
+        subprocess.run(command, check=True, cwd=local_dir)
+    elif os.path.exists(os.path.join(local_dir, "pyproject.toml")):
+        ui.print(f"Building package at {local_dir!r} using {python_interpreter} -m pip install")
+        # Use pip install with --target to build and install the package to the build directory
+        # This handles pyproject.toml files properly using modern Python build standards
+        command = [
+            python_interpreter,
+            "-m",
+            "pip",
+            "install",
+            "--target",
+            build_dir,
+            "--no-deps",  # Don't install dependencies, just the package itself
+            ".",
+        ]
+        subprocess.run(command, check=True, cwd=local_dir)
+    else:
+        ui.warn(f"No setup.py or pyproject.toml found in {local_dir!r} - will not build.")
 
 
 def build_pex_using_setup_py(

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/test_ci_commands.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/test_ci_commands.py
@@ -46,7 +46,7 @@ locations:
 
 @contextmanager
 def with_dagster_yaml(text):
-    pwd = os.curdir
+    pwd = os.getcwd()
     try:
         with tempfile.TemporaryDirectory() as tmpdir:
             os.mkdir(os.path.join(tmpdir, "subdir"))

--- a/python_modules/libraries/dagster-cloud-cli/setup.py
+++ b/python_modules/libraries/dagster-cloud-cli/setup.py
@@ -61,6 +61,7 @@ setup(
             "pytest-mock==3.14.0",
             "buildkite-test-collector",
             "flaky",
+            "pex>=2.1.132,<2.60.0",
         ],
     },
 )


### PR DESCRIPTION
## Summary & Motivation
The old logic here left the working directory different than where it started, breaking relative paths for subsequent builds. Instead, adjust the working directory in the launched subprocesses.

Deploy to two pyproject.toml PEX builds in a single ci build command - before it would hit an error about not being able to find the folder in it due to relative path issues, now it does not.

## How I Tested These Changes
New test case that was failing before

## Changelog
Fixed an issue where deploying multiple serverless code locations simultaneously would sometimes fail with a "he dagster package dependency was expected but not found." error.
