### PR TITLE
docs: add note about removed single-run backfill toggle

### DIFF
--- a/docs/docs/guides/build/partitions-and-backfills/backfilling-data.md
+++ b/docs/docs/guides/build/partitions-and-backfills/backfilling-data.md
@@ -18,6 +18,12 @@ Backfills can also be launched for a selection of partitioned assets as long as 
 
 ![Backfills launch modal](/images/guides/build/partitions-and-backfills/asset-backfill-partition-selection-modal.png)
 
+:::note
+
+The "Launch as..." toggle shown in the screenshot above (for choosing between single run and multiple runs) was removed from the UI in Dagster 1.5. Single-run backfills are now configured in code using `backfill_policy`. See [Launching single-run backfills using backfill policies](#launching-single-run-backfills-using-backfill-policies) below.
+
+:::
+
 To observe the progress of an asset backfill, navigate to the **Runs details** page for the run. This page can be accessed by clicking **Runs tab**, then clicking the ID of the run. To see all runs, including runs launched by a backfill, check the **Show runs within backfills** box:
 
 ![Asset backfill details page](/images/guides/build/partitions-and-backfills/asset-backfill-details-page.png)


### PR DESCRIPTION
## Summary

Added a note after the backfill launch modal screenshot to clarify that the "Launch as..." toggle (for choosing between single run and multiple runs) was removed from the UI in Dagster 1.5.

The screenshot currently shows this toggle, but users won't find it in the current UI. This note directs them to the `backfill_policy` section for configuring single-run backfills in code.

## Changes

- Added a `:::note` admonition after the screenshot explaining the toggle was removed
- Links to the existing "Launching single-run backfills using backfill policies" section

Fixes #33006