### PR TITLE
Fix: Handle InputDefinition objects when mapping asset specs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -142,7 +142,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         input_defs = [
             inp if isinstance(inp, InputDefinition) else inp.to_definition(name)
             for name, inp in sorted(ins.items(), key=lambda inp: inp[0])
-        ]   # sort so that input definition order is deterministic
+        ]  # sort so that input definition order is deterministic
 
         if isinstance(compute_fn, DecoratedOpFunction):
             resolved_input_defs: Sequence[InputDefinition] = resolve_checked_op_fn_inputs(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
@@ -253,27 +253,25 @@ def test_map_asset_specs_additional_deps() -> None:
 
 
 def test_map_asset_specs_asset_with_ins_regression() -> None:
-    """
-    This regression test prevents the recurrence of the AttributeError from OpDefinition.__init__.
-    """
-    
+    """This regression test prevents the recurrence of the AttributeError from OpDefinition.__init__."""
+
     @dg.asset(ins={"my_input": dg.AssetIn(key="upstream")})
     def my_asset(my_input):
         pass
 
     assets = [my_asset]
     spec = next(iter(my_asset.specs))
-    
+
     new_spec = spec.replace_attributes(
         deps={*spec.deps, dg.AssetDep("another_upstream")},
     )
 
     mapped_assets = dg.map_asset_specs(lambda s: new_spec, assets)
-    
+
     mapped_asset = mapped_assets[0]
     mapped_spec = next(iter(mapped_asset.specs))
     dep_keys = {dep.asset_key for dep in mapped_spec.deps}
-    
+
     assert dg.AssetKey("upstream") in dep_keys
     assert dg.AssetKey("another_upstream") in dep_keys
     assert mapped_asset.keys_by_input_name["my_input"] == dg.AssetKey("upstream")


### PR DESCRIPTION
Fixes #32913

## Summary & Motivation

This PR resolves an **AttributeError** that occurred when using the `dagster.map_asset_specs` utility on an asset defined using the explicit `ins` parameter.

The issue occurred during the reconstruction of the asset's underlying `OpDefinition`. When inputs were sourced from the existing `OpDefinition`, they were already fully converted `InputDefinition` objects. However, the `OpDefinition.__init__` logic expected user-facing `In` objects and attempted to call the `.to_definition()` method on the already converted `InputDefinition` object.

## How I Tested These Changes

I created a new regression test case, `test_map_asset_specs_asset_with_ins_regression`, within the `test_asset_spec.py` file.

1.  **Before Fix:** The regression test failed with an `AttributeError`, confirming the issue.
2.  **After Fix:** The test case runs successfully and verifies that both existing and added dependencies are correctly mapped, proving the `OpDefinition` reconstruction now works correctly for assets with explicit `ins`.

## Changelog

> Fixes an AttributeError when calling `map_asset_specs` on assets defined using the `ins` parameter.