### PR TITLE
[dagster] Add support for MultiPartitionsDefinition to ResolvedAssetSpec

### DIFF
--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolvable_transformer.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolvable_transformer.py
@@ -176,6 +176,37 @@ def test_asset_spec_static_partitions_def():
     assert spec.partitions_def.get_partition_keys() == ["a", "b", "c"]
 
 
+def test_asset_spec_multi_partitions_def():
+    model = AssetSpecKwargs.model()(
+        key="asset_key",
+        partitions_def={
+            "type": "multi",
+            "partitions_defs": {
+                "part1": {
+                    "type": "static",
+                    "partition_keys": ["a", "b", "c"],
+                },
+                "part2": {
+                    "type": "daily",
+                    "start_date": "2021-01-01",
+                    "end_date": "2021-01-03",
+                },
+            },
+        },
+    )
+
+    spec = resolve_asset_spec(model=model, context=ResolutionContext.default())
+    assert isinstance(spec.partitions_def, dg.MultiPartitionsDefinition)
+    assert spec.partitions_def.get_partition_keys() == [
+        "a|2021-01-01",
+        "a|2021-01-02",
+        "b|2021-01-01",
+        "b|2021-01-02",
+        "c|2021-01-01",
+        "c|2021-01-02",
+    ]
+
+
 def test_resolved_asset_spec() -> None:
     @dataclass
     class SomeObject(dg.Resolvable):


### PR DESCRIPTION
## Summary & Motivation

A multi-partitioned asset can now be expressed as:
```yaml
  assets:
    - key: my_multi_asset
      partitions_def:
        type: multi
        partitions_defs:
          country:
            type: static
            partition_keys: ["us", "ca", "mx"]
          date:
            type: daily
            start_date: "2021-01-01"
            end_date: "2021-01-02"
            minute_offset: 10
```
  - The type: multi-branch is backed by`MultiPartitionsDefinitionModel`.
  - Each entry under`partitions_defs` is one of the existing partition config models (static, daily, hourly, weekly, time_window, etc.).
  - At resolution time, these config models are converted into real `PartitionsDefinition` instances and combined into a `MultiPartitionsDefinition` whose partitions are the cross-product of the dimensions.

## How I Tested

- pytest `test_resolvable_transformer.py::test_asset_spec_multi_partitions_def`
- Verified that `AssetSpecKwargs.model()` can be derived without errors and `resolve_asset_spec` produces an `AssetSpec` whose `partitions_def` is a `MultiPartitionsDefinition` constructed from the nested dimension configs.

## Changelog

> [dagster] Add support for MultiPartitionsDefinition to ResolvedAssetSpec
 

cc @cmpadden
