### PR TITLE
[ui] Clean up CSS for Codemirror hints

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/NewConfigEditor.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/NewConfigEditor.tsx
@@ -27,6 +27,7 @@ import {
 } from './configeditor/codemirror-yaml/mode';
 import {ConfigEditorHelpContext} from './configeditor/types/ConfigEditorHelpContext';
 import {ConfigSchema} from './configeditor/types/ConfigSchema';
+import {FontFamily} from './styles';
 
 export {isHelpContextEqual} from './configeditor/isHelpContextEqual';
 export {ConfigEditorHelp} from './configeditor/ConfigEditorHelp';
@@ -68,6 +69,30 @@ const ConfigEditorStyle = createGlobalStyle`
     height: initial;
     position: absolute;
     inset: 0;
+  }
+
+  .dagster.CodeMirror-hints {
+    background-color: ${Colors.backgroundDefault()};
+    box-shadow: 2px 3px 5px ${Colors.shadowDefault()};
+    border: none;
+    font-family: ${FontFamily.monospace};
+    font-size: 14px;
+    z-index: 100;
+    border-radius: 8px;
+    overflow: hidden;
+    padding: 2px;
+    margin-top: 2px;
+  }
+
+  .dagster .CodeMirror-hint {
+    border-radius: 6px;
+    padding: 4px 8px;
+    color: ${Colors.textDefault()};
+  }
+
+  .dagster .CodeMirror-hint-active {
+    background-color: ${Colors.backgroundBlue()};
+    color: ${Colors.textDefault()};
   }
 `;
 


### PR DESCRIPTION
## Summary & Motivation

Clean up the default CSS styles for CodeMirror hints, which I guess we've just kind of left alone forever.

Before:

<img width="530" height="294" alt="image" src="https://github.com/user-attachments/assets/4ed18daf-382e-4e84-86b5-8cb06773cc97" />
<img width="528" height="282" alt="Screenshot 2025-11-17 at 16 31 46" src="https://github.com/user-attachments/assets/da63fcee-a2d7-44bb-b417-8a495503f4c9" />

After:

<img width="548" height="311" alt="Screenshot 2025-11-17 at 16 30 32" src="https://github.com/user-attachments/assets/6ce69210-6ec6-4b6d-ac5b-c10a9dac7d58" />
<img width="531" height="308" alt="Screenshot 2025-11-17 at 16 30 22" src="https://github.com/user-attachments/assets/b4facb35-ed3b-4511-8d50-cd507b547268" />


## How I Tested These Changes

Loaded in the browser.