### PR TITLE
[ui] query for run ids in AssetHealthQuery

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -5,7 +5,7 @@
   "AssetAutomationQuery": "a7b9f9d72e79dd3cc60f094649f0e2f810feaa1563b886f7499be3087dc7cb65",
   "AssetGraphLiveQuery": "870d33b271f68fd3fcd1eb64016904deae5b531e7d82f7b22b8b63e6815a6200",
   "AssetsFreshnessInfoQuery": "1049ac5edde1a0f5c16dd8342020c30db8603477f6d7760712c5784a71bdbc01",
-  "AssetHealthQuery": "415aacb9e120af636888a75e032d65e4d64c64d8c0729700e739154a9a5ddeec",
+  "AssetHealthQuery": "35734c1a0cdd13fe842f34a973f65c52ff39dac4f26f6d737e296dc2c6725698",
   "AssetStaleStatusDataQuery": "0168440bb72ae79664e8ba33f41a85f99398d0838b0baaa611b16a4dbb15b004",
   "AssetGraphSidebarQuery": "423d6b155cc63752472fa9bde2ff75a6e872fa1c230473394bdf6057789ad9e8",
   "AssetLiveRunLogsSubscription": "d3ae8fb8b8500d37715da27d84b0840e19a175f27f6e62cc859473345a20f64d",

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -293,7 +293,7 @@ export const ASSETS_HEALTH_INFO_QUERY = gql`
     numMissingPartitions
     numFailedPartitions
     totalNumPartitions
-    failedRunId
+    latestFailedRunId
   }
 
   fragment AssetHealthMaterializationHealthyPartitionedMetaFragment on AssetHealthMaterializationHealthyPartitionedMeta {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetHealthDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetHealthDataProvider.types.ts
@@ -34,7 +34,7 @@ export type AssetHealthQuery = {
                   numMissingPartitions: number;
                   numFailedPartitions: number;
                   totalNumPartitions: number;
-                  failedRunId: string | null;
+                  latestFailedRunId: string | null;
                 }
               | {
                   __typename: 'AssetHealthMaterializationHealthyPartitionedMeta';
@@ -102,7 +102,7 @@ export type AssetHealthFragment = {
           numMissingPartitions: number;
           numFailedPartitions: number;
           totalNumPartitions: number;
-          failedRunId: string | null;
+          latestFailedRunId: string | null;
         }
       | {
           __typename: 'AssetHealthMaterializationHealthyPartitionedMeta';
@@ -141,7 +141,7 @@ export type AssetHealthMaterializationDegradedPartitionedMetaFragment = {
   numMissingPartitions: number;
   numFailedPartitions: number;
   totalNumPartitions: number;
-  failedRunId: string | null;
+  latestFailedRunId: string | null;
 };
 
 export type AssetHealthMaterializationHealthyPartitionedMetaFragment = {
@@ -180,4 +180,4 @@ export type AssetHealthFreshnessMetaFragment = {
   lastMaterializedTimestamp: number | null;
 };
 
-export const AssetHealthQueryVersion = '415aacb9e120af636888a75e032d65e4d64c64d8c0729700e739154a9a5ddeec';
+export const AssetHealthQueryVersion = '35734c1a0cdd13fe842f34a973f65c52ff39dac4f26f6d737e296dc2c6725698';


### PR DESCRIPTION
Update the asset health query to get the run ids for partitioned metadata

Also updates a component that uses the `failedRunId` for non-partitioned assets since apparently it can be a null value