### PR TITLE
Fix pex build for pyproject.tomls with tool.uv.sources defined

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/deps.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/deps.py
@@ -388,6 +388,51 @@ def get_setup_py_deps(code_directory: str, python_interpreter: str) -> list[str]
     return lines
 
 
+def _read_pyproject_toml(directory: str) -> Optional[dict]:
+    """Read and parse pyproject.toml from a directory. Returns None if not found."""
+    pyproject_path = os.path.join(directory, "pyproject.toml")
+    if not os.path.exists(pyproject_path):
+        return None
+    with open(pyproject_path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _find_uv_workspace_root(start_dir: str) -> Optional[tuple[str, dict]]:
+    """Walk up directories to find a uv workspace root.
+
+    Returns (workspace_root_path, workspace_config) or None if not found.
+    """
+    current = os.path.abspath(start_dir)
+    while True:
+        data = _read_pyproject_toml(current)
+        if data:
+            workspace_config = data.get("tool", {}).get("uv", {}).get("workspace", {})
+            if workspace_config:
+                return current, workspace_config
+        parent = os.path.dirname(current)
+        if parent == current:
+            return None
+        current = parent
+
+
+def _resolve_uv_workspace_dep(dep_name: str, code_directory: str) -> Optional[str]:
+    """Find the relative path to a uv workspace member by package name.
+
+    Returns a relative path like "../shared-lib" or None if not found.
+    Assumes the directory name matches the package name.
+    """
+    result = _find_uv_workspace_root(code_directory)
+    if not result:
+        return None
+
+    workspace_root, _ = result
+    candidate = os.path.join(workspace_root, dep_name)
+    if os.path.isdir(candidate):
+        return os.path.relpath(candidate, code_directory)
+
+    return None
+
+
 def get_pyproject_toml_deps(code_directory: str) -> list[str]:
     pyproject_path = os.path.join(code_directory, "pyproject.toml")
     if not os.path.exists(pyproject_path):
@@ -441,6 +486,24 @@ def get_pyproject_toml_deps(code_directory: str) -> list[str]:
                 lines.append(f"{dep_name}{version_spec}")
             else:
                 lines.append(dep_name)
+
+    # Handle [tool.uv.sources] - resolve workspace and path dependencies to local paths
+    uv_sources = pyproject_data.get("tool", {}).get("uv", {}).get("sources", {})
+    if uv_sources:
+        resolved_lines = []
+        for line in lines:
+            source_config = uv_sources.get(line)
+            if source_config:
+                if source_config.get("workspace"):
+                    resolved_path = _resolve_uv_workspace_dep(line, code_directory)
+                    if resolved_path:
+                        resolved_lines.append(resolved_path)
+                        continue
+                elif "path" in source_config:
+                    resolved_lines.append(source_config["path"])
+                    continue
+            resolved_lines.append(line)
+        return resolved_lines
 
     return lines
 


### PR DESCRIPTION
## Summary & Motivation

When parsing out local dependencies, we were not properly handling uv sources.

This PR handles both standard single-project setups (where the tool.uv.sources will just contain the relative path directly), as well as uv workspaces (where tool.uv.sources will just contain `workspace = true`, which requires us to scan upwards to find the workspace config file.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
