### PR TITLE
Speed up instigatorStateOrError

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
@@ -38,27 +38,23 @@ def get_instigator_state_by_selector(
         if state and state.status in (InstigatorStatus.STOPPED, InstigatorStatus.RUNNING):
             return GrapheneInstigationState(state)
 
-    location = graphene_info.context.get_code_location(selector.location_name)
-    repository = location.get_repository(selector.repository_name)
-
-    if repository.has_sensor(selector.name):
-        sensor = repository.get_sensor(selector.name)
+    sensor = graphene_info.context.get_sensor(selector)
+    if sensor:
         stored_state = graphene_info.context.instance.get_instigator_state(
             sensor.get_remote_origin_id(),
             sensor.selector_id,
         )
-        current_state = sensor.get_current_instigator_state(stored_state)
-    elif repository.has_schedule(selector.name):
-        schedule = repository.get_schedule(selector.name)
+        return GrapheneInstigationState(sensor.get_current_instigator_state(stored_state))
+
+    schedule = graphene_info.context.get_schedule(selector)
+    if schedule:
         stored_state = graphene_info.context.instance.get_instigator_state(
             schedule.get_remote_origin_id(),
             schedule.selector_id,
         )
-        current_state = schedule.get_current_instigator_state(stored_state)
-    else:
-        return GrapheneInstigationStateNotFoundError(selector.name)
+        return GrapheneInstigationState(schedule.get_current_instigator_state(stored_state))
 
-    return GrapheneInstigationState(current_state)
+    return GrapheneInstigationStateNotFoundError(selector.name)
 
 
 def get_instigation_states_by_repository_id(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -938,13 +938,13 @@ class GrapheneAssetNode(graphene.ObjectType):
             # global nodes have saved references to their targeting instigators
             schedules = [
                 schedule
-                for schedule_handle in self._remote_node.get_targeting_schedule_handles()
-                if (schedule := graphene_info.context.get_schedule(schedule_handle)) is not None
+                for schedule_selector in self._remote_node.get_targeting_schedule_selectors()
+                if (schedule := graphene_info.context.get_schedule(schedule_selector)) is not None
             ]
             sensors = [
                 sensor
-                for sensor_handle in self._remote_node.get_targeting_sensor_handles()
-                if (sensor := graphene_info.context.get_sensor(sensor_handle)) is not None
+                for sensor_selector in self._remote_node.get_targeting_sensor_selectors()
+                if (sensor := graphene_info.context.get_sensor(sensor_selector)) is not None
             ]
 
         else:

--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/remote_asset_graph.py
@@ -40,9 +40,10 @@ from dagster._core.definitions.freshness_policy import LegacyFreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.partitions.mapping import PartitionMapping
+from dagster._core.definitions.selector import ScheduleSelector, SensorSelector
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.remote_representation.external import RemoteRepository
-from dagster._core.remote_representation.handle import InstigatorHandle, RepositoryHandle
+from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.workspace.workspace import CurrentWorkspace
 from dagster._record import ImportFrom, record
 from dagster._utils.cached_method import cached_method
@@ -395,31 +396,33 @@ class RemoteWorkspaceAssetNode(RemoteAssetNode):
             )
         )
 
-    def get_targeting_schedule_handles(
+    def get_targeting_schedule_selectors(
         self,
-    ) -> Sequence[InstigatorHandle]:
+    ) -> Sequence[ScheduleSelector]:
         selectors = []
         for node in self.repo_scoped_asset_infos:
             for schedule_name in node.targeting_schedule_names:
                 selectors.append(
-                    InstigatorHandle(
-                        repository_handle=node.handle,
-                        instigator_name=schedule_name,
+                    ScheduleSelector(
+                        location_name=node.handle.location_name,
+                        repository_name=node.handle.repository_name,
+                        schedule_name=schedule_name,
                     )
                 )
 
         return selectors
 
-    def get_targeting_sensor_handles(
+    def get_targeting_sensor_selectors(
         self,
-    ) -> Sequence[InstigatorHandle]:
+    ) -> Sequence[SensorSelector]:
         selectors = []
         for node in self.repo_scoped_asset_infos:
             for sensor_name in node.targeting_sensor_names:
                 selectors.append(
-                    InstigatorHandle(
-                        repository_handle=node.handle,
-                        instigator_name=sensor_name,
+                    SensorSelector(
+                        location_name=node.handle.location_name,
+                        repository_name=node.handle.repository_name,
+                        sensor_name=sensor_name,
                     )
                 )
         return selectors

--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -315,6 +315,10 @@ class InstigatorSelector:
     def get_id(self) -> str:
         return create_snapshot_id(self)
 
+    @property
+    def instigator_name(self) -> str:
+        return self.name
+
 
 @record
 class GraphSelector:

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -26,6 +26,7 @@ from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.definitions.partitions.context import partition_loading_context
 from dagster._core.definitions.partitions.definition import PartitionsDefinition
 from dagster._core.definitions.selector import (
+    InstigatorSelector,
     JobSelector,
     JobSubsetSelector,
     RepositorySelector,
@@ -69,7 +70,7 @@ from dagster._core.remote_representation.grpc_server_state_subscriber import (
     LocationStateChangeEventType,
     LocationStateSubscriber,
 )
-from dagster._core.remote_representation.handle import InstigatorHandle, RepositoryHandle
+from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.mode import ResourceDefSnap
 from dagster._core.snap.node import GraphDefSnap, OpDefSnap
@@ -599,7 +600,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
         )
 
     def get_sensor(
-        self, selector: Union[InstigatorHandle, SensorSelector]
+        self, selector: Union[SensorSelector, InstigatorSelector]
     ) -> Optional[RemoteSensor]:
         if not self.has_code_location(selector.location_name):
             return None
@@ -616,7 +617,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
         return repository.get_sensor(selector.instigator_name)
 
     def get_schedule(
-        self, selector: Union[InstigatorHandle, ScheduleSelector]
+        self, selector: Union[ScheduleSelector, InstigatorSelector]
     ) -> Optional[RemoteSchedule]:
         if not self.has_code_location(selector.location_name):
             return None


### PR DESCRIPTION
Summary:
Circumvent the potentially slow repository fetch here. A multi-get would be even better so that we can check for sensors and schedules in parallel (or passing in whether its a schedule or a sensor as a hint) but this should still be a big improvement even for schedules.

Test Plan:
Existing test coverage, dry runs

