### PR TITLE
Add skip_alert_fn parameter to make_teams_on_run_failure_sensor

### DIFF
--- a/python_modules/libraries/dagster-msteams/dagster_msteams/sensors.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/sensors.py
@@ -64,6 +64,7 @@ def make_teams_on_run_failure_sensor(
     monitor_all_code_locations: bool = False,
     webserver_base_url: Optional[str] = None,
     monitor_all_repositories: bool = False,
+    skip_alert_fn: Optional[Callable[[RunFailureSensorContext], bool]] = None,
 ):
     """Create a sensor on run failures that will message the given MS Teams webhook URL.
 
@@ -93,6 +94,10 @@ def make_teams_on_run_failure_sensor(
         monitor_all_repositories (bool): If set to True, the sensor will monitor all runs in the
             Dagster instance. If set to True, an error will be raised if you also specify
             monitored_jobs or job_selection. Defaults to False.
+        skip_alert_fn (Optional[Callable[[RunFailureSensorContext], bool]]): Function that
+            takes in the ``RunFailureSensorContext`` and returns True if the alert should
+            be skipped. Defaults to None (no alerts are skipped). This can be used to
+            conditionally skip alerts, for example based on run tags.
 
     Examples:
         .. code-block:: python
@@ -141,6 +146,9 @@ def make_teams_on_run_failure_sensor(
         monitor_all_code_locations=monitor_all,
     )
     def teams_on_run_failure(context: RunFailureSensorContext):
+        if skip_alert_fn is not None and skip_alert_fn(context):
+            return
+
         text = message_fn(context)
         card = Card() if teams_client.is_legacy_webhook() else AdaptiveCard()
         card.add_attachment(

--- a/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_sensors.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_sensors.py
@@ -1,6 +1,7 @@
 import os
 
 from dagster import repository
+from dagster._core.definitions.run_status_sensor_definition import RunFailureSensorContext
 from dagster._core.test_utils import environ
 from dagster_msteams.sensors import make_teams_on_run_failure_sensor
 
@@ -12,6 +13,29 @@ def test_teams_run_failure_sensor_def():
         my_sensor = make_teams_on_run_failure_sensor(
             hook_url=os.getenv("TEAMS_WEBHOOK_URL"),  # pyright: ignore[reportArgumentType]
             name=sensor_name,
+        )
+        assert my_sensor.name == sensor_name
+
+        @repository
+        def my_repo():
+            return [my_sensor]
+
+        assert my_repo.has_sensor_def(sensor_name)
+
+
+def test_teams_run_failure_sensor_with_skip_alert_fn():
+    """Test that sensor can be created with skip_alert_fn parameter."""
+    with environ({"TEAMS_WEBHOOK_URL": "https://some_url_here/"}):
+        sensor_name = "my_failure_sensor_with_skip"
+
+        def should_skip_alert(context: RunFailureSensorContext) -> bool:
+            # Skip alert if run has will_retry tag
+            return context.dagster_run.tags.get("will_retry") == "true"
+
+        my_sensor = make_teams_on_run_failure_sensor(
+            hook_url=os.getenv("TEAMS_WEBHOOK_URL"),  # pyright: ignore[reportArgumentType]
+            name=sensor_name,
+            skip_alert_fn=should_skip_alert,
         )
         assert my_sensor.name == sensor_name
 


### PR DESCRIPTION
## Summary

Adds a `skip_alert_fn` parameter to `make_teams_on_run_failure_sensor` that allows users to conditionally skip sending alerts based on the run context.

This addresses the feature request in #33000.

**Changes:**
- Add `skip_alert_fn: Optional[Callable[[RunFailureSensorContext], bool]]` parameter
- Add docstring documentation for the new parameter
- Add skip logic in the inner sensor function
- Add test for the new parameter

## Example Usage

```python
def should_skip_alert(context: RunFailureSensorContext) -> bool:
    # Skip alert if run has will_retry tag
    return context.dagster_run.tags.get("will_retry") == "true"

teams_on_run_failure = make_teams_on_run_failure_sensor(
    hook_url=os.getenv("TEAMS_WEBHOOK_URL"),
    skip_alert_fn=should_skip_alert,
)
```

## Test plan

- [x] Added test for sensor creation with `skip_alert_fn` parameter
- [ ] CI tests should pass

Closes #33000