### PR TITLE
[dagster-tableau] TableauWorkspace.connected_app_secret_value is now marked as a secret param that is hidden in the UI

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -572,6 +572,7 @@ class BaseTableauWorkspace(ConfigurableResource):
     connected_app_secret_value: str = Field(
         ...,
         description="The secret value of the connected app used to connect to Tableau Workspace.",
+        json_schema_extra={"dagster__is_secret": True},
     )
     username: str = Field(..., description="The username to authenticate to Tableau Workspace.")
     site_name: str = Field(..., description="The name of the Tableau site to use.")


### PR DESCRIPTION
## Summary & Motivation

`TableauWorkspace.connected_app_secret_value` is now marked as a secret param that is hidden in the UI. See https://github.com/dagster-io/dagster/pull/32995 for what this looks like.

## How I Tested These Changes

Existing test suite.