### PR TITLE
Fix handling of pythonic config with PEP 649

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -1,3 +1,4 @@
+import sys
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -25,6 +26,24 @@ except ImportError:
 
 if TYPE_CHECKING:
     from dagster._config.pythonic_config import PartialResource
+
+
+def _materialize_annotations_for_pydantic(namespaces: dict[str, Any]) -> dict[str, Any]:
+    """Materialize lazy annotations in Python 3.14+ (PEP 649)."""
+    annotations = namespaces.get("__annotations__", {})
+
+    # if annotations are empty, try calling __annotate_func__ (PEP 649)
+    if sys.version_info >= (3, 14) and not annotations:
+        import annotationlib
+
+        annotate_func = annotationlib.get_annotate_from_class_namespace(namespaces)
+        if annotate_func is not None:
+            annotations = annotationlib.call_annotate_function(
+                annotate_func, annotationlib.Format.VALUE
+            )
+            namespaces["__annotations__"] = annotations
+
+    return annotations
 
 
 # Since a metaclass is invoked by Resource before Resource or PartialResource is defined, we need to
@@ -72,7 +91,8 @@ class LateBoundTypesForResourceTypeChecking:
 @dataclass_transform(kw_only_default=True, field_specifiers=(Field,))
 class BaseConfigMeta(ModelMetaclass):  # type: ignore
     def __new__(cls, name, bases, namespaces, **kwargs) -> Any:
-        annotations = namespaces.get("__annotations__", {})
+        # Materialize lazy annotations for Python 3.14+ before Pydantic sees them
+        annotations = _materialize_annotations_for_pydantic(namespaces)
 
         # Need try/catch because DagsterType may not be loaded when some of the base Config classes are
         # being created
@@ -118,11 +138,12 @@ class BaseResourceMeta(BaseConfigMeta):
         from pydantic.fields import FieldInfo
 
         # Gather all type annotations from the class and its base classes
-        annotations = namespaces.get("__annotations__", {})
+        # Materialize lazy annotations for Python 3.14+ before Pydantic sees them
+        annotations = _materialize_annotations_for_pydantic(namespaces)
+
         for field in annotations:
             if not field.startswith("__"):
                 # Check if the annotation is a ResourceDependency
-
                 if (
                     get_origin(annotations[field])
                     == LateBoundTypesForResourceTypeChecking.get_resource_rep_type()


### PR DESCRIPTION
## Summary & Motivation

Pretty gross, but this was the best I could figure out. PEP 649 pretty signficantly changes how annotations are handled on classes in ways that break our existing utilities. In particular, because annotations are lazily evaluated by default, some of our logic which attempts to intercept the annotations to check for things like `ResourceDependency[T]` things would no longer work because we were explicitly analyzing the `__annotations__` value. 

This PR executes the `__annotate_func__` to make sure we have the fully-instantiated types

## How I Tested These Changes

Ran relevant tests in an env with python 3.14 installed -- failed before, pass now. The next pr upstack adds this testing to BK, just split it up here to isolate the spicy changes.

## Changelog

