### PR TITLE
DOC-1559 Update SSO endpoint for EU deployments

### DIFF
--- a/docs/docs/deployment/dagster-plus/authentication-and-access-control/rbac/audit-logs.md
+++ b/docs/docs/deployment/dagster-plus/authentication-and-access-control/rbac/audit-logs.md
@@ -44,7 +44,7 @@ You can programmatically access audit logs with the Dagster+ [GraphQL API](/api/
 To access a visual GraphiQL interface, visit the GraphQL endpoint in a browser:
 
 - **US region:** `https://<org>.dagster.cloud/<deployment>/graphql`
-- **EU region:** `https://<org>.dagster.plus/<deployment>/graphql`
+- **EU region:** `https://<org>.eu.dagster.cloud/<deployment>/graphql`
 
 You can also query the API directly using the Python client:
 

--- a/docs/docs/deployment/dagster-plus/authentication-and-access-control/sso/azure-ad-sso.md
+++ b/docs/docs/deployment/dagster-plus/authentication-and-access-control/sso/azure-ad-sso.md
@@ -55,7 +55,7 @@ In this step, you'll configure and enable SSO for Azure AD in your Azure portal.
 
     :::info
 
-    For EU region customers, the URL will be `https://<organization_name>.dagster.plus/auth/saml/consume`
+    For EU region customers, the URL will be `https://<organization_name>.eu.dagster.cloud/auth/saml/consume`
 
     :::
 
@@ -94,7 +94,7 @@ dagster-cloud organization settings saml upload-identity-provider-metadata <path
 ```shell
 dagster-cloud organization settings saml upload-identity-provider-metadata <path/to/metadata> \
    --api-token=<user_token> \
-   --url https://<organization_name>.dagster.plus
+   --url https://<organization_name>.eu.dagster.cloud
 ```
 </TabItem>
 </Tabs>

--- a/docs/docs/deployment/dagster-plus/authentication-and-access-control/sso/google-workspace-sso.md
+++ b/docs/docs/deployment/dagster-plus/authentication-and-access-control/sso/google-workspace-sso.md
@@ -64,11 +64,11 @@ To complete the steps in this guide, you'll need:
 
       :::info EU region
 
-      For EU region customers, the URL will be `https://<organization_name>.dagster.plus`
+      For EU region customers, the URL will be `https://<organization_name>.eu.dagster.cloud`
 
       :::
 
-   2. Check the **Signed Response** box. The page should look similar to the image below. In this example, the organization's name is `hooli` and the Dagster+ domain is `https://hooli.dagster.cloud` (or `https://hooli.dagster.plus` in the EU region):
+   2. Check the **Signed Response** box. The page should look similar to the image below. In this example, the organization's name is `hooli` and the Dagster+ domain is `https://hooli.dagster.cloud` (or `https://hooli.eu.dagster.cloud` in the EU region):
 
       ![Service Provider Details](/images/dagster-plus/features/authentication-and-access-control/google-workspace/service-provider-details.png)
 

--- a/docs/docs/deployment/dagster-plus/authentication-and-access-control/sso/okta-sso.md
+++ b/docs/docs/deployment/dagster-plus/authentication-and-access-control/sso/okta-sso.md
@@ -39,7 +39,7 @@ To complete the steps in this guide, you'll need:
 2. Scroll down to the **Advanced Sign-on settings** section.
 3. In the **Organization** field, enter your Dagster+ organization name. This is used to route the SAML response to the correct Dagster+ subdomain.
 
-For example, your organization name is `hooli` and your Dagster+ domain is `https://hooli.dagster.cloud` (or `https://hooli.dagster.plus` in the EU region). To configure this correctly, you'd enter `hooli` into the **Organization** field:
+For example, your organization name is `hooli` and your Dagster+ domain is `https://hooli.dagster.cloud` (or `https://hooli.eu.dagster.cloud` in the EU region). To configure this correctly, you'd enter `hooli` into the **Organization** field:
 
 ![Okta Subdomain Configuration](/images/dagster-plus/features/authentication-and-access-control/okta/subdomain-configuration.png)
 

--- a/docs/docs/deployment/dagster-plus/authentication-and-access-control/sso/onelogin-sso.md
+++ b/docs/docs/deployment/dagster-plus/authentication-and-access-control/sso/onelogin-sso.md
@@ -42,7 +42,7 @@ To follow the steps in this guide, you'll need:
 1. In OneLogin, open the application and navigate to its **Configuration**.
 2. In the **Dagster+ organisation name** field, enter your Dagster+ organization name. This is used to route the SAML response to the correct Dagster+ subdomain.
 
-   For example, your organization name is `hooli` and your Dagster+ domain is `https://hooli.dagster.cloud` (or `https://hooli.dagster.plus` in the EU region). To configure this correctly, you'd enter `hooli` into the **Subdomain** field.
+   For example, your organization name is `hooli` and your Dagster+ domain is `https://hooli.dagster.cloud` (or `https://hooli.eu.dagster.cloud` in the EU region). To configure this correctly, you'd enter `hooli` into the **Subdomain** field.
 
 3. When finished, click **Done**.
 

--- a/docs/docs/deployment/dagster-plus/authentication-and-access-control/sso/pingone-sso.md
+++ b/docs/docs/deployment/dagster-plus/authentication-and-access-control/sso/pingone-sso.md
@@ -62,12 +62,12 @@ To complete the steps in this guide, you'll need:
 
       :::info EU region
 
-      For EU region customers, the URL will be `https://<organization_name>.dagster.plus/auth/saml/consume`
+      For EU region customers, the URL will be `https://<organization_name>.eu.dagster.cloud/auth/saml/consume`
 
       :::
 
     - **Assertion Validity Duration**: Type `60`.
-      In the following example, the organization's name is `hooli` and the Dagster+ domain is `https://hooli.dagster.cloud` (or `https://hooli.dagster.plus` in the EU region):
+      In the following example, the organization's name is `hooli` and the Dagster+ domain is `https://hooli.dagster.cloud` (or `https://hooli.eu.dagster.cloud` in the EU region):
 
       ![Service Provider Details](/images/dagster-plus/features/authentication-and-access-control/pingone/service-provider-details.png)
 

--- a/docs/docs/deployment/dagster-plus/hybrid/azure/key-vault.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/azure/key-vault.md
@@ -271,7 +271,7 @@ helm upgrade -n <dagster-namespace> user-cloud dagster-cloud/dagster-cloud-agent
 
 You can verify that the agent is running by looking at its status in the Dagster+ UI at this address:
 
-`https://<org_name>.dagster.plus/<deployment>/deployment/health`
+`https://<org_name>.eu.dagster.cloud/<deployment>/deployment/health`
 
 :::tip
 

--- a/docs/docs/deployment/dagster-plus/hybrid/kubernetes/setup.md
+++ b/docs/docs/deployment/dagster-plus/hybrid/kubernetes/setup.md
@@ -49,7 +49,9 @@ helm --namespace dagster-cloud upgrade --install agent dagster-cloud/dagster-clo
 You can use Helm to do rolling upgrades of your Dagster+ agent. The version of the agent doesn't need to be the same as the version of Dagster used in your projects. The Dagster+ control plane is upgraded automatically but is backwards compatible with older versions of the agent.
 
 :::tip
+
 We recommend upgrading your Dagster+ agent every 6 months. The version of your agent is visible on the "Deployments", "Agents" tab https://your-org.dagster.plus/deployment/health. The current version of the agent matches the most [recent Dagster release](https://github.com/dagster-io/dagster/releases).
+
 :::
 
 ```yaml
@@ -405,7 +407,7 @@ dagsterCloud:
 
 If you want completely separate environments with their own asset graph, run history, and access controls you should create different Dagster+ deployments. Separate deployments are common for isolated tenants or separate dev, stage, and prod environments. Multiple deployments require a Dagster+ Pro plan. To create separate deployments:
 
-- Navigate to the deployments page for your organization: https://your-organizaiton.dagster.plus/org-settings/deployments
+- Navigate to the deployments page for your organization: https://your-organization.dagster.plus/org-settings/deployments
 
 - Click "New Deployment"
 

--- a/docs/docs/partials/_EuRegionUrlNote.md
+++ b/docs/docs/partials/_EuRegionUrlNote.md
@@ -1,5 +1,5 @@
 :::info EU region
 
-For EU region customers, the URL will be `https://<organization_name>.dagster.plus`
+For EU region customers, the URL will be `https://<organization_name>.eu.dagster.cloud`
 
 :::

--- a/docs/docs/partials/_TestSSO.md
+++ b/docs/docs/partials/_TestSSO.md
@@ -10,7 +10,7 @@ Lastly, you'll test your SSO configuration:
 1. Navigate to your Dagster+ sign in page:
 
 - **US region:** `https://<organization_name>.dagster.cloud`
-- **EU region:** `https://<organization_name>.dagster.plus`
+- **EU region:** `https://<organization_name>.eu.dagster.cloud`
 
 2. Click the **Sign in with SSO** button.
 


### PR DESCRIPTION
## Summary & Motivation

The SSO endpoint for EU tenants is `<dagster-org>.eu.dagster.cloud`. Fixes error introduced in https://github.com/dagster-io/dagster/pull/33005

## How I Tested These Changes

Local build

## Changelog

> Insert changelog entry or delete this section.
