### PR TITLE
copy material-icons icon exactly

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/icon-svgs/thumb_down.svg
+++ b/js_modules/dagster-ui/packages/ui-components/src/icon-svgs/thumb_down.svg
@@ -1,3 +1,3 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 <path d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm0 12-4.34 4.34L12 14H3v-2l3-7h9v10zm4-12h4v12h-4z"/>
 </svg>

--- a/js_modules/dagster-ui/packages/ui-components/src/icon-svgs/thumb_up.svg
+++ b/js_modules/dagster-ui/packages/ui-components/src/icon-svgs/thumb_up.svg
@@ -1,3 +1,3 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 <path d="M9 21h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.58 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2zM9 9l4.34-4.34L12 10h9v2l-3 7H9V9zM1 9h4v12H1z"/>
 </svg>


### PR DESCRIPTION
## Summary & Motivation

Make the new icons appear correctly

## How I Tested These Changes

Ran locally, confirmed icon appearance in the UI.

## Notes

I tried to change some of the metadata in the svg opening tag to align with the other svgs in the repo more closely, but this broke the svg. I didn't notice because I was doing the development with another svg until this was merged. This PR reverts the changes to exactly match what was in the https://github.com/marella/material-design-icons/blob/main/svg/outlined (thumb_up|thumb_down).svg files.