### PR TITLE
Organize framework template vars into namespaces

### DIFF
--- a/python_modules/dagster/dagster/components/core/context.py
+++ b/python_modules/dagster/dagster/components/core/context.py
@@ -99,14 +99,7 @@ class ComponentDeclLoadContext:
         return dataclasses.replace(self, resolution_context=resolution_context)
 
     def with_rendering_scope(self, rendering_scope: Mapping[str, Any]) -> "Self":
-        return self._with_resolution_context(
-            self.resolution_context.with_scope(
-                **rendering_scope,
-                **{
-                    "project_root": str(self.project_root.resolve()),
-                },
-            )
-        )
+        return self._with_resolution_context(self.resolution_context.with_scope(**rendering_scope))
 
     def with_source_position_tree(self, source_position_tree: SourcePositionTree) -> "Self":
         return self._with_resolution_context(

--- a/python_modules/dagster/dagster/components/resolved/scopes.py
+++ b/python_modules/dagster/dagster/components/resolved/scopes.py
@@ -1,0 +1,181 @@
+"""Scope objects for use in component template resolution."""
+
+import os
+import warnings
+from typing import Any, Optional, Union
+
+from dagster.components.resolved.errors import ResolutionException
+
+
+class EnvScope:
+    """Provides access to environment variables within templates.
+
+    Available via `{{ env.* }}` in component YAML files.
+    """
+
+    def __call__(self, key: str, default: Optional[Union[str, Any]] = ...) -> Optional[str]:
+        value = os.environ.get(key, default=default)
+        if value is ...:
+            raise ResolutionException(
+                f"Environment variable {key} is not set and no default value was provided."
+                f" To provide a default value, use e.g. `env('{key}', 'default_value')`."
+            )
+        return value
+
+    def __getattr__(self, key: str) -> Optional[str]:
+        # jinja2 applies a hasattr check to any scope fn - we avoid raising our own exception
+        # for this access
+        if key.startswith("jinja"):
+            raise AttributeError(f"{key} not found")
+
+        return os.environ.get(key)
+
+    def __getitem__(self, key: str) -> Optional[str]:
+        raise ResolutionException(
+            f"To access environment variables, use dot access or the `env` function, e.g. `env.{key}` or `env('{key}')`"
+        )
+
+
+class WrappedObjectScope:
+    """Base class for wrapping an object and exposing its attributes in template scope.
+
+    This allows us to expose Python objects (like modules or context objects) to Jinja templates
+    with explicit attribute whitelisting.
+    """
+
+    def __init__(self, wrapped_object: Any, accessible_attributes: set[str]):
+        """Initialize the wrapped object scope.
+
+        Args:
+            wrapped_object: The object to wrap and expose to templates
+            accessible_attributes: Set of attribute names that are allowed to be accessed from templates.
+                                  Only these attributes will be accessible via {{ scope.attr }}
+        """
+        self._wrapped_object = wrapped_object
+        self._accessible_attributes = accessible_attributes
+
+    def __getattr__(self, name: str):
+        """Allow access to whitelisted wrapped object attributes."""
+        # jinja2 applies a hasattr check to any scope fn - we avoid raising our own exception
+        # for this access
+        if name.startswith("jinja") or name.startswith("_"):
+            raise AttributeError(f"{name} not found")
+
+        # Check if this attribute is whitelisted
+        if name not in self._accessible_attributes:
+            raise AttributeError(
+                f"Attribute '{name}' is not accessible. "
+                f"Available attributes: {', '.join(sorted(self._accessible_attributes))}"
+            )
+
+        return getattr(self._wrapped_object, name)
+
+
+class DgScope(WrappedObjectScope):
+    """Provides access to Dagster definitions and utilities within templates.
+
+    Available via `{{ dg.* }}` in component YAML files.
+
+    Examples:
+        {{ dg.AutomationCondition.eager() }}
+        {{ dg.DailyPartitionsDefinition(start_date="2024-01-01") }}
+    """
+
+    def __init__(self):
+        # Import dagster module to expose its contents
+        import dagster as dg
+
+        # Whitelist commonly used Dagster definitions
+        accessible_attributes = {
+            "AutomationCondition",
+            "DailyPartitionsDefinition",
+            "WeeklyPartitionsDefinition",
+            "MonthlyPartitionsDefinition",
+            "HourlyPartitionsDefinition",
+            "StaticPartitionsDefinition",
+            "TimeWindowPartitionsDefinition",
+        }
+
+        super().__init__(dg, accessible_attributes)
+
+
+class LoadContextScope(WrappedObjectScope):
+    """Provides access to component loading utilities within templates.
+
+    Available via `{{ context.* }}` in component YAML files.
+
+    Examples:
+        {{ context.project_root }}/data/input.csv
+        {{ context.load_component_at_path("other_component") }}
+        {{ context.build_defs_at_path("submodule") }}
+    """
+
+    def __init__(self, context):
+        """Initialize with a ComponentLoadContext.
+
+        Args:
+            context: ComponentLoadContext object that provides project_root,
+                    load_component_at_path, and build_defs_at_path
+        """
+        # For now, keep the _at_path suffix in the method names
+        # In a future PR, we'll rename the methods on ComponentLoadContext
+        accessible_attributes = {
+            "load_component_at_path",
+            "build_defs_at_path",
+        }
+
+        super().__init__(context, accessible_attributes)
+
+    @property
+    def project_root(self) -> str:
+        """The root directory of the Dagster project.
+
+        Example:
+            {{ context.project_root }}/data/input.csv
+        """
+        return str(self._wrapped_object.project_root.resolve())
+
+
+class DeprecatedScope:
+    """Wrapper that provides backward compatibility for deprecated scope variables.
+
+    Emits a deprecation warning whenever the variable is accessed.
+    """
+
+    def __init__(self, old_name: str, new_name: str, value: Any):
+        self._old_name = old_name
+        self._new_name = new_name
+        self._value = value
+
+    def _warn(self):
+        warnings.warn(
+            f"Accessing `{{{{{self._old_name}}}}}` is deprecated and will be "
+            f"removed in Dagster 1.13.0. Use `{{{{{self._new_name}}}}}` instead.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+
+    def __call__(self, *args, **kwargs):
+        """Support calling if the underlying value is callable."""
+        self._warn()
+        return self._value(*args, **kwargs)
+
+    def __getattr__(self, key: str):
+        """Support attribute access on the underlying value."""
+        # jinja2 applies a hasattr check to any scope fn - we avoid raising our own exception
+        # for this access
+        if key.startswith("jinja") or key.startswith("_"):
+            raise AttributeError(f"{key} not found")
+
+        self._warn()
+        return getattr(self._value, key)
+
+    def __getitem__(self, key: str):
+        """Support item access on the underlying value."""
+        self._warn()
+        return self._value[key]
+
+    def __str__(self):
+        """Support string conversion."""
+        self._warn()
+        return str(self._value)

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/validation_tests/test_component_validation.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/validation_tests/test_component_validation.py
@@ -29,7 +29,9 @@ DEFS_TEST_CASES = [
             'a_string: "{{ fake.x }}"',
             "                ^ 'fake' is undefined",
             "defs.yaml:4",
-            "available scope is: env, automation_condition",
+            # New namespaces plus backward compatibility scopes
+            "available scope is: env, dg",
+            "context",
         ),
     ),
     ComponentValidationTestCase(


### PR DESCRIPTION
## Summary & Motivation

We've been super messy about our organization here, and I want to formalize and standardize this stuff before it gets worse.

## How I Tested These Changes

## Changelog

The template variables available in the default resolution scope for Components have been reorganized / expanded:

- `{{ automation_condition.on_cron(...) }} ` -> `{{ dg.AutomationCondition.on_cron(...) }}`
- **new: ** All `AutomationCondition` static constructors may be accessed via the `dg` context, e.g.:
  - `{{ dg.AutomationCondition.on_missing() & dg.AutomationCondition.in_latest_time_window() }}`
-  **new: ** All `PartitionsDefinition` subclasses are now available via the `dg` context, e.g.:
  - `{{ dg.StaticPartitionsDefinition(['a', 'b', 'c']) }}`
  - `{{ dg.DailyPartitionsDefinition('2025-01-01') }}`
- `{{ project_root }}` -> `{{ context.project_root }}`
- `{{ build_definitions_at_path(...) }}` -> `{{ context.build_definitions(...) }}`
- `{{ load_component_at_path(...) }}` -> `{{ context.load_component(...) }}`

All previous template vars will continue to work as before for backcompat.