### PR TITLE
[ui components] Clean up disabled TextInput

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
@@ -106,10 +106,8 @@ export const TextInputStyles = css`
   }
 
   :disabled {
-    box-shadow:
-      ${Colors.borderDisabled()} inset 0px 0px 0px 1px,
-      ${Colors.keylineDefault()} inset 2px 2px 1.5px;
-    background-color: ${Colors.backgroundDisabled()};
+    box-shadow: ${Colors.keylineDefault()} inset 0px 0px 0px 1px;
+    background-color: ${Colors.backgroundLight()};
     color: ${Colors.textDisabled()};
   }
 

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/TextInput.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/TextInput.stories.tsx
@@ -76,3 +76,12 @@ export const NextToButton = () => {
     </Box>
   );
 };
+
+export const Disabled = () => {
+  return (
+    <Box flex={{direction: 'column', gap: 8}} style={{width: '300px'}}>
+      <TextInput icon="layers" placeholder="Disabled input…" value="" disabled />
+      <TextInput icon="layers" placeholder="Enabled input…" value="" />
+    </Box>
+  );
+};


### PR DESCRIPTION
## Summary & Motivation

The background and box shadow on disabled `TextInput` is kind of weird. Clean it up. (I'm going to deal with the CSS refactor layer.)

Before:

![Screenshot 2025-11-17 at 15.34.44.png](https://app.graphite.com/user-attachments/assets/07cce459-0cae-4a67-a273-326b963e597f.png)

![Screenshot 2025-11-17 at 15.35.48.png](https://app.graphite.com/user-attachments/assets/307ccfab-0359-4501-97b8-7d978ebb0d08.png)



After:

![Screenshot 2025-11-17 at 15.32.28.png](https://app.graphite.com/user-attachments/assets/2aed6ee7-ca8d-4771-bafc-378bce7bf278.png)

![Screenshot 2025-11-17 at 15.35.40.png](https://app.graphite.com/user-attachments/assets/8cbcb531-715d-4ed4-978c-3fcead112cf0.png)



## How I Tested These Changes

Storybook