### PR TITLE
[fix] Fix issue with default factories in Resolved models

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -178,7 +178,11 @@ def derive_model_type(
 
             field_infos = []
             if annotation_info.field_info:
-                field_infos.append(annotation_info.field_info)
+                # remove the default_factory as we set a `default` marker field on the Model type
+                # for unserializable defaults (and functions are not serializable)
+                field_infos.append(
+                    FieldInfo.merge_field_infos(annotation_info.field_info, default_factory=None)
+                )
 
             if annotation_info.has_default:
                 # if the annotation has a serializable default

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_resolved.py
@@ -625,3 +625,28 @@ def test_dicts():
 
     with pytest.raises(ResolutionException, match="dict key type must be str"):
         BadHasDict.resolve_from_dict({"thing": {"a": {"name": "a", "value": {"key": "a"}}}})
+
+
+def test_default_factory():
+    @dataclass
+    class TargetDataclass(dg.Resolvable):
+        items: dict = field(default_factory=dict)
+
+    # empty yaml should produce an instance with the default dict
+    t = TargetDataclass.resolve_from_yaml("")
+    assert isinstance(t.items, dict)
+    assert t.items == {}
+    t = TargetDataclass.resolve_from_dict({"items": {"a": "b"}})
+    assert t.items == {"a": "b"}
+
+    class TargetModel(dg.Model, dg.Resolvable):
+        some_field: list[str] = Field(default_factory=list)
+
+    t = TargetModel.resolve_from_yaml("")
+    assert isinstance(t.some_field, list)
+    assert t.some_field == []
+    assert TargetModel.resolve_from_yaml("""
+some_field:
+  - a
+  - b
+""").some_field == ["a", "b"]


### PR DESCRIPTION
## Summary & Motivation

Resolves: https://github.com/dagster-io/dagster/pull/32701

## How I Tested These Changes

## Changelog

Fixed issue that would cause errors when attempting to create subclasses of `Resolved` that had fields using `default_factory` arguments.