### PR TITLE
[fix] Fix issue with `dg plus deploy refresh-defs-state`

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/defs_state_storage.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/defs_state_storage.py
@@ -105,7 +105,7 @@ class DagsterPlusCliDefsStateStorage(DefsStateStorage[T_DagsterInstance]):
     def get_latest_defs_state_info(self) -> Optional[DefsStateInfo]:
         res = self._execute_query(GET_LATEST_DEFS_STATE_INFO_QUERY)
         latest_info = res["latestDefsStateInfo"]
-        return DefsStateInfo.from_graphql(latest_info)
+        return DefsStateInfo.from_graphql(latest_info) if latest_info else None
 
     def set_latest_version(self, key: str, version: str) -> None:
         result = self._execute_query(


### PR DESCRIPTION
## Summary & Motivation

It's possible for the `latestDefsStateInfo` to be `null` on a brand-new deployment, so we need to handle this properly

## How I Tested These Changes

## Changelog

NOCHANGELOG
