### PR TITLE
Load schedules and sensors via context in graphql when possible

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -86,13 +86,16 @@ def reset_schedule(
 ) -> "GrapheneScheduleStateResult":
     from dagster_graphql.schema.instigation import GrapheneInstigationState
     from dagster_graphql.schema.schedules import GrapheneScheduleStateResult
+    from dagster_graphql.schema.schedules.schedules import GrapheneScheduleNotFoundError
 
     check.inst_param(schedule_selector, "schedule_selector", ScheduleSelector)
 
-    location = graphene_info.context.get_code_location(schedule_selector.location_name)
-    repository = location.get_repository(schedule_selector.repository_name)
+    schedule = graphene_info.context.get_schedule(schedule_selector)
+    if not schedule:
+        raise UserFacingGraphQLError(
+            GrapheneScheduleNotFoundError(schedule_name=schedule_selector.schedule_name)
+        )
 
-    schedule = repository.get_schedule(schedule_selector.schedule_name)
     stored_state = graphene_info.context.instance.reset_schedule(schedule)
     schedule_state = schedule.get_current_instigator_state(stored_state)
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -512,7 +512,7 @@ def test_dry_run_nonexistent_schedule(graphql_context):
         )
     unknown_repo_selector = {**unknown_instigator_selector}
     unknown_repo_selector["repositoryName"] = "doesnt_exist"
-    with pytest.raises(UserFacingGraphQLError, match="GrapheneRepositoryNotFoundError"):
+    with pytest.raises(UserFacingGraphQLError, match="GrapheneScheduleNotFoundError"):
         execute_dagster_graphql(
             context,
             SCHEDULE_DRY_RUN_MUTATION,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -735,7 +735,7 @@ class TestSensors(NonLaunchableGraphQLContextTestMatrix):
             )
         unknown_repo_selector = {**unknown_instigator_selector}
         unknown_repo_selector["repositoryName"] = "doesnt_exist"
-        with pytest.raises(UserFacingGraphQLError, match="GrapheneRepositoryNotFound"):
+        with pytest.raises(UserFacingGraphQLError, match="GrapheneSensorNotFoundError"):
             execute_dagster_graphql(
                 graphql_context,
                 SENSOR_DRY_RUN_MUTATION,


### PR DESCRIPTION
Summary:
This should speed up turning a schedule/sensor on and off and dry runing a sensor tick for large repositories.

Test Plan:
Existing test coverage of these endpoints