### PR TITLE
fix: partition before default-range URL order

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/assetDetailsPathForKey.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/assetDetailsPathForKey.tsx
@@ -3,7 +3,24 @@ import qs from 'qs';
 import {AssetKey, AssetViewParams} from './types';
 
 export const assetDetailsPathForKey = (key: AssetKey, query?: AssetViewParams) => {
-  return `/assets/${key.path.map(encodeURIComponent).join('/')}?${qs.stringify(query)}`;
+  if (!query) {
+    return `/assets/${key.path.map(encodeURIComponent).join('/')}`;
+  }
+  // Ensure partition comes before default_range in the URL
+  const queryString = qs.stringify(query, {
+    sort: (a, b) => {
+      // Ensure partition comes before default_range
+      if (a === 'partition' && b === 'default_range') {
+        return -1;
+      }
+      if (a === 'default_range' && b === 'partition') {
+        return 1;
+      }
+      // Otherwise maintain alphabetical order for other params
+      return a < b ? -1 : a > b ? 1 : 0;
+    },
+  });
+  return `/assets/${key.path.map(encodeURIComponent).join('/')}?${queryString}`;
 };
 
 export const assetDetailsPathForAssetCheck = (check: {assetKey: AssetKey; name: string}) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionKeyInParams.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionKeyInParams.tsx
@@ -33,9 +33,12 @@ export function usePartitionKeyInParams({
     if (dimensionKey) {
       nextFocusedDimensionKeys.push(dimensionKey);
     }
+    // Ensure partition comes before default_range in the URL by explicitly ordering properties
+    const {partition: _partition, default_range, ...restParams} = params;
     setParams({
-      ...params,
+      ...restParams,
       partition: nextFocusedDimensionKeys.join('|'),
+      ...(default_range ? {default_range} : {}),
     });
   };
 


### PR DESCRIPTION
## Summary & Motivation
Fixed a bug where clicking a partition in `AssetPartitionList` placed default_range before partition in the URL, causing the purple overlay to expand incorrectly. The URL parameter order wasn't controlled, so default_range could appear before partition. This broke the overlay behavior. The fix ensures partition always comes before default_range in the URL, restoring correct overlay behavior.

## How I Tested These Changes
I tested the changes locally by running both the backend and frontend. For the backend, I launched the Dagster GraphQL server using time_based_partitioning.py, static_partitioning.py and files like those using dagster dev -f time_based_partitioning.py -p 3333 for example. For the frontend, I ran the Dagster UI using make dev_webapp. And the Verified Outcomes:

Fixed a bug where clicking a partition in the list put default_range before partition in the URL, which made the purple overlay expand incorrectly. The issue was that the code didn't control the order of URL parameters. Added logic to always place partition before default_range when building URLs, so the overlay behaves correctly.

Don't worry about code format, I did `yarn lint`, `yarn ts` and `yarn jest` within `ui-core` to pick up lint fixes

> fixBug/partition-before-default-range](fix: partition before default-range URL order)

Resolves "View Partitions" features at asset sidebar #32796 
