### PR TITLE
Rename load_component_at_path and build_defs_at_path to remove _at_path suffix

### DIFF
--- a/python_modules/dagster/dagster/components/component/component.py
+++ b/python_modules/dagster/dagster/components/component/component.py
@@ -290,12 +290,12 @@ class Component(ABC):
                     ),
                     "load_component_at_path": DeprecatedScope(
                         "load_component_at_path",
-                        "context.load_component_at_path",
+                        "context.load_component",
                         context.load_component_at_path,
                     ),
                     "build_defs_at_path": DeprecatedScope(
                         "build_defs_at_path",
-                        "context.build_defs_at_path",
+                        "context.build_defs",
                         context.build_defs_at_path,
                     ),
                 }

--- a/python_modules/dagster/dagster/components/core/context.py
+++ b/python_modules/dagster/dagster/components/core/context.py
@@ -10,7 +10,7 @@ from dagster_shared import check
 from dagster_shared.yaml_utils.source_position import SourcePositionTree
 from typing_extensions import Self
 
-from dagster._annotations import PublicAttr, public
+from dagster._annotations import PublicAttr, deprecated, public
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils import pushd
 from dagster.components.resolved.context import ResolutionContext
@@ -158,13 +158,13 @@ class ComponentDeclLoadContext:
         return importlib.import_module(self.defs_relative_module_name(path))
 
     @overload
-    def load_component_at_path(self, defs_path: "ResolvableToComponentPath") -> "Component": ...
+    def load_component(self, defs_path: "ResolvableToComponentPath") -> "Component": ...
     @overload
