### PR TITLE
Better handling for backfill runs materializing unpartitioned materializations when they are supposed to be partitioned (and vice versa)

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/asset_graph_subset.py
@@ -180,7 +180,10 @@ class AssetGraphSubset(NamedTuple):
 
         for asset_key in other.asset_keys:
             if asset_key in other.non_partitioned_asset_keys:
-                check.invariant(asset_key not in self.partitions_subsets_by_asset_key)
+                check.invariant(
+                    asset_key not in self.partitions_subsets_by_asset_key,
+                    f"Asset {asset_key} is partitioned in one subset and non-partitioned in the other",
+                )
                 result_non_partitioned_asset_keys = oper(
                     result_non_partitioned_asset_keys, {asset_key}
                 )


### PR DESCRIPTION
## Summary & Motivation
Before these would move the backfill object into an invalid state where the materialized subset was incompatible with the target subset. Now we detect the invalid case during the backfill and fail it.

## How I Tested These Changes
New test cases

## Changelog
Fixed an issue where backfill runs that incorrectly created unpartitioned materializations of a partitioned asset, or partitioned materializations of an unpartitioned asset due to incorrect asset business logic would move the backfill into an invalid state. Now, the backfill will detect this case and fail the backfill.