### PR TITLE
[docs] Port dagster iceberg docs from community integrations

### DIFF
--- a/docs/docs/integrations/libraries/iceberg/features.md
+++ b/docs/docs/integrations/libraries/iceberg/features.md
@@ -6,47 +6,46 @@ sidebar_position: 200
 
 <p>{frontMatter.description}</p>
 
-## Using Spark
+# Features
 
-Spark is currently the most feature-rich compute engine for Iceberg operations.
+## Supported catalog backends
 
-### Configuration
+`dagster-iceberg` supports most catalog backends that are available through `pyiceberg`. See overview and configuration options [here](https://py.iceberg.apache.org/configuration/#catalogs).
+
+## Configuration
+
+`dagster-iceberg` supports setting configuration values using a `.pyiceberg.yaml` configuration file and environment variables. For more information, see the [PyIceberg documentation](https://py.iceberg.apache.org/configuration/#setting-configuration-values).
+
+You may also pass your catalog configuration through use of the `IcebergCatalogConfig` object, e.g:
+
+<CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/configuring_pyiceberg.py" language="python" />
+
+### Spark
 
 Spark configuration can be set directly on the <PyObject section="libraries" object="io_manager.spark.SparkIcebergIOManager" module="dagster_iceberg" /> or in the `spark-defaults.conf` file. Properties set directly on the I/O manager take precedence over those set in the `spark-defaults.conf` file. To set properties directly, pass a dictionary of configurations to set in the `spark_config` argument of the I/O manager:
 
 <CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/configuring_spark.py" language="python" />
 
-## Using PyIceberg
+## Implemented engines
 
-The following engines are implemented using PyIceberg:
+The following engines are currently implemented.
 
-- [Apache Arrow](https://arrow.apache.org/docs/python/index.html)
-- [Daft](https://www.getdaft.io)
-- [pandas](https://pandas.pydata.org)
-- [Polars](https://pola.rs)
+- [arrow](https://arrow.apache.org/docs/python/index.html)
+- [daft](https://www.getdaft.io/)
+- [pandas](https://pandas.pydata.org/)
+- [polars](https://pola.rs/)
 
-### Supported catalogs
+## PyIceberg Features
 
-`dagster-iceberg` supports [all catalogs available through PyIceberg](https://py.iceberg.apache.org/configuration/#catalogs).
+The table below shows which PyIceberg features are currently available.
 
-### Configuration
-
-`dagster-iceberg` supports setting configuration values using a `.pyiceberg.yaml` configuration file and environment variables. For more information, see the [PyIceberg documentation](https://py.iceberg.apache.org/configuration/#setting-configuration-values).
-
-You can also pass your catalog configuration using <PyObject section="libraries" object="config.IcebergCatalogConfig" module="dagster_iceberg" />:
-
-<CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/configuring_pyiceberg.py" language="python" />
-
-### PyIceberg features
-
-The table below indicates PyIceberg features are currently available in `dagster-iceberg`:
-
-| Feature                  | Supported | Link                                                                                                  | Comment                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ------------------------ | --------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Add existing files       | ❌        | https://py.iceberg.apache.org/api/#add-files                                                          | Useful for existing partitions that users don't want to re-materialize/re-compute.                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| Schema evolution         | ✅        | https://py.iceberg.apache.org/api/#schema-evolution                                                   | More complicated than e.g. delta lake since updates require diffing input table with existing Iceberg table. This is implemented by checking the schema of incoming data, dropping any columns that no longer exist in the data schema, and then using the `union_by_name()` method to merge the current schema with the table schema. Current implementation has a chance of creating a race condition when e.g. partition A tries to write to a table that has not yet processed a schema update. Should be covered by retrying when writing. |
-| Sort order               | ❌        | https://shorturl.at/TycZN                                                                             | Currently limited support in PyIceberg. Sort ordering is supported when creating a table from an Iceberg schema (one must pass the source_id which can be inferred from a PyArrow schema but this is shaky). However, we cannot simply update a sort ordering like a partition or schema spec.                                                                                                                                                                                                                                                  |
-| PyIceberg commit retries | ✅        | https://github.com/apache/iceberg-python/pull/330 https://github.com/apache/iceberg-python/issues/269 | PR to add this to PyIceberg is open. Will probably be merged for an upcoming release. Added a custom retry function using Tenacity for the time being.                                                                                                                                                                                                                                                                                                                                                                                          |
-| Partition evolution      | ✅        | https://py.iceberg.apache.org/api/#partition-evolution                                                | Create, Update, Delete partitions by updating the Dagster partitions definition.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| Table properties         | ✅        | https://py.iceberg.apache.org/api/#table-properties                                                   | Added as metadata on an asset. NB: config options are not checked explicitly because users can add any key-value pair to a table. Available properties [here](https://py.iceberg.apache.org/configuration/#tables).                                                                                                                                                                                                                                                                                                                             |
-| Snapshot properties      | ✅        | https://py.iceberg.apache.org/api/#snapshot-properties                                                | Useful for correlating Dagster runs to snapshots by adding tags to snapshot. Not configurable by end-user.                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Feature | Supported | Link | Comment |
+|---|---|---|---|
+| Add existing files | ❌ | https://py.iceberg.apache.org/api/#add-files | Useful for existing partitions that users don't want to re-materialize/re-compute. |
+| Schema evolution | ✅ | https://py.iceberg.apache.org/api/#schema-evolution | More complicated than e.g. delta lake since updates require diffing input table with existing Iceberg table. This is implemented by checking the schema of incoming data, dropping any columns that no longer exist in the data schema, and then using the `union_by_name()` method to merge the current schema with the table schema. Current implementation has a chance of creating a race condition when e.g. partition A tries to write to a table that has not yet processed a schema update. Should be covered by retrying when writing. |
+| Sort order | ❌ | https://shorturl.at/TycZN | Currently limited support in PyIceberg. Sort ordering is supported when creating a table from an Iceberg schema (one must pass the source_id which can be inferred from a PyArrow schema but this is shaky). However, we cannot simply update a sort ordering like a partition or schema spec. |
+| PyIceberg commit retries | ✅ | https://github.com/apache/iceberg-python/pull/330 https://github.com/apache/iceberg-python/issues/269 | PR to add this to PyIceberg is open. Will probably be merged for an upcoming release. Added a custom retry function using Tenacity for the time being. |
+| Partition evolution | ✅ | https://py.iceberg.apache.org/api/#partition-evolution | Create, Update, Delete partitions by updating the Dagster partitions definition. |
+| Table properties | ✅ | https://py.iceberg.apache.org/api/#table-properties | Added as metadata on an asset. NB: config options are not checked explicitly because users can add any key-value pair to a table. Available properties [here](https://py.iceberg.apache.org/configuration/#tables). |
+| Snapshot properties | ✅ | https://py.iceberg.apache.org/api/#snapshot-properties | Useful for correlating Dagster runs to snapshots by adding tags to snapshot. Not configurable by end-user. |
+| Upsert | ✅ | https://py.iceberg.apache.org/api/#upsert | Update existing rows and insert new rows in a single operation. Configure via `write_mode: "upsert"` and `upsert_options` in asset metadata. |

--- a/docs/docs/integrations/libraries/iceberg/features.md
+++ b/docs/docs/integrations/libraries/iceberg/features.md
@@ -6,8 +6,6 @@ sidebar_position: 200
 
 <p>{frontMatter.description}</p>
 
-# Features
-
 ## Supported catalog backends
 
 `dagster-iceberg` supports most catalog backends that are available through `pyiceberg`. See overview and configuration options [here](https://py.iceberg.apache.org/configuration/#catalogs).

--- a/docs/docs/integrations/libraries/iceberg/usage.md
+++ b/docs/docs/integrations/libraries/iceberg/usage.md
@@ -86,6 +86,7 @@ For partitioning to function correctly, the partition dimension must correspond 
 </Tabs>
 
 ### Partition field naming
+
 Partition fields are named using the column name that they correspond to, with a configurable prefix applied (defaults to `"part-"`). This prefixing is done in order to comply with changes introduced in pyiceberg 0.10.0 which require that partition field names do not exactly match any existing column names.
 
 For example, an asset that is partitioned using hourly partitions on a column `ingestion_time` will be assigned a corresponding partition field name of `part-ingestion_time`.
@@ -178,6 +179,7 @@ Use asset metadata to set table properties:
 <CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/setting_table_properties.py" language="python" />
 
 ## Write modes
+
 The Iceberg I/O manager supports three write modes: 
 - `overwrite` (**default**):  every asset materialization will overwrite the backing Iceberg table. Partitioned assets only overwrite partitions of the Iceberg table that were part of the asset materialization.
 - `append`: results returned from each asset materialization will be inserted into the backing Iceberg table, respecting partitions when appropriate. **Not currently supported in the Spark I/O manager**.
@@ -188,7 +190,9 @@ The write mode is set using the `write_mode` metadata key, which can be set usin
 ### Setting write mode in definition metadata
 
 <CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/write_mode_append.py" language="python" />
+
 ### Overriding definition metadata write mode with output metadata
+
 Setting write mode in output metadata overrides any write mode settings in the asset definition metadata:
 
 <CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/write_mode_override.py" language="python" />

--- a/docs/docs/integrations/libraries/iceberg/usage.md
+++ b/docs/docs/integrations/libraries/iceberg/usage.md
@@ -85,6 +85,17 @@ For partitioning to function correctly, the partition dimension must correspond 
   </TabItem>
 </Tabs>
 
+### Partition field naming
+Partition fields are named using the column name that they correspond to, with a configurable prefix applied (defaults to `"part-"`). This prefixing is done in order to comply with changes introduced in pyiceberg 0.10.0 which require that partition field names do not exactly match any existing column names.
+
+For example, an asset that is partitioned using hourly partitions on a column `ingestion_time` will be assigned a corresponding partition field name of `part-ingestion_time`.
+
+The user may configure the prefix in the IO manager configuration via the `IcebergCatalogConfig`:
+
+<CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/partition_field_naming_config.py" language="python" />
+
+Users may also configure the prefix at launch time via run config if the IO manager is set up using `configure_at_launch()` (see the [resource configuration docs](/guides/build/external-resources/configuring-resources#configuring-resources-at-launch-time) for more details on this pattern).
+
 ## Storing tables in multiple schemas
 
 You may want to have different assets stored in different Iceberg schemas. The Iceberg I/O manager allows you to specify the schema in several ways.
@@ -119,7 +130,36 @@ In the above example:
 
 ## Using different compute engines to read from and write to Iceberg
 
-`dagster-iceberg` supports several compute engines out-of-the-box. You can [find examples of how to use each engine in the API docs](/api/libraries/dagster-iceberg#io-managers).
+`dagster-iceberg` supports several compute engines out-of-the-box. You can [find detailed examples of how to use each engine in the API docs](/api/libraries/dagster-iceberg#io-managers).
+
+<Tabs>
+  <TabItem value="pyarrow" label="PyArrow Tables">
+    The `Iceberg` package relies heavily on Apache Arrow for efficient data transfer, so PyArrow is natively supported.
+
+    You can use `PyArrowIcebergIOManager` to read and write iceberg tables:
+
+    <CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/io_manager_pyarrow.py" language="python" />
+
+  </TabItem>
+  <TabItem value="pandas" label="Pandas DataFrames">
+     You can use `PandasIcebergIOManager` to read and write iceberg tables using Pandas:
+
+    <CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/io_manager_pandas.py" language="python" />
+
+  </TabItem>
+  <TabItem value="polars" label="Polars DataFrames">
+     You can use the `PolarsIcebergIOManager` to read and write iceberg tables using Polars using a full lazily optimized query engine:
+
+    <CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/io_manager_polars.py" language="python" />
+
+  </TabItem>
+  <TabItem value="daft" label="Daft DataFrames">
+     You can use the `DaftIcebergIOManager` to read and write iceberg tables using Daft using a full lazily optimized query engine:
+
+    <CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/io_manager_daft.py" language="python" />
+
+  </TabItem>
+</Tabs>
 
 ## Executing custom SQL commands
 
@@ -136,6 +176,53 @@ PyIceberg tables support table properties to configure table behavior. You can f
 Use asset metadata to set table properties:
 
 <CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/setting_table_properties.py" language="python" />
+
+## Write modes
+The Iceberg I/O manager supports three write modes: 
+- `overwrite` (**default**):  every asset materialization will overwrite the backing Iceberg table. Partitioned assets only overwrite partitions of the Iceberg table that were part of the asset materialization.
+- `append`: results returned from each asset materialization will be inserted into the backing Iceberg table, respecting partitions when appropriate. **Not currently supported in the Spark I/O manager**.
+- `upsert`: asset materialization results will be merged into the backing Iceberg table using [pyiceberg's native implementation](https://py.iceberg.apache.org/api/#upsert), updating any existing records that match on a configurable join key, and inserting records that do not exist in the target table. Insert and update actions can be turned on or off via configuration; for example, you may only want to insert any new records but not update any matching records, or vice versa (see [Using upsert mode](#using-upsert-mode) for usage details). **Not currently supported in the Spark I/O manager**.
+
+The write mode is set using the `write_mode` metadata key, which can be set using asset definition at deployment time, or at runtime within the asset definition body by using output metadata (see the examples in the next section).
+
+### Setting write mode in definition metadata
+
+<CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/write_mode_append.py" language="python" />
+### Overriding definition metadata write mode with output metadata
+Setting write mode in output metadata overrides any write mode settings in the asset definition metadata:
+
+<CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/write_mode_override.py" language="python" />
+
+### Using upsert mode
+
+**Note:** only supported in non-spark IO managers
+
+The Iceberg I/O manager supports upsert operations, which allow you to update existing rows and insert new rows in a single operation. This is useful for maintaining slowly changing dimensions or incrementally updating tables.
+
+#### Options
+
+Upsert options can be set at deployment time via asset definition metadata, or dynamically at runtime via output metadata. Upsert options set at runtime via `context.add_output_metadata()` take precedence over those set in definition metadata.
+
+**Required**:
+  - `join_cols`: **list[str]** - list of columns that make up the join key for the upsert operation
+
+**Optional**:
+  - `when_matched_update_all`: **bool** - Whether to update rows in the target table that join with the dataframe being upserted (default True)
+  - `when_not_matched_insert_all`: **bool** - Whether to insert all rows from the upsert dataframe that do not join with the target table (default True)
+
+Any `upsert_options` set when `write_mode` is not set to `upsert` will be ignored, with a debug log message indicating the options were ignored. This allows a user to set the `write_mode` to `upsert` with `upsert_options` in the asset definition metadata while still being able to override the write mode in the output metadata.
+
+To use upsert mode, set the `write_mode` to `"upsert"` and provide `upsert_options` in the asset or output metadata:
+
+<CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/upsert_mode_basic.py" language="python" />
+
+Upsert options set in definition metadata can be overridden at runtime using output metadata:
+
+<CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/upsert_mode_dynamic.py" language="python" />
+
+The `UpsertOptions` `BaseModel` subclass can be used to represent upsert options metadata to provide deployment-time type validation:
+
+<CodeExample path="docs_snippets/docs_snippets/integrations/iceberg/upsert_mode_typed.py" language="python" />
 
 ## Allowing updates to schema and partitions
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6582,17 +6582,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702":
-  version: 1.0.30001705
-  resolution: "caniuse-lite@npm:1.0.30001705"
-  checksum: 10c0/f135a9075e36cc28a66a8f37145dca2bdc45ea18fd9fae2569e781e0f7156962d4fcac374640aa6421a70c6e8d23587bf9386f5561a1fe81bbbf36055b807243
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001726":
-  version: 1.0.30001727
-  resolution: "caniuse-lite@npm:1.0.30001727"
-  checksum: 10c0/f0a441c05d8925d728c2d02ce23b001935f52183a3bf669556f302568fe258d1657940c7ac0b998f92bc41383e185b390279a7d779e6d96a2b47881f56400221
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001726":
+  version: 1.0.30001756
+  resolution: "caniuse-lite@npm:1.0.30001756"
+  checksum: 10c0/863df07bd8d5139371ce7d4e582f03fef38141726282dcd532421bbd95ea298c7f953a8e1a9790db89ca1816bd8ce3cce638a66361b769dd1f2dc8d4c721d546
   languageName: node
   linkType: hard
 

--- a/examples/docs_snippets/docs_snippets/integrations/iceberg/io_manager_daft.py
+++ b/examples/docs_snippets/docs_snippets/integrations/iceberg/io_manager_daft.py
@@ -1,0 +1,40 @@
+import daft as da
+import pandas as pd
+from dagster import Definitions, asset
+
+from dagster_iceberg.config import IcebergCatalogConfig
+from dagster_iceberg.io_manager.daft import DaftIcebergIOManager
+
+# Replace with your actual catalog and warehouse paths, or use environment variables to set these values at runtime.
+CATALOG_URI = "sqlite:////path/to/your/catalog.db"
+CATALOG_WAREHOUSE = "file:///path/to/your/warehouse"
+
+
+resources = {
+    "io_manager": DaftIcebergIOManager(
+        name="test",
+        config=IcebergCatalogConfig(
+            properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}
+        ),
+        namespace="dagster",
+    )
+}
+
+
+@asset
+def iris_dataset() -> da.DataFrame:
+    return da.from_pandas(
+        pd.read_csv(
+            "https://docs.dagster.io/assets/iris.csv",
+            names=[
+                "sepal_length_cm",
+                "sepal_width_cm",
+                "petal_length_cm",
+                "petal_width_cm",
+                "species",
+            ],
+        )
+    )
+
+
+defs = Definitions(assets=[iris_dataset], resources=resources)

--- a/examples/docs_snippets/docs_snippets/integrations/iceberg/io_manager_pandas.py
+++ b/examples/docs_snippets/docs_snippets/integrations/iceberg/io_manager_pandas.py
@@ -1,0 +1,38 @@
+import pandas as pd
+from dagster import Definitions, asset
+
+from dagster_iceberg.config import IcebergCatalogConfig
+from dagster_iceberg.io_manager.pandas import PandasIcebergIOManager
+
+CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
+CATALOG_WAREHOUSE = (
+    "file:///home/vscode/workspace/.tmp/examples/select_columns/warehouse"
+)
+
+
+resources = {
+    "io_manager": PandasIcebergIOManager(
+        name="test",
+        config=IcebergCatalogConfig(
+            properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}
+        ),
+        namespace="dagster",
+    )
+}
+
+
+@asset
+def iris_dataset() -> pd.DataFrame:
+    return pd.read_csv(
+        "https://docs.dagster.io/assets/iris.csv",
+        names=[
+            "sepal_length_cm",
+            "sepal_width_cm",
+            "petal_length_cm",
+            "petal_width_cm",
+            "species",
+        ],
+    )
+
+
+defs = Definitions(assets=[iris_dataset], resources=resources)

--- a/examples/docs_snippets/docs_snippets/integrations/iceberg/io_manager_polars.py
+++ b/examples/docs_snippets/docs_snippets/integrations/iceberg/io_manager_polars.py
@@ -1,0 +1,41 @@
+import pandas as pd
+import polars as pl
+from dagster import Definitions, asset
+
+from dagster_iceberg.config import IcebergCatalogConfig
+from dagster_iceberg.io_manager.polars import PolarsIcebergIOManager
+
+CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
+CATALOG_WAREHOUSE = (
+    "file:///home/vscode/workspace/.tmp/examples/select_columns/warehouse"
+)
+
+
+resources = {
+    "io_manager": PolarsIcebergIOManager(
+        name="test",
+        config=IcebergCatalogConfig(
+            properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}
+        ),
+        namespace="dagster",
+    )
+}
+
+
+@asset
+def iris_dataset() -> pl.DataFrame:
+    return pl.from_pandas(
+        pd.read_csv(
+            "https://docs.dagster.io/assets/iris.csv",
+            names=[
+                "sepal_length_cm",
+                "sepal_width_cm",
+                "petal_length_cm",
+                "petal_width_cm",
+                "species",
+            ],
+        )
+    )
+
+
+defs = Definitions(assets=[iris_dataset], resources=resources)

--- a/examples/docs_snippets/docs_snippets/integrations/iceberg/io_manager_pyarrow.py
+++ b/examples/docs_snippets/docs_snippets/integrations/iceberg/io_manager_pyarrow.py
@@ -1,0 +1,41 @@
+import pandas as pd
+import pyarrow as pa
+from dagster import Definitions, asset
+
+from dagster_iceberg.config import IcebergCatalogConfig
+from dagster_iceberg.io_manager.arrow import PyArrowIcebergIOManager
+
+CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/select_columns/catalog.db"
+CATALOG_WAREHOUSE = (
+    "file:///home/vscode/workspace/.tmp/examples/select_columns/warehouse"
+)
+
+
+resources = {
+    "io_manager": PyArrowIcebergIOManager(
+        name="test",
+        config=IcebergCatalogConfig(
+            properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE}
+        ),
+        namespace="dagster",
+    )
+}
+
+
+@asset
+def iris_dataset() -> pa.Table:
+    return pa.Table.from_pandas(
+        pd.read_csv(
+            "https://docs.dagster.io/assets/iris.csv",
+            names=[
+                "sepal_length_cm",
+                "sepal_width_cm",
+                "petal_length_cm",
+                "petal_width_cm",
+                "species",
+            ],
+        )
+    )
+
+
+defs = Definitions(assets=[iris_dataset], resources=resources)

--- a/examples/docs_snippets/docs_snippets/integrations/iceberg/partition_field_naming_config.py
+++ b/examples/docs_snippets/docs_snippets/integrations/iceberg/partition_field_naming_config.py
@@ -1,0 +1,18 @@
+from dagster import Definitions
+from dagster_iceberg.config import IcebergCatalogConfig
+from dagster_iceberg.io_manager.pandas import PandasIcebergIOManager
+
+CATALOG_URI = "sqlite:////home/vscode/workspace/.tmp/examples/catalog.db"
+CATALOG_WAREHOUSE = "file:///home/vscode/workspace/.tmp/examples/warehouse"
+
+resources = {
+    "io_manager": PandasIcebergIOManager(
+        name="test",
+        config=IcebergCatalogConfig(
+            properties={"uri": CATALOG_URI, "warehouse": CATALOG_WAREHOUSE},
+            partition_field_name_prefix="custom-prefix"
+        ),
+        namespace="dagster",
+    )
+}
+defs = Definitions(resources=resources, assets=[...])

--- a/examples/docs_snippets/docs_snippets/integrations/iceberg/upsert_mode_basic.py
+++ b/examples/docs_snippets/docs_snippets/integrations/iceberg/upsert_mode_basic.py
@@ -1,0 +1,24 @@
+import pyarrow as pa
+from dagster import AssetExecutionContext, asset
+
+
+@asset(
+    metadata={
+        "write_mode": "upsert",
+        "upsert_options": {
+            "join_cols": ["id"],  # Columns to join on for matching
+            "when_matched_update_all": True,  # Update all columns when matched
+            "when_not_matched_insert_all": True,  # Insert all columns when not matched
+        },
+    }
+)
+def user_profiles(context: AssetExecutionContext) -> pa.Table:
+    # Returns a table with user profiles
+    # Rows with matching 'id' will be updated
+    # Rows with new 'id' values will be inserted
+    return pa.table({
+        "id": [1, 2, 3],
+        "name": ["Alice", "Bob", "Charlie"],
+        "updated_at": ["2024-01-01", "2024-01-02", "2024-01-03"],
+    })
+

--- a/examples/docs_snippets/docs_snippets/integrations/iceberg/upsert_mode_dynamic.py
+++ b/examples/docs_snippets/docs_snippets/integrations/iceberg/upsert_mode_dynamic.py
@@ -1,0 +1,31 @@
+import pyarrow as pa
+from dagster import AssetExecutionContext, asset
+
+
+@asset(
+    metadata={
+        "write_mode": "upsert",
+        "upsert_options": {
+            "join_cols": ["id"],
+            "when_matched_update_all": True,
+            "when_not_matched_insert_all": True,
+        },
+    }
+)
+def user_profiles_dynamic(context: AssetExecutionContext) -> pa.Table:
+    # Override upsert options at runtime based on business logic
+    if context.run.tags.get("upsert_join_keys") == "id_and_timestamp":
+        context.add_output_metadata({
+            "upsert_options": {
+                "join_cols": ["id", "timestamp"],  # Join on multiple columns
+                "when_matched_update_all": False,
+                "when_not_matched_insert_all": False,
+            }
+        })
+
+    return pa.table({
+        "id": [1, 2, 3],
+        "timestamp": ["2024-01-01", "2024-01-01", "2024-01-01"],
+        "name": ["Alice", "Bob", "Charlie"],
+    })
+

--- a/examples/docs_snippets/docs_snippets/integrations/iceberg/upsert_mode_typed.py
+++ b/examples/docs_snippets/docs_snippets/integrations/iceberg/upsert_mode_typed.py
@@ -1,0 +1,29 @@
+import pyarrow as pa
+from dagster import AssetExecutionContext, asset
+from dagster_iceberg.config import UpsertOptions
+
+
+@asset(
+    metadata={
+        "write_mode": "upsert",
+        "upsert_options": UpsertOptions(
+            join_cols=["id", "timestamp"],
+            when_matched_update_all=True,
+            when_not_matched_insert_all=True,
+        ),
+    }
+)
+def my_table_typed_upsert(context: AssetExecutionContext):
+    context.add_output_metadata({
+        "upsert_options": UpsertOptions(
+            join_cols=["id", "timestamp"],
+            when_matched_update_all=True,
+            when_not_matched_insert_all=False,
+        )
+    })
+    return pa.table({
+        "id": [1, 2, 3],
+        "timestamp": ["2024-01-01", "2024-01-01", "2024-01-01"],
+        "name": ["Alice", "Bob", "Charlie"],
+    })
+

--- a/examples/docs_snippets/docs_snippets/integrations/iceberg/write_mode_append.py
+++ b/examples/docs_snippets/docs_snippets/integrations/iceberg/write_mode_append.py
@@ -1,0 +1,12 @@
+import pyarrow as pa
+from dagster import AssetExecutionContext, asset
+
+
+@asset(metadata={"write_mode": "append"})
+def user_profiles(context: AssetExecutionContext) -> pa.Table:
+    return pa.table({
+        "id": [1, 2, 3],
+        "name": ["Alice", "Bob", "Charlie"],
+        "updated_at": ["2024-01-01", "2024-01-02", "2024-01-03"],
+    })
+

--- a/examples/docs_snippets/docs_snippets/integrations/iceberg/write_mode_override.py
+++ b/examples/docs_snippets/docs_snippets/integrations/iceberg/write_mode_override.py
@@ -1,0 +1,13 @@
+import pyarrow as pa
+from dagster import AssetExecutionContext, asset
+
+
+@asset(metadata={"write_mode": "overwrite"})
+def user_profiles(context: AssetExecutionContext) -> pa.Table:
+    context.add_output_metadata({"write_mode": "append"})
+    return pa.table({
+        "id": [1, 2, 3],
+        "name": ["Alice", "Bob", "Charlie"],
+        "updated_at": ["2024-01-01", "2024-01-02", "2024-01-03"],
+    })
+


### PR DESCRIPTION
## Summary & Motivation
The current dagster-iceberg docs are hosted on a github.io page owned by a contributor who is no longer active, so they have fallen out of date. Furthermore, moving the docs to the core Dagster docs site will significantly improve visibility.

## How I Tested These Changes
Built the docs locally and visually inspected for issues. AI reviewed as well.

## Changelog

- Update dagster-iceberg docs to include descriptions of recently-added features.
