### PR TITLE
✨ Huge improvement in UI run/sensor/schedule page speed ✨ (Add correlation statistics on run_tags.key:value)

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/049_d5c0e2416d9e_add_run_tags_key_value_statistics.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/049_d5c0e2416d9e_add_run_tags_key_value_statistics.py
@@ -1,0 +1,38 @@
+"""add run_tags key value statistics
+
+Revision ID: d5c0e2416d9e
+Revises: 7e2f3204cf8e
+Create Date: 2025-11-15 23:13:08.062589
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d5c0e2416d9e"
+down_revision = "7e2f3204cf8e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    # Only postgresql supports cross column statistics
+    if bind.dialect.name == "postgresql":
+        # Add correlation statistics on key, value
+        op.execute(
+            "CREATE STATISTICS run_tags_key_value_stats (dependencies, ndistinct) ON key, value FROM run_tags;"
+        )
+        # Increase number of samples (run_tags can be a huge table)
+        op.execute("ALTER TABLE run_tags ALTER COLUMN value SET STATISTICS 500;")
+        # Update statistics
+        op.execute("ANALYZE run_tags")
+
+
+def downgrade():
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        # Remove correlation statistics on key, value
+        op.execute("DROP STATISTICS run_tags_key_value_stats;")
+        # Reset to default
+        op.execute("ALTER TABLE run_tags ALTER COLUMN value SET STATISTICS -1;")

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/snapshot_1_12_3_add_run_tags_key_value_statistics/postgres/pg_dump.txt
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/snapshot_1_12_3_add_run_tags_key_value_statistics/postgres/pg_dump.txt
@@ -1,0 +1,1959 @@
+--
+-- PostgreSQL database dump
+--
+
+\restrict is5YHaVX7GrG6YagPg0WbdcCbKUXIxFAOffOc9zPhL34K1KWnF15cMz2O0OXfQM
+
+-- Dumped from database version 16.11 (Debian 16.11-1.pgdg13+1)
+-- Dumped by pg_dump version 16.11 (Homebrew)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: public; Type: SCHEMA; Schema: -; Owner: test
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+ALTER SCHEMA public OWNER TO test;
+
+--
+-- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: test
+--
+
+COMMENT ON SCHEMA public IS '';
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: alembic_version; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.alembic_version (
+    version_num character varying(32) NOT NULL
+);
+
+
+ALTER TABLE public.alembic_version OWNER TO test;
+
+--
+-- Name: asset_check_executions; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.asset_check_executions (
+    id bigint NOT NULL,
+    asset_key text,
+    check_name text,
+    partition text,
+    run_id character varying(255),
+    execution_status character varying(255),
+    evaluation_event text,
+    evaluation_event_timestamp timestamp without time zone,
+    evaluation_event_storage_id bigint,
+    materialization_event_storage_id bigint,
+    create_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+ALTER TABLE public.asset_check_executions OWNER TO test;
+
+--
+-- Name: asset_check_executions_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.asset_check_executions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.asset_check_executions_id_seq OWNER TO test;
+
+--
+-- Name: asset_check_executions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.asset_check_executions_id_seq OWNED BY public.asset_check_executions.id;
+
+
+--
+-- Name: asset_daemon_asset_evaluations; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.asset_daemon_asset_evaluations (
+    id bigint NOT NULL,
+    evaluation_id bigint,
+    asset_key text,
+    asset_evaluation_body text,
+    num_requested integer,
+    num_skipped integer,
+    num_discarded integer,
+    create_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+ALTER TABLE public.asset_daemon_asset_evaluations OWNER TO test;
+
+--
+-- Name: asset_daemon_asset_evaluations_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.asset_daemon_asset_evaluations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.asset_daemon_asset_evaluations_id_seq OWNER TO test;
+
+--
+-- Name: asset_daemon_asset_evaluations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.asset_daemon_asset_evaluations_id_seq OWNED BY public.asset_daemon_asset_evaluations.id;
+
+
+--
+-- Name: asset_event_tags; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.asset_event_tags (
+    id bigint NOT NULL,
+    event_id integer,
+    asset_key text NOT NULL,
+    key text NOT NULL,
+    value text,
+    event_timestamp timestamp without time zone
+);
+
+
+ALTER TABLE public.asset_event_tags OWNER TO test;
+
+--
+-- Name: asset_event_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.asset_event_tags_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.asset_event_tags_id_seq OWNER TO test;
+
+--
+-- Name: asset_event_tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.asset_event_tags_id_seq OWNED BY public.asset_event_tags.id;
+
+
+--
+-- Name: asset_keys; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.asset_keys (
+    id integer NOT NULL,
+    asset_key character varying(512),
+    create_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    last_materialization text,
+    last_run_id character varying(255),
+    asset_details text,
+    wipe_timestamp timestamp without time zone,
+    last_materialization_timestamp timestamp without time zone,
+    tags text,
+    cached_status_data text
+);
+
+
+ALTER TABLE public.asset_keys OWNER TO test;
+
+--
+-- Name: asset_keys_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.asset_keys_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.asset_keys_id_seq OWNER TO test;
+
+--
+-- Name: asset_keys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.asset_keys_id_seq OWNED BY public.asset_keys.id;
+
+
+--
+-- Name: backfill_tags; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.backfill_tags (
+    id bigint NOT NULL,
+    backfill_id character varying(255),
+    key text,
+    value text
+);
+
+
+ALTER TABLE public.backfill_tags OWNER TO test;
+
+--
+-- Name: backfill_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.backfill_tags_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.backfill_tags_id_seq OWNER TO test;
+
+--
+-- Name: backfill_tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.backfill_tags_id_seq OWNED BY public.backfill_tags.id;
+
+
+--
+-- Name: bulk_actions; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.bulk_actions (
+    id bigint NOT NULL,
+    key character varying(32) NOT NULL,
+    status character varying(255) NOT NULL,
+    "timestamp" timestamp without time zone NOT NULL,
+    body text,
+    action_type character varying(32),
+    selector_id text,
+    job_name text
+);
+
+
+ALTER TABLE public.bulk_actions OWNER TO test;
+
+--
+-- Name: bulk_actions_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.bulk_actions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.bulk_actions_id_seq OWNER TO test;
+
+--
+-- Name: bulk_actions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.bulk_actions_id_seq OWNED BY public.bulk_actions.id;
+
+
+--
+-- Name: concurrency_limits; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.concurrency_limits (
+    id bigint NOT NULL,
+    concurrency_key character varying(512) NOT NULL,
+    "limit" integer NOT NULL,
+    update_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    create_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    using_default_limit boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE public.concurrency_limits OWNER TO test;
+
+--
+-- Name: concurrency_limits_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.concurrency_limits_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.concurrency_limits_id_seq OWNER TO test;
+
+--
+-- Name: concurrency_limits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.concurrency_limits_id_seq OWNED BY public.concurrency_limits.id;
+
+
+--
+-- Name: concurrency_slots; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.concurrency_slots (
+    id bigint NOT NULL,
+    concurrency_key text NOT NULL,
+    run_id text,
+    step_key text,
+    deleted boolean NOT NULL,
+    create_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+ALTER TABLE public.concurrency_slots OWNER TO test;
+
+--
+-- Name: concurrency_slots_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.concurrency_slots_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.concurrency_slots_id_seq OWNER TO test;
+
+--
+-- Name: concurrency_slots_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.concurrency_slots_id_seq OWNED BY public.concurrency_slots.id;
+
+
+--
+-- Name: daemon_heartbeats; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.daemon_heartbeats (
+    daemon_type character varying(255) NOT NULL,
+    daemon_id character varying(255),
+    "timestamp" timestamp without time zone NOT NULL,
+    body text,
+    id bigint NOT NULL
+);
+
+
+ALTER TABLE public.daemon_heartbeats OWNER TO test;
+
+--
+-- Name: daemon_heartbeats_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.daemon_heartbeats_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.daemon_heartbeats_id_seq OWNER TO test;
+
+--
+-- Name: daemon_heartbeats_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.daemon_heartbeats_id_seq OWNED BY public.daemon_heartbeats.id;
+
+
+--
+-- Name: dynamic_partitions; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.dynamic_partitions (
+    id bigint NOT NULL,
+    partitions_def_name text NOT NULL,
+    partition text NOT NULL,
+    create_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+ALTER TABLE public.dynamic_partitions OWNER TO test;
+
+--
+-- Name: dynamic_partitions_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.dynamic_partitions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.dynamic_partitions_id_seq OWNER TO test;
+
+--
+-- Name: dynamic_partitions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.dynamic_partitions_id_seq OWNED BY public.dynamic_partitions.id;
+
+
+--
+-- Name: event_logs; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.event_logs (
+    id integer NOT NULL,
+    run_id character varying(255),
+    event text NOT NULL,
+    dagster_event_type text,
+    "timestamp" timestamp without time zone,
+    step_key text,
+    asset_key text,
+    partition text
+);
+
+
+ALTER TABLE public.event_logs OWNER TO test;
+
+--
+-- Name: event_logs_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.event_logs_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.event_logs_id_seq OWNER TO test;
+
+--
+-- Name: event_logs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.event_logs_id_seq OWNED BY public.event_logs.id;
+
+
+--
+-- Name: instance_info; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.instance_info (
+    id bigint NOT NULL,
+    run_storage_id text
+);
+
+
+ALTER TABLE public.instance_info OWNER TO test;
+
+--
+-- Name: instance_info_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.instance_info_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.instance_info_id_seq OWNER TO test;
+
+--
+-- Name: instance_info_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.instance_info_id_seq OWNED BY public.instance_info.id;
+
+
+--
+-- Name: instigators; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.instigators (
+    id bigint NOT NULL,
+    selector_id character varying(255),
+    repository_selector_id character varying(255),
+    status character varying(63),
+    instigator_type character varying(63),
+    instigator_body text,
+    create_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    update_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+ALTER TABLE public.instigators OWNER TO test;
+
+--
+-- Name: instigators_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.instigators_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.instigators_id_seq OWNER TO test;
+
+--
+-- Name: instigators_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.instigators_id_seq OWNED BY public.instigators.id;
+
+
+--
+-- Name: job_ticks; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.job_ticks (
+    id bigint NOT NULL,
+    job_origin_id character varying(255),
+    status character varying(63),
+    type character varying(63),
+    "timestamp" timestamp without time zone,
+    tick_body text,
+    create_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    update_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    selector_id character varying(255)
+);
+
+
+ALTER TABLE public.job_ticks OWNER TO test;
+
+--
+-- Name: job_ticks_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.job_ticks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.job_ticks_id_seq OWNER TO test;
+
+--
+-- Name: job_ticks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.job_ticks_id_seq OWNED BY public.job_ticks.id;
+
+
+--
+-- Name: jobs; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.jobs (
+    id bigint NOT NULL,
+    job_origin_id character varying(255),
+    repository_origin_id character varying(255),
+    status character varying(63),
+    job_type character varying(63),
+    job_body text,
+    create_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    update_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    selector_id character varying(255)
+);
+
+
+ALTER TABLE public.jobs OWNER TO test;
+
+--
+-- Name: jobs_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.jobs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.jobs_id_seq OWNER TO test;
+
+--
+-- Name: jobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.jobs_id_seq OWNED BY public.jobs.id;
+
+
+--
+-- Name: kvs; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.kvs (
+    key text NOT NULL,
+    value text,
+    id bigint NOT NULL
+);
+
+
+ALTER TABLE public.kvs OWNER TO test;
+
+--
+-- Name: kvs_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.kvs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.kvs_id_seq OWNER TO test;
+
+--
+-- Name: kvs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.kvs_id_seq OWNED BY public.kvs.id;
+
+
+--
+-- Name: pending_steps; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.pending_steps (
+    id bigint NOT NULL,
+    concurrency_key text NOT NULL,
+    run_id text,
+    step_key text,
+    priority integer,
+    assigned_timestamp timestamp without time zone,
+    create_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+
+ALTER TABLE public.pending_steps OWNER TO test;
+
+--
+-- Name: pending_steps_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.pending_steps_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.pending_steps_id_seq OWNER TO test;
+
+--
+-- Name: pending_steps_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.pending_steps_id_seq OWNED BY public.pending_steps.id;
+
+
+--
+-- Name: run_tags; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.run_tags (
+    id integer NOT NULL,
+    run_id character varying(255),
+    key text,
+    value text
+);
+
+
+ALTER TABLE public.run_tags OWNER TO test;
+
+--
+-- Name: run_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.run_tags_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.run_tags_id_seq OWNER TO test;
+
+--
+-- Name: run_tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.run_tags_id_seq OWNED BY public.run_tags.id;
+
+
+--
+-- Name: runs; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.runs (
+    id integer NOT NULL,
+    run_id character varying(255),
+    snapshot_id character varying(255),
+    pipeline_name text,
+    status character varying(63),
+    run_body text,
+    create_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    update_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    partition text,
+    partition_set text,
+    mode text,
+    start_time double precision,
+    end_time double precision,
+    backfill_id character varying(255)
+);
+
+
+ALTER TABLE public.runs OWNER TO test;
+
+--
+-- Name: runs_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.runs_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.runs_id_seq OWNER TO test;
+
+--
+-- Name: runs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.runs_id_seq OWNED BY public.runs.id;
+
+
+--
+-- Name: secondary_indexes; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.secondary_indexes (
+    id integer NOT NULL,
+    name character varying(512),
+    create_timestamp timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    migration_completed timestamp without time zone
+);
+
+
+ALTER TABLE public.secondary_indexes OWNER TO test;
+
+--
+-- Name: secondary_indexes_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.secondary_indexes_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.secondary_indexes_id_seq OWNER TO test;
+
+--
+-- Name: secondary_indexes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.secondary_indexes_id_seq OWNED BY public.secondary_indexes.id;
+
+
+--
+-- Name: snapshots; Type: TABLE; Schema: public; Owner: test
+--
+
+CREATE TABLE public.snapshots (
+    id integer NOT NULL,
+    snapshot_id character varying(255) NOT NULL,
+    snapshot_body bytea NOT NULL,
+    snapshot_type character varying(63) NOT NULL
+);
+
+
+ALTER TABLE public.snapshots OWNER TO test;
+
+--
+-- Name: snapshots_id_seq; Type: SEQUENCE; Schema: public; Owner: test
+--
+
+CREATE SEQUENCE public.snapshots_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.snapshots_id_seq OWNER TO test;
+
+--
+-- Name: snapshots_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: test
+--
+
+ALTER SEQUENCE public.snapshots_id_seq OWNED BY public.snapshots.id;
+
+
+--
+-- Name: asset_check_executions id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.asset_check_executions ALTER COLUMN id SET DEFAULT nextval('public.asset_check_executions_id_seq'::regclass);
+
+
+--
+-- Name: asset_daemon_asset_evaluations id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.asset_daemon_asset_evaluations ALTER COLUMN id SET DEFAULT nextval('public.asset_daemon_asset_evaluations_id_seq'::regclass);
+
+
+--
+-- Name: asset_event_tags id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.asset_event_tags ALTER COLUMN id SET DEFAULT nextval('public.asset_event_tags_id_seq'::regclass);
+
+
+--
+-- Name: asset_keys id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.asset_keys ALTER COLUMN id SET DEFAULT nextval('public.asset_keys_id_seq'::regclass);
+
+
+--
+-- Name: backfill_tags id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.backfill_tags ALTER COLUMN id SET DEFAULT nextval('public.backfill_tags_id_seq'::regclass);
+
+
+--
+-- Name: bulk_actions id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.bulk_actions ALTER COLUMN id SET DEFAULT nextval('public.bulk_actions_id_seq'::regclass);
+
+
+--
+-- Name: concurrency_limits id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.concurrency_limits ALTER COLUMN id SET DEFAULT nextval('public.concurrency_limits_id_seq'::regclass);
+
+
+--
+-- Name: concurrency_slots id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.concurrency_slots ALTER COLUMN id SET DEFAULT nextval('public.concurrency_slots_id_seq'::regclass);
+
+
+--
+-- Name: daemon_heartbeats id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.daemon_heartbeats ALTER COLUMN id SET DEFAULT nextval('public.daemon_heartbeats_id_seq'::regclass);
+
+
+--
+-- Name: dynamic_partitions id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.dynamic_partitions ALTER COLUMN id SET DEFAULT nextval('public.dynamic_partitions_id_seq'::regclass);
+
+
+--
+-- Name: event_logs id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.event_logs ALTER COLUMN id SET DEFAULT nextval('public.event_logs_id_seq'::regclass);
+
+
+--
+-- Name: instance_info id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.instance_info ALTER COLUMN id SET DEFAULT nextval('public.instance_info_id_seq'::regclass);
+
+
+--
+-- Name: instigators id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.instigators ALTER COLUMN id SET DEFAULT nextval('public.instigators_id_seq'::regclass);
+
+
+--
+-- Name: job_ticks id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.job_ticks ALTER COLUMN id SET DEFAULT nextval('public.job_ticks_id_seq'::regclass);
+
+
+--
+-- Name: jobs id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.jobs ALTER COLUMN id SET DEFAULT nextval('public.jobs_id_seq'::regclass);
+
+
+--
+-- Name: kvs id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.kvs ALTER COLUMN id SET DEFAULT nextval('public.kvs_id_seq'::regclass);
+
+
+--
+-- Name: pending_steps id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.pending_steps ALTER COLUMN id SET DEFAULT nextval('public.pending_steps_id_seq'::regclass);
+
+
+--
+-- Name: run_tags id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.run_tags ALTER COLUMN id SET DEFAULT nextval('public.run_tags_id_seq'::regclass);
+
+
+--
+-- Name: runs id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.runs ALTER COLUMN id SET DEFAULT nextval('public.runs_id_seq'::regclass);
+
+
+--
+-- Name: secondary_indexes id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.secondary_indexes ALTER COLUMN id SET DEFAULT nextval('public.secondary_indexes_id_seq'::regclass);
+
+
+--
+-- Name: snapshots id; Type: DEFAULT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.snapshots ALTER COLUMN id SET DEFAULT nextval('public.snapshots_id_seq'::regclass);
+
+
+--
+-- Data for Name: alembic_version; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.alembic_version (version_num) FROM stdin;
+7e2f3204cf8e
+\.
+
+
+--
+-- Data for Name: asset_check_executions; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.asset_check_executions (id, asset_key, check_name, partition, run_id, execution_status, evaluation_event, evaluation_event_timestamp, evaluation_event_storage_id, materialization_event_storage_id, create_timestamp) FROM stdin;
+\.
+
+
+--
+-- Data for Name: asset_daemon_asset_evaluations; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.asset_daemon_asset_evaluations (id, evaluation_id, asset_key, asset_evaluation_body, num_requested, num_skipped, num_discarded, create_timestamp) FROM stdin;
+\.
+
+
+--
+-- Data for Name: asset_event_tags; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.asset_event_tags (id, event_id, asset_key, key, value, event_timestamp) FROM stdin;
+1	68	["basic_asset_1"]	dagster/data_version	6c9d21d97b078a4cedd1fdc1d1d3991dde75605279a2115ee2c1deea25d89d95	2024-11-15 10:00:51.966126
+\.
+
+
+--
+-- Data for Name: asset_keys; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.asset_keys (id, asset_key, create_timestamp, last_materialization, last_run_id, asset_details, wipe_timestamp, last_materialization_timestamp, tags, cached_status_data) FROM stdin;
+1	["basic_asset_1"]	2024-11-15 18:00:46.166939	{"__class__": "EventLogRecord", "event_log_entry": {"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepMaterializationData", "asset_lineage": [], "materialization": {"__class__": "AssetMaterialization", "asset_key": {"__class__": "AssetKey", "path": ["basic_asset_1"]}, "description": null, "metadata_entries": [], "partition": null, "tags": {"dagster/code_version": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "dagster/data_version": "6c9d21d97b078a4cedd1fdc1d1d3991dde75605279a2115ee2c1deea25d89d95"}}}, "event_type_value": "ASSET_MATERIALIZATION", "logging_tags": {"job_name": "basic_assets_job", "op_name": "basic_asset_1", "resource_fn_name": "None", "resource_name": "None", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1"}, "message": "Materialized value basic_asset_1.", "pid": 3691, "pipeline_name": "basic_assets_job", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}, "step_handle": {"__class__": "StepHandle", "key": "basic_asset_1", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}}, "step_key": "basic_asset_1", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1", "timestamp": 1731664851.966126, "user_message": "Materialized value basic_asset_1."}, "storage_id": 68}	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	\N	\N	2024-11-15 18:00:51.966126	\N	\N
+\.
+
+
+--
+-- Data for Name: backfill_tags; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.backfill_tags (id, backfill_id, key, value) FROM stdin;
+\.
+
+
+--
+-- Data for Name: bulk_actions; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.bulk_actions (id, key, status, "timestamp", body, action_type, selector_id, job_name) FROM stdin;
+2	in_progress_backfill	REQUESTED	2025-11-15 21:46:56.804266	{"__class__": "PartitionBackfill", "asset_backfill_data": null, "asset_selection": null, "backfill_end_timestamp": null, "backfill_id": "in_progress_backfill", "backfill_timestamp": 1763243216.804266, "description": null, "error": null, "failure_count": 0, "from_failure": false, "last_submitted_partition_name": null, "partition_names": null, "partition_set_origin": null, "reexecution_steps": null, "reserved_run_ids": [], "run_config": {}, "serialized_asset_backfill_data": "foo", "status": {"__enum__": "BulkActionStatus.REQUESTED"}, "submitting_run_requests": [], "tags": {}, "title": null}	MULTI_RUN_ASSET_ACTION	\N	\N
+3	no_runs_backfill	CANCELED	2025-11-15 21:46:56.889518	{"__class__": "PartitionBackfill", "asset_backfill_data": null, "asset_selection": null, "backfill_end_timestamp": 1763243216.889518, "backfill_id": "no_runs_backfill", "backfill_timestamp": 1763243216.889518, "description": null, "error": null, "failure_count": 0, "from_failure": false, "last_submitted_partition_name": null, "partition_names": null, "partition_set_origin": null, "reexecution_steps": null, "reserved_run_ids": [], "run_config": {}, "serialized_asset_backfill_data": "foo", "status": {"__enum__": "BulkActionStatus.CANCELED"}, "submitting_run_requests": [], "tags": {}, "title": null}	MULTI_RUN_ASSET_ACTION	\N	\N
+1	before_end_timestamp_migration	COMPLETED_SUCCESS	2025-11-15 21:46:29.523042	{"__class__": "PartitionBackfill", "asset_backfill_data": null, "asset_selection": null, "backfill_end_timestamp": 1763243217.385069, "backfill_id": "before_end_timestamp_migration", "backfill_timestamp": 1763243189.523042, "description": null, "error": null, "failure_count": 0, "from_failure": false, "last_submitted_partition_name": null, "partition_names": null, "partition_set_origin": null, "reexecution_steps": null, "reserved_run_ids": [], "run_config": {}, "serialized_asset_backfill_data": "foo", "status": {"__enum__": "BulkActionStatus.COMPLETED_SUCCESS"}, "submitting_run_requests": [], "tags": {}, "title": null}	MULTI_RUN_ASSET_ACTION	\N	\N
+\.
+
+
+--
+-- Data for Name: concurrency_limits; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.concurrency_limits (id, concurrency_key, "limit", update_timestamp, create_timestamp, using_default_limit) FROM stdin;
+\.
+
+
+--
+-- Data for Name: concurrency_slots; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.concurrency_slots (id, concurrency_key, run_id, step_key, deleted, create_timestamp) FROM stdin;
+\.
+
+
+--
+-- Data for Name: daemon_heartbeats; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.daemon_heartbeats (daemon_type, daemon_id, "timestamp", body, id) FROM stdin;
+SCHEDULER	90746cb1-de8b-452c-a6a6-53494b5eec79	2024-11-15 18:05:00.0053	{"__class__": "DaemonHeartbeat", "daemon_id": "90746cb1-de8b-452c-a6a6-53494b5eec79", "daemon_type": "SCHEDULER", "errors": [], "timestamp": 1731665100.0053}	3
+ASSET	90746cb1-de8b-452c-a6a6-53494b5eec79	2024-11-15 18:05:07.472139	{"__class__": "DaemonHeartbeat", "daemon_id": "90746cb1-de8b-452c-a6a6-53494b5eec79", "daemon_type": "ASSET", "errors": [], "timestamp": 1731665107.472139}	4
+SENSOR	90746cb1-de8b-452c-a6a6-53494b5eec79	2024-11-15 18:05:07.474127	{"__class__": "DaemonHeartbeat", "daemon_id": "90746cb1-de8b-452c-a6a6-53494b5eec79", "daemon_type": "SENSOR", "errors": [], "timestamp": 1731665107.474127}	1
+BACKFILL	90746cb1-de8b-452c-a6a6-53494b5eec79	2024-11-15 18:05:09.489483	{"__class__": "DaemonHeartbeat", "daemon_id": "90746cb1-de8b-452c-a6a6-53494b5eec79", "daemon_type": "BACKFILL", "errors": [], "timestamp": 1731665109.489483}	2
+\.
+
+
+--
+-- Data for Name: dynamic_partitions; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.dynamic_partitions (id, partitions_def_name, partition, create_timestamp) FROM stdin;
+\.
+
+
+--
+-- Data for Name: event_logs; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.event_logs (id, run_id, event, dagster_event_type, "timestamp", step_key, asset_key, partition) FROM stdin;
+1	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": "cli_api_subprocess_init", "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "80538"}, "label": "pid"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Started process for pipeline (pid: 80538).", "pid": null, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 20, "message": "Started process for pipeline (pid: 80538).", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": null, "timestamp": 1610466002.695335, "user_message": "Started process for pipeline (pid: 80538)."}	ENGINE_EVENT	2021-01-12 10:40:02.695335	\N	\N	\N
+2	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": "resources", "metadata_entries": []}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Starting initialization of resources [asset_store].", "pid": 80538, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - ENGINE_EVENT - Starting initialization of resources [asset_store].", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": null, "timestamp": 1610466002.725283, "user_message": "Starting initialization of resources [asset_store]."}	ENGINE_EVENT	2021-01-12 10:40:02.725283	\N	\N	\N
+3	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": "resources", "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": "Initialized in 0.04ms", "entry_data": {"__class__": "PythonArtifactMetadataEntryData", "module": "dagster.core.storage.asset_store", "name": "InMemoryAssetStore"}, "label": "asset_store"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Finished initialization of resources [asset_store].", "pid": 80538, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - ENGINE_EVENT - Finished initialization of resources [asset_store].", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": null, "timestamp": 1610466002.733164, "user_message": "Finished initialization of resources [asset_store]."}	ENGINE_EVENT	2021-01-12 10:40:02.733164	\N	\N	\N
+4	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_START", "logging_tags": {}, "message": "Started execution of pipeline \\"foo\\".", "pid": 80538, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - PIPELINE_START - Started execution of pipeline \\"foo\\".", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": null, "timestamp": 1610466002.747415, "user_message": "Started execution of pipeline \\"foo\\"."}	PIPELINE_START	2021-01-12 10:40:02.747415	\N	\N	\N
+5	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "80538"}, "label": "pid"}, {"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "['do_something.compute', 'do_input.compute']"}, "label": "step_keys"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Executing steps in process (pid: 80538)", "pid": 80538, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - ENGINE_EVENT - Executing steps in process (pid: 80538)", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": null, "timestamp": 1610466002.766284, "user_message": "Executing steps in process (pid: 80538)"}	ENGINE_EVENT	2021-01-12 10:40:02.766284	\N	\N	\N
+6	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "STEP_START", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpOhX8MX\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_something", "solid_definition": "do_something", "step_key": "do_something.compute"}, "message": "Started execution of step \\"do_something.compute\\".", "pid": 80538, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_something", "parent": null}, "step_key": "do_something.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - do_something.compute - STEP_START - Started execution of step \\"do_something.compute\\".", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": "do_something.compute", "timestamp": 1610466002.791495, "user_message": "Started execution of step \\"do_something.compute\\"."}	STEP_START	2021-01-12 10:40:02.791495	do_something.compute	\N	\N
+7	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepOutputData", "intermediate_materialization": null, "step_output_handle": {"__class__": "StepOutputHandle", "output_name": "result", "step_key": "do_something.compute"}, "type_check_data": {"__class__": "TypeCheckData", "description": null, "label": "result", "metadata_entries": [], "success": true}, "version": null}, "event_type_value": "STEP_OUTPUT", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpOhX8MX\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_something", "solid_definition": "do_something", "step_key": "do_something.compute"}, "message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pid": 80538, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_something", "parent": null}, "step_key": "do_something.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - do_something.compute - STEP_OUTPUT - Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": "do_something.compute", "timestamp": 1610466002.801619, "user_message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed)."}	STEP_OUTPUT	2021-01-12 10:40:02.801619	do_something.compute	\N	\N
+8	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "ObjectStoreOperationResultData", "address": "/intermediates/do_something.compute/result", "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "PathMetadataEntryData", "path": "/intermediates/do_something.compute/result"}, "label": "key"}], "op": "SET_OBJECT", "value_name": "result", "version": null}, "event_type_value": "OBJECT_STORE_OPERATION", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpOhX8MX\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_something", "solid_definition": "do_something", "step_key": "do_something.compute"}, "message": "Stored intermediate object for output result in memory object store using pickle.", "pid": 80538, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_something", "parent": null}, "step_key": "do_something.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - do_something.compute - OBJECT_STORE_OPERATION - Stored intermediate object for output result in memory object store using pickle.", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": "do_something.compute", "timestamp": 1610466002.813374, "user_message": "Stored intermediate object for output result in memory object store using pickle."}	OBJECT_STORE_OPERATION	2021-01-12 10:40:02.813374	do_something.compute	\N	\N
+9	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepSuccessData", "duration_ms": 24.420976638793945}, "event_type_value": "STEP_SUCCESS", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpOhX8MX\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_something", "solid_definition": "do_something", "step_key": "do_something.compute"}, "message": "Finished execution of step \\"do_something.compute\\" in 24ms.", "pid": 80538, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_something", "parent": null}, "step_key": "do_something.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - do_something.compute - STEP_SUCCESS - Finished execution of step \\"do_something.compute\\" in 24ms.", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": "do_something.compute", "timestamp": 1610466002.824419, "user_message": "Finished execution of step \\"do_something.compute\\" in 24ms."}	STEP_SUCCESS	2021-01-12 10:40:02.824419	do_something.compute	\N	\N
+10	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "STEP_START", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpOhX8MX\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Started execution of step \\"do_input.compute\\".", "pid": 80538, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - do_input.compute - STEP_START - Started execution of step \\"do_input.compute\\".", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": "do_input.compute", "timestamp": 1610466002.849921, "user_message": "Started execution of step \\"do_input.compute\\"."}	STEP_START	2021-01-12 10:40:02.849921	do_input.compute	\N	\N
+11	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "ObjectStoreOperationResultData", "address": "/intermediates/do_something.compute/result", "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "PathMetadataEntryData", "path": "/intermediates/do_something.compute/result"}, "label": "key"}], "op": "GET_OBJECT", "value_name": "x", "version": null}, "event_type_value": "OBJECT_STORE_OPERATION", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpOhX8MX\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Retrieved intermediate object for input x in memory object store using pickle.", "pid": 80538, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - do_input.compute - OBJECT_STORE_OPERATION - Retrieved intermediate object for input x in memory object store using pickle.", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": "do_input.compute", "timestamp": 1610466002.858748, "user_message": "Retrieved intermediate object for input x in memory object store using pickle."}	OBJECT_STORE_OPERATION	2021-01-12 10:40:02.858748	do_input.compute	\N	\N
+12	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepInputData", "input_name": "x", "type_check_data": {"__class__": "TypeCheckData", "description": null, "label": "x", "metadata_entries": [], "success": true}}, "event_type_value": "STEP_INPUT", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpOhX8MX\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Got input \\"x\\" of type \\"Any\\". (Type check passed).", "pid": 80538, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - do_input.compute - STEP_INPUT - Got input \\"x\\" of type \\"Any\\". (Type check passed).", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": "do_input.compute", "timestamp": 1610466002.914811, "user_message": "Got input \\"x\\" of type \\"Any\\". (Type check passed)."}	STEP_INPUT	2021-01-12 10:40:02.914811	do_input.compute	\N	\N
+19	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": "cli_api_subprocess_init", "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "80630"}, "label": "pid"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Started process for pipeline (pid: 80630).", "pid": null, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 20, "message": "Started process for pipeline (pid: 80630).", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": null, "timestamp": 1610466063.469835, "user_message": "Started process for pipeline (pid: 80630)."}	ENGINE_EVENT	2021-01-12 10:41:03.469835	\N	\N	\N
+13	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepOutputData", "intermediate_materialization": null, "step_output_handle": {"__class__": "StepOutputHandle", "output_name": "result", "step_key": "do_input.compute"}, "type_check_data": {"__class__": "TypeCheckData", "description": null, "label": "result", "metadata_entries": [], "success": true}, "version": null}, "event_type_value": "STEP_OUTPUT", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpOhX8MX\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pid": 80538, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - do_input.compute - STEP_OUTPUT - Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": "do_input.compute", "timestamp": 1610466002.923249, "user_message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed)."}	STEP_OUTPUT	2021-01-12 10:40:02.923249	do_input.compute	\N	\N
+14	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "ObjectStoreOperationResultData", "address": "/intermediates/do_input.compute/result", "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "PathMetadataEntryData", "path": "/intermediates/do_input.compute/result"}, "label": "key"}], "op": "SET_OBJECT", "value_name": "result", "version": null}, "event_type_value": "OBJECT_STORE_OPERATION", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpOhX8MX\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Stored intermediate object for output result in memory object store using pickle.", "pid": 80538, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - do_input.compute - OBJECT_STORE_OPERATION - Stored intermediate object for output result in memory object store using pickle.", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": "do_input.compute", "timestamp": 1610466002.93098, "user_message": "Stored intermediate object for output result in memory object store using pickle."}	OBJECT_STORE_OPERATION	2021-01-12 10:40:02.93098	do_input.compute	\N	\N
+15	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepSuccessData", "duration_ms": 16.441822052001953}, "event_type_value": "STEP_SUCCESS", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpOhX8MX\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Finished execution of step \\"do_input.compute\\" in 16ms.", "pid": 80538, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - do_input.compute - STEP_SUCCESS - Finished execution of step \\"do_input.compute\\" in 16ms.", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": "do_input.compute", "timestamp": 1610466002.938373, "user_message": "Finished execution of step \\"do_input.compute\\" in 16ms."}	STEP_SUCCESS	2021-01-12 10:40:02.938373	do_input.compute	\N	\N
+16	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "80538"}, "label": "pid"}, {"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "['do_something.compute', 'do_input.compute']"}, "label": "step_keys"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Finished steps in process (pid: 80538) in 174ms", "pid": 80538, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - ENGINE_EVENT - Finished steps in process (pid: 80538) in 174ms", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": null, "timestamp": 1610466002.947824, "user_message": "Finished steps in process (pid: 80538) in 174ms"}	ENGINE_EVENT	2021-01-12 10:40:02.947824	\N	\N	\N
+17	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_SUCCESS", "logging_tags": {}, "message": "Finished execution of pipeline \\"foo\\".", "pid": 80538, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - 8c59d1b7-1841-4c60-8346-89e298dbf743 - 80538 - PIPELINE_SUCCESS - Finished execution of pipeline \\"foo\\".", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": null, "timestamp": 1610466002.955528, "user_message": "Finished execution of pipeline \\"foo\\"."}	PIPELINE_SUCCESS	2021-01-12 10:40:02.955528	\N	\N	\N
+18	8c59d1b7-1841-4c60-8346-89e298dbf743	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": []}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Process for pipeline exited (pid: 80538).", "pid": null, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 20, "message": "Process for pipeline exited (pid: 80538).", "pipeline_name": "foo", "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "step_key": null, "timestamp": 1610466002.976421, "user_message": "Process for pipeline exited (pid: 80538)."}	ENGINE_EVENT	2021-01-12 10:40:02.976421	\N	\N	\N
+20	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": "resources", "metadata_entries": []}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Starting initialization of resources [asset_store].", "pid": 80630, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - ENGINE_EVENT - Starting initialization of resources [asset_store].", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": null, "timestamp": 1610466063.497736, "user_message": "Starting initialization of resources [asset_store]."}	ENGINE_EVENT	2021-01-12 10:41:03.497736	\N	\N	\N
+21	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": "resources", "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": "Initialized in 0.04ms", "entry_data": {"__class__": "PythonArtifactMetadataEntryData", "module": "dagster.core.storage.asset_store", "name": "InMemoryAssetStore"}, "label": "asset_store"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Finished initialization of resources [asset_store].", "pid": 80630, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - ENGINE_EVENT - Finished initialization of resources [asset_store].", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": null, "timestamp": 1610466063.505822, "user_message": "Finished initialization of resources [asset_store]."}	ENGINE_EVENT	2021-01-12 10:41:03.505822	\N	\N	\N
+22	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_START", "logging_tags": {}, "message": "Started execution of pipeline \\"foo\\".", "pid": 80630, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - PIPELINE_START - Started execution of pipeline \\"foo\\".", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": null, "timestamp": 1610466063.515559, "user_message": "Started execution of pipeline \\"foo\\"."}	PIPELINE_START	2021-01-12 10:41:03.515559	\N	\N	\N
+23	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "80630"}, "label": "pid"}, {"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "['do_something.compute', 'do_input.compute']"}, "label": "step_keys"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Executing steps in process (pid: 80630)", "pid": 80630, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - ENGINE_EVENT - Executing steps in process (pid: 80630)", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": null, "timestamp": 1610466063.537139, "user_message": "Executing steps in process (pid: 80630)"}	ENGINE_EVENT	2021-01-12 10:41:03.537139	\N	\N	\N
+24	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "STEP_START", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpRbaiCU\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_something", "solid_definition": "do_something", "step_key": "do_something.compute"}, "message": "Started execution of step \\"do_something.compute\\".", "pid": 80630, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_something", "parent": null}, "step_key": "do_something.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - do_something.compute - STEP_START - Started execution of step \\"do_something.compute\\".", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": "do_something.compute", "timestamp": 1610466063.560975, "user_message": "Started execution of step \\"do_something.compute\\"."}	STEP_START	2021-01-12 10:41:03.560975	do_something.compute	\N	\N
+25	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepOutputData", "intermediate_materialization": null, "step_output_handle": {"__class__": "StepOutputHandle", "output_name": "result", "step_key": "do_something.compute"}, "type_check_data": {"__class__": "TypeCheckData", "description": null, "label": "result", "metadata_entries": [], "success": true}, "version": null}, "event_type_value": "STEP_OUTPUT", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpRbaiCU\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_something", "solid_definition": "do_something", "step_key": "do_something.compute"}, "message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pid": 80630, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_something", "parent": null}, "step_key": "do_something.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - do_something.compute - STEP_OUTPUT - Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": "do_something.compute", "timestamp": 1610466063.571169, "user_message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed)."}	STEP_OUTPUT	2021-01-12 10:41:03.571169	do_something.compute	\N	\N
+26	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "ObjectStoreOperationResultData", "address": "/intermediates/do_something.compute/result", "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "PathMetadataEntryData", "path": "/intermediates/do_something.compute/result"}, "label": "key"}], "op": "SET_OBJECT", "value_name": "result", "version": null}, "event_type_value": "OBJECT_STORE_OPERATION", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpRbaiCU\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_something", "solid_definition": "do_something", "step_key": "do_something.compute"}, "message": "Stored intermediate object for output result in memory object store using pickle.", "pid": 80630, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_something", "parent": null}, "step_key": "do_something.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - do_something.compute - OBJECT_STORE_OPERATION - Stored intermediate object for output result in memory object store using pickle.", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": "do_something.compute", "timestamp": 1610466063.578979, "user_message": "Stored intermediate object for output result in memory object store using pickle."}	OBJECT_STORE_OPERATION	2021-01-12 10:41:03.578979	do_something.compute	\N	\N
+27	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepSuccessData", "duration_ms": 17.81296730041504}, "event_type_value": "STEP_SUCCESS", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpRbaiCU\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_something", "solid_definition": "do_something", "step_key": "do_something.compute"}, "message": "Finished execution of step \\"do_something.compute\\" in 17ms.", "pid": 80630, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_something", "parent": null}, "step_key": "do_something.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - do_something.compute - STEP_SUCCESS - Finished execution of step \\"do_something.compute\\" in 17ms.", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": "do_something.compute", "timestamp": 1610466063.587337, "user_message": "Finished execution of step \\"do_something.compute\\" in 17ms."}	STEP_SUCCESS	2021-01-12 10:41:03.587337	do_something.compute	\N	\N
+28	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "STEP_START", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpRbaiCU\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Started execution of step \\"do_input.compute\\".", "pid": 80630, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - do_input.compute - STEP_START - Started execution of step \\"do_input.compute\\".", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": "do_input.compute", "timestamp": 1610466063.610631, "user_message": "Started execution of step \\"do_input.compute\\"."}	STEP_START	2021-01-12 10:41:03.610631	do_input.compute	\N	\N
+29	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "ObjectStoreOperationResultData", "address": "/intermediates/do_something.compute/result", "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "PathMetadataEntryData", "path": "/intermediates/do_something.compute/result"}, "label": "key"}], "op": "GET_OBJECT", "value_name": "x", "version": null}, "event_type_value": "OBJECT_STORE_OPERATION", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpRbaiCU\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Retrieved intermediate object for input x in memory object store using pickle.", "pid": 80630, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - do_input.compute - OBJECT_STORE_OPERATION - Retrieved intermediate object for input x in memory object store using pickle.", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": "do_input.compute", "timestamp": 1610466063.620257, "user_message": "Retrieved intermediate object for input x in memory object store using pickle."}	OBJECT_STORE_OPERATION	2021-01-12 10:41:03.620257	do_input.compute	\N	\N
+30	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepInputData", "input_name": "x", "type_check_data": {"__class__": "TypeCheckData", "description": null, "label": "x", "metadata_entries": [], "success": true}}, "event_type_value": "STEP_INPUT", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpRbaiCU\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Got input \\"x\\" of type \\"Any\\". (Type check passed).", "pid": 80630, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - do_input.compute - STEP_INPUT - Got input \\"x\\" of type \\"Any\\". (Type check passed).", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": "do_input.compute", "timestamp": 1610466063.67839, "user_message": "Got input \\"x\\" of type \\"Any\\". (Type check passed)."}	STEP_INPUT	2021-01-12 10:41:03.67839	do_input.compute	\N	\N
+31	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepOutputData", "intermediate_materialization": null, "step_output_handle": {"__class__": "StepOutputHandle", "output_name": "result", "step_key": "do_input.compute"}, "type_check_data": {"__class__": "TypeCheckData", "description": null, "label": "result", "metadata_entries": [], "success": true}, "version": null}, "event_type_value": "STEP_OUTPUT", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpRbaiCU\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pid": 80630, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - do_input.compute - STEP_OUTPUT - Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": "do_input.compute", "timestamp": 1610466063.688006, "user_message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed)."}	STEP_OUTPUT	2021-01-12 10:41:03.688006	do_input.compute	\N	\N
+39	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": "resources", "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": "Initialized in 0.03ms", "entry_data": {"__class__": "PythonArtifactMetadataEntryData", "module": "dagster.core.storage.asset_store", "name": "InMemoryAssetStore"}, "label": "asset_store"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Finished initialization of resources [asset_store].", "pid": 80827, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - ENGINE_EVENT - Finished initialization of resources [asset_store].", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": null, "timestamp": 1610466123.484303, "user_message": "Finished initialization of resources [asset_store]."}	ENGINE_EVENT	2021-01-12 10:42:03.484303	\N	\N	\N
+32	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "ObjectStoreOperationResultData", "address": "/intermediates/do_input.compute/result", "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "PathMetadataEntryData", "path": "/intermediates/do_input.compute/result"}, "label": "key"}], "op": "SET_OBJECT", "value_name": "result", "version": null}, "event_type_value": "OBJECT_STORE_OPERATION", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpRbaiCU\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Stored intermediate object for output result in memory object store using pickle.", "pid": 80630, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - do_input.compute - OBJECT_STORE_OPERATION - Stored intermediate object for output result in memory object store using pickle.", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": "do_input.compute", "timestamp": 1610466063.695479, "user_message": "Stored intermediate object for output result in memory object store using pickle."}	OBJECT_STORE_OPERATION	2021-01-12 10:41:03.695479	do_input.compute	\N	\N
+33	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepSuccessData", "duration_ms": 16.563892364501953}, "event_type_value": "STEP_SUCCESS", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpRbaiCU\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Finished execution of step \\"do_input.compute\\" in 16ms.", "pid": 80630, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - do_input.compute - STEP_SUCCESS - Finished execution of step \\"do_input.compute\\" in 16ms.", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": "do_input.compute", "timestamp": 1610466063.702914, "user_message": "Finished execution of step \\"do_input.compute\\" in 16ms."}	STEP_SUCCESS	2021-01-12 10:41:03.702914	do_input.compute	\N	\N
+34	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "80630"}, "label": "pid"}, {"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "['do_something.compute', 'do_input.compute']"}, "label": "step_keys"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Finished steps in process (pid: 80630) in 168ms", "pid": 80630, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - ENGINE_EVENT - Finished steps in process (pid: 80630) in 168ms", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": null, "timestamp": 1610466063.712225, "user_message": "Finished steps in process (pid: 80630) in 168ms"}	ENGINE_EVENT	2021-01-12 10:41:03.712225	\N	\N	\N
+35	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_SUCCESS", "logging_tags": {}, "message": "Finished execution of pipeline \\"foo\\".", "pid": 80630, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - d45fa10b-121d-4051-9358-cfd3dfcbc878 - 80630 - PIPELINE_SUCCESS - Finished execution of pipeline \\"foo\\".", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": null, "timestamp": 1610466063.7197, "user_message": "Finished execution of pipeline \\"foo\\"."}	PIPELINE_SUCCESS	2021-01-12 10:41:03.7197	\N	\N	\N
+36	d45fa10b-121d-4051-9358-cfd3dfcbc878	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": []}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Process for pipeline exited (pid: 80630).", "pid": null, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 20, "message": "Process for pipeline exited (pid: 80630).", "pipeline_name": "foo", "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "step_key": null, "timestamp": 1610466063.748248, "user_message": "Process for pipeline exited (pid: 80630)."}	ENGINE_EVENT	2021-01-12 10:41:03.748248	\N	\N	\N
+37	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": "cli_api_subprocess_init", "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "80827"}, "label": "pid"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Started process for pipeline (pid: 80827).", "pid": null, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 20, "message": "Started process for pipeline (pid: 80827).", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": null, "timestamp": 1610466123.454457, "user_message": "Started process for pipeline (pid: 80827)."}	ENGINE_EVENT	2021-01-12 10:42:03.454457	\N	\N	\N
+38	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": "resources", "metadata_entries": []}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Starting initialization of resources [asset_store].", "pid": 80827, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - ENGINE_EVENT - Starting initialization of resources [asset_store].", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": null, "timestamp": 1610466123.476954, "user_message": "Starting initialization of resources [asset_store]."}	ENGINE_EVENT	2021-01-12 10:42:03.476954	\N	\N	\N
+40	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_START", "logging_tags": {}, "message": "Started execution of pipeline \\"foo\\".", "pid": 80827, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - PIPELINE_START - Started execution of pipeline \\"foo\\".", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": null, "timestamp": 1610466123.492956, "user_message": "Started execution of pipeline \\"foo\\"."}	PIPELINE_START	2021-01-12 10:42:03.492956	\N	\N	\N
+41	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "80827"}, "label": "pid"}, {"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "['do_something.compute', 'do_input.compute']"}, "label": "step_keys"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Executing steps in process (pid: 80827)", "pid": 80827, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - ENGINE_EVENT - Executing steps in process (pid: 80827)", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": null, "timestamp": 1610466123.511117, "user_message": "Executing steps in process (pid: 80827)"}	ENGINE_EVENT	2021-01-12 10:42:03.511117	\N	\N	\N
+42	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "STEP_START", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpbmtnrh\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_something", "solid_definition": "do_something", "step_key": "do_something.compute"}, "message": "Started execution of step \\"do_something.compute\\".", "pid": 80827, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_something", "parent": null}, "step_key": "do_something.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - do_something.compute - STEP_START - Started execution of step \\"do_something.compute\\".", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": "do_something.compute", "timestamp": 1610466123.532808, "user_message": "Started execution of step \\"do_something.compute\\"."}	STEP_START	2021-01-12 10:42:03.532808	do_something.compute	\N	\N
+43	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepOutputData", "intermediate_materialization": null, "step_output_handle": {"__class__": "StepOutputHandle", "output_name": "result", "step_key": "do_something.compute"}, "type_check_data": {"__class__": "TypeCheckData", "description": null, "label": "result", "metadata_entries": [], "success": true}, "version": null}, "event_type_value": "STEP_OUTPUT", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpbmtnrh\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_something", "solid_definition": "do_something", "step_key": "do_something.compute"}, "message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pid": 80827, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_something", "parent": null}, "step_key": "do_something.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - do_something.compute - STEP_OUTPUT - Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": "do_something.compute", "timestamp": 1610466123.54216, "user_message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed)."}	STEP_OUTPUT	2021-01-12 10:42:03.54216	do_something.compute	\N	\N
+44	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "ObjectStoreOperationResultData", "address": "/intermediates/do_something.compute/result", "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "PathMetadataEntryData", "path": "/intermediates/do_something.compute/result"}, "label": "key"}], "op": "SET_OBJECT", "value_name": "result", "version": null}, "event_type_value": "OBJECT_STORE_OPERATION", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpbmtnrh\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_something", "solid_definition": "do_something", "step_key": "do_something.compute"}, "message": "Stored intermediate object for output result in memory object store using pickle.", "pid": 80827, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_something", "parent": null}, "step_key": "do_something.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - do_something.compute - OBJECT_STORE_OPERATION - Stored intermediate object for output result in memory object store using pickle.", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": "do_something.compute", "timestamp": 1610466123.549176, "user_message": "Stored intermediate object for output result in memory object store using pickle."}	OBJECT_STORE_OPERATION	2021-01-12 10:42:03.549176	do_something.compute	\N	\N
+45	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepSuccessData", "duration_ms": 15.560150146484375}, "event_type_value": "STEP_SUCCESS", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpbmtnrh\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_something", "solid_definition": "do_something", "step_key": "do_something.compute"}, "message": "Finished execution of step \\"do_something.compute\\" in 15ms.", "pid": 80827, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_something", "parent": null}, "step_key": "do_something.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - do_something.compute - STEP_SUCCESS - Finished execution of step \\"do_something.compute\\" in 15ms.", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": "do_something.compute", "timestamp": 1610466123.556208, "user_message": "Finished execution of step \\"do_something.compute\\" in 15ms."}	STEP_SUCCESS	2021-01-12 10:42:03.556208	do_something.compute	\N	\N
+46	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "STEP_START", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpbmtnrh\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Started execution of step \\"do_input.compute\\".", "pid": 80827, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - do_input.compute - STEP_START - Started execution of step \\"do_input.compute\\".", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": "do_input.compute", "timestamp": 1610466123.579117, "user_message": "Started execution of step \\"do_input.compute\\"."}	STEP_START	2021-01-12 10:42:03.579117	do_input.compute	\N	\N
+47	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "ObjectStoreOperationResultData", "address": "/intermediates/do_something.compute/result", "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "PathMetadataEntryData", "path": "/intermediates/do_something.compute/result"}, "label": "key"}], "op": "GET_OBJECT", "value_name": "x", "version": null}, "event_type_value": "OBJECT_STORE_OPERATION", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpbmtnrh\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Retrieved intermediate object for input x in memory object store using pickle.", "pid": 80827, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - do_input.compute - OBJECT_STORE_OPERATION - Retrieved intermediate object for input x in memory object store using pickle.", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": "do_input.compute", "timestamp": 1610466123.588098, "user_message": "Retrieved intermediate object for input x in memory object store using pickle."}	OBJECT_STORE_OPERATION	2021-01-12 10:42:03.588098	do_input.compute	\N	\N
+48	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepInputData", "input_name": "x", "type_check_data": {"__class__": "TypeCheckData", "description": null, "label": "x", "metadata_entries": [], "success": true}}, "event_type_value": "STEP_INPUT", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpbmtnrh\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Got input \\"x\\" of type \\"Any\\". (Type check passed).", "pid": 80827, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - do_input.compute - STEP_INPUT - Got input \\"x\\" of type \\"Any\\". (Type check passed).", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": "do_input.compute", "timestamp": 1610466123.645675, "user_message": "Got input \\"x\\" of type \\"Any\\". (Type check passed)."}	STEP_INPUT	2021-01-12 10:42:03.645675	do_input.compute	\N	\N
+49	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepOutputData", "intermediate_materialization": null, "step_output_handle": {"__class__": "StepOutputHandle", "output_name": "result", "step_key": "do_input.compute"}, "type_check_data": {"__class__": "TypeCheckData", "description": null, "label": "result", "metadata_entries": [], "success": true}, "version": null}, "event_type_value": "STEP_OUTPUT", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpbmtnrh\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pid": 80827, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - do_input.compute - STEP_OUTPUT - Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": "do_input.compute", "timestamp": 1610466123.653987, "user_message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed)."}	STEP_OUTPUT	2021-01-12 10:42:03.653987	do_input.compute	\N	\N
+50	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "ObjectStoreOperationResultData", "address": "/intermediates/do_input.compute/result", "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "PathMetadataEntryData", "path": "/intermediates/do_input.compute/result"}, "label": "key"}], "op": "SET_OBJECT", "value_name": "result", "version": null}, "event_type_value": "OBJECT_STORE_OPERATION", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpbmtnrh\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Stored intermediate object for output result in memory object store using pickle.", "pid": 80827, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - do_input.compute - OBJECT_STORE_OPERATION - Stored intermediate object for output result in memory object store using pickle.", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": "do_input.compute", "timestamp": 1610466123.661306, "user_message": "Stored intermediate object for output result in memory object store using pickle."}	OBJECT_STORE_OPERATION	2021-01-12 10:42:03.661306	do_input.compute	\N	\N
+73	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": []}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Process for run exited (pid: 3626).", "pid": null, "pipeline_name": "basic_assets_job", "solid_handle": null, "step_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 20, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": null, "timestamp": 1731664852.299335, "user_message": ""}	ENGINE_EVENT	2024-11-15 10:00:52.299335	\N	\N	\N
+51	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepSuccessData", "duration_ms": 15.877008438110352}, "event_type_value": "STEP_SUCCESS", "logging_tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpbmtnrh\\"}", "dagster/schedule_name": "foo_schedule", "pipeline": "foo", "solid": "do_input", "solid_definition": "do_input", "step_key": "do_input.compute"}, "message": "Finished execution of step \\"do_input.compute\\" in 15ms.", "pid": 80827, "pipeline_name": "foo", "solid_handle": {"__class__": "SolidHandle", "name": "do_input", "parent": null}, "step_key": "do_input.compute", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - do_input.compute - STEP_SUCCESS - Finished execution of step \\"do_input.compute\\" in 15ms.", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": "do_input.compute", "timestamp": 1610466123.668594, "user_message": "Finished execution of step \\"do_input.compute\\" in 15ms."}	STEP_SUCCESS	2021-01-12 10:42:03.668594	do_input.compute	\N	\N
+52	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "80827"}, "label": "pid"}, {"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "['do_something.compute', 'do_input.compute']"}, "label": "step_keys"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Finished steps in process (pid: 80827) in 160ms", "pid": 80827, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - ENGINE_EVENT - Finished steps in process (pid: 80827) in 160ms", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": null, "timestamp": 1610466123.677631, "user_message": "Finished steps in process (pid: 80827) in 160ms"}	ENGINE_EVENT	2021-01-12 10:42:03.677631	\N	\N	\N
+53	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_SUCCESS", "logging_tags": {}, "message": "Finished execution of pipeline \\"foo\\".", "pid": 80827, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "foo - 9f130936-1409-4bd0-b15d-67cf6e7a67ec - 80827 - PIPELINE_SUCCESS - Finished execution of pipeline \\"foo\\".", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": null, "timestamp": 1610466123.684907, "user_message": "Finished execution of pipeline \\"foo\\"."}	PIPELINE_SUCCESS	2021-01-12 10:42:03.684907	\N	\N	\N
+54	9f130936-1409-4bd0-b15d-67cf6e7a67ec	{"__class__": "DagsterEventRecord", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": []}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Process for pipeline exited (pid: 80827).", "pid": null, "pipeline_name": "foo", "solid_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 20, "message": "Process for pipeline exited (pid: 80827).", "pipeline_name": "foo", "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "step_key": null, "timestamp": 1610466123.705453, "user_message": "Process for pipeline exited (pid: 80827)."}	ENGINE_EVENT	2021-01-12 10:42:03.705453	\N	\N	\N
+55	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "AssetMaterializationPlannedData", "asset_key": {"__class__": "AssetKey", "path": ["basic_asset_1"]}, "partition": null, "partitions_subset": null}, "event_type_value": "ASSET_MATERIALIZATION_PLANNED", "logging_tags": {}, "message": "basic_assets_job intends to materialize asset [\\"basic_asset_1\\"]", "pid": null, "pipeline_name": "basic_assets_job", "solid_handle": null, "step_handle": null, "step_key": "basic_asset_1", "step_kind_value": null}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1", "timestamp": 1731664846.554184, "user_message": ""}	ASSET_MATERIALIZATION_PLANNED	2024-11-15 10:00:46.554184	basic_asset_1	["basic_asset_1"]	\N
+56	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_STARTING", "logging_tags": {}, "message": null, "pid": null, "pipeline_name": "basic_assets_job", "solid_handle": null, "step_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 20, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": null, "timestamp": 1731664846.564075, "user_message": ""}	PIPELINE_STARTING	2024-11-15 10:00:46.564075	\N	\N	\N
+57	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "3626"}, "label": "pid"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Started process for run (pid: 3626).", "pid": null, "pipeline_name": "basic_assets_job", "solid_handle": null, "step_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 20, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": null, "timestamp": 1731664847.549261, "user_message": ""}	ENGINE_EVENT	2024-11-15 10:00:47.549261	\N	\N	\N
+58	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_START", "logging_tags": {}, "message": "Started execution of run for \\"basic_assets_job\\".", "pid": 3626, "pipeline_name": "basic_assets_job", "solid_handle": null, "step_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": null, "timestamp": 1731664849.2956722, "user_message": "Started execution of run for \\"basic_assets_job\\"."}	PIPELINE_START	2024-11-15 10:00:49.295672	\N	\N	\N
+74	981547f5-f46a-4f06-9028-69c8c0c51c19	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_SUCCESS", "logging_tags": {}, "message": "yay run success", "pid": null, "pipeline_name": "foo", "solid_handle": null, "step_handle": null, "step_key": "bar", "step_kind_value": null}, "error_info": null, "level": 20, "message": "", "pipeline_name": "foo", "run_id": "981547f5-f46a-4f06-9028-69c8c0c51c19", "step_key": "bar", "timestamp": 1763243217.176925, "user_message": ""}	PIPELINE_SUCCESS	2025-11-15 21:46:57.176925	bar	\N	\N
+59	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "3626"}, "label": "pid"}, {"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "['basic_asset_1']"}, "label": "step_keys"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Executing steps using multiprocess executor: parent process (pid: 3626)", "pid": 3626, "pipeline_name": "basic_assets_job", "solid_handle": null, "step_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": null, "timestamp": 1731664849.318593, "user_message": "Executing steps using multiprocess executor: parent process (pid: 3626)"}	ENGINE_EVENT	2024-11-15 10:00:49.318593	\N	\N	\N
+60	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": "step_process_start", "metadata_entries": []}, "event_type_value": "STEP_WORKER_STARTING", "logging_tags": {"job_name": "basic_assets_job", "op_name": "basic_asset_1", "resource_fn_name": "None", "resource_name": "None", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1"}, "message": "Launching subprocess for \\"basic_asset_1\\".", "pid": 3626, "pipeline_name": "basic_assets_job", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}, "step_handle": {"__class__": "StepHandle", "key": "basic_asset_1", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}}, "step_key": "basic_asset_1", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1", "timestamp": 1731664849.323858, "user_message": "Launching subprocess for \\"basic_asset_1\\"."}	STEP_WORKER_STARTING	2024-11-15 10:00:49.323858	basic_asset_1	\N	\N
+61	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": "step_process_start", "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "3691"}, "label": "pid"}]}, "event_type_value": "STEP_WORKER_STARTED", "logging_tags": {}, "message": "Executing step \\"basic_asset_1\\" in subprocess.", "pid": 3691, "pipeline_name": "basic_assets_job", "solid_handle": null, "step_handle": null, "step_key": "basic_asset_1", "step_kind_value": null}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1", "timestamp": 1731664850.176636, "user_message": "Executing step \\"basic_asset_1\\" in subprocess."}	STEP_WORKER_STARTED	2024-11-15 10:00:50.176636	basic_asset_1	\N	\N
+62	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": "resources", "metadata_entries": []}, "event_type_value": "RESOURCE_INIT_STARTED", "logging_tags": {}, "message": "Starting initialization of resources [io_manager].", "pid": 3691, "pipeline_name": "basic_assets_job", "solid_handle": null, "step_handle": {"__class__": "StepHandle", "key": "basic_asset_1", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}}, "step_key": "basic_asset_1", "step_kind_value": null}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1", "timestamp": 1731664851.9047098, "user_message": "Starting initialization of resources [io_manager]."}	RESOURCE_INIT_STARTED	2024-11-15 10:00:51.90471	basic_asset_1	\N	\N
+63	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": "resources", "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "PythonArtifactMetadataEntryData", "module": "dagster._core.storage.fs_io_manager", "name": "PickledObjectFilesystemIOManager"}, "label": "io_manager"}, {"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "4.74ms"}, "label": "io_manager:init_time"}]}, "event_type_value": "RESOURCE_INIT_SUCCESS", "logging_tags": {}, "message": "Finished initialization of resources [io_manager].", "pid": 3691, "pipeline_name": "basic_assets_job", "solid_handle": null, "step_handle": {"__class__": "StepHandle", "key": "basic_asset_1", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}}, "step_key": "basic_asset_1", "step_kind_value": null}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1", "timestamp": 1731664851.916915, "user_message": "Finished initialization of resources [io_manager]."}	RESOURCE_INIT_SUCCESS	2024-11-15 10:00:51.916915	basic_asset_1	\N	\N
+64	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "ComputeLogsCaptureData", "external_stderr_url": null, "external_stdout_url": null, "external_url": null, "log_key": "qrqrjkzj", "step_keys": ["basic_asset_1"]}, "event_type_value": "LOGS_CAPTURED", "logging_tags": {}, "message": "Started capturing logs in process (pid: 3691).", "pid": 3691, "pipeline_name": "basic_assets_job", "solid_handle": null, "step_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": null, "timestamp": 1731664851.938277, "user_message": "Started capturing logs in process (pid: 3691)."}	LOGS_CAPTURED	2024-11-15 10:00:51.938277	\N	\N	\N
+65	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "STEP_START", "logging_tags": {"job_name": "basic_assets_job", "op_name": "basic_asset_1", "resource_fn_name": "None", "resource_name": "None", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1"}, "message": "Started execution of step \\"basic_asset_1\\".", "pid": 3691, "pipeline_name": "basic_assets_job", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}, "step_handle": {"__class__": "StepHandle", "key": "basic_asset_1", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}}, "step_key": "basic_asset_1", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1", "timestamp": 1731664851.946173, "user_message": "Started execution of step \\"basic_asset_1\\"."}	STEP_START	2024-11-15 10:00:51.946173	basic_asset_1	\N	\N
+66	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepOutputData", "metadata_entries": [], "step_output_handle": {"__class__": "StepOutputHandle", "mapping_key": null, "output_name": "result", "step_key": "basic_asset_1"}, "type_check_data": {"__class__": "TypeCheckData", "description": null, "label": "result", "metadata_entries": [], "success": true}, "version": null}, "event_type_value": "STEP_OUTPUT", "logging_tags": {"job_name": "basic_assets_job", "op_name": "basic_asset_1", "resource_fn_name": "None", "resource_name": "None", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1"}, "message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed).", "pid": 3691, "pipeline_name": "basic_assets_job", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}, "step_handle": {"__class__": "StepHandle", "key": "basic_asset_1", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}}, "step_key": "basic_asset_1", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1", "timestamp": 1731664851.952908, "user_message": "Yielded output \\"result\\" of type \\"Any\\". (Type check passed)."}	STEP_OUTPUT	2024-11-15 10:00:51.952908	basic_asset_1	\N	\N
+67	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": null, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1", "timestamp": 1731664851.959577, "user_message": "Writing file at: /Users/hynekblaha/dagster/storage/basic_asset_1 using PickledObjectFilesystemIOManager..."}	\N	2024-11-15 10:00:51.959577	basic_asset_1	\N	\N
+68	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepMaterializationData", "asset_lineage": [], "materialization": {"__class__": "AssetMaterialization", "asset_key": {"__class__": "AssetKey", "path": ["basic_asset_1"]}, "description": null, "metadata_entries": [], "partition": null, "tags": {"dagster/code_version": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "dagster/data_version": "6c9d21d97b078a4cedd1fdc1d1d3991dde75605279a2115ee2c1deea25d89d95"}}}, "event_type_value": "ASSET_MATERIALIZATION", "logging_tags": {"job_name": "basic_assets_job", "op_name": "basic_asset_1", "resource_fn_name": "None", "resource_name": "None", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1"}, "message": "Materialized value basic_asset_1.", "pid": 3691, "pipeline_name": "basic_assets_job", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}, "step_handle": {"__class__": "StepHandle", "key": "basic_asset_1", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}}, "step_key": "basic_asset_1", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1", "timestamp": 1731664851.966126, "user_message": "Materialized value basic_asset_1."}	ASSET_MATERIALIZATION	2024-11-15 10:00:51.966126	basic_asset_1	["basic_asset_1"]	\N
+69	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "HandledOutputData", "manager_key": "io_manager", "metadata_entries": [], "output_name": "result"}, "event_type_value": "HANDLED_OUTPUT", "logging_tags": {"job_name": "basic_assets_job", "op_name": "basic_asset_1", "resource_fn_name": "None", "resource_name": "None", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1"}, "message": "Handled output \\"result\\" using IO manager \\"io_manager\\"", "pid": 3691, "pipeline_name": "basic_assets_job", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}, "step_handle": {"__class__": "StepHandle", "key": "basic_asset_1", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}}, "step_key": "basic_asset_1", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1", "timestamp": 1731664851.989446, "user_message": "Handled output \\"result\\" using IO manager \\"io_manager\\""}	HANDLED_OUTPUT	2024-11-15 10:00:51.989446	basic_asset_1	\N	\N
+70	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "StepSuccessData", "duration_ms": 42.156207986408845}, "event_type_value": "STEP_SUCCESS", "logging_tags": {"job_name": "basic_assets_job", "op_name": "basic_asset_1", "resource_fn_name": "None", "resource_name": "None", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1"}, "message": "Finished execution of step \\"basic_asset_1\\" in 42ms.", "pid": 3691, "pipeline_name": "basic_assets_job", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}, "step_handle": {"__class__": "StepHandle", "key": "basic_asset_1", "solid_handle": {"__class__": "SolidHandle", "name": "basic_asset_1", "parent": null}}, "step_key": "basic_asset_1", "step_kind_value": "COMPUTE"}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": "basic_asset_1", "timestamp": 1731664851.994175, "user_message": "Finished execution of step \\"basic_asset_1\\" in 42ms."}	STEP_SUCCESS	2024-11-15 10:00:51.994175	basic_asset_1	\N	\N
+71	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": {"__class__": "EngineEventData", "error": null, "marker_end": null, "marker_start": null, "metadata_entries": [{"__class__": "EventMetadataEntry", "description": null, "entry_data": {"__class__": "TextMetadataEntryData", "text": "3626"}, "label": "pid"}]}, "event_type_value": "ENGINE_EVENT", "logging_tags": {}, "message": "Multiprocess executor: parent process exiting after 2.95s (pid: 3626)", "pid": 3626, "pipeline_name": "basic_assets_job", "solid_handle": null, "step_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": null, "timestamp": 1731664852.269461, "user_message": "Multiprocess executor: parent process exiting after 2.95s (pid: 3626)"}	ENGINE_EVENT	2024-11-15 10:00:52.269461	\N	\N	\N
+72	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_SUCCESS", "logging_tags": {}, "message": "Finished execution of run for \\"basic_assets_job\\".", "pid": 3626, "pipeline_name": "basic_assets_job", "solid_handle": null, "step_handle": null, "step_key": null, "step_kind_value": null}, "error_info": null, "level": 10, "message": "", "pipeline_name": "basic_assets_job", "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "step_key": null, "timestamp": 1731664852.27652, "user_message": "Finished execution of run for \\"basic_assets_job\\"."}	PIPELINE_SUCCESS	2024-11-15 10:00:52.27652	\N	\N	\N
+75	a1da76e8-629e-4e99-9a17-02ef216f7821	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_SUCCESS", "logging_tags": {}, "message": "yay run success", "pid": null, "pipeline_name": "foo", "solid_handle": null, "step_handle": null, "step_key": "bar", "step_kind_value": null}, "error_info": null, "level": 20, "message": "", "pipeline_name": "foo", "run_id": "a1da76e8-629e-4e99-9a17-02ef216f7821", "step_key": "bar", "timestamp": 1763243217.2877069, "user_message": ""}	PIPELINE_SUCCESS	2025-11-15 21:46:57.287707	bar	\N	\N
+76	5b13b906-583d-4192-9ff9-ae825ba5c1c3	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_SUCCESS", "logging_tags": {}, "message": "yay run success", "pid": null, "pipeline_name": "foo", "solid_handle": null, "step_handle": null, "step_key": "bar", "step_kind_value": null}, "error_info": null, "level": 20, "message": "", "pipeline_name": "foo", "run_id": "5b13b906-583d-4192-9ff9-ae825ba5c1c3", "step_key": "bar", "timestamp": 1763243217.3850691, "user_message": ""}	PIPELINE_SUCCESS	2025-11-15 21:46:57.385069	bar	\N	\N
+77	7d2bb3fd-846d-42eb-bf44-a8f43e8fe604	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_SUCCESS", "logging_tags": {}, "message": "yay run success", "pid": null, "pipeline_name": "foo", "solid_handle": null, "step_handle": null, "step_key": "bar", "step_kind_value": null}, "error_info": null, "level": 20, "message": "", "pipeline_name": "foo", "run_id": "7d2bb3fd-846d-42eb-bf44-a8f43e8fe604", "step_key": "bar", "timestamp": 1763243217.503351, "user_message": ""}	PIPELINE_SUCCESS	2025-11-15 21:46:57.503351	bar	\N	\N
+78	f5bda7ef-a7ad-4049-adbb-c56fac02f613	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_SUCCESS", "logging_tags": {}, "message": "yay run success", "pid": null, "pipeline_name": "foo", "solid_handle": null, "step_handle": null, "step_key": "bar", "step_kind_value": null}, "error_info": null, "level": 20, "message": "", "pipeline_name": "foo", "run_id": "f5bda7ef-a7ad-4049-adbb-c56fac02f613", "step_key": "bar", "timestamp": 1763243217.575178, "user_message": ""}	PIPELINE_SUCCESS	2025-11-15 21:46:57.575178	bar	\N	\N
+79	b2082f26-e096-4355-bdbe-478b33fd35c7	{"__class__": "EventLogEntry", "dagster_event": {"__class__": "DagsterEvent", "event_specific_data": null, "event_type_value": "PIPELINE_SUCCESS", "logging_tags": {}, "message": "yay run success", "pid": null, "pipeline_name": "foo", "solid_handle": null, "step_handle": null, "step_key": "bar", "step_kind_value": null}, "error_info": null, "level": 20, "message": "", "pipeline_name": "foo", "run_id": "b2082f26-e096-4355-bdbe-478b33fd35c7", "step_key": "bar", "timestamp": 1763243217.6451352, "user_message": ""}	PIPELINE_SUCCESS	2025-11-15 21:46:57.645135	bar	\N	\N
+\.
+
+
+--
+-- Data for Name: instance_info; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.instance_info (id, run_storage_id) FROM stdin;
+1	fdb278ce-0fe7-4ea7-896e-22718e9cf268
+\.
+
+
+--
+-- Data for Name: instigators; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.instigators (id, selector_id, repository_selector_id, status, instigator_type, instigator_body, create_timestamp, update_timestamp) FROM stdin;
+\.
+
+
+--
+-- Data for Name: job_ticks; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.job_ticks (id, job_origin_id, status, type, "timestamp", tick_body, create_timestamp, update_timestamp, selector_id) FROM stdin;
+\.
+
+
+--
+-- Data for Name: jobs; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.jobs (id, job_origin_id, repository_origin_id, status, job_type, job_body, create_timestamp, update_timestamp, selector_id) FROM stdin;
+\.
+
+
+--
+-- Data for Name: kvs; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.kvs (key, value, id) FROM stdin;
+MIGRATED_CURSOR_TO_SENSORS	1	1
+MIGRATED_SENSOR_NAMES_KEY	1	2
+\.
+
+
+--
+-- Data for Name: pending_steps; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.pending_steps (id, concurrency_key, run_id, step_key, priority, assigned_timestamp, create_timestamp) FROM stdin;
+\.
+
+
+--
+-- Data for Name: run_tags; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.run_tags (id, run_id, key, value) FROM stdin;
+1	8c59d1b7-1841-4c60-8346-89e298dbf743	dagster/schedule_name	foo_schedule
+2	8c59d1b7-1841-4c60-8346-89e298dbf743	.dagster/grpc_info	{"host": "localhost", "socket": "/tmp/tmpOhX8MX"}
+3	d45fa10b-121d-4051-9358-cfd3dfcbc878	dagster/schedule_name	foo_schedule
+4	d45fa10b-121d-4051-9358-cfd3dfcbc878	.dagster/grpc_info	{"host": "localhost", "socket": "/tmp/tmpRbaiCU"}
+5	9f130936-1409-4bd0-b15d-67cf6e7a67ec	dagster/schedule_name	foo_schedule
+6	9f130936-1409-4bd0-b15d-67cf6e7a67ec	.dagster/grpc_info	{"host": "localhost", "socket": "/tmp/tmpbmtnrh"}
+7	8c59d1b7-1841-4c60-8346-89e298dbf743	.dagster/repository	bar@bar_repo.py:bar
+8	d45fa10b-121d-4051-9358-cfd3dfcbc878	.dagster/repository	bar@bar_repo.py:bar
+9	9f130936-1409-4bd0-b15d-67cf6e7a67ec	.dagster/repository	bar@bar_repo.py:bar
+10	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	.dagster/repository	basic_assets_repository@dagster_test.toys.repo
+11	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	.dagster/grpc_info	{"host": "localhost", "socket": "/var/folders/zt/9txyngt92fxgpd954jkfz6zm0000gn/T/tmpmc6skfzp"}
+12	5b13b906-583d-4192-9ff9-ae825ba5c1c3	dagster/backfill	before_end_timestamp_migration
+13	b2082f26-e096-4355-bdbe-478b33fd35c7	dagster/backfill	in_progress_backfill
+14	a1da76e8-629e-4e99-9a17-02ef216f7821	dagster/backfill	before_end_timestamp_migration
+15	f5bda7ef-a7ad-4049-adbb-c56fac02f613	dagster/backfill	in_progress_backfill
+16	981547f5-f46a-4f06-9028-69c8c0c51c19	dagster/backfill	before_end_timestamp_migration
+17	7d2bb3fd-846d-42eb-bf44-a8f43e8fe604	dagster/backfill	in_progress_backfill
+\.
+
+
+--
+-- Data for Name: runs; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.runs (id, run_id, snapshot_id, pipeline_name, status, run_body, create_timestamp, update_timestamp, partition, partition_set, mode, start_time, end_time, backfill_id) FROM stdin;
+1	8c59d1b7-1841-4c60-8346-89e298dbf743	47992fd61f2aecc862f741e1355e2b910d5850de	foo	SUCCESS	{"__class__": "PipelineRun", "execution_plan_snapshot_id": "53f52f323e0e20f0b8ec27a3d698335b3e0918fb", "external_pipeline_origin": {"__class__": "ExternalPipelineOrigin", "external_repository_origin": {"__class__": "ExternalRepositoryOrigin", "repository_location_origin": {"__class__": "ManagedGrpcPythonEnvRepositoryLocationOrigin", "loadable_target_origin": {"__class__": "LoadableTargetOrigin", "attribute": "bar", "executable_path": "/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python", "module_name": null, "package_name": null, "python_file": "/Users/dgibson/dagster/python_modules/dagit/dagit_tests/toy/bar_repo.py", "working_directory": "/Users/dgibson/dagster-home"}, "location_name": "bar_repo.py:bar"}, "repository_name": "bar"}, "pipeline_name": "foo"}, "mode": "default", "parent_run_id": null, "pipeline_name": "foo", "pipeline_snapshot_id": "47992fd61f2aecc862f741e1355e2b910d5850de", "root_run_id": null, "run_config": {}, "run_id": "8c59d1b7-1841-4c60-8346-89e298dbf743", "solid_selection": null, "solids_to_execute": null, "status": {"__enum__": "PipelineRunStatus.SUCCESS"}, "step_keys_to_execute": null, "tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpOhX8MX\\"}", "dagster/schedule_name": "foo_schedule"}}	2021-01-12 10:40:02.568045	2021-01-12 09:40:02.973559	\N	\N	\N	\N	\N	\N
+2	d45fa10b-121d-4051-9358-cfd3dfcbc878	47992fd61f2aecc862f741e1355e2b910d5850de	foo	SUCCESS	{"__class__": "PipelineRun", "execution_plan_snapshot_id": "53f52f323e0e20f0b8ec27a3d698335b3e0918fb", "external_pipeline_origin": {"__class__": "ExternalPipelineOrigin", "external_repository_origin": {"__class__": "ExternalRepositoryOrigin", "repository_location_origin": {"__class__": "ManagedGrpcPythonEnvRepositoryLocationOrigin", "loadable_target_origin": {"__class__": "LoadableTargetOrigin", "attribute": "bar", "executable_path": "/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python", "module_name": null, "package_name": null, "python_file": "/Users/dgibson/dagster/python_modules/dagit/dagit_tests/toy/bar_repo.py", "working_directory": "/Users/dgibson/dagster-home"}, "location_name": "bar_repo.py:bar"}, "repository_name": "bar"}, "pipeline_name": "foo"}, "mode": "default", "parent_run_id": null, "pipeline_name": "foo", "pipeline_snapshot_id": "47992fd61f2aecc862f741e1355e2b910d5850de", "root_run_id": null, "run_config": {}, "run_id": "d45fa10b-121d-4051-9358-cfd3dfcbc878", "solid_selection": null, "solids_to_execute": null, "status": {"__enum__": "PipelineRunStatus.SUCCESS"}, "step_keys_to_execute": null, "tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpRbaiCU\\"}", "dagster/schedule_name": "foo_schedule"}}	2021-01-12 10:41:03.336991	2021-01-12 09:41:03.737958	\N	\N	\N	\N	\N	\N
+3	9f130936-1409-4bd0-b15d-67cf6e7a67ec	47992fd61f2aecc862f741e1355e2b910d5850de	foo	SUCCESS	{"__class__": "PipelineRun", "execution_plan_snapshot_id": "53f52f323e0e20f0b8ec27a3d698335b3e0918fb", "external_pipeline_origin": {"__class__": "ExternalPipelineOrigin", "external_repository_origin": {"__class__": "ExternalRepositoryOrigin", "repository_location_origin": {"__class__": "ManagedGrpcPythonEnvRepositoryLocationOrigin", "loadable_target_origin": {"__class__": "LoadableTargetOrigin", "attribute": "bar", "executable_path": "/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python", "module_name": null, "package_name": null, "python_file": "/Users/dgibson/dagster/python_modules/dagit/dagit_tests/toy/bar_repo.py", "working_directory": "/Users/dgibson/dagster-home"}, "location_name": "bar_repo.py:bar"}, "repository_name": "bar"}, "pipeline_name": "foo"}, "mode": "default", "parent_run_id": null, "pipeline_name": "foo", "pipeline_snapshot_id": "47992fd61f2aecc862f741e1355e2b910d5850de", "root_run_id": null, "run_config": {}, "run_id": "9f130936-1409-4bd0-b15d-67cf6e7a67ec", "solid_selection": null, "solids_to_execute": null, "status": {"__enum__": "PipelineRunStatus.SUCCESS"}, "step_keys_to_execute": null, "tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/tmp/tmpbmtnrh\\"}", "dagster/schedule_name": "foo_schedule"}}	2021-01-12 10:42:03.334236	2021-01-12 09:42:03.702535	\N	\N	\N	\N	\N	\N
+4	4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54	75080c9f16819e52f57f50a6fad451ba486ee568	basic_assets_job	SUCCESS	{"__class__": "PipelineRun", "asset_check_selection": {"__frozenset__": []}, "asset_selection": {"__frozenset__": [{"__class__": "AssetKey", "path": ["basic_asset_1"]}]}, "execution_plan_snapshot_id": "03002c9d8db5df9d5ce603d57fa7fdda258054b1", "external_pipeline_origin": {"__class__": "ExternalPipelineOrigin", "external_repository_origin": {"__class__": "ExternalRepositoryOrigin", "repository_location_origin": {"__class__": "ManagedGrpcPythonEnvRepositoryLocationOrigin", "loadable_target_origin": {"__class__": "LoadableTargetOrigin", "attribute": null, "executable_path": null, "module_name": "dagster_test.toys.repo", "package_name": null, "python_file": null, "working_directory": "/Users/hynekblaha/dagster"}, "location_name": "dagster_test.toys.repo"}, "repository_name": "basic_assets_repository"}, "pipeline_name": "basic_assets_job"}, "has_repository_load_data": false, "mode": null, "parent_run_id": null, "pipeline_code_origin": {"__class__": "PipelinePythonOrigin", "pipeline_name": "basic_assets_job", "repository_origin": {"__class__": "RepositoryPythonOrigin", "code_pointer": {"__class__": "ModuleCodePointer", "fn_name": "basic_assets_repository", "module": "dagster_test.toys.repo", "working_directory": "/Users/hynekblaha/dagster"}, "container_context": {}, "container_image": null, "entry_point": ["dagster"], "executable_path": "/Users/hynekblaha/dagster/venv/bin/python3"}}, "pipeline_name": "basic_assets_job", "pipeline_snapshot_id": "75080c9f16819e52f57f50a6fad451ba486ee568", "root_run_id": null, "run_config": {}, "run_id": "4e37f0ab-1cd4-4af7-9c5a-76bb1f526d54", "run_op_concurrency": null, "solid_selection": null, "solids_to_execute": null, "status": {"__enum__": "PipelineRunStatus.SUCCESS"}, "step_keys_to_execute": ["basic_asset_1"], "tags": {".dagster/grpc_info": "{\\"host\\": \\"localhost\\", \\"socket\\": \\"/var/folders/zt/9txyngt92fxgpd954jkfz6zm0000gn/T/tmpmc6skfzp\\"}"}}	2024-11-15 18:00:46.162863	2024-11-15 18:00:52.293929	\N	\N	\N	1731664849.313047	1731664852.293929	\N
+5	5b13b906-583d-4192-9ff9-ae825ba5c1c3	\N	foo	SUCCESS	{"__class__": "PipelineRun", "asset_check_selection": null, "asset_selection": null, "execution_plan_snapshot_id": null, "external_pipeline_origin": null, "has_repository_load_data": false, "mode": null, "parent_run_id": null, "partitions_subset": null, "pipeline_code_origin": null, "pipeline_name": "foo", "pipeline_snapshot_id": null, "root_run_id": null, "run_config": {}, "run_id": "5b13b906-583d-4192-9ff9-ae825ba5c1c3", "run_op_concurrency": null, "solid_selection": null, "solids_to_execute": null, "status": {"__enum__": "PipelineRunStatus.SUCCESS"}, "step_keys_to_execute": null, "tags": {"dagster/backfill": "before_end_timestamp_migration"}}	2025-11-15 21:46:56.987656	2025-11-15 21:46:57.385069	\N	\N	\N	\N	1763243217.385069	before_end_timestamp_migration
+6	b2082f26-e096-4355-bdbe-478b33fd35c7	\N	foo	SUCCESS	{"__class__": "PipelineRun", "asset_check_selection": null, "asset_selection": null, "execution_plan_snapshot_id": null, "external_pipeline_origin": null, "has_repository_load_data": false, "mode": null, "parent_run_id": null, "partitions_subset": null, "pipeline_code_origin": null, "pipeline_name": "foo", "pipeline_snapshot_id": null, "root_run_id": null, "run_config": {}, "run_id": "b2082f26-e096-4355-bdbe-478b33fd35c7", "run_op_concurrency": null, "solid_selection": null, "solids_to_execute": null, "status": {"__enum__": "PipelineRunStatus.SUCCESS"}, "step_keys_to_execute": null, "tags": {"dagster/backfill": "in_progress_backfill"}}	2025-11-15 21:46:57.024961	2025-11-15 21:46:57.645135	\N	\N	\N	\N	1763243217.645135	in_progress_backfill
+9	981547f5-f46a-4f06-9028-69c8c0c51c19	\N	foo	SUCCESS	{"__class__": "PipelineRun", "asset_check_selection": null, "asset_selection": null, "execution_plan_snapshot_id": null, "external_pipeline_origin": null, "has_repository_load_data": false, "mode": null, "parent_run_id": null, "partitions_subset": null, "pipeline_code_origin": null, "pipeline_name": "foo", "pipeline_snapshot_id": null, "root_run_id": null, "run_config": {}, "run_id": "981547f5-f46a-4f06-9028-69c8c0c51c19", "run_op_concurrency": null, "solid_selection": null, "solids_to_execute": null, "status": {"__enum__": "PipelineRunStatus.SUCCESS"}, "step_keys_to_execute": null, "tags": {"dagster/backfill": "before_end_timestamp_migration"}}	2025-11-15 21:46:57.10238	2025-11-15 21:46:57.176925	\N	\N	\N	\N	1763243217.176925	before_end_timestamp_migration
+7	a1da76e8-629e-4e99-9a17-02ef216f7821	\N	foo	SUCCESS	{"__class__": "PipelineRun", "asset_check_selection": null, "asset_selection": null, "execution_plan_snapshot_id": null, "external_pipeline_origin": null, "has_repository_load_data": false, "mode": null, "parent_run_id": null, "partitions_subset": null, "pipeline_code_origin": null, "pipeline_name": "foo", "pipeline_snapshot_id": null, "root_run_id": null, "run_config": {}, "run_id": "a1da76e8-629e-4e99-9a17-02ef216f7821", "run_op_concurrency": null, "solid_selection": null, "solids_to_execute": null, "status": {"__enum__": "PipelineRunStatus.SUCCESS"}, "step_keys_to_execute": null, "tags": {"dagster/backfill": "before_end_timestamp_migration"}}	2025-11-15 21:46:57.049245	2025-11-15 21:46:57.287707	\N	\N	\N	\N	1763243217.287707	before_end_timestamp_migration
+10	7d2bb3fd-846d-42eb-bf44-a8f43e8fe604	\N	foo	SUCCESS	{"__class__": "PipelineRun", "asset_check_selection": null, "asset_selection": null, "execution_plan_snapshot_id": null, "external_pipeline_origin": null, "has_repository_load_data": false, "mode": null, "parent_run_id": null, "partitions_subset": null, "pipeline_code_origin": null, "pipeline_name": "foo", "pipeline_snapshot_id": null, "root_run_id": null, "run_config": {}, "run_id": "7d2bb3fd-846d-42eb-bf44-a8f43e8fe604", "run_op_concurrency": null, "solid_selection": null, "solids_to_execute": null, "status": {"__enum__": "PipelineRunStatus.SUCCESS"}, "step_keys_to_execute": null, "tags": {"dagster/backfill": "in_progress_backfill"}}	2025-11-15 21:46:57.128773	2025-11-15 21:46:57.503351	\N	\N	\N	\N	1763243217.503351	in_progress_backfill
+8	f5bda7ef-a7ad-4049-adbb-c56fac02f613	\N	foo	SUCCESS	{"__class__": "PipelineRun", "asset_check_selection": null, "asset_selection": null, "execution_plan_snapshot_id": null, "external_pipeline_origin": null, "has_repository_load_data": false, "mode": null, "parent_run_id": null, "partitions_subset": null, "pipeline_code_origin": null, "pipeline_name": "foo", "pipeline_snapshot_id": null, "root_run_id": null, "run_config": {}, "run_id": "f5bda7ef-a7ad-4049-adbb-c56fac02f613", "run_op_concurrency": null, "solid_selection": null, "solids_to_execute": null, "status": {"__enum__": "PipelineRunStatus.SUCCESS"}, "step_keys_to_execute": null, "tags": {"dagster/backfill": "in_progress_backfill"}}	2025-11-15 21:46:57.074834	2025-11-15 21:46:57.575178	\N	\N	\N	\N	1763243217.575178	in_progress_backfill
+\.
+
+
+--
+-- Data for Name: secondary_indexes; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.secondary_indexes (id, name, create_timestamp, migration_completed) FROM stdin;
+1	run_partitions	2024-11-15 17:59:56.304765	2024-11-15 10:59:56.689595
+2	run_repo_label_tags	2024-11-15 17:59:56.321786	2024-11-15 10:59:56.707363
+3	bulk_action_types	2024-11-15 17:59:56.333672	2024-11-15 10:59:56.719637
+4	run_backfill_id	2024-11-15 17:59:56.348944	2024-11-15 10:59:56.734508
+5	backfill_job_name_and_tags	2024-11-15 17:59:56.363713	2024-11-15 10:59:56.749431
+6	asset_key_index_columns	2024-11-15 17:59:56.391099	2024-11-15 10:59:56.776723
+7	schedule_jobs_selector_id	2024-11-15 17:59:56.42125	2024-11-15 10:59:56.806893
+8	backfill_end_timestamp	2025-11-15 21:49:35.925826	2025-11-15 22:49:36.062647
+\.
+
+
+--
+-- Data for Name: snapshots; Type: TABLE DATA; Schema: public; Owner: test
+--
+
+COPY public.snapshots (id, snapshot_id, snapshot_body, snapshot_type) FROM stdin;
+1	47992fd61f2aecc862f741e1355e2b910d5850de	\\x789ced5d5b6fdb3a12fe2b819fbb814491a278de727ad9069b4d0e929c87c54921f0324cb49525af6417cd29f2df97baf9164ba165cb75db142852491439fce69be1cc8462bf8dc250c63ccfc370f4dbc9e88f68027194c04dc227f9433a1dbd3919c934d1d17d98cb0718f3306f9efc76f26df5ddb765bb9bb2d9f2fb3c8ec3a68fe276281ec3cff0587670963cb67574fb3829c528ba5090cb2c9a4ca334310d92591c9b9b90ccc6e1171ecf205fdcd411c46ae9fa3efa024998f031143d17c3999bd5e8f3ab2851b51065976b32fccb3c3e3dbbfccfe8c9b4cd258f7916d6afd4634c4dab70c2333e2ee6d50c5e343fcb32fe787af3c027708a5d050e204505250461e23a2e21ca118a8b80224ffa1a24284f6c8fc7e822caa727a93ee9355c2f24eb7b0d903dc7b542fefafa6c2becff1a6d29c8a7a2f3dfd334ee817c3ff4aad116f8cd2f2df0b8797b767176bd01904d6fdd942dcaf77ebfbaba28df6a67eb8738e5ad76bd7f10aae116282cae0784e1c3c5d5d9ed0b389c270744a1186c814173352002e7972fcdbf6afc676226765a50f31f3710839ca6d9a900a2881b088f41e073ec49a21180e49a788174b52f29755d41d8017dfaaa27da83e85bc11ffe79797e75b99d7b6aac7d7bd13ead6ba73499c51c95e3708f82173854795432ed33297dc4189598138db94b7d20d23b0af5f4957d70fdccfdd0f6b23d5390b1e7c51439a38c09465de5222e813a1ca920703c1904e6afef61972a87227214eae927f9e0caa91de4f6923d53cdcd348b92fbc51cc1c14558c0146385aeb9402e727cec118110c2546a63a601f28fc3b7f5167e70055592ade8c85ab84a47cd6baed0c2f52907ce1c1a389cfb941166fee548ea0a15489f8089e7d0400af96b63a71f8ac78b5e359fc5d37092a55f22050532d36c064b4fcade439e87ffcdd324cca759d1d3b7a75691a23ccce07fb3282b3bd33cce8bde9a5841453917b179d460df30a30c7815f718f70008f8020b47798810a14133e23b6ec01cae9571600e2bf4797c7383642f53fbf4820d6d4d2e5b83797ff1feededd5a678ecc52c712e1456bea738f1387684c048339f7385a8420464c0994f7c851d46875a200664fc5d5d45b82b44bf1b6560bc04e4f555adfaf2eac9fce9c9a02829c49290e79b492439618eaf18773c4a9189b73000550c3b5c11c208e59a534fb96258fb584362ccbf16c51139cb3248a6c54de7cdc940008d8d545127445a6b8f6ba98dc7f6a9b12f8ecdd2aa45a02962aecb41381068c0606f67d6943ea49d7de740ac9f9d35daeca2573d9205376aae36d428fad84c092c88278c5d680f232f7095a31c621214cf77034f49c6a460be897e516fab19745e93487e8ee1679c59d9d9fac48ae8d8da34f71ed4efc334bf7385e1d5345f4d7318d32cab3ed6b6b9f76ad53e6cf33b97975e6df3d53687b1cdaae2676d9c7b2f55eec338bf73f9ead5385f8d7318e3ac0b8ad6d6b9f752e85eac9320cd4d6a6dc6f65cc508329750c865f26d600ae1805242f171d5325fadf3bb59a735d96d797550b26b49b9cb390d02cd35042e721d6c924d47323f90c244b2421a4becb1d3e5a8ca98bdeb703a8a217fcca730de4c9320608625d88417ae30b8398e123e0d14172c10c2e12ed18a5090ea380bf951128e619c668f872ae55bd3ed9036a091065f69257da33086290f7400549a789172c7450253c72742e2a3b2815787ff1a8ebd148e159b26ad4dd3da0a0e619aa5461076b9c401d3da646ad40d8c6bc5180b0e34c04c8bc0e73e028cdda3b24b1b7f7d373abffc707537eae9b5e3f43e8ce10bc46de1f7804bcddd48f17bb31c66bda52f7ff6cc1bb6a3852d516fafcfdfde86371fcffe78df9fac9ee05cb8beebfb824bb3b619732181eb828f95477cd7455a51cf933f642035275c114b35e42d7ef55968a9ba376745df50a40ad636bb666b8ddb11c85a550725d0707bce7f9828649d1319e4a6d3679cd83aa1b2a3c5be77c3ef8916b661c9cf4b8bf5208e4f1f765a40ac213da8a2fdc0354cf694e1afe7481f71253da21dcf478419b11cbfa0a0d43fb3a2d7ed3f9d4d27b3e9b3fd2fbd3e61b1a386b5120e4b0d50184bcaccd2470d358989c625118879429b0bc6282601b8f457a2067c05392b5f685b1dac77331d473ef7bc3463c2a931a8884fc1749666fcfe79d8bc7559e528ab5026bcbc87ac659b1b0830111a218e448ea305c18e998dab3d8d5cd751506cffc42ea1f238a76622987496496899dc716c0336d17b1a468971b555adb488eccd9d3c1dc3f4c12cabbb5550f3348e54db1e46e2f2c0e8d428316066fec82701d60e363f3170172166c23a8778476aa3fb334bbbc5c9761938e8e2645d013fa6c56950a3ef4a6501f9e048621621a490341928e1265fc1522b13847a0acca284c133ddda51c21afc8352c2505c9818aa08bdb0f6403004ac70dbd224eb5806043430e0441e1525867515639e7d862c9ca646b0346f2d800debe657f7a6f75ed2caedeead4ecffa6b0d3b865b73e9a00ce798fa9a059a4a63ad082b2c7c9f704d1152ae465251cdcc7a868e6b7b9d0d4b9cbedf2bac7c1bb171aff32bb7d7b96dcda28372dbfadb9b1f8ddb2f7dcc34c0726fedbdec0863ad9a8312c63a8b19883056d0590b7950e8acc3c163b2b5612325c173085594ed54e2b5c6f5b0dab6ad65fc3ada36ce334fdbb66458ffa2ce9214b6f01f9414d635906322c5b09fced7d5a8cda4b02ed11f654170b9aeb6ebfcac486f4dafc392def6e3e51f8ef4fd3e131f20f4b44e2e2c7964abb143f1a80a070e76f6d7e2ac94d578c476ba3d4f002b60bafc67d721604fc5b37afb4d58b62944ce275c42c70190efaa170af92e9be6eb0741ae746a771ce452b79de6a9a27c12f3c7f5c31e0ddbc52c8aa751b230378b032097465d3901324eb932f2d7a761eeb2e171cc4dff118fa3bfdbfbdb667fffdabc371cced371d2615f909bc3cc3a50ee3cdd701de6254e6f467a2f07bc0d057d33d536ec5b4e58ec0bfefca4b20ef4bb4f55dc05fe1d0e701b0afff964db14b0f168c7bef0d767917580df759ce32ed0f73e9c6d28e0cf934ed82fd32a38dd1bf44d87ddf02fb5b252c1e5d5edc76665dca4835a987610eb061ba46c43a62de4e80bcc2282e8c0e58530631766ee7230dd50e45c4c77a316aa60072645b83d93d359d619e3c0041205897cbc695a2f8738e5c60493697e49252f1455f5b4213bb8291a9ecfdb353a2e73d4b014a6e5c5f3a2c592142b2f3633fe5adc9a4dcc84c04cb5daf2d6dae355f9f8234f543ce75afdcaf34db3d50437669e4f9fcaa8bf6a61129a7053eefdecfd45566e5857652ecf726c7bb05a055849903b26b122c8a7a736b32bce48e7f72b44699c43aaa01cbc0dee7f9b06ef40775a75b57ba9b39b8bb2c9524755de16961947f9565b1ef3cb6de07f9eafdd3ec0493dbf1399c6a919fda4ae1a9e54d89f8ede3c2f2896fc9ed3a67abf68d7ecc8ea54d875dde8059575953d9ba14d9f302d37f0d53265693a6dced8efb7bd67656a3a4d47cb861425512148dee1174b137db768bafa1f088c27691e157b0ee7a6d962b19dee7207e41a57d13e42ed571776b99ca8aee68b9dbaf9bac692250f573bd52e292a5fbc83189dbbdc6b375e51a66e15cec93b5f112d9cf17e55b106d88a37fe21412b178ec5e5ff0199e65cde	PIPELINE
+2	53f52f323e0e20f0b8ec27a3d698335b3e0918fb	\\x789cd5524d6b023110fd2b92731177ebfad15b29424b290ab6a722c3b899d5d06c12365950c4ffdecc76d50a16f1d86366de9b79ef4d760220d7e83d8078e888c986f23a286b661acddca0f36b1bc45d476015548179f0e0a8f2ca0792115fa0f614bb4e39d2ca10f896028adba23f1c8fd3420e922245caf3d1202d86fd8492fb2ca374394e7a321b653d49bc218e74f0455b0fc102353a28cef814d282b72585b532ab6e6e4bc78d48887565e2e3585bb4533cd3767f189b47001be3090dfd2afa8551078ac4555c5141d83a62b58c7e345b6e192c59b0d8f0a3763e548425d83a443aacd1484d9776f18a69037a6e30cc6e49878915f95a87df2171f5622efbc59e633841ce23e296327c1b5641a62e4f225e63a3fb347d9b7dbc4fc43e22e36c94181054a0b291be386abb9ada8fa51b626b4d36f2bdd54ab699b55fe9608595dd76dbf33c2e7ea5ff9bc9d10e5ffe1baea24ae0	EXECUTION_PLAN
+3	1509d0f29fa194f0a32fb7f369c612eb1302be55	\\x789ced5de973dcb615ff5738db0f6d676299f7916fb2ad349a2a92c752dae9441e1ac7839631976478d8de66f4bf1700c95dee8a5c614fad55651c4b248107e0f70ebcf770f8cf511892181545188e7ed446efa30ce22881eb0465c5382d473f682392262cba0b0b3286090a8bf6cb8fda9f8b75dfca72d7b258b73e8ae3b0a5215e87781a7e86a924709a4c8708dd4c33d90d41824241f2282ba334e105922a8ef94b48aa49f805c51514f3972c8298769eefa22f9084099a80a02c9ae32febd6674f51429b4e48924b7df827ff7c727af99fd13d2f5b1014a33c6caa346d94bc5498a11c4dc4b8dac645f1d33c47d393eb31cae0442706103f60968fecc0a55ec0a8ee52a683e712ec1a34200ef6904fd7c763741115a596326da3e63642b279d702b961bb4ac87ff870ba16f6bf8dd6ecc8c70ea7ca3c4aeeb6e7404d6677c8cee8ed0bb1ba0189c49b348d374060b3d1d6adcdc73b7b5418e7f5dbd38bd30f3d03edab752d4bc87a6faeae2e64ad61bdfd294ed1a085db3d0875737314e6cf7b84e1a78babd39b4770384f0e8882686c8e41fbb44704ce2f1f1bff659a00c2319c6c04c4c6f3d4a20d58e884222497579767a76f2eced63303a20169036a907e4df8384e844abeba86184899e627181cea183eb602f05d645bc461260041ccb17c623097789e6160277832b476d0f5b5c42efcf5f2fcea723d9c5b2bb77ed71e70479a8af918a9ae23cb03cbd73d6a7924606e40886b0681476ce4301b199e0b0eb18e823d9bf67deffc99d9dff5fbf680415ca7e6434481170438f00c6a988880a72393fabe6e11dfe7ffbb966d7854f74ce728d8b359cff7ce9cc60aaedfb307aca9bd9ef91841b73dd322010d02c16b844dc3d45ddb72b0699ab647185753df748fc3b66ddcf9bd3368eeadaedfb9411e4997deb429653e4526b66ddf26282081ae8369066078a6ef72879fdb4af08f437d36ebf921b9b35ecf6ad6b41c3530c386eb214081eef93a42ae173801ff4d279e81a94f5c07a88ecd3db1e2b75ea23f89cf73aa0c5571196679fa25a2206029f30a3a5f24f51015e1ef459a8445990b4a7fde0f76292ac21cfea8a25c1263282e04b5d67da55121bc3419d84ae05b999030536405c80270c0c536d6a9653a0e66c002c7d50d3fd011a37c6ed103c1cce31b1b243b19dac747b4676de152d596b38bb3b737577d21c2a3299c59a75cc63c0c01781e0b3c9beb888519b17407816f213fb079cf4c1c30fdfb93f8db510edc2a40712bfa7edb725b3edddff7c8cce8ec1b90aa040dc5b1569490155a9468482bb8658941e3ed13288a93d1a37215256153b85fb46c9b9936228ea33b0145069fccc1b711f787b98478a003b52cd3740cb25fadb91d4dd03791c224559e4352deced8b3397280c8584227914bf8df34e29daa50bc067c13dee768258018f3c801a867e88161309b2ba3139886ed60cbf55dc3739081b041dd357453590d0ea99bbe65f8cc418c4b06d5ddc0470ef1185086034c89e70803a4bb14fbdf9f6ef6c9504dbeca412bc7a075854003295e69ae9529972e94975a51e1e623145a253454fbc4d2fc7301f917c83f2948d9bcf48092621ef870f0b1a9536619a6eb02ffcf031eb9eaaece0cccc58eea8e7df0a96d7ba08a0c7d4d543092050f353d2a4bfb2155f08943dbcd54b065e32ad16a5a52f09a1a396d6542d018d4180b7b16d716dbb47c830af5200eb35cc3b72809028203d773c1dc5863f63aae2c229f63788e2393c4960726f20dcaaab9f334c92e54f38973b62faaf9a29afb514d994757d6cd9de7ff77a19b4f9cb07fd1cd17dddc8f6ed66b28cacab9f3c59f5d28e7132f08bc28e78b72ee47399b450065eddcf9e2d22eb493990c5cca2871756404b6877ce68347b8f9f0906e98d8f674d7c1c47ed1ceef5d86ffcfb453ec4b55564d652d38846ad61b2f7dc3726cd7b570406dec33cca841b00f96e37bae151866e0f0bf2d76547aa99263bc1d9d5ffe74753beac934de8c418bd3bb3bc8ff5a68e53887629cc6542171c82b85317c8178c844ef31677a3ba2e8ae28211f1c92e8a5d8d63a4dabbc199fc298e4cf0d679cf5244855a66f3e9cbfbd09af7f3e7dbfd68eb825b9dedb06eeef75be114cdbadd8eeb5bb713489cadef4de51f476598dfa3db7ad779828aae08eb7f1ef480519f8966351173bb689086188061808a618010e4ce6da01601ca0a35241c535e6d94c20568fdba9462c310b2ed5ef66e6ba6fb14bd8eba60d8da471ca858aff4c8a340675d35d9fd3e9f7b494adb2a284a9f2f2a01266381e1fa6450ce219c0c74602c22c446d9798860bd831b0ed13cf7b262bc96faa282e5f4589c6a2188a2917ae89767ea54d5082b8bc704706955ac1bd4c28349450addeecf0853fd503689649a57bce7f51d9f091860df17e19f36c0b6c2fd00ddf7108366d87479994ba9605a6e16146b01d20c3409ea28c2973f3b032c6e5daf51cde3e7391ed320a84048e610a6560cc47e006605138aea552452b561b90663b4c77c5bd7db5d94e9adebd34f3e5fd71fab5d98784f853bdb6cfcddfd7a81ccb8d4979952808675d2f1a8aa189e999a60b3a00f26d861df04c4bf781788c21975881e7980483e73de53e0701446dec0b0db8b7a34d38f45cdd8a75b16888f423017ee0d0c0011e78eac098817dee71782eb36d6422ece9dc6fd0891de07d6fcbc2a888087f5f40191ab5a80849eabe36fb5f5bfdafed46de5662cc012c231e17490d875240cdd25c4bb9f4f11f9290cae62d5ebe1f5d1f98432c6e0e4cf00cc712ce976dbb189887b9b8f98cf88487fb36dd37ba735bad828a54c131125e079f2e78bc48a0d6c66892c530e1cabebe42ce08f503a56cdd15270b55b37cd0c9e289f7bc1f61d489b22c9e5e8858ee3d8848e88f0afeb5f9eaf07eb6e7ef84f5cabb5f9f05eb47bfbd3b7bffe1ecede9cdd9bb8f0a7b5f51fe19f2b04c7917d36230dfb45f13b9e8a5f4d8c77f8fa11c734fba716e6af7a4ae24268b242d4fb437d3366efba1af9c929d94b51e60b0f67e7a356d5196cbc36a8bea42c0b3d016a56513548eb7cac32a437a6846abed377e168c1e9d7dcbe28844653cd58a0c48c4a6f56ee694563c6617fb97b31ce214517192407c99efd73ed1ae84f5f91a89a6c56f200d4bf935d50812db9c85dfdae68c9a903e6233d2a22cb7504db3113745da39934dbcab1351daef29d6bea24213cd738bc6f274c29dbbbabe6c512bc40a42fd827b7f71ac6168fbdbd0e32dd4453f35e9ad4f6df9a8e8147ddc0a3665c3a6fb0f56d5ba576928cbbf9aa41d54fe957324cf42fe9552e5fd694ba575d4f5203d28a39503c16362f45ecf212e04fcdb66108ff1a0e542eae2b90fd07aee03b40f92e456361307355eca270fbf37e3255a1ada2e514d30f78a52d69ee114fe99584399a0a9487969f3cc773c5d0cfcca31f776f81f2e36c2a5c3f591351ed8557952bb6682eca76e465dacb890ac0a495a25e5dffeae724c6d31fbbe2c9d0b170dbd44ceeb45ce87de42d0f4b1cebb768f2e0a00480ea814fe7517a1e634632d65a2ae28700da08dcb322b7e7cfd9aa6a438c9a6e5384d4ed2fceeb5f53a8e708ef2e9eb65b11b9793f82f5c904af85616af50425fc93394af269c672955c97ecbf2615d7e107de5838e8747ff546a2a5749b9a9a4517301bdc84ef250a93e572a56a444ce5bac159411a9b819d54a1ee5c8c007357a5d6b7d1d03496ae24d874c9ac4d39a3ec7e7555d274351de444f2a5410c9d3a290c7f59b302f653392b3a8ae4b48348c341a71099303f8349475ad35fe53b76119e7c9f2824ab960182b59b3ed85883fe7ddb84c4ba81f799d025a6805aa99b00455f2838c47efe214a35841c838d4737347a6614d7020305c6fdb8bdad4ac3c091e746a565ec8fcdea6e6be25e7bec9658b9872fd7b10d424459927079514e5b3eb7b921425e8943b7950e894d7c88f49c9f69ea511bbd1067697a96e0753d32765f80f25149bde2c3c7a94d5cdf3e265aa9d2b831712ffaac3ddf04a5501d3e53f56ddaa7a2fbe3599de5096115de6ae298115778b370967d1bfcbb6f8f21de30b44d56e1aef905da96b342ab2184d97ef11e7e28ec50eba28994f500a778b775a5db85c5c66baf3f6a2f56d0e7a4cb8f79f47288efebb4caf19d0d2407a2e8a5b7117f4a6a8b5d79eae806de5fdcfcbb87584b41fba9d5c05ab8c65dbf72130072e95de14cdd925a52be05c7d91f436786e7177ab32a0b3de0f21da7b2bf3a67836f78aae4073d5fdcbdb60b9f145abca489e272b71e481d7b87776da14cb96e06a3c3ba59430bdbcbaf9b99d5dfa406d3aa38c4aa7fd216486a6ed4d8199cfc22b707964aade46d4b6b9355619d779ff7b61ad3d00c8843f5991b2ca574efc90414245f47edd96eecefbdc9f8c6818255f528204f235a51efff75a143c9f956b991625595586b2336dc58f3573e8940f2722e10465d982375b37c93de4707055aa2e32bc68c5193892a1e983b4957a37972a9e8b121db0162a0ef6a4334e92c642263a03ad32ce20e0ac4bab5250196afa4a7efe1925349e294353a5b3919387138f4173fff17e3bf0cdd52d982fe0ef117c6b750bd6d1806f1e1bf862dfdd4340d61e97756ce3b2b6172a7b750bf6a2507dbc1f9a87ef72948d875a29c2df53990810fff215ba5b988e5a9f024a4451897ac03ae36177f94bf3fd2c29f3e98a940dff1a367496c8dcc0b7452aef4431313cfe4114101fb49273af9ee91106119a8dd2af09e43d0b203bead6af79dcdbab2a97adcf968e6a9fe4244a177bc711fd5c676c262905c98021a1fb851778076ca53b559f4a5949e64216e910aaf3b8a14c97c85a0f07f9728eb3ff1ce7c69d5bcef84909985d945ed717e5da031e2b39faa129b40f9e3ed9b6b487d0eee12c66cfa94bc9893c4dcbf69fe4dbec08cc0243fb4c695e25e1cc3077cd7c944462c4c50a9f5fba02efe645bb0e3f4927595a442537d2b38963c175ef793d40fe190b534bb0719e96201af4489b397e1578b56bd0b5d3ddaceb62f27368908d2fd019e3ca6dec8dab514b6e532a9c598e595ca9e05efebf32bddfb3dc98854301c4c027f345b45e446b3fa265bd88d68b686d215a7dfbf6f6d18e352cc2f6f312611982cf1fff0789f66624	PIPELINE
+4	75080c9f16819e52f57f50a6fad451ba486ee568	\\x789ced5deb73db3612ff5738ba0f7737d3387c93e8372771af9e73ed4eecdecd4d9d61f058586c285225a9246a27fffb2d40ea695281644971527752db12c1c5e2877d61b124fe1c2409cf685525c9e07b6bf0733a862ccde13aa7e36a58d483efac012f7299de25151fc28826d5eccaf7d69fabf7bed4edae75b3e5fb699625331aeaeb844d937730d5044ef3691fa19be958b3a14808a878998eebb4c8b1413ec932fc12f2c928794fb309548b2f650a9958fa7c97be873cc9e9081465d51d7ed9f43eff94e6a26542935ce3e1df78f9e4f4f27f834fd8b6e234a365d2ded2f65163ab644c4b3a52e39a75ae9a9f96259d9e5c0fe9184e6cee008f89f462ea935044440a3b14d28628e42c7404e1018b682cb6c763709156b555486ba7ee7642b2fd6e06e48efd1a21fffaf5e956d8ff3ad89291374b335597697ef7f01968c8ec0fd939bd4321d674a091785114d90e08ec36daa6b7c578e71f0dc679fdf2f4e2f475c740bbeebad62df47d2faeae2ef45dfd7afb4356d05e0bb77f109aee16282c3e1f10861f2eae4e6f3e83c3797e441454670b0c669f0e88c0f9e5e7c67f59e4405906273b01b1b39f5ab5012b4c18427279757976fae2e26c3b33a03ad036a001e9971cc771a254f2d93564c0eba23c611088c0899947200ea9eff140ba009ccac08bb923431e458ec302f2c5d0da03eb5b895df2cbe5f9d5e57638cfacdcf6acdd9b1d6d2a166314b64dbd08bcd88e8417712243c279e81212719f06d2a74e1442c0bd47313dbbf27ef0f999dbdfed79bb3741a8538b21521211c248e408c7a51c229bba228e6d8fc731fe1f7abe13093b728347313dbb717ef0c969ade0f69cdd9b9a26ea598c116c3f723d4e04216aae29731dd70e7d2f60aeebfa1197a8a6b11b3e0edbb633f3079fa045b4ba3d73bd73a4437ad71742c682baccf7639f53c2896d83eb127022370e31e0475b09f1e3509fdd383fe6ec6cc7593335b3197598644e1851a0c48e629bd2302201c1bf6c1e394cc43c0c40d8cc3dd054fcda49f40775794155d2495627e3b2789f0a50b0d4e50496ae68ea09ad92dfaa224faaba5494fefcd4cb525a2525fc3e494b4d4cd2ac52d466e1ab482b15a5e985ad067e26131a66413d423d800042e6335b786e1030099204a1edc4c4a652a06fb1899accc73736c8f732b4379fd19ead85cb545bce2ece5ede5c752d113e9bc29933154a193120104592443eea88c724f7ec8042ecd198f8c899cb88b4bf3e89bf1d94805601aa5bc5fbed6cb6f5a74f9f3a646670f611f8a4068b669955d530aeac34b7a855a165c9c0c2fe3954d5c9e0b37295e649dbb85bb47c5fba3ee54160074450079d39c43ec578182524021b84e7b96ee0f0c36acded60443faa14269f9425e4f5ed7c7a76470e281f6ae8347239fe14293235a1d916f08d90e77423808ce1ca0144e4d8c471a48fca1810d7f103e68571e8440175287344b8856e1aabc1317533f69c580654a264083b24310d782441484698e051a00c901d0a167f7dbad925430df94909563d046b59082cd0e25594565da074d1b2b6aa096b2f42654d94865a6f6551beaba07c0fe55b03295bb4ee5152860b1f049fb9b6909ee38621e07f11e0cad50e6de930143b6107fed15ddbc381aac6f4436e82916e782cf7682cedc754c12fbcb4dd4d0567d3b849b4da9e0ca2a6564e6732a168f46a8cc7220fb5c577bdd8114a3d7820bdd0893dc109e18c845108eece1a73d0718d53fe2e836f71649ad8fac054bec15835f79e26d9876a7ee19ced936a3ea9e6615453e7d18d7573eff9ff7de8e6174ed83fe9e6936e1e46379b3d1463e5dcfbe6cf3e94f30b6f083c29e793721e4639db4d0063eddcfbe6d23eb453ba124221050f6dea103fa2b18c21e2683e226a3b2ef3233b0c18f79fb4f36b97e1bf9876aaba5463d534d68263a8665378193b5ee087a1c788f0592c99140e673178411c851e715c12e04f4f3e2abd34c931de0ece2f7fb8ba1d74641a6f866065c5dd1d947fafac7a5842352c32619038c49b920cde43d667a20f9833bd1d087a57d550f60e4971a9ca5aa7c5a46cc7673026fd7b478fb39d0499caf4cdebf39737c9f58fa73f6f5511b726d7072be0fe5afd8d9ab4fd8aed41d9cdd2515a77a6f71e05b7eb6ad41db93db8c2c45005f75cc6bf271594107b81274216f82ee55c52411870261805465c19fa041823f451a9a0e11ef3dc13a8dde399ab515bcc6a969aefe6e6ba6bb34bd9ebb60f8b1759814285bff3aac8c0dc7437cfe974475ac656d950c24ce7f2a812e604110ed3e30e8f1cc0b171c2a547851f72d70981050ef3631e45dfc84ef28b499ad5cfd2dc926906d514856b649d5f59239a5394170c64686d5518654265d15c584db1c37bfcd40ca0dd26d5e139fe6152f051242df16e198b7c0ffc88d84e1c049cb97e80ab4c2142cf03d78998e4cc27d47168642863c6b3795419fbc2658c8f3090a0e37136bd50eef96750ceedf709fc67f784ff612a2ef732f59e743d629350461033977b367362b537281c8a3c869286ae74fc88fd75a69ed12ae548ac823a71ee1985ad57b966c2613c0d47150edfe1e03842ba6e40c3200c10fdd08b0297b868f9a8c06b84dad4fe96135a66f1884e901c3b66c7002badac626ce1cfbca8ad317a45c86b55bfa7aa8bdada40d5a0d2528b777da7afa4f978a24232c5ddcc71d252174f161f3048637835bdcb55c066543289d47aaafd8cc5da4c4b8ce5f1b85a625a13fa4d68c9e0d757673fbf3e7b797a73f6ea8d4145282ddf4199d405b25854bd5998c356cbae56c176849dff1d022a46d9c6938d36b4375945a9b4ebc47a319dad66beeb6a67a029ed5dbd3ec5b8cadc505b4ce5f2b8da4238f780b2c80b18aaab740242058d421262e84b08c6c4911348ef5b8e359f7cca437c0a45d1f5250657be943e8074388a741051df07742d8e1f7891e7da2436d51253793cae96986e227dbb5ab2bee546ebe18372f8c6901e7ba2cd6ad5bf89891e9c7d1c67294feb6c6a5563e0a99c3695f08598646831ea42599caca062667116b5fe27d695f2d11f52d5b5fa0bb481a93f1416a7aa441e9bcef38dad054ae59cb46aab2c5ad36d8a66c83a97ba8b574d12d3faad60d6075a59aa7bb458b22c46166def6f8c5ca5769f9a2fac0f6996590c66fcb6f4b087a6e9db3635fa76d61e0deaa2e9e72d60db3669d9bfe71c965fc3622cff66927654f90f30b691a164a89c36e10243f988627812471107f0632668083c228faba2e9a08f366ece3f6c9994fc6ae2877d450ecbe8b93d051aa6abc8bf367ade137a0f40cfef41cf34da34b3e9c6d6f3a836ddd83c3d269bfec5967846136d0ce951273a76e33022d2b6a52b891ffa61ec5121892401034f4a276494ba76fcf51556fd79dbce58fb18f5f2939ab3af767b02bb33fdb4782c74587c689f5fd7a9a5e6d96c81c1663dd40fb49793dcc01035f7a57db597dc8d5c37c46534d0d8972c80c8f5ec180d859434e41e416bce1944bb870f7b783e5601d1140954168cd2da1a21f4f40eedf39658b444ba91809804820400a1b0010596c5b1cfa350fa3e75d148db310a37f7093b74827225e6eb4f532ee0c1b1d7292e46b47242ad5052cb9f0205077f694226cfeb63fb6e608c1dcb8181596ccf9ba0a2b5674855a109fafe6252f2d69fa7a3710623d4d3ed75694ea81b28e30d7d333b6f6c518f6ae78d536e8fc9ce1f6d93f8fe3263fb4de24751efb7618cf7170307da083716b5a32a80f15b4b1e9302989858d5535fa9f564c4a054c5d68bb750e8faab119d2adb692da29f6cbaba3d56ab8518fe43c951293dd6bcee02e3a2499937cb2c45f6ed7254a5aab5f8788221157ab67ffcd3e41517ab11d8ba80aebca4f4697f71bbfdc5a32fdd1b1e1b07befcda1305002f81d62abfba8c50fb269446cad4bdaac135600c50d7e3eafbe7cf45c1ab93f1b41e16f94951de3df79e67292b69397dbe2e76c37a94fd0d05a9868f75f58ce6e2997effca338cab86853009a374fba469df8bbef14b528e8ffea9d65454495d90deaab9ce838cc7598a32aadf49a356252a785241679df2099a51aba677954e7cd356af1bad6ff22a9a9afa66894c9167d3863ee2f3acb9674cd3b2cd9e9b50a1bc2caa4abfeaab4dd914724e729ed55f26a43aa6964851c2f400def695f7351aff76b9639de7d7ed15957ac5304ef49d332e5400be60e3b2a8a1f988f754308356a13a569660927fa7b3547759c16866206408f5c2dcf169d210ecd918d8ae64decc351b3bc1a3ba66e3c5ecd7e69abbd20e5dcee501f9a7eddfa1662629c673725449317eefd58124c5083a63268f0a9d719ee43129d9c133baea49969e27534c1f2531d32763f88f2514bb9e4a32f8ec54b79f570f62583a6e64a5f0c374b83b1ec7a060bafcd7a613193ea96bed4e7fa2db28963134e5b0e15ca2b6e040f177396bbe7e3ed10a51b3538a96c86ed4359156e38c4ed7cf20427167eae99b345f38a8a57d8a3eac977a5d399848573a94b3439a1ef290f808a3ff32a559fac73abd76406b03b93f57bf6e38476657d46647266c806de3d931ebb82d096937747b3946c218cb19ef7d60f61c48b32b9af3030e36c0b9f9109a87e0f980731f8c019d73df8768e7892ebbe2d99e49b001cd4d67b73c04cb9d0f693046f23cdf88232ebc869dde69572c670437e3b9d4ca08d3cbab9b1f67dea50bd49619635496faef43a6cf6def0accc20b6fc0e533aefa21a2f69013278c715df0df096b1301c058c593135e4fca8d8e1fc6900bb57abf9eb55ef6fb184fa62249f3f705a70af9865247fc7bad1a9ecfdbcd264d574d279a99d98d6f9ac911531c4eca93111d8f57a2d9a64b8c9093aeacbfb3e0aabf3a0d2770a097a66f3ef509ce5d49c7c3be5e301e2f74e4aa8e79a4779bf05b3f0cf2a2b943c74c9a239c47fe2e9997f7b4146459fc01b9ba9ecc75a169bfde72de66ade353d5fadfcdcb257421b23ab862158a37cdf8513e20afe763485285f6c0096c226ce912a9a21d89eec5952c921e3a96d07181399eeda270060bbc97396b51d4172af5284d5b17b014918fa0a682d6b483f7338ca4eb9fdaeb67795d4e37acc2f06ad2d2592373031f57a9bc52cd9400e005d5405db06aa0a346792903156d0d8a0f39941d39cd3db1f54b997572352975eff36c7063664ed262953b94a677cd226c5408d022daa7743f61835720375ac8a6d86023990bdd648950939a49f40a48dfd5b7ae7a7aadc3fa6b1d76666e7d11af25607e6e4a73bf6a37dbfcdf38a3afdb468798d32ff8e0d1115ecdd0f112063d13658196b3c570b7f2889509ed723673c797e6a91a61b5c1ed6877fb6ad174f52ce2d1b8a8d21addd6dc95ae78df8eaf7bc87fc3c23323d806286b10f5c616c5a4be77c31a1257bac9b25d5e4e9cace62ffa06d946474b63dc58178112aecc4323a96dab646e29e6a1e1fdd868f1f1ffbee26c9e	PIPELINE
+5	03002c9d8db5df9d5ce603d57fa7fdda258054b1	\\x789cb5544d6fdb300cfd2b85cfc3900c759aee56140506044303643b0581c0da742344963489eee606f9ef236dd9699a66b71dcd8fa7c7c747ef33a50a03312a957dbdca1efe60d190767669c0ae2cf8b875947dbaca2090aea0a0a83c86a82361c9f5141ae424765d2e280b350a4cdd18d28a03da2a1f5c818c3f14099ab69a3418b5b3eeb7559180a46d7fca6521c991d0aa2be2deb2e55774a16af05edbe7288d078e7b08686904b38d31120df8a25d1355400aad0222ac3d8d4d01a16c956bc8377d902954c1bda28d481d8df546ea785e9fcad48b08e06c1c935e7b34daa28a4930a5459cec269fcc27c56d359dcda7b7987fa9f29b2a9fc0ac82f23a9f3ec1f57c8698cfe632d5d89ad0b97f3abcbbc3362a724941196e9d3d41640d582ba639cd36a9b4e3b4bfb0d21517c84afb05a481d7d2ca0f48e529a6c4b52d9328689bbac7139805273edf3f7e5ffefcf190890435129440a034eb3be21e75fd27a9c7ae6ca056c2338f1214b51e556276675b490df60a18d96059b75ec77e248df1dc3f47e8e5b14aacdc0d586cb1d825fce4953ed187de61dd496a811d0b0fb4fd6807a2838efdf7f1368688f2724232727739159898d2c9d0a7c180bf1a1dde1e19bba33125db9ec5e1dbd1af387474067546976a0bb6341f9cd24ab2dffae41b1dcf16dedf5052e470d8bc034ebe3e6beb5c7af16d4e1e9fbe64b5ffc29f2304e90f71d81cfe024d4caea7	EXECUTION_PLAN
+\.
+
+
+--
+-- Name: asset_check_executions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.asset_check_executions_id_seq', 1, false);
+
+
+--
+-- Name: asset_daemon_asset_evaluations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.asset_daemon_asset_evaluations_id_seq', 1, false);
+
+
+--
+-- Name: asset_event_tags_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.asset_event_tags_id_seq', 1, true);
+
+
+--
+-- Name: asset_keys_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.asset_keys_id_seq', 2, true);
+
+
+--
+-- Name: backfill_tags_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.backfill_tags_id_seq', 1, false);
+
+
+--
+-- Name: bulk_actions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.bulk_actions_id_seq', 3, true);
+
+
+--
+-- Name: concurrency_limits_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.concurrency_limits_id_seq', 1, false);
+
+
+--
+-- Name: concurrency_slots_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.concurrency_slots_id_seq', 1, false);
+
+
+--
+-- Name: daemon_heartbeats_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.daemon_heartbeats_id_seq', 39, true);
+
+
+--
+-- Name: dynamic_partitions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.dynamic_partitions_id_seq', 1, false);
+
+
+--
+-- Name: event_logs_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.event_logs_id_seq', 79, true);
+
+
+--
+-- Name: instance_info_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.instance_info_id_seq', 1, true);
+
+
+--
+-- Name: instigators_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.instigators_id_seq', 1, false);
+
+
+--
+-- Name: job_ticks_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.job_ticks_id_seq', 1, false);
+
+
+--
+-- Name: jobs_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.jobs_id_seq', 1, false);
+
+
+--
+-- Name: kvs_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.kvs_id_seq', 2, true);
+
+
+--
+-- Name: pending_steps_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.pending_steps_id_seq', 1, false);
+
+
+--
+-- Name: run_tags_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.run_tags_id_seq', 17, true);
+
+
+--
+-- Name: runs_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.runs_id_seq', 10, true);
+
+
+--
+-- Name: secondary_indexes_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.secondary_indexes_id_seq', 8, true);
+
+
+--
+-- Name: snapshots_id_seq; Type: SEQUENCE SET; Schema: public; Owner: test
+--
+
+SELECT pg_catalog.setval('public.snapshots_id_seq', 5, true);
+
+
+--
+-- Name: alembic_version alembic_version_pkc; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.alembic_version
+    ADD CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num);
+
+
+--
+-- Name: asset_check_executions asset_check_executions_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.asset_check_executions
+    ADD CONSTRAINT asset_check_executions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: asset_daemon_asset_evaluations asset_daemon_asset_evaluations_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.asset_daemon_asset_evaluations
+    ADD CONSTRAINT asset_daemon_asset_evaluations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: asset_event_tags asset_event_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.asset_event_tags
+    ADD CONSTRAINT asset_event_tags_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: asset_keys asset_keys_asset_key_key; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.asset_keys
+    ADD CONSTRAINT asset_keys_asset_key_key UNIQUE (asset_key);
+
+
+--
+-- Name: asset_keys asset_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.asset_keys
+    ADD CONSTRAINT asset_keys_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: backfill_tags backfill_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.backfill_tags
+    ADD CONSTRAINT backfill_tags_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: bulk_actions bulk_actions_key_key; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.bulk_actions
+    ADD CONSTRAINT bulk_actions_key_key UNIQUE (key);
+
+
+--
+-- Name: bulk_actions bulk_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.bulk_actions
+    ADD CONSTRAINT bulk_actions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: concurrency_limits concurrency_limits_concurrency_key_key; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.concurrency_limits
+    ADD CONSTRAINT concurrency_limits_concurrency_key_key UNIQUE (concurrency_key);
+
+
+--
+-- Name: concurrency_limits concurrency_limits_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.concurrency_limits
+    ADD CONSTRAINT concurrency_limits_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: concurrency_slots concurrency_slots_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.concurrency_slots
+    ADD CONSTRAINT concurrency_slots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: daemon_heartbeats daemon_heartbeats_daemon_type_key; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.daemon_heartbeats
+    ADD CONSTRAINT daemon_heartbeats_daemon_type_key UNIQUE (daemon_type);
+
+
+--
+-- Name: daemon_heartbeats daemon_heartbeats_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.daemon_heartbeats
+    ADD CONSTRAINT daemon_heartbeats_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: dynamic_partitions dynamic_partitions_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.dynamic_partitions
+    ADD CONSTRAINT dynamic_partitions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: event_logs event_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.event_logs
+    ADD CONSTRAINT event_logs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: instance_info instance_info_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.instance_info
+    ADD CONSTRAINT instance_info_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: instigators instigators_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.instigators
+    ADD CONSTRAINT instigators_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: instigators instigators_selector_id_key; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.instigators
+    ADD CONSTRAINT instigators_selector_id_key UNIQUE (selector_id);
+
+
+--
+-- Name: job_ticks job_ticks_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.job_ticks
+    ADD CONSTRAINT job_ticks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: jobs jobs_job_origin_id_key; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.jobs
+    ADD CONSTRAINT jobs_job_origin_id_key UNIQUE (job_origin_id);
+
+
+--
+-- Name: jobs jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.jobs
+    ADD CONSTRAINT jobs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: kvs kvs_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.kvs
+    ADD CONSTRAINT kvs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pending_steps pending_steps_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.pending_steps
+    ADD CONSTRAINT pending_steps_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: run_tags run_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.run_tags
+    ADD CONSTRAINT run_tags_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: runs runs_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.runs
+    ADD CONSTRAINT runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: runs runs_run_id_key; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.runs
+    ADD CONSTRAINT runs_run_id_key UNIQUE (run_id);
+
+
+--
+-- Name: secondary_indexes secondary_indexes_name_key; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.secondary_indexes
+    ADD CONSTRAINT secondary_indexes_name_key UNIQUE (name);
+
+
+--
+-- Name: secondary_indexes secondary_indexes_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.secondary_indexes
+    ADD CONSTRAINT secondary_indexes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: snapshots snapshots_pkey; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.snapshots
+    ADD CONSTRAINT snapshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: snapshots snapshots_snapshot_id_key; Type: CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.snapshots
+    ADD CONSTRAINT snapshots_snapshot_id_key UNIQUE (snapshot_id);
+
+
+--
+-- Name: idx_asset_check_executions; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_asset_check_executions ON public.asset_check_executions USING btree (asset_key, check_name, materialization_event_storage_id, partition);
+
+
+--
+-- Name: idx_asset_check_executions_unique; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE UNIQUE INDEX idx_asset_check_executions_unique ON public.asset_check_executions USING btree (asset_key, check_name, run_id, partition);
+
+
+--
+-- Name: idx_asset_daemon_asset_evaluations_asset_key_evaluation_id; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE UNIQUE INDEX idx_asset_daemon_asset_evaluations_asset_key_evaluation_id ON public.asset_daemon_asset_evaluations USING btree (asset_key, evaluation_id);
+
+
+--
+-- Name: idx_asset_event_tags; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_asset_event_tags ON public.asset_event_tags USING btree (asset_key, key, value);
+
+
+--
+-- Name: idx_asset_event_tags_event_id; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_asset_event_tags_event_id ON public.asset_event_tags USING btree (event_id);
+
+
+--
+-- Name: idx_backfill_tags_backfill_id; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_backfill_tags_backfill_id ON public.backfill_tags USING btree (backfill_id, id);
+
+
+--
+-- Name: idx_bulk_actions_action_type; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_bulk_actions_action_type ON public.bulk_actions USING btree (action_type);
+
+
+--
+-- Name: idx_bulk_actions_key; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE UNIQUE INDEX idx_bulk_actions_key ON public.bulk_actions USING btree (key);
+
+
+--
+-- Name: idx_bulk_actions_selector_id; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_bulk_actions_selector_id ON public.bulk_actions USING btree (selector_id);
+
+
+--
+-- Name: idx_bulk_actions_status; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_bulk_actions_status ON public.bulk_actions USING btree (status);
+
+
+--
+-- Name: idx_dynamic_partitions; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE UNIQUE INDEX idx_dynamic_partitions ON public.dynamic_partitions USING btree (partitions_def_name, partition);
+
+
+--
+-- Name: idx_event_type; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_event_type ON public.event_logs USING btree (dagster_event_type, id);
+
+
+--
+-- Name: idx_events_by_asset; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_events_by_asset ON public.event_logs USING btree (asset_key, dagster_event_type, id) WHERE (asset_key IS NOT NULL);
+
+
+--
+-- Name: idx_events_by_asset_partition; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_events_by_asset_partition ON public.event_logs USING btree (asset_key, dagster_event_type, partition, id) WHERE ((asset_key IS NOT NULL) AND (partition IS NOT NULL));
+
+
+--
+-- Name: idx_events_by_run_id; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_events_by_run_id ON public.event_logs USING btree (run_id, id);
+
+
+--
+-- Name: idx_job_tick_status; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_job_tick_status ON public.job_ticks USING btree (job_origin_id, status);
+
+
+--
+-- Name: idx_job_tick_timestamp; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_job_tick_timestamp ON public.job_ticks USING btree (job_origin_id, "timestamp");
+
+
+--
+-- Name: idx_kvs_keys_unique; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE UNIQUE INDEX idx_kvs_keys_unique ON public.kvs USING btree (key);
+
+
+--
+-- Name: idx_pending_steps; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE UNIQUE INDEX idx_pending_steps ON public.pending_steps USING btree (concurrency_key, run_id, step_key);
+
+
+--
+-- Name: idx_run_partitions; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_run_partitions ON public.runs USING btree (partition_set, partition);
+
+
+--
+-- Name: idx_run_range; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_run_range ON public.runs USING btree (status, update_timestamp, create_timestamp);
+
+
+--
+-- Name: idx_run_status; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_run_status ON public.runs USING btree (status);
+
+
+--
+-- Name: idx_run_tags_run_id; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE UNIQUE INDEX idx_run_tags_run_id ON public.run_tags USING btree (key, value, run_id);
+
+
+--
+-- Name: idx_run_tags_run_idx; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_run_tags_run_idx ON public.run_tags USING btree (run_id, id);
+
+
+--
+-- Name: idx_runs_by_backfill_id; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_runs_by_backfill_id ON public.runs USING btree (backfill_id, id);
+
+
+--
+-- Name: idx_runs_by_job; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_runs_by_job ON public.runs USING btree (pipeline_name, id);
+
+
+--
+-- Name: idx_step_key; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_step_key ON public.event_logs USING btree (step_key);
+
+
+--
+-- Name: idx_tick_selector_timestamp; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX idx_tick_selector_timestamp ON public.job_ticks USING btree (selector_id, "timestamp");
+
+
+--
+-- Name: ix_asset_daemon_asset_evaluations_evaluation_id; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX ix_asset_daemon_asset_evaluations_evaluation_id ON public.asset_daemon_asset_evaluations USING btree (evaluation_id);
+
+
+--
+-- Name: ix_instigators_instigator_type; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX ix_instigators_instigator_type ON public.instigators USING btree (instigator_type);
+
+
+--
+-- Name: ix_job_ticks_job_origin_id; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX ix_job_ticks_job_origin_id ON public.job_ticks USING btree (job_origin_id);
+
+
+--
+-- Name: ix_jobs_job_type; Type: INDEX; Schema: public; Owner: test
+--
+
+CREATE INDEX ix_jobs_job_type ON public.jobs USING btree (job_type);
+
+
+--
+-- Name: asset_event_tags asset_event_tags_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.asset_event_tags
+    ADD CONSTRAINT asset_event_tags_event_id_fkey FOREIGN KEY (event_id) REFERENCES public.event_logs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: runs fk_runs_snapshot_id_snapshots_snapshot_id; Type: FK CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.runs
+    ADD CONSTRAINT fk_runs_snapshot_id_snapshots_snapshot_id FOREIGN KEY (snapshot_id) REFERENCES public.snapshots(snapshot_id);
+
+
+--
+-- Name: run_tags run_tags_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: test
+--
+
+ALTER TABLE ONLY public.run_tags
+    ADD CONSTRAINT run_tags_run_id_fkey FOREIGN KEY (run_id) REFERENCES public.runs(run_id) ON DELETE CASCADE;
+
+
+--
+-- Name: SCHEMA public; Type: ACL; Schema: -; Owner: test
+--
+
+REVOKE USAGE ON SCHEMA public FROM PUBLIC;
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+\unrestrict is5YHaVX7GrG6YagPg0WbdcCbKUXIxFAOffOc9zPhL34K1KWnF15cMz2O0OXfQM
+


### PR DESCRIPTION
## Summary & Motivation
After heavy usage of Dagster for over 3 years, we saw gradual decrease of loading run/schedule/sensor pages. It got to such extreme case where we would have to reload the page several times (due to QueryTimeoutError 15s) just to see the runs. 

I found the root cause and now the Dagster UI is blazingly fast again!
<img width="494" height="250" alt="Screenshot 2025-11-16 at 0 30 34" src="https://github.com/user-attachments/assets/6781c01c-2da0-42bc-8d9b-f7c436085a89" />
(see bottom for full story)

### About:
- Dagster stores all tags in **run_tags** table which has generic key:value schema and can grow to huge proportions.
- Dagster uses tag filter on almost every page (job/schedule/sensor runs), where each condition leads to additional self join. 

- Postgres creates execution plans based on estimates from table statistics ([MORE HERE](https://www.crunchydata.com/blog/hacking-the-postgres-statistics-tables-for-faster-queries)).
- The statistics are randomly sampled for each column **SEPARATELY**.
- The naive approach is to estimate number of selected rows by multiplying selectivity of each column.
- But that doesn't work well if keys have disproportional cardinality. 
- Underestimates lead to bad execution plans (having indexes won't help).
- Fortunately, Postgres supports creating cross-column statistics!

```sql
-- ----------------------------------------------------------------------------
-- Problem 1: Different keys = different value cardinality
-- ----------------------------------------------------------------------------

-- Some keys have few values:
-- key='country': 200 different values (USA, CZ, DE...)
-- key='gender': 3 values (M, F, Other)
-- key='status': 5 values (active, pending...)

-- Other keys have many values:
-- key='email': 500k unique values
-- key='user_id': 800k unique values
-- key='description': 1M+ unique values

-- Query:
SELECT * FROM attributes
WHERE key = 'gender' AND value = 'M';

-- Planner estimate (WRONG!):
-- Selectivity = (1/300) * (1/1000000) = 0.0000033%
-- "Thinks: 0.33 rows"

-- Reality:
-- gender='M' is 50% of all 'gender' records
-- gender has perhaps 100k rows total
-- Reality: 50k rows!
-- Estimate is 150,000x wrong! 🔥


-- ----------------------------------------------------------------------------
-- Problem 2: Nested Loop vs Hash Join disaster
-- ----------------------------------------------------------------------------

-- Query with join:
SELECT a1.value as email, a2.value as country
FROM attributes a1
JOIN attributes a2 ON a1.fk = a2.fk
WHERE a1.key = 'email'
  AND a2.key = 'country'
  AND a2.value = 'CZ';

-- Planner thinks: "country=CZ is highly selective (1/1M values)"
-- Chooses: Nested Loop
--   -> Index Scan on a2 WHERE key='country' AND value='CZ' (estimate: 1 row)
--   -> Index Scan on a1 repeatedly (1x)

-- Reality: "country=CZ" is 200k rows!
-- Nested Loop performs 200k index scans instead of 1!
-- Query runs 5 minutes instead of 5 seconds 😱
```

# Here is the full story of what steps I took and how it improved the execution plans

# PostgreSQL Query Optimization Analysis

```sql
SELECT
    COUNT(DISTINCT key) as unique_keys, -- 206
    COUNT(DISTINCT value) as unique_values, -- 9M
    COUNT(*) as rows -- 117M
FROM run_tags; 
```

## Original Query

```sql
EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
SELECT runs.*
FROM runs
    JOIN run_tags AS run_tags_filter0
        ON runs.run_id = run_tags_filter0.run_id 
        AND run_tags_filter0.key = '.dagster/repository' 
        AND run_tags_filter0.value = '__repository__@data-ops'
WHERE runs.pipeline_name = 'query_monitoring_job'
ORDER BY runs.id DESC
LIMIT 31
```

## Execution Plan #1: Initial State (Before ANALYZE)

```
Limit  (cost=22008.83..22009.87 rows=9 width=1290) (actual time=5575.918..5708.848 rows=31 loops=1)
  Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
  Buffers: shared hit=399530 read=68399 dirtied=4 written=1
  I/O Timings: shared read=9601.536 write=0.034
  ->  Gather Merge  (cost=22008.83..22009.87 rows=9 width=1290) (actual time=5575.915..5708.839 rows=31 loops=1)
        Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
        Workers Planned: 1
        Workers Launched: 1
        Buffers: shared hit=399530 read=68399 dirtied=4 written=1
        I/O Timings: shared read=9601.536 write=0.034
        ->  Sort  (cost=21008.82..21008.85 rows=9 width=1290) (actual time=5568.083..5568.091 rows=23 loops=2)
              Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
              Sort Key: runs.id DESC
              Sort Method: top-N heapsort  Memory: 39kB
              Buffers: shared hit=399530 read=68399 dirtied=4 written=1
              I/O Timings: shared read=9601.536 write=0.034
              Worker 0:  actual time=5568.098..5568.110 rows=31 loops=1
                Sort Method: top-N heapsort  Memory: 38kB
                Buffers: shared hit=194122 read=33539 dirtied=4
                I/O Timings: shared read=4811.726
              ->  Nested Loop  (cost=1.37..21008.68 rows=9 width=1290) (actual time=0.485..5561.481 rows=5206 loops=2)
                    Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
                    Inner Unique: true
                    Buffers: shared hit=399523 read=68399 dirtied=4 written=1
                    I/O Timings: shared read=9601.536 write=0.034
                    Worker 0:  actual time=0.594..5561.015 rows=4960 loops=1
                      Buffers: shared hit=194115 read=33539 dirtied=4
                      I/O Timings: shared read=4811.726
                    ->  Parallel Index Only Scan using sf_idx_run_tags_run_id on dagster.run_tags run_tags_filter0  (cost=0.81..7461.59 rows=3047 width=37) (actual time=0.146..1881.038 rows=34376 loops=2)
                          Output: run_tags_filter0.key, run_tags_filter0.value, run_tags_filter0.run_id
                          Index Cond: ((run_tags_filter0.key = '.dagster/repository'::text) AND (run_tags_filter0.value = '__repository__@data-ops'::text))
                          Heap Fetches: 61561
                          Buffers: shared hit=98059 read=26098 dirtied=3 written=1
                          I/O Timings: shared read=3397.167 write=0.034
                          Worker 0:  actual time=0.132..1767.125 rows=33443 loops=1
                            Buffers: shared hit=47734 read=12702 dirtied=3
                            I/O Timings: shared read=1582.487
                    ->  Index Scan using runs_run_id_key on dagster.runs  (cost=0.56..4.45 rows=1 width=1290) (actual time=0.106..0.106 rows=0 loops=68751)
                          Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
                          Index Cond: ((runs.run_id)::text = (run_tags_filter0.run_id)::text)
                          Filter: (runs.pipeline_name = 'query_monitoring_job'::text)
                          Rows Removed by Filter: 1
                          Buffers: shared hit=301461 read=42301
                          I/O Timings: shared read=6204.368
                          Worker 0:  actual time=0.112..0.112 rows=0 loops=33443
                            Buffers: shared hit=146379 read=20837
                            I/O Timings: shared read=3229.239
Query Identifier: -2466041181315305352
Planning:
  Buffers: shared hit=488
```

### Main Issues

1. **Wrong Join Order**
   - The plan first scans run_tags (68,751 rows in nested loop)
   - For each tag it does a lookup into runs and only then filters pipeline_name
   - It should be reversed: first filter runs by pipeline_name, then join with run_tags

2. **Terrible cardinality estimate**
   - Planner estimated 9 rows, but reality is 5,206 rows (per worker)
   - This causes bad decisions about execution strategy

3. **Massive I/O wait**
   - 9.6 seconds of I/O time out of total ~5.7 seconds (thanks to parallelism)
   - 68,399 read buffers
   - Heap Fetches: 61,561 - index-only scan must go to heap

---

## Attempt #1: Update Statistics

```sql
ANALYZE runs;
ANALYZE run_tags;
```

### Execution Plan #2: After ANALYZE

```
Limit  (cost=21762.97..21763.89 rows=8 width=1286) (actual time=8143.038..8693.107 rows=31 loops=1)
  Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
  Buffers: shared hit=351810 read=116107 written=7
  I/O Timings: shared read=10601.740 write=0.541
  ->  Gather Merge  (cost=21762.97..21763.89 rows=8 width=1286) (actual time=8143.035..8693.099 rows=31 loops=1)
        Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
        Workers Planned: 1
        Workers Launched: 1
        Buffers: shared hit=351810 read=116107 written=7
        I/O Timings: shared read=10601.740 write=0.541
        ->  Sort  (cost=20762.96..20762.98 rows=8 width=1286) (actual time=8107.659..8107.669 rows=23 loops=2)
              Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
              Sort Key: runs.id DESC
              Sort Method: top-N heapsort  Memory: 38kB
              Buffers: shared hit=351810 read=116107 written=7
              I/O Timings: shared read=10601.740 write=0.541
              Worker 0:  actual time=8072.709..8072.725 rows=31 loops=1
                Sort Method: top-N heapsort  Memory: 39kB
                Buffers: shared hit=164288 read=54061
                I/O Timings: shared read=5342.551
              ->  Nested Loop  (cost=1.37..20762.84 rows=8 width=1286) (actual time=0.510..8086.893 rows=5206 loops=2)
                    Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
                    Inner Unique: true
                    Buffers: shared hit=351803 read=116107 written=7
                    I/O Timings: shared read=10601.740 write=0.541
                    Worker 0:  actual time=0.750..8056.104 rows=4763 loops=1
                      Buffers: shared hit=164281 read=54061
                      I/O Timings: shared read=5342.551
                    ->  Parallel Index Only Scan using sf_idx_run_tags_run_id on dagster.run_tags run_tags_filter0  (cost=0.81..7422.44 rows=2999 width=37) (actual time=0.152..2472.237 rows=34376 loops=2)
                          Output: run_tags_filter0.key, run_tags_filter0.value, run_tags_filter0.run_id
                          Index Cond: ((run_tags_filter0.key = '.dagster/repository'::text) AND (run_tags_filter0.value = '__repository__@data-ops'::text))
                          Heap Fetches: 61561
                          Buffers: shared hit=79239 read=44908 written=3
                          I/O Timings: shared read=3589.216 write=0.221
                          Worker 0:  actual time=0.212..2572.569 rows=32101 loops=1
                            Buffers: shared hit=37006 read=20830
                            I/O Timings: shared read=1902.418
                    ->  Index Scan using runs_run_id_key on dagster.runs  (cost=0.56..4.45 rows=1 width=1286) (actual time=0.160..0.160 rows=0 loops=68751)
                          Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
                          Index Cond: ((runs.run_id)::text = (run_tags_filter0.run_id)::text)
                          Filter: (runs.pipeline_name = 'query_monitoring_job'::text)
                          Rows Removed by Filter: 1
                          Buffers: shared hit=272563 read=71199 written=4
                          I/O Timings: shared read=7012.524 write=0.321
                          Worker 0:  actual time=0.167..0.167 rows=0 loops=32101
                            Buffers: shared hit=127275 read=33231
                            I/O Timings: shared read=3440.133
Query Identifier: -2466041181315305352
Planning:
  Buffers: shared hit=196
```

### Result: DID NOT HELP - Actually Made It Worse ❌

| Metric              | Before  | After   | Change         |
|---------------------|---------|---------|----------------|
| Total time          | 5.7s    | 8.7s    | +53% worse ❌   |
| Disk reads          | 68,399  | 116,107 | +70% worse ❌   |
| I/O time            | 9.6s    | 10.6s   | +10% worse ❌   |
| Estimate vs reality | 9 vs 5206 | 8 vs 5206 | Still bad ❌ |
| Execution plan      | Nested Loop | Nested Loop | No change |
| Heap Fetches        | 61,561  | 61,561  | Same           |

### Why It Didn't Help

1. Cardinality estimate still wrong (8 vs 5206 = 650× error)
2. Same execution plan - planner still chooses wrong join order
3. More I/O - possibly due to cold cache after ANALYZE

---

## Solution: Correlated Statistics

```sql
-- Add correlation statistics on key, value
CREATE STATISTICS run_tags_key_value_stats (dependencies, ndistinct)
  ON key, value FROM run_tags;

-- Increase sampling rate (default 100)
ALTER TABLE run_tags ALTER COLUMN value SET STATISTICS 500;

-- Update statistics
ANALYZE run_tags;
```

### Execution Plan #3: After Correlated Statistics

```
Limit  (cost=1001.38..10432.89 rows=31 width=1286) (actual time=51.385..76.317 rows=31 loops=1)
  Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
  Buffers: shared hit=363 read=244
  I/O Timings: shared read=65.963
  ->  Gather Merge  (cost=1001.38..45116.50 rows=145 width=1286) (actual time=51.383..76.300 rows=31 loops=1)
        Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
        Workers Planned: 1
        Workers Launched: 1
        Buffers: shared hit=363 read=244
        I/O Timings: shared read=65.963
        ->  Nested Loop  (cost=1.37..44100.18 rows=85 width=1286) (actual time=3.201..35.112 rows=31 loops=2)
              Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
              Buffers: shared hit=363 read=244
              I/O Timings: shared read=65.963
              Worker 0:  actual time=6.280..45.274 rows=31 loops=1
                Buffers: shared hit=170 read=142
                I/O Timings: shared read=42.806
              ->  Parallel Index Scan Backward using idx_runs_by_job on dagster.runs  (cost=0.56..19736.86 rows=5747 width=1286) (actual time=2.857..21.188 rows=31 loops=2)
                    Output: runs.id, runs.run_id, runs.snapshot_id, runs.pipeline_name, runs.mode, runs.status, runs.run_body, runs.partition, runs.partition_set, runs.create_timestamp, runs.update_timestamp, runs.start_time, runs.end_time, runs.backfill_id
                    Index Cond: (runs.pipeline_name = 'query_monitoring_job'::text)
                    Buffers: shared hit=36 read=134
                    I/O Timings: shared read=41.003
                    Worker 0:  actual time=5.647..28.968 rows=31 loops=1
                      Buffers: shared hit=10 read=83
                      I/O Timings: shared read=28.087
              ->  Index Only Scan using sf_idx_run_tags_run_id on dagster.run_tags run_tags_filter0  (cost=0.81..4.23 rows=1 width=37) (actual time=0.445..0.445 rows=1 loops=62)
                    Output: run_tags_filter0.key, run_tags_filter0.value, run_tags_filter0.run_id
                    Index Cond: ((run_tags_filter0.key = '.dagster/repository'::text) AND (run_tags_filter0.value = '__repository__@data-ops'::text) AND (run_tags_filter0.run_id = (runs.run_id)::text))
                    Heap Fetches: 62
                    Buffers: shared hit=327 read=110
                    I/O Timings: shared read=24.960
                    Worker 0:  actual time=0.521..0.522 rows=1 loops=31
                      Buffers: shared hit=160 read=59
                      I/O Timings: shared read=14.718
Query Identifier: -2466041181315305352
Planning:
  Buffers: shared hit=82
```

### Result: PHENOMENAL Improvement! 🚀

| Metric                 | Original | With corr. stats | Improvement     |
|------------------------|----------|------------------|-----------------|
| Total time             | 8.7s     | 76ms             | **114× faster** ✅ |
| Buffers total          | 467,929  | 607              | **99.9% less** ✅  |
| Disk reads             | 116,107  | 244              | **99.8% less** ✅  |
| I/O time               | 10.6s    | 66ms             | **160× faster** ✅ |
| Nested Loop iterations | 68,751   | 62               | **99.9% less** ✅  |

---

## What Changed - KEY INSIGHT

### 1. CORRECT JOIN ORDER ✅

**BEFORE (Wrong):**
```
run_tags scan (68,751 rows) → runs lookup → filter pipeline_name
```

**AFTER (Correct):**
```
runs scan WHERE pipeline_name (62 rows) → run_tags lookup
```

### 2. Optimal index `idx_runs_by_job`

```
->  Parallel Index Scan Backward using idx_runs_by_job
      Index Cond: (runs.pipeline_name = 'query_monitoring_job'::text)
```

- **Index Scan Backward** = efficiently supports `ORDER BY id DESC`
- Planner now knows that `pipeline_name` filter is highly selective
- Only **62 run_tags lookups** instead of **68,751**

### 3. Correlated Statistics Enabled Correct Estimation

The correlated statistics on `(key, value)` helped PostgreSQL understand that these columns are not independent, leading to much better cardinality estimates and the correct join order decision.


## How I Tested These Changes
Covered by alembic migration + backcomp test
Added correlation statistics on 3 different Dagster clusters and saw major improvement in UI responsiveness on each.


## Changelog

> Improve runs/schedule/sensor page load time (needs [dagster migrate](https://docs.dagster.io/deployment/oss/deployment-options/kubernetes/migrating-while-upgrading#step-3-migrate-the-dagster-instance))
