### PR TITLE
[gql] endpoints to get the latests failing and warning timestamp for asset checks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -5,7 +5,7 @@
   "AssetAutomationQuery": "a7b9f9d72e79dd3cc60f094649f0e2f810feaa1563b886f7499be3087dc7cb65",
   "AssetGraphLiveQuery": "870d33b271f68fd3fcd1eb64016904deae5b531e7d82f7b22b8b63e6815a6200",
   "AssetsFreshnessInfoQuery": "1049ac5edde1a0f5c16dd8342020c30db8603477f6d7760712c5784a71bdbc01",
-  "AssetHealthQuery": "ff7311f69faa34a94e386cd735beccef7a4d933078bc9b5caf9b95e638637e05",
+  "AssetHealthQuery": "f9de7794062a9fc175b768f0308660eefc507c460eeab7dc500bce5b980337cf",
   "AssetStaleStatusDataQuery": "0168440bb72ae79664e8ba33f41a85f99398d0838b0baaa611b16a4dbb15b004",
   "AssetGraphSidebarQuery": "423d6b155cc63752472fa9bde2ff75a6e872fa1c230473394bdf6057789ad9e8",
   "AssetLiveRunLogsSubscription": "d3ae8fb8b8500d37715da27d84b0840e19a175f27f6e62cc859473345a20f64d",

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -62,6 +62,8 @@ function init() {
               latestMaterializationTimestamp: null,
               latestFailedToMaterializeTimestamp: null,
               freshnessStatusChangedTimestamp: null,
+              latestCheckWarningTimestamp: null,
+              latestCheckFailureTimestamp: null,
               assetHealth: null,
             };
           }
