### PR TITLE
Add backfill snippet markers to dagster instance example

### DIFF
--- a/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
+++ b/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
@@ -406,6 +406,15 @@ schedules:
 
 # end_marker_schedules
 
+# start_marker_backfills
+
+backfills:
+  use_threads: true
+  num_workers: 8
+  num_submit_workers: 4
+
+# end_marker_backfills
+
 auto_materialize:
   run_tags:
     key: value


### PR DESCRIPTION
## Summary
- add backfill snippet markers so backfill section renders only its block
- include threaded backfill settings and submit worker count in example

## Testing
- not run (docs only)

## Related issues
Fixes #32938