### PR TITLE
Fixes/improvements for generate_changelog script

### DIFF
--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -407,8 +407,12 @@ def _create_commit_display(
     # GitHub username info
     if should_thank:
         pr_author = commit.github_pr_author_username
-        table.add_row("GitHub PR author:", f"@{pr_author}")
-        table.add_row("Thanks:", "[green]YES[/green]")
+        if pr_author:
+            table.add_row("GitHub PR author:", f"@{pr_author}")
+            table.add_row("Thanks:", "[green]YES[/green]")
+        else:
+            table.add_row("GitHub:", "[dim]Could not parse[/dim]")
+            table.add_row("Thanks:", "[yellow]YES (username unavailable)[/yellow]")
     else:
         table.add_row("GitHub:", "[dim]Will load if Thanks is toggled[/dim]")
         table.add_row("Thanks:", "[red]NO[/red]")


### PR DESCRIPTION
## Summary & Motivation

- Print row indicating if community contribution
- More reliable resolution of actual PR author name for thanks message
- More reliable detection of internal/external contributor (still not perfect)
- Add action to open PR in the browser
- Assorted other tweaks
- Change repo name resolution logic to use DAGSTER_GIT_REPO_DIR and DAGSTER_INTERNAL_GIT_REPO_DIR. This makes sure it works even when the local repo has a different top-level root name (for instance, "oss" instead of "dagster)
- Display multiple authors in table
- Strip auto-injected by Github "Co-authored-by ..." from changelog entry text.

## How I Tested These Changes

Used the updated script to generate the changelog.