### PR TITLE
[ui] Try to fix weird resize loop on asset plot

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetValueGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetValueGraph.tsx
@@ -5,6 +5,7 @@ import {
   ChartEvent,
   Chart as ChartJS,
   ChartOptions,
+  Tooltip as ChartTooltip,
   LineElement,
   LinearScale,
   PointElement,
@@ -19,7 +20,7 @@ import {TimeContext} from '../app/time/TimeContext';
 import {timestampToString} from '../app/time/timestampToString';
 import {useRGBColorsForTheme} from '../app/useRGBColorsForTheme';
 
-ChartJS.register(CategoryScale, LinearScale, LineElement, PointElement, TimeScale);
+ChartJS.register(CategoryScale, LinearScale, LineElement, PointElement, TimeScale, ChartTooltip);
 
 export interface AssetValueGraphData {
   minY: number;
@@ -181,5 +182,9 @@ export const AssetValueGraph = (props: {
     },
   };
 
-  return <Line data={graphData} height={props.height || 100} options={options} key={props.width} />;
+  return (
+    <div style={{height: '100%', position: 'relative'}}>
+      <Line data={graphData} options={options} />
+    </div>
+  );
 };


### PR DESCRIPTION
## Summary & Motivation

One of our users is reporting strange behavior with asset plot charts, where the chart automatically resizes itself smaller and smaller.

I'm going to try to fix this by putting a wrapper div with a set height, and remove the `width` and `height` props from the `Line` component.

I'm not able to repro the issue myself, but this approach seems worth a try.

## How I Tested These Changes

View asset plots, verify that they render properly.