### PR TITLE
Don't always compute num_partitions when re-creating a new TimeWindowPartitionsSubset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/time_window.py
@@ -398,10 +398,11 @@ class TimeWindowPartitionsSubset(
             "num_partitions would become inaccurate if the partitions_defs had different cron"
             " schedules",
         )
+        self_as_dict = self._asdict()
         return TimeWindowPartitionsSubset(
             partitions_def=partitions_def,
-            num_partitions=self.num_partitions,
-            included_time_windows=self.included_time_windows,
+            num_partitions=self_as_dict["num_partitions"],
+            included_time_windows=self_as_dict["included_time_windows"],
         )
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Summary:
This function just intends to create a new copy of the subset with the given partitions definition, but it ends up re-computing the number of partitions whether or not it actually needs to.

BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
