### PR TITLE
Fix the insights icon backgrounds

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsIcon.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsIcon.tsx
@@ -1,4 +1,4 @@
-import {BaseIcon, Icon, IconName, IconNames, IconSize} from '@dagster-io/ui-components';
+import {BaseIcon, Colors, Icon, IconName, IconNames, IconSize} from '@dagster-io/ui-components';
 
 import {KNOWN_TAGS, KnownTagType, extractIconSrc} from '../graph/OpTags';
 
@@ -18,5 +18,12 @@ export const InsightsIcon = (props: InsightsIconProps) => {
   }
 
   const known = KNOWN_TAGS[props.name as IntegrationIconName];
-  return <BaseIcon {...rest} img={extractIconSrc(known)} name={name} />;
+  return (
+    <BaseIcon
+      {...rest}
+      img={extractIconSrc(known)}
+      name={name}
+      style={{backgroundColor: 'transparent'}}
+    />
+  );
 };


### PR DESCRIPTION
## Summary & Motivation
Fixes the branded Insights icons to have a transparent background instead of inheriting the text color

# Before
<img width="833" height="522" alt="image" src="https://github.com/user-attachments/assets/51c71641-0ad2-48ca-bff2-44b008608313" />

# After
<img width="823" height="530" alt="image" src="https://github.com/user-attachments/assets/0d654838-5872-49d1-8a61-d31cf52502f0" />
