### PR TITLE
Don't include the value of an environment variable in the error message for an IntSource or BoolSource failing to validate it

### DIFF
--- a/python_modules/dagster/dagster/_config/source.py
+++ b/python_modules/dagster/dagster/_config/source.py
@@ -60,12 +60,17 @@ class IntSourceType(ScalarUnion):
         key, cfg = next(iter(value.items()))
         check.invariant(key == "env", "Only valid key is env")
         value = _ensure_env_variable(cfg)
+        validation_failed = False
         try:
             return int(value)
-        except ValueError as e:
+        except ValueError:
+            # raise exception separately to ensure the exception chain doesn't leak the value of the env var
+            validation_failed = True
+
+        if validation_failed:
             raise PostProcessingError(
-                f'Value "{value}" stored in env variable "{cfg}" cannot be coerced into an int.'
-            ) from e
+                f'Value stored in env variable "{cfg}" cannot be coerced into an int.'
+            )
 
 
 class BoolSourceType(ScalarUnion):
@@ -87,12 +92,18 @@ class BoolSourceType(ScalarUnion):
         key, cfg = next(iter(value.items()))
         check.invariant(key == "env", "Only valid key is env")
         value = _ensure_env_variable(cfg)
+        validation_failed = False
+
         try:
             return get_boolean_string_value(value)
-        except ValueError as e:
+        except ValueError:
+            # raise exception separately to ensure the exception chain doesn't leak the value of the env var
+            validation_failed = True
+
+        if validation_failed:
             raise PostProcessingError(
-                f'Value "{value}" stored in env variable "{cfg}" cannot be coerced into an bool.'
-            ) from e
+                f'Value stored in env variable "{cfg}" cannot be coerced into an bool.'
+            )
 
 
 StringSource: StringSourceType = StringSourceType()

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_source_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_source_types.py
@@ -49,7 +49,7 @@ def test_int_source():
     with environ({"DAGSTER_TEST_ENV_VAR": "four"}):
         assert not process_config(dg.IntSource, {"env": "DAGSTER_TEST_ENV_VAR"}).success
         assert (
-            'Value "four" stored in env variable "DAGSTER_TEST_ENV_VAR" cannot '
+            'Value stored in env variable "DAGSTER_TEST_ENV_VAR" cannot '
             "be coerced into an int."
             in process_config(dg.IntSource, {"env": "DAGSTER_TEST_ENV_VAR"}).errors[0].message  # pyright: ignore[reportOptionalSubscript]
         )

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_env_vars.py
@@ -180,9 +180,7 @@ def test_int_env_var_non_int_value() -> None:
     with environ({"AN_INT": "NOT_AN_INT"}):
         with pytest.raises(
             dg.DagsterInvalidConfigError,
-            match=(
-                'Value "NOT_AN_INT" stored in env variable "AN_INT" cannot be coerced into an int.'
-            ),
+            match=('Value stored in env variable "AN_INT" cannot be coerced into an int.'),
         ):
             defs.resolve_implicit_global_asset_job_def().execute_in_process(
                 run_config=dg.RunConfig(


### PR DESCRIPTION
## Summary & Motivation
Since the reason these are in environment variables is likely becauase they are sensitive, ensure that the error message (including the stack trace/context) does not include the actual value. Makes things marginally more difficult to debug but seems like the right tradeoff in this case.

## How I Tested These Changes
BK

## Changelog
Errors for IntSource and BoolSource config types failing to validate an environment variable value will no longer include the value of the environment variable in the error message.
