### PR TITLE
fix(dagster-tableau): fix KeyError when using workbook_selector_fn

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -241,6 +241,7 @@ class DagsterTableauTranslator:
                 )
             ).key
             for data_source_id in data_source_ids
+            if data_source_id in data.workspace_data.data_sources_by_id
         ]
 
         workbook_id = data.properties["workbook"]["luid"]
@@ -280,6 +281,7 @@ class DagsterTableauTranslator:
                 )
             ).key
             for sheet_id in sheet_ids
+            if sheet_id in data.workspace_data.sheets_by_id
         ]
 
         dashboard_upstream_data_source_ids = data.properties.get("data_source_ids", [])
@@ -292,6 +294,7 @@ class DagsterTableauTranslator:
                 )
             ).key
             for data_source_id in dashboard_upstream_data_source_ids
+            if data_source_id in data.workspace_data.data_sources_by_id
         ]
 
         upstream_keys = sheet_keys + data_source_keys


### PR DESCRIPTION
## Summary & Motivation

Fixes a KeyError in `dagster-tableau` when using `workbook_selector_fn`. The translator previously crashed when looking up dependencies for filtered-out workbooks. This change adds safeguards to ensure data source and sheet IDs exist in `workspace_data` before accessing them. Resolves #32524.

## How I Tested These Changes

Locally in my own Dagster project.

## Changelog

[dagster-tableau] Fixed a KeyError that occurred when using `workbook_selector_fn` to filter assets, ensuring dependencies are only accessed if they exist in the workspace data.
