### PR TITLE
[dagster-graphql] fix runtime error with gql version detection

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -666,6 +666,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: list[PackageSpec] = [
             ToxFactor("postgres-instance_managed_grpc_env", splits=2),
             ToxFactor("postgres-instance_deployed_grpc_env", splits=2),
             ToxFactor("gql_v3"),
+            ToxFactor("gql_v3_5"),
         ],
         unsupported_python_versions=(
             lambda tox_factor: (

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
@@ -36,7 +36,7 @@ from dagster_shared.ipc import open_ipc_subprocess
 from graphql import print_ast
 
 try:
-    from gql.client import GraphQLRequest  # noqa: F401
+    from gql.client import GraphQLRequest
 
     HAS_GRAPHQL_REQUEST = True
 except ImportError:
@@ -878,7 +878,6 @@ def make_graphql_context_test_suite(context_variants):
             class MockedGraphQLClient:
                 def execute(self, gql_query, variable_values=None):
                     # Handle both gql v3 (DocumentNode) and v4 (GraphQLRequest)
-                    # In gql v4, queries may be wrapped in GraphQLRequest objects
                     if HAS_GRAPHQL_REQUEST and isinstance(gql_query, GraphQLRequest):  # pyright: ignore[reportPossiblyUnboundVariable]
                         document = gql_query.document
                         variables = (

--- a/python_modules/dagster-graphql/tox.ini
+++ b/python_modules/dagster-graphql/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {default,gql_v3}
+envlist = {default,gql_v3,gql_v3_5}
 skipsdist = true
 
 [testenv]
@@ -16,6 +16,7 @@ setenv =
 install_command = uv pip install {opts} {packages}
 deps =
   gql_v3: gql[requests]==3.0.0
+  gql_v3_5: gql[requests]==3.5.0
   -e ../dagster[test]
   -e ../dagster-pipes
   -e ../libraries/dagster-shared


### PR DESCRIPTION
## Summary & Motivation

The https://github.com/dagster-io/dagster/pull/33032 PR introduced a bug:
- It only checked HAS_GRAPHQL_REQUEST (compile-time flag indicating gql v4 is installed)
- It didn't verify the runtime type of gql_query
- When gql v4 was installed but gql_query was a DocumentNode, it tried to access .document attribute which doesn't exist

## How I Tested These Changes

## Changelog

NOCHANGELOG
