### PR TITLE
Add (Optional) PDT Asset Support to Looker Component

### DIFF
--- a/docs/docs/integrations/libraries/looker/index.md
+++ b/docs/docs/integrations/libraries/looker/index.md
@@ -16,7 +16,7 @@ import Beta from '@site/docs/partials/\_Beta.md';
 
 <Beta />
 
-The [dagster-looker](/integrations/libraries/looker) library provides a `LookerComponent` which can be used to easily represent Looker dashboards and explores as assets in Dagster.
+The [dagster-looker](/integrations/libraries/looker) library provides a `LookerComponent` which can be used to easily represent Looker dashboards, explores, and Persistent Derived Tables (PDTs) as assets in Dagster.
 
 :::info
 
@@ -74,7 +74,31 @@ You can filter which Looker dashboards and explores are loaded using the `looker
   language="yaml"
 />
 
-## 5. Customize Looker asset metadata
+## 5. Configure PDT Builds
+
+You can configure the `LookerComponent` to create executable assets for Looker Persistent Derived Tables (PDTs). This allows Dagster to orchestrate the materialization of these tables.
+
+To enable this, add the `pdt_builds` key to your configuration. You must specify the `model_name` and `view_name` for each PDT you wish to build.
+
+You can also specify a `resource_key` if your Looker resource has a custom name (defaults to "looker").
+
+```yaml
+type: dagster_looker.LookerComponent
+attributes:
+  looker_resource:
+    base_url: [https://your-company.looker.com](https://your-company.looker.com)
+    client_id: "{{ env.LOOKER_CLIENT_ID }}"
+    client_secret: "{{ env.LOOKER_CLIENT_SECRET }}"
+  resource_key: "looker"
+  pdt_builds:
+    - model_name: my_model
+      view_name: my_pdt_view
+      force_rebuild: "true"
+    - model_name: sales_model
+      view_name: monthly_report_pdt
+      workspace: dev
+
+## 6. Customize Looker asset metadata
 
 You can customize the metadata and grouping of Looker assets using the `translation` key:
 

--- a/docs/docs/integrations/libraries/looker/index.md
+++ b/docs/docs/integrations/libraries/looker/index.md
@@ -125,3 +125,4 @@ You may also specify distinct translation behavior for specific data types. For 
 <WideContent maxSize={1100}>
   <CliInvocationExample path="docs_snippets/docs_snippets/guides/components/integrations/looker-component/12-list-defs.txt" />
 </WideContent>
+```

--- a/docs/docs/integrations/libraries/looker/index.md
+++ b/docs/docs/integrations/libraries/looker/index.md
@@ -86,7 +86,7 @@ You can also specify a `resource_key` if your Looker resource has a custom name 
 type: dagster_looker.LookerComponent
 attributes:
   looker_resource:
-    base_url: [https://your-company.looker.com](https://your-company.looker.com)
+    base_url: "{{ env.LOOKER_BASE_URL }}"
     client_id: "{{ env.LOOKER_CLIENT_ID }}"
     client_secret: "{{ env.LOOKER_CLIENT_SECRET }}"
   resource_key: "looker"

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
@@ -11,7 +11,7 @@ from dagster_looker.api.dagster_looker_api_translator import (
     LookerStructureData,
     LookerStructureType,
     LookmlView,
-    RequestStartPdtBuild,
+    RequestStartPdtBuild
 )
 
 from dagster_looker.api.resource import LookerResource

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/components/looker_component.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/components/looker_component.py
@@ -29,6 +29,7 @@ from dagster_looker.api.dagster_looker_api_translator import (
     RequestStartPdtBuild
 )
 from dagster_looker.api.resource import LookerApiDefsLoader, LookerFilter, LookerResource
+from dagster_looker.api.assets import build_looker_pdt_assets_definitions
 
 
 class LookerInstanceArgs(Model, Resolvable):
@@ -255,9 +256,6 @@ class LookerComponent(StateBackedComponent, Resolvable):
 
         # If PDT builds are configured, build corresponding executable asset definitions
         if self.pdt_builds:
-            from dagster_looker.api.dagster_looker_api_translator import RequestStartPdtBuild
-            from dagster_looker.api.assets import build_looker_pdt_assets_definitions
-
             requests_for_looker = [
                 RequestStartPdtBuild(**pdt_config.model_dump())
                 for pdt_config in self.pdt_builds

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/components/looker_component.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/components/looker_component.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
-from typing import Annotated, Optional, List
+from typing import Annotated, Optional
 
 import dagster as dg
 from dagster._annotations import beta, public
@@ -14,8 +14,9 @@ from dagster.components.utils.defs_state import (
     ResolvedDefsStateConfig,
 )
 from dagster_shared.serdes.serdes import deserialize_value
-from pydantic import Field, BaseModel
+from pydantic import Field
 
+from dagster_looker.api.assets import build_looker_pdt_assets_definitions
 from dagster_looker.api.components.translation import (
     ResolvedMultilayerTranslationFn,
     create_looker_component_translator,
@@ -26,10 +27,9 @@ from dagster_looker.api.dagster_looker_api_translator import (
     LookerInstanceData,
     LookerStructureData,
     LookerStructureType,
-    RequestStartPdtBuild
+    RequestStartPdtBuild,
 )
 from dagster_looker.api.resource import LookerApiDefsLoader, LookerFilter, LookerResource
-from dagster_looker.api.assets import build_looker_pdt_assets_definitions
 
 
 class LookerInstanceArgs(Model, Resolvable):
@@ -59,12 +59,14 @@ class LookerFilterArgs(Model, Resolvable):
         description="If True, only load explores that are used in dashboards. If False, load all explores.",
     )
 
+
 class PdtBuildConfig(Model):
     model_name: str
     view_name: str
     force_rebuild: Optional[str] = None
     force_full_incremental: Optional[str] = None
     workspace: Optional[str] = "production"
+
 
 @beta
 @public
@@ -257,15 +259,11 @@ class LookerComponent(StateBackedComponent, Resolvable):
         # If PDT builds are configured, build corresponding executable asset definitions
         if self.pdt_builds:
             requests_for_looker = [
-                RequestStartPdtBuild(**pdt_config.model_dump())
-                for pdt_config in self.pdt_builds
+                RequestStartPdtBuild(**pdt_config.model_dump()) for pdt_config in self.pdt_builds
             ]
-            
-            pdt_assets = build_looker_pdt_assets_definitions(
-                self.resource_key,
-                requests_for_looker
-            )
-            
+
+            pdt_assets = build_looker_pdt_assets_definitions(self.resource_key, requests_for_looker)
+
             return dg.Definitions(assets=[*specs, *pdt_assets])
 
         return dg.Definitions(assets=specs)

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/components/looker_component.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/components/looker_component.py
@@ -232,12 +232,11 @@ class LookerComponent(StateBackedComponent, Resolvable):
 
         # Fetch the instance data
         instance_data = loader.fetch_looker_instance_data()
-        
+
         # Convert to state format and serialize
         state = instance_data.to_state(sdk)
         state_path.write_text(dg.serialize_value(state))
 
-    # 🟢 הפונקציה החדשה שעונה להערה של Owen: שימוש ב-self.looker_resource
     def _build_pdt_assets_definition(
         self, request: RequestStartPdtBuild
     ) -> dg.AssetsDefinition:

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/components/looker_component.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/components/looker_component.py
@@ -118,7 +118,6 @@ class LookerComponent(StateBackedComponent, Resolvable):
     pdt_builds: Annotated[
         Optional[list[RequestStartPdtBuild]],
         Resolver.default(
-            model_field_type=RequestStartPdtBuild,
             description=("A list of PDT build requests. Each request defined here will be converted "
                          "into a materializable asset definition representing that PDT build."),
             examples=[

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
@@ -11,9 +11,9 @@ from dagster._annotations import deprecated, public
 from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._record import record
 from dagster._utils.log import get_dagster_logger
+from dagster.components import Model, Resolvable
 from looker_sdk.sdk.api40.methods import Looker40SDK
 from looker_sdk.sdk.api40.models import Dashboard, DashboardFilter, LookmlModelExplore, User
-from dagster.components import Model, Resolvable
 
 logger = get_dagster_logger("dagster_looker")
 
@@ -66,7 +66,6 @@ class LookerInstanceData:
             dashboards_by_id=dashboards_by_id,
             users_by_id=users_by_id,
         )
-
 
 
 class RequestStartPdtBuild(Model, Resolvable):

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
@@ -13,6 +13,7 @@ from dagster._record import record
 from dagster._utils.log import get_dagster_logger
 from looker_sdk.sdk.api40.methods import Looker40SDK
 from looker_sdk.sdk.api40.models import Dashboard, DashboardFilter, LookmlModelExplore, User
+from dagster.components import Model, Resolvable
 
 logger = get_dagster_logger("dagster_looker")
 
@@ -67,8 +68,8 @@ class LookerInstanceData:
         )
 
 
-@record
-class RequestStartPdtBuild:
+
+class RequestStartPdtBuild(Model, Resolvable):
     """A request to start a PDT build. See https://developers.looker.com/api/explorer/4.0/types/DerivedTable/RequestStartPdtBuild?sdk=py
     for documentation on all available fields.
 

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_component.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_component.py
@@ -42,11 +42,8 @@ def setup_looker_component(
             scoped_definitions_load_context(),
             sandbox.load_component_and_build_defs(defs_path=defs_path) as (component, defs),
         ):
-            merged_defs = Definitions.merge(
-                defs, Definitions(resources={"looker": mock_looker_resource})
-            )
             assert isinstance(component, LookerComponent)
-            yield component, merged_defs
+            yield component, defs
 
 
 @pytest.mark.parametrize(
@@ -146,5 +143,4 @@ def test_pdt_assets_configuration(looker_api_mocks):
 
         assert AssetKey(["view", "monthly_report"]) in all_keys
 
-        assert component.resource_key == "looker"
         assert len(component.pdt_builds) == 2

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_component.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_component.py
@@ -149,4 +149,4 @@ def test_pdt_assets_configuration(looker_api_mocks):
 
             assert AssetKey(["view", "monthly_report"]) in all_keys
 
-            assert len(component.pdt_builds) == 2
+            assert len(component.pdt_builds or []) == 2

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_component.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_component.py
@@ -5,17 +5,16 @@ import copy
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from typing import Any, Optional
+from unittest.mock import MagicMock
 
 import pytest
-from dagster import AssetKey
+from dagster import AssetKey, resource
 from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils.test.definitions import scoped_definitions_load_context
 from dagster.components.testing import create_defs_folder_sandbox
 from dagster.components.testing.test_cases import TestTranslation
 from dagster_looker.api.components import LookerComponent
-from unittest.mock import MagicMock
-from dagster import resource, build_init_resource_context
 
 BASIC_LOOKER_COMPONENT_BODY = {
     "type": "dagster_looker.LookerComponent",
@@ -42,11 +41,9 @@ def setup_looker_component(
         with (
             scoped_definitions_load_context(),
             sandbox.load_component_and_build_defs(defs_path=defs_path) as (component, defs),
-
         ):
             merged_defs = Definitions.merge(
-                defs, 
-                Definitions(resources={"looker": mock_looker_resource})
+                defs, Definitions(resources={"looker": mock_looker_resource})
             )
             assert isinstance(component, LookerComponent)
             yield component, merged_defs
@@ -128,32 +125,26 @@ class TestLookerTranslation(TestTranslation):
                 assets_def = defs.resolve_assets_def(key)
                 assert assertion(assets_def.get_asset_spec(key))
 
+
 @resource
 def mock_looker_resource(looker_api_mocks: Any):
     return MagicMock()
+
+
 def test_pdt_assets_configuration(looker_api_mocks):
     """Test that PDT assets are created from YAML configuration."""
-    
     body = copy.deepcopy(BASIC_LOOKER_COMPONENT_BODY)
     body["attributes"]["pdt_builds"] = [
-        {
-            "model_name": "my_model",
-            "view_name": "my_pdt_view",
-            "force_rebuild": "true"
-        },
-        {
-            "model_name": "sales_model",
-            "view_name": "monthly_report",
-            "workspace": "dev"
-        }
+        {"model_name": "my_model", "view_name": "my_pdt_view", "force_rebuild": "true"},
+        {"model_name": "sales_model", "view_name": "monthly_report", "workspace": "dev"},
     ]
 
     with setup_looker_component(defs_yaml_contents=body) as (component, defs):
         all_keys = defs.resolve_asset_graph().get_all_asset_keys()
-    
+
         assert AssetKey(["view", "my_pdt_view"]) in all_keys
-        
+
         assert AssetKey(["view", "monthly_report"]) in all_keys
 
-        assert component.resource_key == "looker" 
+        assert component.resource_key == "looker"
         assert len(component.pdt_builds) == 2

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_component.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_component.py
@@ -135,7 +135,11 @@ def test_pdt_assets_configuration(looker_api_mocks):
         body = copy.deepcopy(BASIC_LOOKER_COMPONENT_BODY)
         body["attributes"]["pdt_builds"] = [
             {"model_name": "my_model", "view_name": "my_pdt_view", "force_rebuild": "true"},
-            {"model_name": "sales_model", "view_name": "{{ env.LOOKER_VIEW_ENV }}", "workspace": "dev"},
+            {
+                "model_name": "sales_model",
+                "view_name": "{{ env.LOOKER_VIEW_ENV }}",
+                "workspace": "dev",
+            },
         ]
 
         with setup_looker_component(defs_yaml_contents=body) as (component, defs):


### PR DESCRIPTION
## Summary & Motivation
feat: Extend LookerComponent to support Persistent Derived Tables (PDTs) via YAML configuration. feat: Add optional resource_key parameter to allow specifying a custom Looker resource key (defaults to "looker").

This allows users to declaratively configure PDT builds alongside dashboards and explores in their defs.yaml, enabling Dagster to orchestrate the materialization of these tables.

## How I Tested These Changes
Added a new unit test test_pdt_assets_configuration in test_component.py.

Mocked the Looker resource to verify that the component correctly parses the YAML configuration and generates the expected Asset Keys (e.g., view / my_view) without requiring a live Looker connection.

Ran the full dagster-looker test suite to ensure no regressions for existing dashboard/explore loading logic.

## Changelog
feat: dagster-looker: add optional PDT asset support to LookerComponent via YAML configuration.