### PR TITLE
[ui components] Convert Spinner and Icon to CSS modules

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/BaseTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/BaseTag.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import {Colors} from './Color';
-import {IconWrapper} from './Icon';
-import {SpinnerWrapper} from './Spinner';
 
 export interface BaseTagProps {
   fillColor?: string;
@@ -91,17 +89,20 @@ export const StyledTag = styled.div<StyledTagProps>`
     text-overflow: ellipsis;
   }
 
-  > ${IconWrapper}:first-child, > ${SpinnerWrapper}:first-child {
+  > .iconGlobal:first-child,
+  > .spinnerGlobal:first-child {
     margin-right: 4px;
     margin-left: -4px;
   }
 
-  > ${IconWrapper}:last-child, > ${SpinnerWrapper}:last-child {
+  > .iconGlobal:last-child,
+  > .spinnerGlobal:last-child {
     margin-left: 4px;
     margin-right: -4px;
   }
 
-  > ${IconWrapper}:first-child:last-child, > ${SpinnerWrapper}:first-child:last-child {
+  > .iconGlobal:first-child:last-child,
+  > .spinnerGlobal:first-child:last-child {
     margin: 0 -4px;
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Icon.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Icon.tsx
@@ -1,7 +1,10 @@
+import clsx from 'clsx';
+import memoize from 'lodash/memoize';
 import * as React from 'react';
-import styled from 'styled-components';
+import {CSSProperties} from 'react';
 
 import {Colors} from './Color';
+import styles from './css/Icon.module.css';
 import abc from '../icon-svgs/abc.svg';
 import account_circle from '../icon-svgs/account_circle.svg';
 import account_tree from '../icon-svgs/account_tree.svg';
@@ -428,7 +431,7 @@ export const Icons = {
   partition_set,
   op_dynamic,
   new: new_svg,
-  //Core Icons
+  // Core Icons
   abc,
   account_circle,
   account_tree,
@@ -844,74 +847,65 @@ export const Icons = {
 
 export type IconName = keyof typeof Icons;
 
-const rotations: {[key in IconName]?: string} = {
-  // waterfall_chart: '-90deg',
-};
-
 export const IconNames = Object.keys(Icons) as IconName[];
+export type IconSize = 12 | 16 | 20 | 24 | 48;
+
+const getSizeClass = memoize((size: IconSize) => {
+  return clsx(
+    size === 12 && styles.size12,
+    size === 16 && styles.size16,
+    size === 20 && styles.size20,
+    size === 24 && styles.size24,
+    size === 48 && styles.size48,
+  );
+});
 
 interface Props {
   color?: string;
-  name: IconName;
-  size?: 12 | 16 | 20 | 24 | 48;
-  style?: React.CSSProperties;
-  useOriginalColor?: boolean;
+  size?: IconSize;
+  style?: CSSProperties;
+  className?: string;
 }
 
-export const Icon = React.memo((props: Props) => {
-  const {name, size = 16, style} = props;
+interface IconProps extends Props {
+  name: IconName;
+}
+
+export const Icon = React.memo((props: IconProps) => {
+  const {name, color = Colors.accentPrimary(), ...rest} = props;
 
   // Storybook imports SVGs are string but nextjs imports them as object.
   // This is a temporary work around until we can get storybook to import them the same way as nextjs
   const img = typeof Icons[name] === 'string' ? (Icons[name] as any) : Icons[name].src;
 
-  const color: string | null = props.useOriginalColor
-    ? null
-    : props.color || Colors.accentPrimary();
-  return (
-    <IconWrapper
-      role="img"
-      $size={size}
-      $img={img}
-      $color={color}
-      $rotation={rotations[name] || null}
-      aria-label={name}
-      style={style}
-    />
-  );
+  return <BaseIcon {...rest} img={img} name={name} color={color} />;
 });
-interface WrapperProps {
-  $color: string | null;
-  $size: number;
-  $img: string;
-  $rotation: string | null;
+
+interface BaseIconProps extends Props {
+  img: string;
+  name: string;
 }
 
-export const IconWrapper = styled.div<WrapperProps>`
-  width: ${(p) => p.$size}px;
-  height: ${(p) => p.$size}px;
-  flex-shrink: 0;
-  flex-grow: 0;
-  ${(p) =>
-    p.$color === null
-      ? // Increased specificity so that StyledButton background-color logic doesn't apply here.
-        // We could just use !important but specificity is a little more flexible
-        `
-        background: url(${p.$img});
-        background-size: cover;
-        &[role='img'][role='img'] {
-          background-color: transparent;
-        }
-      `
-      : `
-        background: ${p.$color};
-        mask-size: contain;
-        mask-repeat: no-repeat;
-        mask-position: center;
-        mask-image: url(${p.$img});
-      `}
-  object-fit: contain;
-  transition: transform 150ms linear;
+export const BaseIcon = React.memo((props: BaseIconProps) => {
+  const {name, color, size = 16, style, img, className} = props;
 
-  ${({$rotation}) => ($rotation ? `transform: rotate(${$rotation});` : null)}
-`;
+  const allClassNames = clsx(
+    'iconGlobal', // Global class for targeting icons
+    className,
+    styles.icon,
+    getSizeClass(size),
+    color ? styles.usePropColor : styles.useOriginalColor,
+  );
+
+  const iconStyle = {
+    ...(style ?? {}),
+    ...(color ? {'--icon-color': color} : {}),
+    '--icon-image-path': `url(${img})`,
+  } as CSSProperties;
+
+  return <div className={allClassNames} role="img" aria-label={name} style={iconStyle} />;
+});
+
+BaseIcon.displayName = 'BaseIcon';
+
+Icon.displayName = 'Icon';

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Menu.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Menu.tsx
@@ -9,7 +9,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import {Colors} from './Color';
-import {Icon, IconName, IconWrapper} from './Icon';
+import {Icon, IconName} from './Icon';
 
 interface Props extends React.ComponentProps<typeof BlueprintMenu> {}
 
@@ -143,7 +143,7 @@ const StyledMenuItem = styled(BlueprintMenuItem)<StyledMenuItemProps>`
    * Use margin instead of align-items: center because the contents of the menu item may wrap 
    * in unusual circumstances.
    */
-  ${IconWrapper} {
+  .iconGlobal {
     margin-top: 2px;
   }
 
@@ -152,20 +152,20 @@ const StyledMenuItem = styled(BlueprintMenuItem)<StyledMenuItemProps>`
     background-color: ${Colors.backgroundBlue()};
     color: ${Colors.textDefault()};
 
-    ${IconWrapper} {
+    .iconGlobal {
       background-color: ${Colors.textDefault()};
     }
   }
 
-  &.bp5-disabled ${IconWrapper} {
+  &.bp5-disabled .iconGlobal {
     opacity: 0.5;
   }
 
-  &.bp5-active ${IconWrapper} {
+  &.bp5-active .iconGlobal {
     color: ${Colors.textDefault()};
   }
 
-  ${IconWrapper}:first-child {
+  .iconGlobal:first-child {
     margin-left: -4px;
   }
 

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Radio.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Radio.tsx
@@ -3,7 +3,6 @@ import {Radio as BlueprintRadio} from '@blueprintjs/core';
 import styled from 'styled-components';
 
 import {Colors} from './Color';
-import {IconWrapper} from './Icon';
 
 // Re-export Radio from Blueprint so that we don't have to deal with the lint
 // error elsewhere.
@@ -28,7 +27,7 @@ export const RadioContainer = styled.div`
     cursor: default;
     color: ${Colors.textDisabled()};
 
-    ${IconWrapper} {
+    .iconGlobal {
       opacity: 0.4;
     }
   }

--- a/js_modules/dagster-ui/packages/ui-components/src/components/RefreshableCountdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/RefreshableCountdown.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import {Colors} from './Color';
 import {Group} from './Group';
-import {Icon, IconWrapper} from './Icon';
+import {Icon} from './Icon';
 import {Tooltip} from './Tooltip';
 import {secondsToCountdownTime} from './secondsToCountdownTime';
 
@@ -49,7 +49,7 @@ export const RefreshButton = styled.button`
   position: relative;
   top: 1px;
 
-  & ${IconWrapper} {
+  & .iconGlobal {
     display: block;
     transition: color 100ms linear;
 

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Spinner.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Spinner.tsx
@@ -1,10 +1,18 @@
 // eslint-disable-next-line no-restricted-imports
 import {Spinner as BlueprintSpinner} from '@blueprintjs/core';
-import styled from 'styled-components';
+import clsx from 'clsx';
+import {CSSProperties} from 'react';
 
-import {Colors} from './Color';
+import styles from './css/Spinner.module.css';
 
 type SpinnerPurpose = 'page' | 'section' | 'body-text' | 'caption-text';
+
+const SPINNER_SIZES: Record<SpinnerPurpose, number> = {
+  page: 80,
+  section: 32,
+  'caption-text': 10,
+  'body-text': 12,
+};
 
 interface Props {
   purpose: SpinnerPurpose;
@@ -14,67 +22,24 @@ interface Props {
   title?: string;
 }
 
-export const Spinner = ({
-  purpose,
-  value,
-  fillColor = Colors.accentGray(),
-  stopped,
-  title = 'Loading…',
-}: Props) => {
-  const size = () => {
-    switch (purpose) {
-      case 'page':
-        return 80;
-      case 'section':
-        return 32;
-      case 'caption-text':
-        return 10;
-      case 'body-text':
-      default:
-        return 12;
-    }
-  };
+export const Spinner = ({purpose, value, fillColor, stopped, title = 'Loading…'}: Props) => {
+  const className = clsx(
+    'spinnerGlobal', // Global class for targeting spinners
+    styles.spinner,
+    stopped ? styles.stopped : null,
+    purpose === 'caption-text' && styles.captionText,
+    purpose === 'body-text' && styles.bodyText,
+  );
 
-  const padding = () => {
-    switch (purpose) {
-      case 'caption-text':
-        return 1;
-      case 'body-text':
-        return 2;
-      default:
-        return 0;
-    }
-  };
+  const style = fillColor ? ({'--spinner-fill-color': fillColor} as CSSProperties) : undefined;
 
   return (
-    <SpinnerWrapper $padding={padding()} title={title}>
-      <SlowSpinner size={size()} value={value} $fillColor={fillColor} $stopped={stopped} />
-    </SpinnerWrapper>
+    <div className={className} title={title} style={style}>
+      <BlueprintSpinner
+        className={styles.slowSpinner}
+        value={value}
+        size={SPINNER_SIZES[purpose]}
+      />
+    </div>
   );
 };
-
-export const SpinnerWrapper = styled.div<{$padding: number}>`
-  padding: ${({$padding}) => $padding}px;
-`;
-
-const SlowSpinner = styled(BlueprintSpinner)<{$fillColor: string; $stopped?: boolean}>`
-  .bp5-spinner-animation {
-    animation-duration: 0.8s;
-    ${(p) => (p.$stopped ? 'animation: none;' : '')}
-
-    path.bp5-spinner-track {
-      stroke: ${(p) => p.$fillColor};
-      stroke-opacity: 0.25;
-    }
-    path.bp5-spinner-head {
-      ${(p) =>
-        p.$stopped
-          ? `stroke-opacity: 0;
-             fill: ${p.$fillColor};
-             fill-opacity: 1;
-             transform: scale(44%);`
-          : `stroke: ${p.$fillColor};
-             stroke-opacity: 1;`}
-    }
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/StyledButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/StyledButton.tsx
@@ -1,8 +1,6 @@
 import styled from 'styled-components';
 
 import {Colors} from './Color';
-import {IconWrapper} from './Icon';
-import {SpinnerWrapper} from './Spinner';
 import {FontFamily} from './styles';
 
 interface StyledButtonProps {
@@ -73,34 +71,34 @@ export const StyledButton = styled.button<StyledButtonProps>`
     box-shadow: ${({$strokeColor}) => `${$strokeColor} inset 0px 0px 0px 1px`};
   }
 
-  ${SpinnerWrapper} {
+  .spinnerGlobal {
     align-self: center;
     display: block;
   }
 
-  ${IconWrapper} {
+  .iconGlobal {
     color: ${({$iconColor}) => $iconColor};
     background-color: ${({$iconColor}) => $iconColor};
     align-self: center;
     display: block;
   }
 
-  ${SpinnerWrapper}:first-child,
-  ${IconWrapper}:first-child {
+  .spinnerGlobal:first-child,
+  .iconGlobal:first-child {
     margin-left: -4px;
     margin-right: 4px;
   }
 
-  ${SpinnerWrapper}:last-child,
-  ${IconWrapper}:last-child {
+  .spinnerGlobal:last-child,
+  .iconGlobal:last-child {
     margin-right: -4px;
     margin-left: 4px;
   }
 
-  ${SpinnerWrapper}:first-child:last-child {
+  .spinnerGlobal:first-child:last-child {
     margin: 2px -4px;
   }
-  ${IconWrapper}:first-child:last-child {
+  .iconGlobal:first-child:last-child {
     margin: 2px -4px;
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Suggest.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Suggest.tsx
@@ -14,7 +14,7 @@ import styled, {createGlobalStyle} from 'styled-components';
 
 import {Box} from './Box';
 import {Colors} from './Color';
-import {Icon, IconName, IconWrapper} from './Icon';
+import {Icon, IconName} from './Icon';
 import {TextInputContainerStyles, TextInputStyles} from './TextInput';
 import {Container, Inner, Row} from './VirtualizedTable';
 
@@ -22,7 +22,7 @@ export const GlobalSuggestStyle = createGlobalStyle`
   .dagster-suggest-input.bp5-input-group {
     ${TextInputContainerStyles}
 
-    &:disabled ${IconWrapper}:first-child {
+    &:disabled .iconGlobal:first-child {
       background-color: ${Colors.accentGray()};
     }
 

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Tabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Tabs.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import styled, {css} from 'styled-components';
 
 import {Colors} from './Color';
-import {IconWrapper} from './Icon';
 import {FontFamily} from './styles';
 
 export interface TabStyleProps {
@@ -74,7 +73,7 @@ export const tabCSS = css<TabStyleProps>`
   ${({disabled}) =>
     disabled
       ? css`
-          & ${IconWrapper} {
+          & .iconGlobal {
             background-color: ${Colors.textDisabled()};
           }
         `

--- a/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled, {css} from 'styled-components';
 
 import {Colors} from './Color';
-import {Icon, IconName, IconWrapper} from './Icon';
+import {Icon, IconName} from './Icon';
 import {FontFamily} from './styles';
 
 interface Props extends Omit<React.ComponentPropsWithRef<'input'>, 'onChange'> {
@@ -64,7 +64,7 @@ export const TextInputContainerStyles = css`
 export const TextInputContainer = styled.div<{$disabled?: boolean}>`
   ${TextInputContainerStyles}
 
-  > ${IconWrapper}:first-child {
+  > .iconGlobal:first-child {
     position: absolute;
     left: 8px;
     top: 8px;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/css/Icon.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/css/Icon.module.css
@@ -1,0 +1,44 @@
+.icon {
+  --icon-color: var(--color-accent-primary);
+
+  flex-grow: 0;
+  flex-shrink: 0;
+  height: var(--icon-size);
+  object-fit: contain;
+  transition: transform 150ms linear;
+  width: var(--icon-size);
+}
+
+.size12 {
+  --icon-size: 12px;
+}
+
+.size16 {
+  --icon-size: 16px;
+}
+
+.size20 {
+  --icon-size: 20px;
+}
+
+.size24 {
+  --icon-size: 24px;
+}
+
+.size48 {
+  --icon-size: 48px;
+}
+
+.useOriginalColor {
+  background: var(--icon-image-path);
+  background-size: cover;
+  background-color: transparent;
+}
+
+.usePropColor {
+  background: var(--icon-color);
+  mask-image: var(--icon-image-path);
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
+}

--- a/js_modules/dagster-ui/packages/ui-components/src/components/css/Spinner.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/css/Spinner.module.css
@@ -1,0 +1,38 @@
+.spinner {
+  --spinner-fill-color: var(--color-accent-gray);
+  --spinner-padding: 0px;
+  padding: var(--spinner-padding);
+}
+
+.spinner.captionText {
+  --spinner-padding: 1px;
+}
+
+.spinner.bodyText {
+  --spinner-padding: 2px;
+}
+
+.spinner .slowSpinner :global(.bp5-spinner-animation) {
+  animation-duration: 0.8s;
+}
+
+.spinner.stopped .slowSpinner :global(.bp5-spinner-animation) {
+  animation: none;
+}
+
+.spinner .slowSpinner path:global(.bp5-spinner-track) {
+  stroke: var(--spinner-fill-color);
+  stroke-opacity: 0.25;
+}
+
+.spinner:not(.stopped) .slowSpinner path:global(.bp5-spinner-head) {
+  stroke: var(--spinner-fill-color);
+  stroke-opacity: 1;
+}
+
+.spinner.stopped .slowSpinner path:global(.bp5-spinner-head) {
+  stroke-opacity: 0;
+  fill: var(--spinner-fill-color);
+  fill-opacity: 1;
+  transform: scale(44%);
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNav.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Icon, IconWrapper} from '@dagster-io/ui-components';
+import {Box, Colors, Icon} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {NavLink} from 'react-router-dom';
 import {AppTopNavRightOfLogo} from 'shared/app/AppTopNav/AppTopNavRightOfLogo.oss';
@@ -168,15 +168,15 @@ const NavButton = styled.button`
   background: ${Colors.navBackground()};
   display: block;
 
-  ${IconWrapper} {
+  .iconGlobal {
     transition: background 100ms linear;
   }
 
-  :hover ${IconWrapper} {
+  :hover .iconGlobal {
     background: ${Colors.navTextHover()};
   }
 
-  :active ${IconWrapper} {
+  :active .iconGlobal {
     background: ${Colors.navTextHover()};
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/TopNavButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/TopNavButton.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, FontFamily, IconWrapper, UnstyledButton} from '@dagster-io/ui-components';
+import {Box, Colors, FontFamily, UnstyledButton} from '@dagster-io/ui-components';
 import {ReactNode} from 'react';
 import styled from 'styled-components';
 
@@ -20,12 +20,13 @@ export const TopNavButton = styled(UnstyledButton)`
     outline: ${Colors.focusRing()} auto 1px;
   }
 
-  ${IconWrapper} {
+  .iconGlobal {
     background-color: ${Colors.accentWhite()};
     transition: background-color 100ms linear;
   }
 
-  :focus ${IconWrapper}, :hover ${IconWrapper} {
+  :focus .iconGlobal,
+  :hover .iconGlobal {
     background-color: ${Colors.navTextHover()};
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AllIndividualEventsButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AllIndividualEventsButton.tsx
@@ -6,7 +6,6 @@ import {
   DialogFooter,
   Group,
   Icon,
-  IconWrapper,
   Mono,
   Table,
 } from '@dagster-io/ui-components';
@@ -388,7 +387,7 @@ const DisclosureTriangleButton = styled.button<{$open: boolean}>`
   background: transparent;
   outline: none;
 
-  ${IconWrapper} {
+  .iconGlobal {
     margin: -2px -5px;
     transform: ${({$open}) => ($open ? 'rotate(0deg)' : 'rotate(-90deg)')};
     opacity: 0.25;
@@ -397,7 +396,7 @@ const DisclosureTriangleButton = styled.button<{$open: boolean}>`
   :focus {
     outline: none;
 
-    ${IconWrapper} {
+    .iconGlobal {
       background: ${Colors.textDefault()};
       opacity: 0.5;
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationAssetsList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationAssetsList.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   Colors,
   Icon,
-  IconWrapper,
   NonIdealState,
   SpinnerWithText,
   Tag,
@@ -225,7 +224,7 @@ const ClickableRow = styled(Row)<{$open: boolean}>`
     outline: none;
   }
 
-  ${IconWrapper}[aria-label="arrow_drop_down"] {
+  .iconGlobal[aria-label='arrow_drop_down'] {
     transition: transform 100ms linear;
     ${({$open}) => ($open ? null : `transform: rotate(-90deg);`)}
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/GanttChart.tsx
@@ -6,7 +6,6 @@ import {
   Group,
   Icon,
   Spinner,
-  SpinnerWrapper,
   SplitPanelContainer,
   useViewport,
 } from '@dagster-io/ui-components';
@@ -813,7 +812,7 @@ const GanttChartContainer = styled.div`
       filter: brightness(115%);
     }
 
-    ${SpinnerWrapper} {
+    .spinnerGlobal {
       display: inline-block;
       vertical-align: text-bottom;
       padding-right: 4px;

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/OpTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/OpTags.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, FontFamily, IconWrapper} from '@dagster-io/ui-components';
+import {BaseIcon, Box, Colors, FontFamily} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -1446,6 +1446,7 @@ export const OpTags = React.memo(({tags, style, reduceColor, reduceText}: OpTags
         const known = KNOWN_TAGS[coerceToStandardLabel(tag.label) as KnownTagType];
         const blackAndWhite = known && 'blackAndWhite' in known && known.blackAndWhite;
         const text = known?.content || tag.label;
+        const knownIcon = known && 'icon' in known ? known : undefined;
 
         return (
           <Box
@@ -1458,17 +1459,15 @@ export const OpTags = React.memo(({tags, style, reduceColor, reduceText}: OpTags
               fontWeight: reduceColor ? 500 : 600,
             }}
           >
-            {known && 'icon' in known && (
-              <OpTagIconWrapper
-                role="img"
-                $size={16}
-                $img={extractIconSrc(known)}
-                $color={blackAndWhite ? Colors.accentPrimary() : null}
-                $rotation={null}
-                aria-label={tag.label}
+            {knownIcon ? (
+              <BaseIcon
+                size={16}
+                img={extractIconSrc(knownIcon)}
+                color={blackAndWhite ? Colors.accentPrimary() : undefined}
+                name={tag.label}
               />
-            )}
-            {known && 'icon' in known && reduceText ? undefined : text}
+            ) : null}
+            {knownIcon && reduceText ? undefined : text}
           </Box>
         );
       })}
@@ -1479,29 +1478,19 @@ export const OpTags = React.memo(({tags, style, reduceColor, reduceText}: OpTags
 export const TagIcon = React.memo(({label}: {label: string}) => {
   const known = KNOWN_TAGS[coerceToStandardLabel(label) as KnownTagType];
   const blackAndWhite = known && 'blackAndWhite' in known && known.blackAndWhite;
-  if (known && 'icon' in known) {
-    return (
-      <OpTagIconWrapper
-        role="img"
-        $size={16}
-        $img={extractIconSrc(known)}
-        $color={blackAndWhite ? Colors.accentPrimary() : null}
-        $rotation={null}
-        aria-label={label}
-      />
-    );
+  if (!known || !('icon' in known)) {
+    return null;
   }
-  return null;
-});
 
-const OpTagIconWrapper = styled(IconWrapper)`
-  mask-size: contain;
-  mask-repeat: no-repeat;
-  mask-position: center;
-  -webkit-mask-size: contain;
-  -webkit-mask-repeat: no-repeat;
-  -webkit-mask-position: center;
-`;
+  return (
+    <BaseIcon
+      size={16}
+      img={extractIconSrc(known)}
+      color={blackAndWhite ? Colors.accentPrimary() : undefined}
+      name={label}
+    />
+  );
+});
 
 const OpTagsContainer = styled.div`
   gap: 6px;

--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsIcon.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsIcon.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import {Colors, Icon, IconName, IconNames, IconWrapper} from '@dagster-io/ui-components';
+import {BaseIcon, Icon, IconName, IconNames, IconSize} from '@dagster-io/ui-components';
 
 import {KNOWN_TAGS, KnownTagType, extractIconSrc} from '../graph/OpTags';
 
@@ -9,27 +8,15 @@ export type InsightsIconType = IconName | IntegrationIconName;
 interface InsightsIconProps {
   name: InsightsIconType;
   color?: string;
-  size?: number;
+  size?: IconSize;
 }
 
 export const InsightsIcon = (props: InsightsIconProps) => {
-  const {name, color = Colors.accentPrimary(), size = 16} = props;
+  const {name, ...rest} = props;
   if (IconNames.includes(name as IconName)) {
-    return (
-      <Icon name={name as IconName} style={{marginLeft: 0}} color={color} size={size as any} />
-    );
-  } else {
-    const known = KNOWN_TAGS[props.name as IntegrationIconName];
-    return (
-      <IconWrapper
-        role="img"
-        $size={size}
-        $img={extractIconSrc(known)}
-        $color={color}
-        $rotation={null}
-        style={{marginLeft: 0}}
-        aria-label={props.name}
-      />
-    );
+    return <Icon {...rest} name={name as IconName} />;
   }
+
+  const known = KNOWN_TAGS[props.name as IntegrationIconName];
+  return <BaseIcon {...rest} img={extractIconSrc(known)} name={name} />;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadTabs.tsx
@@ -1,4 +1,4 @@
-import {Box, ButtonLink, Colors, Icon, IconWrapper} from '@dagster-io/ui-components';
+import {Box, ButtonLink, Colors, Icon} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled, {css} from 'styled-components';
 
@@ -241,11 +241,11 @@ const RemoveButton = styled.button`
   cursor: pointer;
   padding: 0;
 
-  ${IconWrapper} {
+  .iconGlobal {
     transition: background-color 100ms;
   }
 
-  &:hover ${IconWrapper} {
+  &:hover .iconGlobal {
     background-color: ${Colors.accentPrimaryHover()};
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/RepoNavItem.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/RepoNavItem.tsx
@@ -7,7 +7,6 @@ import {
   DialogHeader,
   Group,
   Icon,
-  IconWrapper,
   Spinner,
   Tooltip,
 } from '@dagster-io/ui-components';
@@ -204,11 +203,11 @@ const ReloadButton = styled.button`
     outline: none;
   }
 
-  & ${IconWrapper} {
+  & .iconGlobal {
     transition: color 0.1s ease-in-out;
   }
 
-  :hover ${IconWrapper} {
+  :hover .iconGlobal {
     color: ${Colors.accentBlue()};
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/RepoSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/RepoSelector.tsx
@@ -4,7 +4,6 @@ import {
   Checkbox,
   Colors,
   Icon,
-  IconWrapper,
   Spinner,
   Table,
   Tooltip,
@@ -192,21 +191,21 @@ const ReloadButtonInner = styled.button`
     cursor: default;
   }
 
-  :disabled ${IconWrapper} {
+  :disabled .iconGlobal {
     background-color: ${Colors.textDisabled()};
     transition: background-color 100ms;
   }
 
-  ${IconWrapper} {
+  .iconGlobal {
     background-color: ${Colors.textLight()};
     transition: background-color 100ms;
   }
 
-  :hover:not(:disabled) ${IconWrapper} {
+  :hover:not(:disabled) .iconGlobal {
     background-color: ${Colors.textLighter()};
   }
 
-  :focus ${IconWrapper} {
+  :focus .iconGlobal {
     background-color: ${Colors.linkDefault()};
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/RepositoryLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/RepositoryLink.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  Colors,
-  Icon,
-  IconWrapper,
-  MiddleTruncate,
-  Spinner,
-  Tooltip,
-} from '@dagster-io/ui-components';
+import {Box, Colors, Icon, MiddleTruncate, Spinner, Tooltip} from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -103,12 +95,12 @@ const StyledButton = styled.button`
     outline: none;
   }
 
-  & ${IconWrapper} {
+  & .iconGlobal {
     display: block;
     transition: color 100ms linear;
   }
 
-  :hover ${IconWrapper} {
+  :hover .iconGlobal {
     color: ${Colors.accentBlue()};
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOpHelpers.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarOpHelpers.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import {Text} from '@blueprintjs/core';
-import {Code, Colors, FontFamily, Group, Icon, IconWrapper} from '@dagster-io/ui-components';
+import {Code, Colors, FontFamily, Group, Icon} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
@@ -115,7 +115,7 @@ export const ResourceContainer = styled.div`
   & h4 {
     margin-top: 0;
   }
-  & ${IconWrapper} {
+  & .iconGlobal {
     margin-right: 8px;
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarResourcesSection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/SidebarResourcesSection.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, ConfigTypeSchema, Icon, IconWrapper} from '@dagster-io/ui-components';
+import {Box, Colors, ConfigTypeSchema, Icon} from '@dagster-io/ui-components';
 import styled from 'styled-components';
 
 import {Description} from './Description';
@@ -91,7 +91,7 @@ const ContextResourceContainer = styled.div`
   & h4 {
     margin-top: -2px;
   }
-  & ${IconWrapper} {
+  & .iconGlobal {
     margin-right: 8px;
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/FilterDropdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/FilterDropdown.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   Colors,
   Icon,
-  IconWrapper,
   Menu,
   MenuItem,
   Popover,
@@ -381,7 +380,7 @@ export const FilterDropdownButton = React.memo(({filters, label}: FilterDropdown
 });
 
 const DropdownMenuContainer = styled.div`
-  ${IconWrapper} {
+  .iconGlobal {
     margin-left: 0 !important;
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/ClearButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/ClearButton.tsx
@@ -1,4 +1,4 @@
-import {Colors, IconWrapper} from '@dagster-io/ui-components';
+import {Colors} from '@dagster-io/ui-components';
 import styled from 'styled-components';
 
 export const ClearButton = styled.button`
@@ -8,16 +8,17 @@ export const ClearButton = styled.button`
   margin: 0 -2px 0 0;
   padding: 2px;
 
-  ${IconWrapper} {
+  .iconGlobal {
     background-color: ${Colors.accentGray()};
     transition: background-color 100ms linear;
   }
 
-  :hover ${IconWrapper}, :focus ${IconWrapper} {
+  :hover .iconGlobal,
+  :focus .iconGlobal {
     background-color: ${Colors.accentGrayHover()};
   }
 
-  :active ${IconWrapper} {
+  :active .iconGlobal {
     background-color: ${Colors.textDefault()};
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/MenuLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/MenuLink.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Colors,
-  CommonMenuItemProps,
-  IconWrapper,
-  MenuItem,
-  iconWithColor,
-} from '@dagster-io/ui-components';
+import {Box, Colors, CommonMenuItemProps, MenuItem, iconWithColor} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link, LinkProps} from 'react-router-dom';
 import styled from 'styled-components';
@@ -51,11 +44,11 @@ const StyledMenuLink = styled(Link)`
    * Use margin instead of align-items: center because the contents of the menu item may wrap 
    * in unusual circumstances.
    */
-  ${IconWrapper} {
+  .iconGlobal {
     margin-top: 2px;
   }
 
-  ${IconWrapper}:first-child {
+  .iconGlobal:first-child {
     margin-left: -4px;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/SectionedLeftNav.tsx
@@ -1,12 +1,4 @@
-import {
-  BaseTag,
-  Box,
-  Colors,
-  Icon,
-  IconWrapper,
-  MiddleTruncate,
-  StyledTag,
-} from '@dagster-io/ui-components';
+import {BaseTag, Box, Colors, Icon, MiddleTruncate, StyledTag} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 import {useRouteMatch} from 'react-router-dom';
@@ -534,12 +526,12 @@ const SectionHeader = styled.button<{
     outline: none;
   }
 
-  ${IconWrapper}[aria-label="arrow_drop_down"] {
+  .iconGlobal[aria-label="arrow_drop_down"] {
     transition: transform 100ms linear;
     ${({$open}) => ($open ? null : `transform: rotate(-90deg);`)}
   }
 
-  :disabled ${IconWrapper} {
+  :disabled .iconGlobal {
     background-color: ${Colors.textDisabled()};
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/SideNavItem.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/SideNavItem.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, IconWrapper, Tooltip, UnstyledButton} from '@dagster-io/ui-components';
+import {Box, Colors, Tooltip, UnstyledButton} from '@dagster-io/ui-components';
 import {Link} from 'react-router-dom';
 import styled, {css} from 'styled-components';
 
@@ -91,7 +91,7 @@ const sharedSideNavItemStyle = css<{$active: boolean}>`
   }
 
   .iconAndLabel {
-    ${IconWrapper} {
+    .iconGlobal {
       background-color: ${({$active}) => ($active ? Colors.textBlue() : Colors.textDefault())};
     }
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/TableSectionHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/TableSectionHeader.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Icon, IconWrapper} from '@dagster-io/ui-components';
+import {Box, Colors, Icon} from '@dagster-io/ui-components';
 import styled from 'styled-components';
 
 export const SECTION_HEADER_HEIGHT = 32;
@@ -54,7 +54,7 @@ const SectionHeaderButton = styled.button<{$open: boolean}>`
     background-color: ${Colors.backgroundLightHover()};
   }
 
-  ${IconWrapper}[aria-label="arrow_drop_down"] {
+  .iconGlobal[aria-label='arrow_drop_down'] {
     transition: transform 100ms linear;
     ${({$open}) => ($open ? null : `transform: rotate(-90deg);`)}
   }


### PR DESCRIPTION
## Summary & Motivation

Corresponding internal PR is https://github.com/dagster-io/internal/pull/19305.

Refactor Icon and Spinner to use CSS modules.

- Replace `IconWrapper` with `BaseIcon`, which can be used for custom icon behavior.
- Use `globalIcon` and `globalSpinner` CSS classes for targeting by other use cases.

## How I Tested These Changes

TS, lint, jest. View app, verify that icons and spinners look correct. View Storybook for ui-core and ui-components, verify same.