### PR TITLE
Skip flaky test_k8s_executor_owner_references_disabled if Python 3.12 or 3.13

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import sys
 import time
 from collections.abc import Mapping
 from typing import Any
@@ -522,6 +523,8 @@ def test_k8s_executor_owner_references_garbage_collection(
         time.sleep(1)
 
 
+# K8s issue for Python 3.12 and 3.13 not supported https://github.com/kubernetes-client/python/issues/2419
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason="Python 3.12 and 3.13 not supported")
 @pytest.mark.integration
 def test_k8s_executor_owner_references_disabled(
     dagster_instance_for_k8s_run_launcher,


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
