### PR TITLE
[docs] fix masking for snowflake component in docs snippet

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_snowflake_sql_component.py
+++ b/examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_snowflake_sql_component.py
@@ -20,6 +20,7 @@ from docs_snippets_tests.snippet_checks.utils import (
 MASK_MY_PROJECT = (r" \/.*?\/my-project", " /.../my-project")
 MASK_VENV = (r"Using.*\.venv.*", "")
 MASK_USING_LOG_MESSAGE = (r"Using.*\n", "")
+MASK_PKG_RESOURCES = (r"\n.*import pkg_resources\n", "")
 
 SNIPPETS_DIR = (
     DAGSTER_ROOT
@@ -46,6 +47,7 @@ def test_components_docs_snowflake_sql(
                 MASK_VENV,
                 MASK_USING_LOG_MESSAGE,
                 MASK_MY_PROJECT,
+                MASK_PKG_RESOURCES,
             ],
         ) as context,
         environ(


### PR DESCRIPTION
## Summary & Motivation

Following the pattern here:

```
 λ grep MASK_PKG
examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_snowflake_sql_component.py
23:MASK_PKG_RESOURCES = (r"\n.*import pkg_resources\n", "")
50:                MASK_PKG_RESOURCES,

examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/components/integrations/test_dlt_component.py
22:MASK_PKG_RESOURCES = (r"\n.*import pkg_resources\n", "")
48:                    MASK_PKG_RESOURCES,

examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_migrating_definitions/test_migrating_definitions.py
20:MASK_PKG_RESOURCES = (r"\n.*import pkg_resources\n", "")
41:        global_snippet_replace_regexes=[MASK_PKG_RESOURCES],

examples/docs_snippets/docs_snippets_tests/snippet_checks/guides/dg/test_adding_components_to_existing_project/test_components_existing_project.py
21:MASK_PKG_RESOURCES = (r"\n.*import pkg_resources\n", "")
42:        global_snippet_replace_regexes=[MASK_PKG_RESOURCES],
```

## How I Tested These Changes

## Changelog

NOCHANGELOG
