### PR TITLE
Include thread name in DA logging output

### DIFF
--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -806,6 +806,7 @@ class AssetDaemon(DagsterDaemon):
                 f"Checking {num_target_entities} assets/checks and"
                 f" {num_auto_observe_assets} observable source"
                 f" asset{'' if num_auto_observe_assets == 1 else 's'}{print_group_name}"
+                f" in thread {threading.current_thread().name}"
             )
 
             if sensor:


### PR DESCRIPTION
Summary:
Makes it easier to identify which specific thread to look at during profiling.

Turn on a DA sensor locally, view logging output

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
