### PR TITLE
Fix time window subset type check

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/time_window.py
@@ -576,7 +576,7 @@ class TimeWindowPartitionsSubset(
         # note that we rarely serialize subsets on the user code side of a serialization boundary,
         # and so this conversion is rarely necessary.
         partitions_def = self.partitions_def
-        if type(self.partitions_def) != TimeWindowPartitionsSubset:
+        if type(self.partitions_def) != TimeWindowPartitionsDefinition:
             partitions_def = TimeWindowPartitionsSnap.from_def(
                 partitions_def
             ).get_partitions_definition()


### PR DESCRIPTION
Summary:
This was previously always passing

## How I Tested These Changes
this test: https://github.com/dagster-io/dagster/blob/f7eaaf254969f6f431fd9869f3e11f2c6cc2f1c7/python_modules/dagster/dagster_tests/asset_defs_tests/test_entity_subset.py#L95 - still passes, fails if I remove this section a\
ltogether
