### PR TITLE
Add a definitionsSource enum on GrapheneWorkspaceLocationEntry

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1797,6 +1797,7 @@ type WorkspaceLocationEntry {
   defsStateInfo: DefsStateInfo
   permissions: [Permission!]!
   featureFlags: [FeatureFlag!]!
+  definitionsSource: DefinitionsSource!
 }
 
 union RepositoryLocationOrLoadError = RepositoryLocation | PythonError
@@ -1815,6 +1816,11 @@ type Permission {
 type FeatureFlag {
   name: String!
   enabled: Boolean!
+}
+
+enum DefinitionsSource {
+  CODE_SERVER
+  CONNECTION
 }
 
 type ReloadWorkspaceMutation {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -1282,6 +1282,11 @@ export type DefinitionTag = {
   value: Scalars['String']['output'];
 };
 
+export enum DefinitionsSource {
+  CODE_SERVER = 'CODE_SERVER',
+  CONNECTION = 'CONNECTION',
+}
+
 export type DefsKeyStateInfo = {
   __typename: 'DefsKeyStateInfo';
   createTimestamp: Scalars['Float']['output'];
@@ -6146,6 +6151,7 @@ export type Workspace = {
 
 export type WorkspaceLocationEntry = {
   __typename: 'WorkspaceLocationEntry';
+  definitionsSource: DefinitionsSource;
   defsStateInfo: Maybe<DefsStateInfo>;
   displayMetadata: Array<RepositoryMetadata>;
   featureFlags: Array<FeatureFlag>;
@@ -16596,6 +16602,10 @@ export const buildWorkspaceLocationEntry = (
   relationshipsToOmit.add('WorkspaceLocationEntry');
   return {
     __typename: 'WorkspaceLocationEntry',
+    definitionsSource:
+      overrides && overrides.hasOwnProperty('definitionsSource')
+        ? overrides.definitionsSource!
+        : DefinitionsSource.CODE_SERVER,
     defsStateInfo:
       overrides && overrides.hasOwnProperty('defsStateInfo')
         ? overrides.defsStateInfo!

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -14,7 +14,11 @@ from dagster._core.remote_representation.grpc_server_state_subscriber import (
 )
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.workspace.context import WorkspaceProcessContext
-from dagster._core.workspace.workspace import CodeLocationEntry, CodeLocationLoadStatus
+from dagster._core.workspace.workspace import (
+    CodeLocationEntry,
+    CodeLocationLoadStatus,
+    DefinitionsSource,
+)
 from dagster.components.core.load_defs import PLUGIN_COMPONENT_TYPES_JSON_METADATA_KEY
 from dagster_shared.serdes.objects.models.defs_state_info import (
     DefsStateInfo,
@@ -189,6 +193,9 @@ class GrapheneFeatureFlag(graphene.ObjectType):
     enabled = graphene.NonNull(graphene.Boolean)
 
 
+GrapheneDefinitionsSource = graphene.Enum.from_enum(DefinitionsSource)
+
+
 class GrapheneWorkspaceLocationEntry(graphene.ObjectType):
     id = graphene.NonNull(graphene.ID)
     name = graphene.NonNull(graphene.String)
@@ -203,12 +210,17 @@ class GrapheneWorkspaceLocationEntry(graphene.ObjectType):
 
     featureFlags = non_null_list(GrapheneFeatureFlag)
 
+    definitionsSource = graphene.NonNull(GrapheneDefinitionsSource)
+
     class Meta:
         name = "WorkspaceLocationEntry"
 
     def __init__(self, location_entry: CodeLocationEntry):
         self._location_entry = check.inst_param(location_entry, "location_entry", CodeLocationEntry)
-        super().__init__(name=self._location_entry.origin.location_name)
+        super().__init__(
+            name=self._location_entry.origin.location_name,
+            definitionsSource=self._location_entry.definitions_source,
+        )
 
     def resolve_id(self, _):
         return self.name

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
@@ -25,6 +25,7 @@ fragment locationEntryFragment on WorkspaceLocationEntry {
   __typename
   id
   name
+  definitionsSource
   locationOrLoadError {
     __typename
     ... on RepositoryLocation {
@@ -175,6 +176,7 @@ class TestLoadWorkspace(BaseTestSuite):
             assert all([node["__typename"] == "WorkspaceLocationEntry" for node in nodes]), str(
                 nodes
             )
+            assert all([node["definitionsSource"] == "CODE_SERVER" for node in nodes]), str(nodes)
 
             success_nodes = [
                 node["locationOrLoadError"]

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -85,6 +85,7 @@ from dagster._core.workspace.workspace import (
     CodeLocationLoadStatus,
     CodeLocationStatusEntry,
     CurrentWorkspace,
+    DefinitionsSource,
     location_status_from_location_entry,
 )
 from dagster._grpc.constants import INCREASE_TIMEOUT_DAGSTER_YAML_MSG, GrpcServerCommand
@@ -1121,6 +1122,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext[WorkspaceRequestContext])
             ),
             update_timestamp=load_time,
             version_key=version_key,
+            definitions_source=DefinitionsSource.CODE_SERVER,
         )
 
     def get_current_workspace(self) -> CurrentWorkspace:

--- a/python_modules/dagster/dagster/_core/workspace/workspace.py
+++ b/python_modules/dagster/dagster/_core/workspace/workspace.py
@@ -18,6 +18,11 @@ class CodeLocationLoadStatus(Enum):
     LOADED = "LOADED"  # Finished loading (may be an error)
 
 
+class DefinitionsSource(Enum):
+    CODE_SERVER = "CODE_SERVER"
+    CONNECTION = "CONNECTION"
+
+
 @record
 class CodeLocationEntry:
     origin: Annotated[
@@ -35,6 +40,7 @@ class CodeLocationEntry:
     display_metadata: Mapping[str, str]
     update_timestamp: float
     version_key: str
+    definitions_source: DefinitionsSource
 
 
 @record

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -17,6 +17,7 @@ from dagster._core.workspace.workspace import (
     CodeLocationEntry,
     CodeLocationLoadStatus,
     CurrentWorkspace,
+    DefinitionsSource,
 )
 
 
@@ -143,6 +144,7 @@ def _make_location_entry(defs_attr: str, instance: DagsterInstance):
         display_metadata={},
         update_timestamp=time.time(),
         version_key="test",
+        definitions_source=DefinitionsSource.CODE_SERVER,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/workspace_tests/test_request_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/workspace_tests/test_request_context.py
@@ -15,6 +15,7 @@ from dagster._core.workspace.workspace import (
     CodeLocationEntry,
     CodeLocationLoadStatus,
     CurrentWorkspace,
+    DefinitionsSource,
 )
 from dagster._utils.error import SerializableErrorInfo
 
@@ -37,6 +38,7 @@ def workspace_request_context() -> WorkspaceRequestContext:
                     display_metadata={},
                     update_timestamp=now,
                     version_key=str(now),
+                    definitions_source=DefinitionsSource.CODE_SERVER,
                 ),
                 "loaded_loc": CodeLocationEntry(
                     origin=RegisteredCodeLocationOrigin("loaded_loc"),
@@ -46,6 +48,7 @@ def workspace_request_context() -> WorkspaceRequestContext:
                     display_metadata={},
                     update_timestamp=now,
                     version_key=str(now),
+                    definitions_source=DefinitionsSource.CODE_SERVER,
                 ),
                 "error_loc": CodeLocationEntry(
                     origin=RegisteredCodeLocationOrigin("error_loc"),
@@ -55,6 +58,7 @@ def workspace_request_context() -> WorkspaceRequestContext:
                     display_metadata={},
                     update_timestamp=now,
                     version_key=str(now),
+                    definitions_source=DefinitionsSource.CODE_SERVER,
                 ),
             }
         ),
@@ -97,6 +101,7 @@ def _location_with_mocked_versions(dagster_library_versions: Mapping[str, str]):
         display_metadata={},
         update_timestamp=time.time(),
         version_key="test",
+        definitions_source=DefinitionsSource.CODE_SERVER,
     )
 
 

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -24,6 +24,7 @@ from dagster._core.workspace.workspace import (
     CodeLocationEntry,
     CodeLocationLoadStatus,
     CurrentWorkspace,
+    DefinitionsSource,
 )
 
 
@@ -59,6 +60,7 @@ def _make_location_entry(scenario_name: str, definitions_file: str, instance: Da
         display_metadata={},
         update_timestamp=time.time(),
         version_key="test",
+        definitions_source=DefinitionsSource.CODE_SERVER,
     )
 
 


### PR DESCRIPTION
Summary:
Give frontend the tool to distinguish between workspace entries from differnet sources.

BK

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
