### PR TITLE
Fix cursor unique id generation

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -15,6 +15,7 @@ from dagster._core.definitions.asset_key import (
     AssetCheckKey,
     AssetKey,
     CoercibleToAssetKey,
+    EntityKey,
     T_EntityKey,
 )
 from dagster._core.definitions.declarative_automation.serialized_objects import (
@@ -136,7 +137,9 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
         self, *, parent_unique_id: Optional[str] = None, index: Optional[int] = None
     ) -> AutomationConditionSnapshot:
         """Returns a serializable snapshot of the entire AutomationCondition tree."""
-        unique_id = self.get_node_unique_id(parent_unique_id=parent_unique_id, index=index)
+        unique_id = self.get_node_unique_id(
+            parent_unique_id=parent_unique_id, index=index, target_key=None
+        )
         node_snapshot = self.get_node_snapshot(unique_id)
         children = [
             child.get_snapshot(parent_unique_id=unique_id, index=i)
@@ -144,12 +147,22 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
         ]
         return AutomationConditionSnapshot(node_snapshot=node_snapshot, children=children)
 
-    def get_node_unique_id(self, *, parent_unique_id: Optional[str], index: Optional[int]) -> str:
+    def get_node_unique_id(
+        self,
+        *,
+        parent_unique_id: Optional[str],
+        index: Optional[int],
+        target_key: Optional[EntityKey],
+    ) -> str:
         """Returns a unique identifier for this condition within the broader condition tree."""
         return non_secure_md5_hash_str(f"{parent_unique_id}{index}{self.name}".encode())
 
     def get_backcompat_node_unique_ids(
-        self, *, parent_unique_id: Optional[str] = None, index: Optional[int] = None
+        self,
+        *,
+        parent_unique_id: Optional[str] = None,
+        index: Optional[int] = None,
+        target_key: Optional[EntityKey] = None,
     ) -> Sequence[str]:
         """Used for backwards compatibility when condition unique id logic changes."""
         return []
@@ -159,6 +172,7 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
         *,
         parent_unique_ids: Sequence[Optional[str]],
         child_indices: Sequence[Optional[int]],
+        target_key: Optional[EntityKey],
     ) -> Sequence[str]:
         unique_ids = []
         for parent_unique_id in parent_unique_ids:
@@ -166,10 +180,14 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
                 unique_ids.extend(
                     [
                         self.get_node_unique_id(
-                            parent_unique_id=parent_unique_id, index=child_index
+                            parent_unique_id=parent_unique_id,
+                            index=child_index,
+                            target_key=target_key,
                         ),
                         *self.get_backcompat_node_unique_ids(
-                            parent_unique_id=parent_unique_id, index=child_index
+                            parent_unique_id=parent_unique_id,
+                            index=child_index,
+                            target_key=target_key,
                         ),
                     ]
                 )
