### PR TITLE
[docs] update markdown link validation hook deprecation warning

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -12,12 +12,14 @@ const config: Config = {
   favicon: 'img/favicon.ico',
   baseUrl: '/',
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
   onBrokenAnchors: 'throw',
   organizationName: 'dagster',
   projectName: 'dagster',
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
   },
   themes: ['@docusaurus/theme-mermaid'],
   clientModules: [require.resolve('./src/clientModules/disableSlashSearch.js')],


### PR DESCRIPTION
## Summary & Motivation

Updates docusarus configuration to resolve deprecation warning.

    [WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
    Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.
    [INFO] [en] Creating an optimized production build...
    [WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
    Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.

## How I Tested These Changes

## Changelog

NOCHANGELOG
