### PR TITLE
CHORE: When the daemon gracefully shuts down we should INFO not WARN

### DIFF
--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -231,8 +231,11 @@ class DagsterProxyApiServicer(DagsterApiServicer):
             if self._shutdown_once_executions_finish_event.is_set():
                 break
 
+            if self._server_termination_event.is_set():
+                break
+
             if self.__last_heartbeat_time < time.time() - heartbeat_timeout:
-                self._logger.warning(
+                self._logger.info(
                     f"No heartbeat received in {heartbeat_timeout} seconds, shutting down"
                 )
                 self._shutdown_once_executions_finish_event.set()

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -523,9 +523,12 @@ class DagsterApiServer(DagsterApiServicer):
             self._shutdown_once_executions_finish_event.wait(heartbeat_timeout)
             if self._shutdown_once_executions_finish_event.is_set():
                 break
-
+            
+            if self._server_termination_event.is_set():
+                break
+            
             if self.__last_heartbeat_time < time.time() - heartbeat_timeout:
-                self._logger.warning(
+                self._logger.info(
                     f"No heartbeat received in {heartbeat_timeout} seconds, shutting down"
                 )
                 self._shutdown_once_executions_finish_event.set()


### PR DESCRIPTION
## Summary & Motivation
When the daemon thread gracefully shuts down due to no activity this message should be `info` not `warning` since it's expected behavior. In our OSS deployment of `dagster 1.12.2` this has been causing Sentry warnings because we subscribe to `logger.warning` messages:
<img width="544" height="666" alt="image" src="https://github.com/user-attachments/assets/73120e0b-5e51-4e20-82c8-7b2c727e5486" />

I found a few other users that stumbled into this so I thought it would be helpful to downgrade the log to a `info`:
- https://dagster.slack.com/archives/C066HKS7EG1/p1759786875029299
- https://dagster.slack.com/archives/C066HKS7EG1/p1760575277666139
- https://dagster.slack.com/archives/C066HKS7EG1/p1757504125834629
- https://dagster.slack.com/archives/C066HKS7EG1/p1760575277666139


## How I Tested These Changes
When the daemon thread now shuts down we see `info` not `warning`

## Changelog

> Insert changelog entry or delete this section.
Make f"No heartbeat received in {heartbeat_timeout} seconds, shutting down" `INFO` not `WARNING`