@@ -267,6 +269,8 @@ export const ASSETS_HEALTH_INFO_QUERY = gql`
     latestMaterializationTimestamp
     latestFailedToMaterializeTimestamp
     freshnessStatusChangedTimestamp
+    latestCheckWarningTimestamp
+    latestCheckFailureTimestamp
 
     assetHealth {
       assetHealth
@@ -341,6 +345,8 @@ function buildEmptyAssetHealthFragment(key: string): AssetHealthFragment {
     latestMaterializationTimestamp: null,
     latestFailedToMaterializeTimestamp: null,
     freshnessStatusChangedTimestamp: null,
+    latestCheckWarningTimestamp: null,
+    latestCheckFailureTimestamp: null,
     assetHealth: null,
   };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetHealthDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetHealthDataProvider.test.tsx
@@ -80,6 +80,8 @@ describe('AssetHealthDataProvider integration tests', () => {
           latestMaterializationTimestamp: null,
           latestFailedToMaterializeTimestamp: null,
           freshnessStatusChangedTimestamp: null,
+          latestCheckWarningTimestamp: null,
+          latestCheckFailureTimestamp: null,
           assetHealth: null,
         });
       });
@@ -152,6 +154,8 @@ describe('AssetHealthDataProvider integration tests', () => {
           latestMaterializationTimestamp: null,
           latestFailedToMaterializeTimestamp: null,
           freshnessStatusChangedTimestamp: null,
+          latestCheckWarningTimestamp: null,
+          latestCheckFailureTimestamp: null,
           assetHealth: null,
         });
 
@@ -164,6 +168,8 @@ describe('AssetHealthDataProvider integration tests', () => {
           latestMaterializationTimestamp: null,
           latestFailedToMaterializeTimestamp: null,
           freshnessStatusChangedTimestamp: null,
+          latestCheckWarningTimestamp: null,
+        latestCheckFailureTimestamp: null,
           assetHealth: null,
         });
       });
@@ -216,6 +222,8 @@ describe('AssetHealthDataProvider integration tests', () => {
           latestMaterializationTimestamp: null,
           latestFailedToMaterializeTimestamp: null,
           freshnessStatusChangedTimestamp: null,
+          latestCheckWarningTimestamp: null,
+          latestCheckFailureTimestamp: null,
           assetHealth: null,
         });
       });
@@ -323,6 +331,8 @@ describe('AssetHealthDataProvider integration tests', () => {
           latestMaterializationTimestamp: null,
           latestFailedToMaterializeTimestamp: null,
           freshnessStatusChangedTimestamp: null,
+          latestCheckWarningTimestamp: null,
+          latestCheckFailureTimestamp: null,
           assetHealth: null,
         });
       });
@@ -352,6 +362,8 @@ describe('AssetHealthDataProvider integration tests', () => {
           latestMaterializationTimestamp: null,
           latestFailedToMaterializeTimestamp: null,
           freshnessStatusChangedTimestamp: null,
+          latestCheckWarningTimestamp: null,
+          latestCheckFailureTimestamp: null,
           assetHealth: null,
         });
       });

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetHealthDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetHealthDataProvider.types.ts
@@ -17,6 +17,8 @@ export type AssetHealthQuery = {
           latestMaterializationTimestamp: number | null;
           latestFailedToMaterializeTimestamp: number | null;
           freshnessStatusChangedTimestamp: number | null;
+          latestCheckWarningTimestamp: number | null;
+          latestCheckFailureTimestamp: number | null;
           key: {__typename: 'AssetKey'; path: Array<string>};
           assetHealth: {
             __typename: 'AssetHealth';
@@ -83,6 +85,8 @@ export type AssetHealthFragment = {
   latestMaterializationTimestamp: number | null;
   latestFailedToMaterializeTimestamp: number | null;
   freshnessStatusChangedTimestamp: number | null;
+  latestCheckWarningTimestamp: number | null;
+  latestCheckFailureTimestamp: number | null;
   key: {__typename: 'AssetKey'; path: Array<string>};
   assetHealth: {
     __typename: 'AssetHealth';
@@ -171,4 +175,4 @@ export type AssetHealthFreshnessMetaFragment = {
   lastMaterializedTimestamp: number | null;
 };
 
-export const AssetHealthQueryVersion = 'ff7311f69faa34a94e386cd735beccef7a4d933078bc9b5caf9b95e638637e05';
+export const AssetHealthQueryVersion = 'f9de7794062a9fc175b768f0308660eefc507c460eeab7dc500bce5b980337cf';

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -633,6 +633,8 @@ type Asset {
   hasDefinitionOrRecord: Boolean!
   latestFailedToMaterializeTimestamp: Float
   freshnessStatusChangedTimestamp: Float
+  latestCheckWarningTimestamp: Float
+  latestCheckFailureTimestamp: Float
 }
 
 type AssetResultEventHistoryConnection {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -109,6 +109,8 @@ export type Asset = {
   hasDefinitionOrRecord: Scalars['Boolean']['output'];
   id: Scalars['String']['output'];
   key: AssetKey;
+  latestCheckFailureTimestamp: Maybe<Scalars['Float']['output']>;
+  latestCheckWarningTimestamp: Maybe<Scalars['Float']['output']>;
   latestEventSortKey: Maybe<Scalars['ID']['output']>;
   latestFailedToMaterializeTimestamp: Maybe<Scalars['Float']['output']>;
   latestMaterializationTimestamp: Maybe<Scalars['Float']['output']>;
@@ -6394,6 +6396,14 @@ export const buildAsset = (
         : relationshipsToOmit.has('AssetKey')
           ? ({} as AssetKey)
           : buildAssetKey({}, relationshipsToOmit),
+    latestCheckFailureTimestamp:
+      overrides && overrides.hasOwnProperty('latestCheckFailureTimestamp')
+        ? overrides.latestCheckFailureTimestamp!
+        : 0.75,
+    latestCheckWarningTimestamp:
+      overrides && overrides.hasOwnProperty('latestCheckWarningTimestamp')
+        ? overrides.latestCheckWarningTimestamp!
+        : 1.93,
     latestEventSortKey:
       overrides && overrides.hasOwnProperty('latestEventSortKey')
         ? overrides.latestEventSortKey!


### PR DESCRIPTION
With streamline we can now store the timestamp of the most recent asset check failure/warning for an asset (ie the most recent failure/warning across all checks for an asset). expose those timestamps via gql