### PR TITLE
[ui] Ensure only asset key is provided as arg in Asset permissions query

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetPermissions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetPermissions.tsx
@@ -15,7 +15,7 @@ export const useAssetPermissions = (assetKey: AssetKeyInput, locationName: strin
   const {data, loading} = useQuery<AssetPermissionsQuery, AssetPermissionsQueryVariables>(
     ASSET_PERMISSIONS_QUERY,
     {
-      variables: {assetKey},
+      variables: {assetKey: {path: assetKey.path}},
     },
   );
 


### PR DESCRIPTION
## Summary & Motivation

A GraphQL error currently shows up in OSS dev when viewing an asset detail page, in which `AssetPermissonsQuery` fails because the asset key arg being provided includes a `__typename`.

This means that upstream, a full GraphQL object (including `__typename`) is being passed through, and TypeScript doesn't object because it satisfies the required object properties for the input value.

To resolve this, just use the `path` value for the argument.

## How I Tested These Changes

Local dev, view asset detail page for an SDA. Verify that there are no GraphQL errors.