### PR TITLE
toy asset with randomly changing schema

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/alert_helpers.py
+++ b/python_modules/dagster-test/dagster_test/toys/alert_helpers.py
@@ -1,0 +1,44 @@
+import random
+import time
+
+import dagster as dg
+
+"""
+Repo of assets and ops that are useful for testing alerts
+"""
+
+
+def generate_random_schema(column_names: list[str]):
+    column_types = ["string", "int", "timestamp", "float"]
+    tags = [{"priority": "high"}, {"team": "marketing"}, {"region": "eu"}]
+    columns = [
+        dg.TableColumn(
+            name=column_name,
+            type=random.choice(column_types),
+            tags=random.choice(tags),
+            constraints=dg.TableColumnConstraints(
+                nullable=random.choice([True, False]), unique=random.choice([True, False])
+            ),
+        )
+        for column_name in column_names
+    ]
+
+    return dg.TableSchema(columns=columns)
+
+
+@dg.asset
+def schema_change_asset(context):
+    random.seed(time.time())
+    columns = ["name", "email", "age", "city", "country", "phone", "job_title", "pet_name"]
+
+    return dg.MaterializeResult(
+        metadata={
+            "dagster/column_schema": generate_random_schema(
+                random.sample(columns, random.randint(4, len(columns)))
+            )
+        }
+    )
+
+
+def get_assets_and_checks():
+    return [schema_change_asset]

--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -248,6 +248,13 @@ def asset_health_repository():
 
 
 @repository
+def alert_helpers_repository():
+    from dagster_test.toys.alert_helpers import get_assets_and_checks
+
+    return get_assets_and_checks()
+
+
+@repository
 def freshness_repository():
     from dagster_test.toys.freshness import get_freshness_assets
 


### PR DESCRIPTION
Adds a repo to the toys code location to put some assets that are useful for testing alerts. Starting with an asset that reports random table schema metadata