### PR TITLE
[ui] Make TimezoneSelect available outside of timezone context

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserPreferences.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserPreferences.oss.tsx
@@ -1,14 +1,15 @@
 import {Box, Button, Checkbox, Icon, Subheading, Tooltip} from '@dagster-io/ui-components';
-import React from 'react';
+import React, {useContext} from 'react';
 
 import {useStateWithStorage} from '../../hooks/useStateWithStorage';
 import {SHORTCUTS_STORAGE_KEY} from '../ShortcutHandler';
+import {useShowAssetsWithoutDefinitions} from './useShowAssetsWithoutDefinitions';
 import {HourCycleSelect} from '../time/HourCycleSelect';
 import {ThemeSelect} from '../time/ThemeSelect';
+import {TimeContext} from '../time/TimeContext';
 import {TimezoneSelect} from '../time/TimezoneSelect';
 import {automaticLabel} from '../time/browserTimezone';
 import {useThemeState} from '../useThemeState';
-import {useShowAssetsWithoutDefinitions} from './useShowAssetsWithoutDefinitions';
 
 export const UserPreferences = ({
   onChangeRequiresReload,
@@ -34,6 +35,9 @@ export const UserPreferences = ({
     }
   }, [shortcutsEnabled, theme, onChangeRequiresReload]);
 
+  const {
+    timezone: [timezone, setTimezone],
+  } = useContext(TimeContext);
   const trigger = React.useCallback(
     (timezone: string) => (
       <Button
@@ -63,7 +67,13 @@ export const UserPreferences = ({
       </Box>
       <Box flex={{justifyContent: 'space-between', alignItems: 'center'}}>
         <div>Timezone</div>
-        <TimezoneSelect trigger={trigger} />
+        <TimezoneSelect
+          timezone={timezone}
+          setTimezone={setTimezone}
+          includeAutomatic
+          trigger={trigger}
+          popoverProps={{position: 'bottom-right'}}
+        />
       </Box>
       <Box flex={{justifyContent: 'space-between', alignItems: 'center'}}>
         <div>Hour format</div>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/__stories__/TimezoneSelect.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/__stories__/TimezoneSelect.stories.tsx
@@ -1,0 +1,32 @@
+import {Button, Icon} from '@dagster-io/ui-components';
+import {Meta, StoryFn} from '@storybook/nextjs';
+import {useState} from 'react';
+
+import {TimezoneSelect} from '../TimezoneSelect';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'TimezoneSelect',
+  component: TimezoneSelect,
+} as Meta<typeof TimezoneSelect>;
+
+export const Default: StoryFn<typeof TimezoneSelect> = () => {
+  const [timezone, setTimezone] = useState('America/New_York');
+  return (
+    <div style={{width: '300px'}}>
+      <TimezoneSelect
+        timezone={timezone}
+        setTimezone={setTimezone}
+        trigger={() => (
+          <Button
+            rightIcon={<Icon name="arrow_drop_down" />}
+            style={{minWidth: '200px', display: 'flex', justifyContent: 'space-between'}}
+          >
+            {timezone}
+          </Button>
+        )}
+        includeAutomatic={false}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary & Motivation

I'd like to use a timezone selector in the new Connections edit/create flow, but right now it only exist in User Settings, and it's tied to `TimeContext`.

Remove context-specific behavior from `TimezoneSelect` and make it a bit more generic/configurable for usage outside of User Settings.

## How I Tested These Changes

Storybook example. View app, then User Settings. Change timezone, verify correct rendering and behavior. Reload page, verify that the timezone change persists.