### PR TITLE
Transform JsonMetadataValue before storing it

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/metadata_value.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/metadata_value.py
@@ -1,10 +1,10 @@
+import json
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
 from os import PathLike
 from typing import Any, Generic, Optional, Union
 
-import dagster_shared.seven as seven
 from dagster_shared.record import IHaveNew, LegacyNamedTupleMixin, record, record_custom
 from dagster_shared.serdes.serdes import (
     FieldSerializer,
@@ -668,8 +668,9 @@ class JsonMetadataValue(
 
     def __new__(cls, data: Optional[Union[Sequence[Any], Mapping[str, Any]]]):
         try:
-            # check that the value is JSON serializable
-            seven.dumps(data)
+            # check that the value is JSON serializable (and do any transformation
+            # that json.dumps would do under the hood, like enums to string values)
+            data = json.loads(json.dumps(data))
         except TypeError:
             raise DagsterInvalidMetadata("Value is not JSON serializable.")
         return super().__new__(cls, data=data)


### PR DESCRIPTION
## Summary & Motivation
This fixes an issue where you could pass in a string enum to JsonMetadataValue and it would pass this validation check, but fail when you later try to serdes it into the database.

## Changelog
Fixed an issue where passing in JSON serializable enums to JsonMetadataValue would sometimes result in an error.

