### PR TITLE
[ui] Make config schema scaffolding a bit more generic

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -35,7 +35,7 @@ import {OpSelector} from './OpSelector';
 import {RUN_PREVIEW_VALIDATION_FRAGMENT, RunPreview} from './RunPreview';
 import {SessionSettingsBar} from './SessionSettingsBar';
 import {TagContainer, TagEditor} from './TagEditor';
-import {scaffoldPipelineConfig} from './scaffoldType';
+import {scaffoldConfig} from './scaffoldType';
 import {LaunchpadType} from './types';
 import {
   LaunchpadSessionPartitionSetsFragment,
@@ -274,7 +274,14 @@ const LaunchpadSession = (props: LaunchpadSessionProps) => {
   };
 
   const onScaffoldMissingConfig = () => {
-    const config = runConfigSchema ? scaffoldPipelineConfig(runConfigSchema) : {};
+    const config = runConfigSchema ? scaffoldConfig(runConfigSchema) : {};
+
+    // Unmergeable scaffolded config. Don't do anything with this.
+    if (!config || typeof config !== 'object') {
+      showCustomAlert({title: 'Invalid YAML', body: YAML_SYNTAX_INVALID});
+      return;
+    }
+
     try {
       onSaveSession({runConfigYaml: mergeYaml(config, currentSession.runConfigYaml)});
     } catch {

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/__tests__/scaffoldTypes.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/__tests__/scaffoldTypes.test.ts
@@ -1,8 +1,7 @@
-import {AllConfigTypesForEditorFragment} from '../../configeditor/types/ConfigEditorUtils.types';
-import {createTypeLookup, scaffoldType} from '../scaffoldType';
+import {AllConfigTypes, createTypeLookup, scaffoldType} from '../scaffoldType';
 
 // prettier-ignore
-const allConfigTypes: AllConfigTypesForEditorFragment[] = [
+const allConfigTypes: AllConfigTypes[] = [
   {"__typename":"RegularConfigType","key":"Any","description":null,"isSelector":false,"typeParamKeys":[],"givenName":"Any"},
   {"__typename":"ArrayConfigType","key":"Array.Shape.41de0e2d7b75524510155d0bdab8723c6feced3b","description":"List of Array.Shape.41de0e2d7b75524510155d0bdab8723c6feced3b","isSelector":false,"typeParamKeys":["Shape.41de0e2d7b75524510155d0bdab8723c6feced3b"]},
   {"__typename":"ArrayConfigType","key":"Array.String","description":"List of Array.String","isSelector":false,"typeParamKeys":["String"]},

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/scaffoldType.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/scaffoldType.ts
@@ -1,15 +1,17 @@
+import {ConfigSchema} from '@dagster-io/ui-components/editor';
+
 import {assertUnreachable} from '../app/Util';
-import {
-  AllConfigTypesForEditorFragment,
-  ConfigEditorRunConfigSchemaFragment,
-} from '../configeditor/types/ConfigEditorUtils.types';
+
+export type AllConfigTypes = ConfigSchema['allConfigTypes'][number];
 
 export const scaffoldType = (
   configTypeKey: string,
-  typeLookup: {[key: string]: AllConfigTypesForEditorFragment},
-): any => {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const type = typeLookup[configTypeKey]!;
+  typeLookup: {[key: string]: AllConfigTypes},
+): object | string | number | boolean | null | undefined => {
+  const type = typeLookup[configTypeKey];
+  if (!type) {
+    return undefined;
+  }
 
   switch (type.__typename) {
     case 'CompositeConfigType':
@@ -19,15 +21,11 @@ export const scaffoldType = (
         return '<selector>';
       }
 
-      const config = {};
-      for (const field of type.fields) {
-        const {name, isRequired, configTypeKey} = field;
-        if (isRequired) {
-          (config as any)[name] = scaffoldType(configTypeKey, typeLookup);
-        }
-      }
-
-      return config;
+      return Object.fromEntries(
+        type.fields
+          .filter((field) => field.isRequired)
+          .map((field) => [field.name, scaffoldType(field.configTypeKey, typeLookup)]),
+      );
     case 'ArrayConfigType':
       return [];
     case 'MapConfigType':
@@ -35,8 +33,10 @@ export const scaffoldType = (
     case 'NullableConfigType':
       // If a type is nullable we include it in the scaffolded config anyway
       // by using the inner type
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const innerType = type.typeParamKeys[0]!;
+      const [innerType] = type.typeParamKeys;
+      if (!innerType) {
+        return undefined;
+      }
       return scaffoldType(innerType, typeLookup);
     case 'EnumConfigType':
       // Here we just join all the potential enum values with a |. The user needs to delete
@@ -60,18 +60,12 @@ export const scaffoldType = (
   }
 };
 
-export const createTypeLookup = (allConfigTypes: AllConfigTypesForEditorFragment[]) => {
-  const typeLookup: {[key: string]: AllConfigTypesForEditorFragment} = {};
-  for (const type of allConfigTypes) {
-    typeLookup[type.key] = type;
-  }
-
-  return typeLookup;
+export const createTypeLookup = (allConfigTypes: AllConfigTypes[]) => {
+  return Object.fromEntries(allConfigTypes.map((type) => [type.key, type]));
 };
 
-export const scaffoldPipelineConfig = (configSchema: ConfigEditorRunConfigSchemaFragment) => {
+export const scaffoldConfig = (configSchema: ConfigSchema) => {
   const {allConfigTypes, rootConfigType} = configSchema;
   const typeLookup = createTypeLookup(allConfigTypes);
-  const config = scaffoldType(rootConfigType.key, typeLookup);
-  return config;
+  return scaffoldType(rootConfigType.key, typeLookup);
 };


### PR DESCRIPTION
## Summary & Motivation

We can use schema scaffolding in other situations, and we already have some generic types defined instead of the pipeline-specific stuff. So let's make the scaffolding more generic.

## How I Tested These Changes

TS, lint, jest.