### PR TITLE
[dg] Update `dg plus deploy configure`

### DIFF
--- a/examples/docs_snippets/docs_snippets/dagster-plus/deployment/serverless/runtime-environment/github_python_version.yaml
+++ b/examples/docs_snippets/docs_snippets/dagster-plus/deployment/serverless/runtime-environment/github_python_version.yaml
@@ -5,4 +5,3 @@ env:
   # highlight-start
   PYTHON_VERSION: '3.11'
   # highlight-end
-  DAGSTER_CLOUD_FILE: 'dagster_cloud.yaml'

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/commands.py
@@ -22,12 +22,11 @@ from dagster_dg_cli.cli.plus.deploy.configure.configure_build_artifacts import (
 )
 from dagster_dg_cli.cli.plus.deploy.configure.configure_ci import configure_ci_impl
 from dagster_dg_cli.cli.plus.deploy.configure.utils import (
-    DeploymentScaffoldConfig,
+    DgPlusDeployConfigureOptions,
     GitProvider,
+    detect_agent_type_and_platform,
     search_for_git_root,
 )
-from dagster_dg_cli.utils.plus.build import get_agent_type_and_platform_from_graphql
-from dagster_dg_cli.utils.plus.gql_client import DagsterPlusGraphQLClient
 
 
 def resolve_agent_type_and_platform(
@@ -41,8 +40,7 @@ def resolve_agent_type_and_platform(
 
     # Try to detect from Plus config via GraphQL
     if resolved_type is None and plus_config:
-        gql_client = DagsterPlusGraphQLClient.from_config(plus_config)
-        detected_type, detected_platform = get_agent_type_and_platform_from_graphql(gql_client)
+        detected_type, detected_platform = detect_agent_type_and_platform(plus_config)
         resolved_type = detected_type
         if resolved_platform is None:
             resolved_platform = detected_platform
@@ -159,7 +157,7 @@ def resolve_python_version(python_version: Optional[str]) -> str:
 
 
 def _resolve_config_with_prompts(
-    agent_type: DgPlusAgentType,
+    agent_type: Optional[DgPlusAgentType],
     agent_platform: Optional[DgPlusAgentPlatform],
     organization: Optional[str],
     deployment: Optional[str],
@@ -170,7 +168,8 @@ def _resolve_config_with_prompts(
     git_provider: Optional[GitProvider],
     dg_context: DgContext,
     cli_config,
-) -> DeploymentScaffoldConfig:
+    pex_deploy: Optional[bool] = None,
+) -> DgPlusDeployConfigureOptions:
     """Resolve all configuration for deployment-config commands, prompting for missing values.
 
     This is used by the primary deployment-config commands (serverless/hybrid).
@@ -202,9 +201,27 @@ def _resolve_config_with_prompts(
     resolved_git_root = resolve_git_root(git_root, resolved_git_provider)
 
     # Resolve Python version
-    resolved_python_version = resolve_python_version(python_version)
+    if resolved_agent_type == DgPlusAgentType.SERVERLESS:
+        # Required for serverless
+        resolved_python_version = resolve_python_version(python_version)
+    else:
+        # Optional for hybrid (used for Dockerfile creation)
+        resolved_python_version = (
+            resolve_python_version(python_version) if python_version is not None else None
+        )
 
-    return DeploymentScaffoldConfig(
+    # Resolve pex_deploy for serverless (prompt if not provided)
+    resolved_pex_deploy = None
+    if resolved_agent_type == DgPlusAgentType.SERVERLESS:
+        if pex_deploy is None:
+            resolved_pex_deploy = click.confirm(
+                "Enable PEX-based fast deploys?",
+                default=True,
+            )
+        else:
+            resolved_pex_deploy = pex_deploy
+
+    return DgPlusDeployConfigureOptions(
         dg_context=dg_context,
         cli_config=cli_config,
         plus_config=plus_config,
@@ -217,6 +234,7 @@ def _resolve_config_with_prompts(
         skip_confirmation_prompt=skip_confirmation_prompt,
         git_provider=resolved_git_provider,
         use_editable_dagster=use_editable_dagster,
+        pex_deploy=resolved_pex_deploy,
     )
 
 
@@ -225,9 +243,51 @@ def _resolve_config_with_prompts(
 # ########################
 
 
-@click.group(name="configure", cls=DgClickGroup)
-def deploy_configure_group():
-    """Scaffold deployment configuration files for Dagster Plus."""
+@click.group(name="configure", cls=DgClickGroup, invoke_without_command=True)
+@click.option(
+    "--git-provider",
+    type=click.Choice(["github", "gitlab"]),
+    help="Git provider for CI/CD scaffolding",
+)
+@dg_global_options
+@cli_telemetry_wrapper
+@click.pass_context
+def deploy_configure_group(
+    ctx: click.Context,
+    git_provider: Optional[str],
+    **global_options: object,
+) -> None:
+    """Scaffold deployment configuration files for Dagster Plus.
+
+    If no subcommand is specified, will attempt to auto-detect the agent type from your
+    Dagster Plus deployment. If detection fails, you will be prompted to choose between
+    serverless or hybrid.
+    """
+    # If a subcommand was invoked, let Click handle it
+    if ctx.invoked_subcommand is not None:
+        return
+
+    cli_config = normalize_cli_config(global_options, ctx)
+    dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
+
+    # Resolve all configuration via prompts and auto-detection
+    config = _resolve_config_with_prompts(
+        agent_type=None,
+        agent_platform=None,
+        organization=None,
+        deployment=None,
+        git_root=None,
+        python_version=None,
+        skip_confirmation_prompt=False,
+        use_editable_dagster=False,
+        git_provider=GitProvider(git_provider) if git_provider else None,
+        dg_context=dg_context,
+        cli_config=cli_config,
+        pex_deploy=None,
+    )
+
+    configure_build_artifacts_impl(config)
+    configure_ci_impl(config)
 
 
 @click.command(name="serverless", cls=DgClickCommand)
@@ -256,6 +316,11 @@ def deploy_configure_group():
     help="Path to the git repository root",
 )
 @click.option(
+    "--pex-deploy/--no-pex-deploy",
+    default=True,
+    help="Enable PEX-based fast deploys (default: True). If disabled, Docker builds will be used.",
+)
+@click.option(
     "-y",
     "--yes",
     "skip_confirmation_prompt",
@@ -271,6 +336,7 @@ def deploy_configure_serverless(
     organization: Optional[str],
     deployment: Optional[str],
     git_root: Optional[Path],
+    pex_deploy: bool,
     skip_confirmation_prompt: bool,
     use_editable_dagster: Optional[str],
     **global_options: object,
@@ -278,15 +344,15 @@ def deploy_configure_serverless(
     """Scaffold deployment configuration for Dagster Plus Serverless.
 
     This creates:
-    - Dockerfile and build.yaml for containerization
-    - GitHub Actions workflow (if --git-provider github is specified)
+    - Required files for CI/CD based on your Git provider (GitHub Actions or GitLab CI)
+    - Dockerfile and build.yaml for containerization (if --no-pex-deploy is used)
     """
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)
 
     config = _resolve_config_with_prompts(
         agent_type=DgPlusAgentType.SERVERLESS,
-        agent_platform=None,  # Not needed for serverless
+        agent_platform=None,
         organization=organization,
         deployment=deployment,
         git_root=git_root,
@@ -296,6 +362,7 @@ def deploy_configure_serverless(
         git_provider=GitProvider(git_provider) if git_provider else None,
         dg_context=dg_context,
         cli_config=cli_config,
+        pex_deploy=pex_deploy,
     )
 
     configure_build_artifacts_impl(config)
@@ -358,7 +425,7 @@ def deploy_configure_hybrid(
     This creates:
     - Dockerfile and build.yaml for containerization
     - container_context.yaml with platform-specific config (k8s/ecs/docker)
-    - GitHub Actions workflow with Docker build steps (if --git-provider github is specified)
+    - Required files for CI/CD based on your Git provider (GitHub Actions or GitLab CI)
     """
     cli_config = normalize_cli_config(global_options, click.get_current_context())
     dg_context = DgContext.for_workspace_or_project_environment(Path.cwd(), cli_config)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/build_artifacts.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/build_artifacts.py
@@ -20,7 +20,7 @@ from dagster_dg_cli.cli.plus.deploy.configure.commands import resolve_python_ver
 from dagster_dg_cli.cli.plus.deploy.configure.configure_build_artifacts import (
     configure_build_artifacts_impl,
 )
-from dagster_dg_cli.cli.plus.deploy.configure.utils import DeploymentScaffoldConfig
+from dagster_dg_cli.cli.plus.deploy.configure.utils import DgPlusDeployConfigureOptions
 from dagster_dg_cli.utils.plus.build import get_agent_type_and_platform_from_graphql
 from dagster_dg_cli.utils.plus.gql_client import DagsterPlusGraphQLClient
 
@@ -31,7 +31,7 @@ def _resolve_config_for_build_artifacts(
     use_editable_dagster: bool,
     dg_context: DgContext,
     cli_config,
-) -> DeploymentScaffoldConfig:
+) -> DgPlusDeployConfigureOptions:
     """Resolve config for legacy build-artifacts command.
 
     This command only scaffolds build artifacts (no CI/CD), and tries to detect
@@ -56,7 +56,7 @@ def _resolve_config_for_build_artifacts(
 
     resolved_python_version = resolve_python_version(python_version)
 
-    return DeploymentScaffoldConfig(
+    return DgPlusDeployConfigureOptions(
         dg_context=dg_context,
         cli_config=cli_config,
         plus_config=plus_config,

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/github_actions.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/github_actions.py
@@ -22,7 +22,7 @@ from dagster_dg_cli.cli.plus.deploy.configure.commands import (
     resolve_python_version,
 )
 from dagster_dg_cli.cli.plus.deploy.configure.configure_ci import configure_ci_impl
-from dagster_dg_cli.cli.plus.deploy.configure.utils import DeploymentScaffoldConfig, GitProvider
+from dagster_dg_cli.cli.plus.deploy.configure.utils import DgPlusDeployConfigureOptions, GitProvider
 from dagster_dg_cli.utils.plus.build import get_agent_type_and_platform_from_graphql
 from dagster_dg_cli.utils.plus.gql_client import DagsterPlusGraphQLClient
 
@@ -31,7 +31,7 @@ def _resolve_config_for_github_actions(
     git_root: Optional[Path],
     dg_context: DgContext,
     cli_config,
-) -> DeploymentScaffoldConfig:
+) -> DgPlusDeployConfigureOptions:
     """Resolve config for legacy github-actions command.
 
     This command prompts in the legacy order: org, deployment, agent type (no platform).
@@ -69,7 +69,7 @@ def _resolve_config_for_github_actions(
     # Use default Python version
     resolved_python_version = resolve_python_version(None)
 
-    return DeploymentScaffoldConfig(
+    return DgPlusDeployConfigureOptions(
         dg_context=dg_context,
         cli_config=cli_config,
         plus_config=plus_config,

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-github-action.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-github-action.yaml
@@ -12,13 +12,18 @@ concurrency:
   group: ${{ github.ref }}/deploy
   cancel-in-progress: true
 env:
-  DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
-  ENABLE_FAST_DEPLOYS: "true"
-  PYTHON_VERSION: "3.10"
-  DAGSTER_CLOUD_FILE: "dagster_cloud.yaml"
+  # The organization name in Dagster Cloud
   DAGSTER_CLOUD_ORGANIZATION: "TEMPLATE_ORGANIZATION_NAME"
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # The API token from https://dagster.cloud/ should be stored in Secrets
+  DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
+  # Path to the root folder containing the dagster project
   DAGSTER_PROJECT_DIR: "TEMPLATE_PROJECT_DIR"
+  # Enable PEX-based fast deploys (set to "false" to use Docker builds instead)
+  ENABLE_FAST_DEPLOYS: "TEMPLATE_ENABLE_FAST_DEPLOYS"
+  # Python version used to deploy the project
+  PYTHON_VERSION: "3.10"
+  # GitHub token for PR comments and branch deployments
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   dagster_cloud_default_deploy:
@@ -75,27 +80,21 @@ jobs:
         with:
           command: "plus deploy refresh-defs-state"
 
-      # If using fast build, build the PEX
+      # If using fast build, install setuptools for PEX builds
       - name: Install setuptools
         if: steps.prerun.outputs.result == 'pex-deploy'
         run: ${{ steps.setup-python-version.outputs.python-path }} -m pip install setuptools
         shell: bash
 
-      - name: Run PEX build
-        id: run-pex-build
-        if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: dagster-io/dagster-cloud-action/actions/utils/dg-cli@TEMPLATE_DAGSTER_CLOUD_ACTION_VERSION
-        with:
-          command: "plus deploy build-and-push --agent-type=serverless --python-version ${{ env.PYTHON_VERSION }}"
-
-      # Otherwise, enable buildx for caching and build the Docker image
+      # Otherwise, enable buildx for caching Docker builds
       - name: Set up Docker Buildx
         if: steps.prerun.outputs.result == 'docker-deploy'
         uses: docker/setup-buildx-action@v2
 
-      - name: Run Docker build
-        id: run-docker-build
-        if: steps.prerun.outputs.result == 'docker-deploy'
+      # Build and push (PEX or Docker based on project configuration)
+      - name: Build and push
+        id: build-and-push
+        if: steps.prerun.outputs.result == 'pex-deploy' || steps.prerun.outputs.result == 'docker-deploy'
         uses: dagster-io/dagster-cloud-action/actions/utils/dg-cli@TEMPLATE_DAGSTER_CLOUD_ACTION_VERSION
         with:
           command: "plus deploy build-and-push --agent-type=serverless --python-version ${{ env.PYTHON_VERSION }}"

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-gitlab-ci.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-gitlab-ci.yaml
@@ -1,9 +1,15 @@
 variables:
+  # The organization name in Dagster Cloud
   DAGSTER_CLOUD_ORGANIZATION: TEMPLATE_ORGANIZATION_NAME
+  # The API token from https://dagster.cloud/ should be stored in a CI/CD Variable called DAGSTER_CLOUD_API_TOKEN
   DAGSTER_CLOUD_API_TOKEN: $DAGSTER_CLOUD_API_TOKEN
+  # Path to the root folder containing the dagster project
   DAGSTER_PROJECT_DIR: TEMPLATE_PROJECT_DIR
+  # State directory for deploy session
   DAGSTER_BUILD_STATEDIR: /tmp/dagster-build-state-$CI_PIPELINE_ID
-  ENABLE_FAST_DEPLOYS: "true"
+  # Enable PEX-based fast deploys (set to "false" to use Docker builds instead)
+  ENABLE_FAST_DEPLOYS: "TEMPLATE_ENABLE_FAST_DEPLOYS"
+  # Python version used to deploy the project
   PYTHON_VERSION: "3.10"
 
 stages:


### PR DESCRIPTION
## Summary & Motivation

A set up updates for smoothing out the experience of using `dg plus deploy configure`.

1. Now if you just run `dg plus deploy configure` (without serverless/hybrid), we'll attempt to auto-detect your agent type (and prompt if we can't) and automatically put you into the correct flow
2. For almost all serverless users, they'll be using pex deploys which don't require a Dockerfile/build.yaml, so we make this an option in the flow and just don't generate the files if not necessary
3. Cleaned up the generated github action slightly to be less duplicative / have better comments around the env vars that it sets
4. Some minor edits to the command descriptions

## How I Tested These Changes

## Changelog

NOCHANGELOG
