### PR TITLE
[dagster-dbt] Allow errors to bubble up when using rmtree

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project_manager.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project_manager.py
@@ -38,7 +38,8 @@ class DbtProjectManager(ABC):
         """
         # ensure local dir is empty
         local_dir = self._local_project_dir(state_path)
-        shutil.rmtree(local_dir, ignore_errors=True)
+        if local_dir.exists():
+            shutil.rmtree(local_dir)
         local_dir.mkdir()
 
         # ensure project exists in the dir and is compiled


### PR DESCRIPTION
## Summary & Motivation

Previously, if the rmtree step failed, then we'd just end up failing on the directory creation step, which is less informative.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