-    def load_component_at_path(
+    def load_component(
         self, defs_path: "ResolvableToComponentPath", expected_type: type[T]
     ) -> T: ...
 
-    def load_component_at_path(
+    def load_component(
         self, defs_path: "ResolvableToComponentPath", expected_type: Optional[type[T]] = None
     ) -> Any:
         """Loads a component from the given path.
@@ -181,7 +181,32 @@ class ComponentDeclLoadContext:
         self.component_tree.mark_component_load_dependency(
             from_path=self.component_path, to_path=resolved_path
         )
-        return self.component_tree.load_component_at_path(resolved_path, expected_type)  # type: ignore[reportIncompatibleArgumentType]
+        return self.component_tree.load_component(resolved_path, expected_type)  # type: ignore[reportIncompatibleArgumentType]
+
+    @overload
+    def load_component_at_path(self, defs_path: "ResolvableToComponentPath") -> "Component": ...
+    @overload
+    def load_component_at_path(
+        self, defs_path: "ResolvableToComponentPath", expected_type: type[T]
+    ) -> T: ...
+
+    @deprecated(
+        breaking_version="1.13.0",
+        additional_warn_text="Use load_component instead.",
+    )
+    def load_component_at_path(
+        self, defs_path: "ResolvableToComponentPath", expected_type: Optional[type[T]] = None
+    ) -> Any:
+        """Loads a component from the given path.
+
+        Args:
+            defs_path: Path to the component to load. If relative, resolves relative to the defs root.
+
+        Returns:
+            Component: The component loaded from the given path.
+
+        """
+        return self.load_component(defs_path, expected_type)  # type: ignore[reportIncompatibleArgumentType]
 
     def load_structural_component_at_path(
         self, defs_path: "ResolvableToComponentPath"
@@ -277,7 +302,7 @@ class ComponentLoadContext(ComponentDeclLoadContext):
             component_decl=component_decl,
         )
 
-    def build_defs_at_path(self, defs_path: Union[Path, "ComponentPath"]) -> Definitions:
+    def build_defs(self, defs_path: Union[Path, "ComponentPath"]) -> Definitions:
         """Builds definitions from the given defs subdirectory. Currently
         does not incorporate postprocessing from parent defs modules.
 
@@ -293,7 +318,24 @@ class ComponentLoadContext(ComponentDeclLoadContext):
         self.component_tree.mark_component_defs_dependency(
             from_path=self.component_path, to_path=resolved_path
         )
-        return self.component_tree.build_defs_at_path(resolved_path)
+        return self.component_tree.build_defs(resolved_path)
+
+    @deprecated(
+        breaking_version="1.13.0",
+        additional_warn_text="Use build_defs instead.",
+    )
+    def build_defs_at_path(self, defs_path: Union[Path, "ComponentPath"]) -> Definitions:
+        """Builds definitions from the given defs subdirectory. Currently
+        does not incorporate postprocessing from parent defs modules.
+
+        Args:
+            defs_path: Path to the defs module to load. If relative, resolves relative to the defs root.
+
+        Returns:
+            Definitions: The definitions loaded from the given path.
+
+        """
+        return self.build_defs(defs_path)
 
     def for_path(self, path: Path) -> "Self":
         """Creates a new context for the given path.

--- a/python_modules/dagster/dagster/components/list/list.py
+++ b/python_modules/dagster/dagster/components/list/list.py
@@ -110,7 +110,7 @@ def _load_defs_at_path(dg_context: DgContext, path: Optional[Path]) -> Repositor
     tree = ComponentTree.for_project(dg_context.root_path)
 
     try:
-        defs = tree.build_defs_at_path(path) if path else tree.build_defs()
+        defs = tree.build_defs(path) if path else tree.build_defs()
     except Exception as e:
         path_text = f" at {path}" if path else ""
         raise click.ClickException(f"Unable to load definitions{path_text}: {e}") from e

--- a/python_modules/dagster/dagster/components/testing/utils.py
+++ b/python_modules/dagster/dagster/components/testing/utils.py
@@ -184,8 +184,8 @@ class DefsFolderSandbox:
                     assert defs.get_asset_def("my_asset").key == AssetKey("my_asset")
         """
         with self.build_component_tree() as tree:
-            component = tree.load_component_at_path(defs_path)
-            defs = tree.build_defs_at_path(defs_path)
+            component = tree.load_component(defs_path)
+            defs = tree.build_defs(defs_path)
             yield component, defs
 
     def scaffold_component(

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps/defs/depends_on_my_python_defs/definitions.py
@@ -7,9 +7,7 @@ from dagster.components.core.context import ComponentLoadContext
 @dg.definitions
 def defs(context: ComponentLoadContext) -> dg.Definitions:
     @dg.asset(
-        deps=context.component_tree.build_defs_at_path(
-            Path("my_python_defs")
-        ).resolve_all_asset_specs()
+        deps=context.component_tree.build_defs(Path("my_python_defs")).resolve_all_asset_specs()
     )
     def downstream_of_all_my_python_defs(): ...
 

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_custom_component/defs/depends_on_my_python_defs/custom_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/component_component_deps_custom_component/defs/depends_on_my_python_defs/custom_component.py
@@ -7,7 +7,7 @@ MY_PYTHON_DEFS_COMPONENT_PATH = Path(__file__).parent.parent / "my_python_defs"
 
 class MyCustomComponent(dg.Component):
     def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
-        assets_from_my_python_defs = context.component_tree.build_defs_at_path(
+        assets_from_my_python_defs = context.component_tree.build_defs(
             MY_PYTHON_DEFS_COMPONENT_PATH
         ).resolve_all_asset_keys()
 

--- a/python_modules/dagster/dagster_tests/components_tests/integration_tests/component_loader.py
+++ b/python_modules/dagster/dagster_tests/components_tests/integration_tests/component_loader.py
@@ -22,7 +22,7 @@ def load_test_component_defs(
     """
     src_path = Path(src_path)
     with construct_component_tree_for_test(src_path, local_component_defn_to_inject) as tree:
-        yield tree.build_defs_at_path(Path(src_path.stem))
+        yield tree.build_defs(Path(src_path.stem))
 
 
 @contextmanager


### PR DESCRIPTION
## Summary & Motivation

It's shorter

## How I Tested These Changes

## Changelog

The `build_defs_at_path` and `load_component_at_path` methods on the `ComponentLoadContext` class have been renamed to `build_defs` and `load_component` respectively. The previous names have been preserved for backcompat.
