### PR TITLE
Allow RemoteRepositories without CodePointers to exist

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -154,9 +154,6 @@ class ReconstructableRepository(
             container_context=self.container_context,
         )
 
-    def get_python_origin_id(self) -> str:
-        return self.get_python_origin().get_id()
-
     # Allow this to be hashed for use in `lru_cache`. This is needed because:
     # - `ReconstructableJob` uses `lru_cache`
     # - `ReconstructableJob` has a `ReconstructableRepository` attribute
@@ -312,9 +309,6 @@ class ReconstructableJob(  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def get_python_origin(self) -> JobPythonOrigin:
         return JobPythonOrigin(self.job_name, self.repository.get_python_origin())
-
-    def get_python_origin_id(self) -> str:
-        return self.get_python_origin().get_id()
 
     def get_module(self) -> Optional[str]:
         """Return the module the job is found in, the origin is a module code pointer."""

--- a/python_modules/dagster/dagster/_core/remote_representation/handle.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/handle.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 class RepositoryHandle:
     repository_name: str
     code_location_origin: CodeLocationOrigin
-    repository_python_origin: RepositoryPythonOrigin
+    repository_python_origin: Optional[RepositoryPythonOrigin]
     display_metadata: Mapping[str, str]
 
     @classmethod
@@ -51,7 +51,9 @@ class RepositoryHandle:
         )
 
     def get_python_origin(self) -> RepositoryPythonOrigin:
-        return self.repository_python_origin
+        return check.not_none(
+            self.repository_python_origin, "Repository does not have a RepositoryPythonOrigin"
+        )
 
     def to_selector(self) -> RepositorySelector:
         return RepositorySelector(

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_repo_handle.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_repo_handle.py
@@ -1,0 +1,62 @@
+import os
+import sys
+from collections.abc import Mapping
+from typing import Optional
+
+import dagster as dg
+import pytest
+from dagster._core.code_pointer import CodePointer
+from dagster._core.remote_origin import InProcessCodeLocationOrigin
+from dagster._core.remote_representation.code_location import InProcessCodeLocation
+from dagster._core.test_utils import instance_for_test
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+
+
+class InProcesssCodeLocationWithoutCodePointers(InProcessCodeLocation):
+    @property
+    def repository_code_pointer_dict(self) -> Mapping[str, Optional[CodePointer]]:
+        return {}
+
+
+@dg.asset
+def my_asset():
+    pass
+
+
+defs = dg.Definitions(assets=[my_asset])
+
+
+def test_repo_handle_without_code_pointers():
+    origin = InProcessCodeLocationOrigin(
+        loadable_target_origin=LoadableTargetOrigin(
+            executable_path=sys.executable,
+            python_file=__file__,
+            working_directory=os.path.dirname(__file__),
+            attribute=None,
+        ),
+        container_image=None,
+        entry_point=None,
+        container_context=None,
+        location_name=None,
+    )
+
+    with instance_for_test() as instance:
+        location = InProcesssCodeLocationWithoutCodePointers(origin=origin, instance=instance)
+
+        assert location.repository_code_pointer_dict == {}
+
+        assert len(location.get_repositories()) == 1
+
+        repo = next(iter(location.get_repositories().values()))
+        assert repo.handle is not None
+        assert repo.handle.repository_python_origin is None
+
+        with pytest.raises(Exception, match="Repository does not have a RepositoryPythonOrigin"):
+            repo.handle.get_python_origin()
+
+        job = next(iter(repo.get_all_jobs()))
+        assert job.handle is not None
+
+        assert job.handle.get_remote_origin() is not None
+        with pytest.raises(Exception, match="Repository does not have a RepositoryPythonOrigin"):
+            job.handle.get_python_origin()


### PR DESCRIPTION
Summary:
this is a data model change to allow for experimenting with repositories that are sourced from places other than code/python. The APIs that expect to receive a RepositoryPythonOrigin (when subsetting jobs and creating runs) still expect one, but the object itself can exist without a RepositoryPythonOrigin.

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
