### PR TITLE
Temporarily disable showing partition statuses in the UI from streamline

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
@@ -1,9 +1,6 @@
 import asyncio
 from typing import Optional
 
-from dagster._core.definitions.asset_health.asset_materialization_health import (
-    AssetMaterializationHealthState,
-)
 from dagster._core.definitions.partitions.subset import PartitionsSubset
 from dagster._core.instance.types import CachingDynamicPartitionsLoader
 from dagster._core.remote_representation.external_data import AssetNodeSnap
@@ -21,10 +18,8 @@ async def regenerate_and_check_partition_subsets(
     Optional[PartitionsSubset[str]],
 ]:
     (
-        asset_health_state,
         (materialized_partition_subset, failed_partition_subset, in_progress_subset),
     ) = await asyncio.gather(
-        AssetMaterializationHealthState.gen(context, asset_node_snap.asset_key),
         get_partition_subsets(
             context.instance,
             context,
@@ -37,19 +32,6 @@ async def regenerate_and_check_partition_subsets(
             ),
         ),
     )
-
-    if asset_health_state:
-        # prefer sourcing materialized and failed subsets from the health object if possible
-        materialized_partition_subset = (
-            asset_health_state.materialized_subset.subset_value
-            if asset_health_state.materialized_subset.is_partitioned
-            else None
-        )
-        failed_partition_subset = (
-            asset_health_state.failed_subset.subset_value
-            if asset_health_state.failed_subset.is_partitioned
-            else None
-        )
 
     return (
         materialized_partition_subset,


### PR DESCRIPTION
Summary:
While we sort out a DST issue causing some hourly partitions to be skipped.

View hourly partitions, no longer seeing dst issue.

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
