### PR TITLE
Add partitions facet

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeFacetSettingsButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeFacetSettingsButton.tsx
@@ -66,7 +66,7 @@ const ExampleAssetNode: AssetNodeFragment = {
   isAutoCreatedStub: false,
   id: '["asset1"]',
   isObservable: false,
-  isPartitioned: false,
+  isPartitioned: true,
   isMaterializable: true,
   jobNames: ['job1'],
   opNames: ['asset1'],
@@ -110,7 +110,12 @@ const ExampleLiveData: LiveDataForNodeWithStaleData = {
     __typename: 'AssetFreshnessInfo',
     currentMinutesLate: 12,
   },
-  partitionStats: null,
+  partitionStats: {
+    numMaterialized: 90,
+    numMaterializing: 0,
+    numPartitions: 100,
+    numFailed: 2,
+  },
   opNames: [],
   assetChecks: ExampleAssetChecks,
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeFacets.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeFacets.tsx
@@ -14,6 +14,7 @@ export const AllAssetNodeFacets = [
   AssetNodeFacet.Status,
   AssetNodeFacet.KindTag,
   AssetNodeFacet.Automation,
+  AssetNodeFacet.Partitions,
 ];
 
 export const AssetNodeFacetDefaults = [
@@ -23,6 +24,7 @@ export const AssetNodeFacetDefaults = [
   AssetNodeFacet.Status,
   AssetNodeFacet.KindTag,
   AssetNodeFacet.Automation,
+  AssetNodeFacet.Partitions,
 ];
 
 function validateSavedFacets(input: any) {
@@ -58,6 +60,8 @@ export function labelForFacet(facet: AssetNodeFacet) {
       return 'Sync status tags';
     case AssetNodeFacet.Automation:
       return 'Automation';
+    case AssetNodeFacet.Partitions:
+      return 'Partitions';
     default:
       assertUnreachable(facet);
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeFacetsUtil.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeFacetsUtil.ts
@@ -8,4 +8,5 @@ export enum AssetNodeFacet {
   Status = 'status',
   KindTag = 'kind-tag',
   Automation = 'automation',
+  Partitions = 'partitions',
 }


### PR DESCRIPTION
## Summary & Motivation
Adds a partition facet back to the lineage graph.

<img width="420" height="240" alt="image" src="https://github.com/user-attachments/assets/81932eab-0196-42f1-926b-c264d800e742" />
<img width="753" height="442" alt="image" src="https://github.com/user-attachments/assets/c1702e61-1e8a-40b0-be1c-973f31f96cf3" />


## How I Tested These Changes

## Changelog
Added a new Partitions facet to the Asset Lineage Graph