### PR TITLE
[ui] Improvements to AI Summary UI

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/SplitPanelContainer.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/SplitPanelContainer.tsx
@@ -70,6 +70,8 @@ export const SplitPanelContainer = forwardRef<SplitPanelContainerHandle, SplitPa
 
     const firstPaneStyles: React.CSSProperties = {flexShrink: 0};
 
+    const dividerReservedSpace = first && second ? DIVIDER_THICKNESS : 0;
+
     // Note: The divider appears after the first panel, so making the first panel 100% wide
     // hides the divider offscreen. To prevent this, we subtract the divider depth.
     if (axis === 'horizontal') {
@@ -79,7 +81,7 @@ export const SplitPanelContainer = forwardRef<SplitPanelContainerHandle, SplitPa
       } else {
         firstPaneStyles.minWidth = firstMinSize;
         firstPaneStyles.width = `calc(${firstSize / 100} * (100% - ${
-          DIVIDER_THICKNESS + (second ? secondMinSize : 0)
+          dividerReservedSpace + (second ? secondMinSize : 0)
         }px))`;
       }
     } else {
@@ -89,7 +91,7 @@ export const SplitPanelContainer = forwardRef<SplitPanelContainerHandle, SplitPa
       } else {
         firstPaneStyles.minHeight = firstMinSize;
         firstPaneStyles.height = `calc(${firstSize / 100} * (100% - ${
-          DIVIDER_THICKNESS + (second ? secondMinSize : 0)
+          dividerReservedSpace + (second ? secondMinSize : 0)
         }px))`;
       }
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunAssetCheckTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunAssetCheckTags.tsx
@@ -4,7 +4,9 @@ import {RunAssetChecksQuery, RunAssetChecksQueryVariables} from './types/RunAsse
 import {RunFragment} from './types/RunFragments.types';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 
-export const RunAssetCheckTags = (props: {run: RunFragment}) => {
+export const RunAssetCheckTags = (props: {
+  run: Pick<RunFragment, 'id' | 'pipelineName' | 'assetCheckSelection'>;
+}) => {
   const {run} = props;
   const skip = isHiddenAssetGroupJob(run.pipelineName);
   const queryResult = useQuery<RunAssetChecksQuery, RunAssetChecksQueryVariables>(

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunAssetTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunAssetTags.tsx
@@ -7,7 +7,9 @@ import {RunAssetsQuery, RunAssetsQueryVariables} from './types/RunAssetTags.type
 import {RunFragment} from './types/RunFragments.types';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 
-export const RunAssetTags = (props: {run: RunFragment}) => {
+export const RunAssetTags = (props: {
+  run: Pick<RunFragment, 'id' | 'stepKeysToExecute' | 'pipelineName' | 'assetSelection'>;
+}) => {
   const {run} = props;
   const skip = isHiddenAssetGroupJob(run.pipelineName);
   const queryResult = useQuery<RunAssetsQuery, RunAssetsQueryVariables>(RUN_ASSETS_QUERY, {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
@@ -1,6 +1,7 @@
 import {Button, Group, Icon, Menu, MenuItem, Popover, Tooltip} from '@dagster-io/ui-components';
 import {useContext, useState} from 'react';
 import {useHistory} from 'react-router-dom';
+import {AISummaryForRunMenuItem} from 'shared/runs/AISummaryForRunMenuItem.oss';
 import {RunAlertNotifications} from 'shared/runs/RunAlertNotifications.oss';
 import {RunMetricsDialog} from 'shared/runs/RunMetricsDialog.oss';
 
@@ -98,6 +99,7 @@ export const RunHeaderActions = ({run, isJob}: {run: RunFragment; isJob: boolean
               <Menu>
                 {!isExternalRun(run) ? (
                   <>
+                    <AISummaryForRunMenuItem run={run} />
                     <Tooltip
                       content="Loadable in dagster-webserver-debug"
                       position="left"


### PR DESCRIPTION
Related: https://github.com/dagster-io/internal/pull/19444

- The split panel no longer has an unused 2px divider space on the right hand side if the second panel is unmounted.

- The AI summary menu item appears on the run details page in the top right menu.

- The types for RunAssetTags and RunAssetCheckTags have been scoped down so they’re easier to re-use.

[INTERNAL_BRANCH=bengotow/ai-summary-feedback]
