### PR TITLE
fix(instigation logger): stringify non-json objects

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/test_instigation_logger.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_instigation_logger.py
@@ -88,7 +88,7 @@ def test_instigation_logger_logs_weird_record_ok(capsys):
 
     log_key = ["test-repo", "test-instigator", "123"]
 
-    with dg.instance_for_test() as instance:  # pyright: ignore[reportAttributeAccessIssue]
+    with dg.instance_for_test() as instance:
         with InstigationLogger(
             log_key=log_key,
             instance=instance,


### PR DESCRIPTION
## Summary & Motivation

Fixes #32845. Although, here is probably some underlying issue that is _not_ fixed by this PR. But I think that can go in another issue.

## How I Tested These Changes

Implemented a test with a "weird" log record to show that logging does not error in this case any more.

## Changelog

> InstigationLogger handles LogRecord attributes that are not json serializable by stringifying them instead of logging an error
