### PR TITLE
[ui] Fix icon display in list items

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/css/ListItem.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/css/ListItem.module.css
@@ -60,15 +60,6 @@
   color: var(--color-text-default);
 }
 
-.listItem .listItemAnchor div[role='img'] {
-  background-color: var(--color-text-default);
-  transition: background-color 0.1s ease-in-out;
-}
-
-.listItem:hover .listItemAnchor div[role='img'] {
-  background-color: var(--color-text-default);
-}
-
 .listItem .checkboxContainer label {
   display: block;
   line-height: 0;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryListItem.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetSelectionSummaryListItem.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Colors,
   HorizontalControls,
   ListItem,
   MiddleTruncate,
@@ -27,7 +28,13 @@ export const AssetSelectionSummaryListItemFromSelection = React.memo(
     return (
       <AssetSelectionSummaryListItemWithHealthStatus
         index={index}
-        icon={<InsightsIcon name={item.icon as InsightsIconType} size={16} />}
+        icon={
+          <InsightsIcon
+            name={item.icon as InsightsIconType}
+            size={16}
+            color={Colors.textDefault()}
+          />
+        }
         label={item.name}
         link={item.link}
         statusJsx={jsx}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsGroupedView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetsGroupedView.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Colors,
   Container,
   Icon,
   IconName,
@@ -197,6 +198,7 @@ const getListItems = weakMapMemoize(
                 ? (label as KnownTagType)
                 : propertyToLabelAndIcon[selectedTab].icon
             }
+            color={Colors.textDefault()}
             size={24}
           />
         );


### PR DESCRIPTION
## Summary & Motivation

@braunjj noticed that the insights icons in catalog lists are rendering with their original color, and with weird background behavior.

This is related to the recent Icon refactor, and the fact that ListItem has CSS that explicitly sets `background-color` on icons. I think we can remove the ListItem CSS and require callers to set their icon color themselves. Then, by setting icon color explicitly on these `InsightsIcon` use cases, we'll get the correct colors again.

## How I Tested These Changes

View Catalog, verify that insights icons are rendered with the same color as other icons in the list.

## Changelog

[ui] Fix icon colors in list items.
