### PR TITLE
[dg] Update `dg plus deploy refresh-defs-state` command to handle subprocesses

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/defs_state.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/defs_state.py
@@ -168,19 +168,3 @@ def get_updated_defs_state_info_task_and_statuses(
         )
     )
     return refresh_task, statuses
-
-
-async def get_updated_defs_state_info_and_statuses(
-    project_path: Path,
-    defs_state_storage: "DefsStateStorage",
-    management_types: set["DefsStateManagementType"],
-    defs_state_keys: Optional[set[str]] = None,
-) -> tuple[Optional["DefsStateInfo"], dict[str, ComponentStateRefreshStatus]]:
-    """Refreshes the defs state for all selected components within the specified project path,
-    and returns the updated defs state info and statuses.
-    """
-    task, statuses = get_updated_defs_state_info_task_and_statuses(
-        project_path, defs_state_storage, management_types, defs_state_keys
-    )
-    await task
-    return task.result(), statuses

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/list.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/list.py
@@ -73,12 +73,18 @@ def DagsterOuterTable(columns: Sequence[str]) -> "Table":
 @dg_path_options
 @cli_telemetry_wrapper
 def list_project_command(target_path: Path, **global_options: object) -> None:
-    """List projects in the current workspace."""
+    """List projects in the current workspace or emit the current project directory."""
     cli_config = normalize_cli_config(global_options, click.get_current_context())
-    dg_context = DgContext.for_workspace_environment(target_path, cli_config)
+    dg_context = DgContext.for_workspace_or_project_environment(target_path, cli_config)
 
-    for project in dg_context.project_specs:
-        click.echo(project.path)
+    if dg_context.is_in_workspace:
+        # In a workspace, list all projects with their relative paths
+        for project in dg_context.project_specs:
+            click.echo(project.path)
+    elif dg_context.is_project:
+        # In a standalone project (not in a workspace), emit the current directory
+        # This allows the command to work in both contexts for CI/CD workflows
+        click.echo(".")
 
 
 # ########################

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
@@ -1,5 +1,8 @@
-import asyncio
 import os
+import subprocess
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -15,13 +18,11 @@ from dagster_dg_core.shared_options import (
 )
 from dagster_dg_core.utils import DgClickCommand, DgClickGroup, not_none
 from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
+from dagster_shared import check
 from dagster_shared.plus.config import DagsterPlusCliConfig
+from dagster_shared.serdes import serialize_value
 from dagster_shared.seven.temp_dir import get_system_temp_directory
 
