### PR TITLE
add default Nones to AssetHealthMaterializationHealthyPartitionedMeta and AssetHealthMaterializationDegradedPartitionedMeta

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py
@@ -331,8 +331,8 @@ class AssetHealthMaterializationDegradedPartitionedMeta:
     num_failed_partitions: int
     num_missing_partitions: int
     total_num_partitions: int
-    latest_run_id: Optional[str]
-    latest_failed_to_materialize_run_id: Optional[str]
+    latest_run_id: Optional[str] = None
+    latest_failed_to_materialize_run_id: Optional[str] = None
 
 
 @whitelist_for_serdes
@@ -340,8 +340,8 @@ class AssetHealthMaterializationDegradedPartitionedMeta:
 class AssetHealthMaterializationHealthyPartitionedMeta:
     num_missing_partitions: int
     total_num_partitions: int
-    latest_run_id: Optional[str]
-    latest_failed_to_materialize_run_id: Optional[str]
+    latest_run_id: Optional[str] = None
+    latest_failed_to_materialize_run_id: Optional[str] = None
 
 
 @whitelist_for_serdes


### PR DESCRIPTION
These are stored in the DB oops

fields originally added in [https://app.graphite.com/github/pr/dagster-io/dagster/32970/[asset-health]-add-latest-run-id-to-partitioned-asset-materialization-health-metadata#file-python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py](https://app.graphite.com/github/pr/dagster-io/dagster/32970/%5Basset-health%5D-add-latest-run-id-to-partitioned-asset-materialization-health-metadata#file-python_modules/dagster/dagster/_core/definitions/asset_health/asset_materialization_health.py)