### PR TITLE
[ui] Fix param extraction on asset partition ranges

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/usePartitionDimensionSelections.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/usePartitionDimensionSelections.test.tsx
@@ -1,0 +1,151 @@
+import {PartitionDefinitionType} from '../../graphql/types';
+import {DimensionQueryState, buildSerializer} from '../usePartitionDimensionSelections';
+
+describe('usePartitionDimensionSelections', () => {
+  describe('buildSerializer', () => {
+    it('should encode', () => {
+      const state: DimensionQueryState[] = [
+        {
+          name: 'default',
+          rangeText: '2025-11-13',
+          isFromPartitionQueryStringParam: false,
+        },
+      ];
+
+      const {encode} = buildSerializer({dimensions: []});
+      if (!encode) {
+        throw new Error('encode is undefined');
+      }
+
+      expect(encode(state)).toEqual({
+        default_range: '2025-11-13',
+      });
+    });
+
+    it('should encode multiple dimensions', () => {
+      const state: DimensionQueryState[] = [
+        {
+          name: 'default',
+          rangeText: '2025-11-13',
+          isFromPartitionQueryStringParam: false,
+        },
+        {
+          name: 'secondary',
+          rangeText: '2025-11-14',
+          isFromPartitionQueryStringParam: false,
+        },
+      ];
+
+      const {encode} = buildSerializer({dimensions: []});
+      if (!encode) {
+        throw new Error('encode is undefined');
+      }
+
+      expect(encode(state)).toEqual({
+        default_range: '2025-11-13',
+        secondary_range: '2025-11-14',
+      });
+    });
+
+    it('should decode one dimension, just range', () => {
+      const dimensions = [
+        {
+          name: 'default',
+          type: PartitionDefinitionType.STATIC,
+          partitionKeys: ['2025-11-12', '2025-11-13'],
+        },
+      ];
+
+      const {decode} = buildSerializer({dimensions});
+      if (!decode) {
+        throw new Error('decode is undefined');
+      }
+
+      expect(decode({default_range: '2025-11-13'})).toEqual([
+        {name: 'default', rangeText: '2025-11-13', isFromPartitionQueryStringParam: false},
+      ]);
+    });
+
+    it('should decode one dimension, range and partition params', () => {
+      const dimensions = [
+        {
+          name: 'default',
+          type: PartitionDefinitionType.STATIC,
+          partitionKeys: ['2025-11-12', '2025-11-13'],
+        },
+      ];
+
+      const {decode} = buildSerializer({dimensions});
+      if (!decode) {
+        throw new Error('decode is undefined');
+      }
+
+      expect(decode({default_range: '2025-11-13', partition: '2025-11-12'})).toEqual([
+        {name: 'default', rangeText: '2025-11-13', isFromPartitionQueryStringParam: false},
+      ]);
+    });
+
+    it('should decode one dimension, reverse order of params, range and partition params', () => {
+      const dimensions = [
+        {
+          name: 'default',
+          type: PartitionDefinitionType.STATIC,
+          partitionKeys: ['2025-11-12', '2025-11-13'],
+        },
+      ];
+
+      const {decode} = buildSerializer({dimensions});
+      if (!decode) {
+        throw new Error('decode is undefined');
+      }
+
+      expect(decode({partition: '2025-11-12', default_range: '2025-11-13'})).toEqual([
+        {name: 'default', rangeText: '2025-11-13', isFromPartitionQueryStringParam: false},
+      ]);
+    });
+
+    it('should decode one dimension, partition params', () => {
+      const dimensions = [
+        {
+          name: 'default',
+          type: PartitionDefinitionType.STATIC,
+          partitionKeys: ['2025-11-12', '2025-11-13'],
+        },
+      ];
+
+      const {decode} = buildSerializer({dimensions});
+      if (!decode) {
+        throw new Error('decode is undefined');
+      }
+
+      expect(decode({partition: '2025-11-12'})).toEqual([
+        {name: 'default', rangeText: '2025-11-12', isFromPartitionQueryStringParam: true},
+      ]);
+    });
+
+    it('should decode multiple dimensions, partition params', () => {
+      const dimensions = [
+        {
+          name: 'default',
+          type: PartitionDefinitionType.STATIC,
+          partitionKeys: ['2025-11-12', '2025-11-13'],
+        },
+        {
+          name: 'secondary',
+          type: PartitionDefinitionType.STATIC,
+          partitionKeys: ['2025-11-14', '2025-11-15'],
+        },
+      ];
+
+      const {decode} = buildSerializer({dimensions});
+      if (!decode) {
+        throw new Error('decode is undefined');
+      }
+
+      expect(decode({partition: '2025-11-12|2025-11-14'})).toEqual([
+        {name: 'default', rangeText: '2025-11-12', isFromPartitionQueryStringParam: true},
+        {name: 'secondary', rangeText: '2025-11-14', isFromPartitionQueryStringParam: true},
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary & Motivation

There is currently a bug in the asset partition view that causes interaction with the partition range selector to fail.

The issue is that the order in which we extract query params from the URL affects the value returned from decoding the params. Since the order of query params shouldn't actually ever matter, this is a bug within our own extraction code. Resolve it by ensuring that we extract in an order that will allow the UI to behave correctly, namely with the `partition` parameter being decoded first, then `_range` parameters.

## How I Tested These Changes

Proxy, view an asset with partitions. Select a range of partitions, verify correct behavior. Click on a partition, verify same. Reload the page, verify that the values are persisted.

Reverse the order of the `default_range` and `partition` params in the URL, load the page. Verify that the controls still work correctly, and that I can choose a partition range or click partitions and the UI works.

## Changelog

[ui] Fix a bug in asset partitions where the partition range selector would sometimes stop working.