### PR TITLE
fix(dagster-tableau): adding missing data sources

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -639,7 +639,7 @@ class BaseTableauWorkspace(ConfigurableResource):
                 for sheet_data in workbook_data["sheets"]:
                     sheet_id = sheet_data["luid"]
                     sheet_metadata_id = sheet_data["id"]
-                    if sheet_id:
+                    if sheet_id or sheet_metadata_id:
                         augmented_sheet_data = {**sheet_data, "workbook": {"luid": workbook_id}}
                         sheets.append(
                             TableauContentData(
@@ -951,9 +951,18 @@ class TableauWorkspaceDefsLoader(StateBackedDefinitionsLoader[TableauWorkspaceDa
             workbook_selector_fn=self.workbook_selector_fn
         )
 
+        # Filter hidden sheets:
+        # 1. They typically lack a path.
+        # 2. They are required in workspace data to maintain data source lineage.
+        visible_sheets = [
+            sheet
+            for sheet in selected_state.sheets_by_id.values()
+            if sheet.properties.get("path") != ""
+        ]
+
         all_external_data = [
             *selected_state.data_sources_by_id.values(),
-            *selected_state.sheets_by_id.values(),
+            *visible_sheets,
             *selected_state.dashboards_by_id.values(),
         ]
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -121,7 +121,7 @@ class TableauWorkspaceData:
                 if workbook.content_type == TableauContentType.WORKBOOK
             },
             sheets_by_id={
-                sheet.properties["luid"]: sheet
+                sheet.properties["luid"] or sheet.properties["id"]: sheet
                 for sheet in content_data
                 if sheet.content_type == TableauContentType.SHEET
             },

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -83,7 +83,7 @@ SAMPLE_HIDDEN_SHEET = {
     "name": "hidden",
     "createdAt": "2024-09-06T22:33:26Z",
     "updatedAt": "2024-09-14T01:15:23Z",
-    "path": "TestWorkbook/Account",
+    "path": "",
     "parentEmbeddedDatasources": [
         {
             "parentPublishedDatasources": [

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -57,7 +57,8 @@ def test_fetch_tableau_workspace_data(
 
     actual_workspace_data = resource.get_or_fetch_workspace_data()
     assert len(actual_workspace_data.workbooks_by_id) == 1
-    assert len(actual_workspace_data.sheets_by_id) == 2
+    # Hidden sheets are included in sheets_by_id to preserve their data source dependencies
+    assert len(actual_workspace_data.sheets_by_id) == 3
     assert len(actual_workspace_data.dashboards_by_id) == 1
     assert len(actual_workspace_data.data_sources_by_id) == 3
 
@@ -147,7 +148,7 @@ def test_translator_spec(
         all_assets = load_tableau_asset_specs(resource)
         all_assets_keys = [asset.key for asset in all_assets]
 
-        # 2 sheet, 1 dashboard and 3 data source as external assets
+        # 2 visible sheets (1 hidden sheet filtered out), 1 dashboard and 3 data sources
         assert len(all_assets) == 6
         assert len(all_assets_keys) == 6
 


### PR DESCRIPTION
## Summary & Motivation

This pull request improves how hidden Tableau sheets are handled in the Dagster-Tableau integration. The main focus is to ensure hidden sheets are retained in the internal workspace data for lineage purposes, but are excluded from external asset definitions. The changes also update tests and data to reflect this new logic.

## How I Tested These Changes
Locally in my own Dagster project. 

### Before
<img width="1055" height="411" alt="Screenshot 2025-12-04 at 17 54 01" src="https://github.com/user-attachments/assets/a173c74c-1b82-415d-b0a4-bf635a9f7a54" />

###  After
<img width="965" height="497" alt="after" src="https://github.com/user-attachments/assets/ebb08908-3718-4b76-ab03-374bd15716c8" />

## Changelog
[Tableau] Updated extraction logic to handle hidden sheets. Consequently, the materializable data sources connected to these sheets are now successfully detected and included as materializable data assets.