### PR TITLE
Rename GraphenePipelineConfigValidationError to GrapheneConfigValidationError

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/run_config_schema.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/run_config_schema.py
@@ -44,7 +44,7 @@ def resolve_is_run_config_valid(
     run_config: Mapping[str, object],
 ) -> "GraphenePipelineConfigValidationValid":
     from dagster_graphql.schema.pipelines.config import (
-        GraphenePipelineConfigValidationError,
+        GrapheneConfigValidationError,
         GraphenePipelineConfigValidationValid,
         GrapheneRunConfigValidationInvalid,
     )
@@ -69,7 +69,7 @@ def resolve_is_run_config_valid(
             GrapheneRunConfigValidationInvalid(
                 pipeline_name=represented_pipeline.name,
                 errors=[
-                    GraphenePipelineConfigValidationError.from_dagster_error(
+                    GrapheneConfigValidationError.from_dagster_error(
                         represented_pipeline.config_schema_snapshot.get_config_snap,
                         err,
                     )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/__init__.py
@@ -1,5 +1,6 @@
 def types():
     from dagster_graphql.schema.pipelines.config import (
+        GrapheneConfigValidationError,
         GrapheneEvaluationErrorReason,
         GrapheneEvaluationStack,
         GrapheneEvaluationStackEntry,
@@ -11,7 +12,6 @@ def types():
         GrapheneFieldsNotDefinedConfigError,
         GrapheneMissingFieldConfigError,
         GrapheneMissingFieldsConfigError,
-        GraphenePipelineConfigValidationError,
         GraphenePipelineConfigValidationInvalid,
         GraphenePipelineConfigValidationValid,
         GrapheneRunConfigValidationInvalid,
@@ -70,7 +70,7 @@ def types():
         GrapheneMissingFieldsConfigError,
         GrapheneMode,
         GraphenePipeline,
-        GraphenePipelineConfigValidationError,
+        GrapheneConfigValidationError,
         GraphenePipelineConfigValidationInvalid,
         GrapheneRunConfigValidationInvalid,
         GraphenePipelineConfigValidationResult,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/config.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/config.py
@@ -131,14 +131,14 @@ class GrapheneEvaluationErrorReason(graphene.Enum):
         name = "EvaluationErrorReason"
 
 
-class GraphenePipelineConfigValidationError(graphene.Interface):
+class GrapheneConfigValidationError(graphene.Interface):
     message = graphene.NonNull(graphene.String)
     path = non_null_list(graphene.String)
     stack = graphene.NonNull(GrapheneEvaluationStack)
     reason = graphene.NonNull(GrapheneEvaluationErrorReason)
 
     class Meta:
-        name = "PipelineConfigValidationError"
+        name = "PipelineConfigValidationError"  # back-compat
 
     @staticmethod
     def from_dagster_error(
@@ -212,7 +212,7 @@ class GrapheneRuntimeMismatchConfigError(graphene.ObjectType):
     value_rep = graphene.Field(graphene.String)
 
     class Meta:
-        interfaces = (GraphenePipelineConfigValidationError,)
+        interfaces = (GrapheneConfigValidationError,)
         name = "RuntimeMismatchConfigError"
 
 
@@ -220,7 +220,7 @@ class GrapheneMissingFieldConfigError(graphene.ObjectType):
     field = graphene.NonNull(GrapheneConfigTypeField)
 
     class Meta:
-        interfaces = (GraphenePipelineConfigValidationError,)
+        interfaces = (GrapheneConfigValidationError,)
         name = "MissingFieldConfigError"
 
 
@@ -228,7 +228,7 @@ class GrapheneMissingFieldsConfigError(graphene.ObjectType):
     fields = non_null_list(GrapheneConfigTypeField)
 
     class Meta:
-        interfaces = (GraphenePipelineConfigValidationError,)
+        interfaces = (GrapheneConfigValidationError,)
         name = "MissingFieldsConfigError"
 
 
@@ -236,7 +236,7 @@ class GrapheneFieldNotDefinedConfigError(graphene.ObjectType):
     field_name = graphene.NonNull(graphene.String)
 
     class Meta:
-        interfaces = (GraphenePipelineConfigValidationError,)
+        interfaces = (GrapheneConfigValidationError,)
         name = "FieldNotDefinedConfigError"
 
 
@@ -244,7 +244,7 @@ class GrapheneFieldsNotDefinedConfigError(graphene.ObjectType):
     field_names = non_null_list(graphene.String)
 
     class Meta:
-        interfaces = (GraphenePipelineConfigValidationError,)
+        interfaces = (GrapheneConfigValidationError,)
         name = "FieldsNotDefinedConfigError"
 
 
@@ -252,7 +252,7 @@ class GrapheneSelectorTypeConfigError(graphene.ObjectType):
     incoming_fields = non_null_list(graphene.String)
 
     class Meta:
-        interfaces = (GraphenePipelineConfigValidationError,)
+        interfaces = (GrapheneConfigValidationError,)
         name = "SelectorTypeConfigError"
 
 
@@ -287,7 +287,7 @@ class GraphenePipelineConfigValidationValid(graphene.ObjectType):
 
 class GraphenePipelineConfigValidationInvalid(graphene.Interface):
     pipeline_name = graphene.NonNull(graphene.String)
-    errors = non_null_list(GraphenePipelineConfigValidationError)
+    errors = non_null_list(GrapheneConfigValidationError)
 
     class Meta:
         name = "PipelineConfigValidationInvalid"
@@ -295,7 +295,7 @@ class GraphenePipelineConfigValidationInvalid(graphene.Interface):
 
 class GrapheneRunConfigValidationInvalid(graphene.ObjectType):
     pipeline_name = graphene.NonNull(graphene.String)
-    errors = non_null_list(GraphenePipelineConfigValidationError)
+    errors = non_null_list(GrapheneConfigValidationError)
 
     class Meta:
         interfaces = (GraphenePipelineConfigValidationInvalid,)
@@ -310,7 +310,7 @@ class GrapheneRunConfigValidationInvalid(graphene.ObjectType):
         return GrapheneRunConfigValidationInvalid(
             pipeline_name=represented_pipeline.name,
             errors=[
-                GraphenePipelineConfigValidationError.from_dagster_error(
+                GrapheneConfigValidationError.from_dagster_error(
                     represented_pipeline.config_schema_snapshot.get_config_snap,
                     err,
                 )


### PR DESCRIPTION
## Summary & Motivation
Can't rename the graphql type easily due to back-compat, but can rename the python class at least

## How I Tested These Changes
BK