### PR TITLE
Bump asset kind limit to 10

### DIFF
--- a/docs/docs/guides/build/assets/metadata-and-tags/kind-tags.md
+++ b/docs/docs/guides/build/assets/metadata-and-tags/kind-tags.md
@@ -8,7 +8,7 @@ Kind tags can help you quickly identify the underlying system or technology used
 
 ## Adding kinds to an asset
 
-You may add up to three kinds to the `kinds` argument of an <PyObject section="assets" module="dagster" object="asset" decorator />, which can be useful to represent multiple technologies or systems that an asset is associated with. For example, an asset which is built by Python code and stored in Snowflake can be tagged with both `python` and `snowflake` kinds:
+You may add up to ten kinds to the `kinds` argument of an <PyObject section="assets" module="dagster" object="asset" decorator />, which can be useful to represent multiple technologies or systems that an asset is associated with. For example, an asset which is built by Python code and stored in Snowflake can be tagged with both `python` and `snowflake` kinds:
 
 <CodeExample path="docs_snippets/docs_snippets/concepts/metadata-tags/asset_kinds.py" title="src/<project_name>/defs/assets.py" />
 

--- a/python_modules/dagster/dagster/_core/definitions/assets/definition/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/definition/asset_spec.py
@@ -97,8 +97,8 @@ class AssetExecutionType(Enum):
 
 
 def validate_kind_tags(kinds: Optional[AbstractSet[str]]) -> None:
-    if kinds is not None and len(kinds) > 3:
-        raise DagsterInvalidDefinitionError("Assets can have at most three kinds currently.")
+    if kinds is not None and len(kinds) > 10:
+        raise DagsterInvalidDefinitionError("Assets can have at most ten kinds currently.")
 
 
 @hidden_param(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2317,10 +2317,11 @@ def test_asset_decorator_with_kinds() -> None:
     assert asset1.specs_by_key[dg.AssetKey("asset1")].kinds == {"python"}
 
     with pytest.raises(
-        dg.DagsterInvalidDefinitionError, match="Assets can have at most three kinds currently."
+        dg.DagsterInvalidDefinitionError, match="Assets can have at most ten kinds currently."
     ):
+        kinds = {f"kind_{i}" for i in range(11)}
 
-        @dg.asset(kinds={"python", "snowflake", "bigquery", "airflow"})
+        @dg.asset(kinds=kinds)
         def asset2(): ...
 
     with pytest.raises(
@@ -2339,12 +2340,11 @@ def test_asset_spec_with_kinds() -> None:
     assert assets.specs_by_key[dg.AssetKey("asset1")].kinds == {"python"}
 
     with pytest.raises(
-        dg.DagsterInvalidDefinitionError, match="Assets can have at most three kinds currently."
+        dg.DagsterInvalidDefinitionError, match="Assets can have at most ten kinds currently."
     ):
+        kinds = {f"kind_{i}" for i in range(11)}
 
-        @dg.multi_asset(
-            specs=[dg.AssetSpec("asset1", kinds={"python", "snowflake", "bigquery", "airflow"})]
-        )
+        @dg.multi_asset(specs=[dg.AssetSpec("asset1", kinds=kinds)])
         def assets2(): ...
 
     with pytest.raises(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -1023,10 +1023,11 @@ def test_graph_asset_kinds() -> None:
     assert my_graph_asset.tags_by_key[dg.AssetKey("my_graph_asset")] == build_kind_tag("python")
 
     with pytest.raises(
-        dg.DagsterInvalidDefinitionError, match="Assets can have at most three kinds currently."
+        dg.DagsterInvalidDefinitionError, match="Assets can have at most ten kinds currently."
     ):
+        kinds = {f"kind_{i}" for i in range(11)}
 
-        @dg.graph_asset(kinds={"python", "snowflake", "bigquery", "airflow"})
+        @dg.graph_asset(kinds=kinds)
         def assets2(): ...
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
@@ -68,7 +68,8 @@ def test_replace_attributes_kinds() -> None:
     assert new_spec.tags == {"c": "d", "dagster/kind/bar": ""}
 
     with pytest.raises(dg.DagsterInvalidDefinitionError):
-        spec.replace_attributes(kinds={"a", "b", "c", "d", "e"})
+        kinds = {f"kind_{i}" for i in range(11)}
+        spec.replace_attributes(kinds=kinds)
 
 
 def test_replace_attributes_deps_coercion() -> None:


### PR DESCRIPTION
## Summary & Motivation

Bumps limit on number of kinds that can be set on an asset to 10 (previously 3).

Kinds do start to look a little weird if they get too long (see screenshot) but this is already an issue with 3, if the text is long enough.

Resolves #32976

![image.png](https://app.graphite.com/user-attachments/assets/587f4a8a-3e6f-4c49-9891-ab04b5b918f9.png)

Have confirmed with @benpankow that there's no reason for the limit of 3 other than it starting to look odd in the UI.

## How I Tested These Changes

Existing test suite.

## Changelog

Assets may now be annotated with up to 10 kinds (limit was previously 3).