### PR TITLE
[ui] Show appropriate reason on tooltip when disabling sensor switch

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorSwitch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorSwitch.tsx
@@ -33,7 +33,7 @@ import {
 } from './types/SensorMutations.types';
 import {SensorStateQuery, SensorStateQueryVariables} from './types/SensorStateQuery.types';
 import {SensorSwitchFragment} from './types/SensorSwitchFragment.types';
-import {DEFAULT_DISABLED_REASON} from '../app/Permissions';
+import {usePermissionsForLocation} from '../app/Permissions';
 import {InstigationStatus, SensorType} from '../graphql/types';
 import {TimeFromNow} from '../ui/TimeFromNow';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
@@ -50,6 +50,12 @@ interface Props {
 export const SensorSwitch = (props: Props) => {
   const {repoAddress, sensor, size = 'large'} = props;
   const repoAddressSelector = useMemo(() => repoAddressToSelector(repoAddress), [repoAddress]);
+
+  // We retrieve the permissions for the sensor from the sensor state, but it doesn't include
+  // the reason for a permission being disabled. This is available on the permissions for the
+  // location, so use that.
+  const {disabledReasons} = usePermissionsForLocation(repoAddress.location);
+  const {canStartSensor: cannotStartReason, canStopSensor: cannotStopReason} = disabledReasons;
 
   const {id, name} = sensor;
 
@@ -74,6 +80,7 @@ export const SensorSwitch = (props: Props) => {
     refetchQueries: [{variables, query: SENSOR_STATE_QUERY}],
     awaitRefetchQueries: true,
   });
+
   const [stopSensor, {loading: toggleOffInFlight}] = useMutation<
     StopRunningSensorMutation,
     StopRunningSensorMutationVariables
@@ -82,10 +89,12 @@ export const SensorSwitch = (props: Props) => {
     refetchQueries: [{variables, query: SENSOR_STATE_QUERY}],
     awaitRefetchQueries: true,
   });
+
   const [setSensorCursor, {loading: cursorMutationInFlight}] = useMutation<
     SetSensorCursorMutation,
     SetSensorCursorMutationVariables
   >(SET_CURSOR_MUTATION);
+
   const clearCursor = async () => {
     await setSensorCursor({
       variables: {
@@ -129,20 +138,22 @@ export const SensorSwitch = (props: Props) => {
   }
 
   // Status according to sensor object passed in (may be outdated if its from the workspace snapshot)
-  let status = sensor.sensorState.status;
+  let {status} = sensor.sensorState;
+
+  // If the sensor was never toggled before then InstigationStateNotFoundError is returned
+  // in this case we should rely on the data from the WorkspaceSnapshot.
   if (
-    // If the sensor was never toggled before then InstigationStateNotFoundError is returned
-    // in this case we should rely on the data from the WorkspaceSnapshot.
-    !['InstigationState', 'InstigationStateNotFoundError'].includes(
-      data?.instigationStateOrError.__typename as any,
-    )
+    data?.instigationStateOrError.__typename !== 'InstigationState' &&
+    data?.instigationStateOrError.__typename !== 'InstigationStateNotFoundError'
   ) {
     return (
       <Tooltip content="Error loading sensor state">
         <Icon name="error" color={Colors.accentRed()} />;
       </Tooltip>
     );
-  } else if (data?.instigationStateOrError.__typename === 'InstigationState') {
+  }
+
+  if (data?.instigationStateOrError.__typename === 'InstigationState') {
     // status according to latest data
     status = data?.instigationStateOrError.status;
   }
@@ -240,23 +251,18 @@ export const SensorSwitch = (props: Props) => {
     (running && !sensor.sensorState?.hasStopPermission) ||
     (!running && !sensor.sensorState?.hasStartPermission);
   const disabled = toggleOffInFlight || toggleOnInFlight || lacksPermission;
+  const disabledReason = running ? cannotStopReason : cannotStartReason;
 
-  const switchElement = (
-    <Checkbox
-      format="switch"
-      disabled={disabled}
-      checked={running || toggleOnInFlight}
-      onChange={onChangeSwitch}
-      size={size}
-    />
-  );
-
-  return lacksPermission ? (
-    <Tooltip content={DEFAULT_DISABLED_REASON} display="flex">
-      {switchElement}
+  return (
+    <Tooltip content={disabledReason} display="flex" canShow={lacksPermission}>
+      <Checkbox
+        format="switch"
+        disabled={disabled}
+        checked={running || toggleOnInFlight}
+        onChange={onChangeSwitch}
+        size={size}
+      />
     </Tooltip>
-  ) : (
-    switchElement
   );
 };
 


### PR DESCRIPTION
## Summary & Motivation

We currently retrieve the permissions for starting/stopping a sensor for rendering the sensor switch, but we don't show a good reason to represent the disabled state when permissions are false.

This reason value doesn't appear to be available via GraphQL, but I think it should be okay to use the permissions for the code location, so use that here.

![Screenshot 2025-12-16 at 20.28.00.png](https://app.graphite.com/user-attachments/assets/82b8070e-4294-406e-ab20-ed20341df9ac.png)

## How I Tested These Changes

View branch deployment, go to an automation. Hover on the switch, verify that I've got a useful tooltip.

View prod deployment, verify that enabled sensor switches render without tooltips.

## Changelog

[ui] Improve text for the tooltip on sensor switches when they are disabled for permissions reasons.
