### PR TITLE
Add `FreshnessPolicy` support to `DgScope`

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/context.py
+++ b/python_modules/dagster/dagster/components/resolved/context.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 )
 from dagster._record import copy, record
 from dagster.components.resolved.errors import ResolutionException
-from dagster.components.resolved.scopes import DeprecatedScope, DgScope, EnvScope
+from dagster.components.resolved.scopes import DatetimeScope, DeprecatedScope, DgScope, EnvScope
 
 T = TypeVar("T")
 
@@ -69,6 +69,7 @@ class ResolutionContext:
             scope={
                 "env": EnvScope(),
                 "dg": DgScope(),
+                "datetime": DatetimeScope(),
                 # Backward compatibility - deprecated, will be removed in 1.13.0
                 "automation_condition": DeprecatedScope(
                     "automation_condition.*", "dg.AutomationCondition.*", automation_condition_obj

--- a/python_modules/dagster/dagster/components/resolved/scopes.py
+++ b/python_modules/dagster/dagster/components/resolved/scopes.py
@@ -83,6 +83,7 @@ class DgScope(WrappedObjectScope):
 
         accessible_attributes = {
             "AutomationCondition",
+            "FreshnessPolicy",
             "DailyPartitionsDefinition",
             "WeeklyPartitionsDefinition",
             "MonthlyPartitionsDefinition",
@@ -92,6 +93,24 @@ class DgScope(WrappedObjectScope):
         }
 
         super().__init__(dg, accessible_attributes)
+
+
+class DatetimeScope(WrappedObjectScope):
+    """Provides access to Python datetime utilities within templates.
+
+    Available via `{{ datetime.* }}` in component YAML files.
+
+    Examples:
+        {{ datetime.datetime.now() }}
+        {{ datetime.timedelta(days=7) }}
+    """
+
+    def __init__(self):
+        import datetime
+
+        accessible_attributes = {"datetime", "timedelta"}
+
+        super().__init__(datetime, accessible_attributes)
 
 
 class LoadContextScope(WrappedObjectScope):

--- a/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/scripts/defs.yaml
+++ b/python_modules/dagster/dagster_tests/components_tests/code_locations/python_script_location/defs/scripts/defs.yaml
@@ -6,8 +6,14 @@ attributes:
   assets:
     - key: a
       automation_condition: "{{ dg.AutomationCondition.eager() }}"
+      freshness_policy: "{{ dg.FreshnessPolicy.time_window(fail_window=datetime.timedelta(days=2), warn_window=datetime.timedelta(days=1)) }}"
     - key: b
       automation_condition: "{{ dg.AutomationCondition.on_cron('@daily') }}"
+      freshness_policy: "{{ dg.FreshnessPolicy.time_window(fail_window=datetime.timedelta(days=3)) }}"
+      deps: [up1, up2]
+    - key: b_cron
+      automation_condition: "{{ dg.AutomationCondition.on_cron('@daily') }}"
+      freshness_policy: "{{ dg.FreshnessPolicy.cron(deadline_cron='0 10 * * *', lower_bound_delta=datetime.timedelta(hours=1)) }}"
       deps: [up1, up2]
 ---
 type: dagster.components.lib.executable_component.python_script_component.PythonScriptComponent


### PR DESCRIPTION
## Summary & Motivation

This PR adds support for Freshness Policy definitions in YAML.

## How I Tested These Changes

Extended existing test cases, including testing `AutomationCondition` defs.

There are 12 tests failing under `dagster/dagster_tests/component_tests`, but they seem unrelated to my changes because they fail on master also.

## Changelog

> - `timedelta` and `datetime` are now available via the `datetime` context.
> - All `FreshnessPolicy` subclasses are now available via the `dg` context, e.g.:
>   - `{{ dg.FreshnessPolicy.time_window(fail_window=datetime.timedelta(days=3)) }}"`
>   - `{{ dg.FreshnessPolicy.time_window(fail_window=datetime.timedelta(days=2), warn_window=datetime.timedelta(days=1)) }}`
>   - `{{ dg.FreshnessPolicy.cron(deadline_cron='0 10 * * *', lower_bound_delta=datetime.timedelta(hours=1)) }}`


@cmpadden 
