### PR TITLE
[RFC] Add functionality for automatically mapping upstream dependencies

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets/definition/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/definition/asset_spec.py
@@ -88,6 +88,12 @@ SYSTEM_METADATA_KEY_AUTO_OBSERVE_INTERVAL_MINUTES = "dagster/auto_observe_interv
 # During normalization we create a "stub" definition for `foo` and attach this metadata to it.
 SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET = "dagster/auto_created_stub_asset"
 
+# SYSTEM_METADATA_KEY_UPSTREAM_DEP_ASSET marks AssetSpecs that represent upstream
+# dependencies from an integration. These can be later remapped to the appropriate
+# AssetKeys produced by other integrations during a Definitions.merge() operation
+# using additional metadata we have for this spec.
+SYSTEM_METADATA_KEY_UPSTREAM_DEP_MARKER_ASSET = "dagster/upstream_dep_asset"
+
 
 @whitelist_for_serdes
 class AssetExecutionType(Enum):

--- a/python_modules/dagster/dagster/_core/definitions/assets/definition/assets_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/definition/assets_definition.py
@@ -2041,8 +2041,8 @@ def replace_specs_on_asset(
         )
 
     remaining_ins = {
-        input_name: the_in
-        for input_name, the_in in assets_def.node_def.input_dict.items()
+        input_name: In.from_definition(input_def)
+        for input_name, input_def in assets_def.node_def.input_dict.items()
         if assets_def.node_keys_by_input_name[input_name] in remaining_original_deps_by_key
     }
     all_ins = merge_dicts(


### PR DESCRIPTION
## Summary & Motivation

This aims to solve a common problem with our integration libraries at the framework level. The core issue is that each integration decides to generate its asset keys in different ways. While broadly-speaking, they are generally somewhat based on the table name (for tabular data assets), the specifics vary.

Even in cases where the out of the box asset keys match, it's possible for users to override behavior in one integration, which would require them to update all associated integrations in order to have keys continue to match, which is incredibly tedious, time consuming, and error-prone.

This change allows integration libraries to emit a set of "marker asset specs" that codify data about the upstream dependencies that they know about. So an integration library such as dbt may decide on a key of "foo/bar/baz" for some upstream source, but it can also create an AssetSpec for that key, and attach information about the table that this upstream source represents to that spec.

Then the framework can use the table name as the true "unique identifier", and go back and replace all instances of that marker key with the key generated by a different library.

This allows integrations to use a universal identifier (in this case table names) for lineage information, while leaving asset keys unaffected.

This currently only uses the `dagster/table_name` key as the "unique identifier" but we could easily extend this logic to include URIs or other such more general concepts.

Not attached to any of the naming conventions here.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