@@ -180,7 +198,7 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
     ) -> str:
         """Returns a unique identifier for the entire subtree."""
         node_unique_id = self.get_node_unique_id(
-            parent_unique_id=parent_node_unique_id, index=index
+            parent_unique_id=parent_node_unique_id, index=index, target_key=None
         )
         child_unique_ids = [
             child.get_unique_id(parent_node_unique_id=node_unique_id, index=i)
@@ -844,6 +862,22 @@ class BuiltinAutomationCondition(AutomationCondition[T_EntityKey]):
     def with_label(self, label: Optional[str]) -> Self:
         """Returns a copy of this AutomationCondition with a human-readable label."""
         return copy(self, label=label)
+
+    def _get_stable_unique_id(self, target_key: Optional[EntityKey]) -> str:
+        """Returns an identifier that is stable regardless of where it exists in the broader condition tree.
+        This should only be used for conditions that don't change their output based on what conditions are
+        evaluated before them (i.e. they explicitly set their candidate subset to the entire subset).
+        """
+        child_ids = [
+            child.get_node_unique_id(
+                parent_unique_id=None,
+                index=i,
+                target_key=target_key,
+            )
+            for i, child in enumerate(self.children)
+        ]
+        parts = [self.name, *child_ids, target_key.to_user_string() if target_key else ""]
+        return non_secure_md5_hash_str("".join(parts).encode())
 
 
 @public

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -73,7 +73,9 @@ class AutomationContext(Generic[T_EntityKey]):
         condition = check.not_none(
             evaluator.asset_graph.get(key).automation_condition or evaluator.default_condition
         )
-        unique_ids = condition.get_node_unique_ids(parent_unique_ids=[None], child_indices=[None])
+        unique_ids = condition.get_node_unique_ids(
+            parent_unique_ids=[None], child_indices=[None], target_key=None
+        )
 
         return AutomationContext(
             condition=condition,
@@ -101,7 +103,11 @@ class AutomationContext(Generic[T_EntityKey]):
         check.invariant(len(child_indices) > 0, "Must be at least one child index")
 
         unique_ids = child_condition.get_node_unique_ids(
-            parent_unique_ids=self.condition_unique_ids, child_indices=child_indices
+            parent_unique_ids=self.condition_unique_ids,
+            child_indices=child_indices,
+            target_key=candidate_subset.key
+            if candidate_subset.key != self.root_context.key
+            else None,
         )
         return AutomationContext(
             condition=child_condition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
@@ -88,7 +88,7 @@ class LegacyRuleEvaluationContext:
             condition=condition,
             cursor=cursor,
             node_cursor=cursor.node_cursors_by_unique_id.get(
-                condition.get_node_unique_id(parent_unique_id=None, index=0)
+                condition.get_node_unique_id(parent_unique_id=None, index=0, target_key=None)
             )
             if cursor
             else None,
@@ -224,17 +224,23 @@ class LegacyRuleEvaluationContext:
         # Or(MaterializeCond, Not(SkipCond), Not(DiscardCond))
         if len(self.condition.children) != 3:
             return None
-        unique_id = self.condition.get_node_unique_id(parent_unique_id=None, index=None)
+        unique_id = self.condition.get_node_unique_id(
+            parent_unique_id=None, index=None, target_key=None
+        )
 
         # get Not(DiscardCond)
         not_discard_condition = self.condition.children[2]
-        unique_id = not_discard_condition.get_node_unique_id(parent_unique_id=unique_id, index=2)
+        unique_id = not_discard_condition.get_node_unique_id(
+            parent_unique_id=unique_id, index=2, target_key=None
+        )
         if not isinstance(not_discard_condition, NotAutomationCondition):
             return None
 
         # get DiscardCond
         discard_condition = not_discard_condition.children[0]
-        unique_id = discard_condition.get_node_unique_id(parent_unique_id=unique_id, index=0)
+        unique_id = discard_condition.get_node_unique_id(
+            parent_unique_id=unique_id, index=0, target_key=None
+        )
         if not isinstance(discard_condition, RuleCondition) or not isinstance(
             discard_condition.rule, DiscardOnMaxMaterializationsExceededRule
         ):

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/rule_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/rule_condition.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Optional
 
 from dagster_shared.serdes import whitelist_for_serdes
 
-from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_key import AssetKey, EntityKey
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationResult,
@@ -24,7 +24,13 @@ class RuleCondition(BuiltinAutomationCondition[AssetKey]):
 
     rule: AutoMaterializeRule
 
-    def get_node_unique_id(self, *, parent_unique_id: Optional[str], index: Optional[int]) -> str:
+    def get_node_unique_id(
+        self,
+        *,
+        parent_unique_id: Optional[str],
+        index: Optional[int],
+        target_key: Optional[EntityKey],
+    ) -> str:
         # preserves old (bad) behavior of not including the parent_unique_id to avoid invalidating
         # old serialized information
         parts = [self.rule.__class__.__name__, self.description]

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -8,7 +8,7 @@ from typing_extensions import Self
 import dagster._check as check
 from dagster._annotations import public
 from dagster._core.asset_graph_view.asset_graph_view import U_EntityKey
-from dagster._core.definitions.asset_key import AssetKey, T_EntityKey
+from dagster._core.definitions.asset_key import AssetKey, EntityKey, T_EntityKey
 from dagster._core.definitions.assets.graph.base_asset_graph import BaseAssetGraph, BaseAssetNode
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
@@ -123,16 +123,30 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     def requires_cursor(self) -> bool:
         return False
 
-    def get_node_unique_id(self, *, parent_unique_id: Optional[str], index: Optional[int]) -> str:
+    def get_node_unique_id(
+        self,
+        *,
+        parent_unique_id: Optional[str],
+        index: Optional[int],
+        target_key: Optional[EntityKey],
+    ) -> str:
         """Ignore allow_selection / ignore_selection for the cursor hash."""
         parts = [str(parent_unique_id), str(index), self.base_name]
         return non_secure_md5_hash_str("".join(parts).encode())
 
     def get_backcompat_node_unique_ids(
-        self, *, parent_unique_id: Optional[str] = None, index: Optional[int] = None
+        self,
+        *,
+        parent_unique_id: Optional[str] = None,
+        index: Optional[int] = None,
+        target_key: Optional[EntityKey] = None,
     ) -> Sequence[str]:
         # backcompat for previous cursors where the allow/ignore selection influenced the hash
-        return [super().get_node_unique_id(parent_unique_id=parent_unique_id, index=index)]
+        return [
+            super().get_node_unique_id(
+                parent_unique_id=parent_unique_id, index=index, target_key=target_key
+            )
+        ]
 
     @public
     def allow(self, selection: "AssetSelection") -> "DepsAutomationCondition":

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
@@ -5,7 +5,7 @@ from dagster_shared.serdes import whitelist_for_serdes
 
 from dagster._core.asset_graph_view.entity_subset import EntitySubset
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
-from dagster._core.definitions.asset_key import T_EntityKey
+from dagster._core.definitions.asset_key import EntityKey, T_EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
     AutomationResult,
@@ -38,6 +38,15 @@ class NewlyTrueCondition(BuiltinAutomationCondition[T_EntityKey]):
         if not true_subset:
             return None
         return context.asset_graph_view.get_subset_from_serializable_subset(true_subset)
+
+    def get_backcompat_node_unique_ids(
+        self,
+        *,
+        parent_unique_id: Optional[str] = None,
+        index: Optional[int] = None,
+        target_key: Optional[EntityKey] = None,
+    ) -> Sequence[str]:
+        return [self._get_stable_unique_id(target_key)]
 
     async def evaluate(self, context: AutomationContext) -> AutomationResult:  # pyright: ignore[reportIncompatibleMethodOverride]
         # evaluate child condition

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -8,7 +8,7 @@ from typing_extensions import Self
 
 import dagster._check as check
 from dagster._annotations import public
-from dagster._core.definitions.asset_key import T_EntityKey
+from dagster._core.definitions.asset_key import EntityKey, T_EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
     AutomationResult,
@@ -92,6 +92,15 @@ class SinceCondition(BuiltinAutomationCondition[T_EntityKey]):
     @property
     def children(self) -> Sequence[AutomationCondition[T_EntityKey]]:
         return [self.trigger_condition, self.reset_condition]
+
+    def get_backcompat_node_unique_ids(
+        self,
+        *,
+        parent_unique_id: Optional[str] = None,
+        index: Optional[int] = None,
+        target_key: Optional[EntityKey] = None,
+    ) -> Sequence[str]:
+        return [self._get_stable_unique_id(target_key)]
 
     async def evaluate(  # pyright: ignore[reportIncompatibleMethodOverride]
         self, context: AutomationContext[T_EntityKey]

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
@@ -1,6 +1,9 @@
+import datetime
+
 import dagster as dg
 import pytest
 from dagster import AutomationCondition as SC
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_selection import AssetSelection
 
 from dagster_tests.declarative_automation_tests.scenario_utils.automation_condition_scenario import (
@@ -74,9 +77,60 @@ def test_node_unique_id() -> None:
         .ignore(AssetSelection.keys("b"))
     )
     assert (
-        condition.get_node_unique_id(parent_unique_id=None, index=None)
+        condition.get_node_unique_id(parent_unique_id=None, index=None, target_key=None)
         == "80f87fb32baaf7ce3f65f68c12d3eb11"
     )
     assert condition.get_backcompat_node_unique_ids(parent_unique_id=None, index=None) == [
         "35b152923d1d99348e85c3cbe426bcb7"
     ]
+
+
+def test_since_condition_cursor_backcompat() -> None:
+    # This cursor was generated on master branch after:
+    # - Initial evaluation at 2025-08-16 08:16:00
+    # - Advancing time by 1 hour (passing a cron tick) and evaluating
+    # - Materializing u1 and evaluating
+    # - Materializing u2 and evaluating
+    # It represents the state where we've seen u1 and u2 materialized, but not u3 yet.
+    SERIALIZED_CURSOR = '{"__class__": "AssetDaemonCursor", "evaluation_id": 4, "last_observe_request_timestamp_by_asset_key": {"__mapping_items__": []}, "previous_condition_cursors": [{"__class__": "AutomationConditionCursor", "effective_timestamp": 1755360960.0, "last_event_id": 2, "node_cursors_by_unique_id": {"3a9f75060a801f9d701f3a413d3bf357": {"__class__": "AutomationConditionNodeCursor", "candidate_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["downstream"]}, "value": true}, "extra_state": null, "metadata": {}, "subsets_with_metadata": [], "true_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["downstream"]}, "value": false}}, "70f16bbec00eb312c4da7cfd827c0d6f": {"__class__": "AutomationConditionNodeCursor", "candidate_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["u2"]}, "value": true}, "extra_state": null, "metadata": {"reset_evaluation_id": {"__class__": "IntMetadataEntryData", "value": 1}, "reset_timestamp": {"__class__": "FloatMetadataEntryData", "value": 1755360960.0}, "trigger_evaluation_id": {"__class__": "IntMetadataEntryData", "value": 3}, "trigger_timestamp": {"__class__": "FloatMetadataEntryData", "value": 1755360960.0}}, "subsets_with_metadata": [], "true_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["u2"]}, "value": true}}, "78fcf9818d90b7a754ce5ca8438f38a7": {"__class__": "AutomationConditionNodeCursor", "candidate_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["downstream"]}, "value": true}, "extra_state": null, "metadata": {"reset_evaluation_id": {"__class__": "IntMetadataEntryData", "value": 0}, "reset_timestamp": {"__class__": "FloatMetadataEntryData", "value": 1755357360.0}, "trigger_evaluation_id": {"__class__": "IntMetadataEntryData", "value": 1}, "trigger_timestamp": {"__class__": "FloatMetadataEntryData", "value": 1755360960.0}}, "subsets_with_metadata": [], "true_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["downstream"]}, "value": true}}, "8cdd899bf2549b7a5c2e859374ece3e0": {"__class__": "AutomationConditionNodeCursor", "candidate_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["u1"]}, "value": true}, "extra_state": null, "metadata": {"reset_evaluation_id": {"__class__": "IntMetadataEntryData", "value": 1}, "reset_timestamp": {"__class__": "FloatMetadataEntryData", "value": 1755360960.0}, "trigger_evaluation_id": {"__class__": "IntMetadataEntryData", "value": 2}, "trigger_timestamp": {"__class__": "FloatMetadataEntryData", "value": 1755360960.0}}, "subsets_with_metadata": [], "true_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["u1"]}, "value": true}}, "96cdedfb5f6eda4a495cd248e15b0199": {"__class__": "AutomationConditionNodeCursor", "candidate_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["downstream"]}, "value": true}, "extra_state": null, "metadata": {}, "subsets_with_metadata": [], "true_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["downstream"]}, "value": true}}, "9a75684cd0cb75d2ebc6d5766664af8d": {"__class__": "AutomationConditionNodeCursor", "candidate_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["downstream"]}, "value": true}, "extra_state": "30941eb8f7bb4d6d5a93ddcb3d7d9a44", "metadata": {}, "subsets_with_metadata": [], "true_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["downstream"]}, "value": false}}, "cb267651e07bf0097d6897293b5e0a16": {"__class__": "AutomationConditionNodeCursor", "candidate_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["downstream"]}, "value": true}, "extra_state": null, "metadata": {}, "subsets_with_metadata": [], "true_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["downstream"]}, "value": true}}, "de921ed0f21116b1537bdad77a7c3300": {"__class__": "AutomationConditionNodeCursor", "candidate_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["u3"]}, "value": true}, "extra_state": null, "metadata": {"reset_evaluation_id": {"__class__": "IntMetadataEntryData", "value": 1}, "reset_timestamp": {"__class__": "FloatMetadataEntryData", "value": 1755360960.0}, "trigger_evaluation_id": {"__class__": "IntMetadataEntryData", "value": null}, "trigger_timestamp": {"__class__": "FloatMetadataEntryData", "value": null}}, "subsets_with_metadata": [], "true_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["u3"]}, "value": false}}}, "previous_requested_subset": {"__class__": "AssetSubset", "asset_key": {"__class__": "AssetKey", "path": ["downstream"]}, "value": false}, "result_value_hash": "4600b054dde72ed5b654f1e698b73e0e"}], "previous_evaluation_state": []}'
+
+    downstream_key = dg.AssetKey("downstream")
+
+    @dg.asset
+    def u1() -> None: ...
+
+    @dg.asset
+    def u2() -> None: ...
+
+    @dg.asset
+    def u3() -> None: ...
+
+    condition = SC.on_cron("@hourly")
+
+    @dg.asset(key=downstream_key, deps=[u1, u2, u3], automation_condition=condition)
+    def downstream() -> None: ...
+
+    defs = dg.Definitions(assets=[u1, u2, u3, downstream])
+    instance = dg.DagsterInstance.ephemeral()
+
+    # Start at the same time as when the cursor was generated (after the cron tick)
+    current_time = datetime.datetime(2025, 8, 16, 8, 16, 0) + datetime.timedelta(hours=1)
+
+    # Deserialize the cursor from the string representation
+    cursor = dg.deserialize_value(SERIALIZED_CURSOR, AssetDaemonCursor)
+
+    # First evaluation with the deserialized cursor - nothing should be requested yet
+    # because we haven't materialized u3
+    result = dg.evaluate_automation_conditions(
+        defs, instance=instance, evaluation_time=current_time, cursor=cursor
+    )
+    assert result.total_requested == 0
+
+    # Now materialize u3 (the final parent that was missing)
+    instance.report_runless_asset_event(dg.AssetMaterialization(dg.AssetKey("u3")))
+
+    # Evaluate again - now downstream should be requested since all parents are materialized
+    result = dg.evaluate_automation_conditions(
+        defs, instance=instance, evaluation_time=current_time, cursor=result.cursor
+    )
+    assert result.total_requested == 1


### PR DESCRIPTION
## Summary & Motivation

This makes it so that, for SINCE / NEWLY_TRUE conditions specifically, we can retain memory of their value no matter where they move in the tree.

This is safe for these conditions because they always execute against the entire set of partitions of an asset, regardless of what their candidate subset is. This means that their result value is not actually influenced by anything other than their sub conditions and the key that they are being applied against.

This uses the existing backcompat_node_unique_ids() functionality to ensure that we can still find cursors stored with the old serialization format.

## How I Tested These Changes

## Changelog

Updated the cursoring logic of `AutomationCondition.since()`/`AutomationCondition.newly_true()` to make them retain access to their stored data in a wider range of scenarios where the underlying condition structure is changed.
