### PR TITLE
Update dagster-tableau library

### DIFF
--- a/docs/docs/integrations/libraries/tableau/index.md
+++ b/docs/docs/integrations/libraries/tableau/index.md
@@ -93,7 +93,55 @@ attributes:
   <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/integrations/tableau-component/7-list-defs.txt" />
 </WideContent>
 
-## 4. Customize Tableau asset metadata
+## 4. Enable data source refresh
+
+You can enable refreshing data sources by adding the `enable_published_datasource_refresh` or `enable_embedded_datasource_refresh` keys. To enable refresh for all data sources of a given type, set the value to `True`:
+
+```yaml
+type: dagster_tableau.TableauComponent
+
+attributes:
+  workspace:
+    type: cloud
+    connected_app_client_id: '{{ env.TABLEAU_CLIENT_ID }}'
+    connected_app_secret_id: '{{ env.TABLEAU_SECRET_ID }}'
+    connected_app_secret_value: '{{ env.TABLEAU_SECRET_VALUE }}'
+    username: '{{ env.TABLEAU_USERNAME }}'
+    site_name: my_site
+    pod_name: my_pod
+  enable_published_datasource_refresh: true
+  enable_embedded_datasource_refresh: true
+```
+
+To enable refreshing specific published data sources, set `enable_published_datasource_refresh` to a list of published data source names or ids. To enable refreshing embedded data sources for specific workbooks, set `enable_embedded_datasource_refresh` to a list of workbook names or ids:
+
+```yaml
+type: dagster_tableau.TableauComponent
+
+attributes:
+  workspace:
+    type: cloud
+    connected_app_client_id: '{{ env.TABLEAU_CLIENT_ID }}'
+    connected_app_secret_id: '{{ env.TABLEAU_SECRET_ID }}'
+    connected_app_secret_value: '{{ env.TABLEAU_SECRET_VALUE }}'
+    username: '{{ env.TABLEAU_USERNAME }}'
+    site_name: my_site
+    pod_name: my_pod
+  enable_published_datasource_refresh:
+    - sales_data
+    - marketing_data
+  enable_embedded_datasource_refresh:
+    - sales_workbook
+    - marketing_workbook
+```
+
+:::note
+
+Only data sources with extracts can be refreshed. For more information, see [Refreshing Data Sources](https://help.tableau.com/current/pro/desktop/en-us/refreshing_data.htm) in the Tableau documentation.
+
+:::
+
+## 5. Customize Tableau asset metadata
 
 You can customize the metadata and grouping of Tableau assets using the `translation` key:
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/components/tableau_component.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/components/tableau_component.py
@@ -5,6 +5,7 @@ from typing import Annotated, Literal, Optional, Union
 
 import dagster as dg
 from dagster._annotations import beta, public
+from dagster._utils.names import clean_name_lower
 from dagster.components import ComponentLoadContext, Model, Resolvable, Resolver
 from dagster.components.component.state_backed_component import StateBackedComponent
 from dagster.components.resolved.base import resolve_fields
@@ -14,7 +15,6 @@ from dagster.components.utils.defs_state import (
     DefsStateConfigArgs,
     ResolvedDefsStateConfig,
 )
-from dagster._utils.names import clean_name_lower
 from pydantic import BaseModel, Field
 
 from dagster_tableau.components.translation import (
@@ -263,7 +263,7 @@ class TableauComponent(StateBackedComponent, Resolvable):
                 content_data=dashboard_data, workspace_data=state
             )
             asset_specs.append(self.translator.get_asset_spec(translator_data))
-        
+
         for data_source_data in state.data_sources_by_id.values():
             translator_data = TableauTranslatorData(
                 content_data=data_source_data, workspace_data=state
@@ -280,27 +280,25 @@ class TableauComponent(StateBackedComponent, Resolvable):
         # Serialize and write to path
         state_path.write_text(dg.serialize_value(workspace_data))
 
-    def build_refreshable_embedded_data_sources_asset_definition(self, workbook_id: str, specs: list[dg.AssetSpec]) -> dg.AssetsDefinition:
-        @dg.multi_asset(
-            specs=specs,
-            can_subset=False,
-            name=clean_name_lower(workbook_id)
-        )
+    def build_refreshable_embedded_data_sources_asset_definition(
+        self, workbook_id: str, specs: list[dg.AssetSpec]
+    ) -> dg.AssetsDefinition:
+        @dg.multi_asset(specs=specs, can_subset=False, name=clean_name_lower(workbook_id))
         def asset_fn(context: dg.AssetExecutionContext):
             with self.workspace.get_client() as client:
                 client.refresh_and_poll_workbook(workbook_id)
                 for spec in context.assets_def.specs:
-                        yield dg.AssetMaterialization(
-                            asset_key=spec.key,
-                        )
+                    yield dg.AssetMaterialization(
+                        asset_key=spec.key,
+                    )
 
         return asset_fn
-    
-    def build_refreshable_published_data_sources_asset_definition(self, specs: list[dg.AssetSpec]) -> dg.AssetsDefinition:
+
+    def build_refreshable_published_data_sources_asset_definition(
+        self, specs: list[dg.AssetSpec]
+    ) -> dg.AssetsDefinition:
         @dg.multi_asset(
-            specs=specs,
-            can_subset=True,
-            name="tableau_published_data_sources_multi_asset"
+            specs=specs, can_subset=True, name="tableau_published_data_sources_multi_asset"
         )
         def asset_fn(context: dg.AssetExecutionContext):
             specs_by_data_source_id = {
@@ -309,51 +307,60 @@ class TableauComponent(StateBackedComponent, Resolvable):
             }
             assert all(specs_by_data_source_id.keys())
             with self.workspace.get_client() as client:
-                for datasource_id in client.refresh_and_poll_data_sources(specs_by_data_source_id.keys()):
-                    yield dg.AssetMaterialization(asset_key=specs_by_data_source_id[datasource_id].key)
+                # pyright false positive (he can't parse the 'assert' line)
+                for datasource_id in client.refresh_and_poll_data_sources(
+                    specs_by_data_source_id.keys()  # pyright: ignore[reportArgumentType]
+                ):
+                    yield dg.AssetMaterialization(
+                        asset_key=specs_by_data_source_id[datasource_id].key
+                    )
 
         return asset_fn
 
-
-    def is_refreshable_published_data_source(self, spec: dg.AssetSpec, workspace_data: TableauWorkspaceData) -> bool:
+    def is_refreshable_published_data_source(
+        self, spec: dg.AssetSpec, workspace_data: TableauWorkspaceData
+    ) -> bool:
         if not self.enable_published_datasource_refresh:
             return False
-        
-        if ("published datasource" not in spec.kinds) or ('extract' not in spec.kinds):
+
+        if ("published datasource" not in spec.kinds) or ("extract" not in spec.kinds):
             return False
-        
+
         metadataset = TableauDataSourceMetadataSet.extract(spec.metadata)
         data_source_id = metadataset.id
         assert data_source_id is not None
         data_source_name = workspace_data.data_sources_by_id[data_source_id].properties["name"]
 
-        if (isinstance(self.enable_published_datasource_refresh, list)
+        if (
+            isinstance(self.enable_published_datasource_refresh, list)
             and (data_source_id not in self.enable_published_datasource_refresh)
-            and (data_source_name not in self.enable_published_datasource_refresh)):
+            and (data_source_name not in self.enable_published_datasource_refresh)
+        ):
             return False
         return True
 
-        
-
-    def is_refreshable_embedded_data_source(self, spec: dg.AssetSpec, workspace_data: TableauWorkspaceData) -> bool:
+    def is_refreshable_embedded_data_source(
+        self, spec: dg.AssetSpec, workspace_data: TableauWorkspaceData
+    ) -> bool:
         if not self.enable_embedded_datasource_refresh:
             return False
 
-        if ("embedded datasource" not in spec.kinds) or ('extract' not in spec.kinds):
+        if ("embedded datasource" not in spec.kinds) or ("extract" not in spec.kinds):
             return False
 
         metadataset = TableauDataSourceMetadataSet.extract(spec.metadata)
         workbook_id = metadataset.workbook_id
         # should never happen - an embedded datasource will always be embedded in a workbook
-        assert workbook_id is not None 
+        assert workbook_id is not None
         workbook_name = workspace_data.workbooks_by_id[workbook_id].properties["name"]
 
-        if (isinstance(self.enable_embedded_datasource_refresh, list) 
+        if (
+            isinstance(self.enable_embedded_datasource_refresh, list)
             and (workbook_id not in self.enable_embedded_datasource_refresh)
-            and (workbook_name not in self.enable_embedded_datasource_refresh)):
+            and (workbook_name not in self.enable_embedded_datasource_refresh)
+        ):
             return False
         return True
-
 
     def build_defs_from_state(
         self, context: ComponentLoadContext, state_path: Optional[Path]
@@ -367,22 +374,39 @@ class TableauComponent(StateBackedComponent, Resolvable):
 
         specs = self._load_asset_specs(workspace_data)
 
-        non_refreshable_specs = [spec for spec in specs if (not self.is_refreshable_embedded_data_source(spec, workspace_data)) and (not self.is_refreshable_published_data_source(spec, workspace_data))]
-        refreshable_embedded_data_source_specs = [spec for spec in specs if self.is_refreshable_embedded_data_source(spec, workspace_data)]
-        refreshable_published_data_source_specs = [spec for spec in specs if self.is_refreshable_published_data_source(spec, workspace_data)]
-        
+        non_refreshable_specs = [
+            spec
+            for spec in specs
+            if (not self.is_refreshable_embedded_data_source(spec, workspace_data))
+            and (not self.is_refreshable_published_data_source(spec, workspace_data))
+        ]
+        refreshable_embedded_data_source_specs = [
+            spec for spec in specs if self.is_refreshable_embedded_data_source(spec, workspace_data)
+        ]
+        refreshable_published_data_source_specs = [
+            spec
+            for spec in specs
+            if self.is_refreshable_published_data_source(spec, workspace_data)
+        ]
+
         refreshable_specs_by_workbook_id = {}
         for spec in refreshable_embedded_data_source_specs:
             workbook_id = TableauDataSourceMetadataSet.extract(spec.metadata).workbook_id
             if workbook_id not in refreshable_specs_by_workbook_id:
                 refreshable_specs_by_workbook_id[workbook_id] = []
             refreshable_specs_by_workbook_id[workbook_id].append(spec)
-            
+
         assets_defs = []
 
         for workbook_id, specs in refreshable_specs_by_workbook_id.items():
-            assets_defs.append(self.build_refreshable_embedded_data_sources_asset_definition(workbook_id, specs))
+            assets_defs.append(
+                self.build_refreshable_embedded_data_sources_asset_definition(workbook_id, specs)
+            )
 
-        assets_defs.append(self.build_refreshable_published_data_sources_asset_definition(refreshable_published_data_source_specs))
+        assets_defs.append(
+            self.build_refreshable_published_data_sources_asset_definition(
+                refreshable_published_data_source_specs
+            )
+        )
 
         return dg.Definitions(assets=non_refreshable_specs + assets_defs)

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -83,6 +83,11 @@ class BaseTableauClient:
         return get_dagster_logger()
 
     @cached_method
+    def get_data_sources(self) -> list[TSC.DatasourceItem]: # TODO: pagination
+        datasources, _ = self._server.datasources.get()
+        return datasources
+
+    @cached_method
     def get_data_source(
         self,
         data_source_id: str,
@@ -223,52 +228,119 @@ class BaseTableauClient:
         job = self.poll_job(job_id=job.id, poll_interval=poll_interval, poll_timeout=poll_timeout)
         return job.datasource_id
 
+    def refresh_and_poll_data_sources(
+        self,
+        data_source_ids: Sequence[str],
+        poll_interval: Optional[float] = None,
+        poll_timeout: Optional[float] = None,
+    ) -> Iterator[str]:
+        """Refreshes multiple data sources and yields their IDs as they complete.
+
+        Args:
+            data_source_ids: List of data source IDs to refresh
+            poll_interval: Optional polling interval in seconds
+            poll_timeout: Optional timeout in seconds
+
+        Yields:
+            str: Data source IDs as their refresh jobs complete
+        """
+        # First, kick off all refresh jobs
+        job_ids = []
+        for data_source_id in data_source_ids:
+            job = self.refresh_data_source(data_source_id)
+            self._log.info(f"Job {job.id} initialized for data_source_id={data_source_id}.")
+            job_ids.append(job.id)
+
+        # Then poll all jobs until they complete, yielding datasource_id as each completes
+        for job in self.poll_jobs(job_ids=job_ids, poll_interval=poll_interval, poll_timeout=poll_timeout):
+            if job.datasource_id:
+                yield job.datasource_id
+
+    def poll_jobs(
+        self,
+        job_ids: Sequence[str],
+        poll_interval: Optional[float] = None,
+        poll_timeout: Optional[float] = None,
+    ) -> Iterator[TSC.JobItem]:
+        """Polls multiple jobs and yields them as they complete.
+
+        Args:
+            job_ids: List of job IDs to poll
+            poll_interval: Optional polling interval in seconds
+            poll_timeout: Optional timeout in seconds
+
+        Yields:
+            TSC.JobItem: Completed job items as they finish successfully
+        """
+        if not poll_interval:
+            poll_interval = DEFAULT_POLL_INTERVAL_SECONDS
+        if not poll_timeout:
+            poll_timeout = DEFAULT_POLL_TIMEOUT
+
+        start = time.monotonic()
+        pending_job_ids = set(job_ids)
+
+        try:
+            while pending_job_ids:
+                if poll_timeout and start + poll_timeout < time.monotonic():
+                    raise Failure(
+                        f"Timeout: Tableau jobs {pending_job_ids} are not ready after the timeout"
+                        f" {poll_timeout} seconds"
+                    )
+
+                time.sleep(poll_interval)
+
+                # Check status of all pending jobs
+                for job_id in list(pending_job_ids):
+                    job = self.get_job(job_id=job_id)
+
+                    if job.finish_code == -1:
+                        # -1 is the default value for JobItem.finish_code, when the job is in progress
+                        continue
+                    elif job.finish_code == TSC.JobItem.FinishCode.Success:
+                        pending_job_ids.remove(job_id)
+                        yield job
+                    elif job.finish_code == TSC.JobItem.FinishCode.Failed:
+                        pending_job_ids.remove(job_id)
+                        raise Failure(f"Job failed: {job.id}")
+                    elif job.finish_code == TSC.JobItem.FinishCode.Cancelled:
+                        pending_job_ids.remove(job_id)
+                        raise Failure(f"Job was cancelled: {job.id}")
+                    else:
+                        pending_job_ids.remove(job_id)
+                        raise Failure(
+                            f"Encountered unexpected finish code `{job.finish_code}` for job {job.id}"
+                        )
+        finally:
+            # if any Tableau syncs have not completed, make sure to cancel them so they don't outlive
+            # the python process
+            for job_id in pending_job_ids:
+                job = self.get_job(job_id=job_id)
+                if job.finish_code not in (
+                    TSC.JobItem.FinishCode.Success,
+                    TSC.JobItem.FinishCode.Failed,
+                    TSC.JobItem.FinishCode.Cancelled,
+                ):
+                    self.cancel_job(job_id)
+
     def poll_job(
         self,
         job_id: str,
         poll_interval: Optional[float] = None,
         poll_timeout: Optional[float] = None,
     ) -> TSC.JobItem:
-        if not poll_interval:
-            poll_interval = DEFAULT_POLL_INTERVAL_SECONDS
-        if not poll_timeout:
-            poll_timeout = DEFAULT_POLL_TIMEOUT
+        """Polls a single job until it completes.
 
-        job = self.get_job(job_id=job_id)
-        start = time.monotonic()
+        Args:
+            job_id: The job ID to poll
+            poll_interval: Optional polling interval in seconds
+            poll_timeout: Optional timeout in seconds
 
-        try:
-            while True:
-                if poll_timeout and start + poll_timeout < time.monotonic():
-                    raise Failure(
-                        f"Timeout: Tableau job {job.id} is not ready after the timeout"
-                        f" {poll_timeout} seconds"
-                    )
-                time.sleep(poll_interval)
-                job = self.get_job(job_id=job.id)
-
-                if job.finish_code == -1:
-                    # -1 is the default value for JobItem.finish_code, when the job is in progress
-                    continue
-                elif job.finish_code == TSC.JobItem.FinishCode.Success:
-                    return job
-                elif job.finish_code == TSC.JobItem.FinishCode.Failed:
-                    raise Failure(f"Job failed: {job.id}")
-                elif job.finish_code == TSC.JobItem.FinishCode.Cancelled:
-                    raise Failure(f"Job was cancelled: {job.id}")
-                else:
-                    raise Failure(
-                        f"Encountered unexpected finish code `{job.finish_code}` for job {job.id}"
-                    )
-        finally:
-            # if Tableau sync has not completed, make sure to cancel it so that it doesn't outlive
-            # the python process
-            if job.finish_code not in (
-                TSC.JobItem.FinishCode.Success,
-                TSC.JobItem.FinishCode.Failed,
-                TSC.JobItem.FinishCode.Cancelled,
-            ):
-                self.cancel_job(job.id)
+        Returns:
+            TSC.JobItem: The completed job item
+        """
+        jobs = list(self.poll_jobs(job_ids=[job_id], poll_interval=poll_interval, poll_timeout=poll_timeout))
+        return jobs[0]
 
     def add_data_quality_warning_to_data_source(
         self,
@@ -618,6 +690,31 @@ class BaseTableauWorkspace(ConfigurableResource):
                                 properties=augmented_dashboard_data,
                             )
                         )
+
+            """
+            We add to the data all the published-data-sources, that weren't already added from a workbook.
+            """
+            for published_data_source in client.get_data_sources():
+            
+                # if we already processed this data_source, skip it
+                if published_data_source.id in data_source_ids: 
+                    continue
+                
+                data_sources.append(
+                    TableauContentData(
+                        content_type=TableauContentType.DATA_SOURCE,
+                        properties={
+                            "id": published_data_source.id,
+                            "name": published_data_source.name,
+                            "hasExtracts": published_data_source.has_extracts,
+                            "luid": published_data_source.id,
+                            "isPublished": True,
+                            "workbook": None
+                        }
+                    )
+                )
+                
+
 
         return TableauWorkspaceData.from_content_data(
             self.site_name,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -277,7 +277,9 @@ class BaseTableauClient:
             job_ids.append(job.id)
 
         # Then poll all jobs until they complete, yielding datasource_id as each completes
-        for job in self.poll_jobs(job_ids=job_ids, poll_interval=poll_interval, poll_timeout=poll_timeout):
+        for job in self.poll_jobs(
+            job_ids=job_ids, poll_interval=poll_interval, poll_timeout=poll_timeout
+        ):
             if job.datasource_id:
                 yield job.datasource_id
 
@@ -364,7 +366,9 @@ class BaseTableauClient:
         Returns:
             TSC.JobItem: The completed job item
         """
-        jobs = list(self.poll_jobs(job_ids=[job_id], poll_interval=poll_interval, poll_timeout=poll_timeout))
+        jobs = list(
+            self.poll_jobs(job_ids=[job_id], poll_interval=poll_interval, poll_timeout=poll_timeout)
+        )
         return jobs[0]
 
     def add_data_quality_warning_to_data_source(
@@ -720,11 +724,10 @@ class BaseTableauWorkspace(ConfigurableResource):
             We add to the data all the published-data-sources, that weren't already added from a workbook.
             """
             for published_data_source in client.get_data_sources():
-            
                 # if we already processed this data_source, skip it
-                if published_data_source.id in data_source_ids: 
+                if published_data_source.id in data_source_ids:
                     continue
-                
+
                 data_sources.append(
                     TableauContentData(
                         content_type=TableauContentType.DATA_SOURCE,
@@ -734,12 +737,10 @@ class BaseTableauWorkspace(ConfigurableResource):
                             "hasExtracts": published_data_source.has_extracts,
                             "luid": published_data_source.id,
                             "isPublished": True,
-                            "workbook": None
-                        }
+                            "workbook": None,
+                        },
                     )
                 )
-                
-
 
         return TableauWorkspaceData.from_content_data(
             self.site_name,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -328,8 +328,21 @@ class DagsterTableauTranslator:
             *["published datasource" if data.properties["isPublished"] else "embedded datasource"],
         }
 
+        if data.properties["isPublished"]:
+            asset_key = AssetKey([_coerce_input_to_valid_name(data.properties["name"])])
+        else:
+            workbook_id = data.properties["workbook"]["luid"]
+            workbook_data = data.workspace_data.workbooks_by_id[workbook_id]
+            asset_key = AssetKey(
+                [
+                    _coerce_input_to_valid_name(workbook_data.properties["name"]),
+                    "embedded_datasource",
+                    _coerce_input_to_valid_name(data.properties["name"]),
+                ]
+            )
+
         return AssetSpec(
-            key=AssetKey([_coerce_input_to_valid_name(data.properties["name"])]),
+            key=asset_key,
             tags={"dagster/storage_kind": "tableau", **TableauTagSet(asset_type="data_source")},
             metadata={
                 **TableauDataSourceMetadataSet(

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -10,11 +10,11 @@ from dagster._core.definitions.tags.tag_set import NamespacedTagSet
 from dagster._record import record
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.cached_method import cached_method
-from dagster._utils.names import clean_name_lower_with_dots
+from dagster._utils.names import clean_name_lower
 
 TABLEAU_PREFIX = "tableau/"
 
-_coerce_input_to_valid_name = clean_name_lower_with_dots
+_coerce_input_to_valid_name = clean_name_lower
 
 
 WorkbookSelectorFn: TypeAlias = Callable[["TableauWorkbookMetadata"], bool]

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -245,6 +245,12 @@ def get_data_source_fixture(build_data_source_item):
         mocked_function.return_value = build_data_source_item()
         yield mocked_function
 
+@pytest.fixture(name="get_data_sources", autouse=True)
+def get_data_sources_fixture(build_data_sources_item):
+    with patch("dagster_tableau.resources.BaseTableauClient.get_data_sources") as mocked_function:
+        mocked_function.return_value = build_data_sources_item
+        yield mocked_function
+
 
 @pytest.fixture(name="get_job", autouse=True)
 def get_job_fixture(workbook_id, job_id):
@@ -356,6 +362,27 @@ def build_data_source_item_fixture():
         type(mock_embedded_data_source.return_value).updated_at = PropertyMock(return_value=None)
         mocked_class.side_effect = [mock_embedded_data_source]
         yield mocked_class
+
+
+@pytest.fixture(name="build_data_sources_item", autouse=True)
+def build_data_sources_item_fixture():
+    mock_data_source_1 = MagicMock()
+    type(mock_data_source_1).id = PropertyMock(return_value=SAMPLE_DATA_SOURCE["luid"])
+    type(mock_data_source_1).owner_id = PropertyMock(return_value=None)
+    type(mock_data_source_1).name = PropertyMock(return_value=SAMPLE_DATA_SOURCE["name"])
+    type(mock_data_source_1).content_url = PropertyMock(return_value=None)
+    type(mock_data_source_1).created_at = PropertyMock(return_value=None)
+    type(mock_data_source_1).updated_at = PropertyMock(return_value=None)
+
+    mock_data_source_2 = MagicMock()
+    type(mock_data_source_2).id = PropertyMock(return_value=SAMPLE_DATA_SOURCE_HIDDEN_SHEET["luid"])
+    type(mock_data_source_2).owner_id = PropertyMock(return_value=None)
+    type(mock_data_source_2).name = PropertyMock(return_value=SAMPLE_DATA_SOURCE_HIDDEN_SHEET["name"])
+    type(mock_data_source_2).content_url = PropertyMock(return_value=None)
+    type(mock_data_source_2).created_at = PropertyMock(return_value=None)
+    type(mock_data_source_2).updated_at = PropertyMock(return_value=None)
+
+    yield [mock_data_source_1, mock_data_source_2]
 
 
 @pytest.fixture(name="get_data_source_by_id", autouse=True)

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -245,6 +245,7 @@ def get_data_source_fixture(build_data_source_item):
         mocked_function.return_value = build_data_source_item()
         yield mocked_function
 
+
 @pytest.fixture(name="get_data_sources", autouse=True)
 def get_data_sources_fixture(build_data_sources_item):
     with patch("dagster_tableau.resources.BaseTableauClient.get_data_sources") as mocked_function:
@@ -377,7 +378,9 @@ def build_data_sources_item_fixture():
     mock_data_source_2 = MagicMock()
     type(mock_data_source_2).id = PropertyMock(return_value=SAMPLE_DATA_SOURCE_HIDDEN_SHEET["luid"])
     type(mock_data_source_2).owner_id = PropertyMock(return_value=None)
-    type(mock_data_source_2).name = PropertyMock(return_value=SAMPLE_DATA_SOURCE_HIDDEN_SHEET["name"])
+    type(mock_data_source_2).name = PropertyMock(
+        return_value=SAMPLE_DATA_SOURCE_HIDDEN_SHEET["name"]
+    )
     type(mock_data_source_2).content_url = PropertyMock(return_value=None)
     type(mock_data_source_2).created_at = PropertyMock(return_value=None)
     type(mock_data_source_2).updated_at = PropertyMock(return_value=None)

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -361,6 +361,7 @@ def build_data_source_item_fixture():
         type(mock_embedded_data_source.return_value).content_url = PropertyMock(return_value=None)
         type(mock_embedded_data_source.return_value).created_at = PropertyMock(return_value=None)
         type(mock_embedded_data_source.return_value).updated_at = PropertyMock(return_value=None)
+        type(mock_embedded_data_source.return_value).has_extracts = PropertyMock(return_value=True)
         mocked_class.side_effect = [mock_embedded_data_source]
         yield mocked_class
 
@@ -374,6 +375,7 @@ def build_data_sources_item_fixture():
     type(mock_data_source_1).content_url = PropertyMock(return_value=None)
     type(mock_data_source_1).created_at = PropertyMock(return_value=None)
     type(mock_data_source_1).updated_at = PropertyMock(return_value=None)
+    type(mock_data_source_1).has_extracts = PropertyMock(return_value=False)
 
     mock_data_source_2 = MagicMock()
     type(mock_data_source_2).id = PropertyMock(return_value=SAMPLE_DATA_SOURCE_HIDDEN_SHEET["luid"])
@@ -384,6 +386,7 @@ def build_data_sources_item_fixture():
     type(mock_data_source_2).content_url = PropertyMock(return_value=None)
     type(mock_data_source_2).created_at = PropertyMock(return_value=None)
     type(mock_data_source_2).updated_at = PropertyMock(return_value=None)
+    type(mock_data_source_1).has_extracts = PropertyMock(return_value=True)
 
     yield [mock_data_source_1, mock_data_source_2]
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -36,7 +36,7 @@ def test_fetch_tableau_workspace_data(
     site_name: str,
     sign_in: MagicMock,
     get_workbooks: MagicMock,
-    get_workbook: MagicMock,
+    get_workbook: MagicMock
 ) -> None:
     connected_app_client_id = uuid.uuid4().hex
     connected_app_secret_id = uuid.uuid4().hex
@@ -180,7 +180,7 @@ def test_translator_spec(
         ]
         assert next(asset_deps_iter).asset_key.path == ["hidden_sheet_datasource"]
 
-        iter_data_source = iter(spec for spec in all_assets if "datasource" in spec.key.path[0])
+        iter_data_source = iter(spec for spec in all_assets if "datasource" in spec.key.path[-1])
         published_data_source_asset_spec = next(iter_data_source)
         assert published_data_source_asset_spec.key.path == ["superstore_datasource"]
         assert published_data_source_asset_spec.metadata == {
@@ -190,7 +190,7 @@ def test_translator_spec(
         }
 
         embedded_data_source_asset_spec = next(iter_data_source)
-        assert embedded_data_source_asset_spec.key.path == ["embedded_superstore_datasource"]
+        assert embedded_data_source_asset_spec.key.path == ["test_workbook", "embedded_datasource", "embedded_superstore_datasource"]
         assert embedded_data_source_asset_spec.metadata == {
             "dagster-tableau/id": TEST_EMBEDDED_DATA_SOURCE_ID,
             "dagster-tableau/has_extracts": True,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -36,7 +36,7 @@ def test_fetch_tableau_workspace_data(
     site_name: str,
     sign_in: MagicMock,
     get_workbooks: MagicMock,
-    get_workbook: MagicMock
+    get_workbook: MagicMock,
 ) -> None:
     connected_app_client_id = uuid.uuid4().hex
     connected_app_secret_id = uuid.uuid4().hex
@@ -190,7 +190,11 @@ def test_translator_spec(
         }
 
         embedded_data_source_asset_spec = next(iter_data_source)
-        assert embedded_data_source_asset_spec.key.path == ["test_workbook", "embedded_datasource", "embedded_superstore_datasource"]
+        assert embedded_data_source_asset_spec.key.path == [
+            "test_workbook",
+            "embedded_datasource",
+            "embedded_superstore_datasource",
+        ]
         assert embedded_data_source_asset_spec.metadata == {
             "dagster-tableau/id": TEST_EMBEDDED_DATA_SOURCE_ID,
             "dagster-tableau/has_extracts": True,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_component.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_component.py
@@ -28,7 +28,7 @@ BASIC_TABLEAU_COMPONENT_BODY = {
             "pod_name": "10ax",
         },
         "enable_embedded_datasource_refresh": True,
-        "enable_published_datasource_refresh": True
+        "enable_published_datasource_refresh": True,
     },
 }
 
@@ -93,6 +93,7 @@ def test_component_load_with_defs_state(
             assert AssetKey(["test_workbook", "dashboard", "dashboard_sales"]) in asset_keys
             # Check for data sources
             assert AssetKey(["superstore_datasource"]) in asset_keys
+
 
 class TestTableauTranslation(TestTranslation):
     """Test translation of asset attributes for Tableau components."""

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_component.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_component.py
@@ -27,6 +27,8 @@ BASIC_TABLEAU_COMPONENT_BODY = {
             "site_name": "test_site",
             "pod_name": "10ax",
         },
+        "enable_embedded_datasource_refresh": True,
+        "enable_published_datasource_refresh": True
     },
 }
 
@@ -91,7 +93,6 @@ def test_component_load_with_defs_state(
             assert AssetKey(["test_workbook", "dashboard", "dashboard_sales"]) in asset_keys
             # Check for data sources
             assert AssetKey(["superstore_datasource"]) in asset_keys
-
 
 class TestTableauTranslation(TestTranslation):
     """Test translation of asset attributes for Tableau components."""

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
@@ -279,7 +279,7 @@ def test_load_assets_workspace_data_refreshable_workbooks(
         assert get_workbook.call_count == 1
         assert get_view.call_count == 3
         assert refresh_workbook.call_count == 1
-        assert get_job.call_count == 2
+        assert get_job.call_count == 1
         # The finish_code of the mocked get_job is 0, so no cancel_job is not called
         assert cancel_job.call_count == 0
 
@@ -382,7 +382,7 @@ def test_load_assets_workspace_data_refreshable_data_sources(
         assert get_view.call_count == 3
         assert get_data_source.call_count == 1
         assert refresh_data_source.call_count == 1
-        assert get_job.call_count == 2
+        assert get_job.call_count == 1
         # The finish_code of the mocked get_job is 0, so no cancel_job is not called
         assert cancel_job.call_count == 0
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_translator.py
@@ -14,8 +14,10 @@ from dagster_tableau_tests.conftest import (
 
 def test_translator_sheet_spec(workspace_data: TableauWorkspaceData) -> None:
     translator = DagsterTableauTranslator()
-    asset_key_list = [AssetKey(["superstore_datasource"]), 
-                      AssetKey(["test_workbook","embedded_datasource","embedded_superstore_datasource"])]
+    asset_key_list = [
+        AssetKey(["superstore_datasource"]),
+        AssetKey(["test_workbook", "embedded_datasource", "embedded_superstore_datasource"]),
+    ]
     index = 0
     for sheet in workspace_data.sheets_by_id.values():
         asset_spec = translator.get_asset_spec(
@@ -102,7 +104,11 @@ def test_translator_data_source_spec(
         TableauTranslatorData(content_data=embedded_data_source, workspace_data=workspace_data)
     )
 
-    assert asset_spec.key.path == ["test_workbook","embedded_datasource","embedded_superstore_datasource"]
+    assert asset_spec.key.path == [
+        "test_workbook",
+        "embedded_datasource",
+        "embedded_superstore_datasource",
+    ]
     assert asset_spec.metadata == {
         "dagster-tableau/id": TEST_EMBEDDED_DATA_SOURCE_ID,
         "dagster-tableau/has_extracts": True,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_translator.py
@@ -14,7 +14,8 @@ from dagster_tableau_tests.conftest import (
 
 def test_translator_sheet_spec(workspace_data: TableauWorkspaceData) -> None:
     translator = DagsterTableauTranslator()
-    asset_key_list = ["superstore_datasource", "embedded_superstore_datasource"]
+    asset_key_list = [AssetKey(["superstore_datasource"]), 
+                      AssetKey(["test_workbook","embedded_datasource","embedded_superstore_datasource"])]
     index = 0
     for sheet in workspace_data.sheets_by_id.values():
         asset_spec = translator.get_asset_spec(
@@ -39,7 +40,7 @@ def test_translator_sheet_spec(workspace_data: TableauWorkspaceData) -> None:
         }
         deps = list(asset_spec.deps)
         assert len(deps) == 1
-        assert deps[0].asset_key == AssetKey([asset_key_list[index]])
+        assert deps[0].asset_key == asset_key_list[index]
         index += 1
 
 
@@ -101,7 +102,7 @@ def test_translator_data_source_spec(
         TableauTranslatorData(content_data=embedded_data_source, workspace_data=workspace_data)
     )
 
-    assert asset_spec.key.path == ["embedded_superstore_datasource"]
+    assert asset_spec.key.path == ["test_workbook","embedded_datasource","embedded_superstore_datasource"]
     assert asset_spec.metadata == {
         "dagster-tableau/id": TEST_EMBEDDED_DATA_SOURCE_ID,
         "dagster-tableau/has_extracts": True,


### PR DESCRIPTION
## Summary & Motivation

features: enable_embedded_datasource_refresh, enable_embedded_datsource_refresh flags
fix: pagination handling (https://github.com/dagster-io/dagster/issues/32787)
fix: add workbook to the asset-key-path of embedded datasources (similar to the sheets) - this avoids asset-key conflicts when we have the same-named embedded datasource in different workbooks
fix: use `clean_name_lower` instead of `clean_name_lower_with_dots` - avoids issues for tableau resources with dots in the name.

## How I Tested These Changes

- tested against real tableau - both with embedded and published datasources.
- passes all existing mock tests.

## Changelog

feat: tableau-component: datasource_refresh and fixes
