### PR TITLE
Add B012 (no returns in finally statements) to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,10 @@ select = [
   "A001",
   "A002",
 
+  # (jump-statement-in-finally) break, continue, and return statements in finally blocks
+  # are usually mistakes that swallow exceptions.
+  "B012",
+
   # (useless expression): Expressions that aren't assigned to anything are typically bugs.
   "B018",
 
@@ -329,5 +333,3 @@ exclude = ["examples/docs_snippets/docs_snippets/guides/etl/transform-dbt/dbt_de
 
 [tool.dagster]
 module_name = "dagster_test.toys.repo"
-
-


### PR DESCRIPTION
Summary:
Learned about this one today, seems like a nice footgun to avoid. No current violations.

https://docs.astral.sh/ruff/rules/jump-statement-in-finally/

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
