### PR TITLE
[dagster-dbt] Fix `enable_source_tests_as_checks` on DbtProjectComponent

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -394,6 +394,7 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
             backfill_policy=op_spec.backfill_policy,
             pool=op_spec.pool,
             config_schema=self.config_cls.to_fields_dict() if self.config_cls else None,
+            allow_arbitrary_check_specs=self.translator.settings.enable_source_tests_as_checks,
         )
         def _fn(context: dg.AssetExecutionContext):
             with _set_resolution_context(res_ctx):


### PR DESCRIPTION
## Summary & Motivation

In the `@dbt_assets` decorator, it sets `allow_arbitrary_check_specs=True` on the multi-asset definition to allow for source tests. After upgrading to 1.12.2 this breaks because this setting isn't set on the multi-asset defined in the component.

cc @OwenKephart 

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
