### PR TITLE
[docs] excludes community-integrations for docs_snippets test

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/test_integration_files_load.py
+++ b/examples/docs_snippets/docs_snippets_tests/test_integration_files_load.py
@@ -14,6 +14,9 @@ EXCLUDED_FILES = {
     f"{snippets_folder}/hashicorp.py",
     f"{snippets_folder}/meltano.py",
     f"{snippets_folder}/lakefs.py",
+    f"{snippets_folder}/salesforce.py",
+    f"{snippets_folder}/sftp.py",
+    f"{snippets_folder}/sharepoint.py",
     # FIXME: need to enable the following once we have a way to run their init/compile script in CI
     f"{snippets_folder}/dbt.py",
     f"{snippets_folder}/sdf.py",


### PR DESCRIPTION
## Summary & Motivation

Resolve

```
[2025-11-11T00:17:47Z] file_path = '/workdir/examples/docs_snippets/docs_snippets/integrations/salesforce.py'
[2025-11-11T00:17:47Z]
[2025-11-11T00:17:47Z]     @pytest.mark.parametrize("file_path", get_python_files(snippets_folder))
[2025-11-11T00:17:47Z]     def test_file_loads(file_path):
[2025-11-11T00:17:47Z]         if file_path in EXCLUDED_FILES:
[2025-11-11T00:17:47Z]             pytest.skip(f"Skipped {file_path}")
[2025-11-11T00:17:47Z]             return
[2025-11-11T00:17:47Z]         spec = importlib.util.spec_from_file_location("module", file_path)
[2025-11-11T00:17:47Z]         assert spec is not None and spec.loader is not None
[2025-11-11T00:17:47Z]         module = importlib.util.module_from_spec(spec)
[2025-11-11T00:17:47Z]         try:
[2025-11-11T00:17:47Z]             spec.loader.exec_module(module)
[2025-11-11T00:17:47Z]         except Exception as e:
[2025-11-11T00:17:47Z] >           pytest.fail(f"Failed to load {file_path}: {e!s}")
[2025-11-11T00:17:47Z] E           Failed: Failed to load /workdir/examples/docs_snippets/docs_snippets/integrations/salesforce.py: No module named 'dagster_salesforce'
```

## How I Tested These Changes

## Changelog

NOCHANGELOG
