### PR TITLE
[ui-core] fix race condition resulting in flaky unit test

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
@@ -204,16 +204,18 @@ describe('AssetCatalogTableV2', () => {
       expect(resultFn).toHaveBeenCalled();
     });
 
-    const calls = (AssetCatalogV2VirtualizedTable as unknown as jest.Mock).mock.calls;
-    const props = calls[calls.length - 1][0];
-    await waitFor(() =>
+    await waitFor(() => {
+      const calls = (AssetCatalogV2VirtualizedTable as unknown as jest.Mock).mock.calls;
+      const props = calls[calls.length - 1][0];
       expect(props).toEqual(
         expect.objectContaining({
           healthDataLoading: false,
         }),
-      ),
-    );
+      );
+    });
 
+    const calls = (AssetCatalogV2VirtualizedTable as unknown as jest.Mock).mock.calls;
+    const props = calls[calls.length - 1][0];
     expect(props).toEqual(
       expect.objectContaining({
         checkedDisplayKeys: new Set(),
@@ -271,9 +273,9 @@ describe('AssetCatalogTableV2', () => {
       expect(resultFn).toHaveBeenCalled();
     });
 
-    const calls = (AssetCatalogV2VirtualizedTable as unknown as jest.Mock).mock.calls;
-    const props = calls[calls.length - 1][0];
-    await waitFor(() =>
+    await waitFor(() => {
+      const calls = (AssetCatalogV2VirtualizedTable as unknown as jest.Mock).mock.calls;
+      const props = calls[calls.length - 1][0];
       expect(props).toEqual(
         expect.objectContaining({
           checkedDisplayKeys: new Set(['asset1', 'asset2']),
@@ -288,7 +290,7 @@ describe('AssetCatalogTableV2', () => {
             }),
           }),
         }),
-      ),
-    );
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary & Motivation

Attempt to fix flaky test:

```
[2025-12-12T20:05:57Z]  FAIL  src/assets/__tests__/AssetCatalogTablev2.test.tsx (5.841 s, 520 MB heap size)
[2025-12-12T20:05:57Z]   ● AssetCatalogTableV2 › renders
[2025-12-12T20:05:57Z]
[2025-12-12T20:05:57Z]     expect(received).toEqual(expected) // deep equality
[2025-12-12T20:05:57Z]
[2025-12-12T20:05:57Z]     - Expected  -  2
[2025-12-12T20:05:57Z]     + Received  + 14
[2025-12-12T20:05:57Z]
[2025-12-12T20:05:57Z]     - ObjectContaining {
[2025-12-12T20:05:57Z]     -   "healthDataLoading": false,
[2025-12-12T20:05:57Z]     + Object {
[2025-12-12T20:05:57Z]     +   "allGroups": Array [
[2025-12-12T20:05:57Z]     +     "Degraded",
[2025-12-12T20:05:57Z]     +     "Warning",
[2025-12-12T20:05:57Z]     +     "Healthy",
[2025-12-12T20:05:57Z]     +     "Unknown",
[2025-12-12T20:05:57Z]     +   ],
[2025-12-12T20:05:57Z]     +   "checkedDisplayKeys": Set {},
[2025-12-12T20:05:57Z]     +   "grouped": Object {},
[2025-12-12T20:05:57Z]     +   "healthDataLoading": true,
[2025-12-12T20:05:57Z]     +   "id": "asset-catalog-table-health_status",
[2025-12-12T20:05:57Z]     +   "loading": false,
[2025-12-12T20:05:57Z]     +   "onToggleFactory": [Function onToggleFactory],
[2025-12-12T20:05:57Z]     +   "onToggleGroup": [Function anonymous],
[2025-12-12T20:05:57Z]       }
```

- props is a reference to a specific object from a specific render
- When the component re-renders with healthDataLoading: false, it creates a NEW props object
- The waitFor keeps checking the OLD props object which never changes
- Sometimes passes if health data loads before we capture props
- Sometimes fails if we capture props during loading

Move props retrieval inside the waitFor callback to get fresh props on each poll:
```
await waitFor(() => {
  const calls = (AssetCatalogV2VirtualizedTable as unknown as jest.Mock).mock.calls;
  const props = calls[calls.length - 1][0];
  expect(props).toEqual(
    expect.objectContaining({
      healthDataLoading: false,
    }),
  );
});
```
Now each poll gets the latest mock call → checks current props → passes when health data is loaded.

## How I Tested These Changes

bk

## Changelog

NOCHANGELOG
