### PR TITLE
[nux] Fix refresh_defs_state handling of subprocesses

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
@@ -16,7 +16,7 @@ from dagster_dg_core.shared_options import (
     dg_path_options,
     make_option_group,
 )
-from dagster_dg_core.utils import DgClickCommand, DgClickGroup, not_none
+from dagster_dg_core.utils import DgClickCommand, DgClickGroup, activate_venv, not_none
 from dagster_dg_core.utils.telemetry import cli_telemetry_wrapper
 from dagster_shared import check
 from dagster_shared.plus.config import DagsterPlusCliConfig
@@ -488,7 +488,9 @@ def refresh_defs_state_impl(
             )
 
             try:
-                subprocess.run(cmd, check=True, capture_output=False)
+                # activate the venv for the subprocess to ensure CLIs are available
+                with activate_venv(project_context.root_path / ".venv"):
+                    subprocess.run(cmd, check=True, capture_output=False)
             except subprocess.CalledProcessError as e:
                 click.echo(
                     click.style(


### PR DESCRIPTION
## Summary & Motivation

While the code before did use the correct python executable, and so all python dependencies were correctly handled, if the code required invoking a CLI that was only available in the project environment, this would fail because we did not update the `PATH` to include this.

This uses the activate_venv utility to update the path -- it also updates the VIRTUAL_ENV env var which avoids an annoying warning we were getting before about the project env not matching (even though it did -- we just didn't have the right env var set)

## How I Tested These Changes

## Changelog

Fixed an issue with `dg plus deploy refresh-defs-state` which could cause errors when refreshing state for components that required CLIs that were only available in the project environment.
