### PR TITLE
[dagster-graphql] fix error where `-f` was being overridden in @workspace_options

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -150,9 +150,7 @@ PREDEFINED_QUERIES = {
 @click.option(
     "--text", "-t", type=click.STRING, help="GraphQL document to execute passed as a string"
 )
-@click.option(
-    "--file", type=click.File(), help="GraphQL document to execute passed as a file"
-)
+@click.option("--file", type=click.File(), help="GraphQL document to execute passed as a file")
 @click.option(
     "--predefined",
     "-p",


### PR DESCRIPTION
## Summary & Motivation


Resolves issue where `-f` was being defined twice. In `--file` and `@workspace_options`

    UserWarning: The parameter -f is used more than once. Remove its duplicate as parameters should be unique.
      pieces = ctx.command.collect_usage_pieces(ctx)
      
https://github.com/dagster-io/dagster/blob/colton/fix/dagster-graphql-cli-f/python_modules/libraries/dagster-shared/dagster_shared/cli/__init__.py#L42-L57

## How I Tested These Changes

## Changelog

NOCHANGELOG
