### PR TITLE
[dagster-dbt] Be more resilient to missing timing data from dbt cloud

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -12,6 +12,7 @@ from dagster import (
     get_dagster_logger,
 )
 from dagster._record import record
+from dagster._time import get_current_timestamp
 from dateutil import parser
 from requests.exceptions import RequestException
 
@@ -80,6 +81,10 @@ class DbtCloudJobRunHandler:
 
 
 def get_completed_at_timestamp(result: Mapping[str, Any]) -> float:
+    timing = result["timing"]
+    if len(timing) == 0:
+        # as a fallback, use the current timestamp
+        return get_current_timestamp()
     # result["timing"] is a list of events in run_results.json
     # For successful models and passing tests,
     # the last item of that list includes the timing details of the execution.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/sensor_builder.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/sensor_builder.py
@@ -142,7 +142,7 @@ def sorted_asset_events(
     return [
         sorted_event[1]
         for sorted_event in sorted(
-            materializations_and_timestamps, key=lambda x: (x[0], topo_aks.index(x[1].asset_key))
+            materializations_and_timestamps, key=lambda x: (topo_aks.index(x[1].asset_key), x[0])
         )
     ]
 


### PR DESCRIPTION
## Summary & Motivation

It's possible for dbt cloud to not return any timing data in some circumstances. The main purpose of us tracking this is to be able to emit materialization events in the proper order. This gives a fallback of using the time we received the event as the completed_at time, and swaps the tuple that we're using to sort our materialization events to prioritize the topological order

## How I Tested These Changes

## Changelog

[dagster-dbt] Fixed issue that could cause errors when emitting events for a dbt Cloud job run
