### PR TITLE
Add migration integration tag

### DIFF
--- a/docs/docs/tags.yml
+++ b/docs/docs/tags.yml
@@ -38,6 +38,10 @@ metadata:
   label: 'metadata'
   permalink: '/integrations/metadata'
   description: 'Metadata integrations.'
+migration:
+  label: 'migration'
+  permalink: '/integrations/migration'
+  description: 'Migration integrations.'
 other:
   label: 'other'
   permalink: '/integrations/other'


### PR DESCRIPTION
## Summary & Motivation

Looks like a new 'migration' tag is in use on an Airbyte integration page, but it wasn't added to the tags.yml file.

## How I Tested These Changes

Local build

## Changelog

> Insert changelog entry or delete this section.
