### PR TITLE
[docs] Dagster nanochat example

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -161,6 +161,11 @@ const sidebars: SidebarsConfig = {
             },
             {
               type: 'link',
+              label: 'Dagster Nanochat',
+              href: 'https://dagster.io/blog/orchestrating-nanochat-building-the-tokenizer/',
+            },
+            {
+              type: 'link',
               label: 'Sales demo example pipelines',
               href: 'https://github.com/dagster-io/hooli-data-eng-pipelines/',
             },


### PR DESCRIPTION
## Summary & Motivation
Include the Dagster nanochat as an external example (repo is too large to include within Dagster). Currently this links out to the first blog post. The other external example link to repos so there are probably two options for what the link should be.

1. Link to the blog series
2. Link to the nanochat repo and update the nanochat README to include the blog posts (which I should probably do anyway)

NOTE
The spacing doesn't look as good with an odd number of external links

<img width="937" height="302" alt="Screenshot 2025-12-11 at 8 01 42 AM" src="https://github.com/user-attachments/assets/ab0efcf2-f279-44b7-81ed-4a8dec08eba1" />

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
