### PR TITLE
Bring back showing partition statuses in the UI from asset health object

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_subsets.py
@@ -1,15 +1,29 @@
 import asyncio
 from typing import Optional
 
+from dagster._core.definitions.asset_health.asset_materialization_health import (
+    AssetMaterializationHealthState,
+)
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.partitions.subset import PartitionsSubset
 from dagster._core.instance.types import CachingDynamicPartitionsLoader
 from dagster._core.remote_representation.external_data import AssetNodeSnap
 from dagster._core.storage.partition_status_cache import get_partition_subsets
-from dagster._core.workspace.context import WorkspaceRequestContext
+from dagster._core.workspace.context import BaseWorkspaceRequestContext
+
+
+async def _gen_asset_health_for_partition_subsets(
+    context: BaseWorkspaceRequestContext,
+    asset_key: AssetKey,
+) -> Optional[AssetMaterializationHealthState]:
+    if not context.read_partition_subsets_from_asset_health():
+        return None
+
+    return await AssetMaterializationHealthState.gen(context, asset_key)
 
 
 async def regenerate_and_check_partition_subsets(
-    context: WorkspaceRequestContext,
+    context: BaseWorkspaceRequestContext,
     asset_node_snap: AssetNodeSnap,
     dynamic_partitions_loader: CachingDynamicPartitionsLoader,
 ) -> tuple[
@@ -18,8 +32,10 @@ async def regenerate_and_check_partition_subsets(
     Optional[PartitionsSubset[str]],
 ]:
     (
+        asset_health_state,
         (materialized_partition_subset, failed_partition_subset, in_progress_subset),
     ) = await asyncio.gather(
+        _gen_asset_health_for_partition_subsets(context, asset_node_snap.asset_key),
         get_partition_subsets(
             context.instance,
             context,
@@ -32,6 +48,19 @@ async def regenerate_and_check_partition_subsets(
             ),
         ),
     )
+
+    if asset_health_state:
+        # prefer sourcing materialized and failed subsets from the health object if possible
+        materialized_partition_subset = (
+            asset_health_state.materialized_subset.subset_value
+            if asset_health_state.materialized_subset.is_partitioned
+            else None
+        )
+        failed_partition_subset = (
+            asset_health_state.failed_subset.subset_value
+            if asset_health_state.failed_subset.is_partitioned
+            else None
+        )
 
     return (
         materialized_partition_subset,

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -284,6 +284,9 @@ class BaseWorkspaceRequestContext(LoadingContext):
     def viewer_has_any_owner_definition_permissions(self) -> bool:
         return False
 
+    def read_partition_subsets_from_asset_health(self) -> bool:
+        return False
+
     def get_viewer_tags(self) -> dict[str, str]:
         return {}
 


### PR DESCRIPTION
## Summary & Motivation
Now with the ability to gate via method on graphql context

## How I Tested These Changes
Inspect partition statuses with gating turned off and on
