### PR TITLE
[rfc][rip] dedup serdes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/time_window.py
@@ -55,6 +55,7 @@ class TimeWindowPartitionsSubsetSerializer(NamedTupleSerializer):
         # value.num_partitions will calculate the number of partitions if the field is None
         # We want to check if the field is None and replace the value with the calculated value
         # for serialization
+
         if value._asdict()["num_partitions"] is None:
             return TimeWindowPartitionsSubset(
                 partitions_def=value.partitions_def,

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes_dedup.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes_dedup.py
@@ -1,0 +1,84 @@
+import dagster as dg
+from dagster import DagsterInstance
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
+from dagster_shared.record import record
+from dagster_shared.serdes import whitelist_for_serdes
+from dagster_shared.serdes.serdes import deserialize_value_with_dedup, serialize_value_with_dedup
+
+
+@whitelist_for_serdes
+@record
+class Inner:
+    number: float
+
+
+@whitelist_for_serdes
+@record
+class Foo:
+    name: str
+    value: int
+    inner: Inner
+
+
+@whitelist_for_serdes
+@record
+class Bar:
+    name: str
+    single: Foo
+    multiple: list[Foo]
+
+
+def test_dedup():
+    # same object, different ids
+    f1 = Foo(name="f1", value=1, inner=Inner(number=1.0))
+    f1_same = Foo(name="f1", value=1, inner=Inner(number=1.0))
+
+    f2 = Foo(name="f2", value=2, inner=Inner(number=2.0))
+
+    bar = Bar(name="bar", single=f1, multiple=[f1, f1, f1_same, f1_same, f2])
+
+    serialized = serialize_value_with_dedup(bar)
+    assert "__dedup_mapping__" in serialized
+    assert "__dedup_ref__" in serialized
+    deserialized = deserialize_value_with_dedup(serialized, as_type=Bar)
+    assert deserialized == bar
+
+
+def test_cursor():
+    daily_partitions = dg.DailyPartitionsDefinition(start_date="2024-01-01")
+
+    @dg.asset(partitions_def=daily_partitions)
+    def upstream_1() -> None: ...
+
+    @dg.asset(partitions_def=daily_partitions)
+    def upstream_2() -> None: ...
+
+    @dg.asset(partitions_def=daily_partitions)
+    def upstream_3() -> None: ...
+
+    @dg.asset(partitions_def=daily_partitions)
+    def upstream_4() -> None: ...
+
+    @dg.asset(partitions_def=daily_partitions)
+    def upstream_5() -> None: ...
+
+    @dg.asset(
+        deps=[upstream_1, upstream_2, upstream_3, upstream_4, upstream_5],
+        automation_condition=dg.AutomationCondition.on_cron(cron_schedule="0 * * * *"),
+    )
+    def downstream() -> None: ...
+
+    defs = dg.Definitions(
+        assets=[upstream_1, upstream_2, upstream_3, upstream_4, upstream_5, downstream]
+    )
+    instance = DagsterInstance.ephemeral()
+
+    result = dg.evaluate_automation_conditions(defs=defs, instance=instance)
+    cursor = result.cursor
+    assert isinstance(cursor, AssetDaemonCursor)
+
+    serialized = serialize_value_with_dedup(cursor)
+    assert "__dedup_mapping__" in serialized
+    assert "__dedup_ref__" in serialized
+    deserialized = deserialize_value_with_dedup(serialized, as_type=AssetDaemonCursor)
+    assert deserialized == cursor


### PR DESCRIPTION
## Summary & Motivation

This is a proof of concept that allows us to detect repeated objects in when serializing them and store a lazy reference to them in a separate mapping object.

This results in faster serialization AND deserialization for large objects -- you pay a little bit of a tax to do the hashing of the objects while serializing, but you earn it all back by having to do way less transformation / serialization. This sort of thing is of course only advantageous for particular types of objects that are prone to high levels of repetition (the asset daemon cursor is the main example of this but I imagine we could find others in the codebase).

It also massively decreases the size of the deserialized object (nearly half for the example I had).

The rough algorithm is to hash objects as they come in and see if we've seen it before. If so, we get the packed representation of that object and store it in a global map in the context. Then then next time we see that we can just directly sub in the packed representation. This means that:

- If you have exactly one instance of a sub-object -> never goes to the global map
- If you have exactly two instances of a sub-object -> one instance will be serialized normally, the other will be stored as a reference (so slight size increase, but marginal)
- If you have three or more instance -> after the first instance, all are stored as references, so you get pretty big savings

Some stats:

```
INFO:root:Loading cursor from /Users/owen/Downloads/giant_cursor.txt...
INFO:root:  Loaded cursor
INFO:root:Benchmarking serialize_value...
INFO:root:       9.092s
INFO:root:       7.867s
INFO:root:       7.816s
INFO:root:  Results:
INFO:root:    Average time: 8.259s
INFO:root:    Size: 168,867,564 bytes (161.04 MB)
INFO:root:Benchmarking serialize_value_with_dedup...
INFO:root:       6.105s
INFO:root:       6.001s
INFO:root:       6.750s
INFO:root:  Results:
INFO:root:    Average time: 6.285s
INFO:root:    Size: 81,605,028 bytes (77.82 MB)
INFO:root:Benchmarking deserialize_value...
INFO:root:      4.723s
INFO:root:      5.839s
INFO:root:      4.699s
INFO:root:  Results:
INFO:root:    Average time: 5.087s
INFO:root:Benchmarking deserialize_value_with_dedup...
INFO:root:      4.445s
INFO:root:      3.390s
INFO:root:      3.392s
INFO:root:  Results:
INFO:root:    Average time: 3.742s
INFO:root:Checking equality of deserialized values...
```

Confirmed that this results in exact equality of the deserialized object after a round trip.

## How I Tested These Changes

## Changelog

NOCHANGELOG
