### PR TITLE
DOCS add gitignore files to prepare for #32987

### DIFF
--- a/docs/docs/api/graphql/.gitignore
+++ b/docs/docs/api/graphql/.gitignore
@@ -1,0 +1,2 @@
+**/*.mdx
+!index.mdx

--- a/docs/docs/integrations/libraries/.gitignore
+++ b/docs/docs/integrations/libraries/.gitignore
@@ -1,0 +1,2 @@
+**/*.mdx
+!index.mdx


### PR DESCRIPTION
## Summary & Motivation

Adds gitignore files to the GraphQL docs section and Integrations > Libraries docs section so I'm not driven crazy by build artifacts following me from branch to branch while I work on https://github.com/dagster-io/dagster/pull/32987

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
