### PR TITLE
[secret-resource-param] frontend

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
@@ -342,6 +342,7 @@ const ResourceConfig = (props: {
                         </Tooltip>
                         {isDefault && <Tag>Default</Tag>}
                         {type === 'ENV_VAR' && <Tag intent="success">Env var</Tag>}
+                        {type === 'SECRET' && <Tag intent="warning">Secret</Tag>}
                       </Box>
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary & Motivation

Updates the frontend rendering of resource config to hide secret parameter values for resources.

![image.png](https://app.graphite.com/user-attachments/assets/51978e3e-41b3-450a-a05f-86d6e88adeb5.png)

The styling here is inspired by the existing handling of env vars.

## How I Tested These Changes

Manually in UI.