### PR TITLE
Change catalog layout feature flag default to True

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/DefaultFeatureFlags.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/DefaultFeatureFlags.oss.tsx
@@ -6,6 +6,7 @@ import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 export const DEFAULT_FEATURE_FLAG_VALUES: Partial<Record<FeatureFlag, boolean>> = {
   [FeatureFlag.flagAssetNodeFacets]: true,
   [FeatureFlag.flagNavigationUpdate]: true,
+  [FeatureFlag.flagAssetCatalogSidebar]: true,
 
   // Flags for tests
   [FeatureFlag.__TestFlagDefaultTrue]: true,


### PR DESCRIPTION
## Summary & Motivation
Make the experimental catalog UI changes default to on

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Default-enable the `flagAssetCatalogSidebar` feature flag in `DefaultFeatureFlags.oss.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06dc131665a466bb58efb34cdb2df0f10175565b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->