### PR TITLE
[dagster-dbt] Opt-in for enabling AssetDep metadata in DagsterDbtTranslator

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -572,6 +572,9 @@ def default_metadata_from_dbt_resource_props(
             dbt_resource_props.get("database"),
             dbt_resource_props.get("schema"),
             dbt_resource_props.get("alias"),
+            dbt_resource_props.get("name")
+            if dbt_resource_props.get("resource_type") == "source"
+            else None,
         ]
         if relation_part
     ]

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/dbt_project/expected_example
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/dbt_project/expected_example
@@ -56,4 +56,5 @@ attributes:
     enable_code_references: true
     enable_dbt_selection_by_name: true
     enable_source_tests_as_checks: true
+    enable_source_metadata: true
   prepare_if_dev: true

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/dbt_project/expected_schema
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/dbt_project/expected_schema
@@ -97,4 +97,5 @@ attributes:  # Optional: Attributes details
     enable_code_references: <one of: boolean, string>  # Optional: 
     enable_dbt_selection_by_name: <one of: boolean, string>  # Optional: 
     enable_source_tests_as_checks: <one of: boolean, string>  # Optional: 
+    enable_source_metadata: <one of: boolean, string>  # Optional: 
   prepare_if_dev: <one of: boolean, string>  # Optional: Whether to prepare the dbt project every time in `dagster dev` or `dg` cli calls.


### PR DESCRIPTION
## Summary & Motivation

Adds the ability to add in AssetDep metadata to specs produced by the DagsterDbtTranslator.

When this is set, the framework changes made in downstack PRs will allow these keys to be automatically remapped to upstream assets that share the same dagster/table_name metadata

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
