### PR TITLE
Restore deprecated annotation on get_event_records

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/methods/event_methods.py
+++ b/python_modules/dagster/dagster/_core/instance/methods/event_methods.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Optional, Union
 
 import dagster._check as check
+from dagster._annotations import deprecated
 from dagster._time import get_current_timestamp
 from dagster._utils.warnings import beta_warning
 
@@ -115,6 +116,7 @@ class EventMethods:
         """End watch event logs."""
         return self._event_storage_impl.end_watch(run_id, cb)
 
+    @deprecated(breaking_version="2.0")
     def get_event_records(
         self,
         event_records_filter: "EventRecordsFilter",


### PR DESCRIPTION
## Summary & Motivation
I think the big instance refactor to move this out into separate methods classes inadvertently wiped out the annotation that this method is intended to be deprecated and replaced with more use case specific callsites over time (like fetch_materializations, etc.).

## How I Tested These Changes
Inspection