### PR TITLE
move dg api and dg deploy commands to separate pages

### DIFF
--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -276,7 +276,7 @@ To deploy to OSS production, see the [OSS deployment docs](/deployment/oss). If 
 <TabItem value="hybrid" label="Dagster+ Hybrid">
 
 1. Set up a [Hybrid deployment](/deployment/dagster-plus/hybrid), if you haven't already.
-2. In the root directory of your project, run [`dg scaffold build-artifacts`](/api/clis/dg-cli/dg-cli-reference#dg-scaffold-build-artifacts) to create a `build.yaml` deployment configuration file and a Dockerfile.
+2. In the root directory of your project, run [`dg scaffold build-artifacts`](/api/clis/dg-cli/dg-cli-reference#dg-scaffold) to create a `build.yaml` deployment configuration file and a Dockerfile.
 3. To deploy to the cloud, you can either:
    - Perform a one-time deployment with the [`dagster-cloud` CLI](/api/clis/dagster-cloud-cli)
    - [Set up CI/CD](/deployment/dagster-plus/deploying-code/ci-cd/ci-cd-in-hybrid) for continuous deployment.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -318,8 +318,12 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'dg cli',
           collapsed: true,
-          items: ['api/clis/dg-cli/dg-cli-reference', 'api/clis/dg-cli/dg-plus',
-                  'api/clis/dg-cli/dg-api', 'api/clis/dg-cli/dg-cli-configuration'],
+          items: [
+            'api/clis/dg-cli/dg-cli-reference',
+            'api/clis/dg-cli/dg-plus',
+            'api/clis/dg-cli/dg-api',
+            'api/clis/dg-cli/dg-cli-configuration',
+          ],
         },
         'api/clis/cli',
         {

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -318,7 +318,8 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'dg cli',
           collapsed: true,
-          items: ['api/clis/dg-cli/dg-cli-reference', 'api/clis/dg-cli/dg-cli-configuration'],
+          items: ['api/clis/dg-cli/dg-cli-reference', 'api/clis/dg-cli/dg-plus',
+                  'api/clis/dg-cli/dg-api', 'api/clis/dg-cli/dg-cli-configuration'],
         },
         'api/clis/cli',
         {

--- a/docs/sphinx/sections/api/apidocs/clis/dg-cli/dg-api.rst
+++ b/docs/sphinx/sections/api/apidocs/clis/dg-cli/dg-api.rst
@@ -1,0 +1,7 @@
+================
+dg api reference
+================
+
+.. click:: dagster_dg_cli.cli.api.cli_group:api_group
+    :prog: dg api
+    :nested: full

--- a/docs/sphinx/sections/api/apidocs/clis/dg-cli/dg-cli-reference.rst
+++ b/docs/sphinx/sections/api/apidocs/clis/dg-cli/dg-cli-reference.rst
@@ -1,44 +1,31 @@
-======
-dg CLI
-======
+====================================
+dg CLI local build command reference
+====================================
 
-.. currentmodule:: dagster_dg_cli
+``dg`` commands for scaffolding, checking, and listing Dagster entities, and running pipelines in a local Dagster instance.
 
-.. click:: dagster_dg_cli.cli.check:check_group
-    :prog: dg check
-    :nested: full
+.. click:: dagster_dg_cli.cli.scaffold:scaffold_group
+    :prog: dg scaffold
+    :nested:
 
 .. click:: dagster_dg_cli.cli.dev:dev_command
     :prog: dg dev
     :nested: full
 
-.. click:: dagster_dg_cli.cli.launch:launch_command
-    :prog: dg launch
+.. click:: dagster_dg_cli.cli.check:check_group
+    :prog: dg check
     :nested: full
 
 .. click:: dagster_dg_cli.cli.list:list_group
     :prog: dg list
     :nested: full
 
-.. click:: dagster_dg_cli.cli.api.cli_group:api_group
-    :prog: dg api
+.. click:: dagster_dg_cli.cli.launch:launch_command
+    :prog: dg launch
     :nested: full
 
-.. click:: dagster_dg_cli.cli.plus:plus_group
-    :prog: dg plus
-    :nested: full
-
-.. click:: dagster_dg_cli.cli.scaffold:scaffold_group
-    :prog: dg scaffold
-    :nested:
-
-
---------
-Examples
---------
-
-dg scaffold defs
-================
+dg scaffold defs example
+========================
 
 **Note:** Before scaffolding definitions with ``dg``, you must `create a project <https://docs.dagster.io/guides/build/projects/creating-a-new-project>`_ with the `create-dagster CLI <https://docs.dagster.io/api/clis/create-dagster>`_ and activate its virtual environment.
 
@@ -112,39 +99,3 @@ To confirm that the new asset now appears in the list of definitions, run `dg li
     │         │ │ my_asset │ my_group │      │       │ Asset that greets you. │ │
     │         │ └──────────┴──────────┴──────┴───────┴────────────────────────┘ │
     └─────────┴─────────────────────────────────────────────────────────────────┘
-
-dg scaffold build-artifacts
-===========================
-
-**Note:** Before scaffolding build artifacts with ``dg``, you must `create a Dagster project <https://docs.dagster.io/guides/build/projects/creating-a-new-project>`_ with the `create-dagster CLI <https://docs.dagster.io/api/clis/create-dagster>`_ and activate its virtual environment.
-
-If you have a `Dagster+ Hybrid <https://docs.dagster.io/deployment/dagster-plus/hybrid>`_ deployment, you can use ``dg scaffold build-artifacts`` to scaffold a deployment configuration file (``build.yaml``) and a Dockerfile for your Dagster project:
-
-.. code-block:: bash
-
-    dg scaffold build-artifacts
-    Scaffolding build artifacts for my-project...
-    Project build config created at /.../my-project/build.yaml.
-    Dockerfile created at /.../my-project/Dockerfile.
-
-dg scaffold github-actions
-==========================
-
-**Note:** Before scaffolding GitHub Actions with ``dg``, you must `create a Dagster project <https://docs.dagster.io/guides/build/projects/creating-a-new-project>`_ with the `create-dagster CLI <https://docs.dagster.io/api/clis/create-dagster>`_ and activate its virtual environment.
-You will also need to place the project under version control, which you can do by running ``git init`` in the project root directory.
-
-You can use the ``dg scaffold github-actions`` command to scaffold a GitHub CI/CD workflow YAML file in a ``.github/workflows`` directory:
-
-.. code-block:: bash
-
-    dg scaffold github-actions
-    Dagster Plus organization name: ExampleCo
-    Default deployment name [prod]: 
-    Deployment agent type:  (serverless, hybrid): serverless
-    Using serverless workflow template.
-
-    GitHub Actions workflow created successfully. Commit and push your changes in order to deploy to Dagster Plus.
-
-    You will need to set up the following secrets in your GitHub repository using
-    the GitHub UI or CLI (https://cli.github.com/):
-    dg plus create ci-api-token --description 'Used in my-project GitHub Actions' | gh secret set DAGSTER_CLOUD_API_TOKEN

--- a/docs/sphinx/sections/api/apidocs/clis/dg-cli/dg-plus.rst
+++ b/docs/sphinx/sections/api/apidocs/clis/dg-cli/dg-plus.rst
@@ -1,0 +1,7 @@
+=================
+dg plus reference
+=================
+
+.. click:: dagster_dg_cli.cli.plus:plus_group
+    :prog: dg plus
+    :nested: full


### PR DESCRIPTION
## Summary & Motivation

- Move `dg api` and `dg plus` docs to separate pages
- Remove `dg scaffold build-artifacts` and `dg scaffold github-actions`  examples, since those will be turned into `dg deploy configure` commands

## How I Tested These Changes

Local build

## Changelog

> Insert changelog entry or delete this section.
