### PR TITLE
[ui] Improve buildGraphData performance

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -86,14 +86,14 @@ export const buildGraphData = (assetNodes: AssetNode[]) => {
       // Skip add edges for self-dependencies (eg: assets relying on older partitions of themselves)
       return;
     }
-    data.downstream[upstreamGraphId] = {
-      ...(data.downstream[upstreamGraphId] || {}),
-      [downstreamGraphId]: true,
-    };
-    data.upstream[downstreamGraphId] = {
-      ...(data.upstream[downstreamGraphId] || {}),
-      [upstreamGraphId]: true,
-    };
+    if (!data.downstream[upstreamGraphId]) {
+      data.downstream[upstreamGraphId] = {};
+    }
+    if (!data.upstream[downstreamGraphId]) {
+      data.upstream[downstreamGraphId] = {};
+    }
+    data.downstream[upstreamGraphId][downstreamGraphId] = true;
+    data.upstream[downstreamGraphId][upstreamGraphId] = true;
   };
 
   assetNodes.forEach((definition: AssetNode) => {


### PR DESCRIPTION
## Summary & Motivation

In `buildGraphData`, we're currently using spread operators to keep the internal `data` value from being mutated, but this avoidance isn't useful and it's causing a perf bottleneck for large asset graphs.

Just mutate `data` directly within the function.

This gets the large sample asset graph (~15k assets) from 8+ seconds of chug time to ~80ms.

## How I Tested These Changes

Proxy as izzy's org, load Catalog. Verify with logging that the timing for this function has dropped.

## Changelog

[ui] Improve browser performance for large asset graphs.