### PR TITLE
Fix unit error when computing if a tick was hanging or not

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/util.ts
@@ -8,7 +8,7 @@ import {
 const TRUNCATION_THRESHOLD = 100;
 const TRUNCATION_BUFFER = 5;
 
-const THREE_DAYS = 60 * 60 * 24 * 3;
+const THREE_DAYS_MS = 60 * 60 * 24 * 3 * 1000;
 
 export const truncate = (str: string) =>
   str.length > TRUNCATION_THRESHOLD
@@ -24,7 +24,7 @@ export function isStuckStartedTick(
     // If the index is 0 and the tick does have an end timestamp then we can't know if its actually stuck or still in progress
     // but if its older than three days then its very likely stuck
     ((index !== 0 && tick.status === InstigationTickStatus.STARTED) ||
-      tick.timestamp * 1000 < Date.now() - THREE_DAYS)
+      tick.timestamp * 1000 < Date.now() - THREE_DAYS_MS)
   );
 }
 


### PR DESCRIPTION
Summary:
Instead of triggering after a tick was more than 3 days old, this was triggering after a tick was about 4 minutes ole.

View a DA sensor tick taking more than 4 minutes

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