-from dagster_dg_cli.cli.defs_state import (
-    get_updated_defs_state_info_and_statuses,
-    raise_component_state_refresh_errors,
-)
 from dagster_dg_cli.cli.plus.constants import DgPlusAgentType, DgPlusDeploymentType
 from dagster_dg_cli.cli.plus.deploy.configure.commands import deploy_configure_group
 from dagster_dg_cli.cli.plus.deploy.deploy_session import (
@@ -29,9 +30,10 @@ from dagster_dg_cli.cli.plus.deploy.deploy_session import (
     finish_deploy_session,
     init_deploy_session,
 )
-from dagster_dg_cli.utils.plus.build import defs_state_storage_from_location_state, get_agent_type
+from dagster_dg_cli.utils.plus.build import get_agent_type
 
 if TYPE_CHECKING:
+    from dagster._core.instance import DagsterInstance
     from dagster_shared.serdes.objects.models.defs_state_info import DefsStateManagementType
 
 DEFAULT_STATEDIR_PATH = os.path.join(get_system_temp_directory(), "dg-build-state")
@@ -390,10 +392,44 @@ def build_and_push_command(
     )
 
 
+@contextmanager
+def _instance_with_defs_state_storage(
+    ctx: click.Context, location_state
+) -> Iterator["DagsterInstance"]:
+    """Create a temporary instance with DagsterPlusCliDefsStateStorage configuration based off of the given LocationState."""
+    import yaml
+    from dagster._core.instance import DagsterInstance
+    from dagster_cloud_cli.config_utils import get_organization, get_user_token
+
+    api_token = check.not_none(get_user_token(ctx))
+    organization = check.not_none(get_organization(ctx))
+
+    # create dagster.yaml config
+    dagster_config = {
+        "defs_state_storage": {
+            "module": "dagster_dg_cli.utils.plus.defs_state_storage",
+            "class": "DagsterPlusCliDefsStateStorage",
+            "config": {
+                "url": location_state.url,
+                "api_token": api_token,
+                "deployment": location_state.deployment_name,
+                "organization": organization,
+            },
+        }
+    }
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        dagster_yaml_path = Path(temp_dir) / "dagster.yaml"
+        dagster_yaml_path.write_text(yaml.dump(dagster_config))
+        with DagsterInstance.from_config(temp_dir) as instance:
+            yield instance
+
+
 def refresh_defs_state_impl(
     ctx: click.Context,
     statedir: str,
-    project_path: Path,
+    dg_context: DgContext,
+    cli_config: DgRawCliConfig,
     management_types: set["DefsStateManagementType"],
 ):
     from dagster_cloud_cli.commands.ci import state
@@ -401,20 +437,79 @@ def refresh_defs_state_impl(
     state_store = state.FileStore(statedir=statedir)
     locations = state_store.list_selected_locations()
 
-    for location_state in locations:
-        with defs_state_storage_from_location_state(ctx, location_state) as defs_state_storage:
-            defs_state_info, statuses = asyncio.run(
-                get_updated_defs_state_info_and_statuses(
-                    project_path, defs_state_storage, management_types=management_types
-                )
+    if not locations:
+        click.echo("No locations to refresh.")
+        return
+
+    # Determine which projects/locations to process
+    if dg_context.is_project:
+        # Single project - process it with each matching location_state
+        project_contexts = [(dg_context, location_state) for location_state in locations]
+    else:
+        # Workspace - match projects to location states
+        project_contexts = []
+        for location_state in locations:
+            # Find matching project by location_name
+            for project_spec in dg_context.project_specs:
+                project_context = dg_context.for_project_environment(project_spec.path, cli_config)
+                if project_context.code_location_name == location_state.location_name:
+                    project_contexts.append((project_context, location_state))
+                    break
+
+    # Create temp instance with defs_state_storage - shared across all locations
+    # We'll use the first location_state to create the instance
+    with _instance_with_defs_state_storage(ctx, locations[0]) as instance:
+        instance_ref = instance.get_ref()
+        serialized_instance_ref = serialize_value(instance_ref)
+
+        # Run subprocess for each project/location
+        for project_context, location_state in project_contexts:
+            python_executable = project_context.project_python_executable
+
+            # Build command
+            cmd = [
+                str(python_executable),
+                "-m",
+                "dagster_dg_cli.cli.entrypoint",
+                "utils",
+                "refresh-defs-state",
+                "--instance-ref",
+                serialized_instance_ref,
+                "--target-path",
+                str(project_context.root_path),
+            ]
+
+            # Add management-type args if specified
+            for mt in management_types:
+                cmd.extend(["--management-type", mt.value])
+
+            click.echo(
+                f"Refreshing defs state for location: {location_state.location_name} with command: {cmd}"
             )
-            raise_component_state_refresh_errors(statuses)
-        if defs_state_info is None:
+
+            try:
+                subprocess.run(cmd, check=True, capture_output=False)
+            except subprocess.CalledProcessError as e:
+                click.echo(
+                    click.style(
+                        f"Failed to refresh defs state for {location_state.location_name}: {e}",
+                        fg="red",
+                    )
+                )
+                raise
+
+        # After all subprocesses complete, get the final DefsStateInfo
+        defs_state_storage = check.not_none(instance.defs_state_storage)
+        final_defs_state_info = defs_state_storage.get_latest_defs_state_info()
+
+        if final_defs_state_info is None:
             click.echo("No defs_state_info to update")
             return
 
-        location_state.defs_state_info = defs_state_info
-        state_store.save(location_state)
+        # Set the same DefsStateInfo on all location states
+        for location_state in locations:
+            location_state.defs_state_info = final_defs_state_info
+            state_store.save(location_state)
 
     click.echo(f"Updated defs_state_info for all {len(locations)} locations.")
 
@@ -442,8 +537,8 @@ def refresh_defs_state_command(
 
     ctx = click.get_current_context()
     cli_config = normalize_cli_config(global_options, ctx)
-    # ensure that the command is executed in a project
-    dg_context = DgContext.for_project_environment(target_path, cli_config)
+    # Support both workspace and project contexts
+    dg_context = DgContext.for_workspace_or_project_environment(target_path, cli_config)
     management_types = (
         {DefsStateManagementType(mt) for mt in management_type}
         if management_type
@@ -455,7 +550,8 @@ def refresh_defs_state_command(
     refresh_defs_state_impl(
         ctx=ctx,
         statedir=_get_statedir(),
-        project_path=dg_context.root_path,
+        dg_context=dg_context,
+        cli_config=cli_config,
         management_types=management_types,
     )
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/hybrid-github-action.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/hybrid-github-action.yaml
@@ -60,13 +60,22 @@ jobs:
         run: ${{ steps.setup-python-version.outputs.python-path }} -m pip install uv
         shell: bash
 
-      # Refresh state for any StateBackedComponents in the project
-      - name: Refresh defs state
+      # Sync all projects (workspace or single project)
+      - name: Sync project dependencies
         if: steps.prerun.outputs.result != 'skip'
         run: |
           cd ${{ env.DAGSTER_PROJECT_DIR }}
-          ${{ steps.setup-python-version.outputs.python-path }} -m uv run dg plus deploy refresh-defs-state
+          for project in $(${{ steps.setup-python-version.outputs.python-path }} -m uv run dg list projects); do
+            (cd "$project" && ${{ steps.setup-python-version.outputs.python-path }} -m uv sync)
+          done
         shell: bash
+
+      # Refresh state for any StateBackedComponents in the project
+      - name: Refresh defs state
+        if: steps.prerun.outputs.result != 'skip'
+        uses: dagster-io/dagster-cloud-action/actions/utils/dg-cli@TEMPLATE_DAGSTER_CLOUD_ACTION_VERSION
+        with:
+          command: "plus deploy refresh-defs-state"
 
       # Any value can be used as the docker image tag. It is recommended to use a unique value
       # for each build so that multiple builds do not overwrite each other.

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/hybrid-gitlab-ci.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/hybrid-gitlab-ci.yaml
@@ -34,6 +34,7 @@ dagster-cloud-deploy:
     # Install Python and uv for running dg CLI
     - apk add --no-cache python3 py3-pip
     - pip install --break-system-packages uv
+    - uv pip install dagster dagster-dg-cli dagster-cloud
   script:
     # Checkout is automatic in GitLab CI
 
@@ -43,6 +44,9 @@ dagster-cloud-deploy:
       python -m uv run dg plus deploy start
       --deployment=TEMPLATE_DEFAULT_DEPLOYMENT_NAME
       --yes
+
+    # Sync all projects (workspace or single project)
+    - find . -maxdepth 3 -name "pyproject.toml" -type f -execdir python -m uv sync \;
 
     # Refresh state for any StateBackedComponents in the project
     - python -m uv run dg plus deploy refresh-defs-state

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-github-action.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-github-action.yaml
@@ -58,13 +58,22 @@ jobs:
         run: ${{ steps.setup-python-version.outputs.python-path }} -m pip install uv
         shell: bash
 
-      # Refresh state for any StateBackedComponents in the project
-      - name: Refresh defs state
+      # Sync all projects (workspace or single project)
+      - name: Sync project dependencies
         if: steps.prerun.outputs.result != 'skip'
         run: |
           cd ${{ env.DAGSTER_PROJECT_DIR }}
-          ${{ steps.setup-python-version.outputs.python-path }} -m uv run dg plus deploy refresh-defs-state
+          for project in $(${{ steps.setup-python-version.outputs.python-path }} -m uv run dg list projects); do
+            (cd "$project" && ${{ steps.setup-python-version.outputs.python-path }} -m uv sync)
+          done
         shell: bash
+
+      # Refresh state for any StateBackedComponents in the project
+      - name: Refresh defs state
+        if: steps.prerun.outputs.result != 'skip'
+        uses: dagster-io/dagster-cloud-action/actions/utils/dg-cli@TEMPLATE_DAGSTER_CLOUD_ACTION_VERSION
+        with:
+          command: "plus deploy refresh-defs-state"
 
       # If using fast build, build the PEX
       - name: Install setuptools

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-gitlab-ci.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-gitlab-ci.yaml
@@ -24,12 +24,16 @@ dagster-cloud-serverless-deploy:
     # Install Python and uv for running dg CLI
     - apk add --no-cache python3 py3-pip
     - pip install --break-system-packages uv
+    - uv pip install dagster dagster-dg-cli dagster-cloud
   script:
     - cd $DAGSTER_PROJECT_DIR
     - >
       python -m uv run dg plus deploy start
       --deployment=TEMPLATE_DEFAULT_DEPLOYMENT_NAME
       --yes
+
+    # Sync all projects (workspace or single project)
+    - find . -maxdepth 3 -name "pyproject.toml" -type f -execdir python -m uv sync \;
 
     # Refresh state for any StateBackedComponents in the project
     - python -m uv run dg plus deploy refresh-defs-state

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/build.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/build.py
@@ -1,8 +1,6 @@
 import os
-from collections.abc import Iterator
-from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 import click
 from dagster_dg_core.config import DgRawBuildConfig, merge_build_configs
@@ -13,10 +11,6 @@ from dagster_shared.plus.config import DagsterPlusCliConfig
 from dagster_dg_cli.cli.plus.constants import DgPlusAgentPlatform, DgPlusAgentType
 from dagster_dg_cli.utils.plus.gql import DEPLOYMENT_INFO_QUERY
 from dagster_dg_cli.utils.plus.gql_client import DagsterPlusGraphQLClient
-
-if TYPE_CHECKING:
-    from dagster._core.storage.defs_state.base import DefsStateStorage
-    from dagster_cloud_cli.commands.ci.state import LocationState
 
 
 def get_dockerfile_path(
@@ -101,26 +95,3 @@ def create_deploy_dockerfile(dst_path: Path, python_version: str, use_editable_d
     with open(dst_path, "w", encoding="utf8") as f:
         f.write(template.render(python_version=python_version))
         f.write("\n")
-
-
-@contextmanager
-def defs_state_storage_from_location_state(
-    ctx: click.Context,
-    location_state: "LocationState",
-) -> Iterator["DefsStateStorage"]:
-    """Creates a DefsStateStorage based on the provided LocationState and sets it as the current
-    DefsStateStorage within the bounds of the context manager.
-    """
-    from dagster._core.storage.defs_state.base import set_defs_state_storage
-    from dagster_cloud_cli.config_utils import get_organization, get_user_token
-
-    from dagster_dg_cli.utils.plus.defs_state_storage import DagsterPlusCliDefsStateStorage
-
-    api_token = check.not_none(get_user_token(ctx))
-    organization = check.not_none(get_organization(ctx))
-
-    defs_state_storage = DagsterPlusCliDefsStateStorage.from_location_state(
-        location_state, api_token, organization
-    )
-    with set_defs_state_storage(defs_state_storage):
-        yield defs_state_storage

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_environment_validation.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_environment_validation.py
@@ -64,13 +64,12 @@ PROJECT_CONTEXT_COMMANDS = [
     CommandSpec(("scaffold", "defs", DEFAULT_COMPONENT_TYPE, "foot")),
 ]
 
-WORKSPACE_CONTEXT_COMMANDS = [
-    CommandSpec(("list", "project")),
-]
+WORKSPACE_CONTEXT_COMMANDS = []
 
 WORKSPACE_OR_PROJECT_CONTEXT_COMMANDS = [
     CommandSpec(("dev",)),
     CommandSpec(("check", "defs")),
+    CommandSpec(("list", "project")),
 ]
 
 # ########################
@@ -159,27 +158,6 @@ def test_no_component_library_failure(spec: CommandSpec) -> None:
         result = runner.invoke(*spec.to_cli_args())
         assert_runner_result(result, exit_0=False)
         assert "must be run inside a Dagster component library directory" in result.output
-
-
-@pytest.mark.parametrize(
-    "spec", WORKSPACE_CONTEXT_COMMANDS, ids=lambda spec: "-".join(spec.command)
-)
-def test_no_workspace_failure(spec: CommandSpec) -> None:
-    with (
-        ProxyRunner.test(use_fixed_test_components=True) as runner,
-        isolated_components_venv(runner),
-    ):
-        result = runner.invoke(*spec.to_cli_args())
-        assert_runner_result(result, exit_0=False)
-        assert "must be run inside a Dagster workspace directory" in result.output
-        assert "You may have wanted to" not in result.output
-
-        runner.invoke_create_dagster("workspace", "foo")
-        result = runner.invoke(*spec.to_cli_args())
-        assert_runner_result(result, exit_0=False)
-        assert "must be run inside a Dagster workspace directory" in result.output
-        assert "You may have wanted to" in result.output
-        assert "/foo" in result.output
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_list_commands.py
@@ -67,6 +67,17 @@ def test_list_projects_aliases(alias: str):
         assert_runner_result(runner.invoke("list", alias, "--help"))
 
 
+def test_list_project_in_standalone_project():
+    """Test that `dg list projects` works in a standalone project (not in a workspace)."""
+    with (
+        ProxyRunner.test() as runner,
+        isolated_example_project_foo_bar(runner, in_workspace=False, uv_sync=False),
+    ):
+        result = runner.invoke("list", "project")
+        assert_runner_result(result)
+        assert result.output.strip() == "."
+
+
 # ########################
 # ##### COMPONENTS
 # ########################


### PR DESCRIPTION
## Summary & Motivation

This makes it so `dg plus deploy refresh-defs-state` can handle workspaces in addition to projects. previously we assumed we were executing in the same python environment as the main dg command, but this isn't always the case. Now, we create an InstanceRef that has access to our prod DefsStateStorage. We can then serialize this reference and pass it to the subprocess, which then invokes `dg utils refresh-defs-state` *in the project's python env*. This results in the instance in the main process being mutated, which we can then read from at the end to get the updated defs state info.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
