### PR TITLE
[dg] Support builds with uv workspace

### DIFF
--- a/python_modules/dagster-test/dagster_test/dg_utils/utils.py
+++ b/python_modules/dagster-test/dagster_test/dg_utils/utils.py
@@ -11,7 +11,7 @@ import textwrap
 import time
 import traceback
 from collections.abc import Iterator, Sequence
-from contextlib import contextmanager, nullcontext, redirect_stderr, redirect_stdout
+from contextlib import ExitStack, contextmanager, nullcontext, redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
@@ -223,6 +223,9 @@ def isolated_example_project_foo_bar(
     use_editable_dagster: bool = True,
     include_entry_point: bool = False,
     uv_sync: bool = False,
+    use_uv_workspace: bool = False,
+    project_name: str = "foo-bar",
+    use_tempdir: bool = True,
 ) -> Iterator[Path]:
     """Scaffold a project named foo_bar in an isolated filesystem.
 
@@ -237,62 +240,108 @@ def isolated_example_project_foo_bar(
     """
     uv_sync_args = ["--uv-sync"] if uv_sync else ["--no-uv-sync"]
 
+    hyph_name = project_name
+    snake_name = project_name.replace("-", "_")
+
     runner = ProxyRunner(runner) if isinstance(runner, CliRunner) else runner
     dagster_git_repo_dir = str(discover_repo_root(Path(__file__)))
-    project_path = Path("foo-bar")
+    project_path = Path(hyph_name)
     if in_workspace:
-        fs_context = isolated_example_workspace(runner)
-    else:
+        fs_context = isolated_example_workspace(
+            runner, workspace_config_file_type="pyproject.toml" if use_uv_workspace else "dg.toml"
+        )
+    elif use_tempdir:
         fs_context = runner.isolated_filesystem()
-    with fs_context, environ({"DAGSTER_GIT_REPO_DIR": dagster_git_repo_dir}):
+    else:
+        fs_context = nullcontext()
+
+    with ExitStack() as stack:
+        stack.enter_context(fs_context)
+        stack.enter_context(environ({"DAGSTER_GIT_REPO_DIR": dagster_git_repo_dir}))
+
+        if use_uv_workspace and not in_workspace:
+            raise Exception("Must set 'in_workspace' to use uv_workspace_dep")
+        elif use_uv_workspace:
+            stack.enter_context(
+                isolated_example_component_library_foo_bar(
+                    runner, library_name="test-lib-baz", use_tempdir=False
+                )
+            )
+            stack.enter_context(pushd(".."))  # pop out of library directory
+
+            # modify workspace config so it's a uv workspace that includes both the contents of
+            # "projects" and the "test-lib-baz" lib
+            # convert_dg_toml_to_pyproject_toml(Path("dg.toml"))
+            with modify_toml_as_dict(Path("pyproject.toml")) as toml:
+                toml["project"] = {
+                    "name": f"{snake_name}_workspace",
+                    "version": "0.1.0",
+                }
+                toml.setdefault("tool", {})["uv"] = {
+                    "sources": {
+                        "test-lib-baz": {"workspace": True},
+                    },
+                    "workspace": {
+                        "members": ["foo-bar", "test-lib-baz"],
+                        "exclude": [],
+                    },
+                }
+
         args = [
             "project",
-            "foo-bar",
+            hyph_name,
             *uv_sync_args,
             *(["--use-editable-dagster"] if use_editable_dagster else []),
         ]
         result = runner.invoke_create_dagster(*args)
+        assert_runner_result(result)
+
+        # inject the baz dependency
+        if use_uv_workspace:
+            with modify_toml_as_dict(Path(f"{hyph_name}/pyproject.toml")) as toml:
+                toml["project"]["dependencies"].append("test-lib-baz")
+                # toml["tool"]["uv"].setdefault("sources", {})["baz"]
 
         assert_runner_result(result)
         if config_file_type == "dg.toml":
             convert_pyproject_toml_to_dg_toml(
-                Path("foo-bar") / "pyproject.toml",
-                Path("foo-bar") / "dg.toml",
+                Path(hyph_name) / "pyproject.toml",
+                Path(hyph_name) / "dg.toml",
             )
 
-        module_parent_dir = Path("foo-bar").joinpath("src").resolve()
+        module_parent_dir = Path(hyph_name).joinpath("src").resolve()
         if package_layout == "root":
             # Move the src directory to the root of the project
-            curr_pkg_root = Path("foo-bar") / "src" / "foo_bar"
-            new_pkg_root = Path("foo-bar") / "foo_bar"
+            curr_pkg_root = Path(hyph_name) / "src" / snake_name
+            new_pkg_root = Path(hyph_name) / snake_name
             shutil.move(curr_pkg_root, new_pkg_root)
-            Path("foo-bar", "src").rmdir()
+            (Path(hyph_name) / "src").rmdir()
 
             # Adjust definitions.py to match root package layout
-            definitions_py = Path("foo-bar") / "foo_bar" / "definitions.py"
+            definitions_py = Path(hyph_name) / snake_name / "definitions.py"
             definitions_py.write_text(
                 definitions_py.read_text().replace(".parent.parent", ".parent")
             )
 
-            module_parent_dir = Path("foo-bar").resolve()
+            module_parent_dir = Path(hyph_name).resolve()
 
-            with modify_toml_as_dict(Path("foo-bar/pyproject.toml")) as toml:
-                create_toml_node(toml, ("tool", "hatch", "build", "packages"), ["foo_bar"])
+            with modify_toml_as_dict(Path(f"{hyph_name}/pyproject.toml")) as toml:
+                create_toml_node(toml, ("tool", "hatch", "build", "packages"), [snake_name])
 
             if not uv_sync:
                 # Reinstall to venv since package root changed
-                install_to_venv(Path("foo-bar/.venv"), ["-e", "foo-bar"])
+                install_to_venv(Path(f"{hyph_name}/.venv"), ["-e", hyph_name])
 
-        with clear_module_from_cache("foo_bar"), pushd(project_path):
+        with clear_module_from_cache(snake_name), pushd(project_path):
             for src_dir in component_dirs:
                 component_name = src_dir.name
-                components_dir = Path.cwd() / "src" / "foo_bar" / "defs" / component_name
+                components_dir = Path.cwd() / "src" / snake_name / "defs" / component_name
                 components_dir.mkdir(parents=True, exist_ok=True)
                 shutil.copytree(src_dir, components_dir, dirs_exist_ok=True)
 
             # Used for backcompat testing
             if include_entry_point:
-                _add_python_entry_point("foo_bar.components")
+                _add_python_entry_point(f"{snake_name}.components")
                 # reinstall to venv since we added an entry point
                 if Path(".venv").exists():
                     install_to_venv(Path(".venv"), ["-e", "."])
@@ -314,15 +363,24 @@ def isolated_example_project_foo_bar(
 @contextmanager
 def isolated_example_component_library_foo_bar(
     runner: Union[CliRunner, "ProxyRunner"],
-    components_module_name: str = "foo_bar.components",
+    library_name: str = "foo-bar",
+    components_module_name: Optional[str] = None,
+    uv_sync: bool = True,
+    use_tempdir: bool = True,
 ) -> Iterator[None]:
+    hyph_name = library_name  # noqa: F841
+    snake_name = library_name.replace("-", "_")
+    components_module_name = components_module_name or f"{snake_name}.components"
+
     runner = ProxyRunner(runner) if isinstance(runner, CliRunner) else runner
     with isolated_example_project_foo_bar(
         runner,
         in_workspace=False,
-        uv_sync=True,
+        uv_sync=uv_sync,
+        project_name=library_name,
+        use_tempdir=use_tempdir,
     ):
-        shutil.rmtree(Path("src/foo_bar/defs"))
+        shutil.rmtree(Path(f"src/{snake_name}/defs"))
 
         # Make it not a project
         with modify_toml_as_dict(Path("pyproject.toml")) as toml:
@@ -330,12 +388,13 @@ def isolated_example_component_library_foo_bar(
 
         _add_python_entry_point(components_module_name)
 
-        # Install the component library into our venv
-        venv_path = Path(".venv")
-        assert venv_path.exists()
-        install_to_venv(venv_path, ["-e", "."])
-        with activate_venv(venv_path):
-            yield
+        if uv_sync:
+            # Install the component library into our venv
+            venv_path = Path(".venv")
+            assert venv_path.exists()
+            install_to_venv(venv_path, ["-e", "."])
+            with activate_venv(venv_path):
+                yield
 
 
 def _add_python_entry_point(module_name: str):
@@ -402,9 +461,12 @@ def convert_pyproject_toml_to_dg_toml(pyproject_toml_path: Path, dg_toml_path: P
         pyproject_toml_path.write_text(tomlkit.dumps(pyproject_toml))
 
 
-def convert_dg_toml_to_pyproject_toml(dg_toml_path: Path, pyproject_toml_path: Path) -> None:
+def convert_dg_toml_to_pyproject_toml(
+    dg_toml_path: Path, pyproject_toml_path: Optional[Path] = None
+) -> None:
     """Convert a dg.toml file to a pyproject.toml file."""
     dg_toml = tomlkit.parse(dg_toml_path.read_text()).unwrap()
+    pyproject_toml_path = pyproject_toml_path or dg_toml_path.with_stem("pyproject.toml")
     if not pyproject_toml_path.exists():
         pyproject_toml_path.write_text(tomlkit.dumps({}))
     with modify_toml(pyproject_toml_path) as pyproject_toml:

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/deps.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/deps.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import click
+from dagster_shared.utils import find_uv_workspace_root
 from packaging import version
 
 try:
@@ -388,45 +389,18 @@ def get_setup_py_deps(code_directory: str, python_interpreter: str) -> list[str]
     return lines
 
 
-def _read_pyproject_toml(directory: str) -> Optional[dict]:
-    """Read and parse pyproject.toml from a directory. Returns None if not found."""
-    pyproject_path = os.path.join(directory, "pyproject.toml")
-    if not os.path.exists(pyproject_path):
-        return None
-    with open(pyproject_path, "rb") as f:
-        return tomllib.load(f)
-
-
-def _find_uv_workspace_root(start_dir: str) -> Optional[tuple[str, dict]]:
-    """Walk up directories to find a uv workspace root.
-
-    Returns (workspace_root_path, workspace_config) or None if not found.
-    """
-    current = os.path.abspath(start_dir)
-    while True:
-        data = _read_pyproject_toml(current)
-        if data:
-            workspace_config = data.get("tool", {}).get("uv", {}).get("workspace", {})
-            if workspace_config:
-                return current, workspace_config
-        parent = os.path.dirname(current)
-        if parent == current:
-            return None
-        current = parent
-
-
 def _resolve_uv_workspace_dep(dep_name: str, code_directory: str) -> Optional[str]:
     """Find the relative path to a uv workspace member by package name.
 
     Returns a relative path like "../shared-lib" or None if not found.
     Assumes the directory name matches the package name.
     """
-    result = _find_uv_workspace_root(code_directory)
+    result = find_uv_workspace_root(code_directory)
     if not result:
         return None
 
     workspace_root, _ = result
-    candidate = os.path.join(workspace_root, dep_name)
+    candidate = os.path.join(str(workspace_root), dep_name)
     if os.path.isdir(candidate):
         return os.path.relpath(candidate, code_directory)
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/configure_build_artifacts.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/configure_build_artifacts.py
@@ -138,6 +138,7 @@ def configure_build_artifacts_impl(config: DgPlusDeployConfigureOptions) -> None
                 dockerfile_path,
                 config.python_version,
                 config.use_editable_dagster,
+                project_context.package_name,
             )
             click.echo(f"Dockerfile created at {dockerfile_path}.")
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/deploy_session.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/deploy_session.py
@@ -221,7 +221,7 @@ def _build_artifact_for_project(
         dg_context.build_config,
     )
 
-    build_directory = dg_context.root_path
+    build_directory = dg_context.build_root_path
     if merged_build_config.get("directory"):
         build_directory = Path(check.not_none(merged_build_config["directory"]))
         assert build_directory.is_absolute(), "Build directory must be an absolute path"
@@ -229,7 +229,9 @@ def _build_artifact_for_project(
     dockerfile_path = get_dockerfile_path(dg_context, workspace_context)
     if not os.path.exists(dockerfile_path):
         click.echo(f"No Dockerfile found - scaffolding a default one at {dockerfile_path}.")
-        create_deploy_dockerfile(dockerfile_path, python_version, use_editable_dagster)
+        create_deploy_dockerfile(
+            dockerfile_path, python_version, use_editable_dagster, dg_context.package_name
+        )
     else:
         click.echo(f"Building using Dockerfile at {dockerfile_path}.")
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/deploy_uv_Dockerfile.jinja
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/deploy_uv_Dockerfile.jinja
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --no-dev
 ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev
+    uv sync --frozen --no-dev --package {{ package_arg }}
 
 
 # Then, use a final image without uv

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/deploy_uv_editable_Dockerfile.jinja
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/deploy_uv_editable_Dockerfile.jinja
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --no-dev
 ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev
+    uv sync --frozen --no-dev --package {{ package_arg }}
 
 
 # Then, use a final image without uv

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/build.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/utils/plus/build.py
@@ -73,7 +73,9 @@ def get_agent_type(cli_config: Optional[DagsterPlusCliConfig] = None) -> DgPlusA
         )
 
 
-def create_deploy_dockerfile(dst_path: Path, python_version: str, use_editable_dagster: bool):
+def create_deploy_dockerfile(
+    dst_path: Path, python_version: str, use_editable_dagster: bool, package_name: str
+):
     # defer for import performance
     import jinja2
 
@@ -93,5 +95,5 @@ def create_deploy_dockerfile(dst_path: Path, python_version: str, use_editable_d
     template = env.get_template(os.path.basename(dockerfile_template_path))
 
     with open(dst_path, "w", encoding="utf8") as f:
-        f.write(template.render(python_version=python_version))
+        f.write(template.render(python_version=python_version, package_arg=package_name))
         f.write("\n")

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_scaffold_commands.py
@@ -178,6 +178,18 @@ def test_scaffold_defs_component_substring_single_match_success(selection: str) 
             assert "Exiting." in result.output
 
 
+def test_scaffold_project_uv_workspace():
+    with (
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
+        # isolated_example_project_foo_bar(runner, in_workspace=True, uv_sync=True, use_uv_workspace=True),
+        isolated_example_project_foo_bar(
+            runner, in_workspace=True, uv_sync=True, use_uv_workspace=True
+        ),
+    ):
+        # Make sure venv created in uv workspace root
+        assert Path("../.venv").exists()
+
+
 def test_scaffold_defs_component_unregistered_success() -> None:
     """Ensure that a valid python symbol reference to a component type still works even if it is not registered."""
     with ProxyRunner.test() as runner, isolated_example_project_foo_bar(runner):

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_context.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_context.py
@@ -170,11 +170,19 @@ def test_context_with_user_config(monkeypatch, user_config_file: str):
 # Temporary test until we switch src layout to the default.
 def test_context_with_root_layout():
     with (
-        ProxyRunner.test() as runner,
+        ProxyRunner.test(use_fixed_test_components=True) as runner,
         isolated_example_project_foo_bar(
             runner, uv_sync=True, in_workspace=False, package_layout="root"
         ),
     ):
+        # Suppress venv mismatch warning since test runs from different venv
+        with modify_toml_as_dict(Path("pyproject.toml")) as toml:
+            create_toml_node(
+                toml,
+                ("tool", "dg", "cli", "suppress_warnings"),
+                ["project_and_activated_venv_mismatch"],
+            )
+
         context = DgContext.from_file_discovery_and_command_line_config(Path.cwd(), {})
         assert context.root_path == Path.cwd()
         assert context.defs_path == Path.cwd() / "foo_bar" / "defs"


### PR DESCRIPTION
## Summary & Motivation

Two changes to how `dg plus deploy` works:

- The default Dockerfiles now build the `uv` env with a `--package <PACKAGE_NAME>` arg. This is redundant when the `dg` project is outside of a uv workspace, but it is necessary when the package is inside a workspace.
- The build context directory when deploying will be set to the uv workspace root if we're in a workspace, otherwise to the project root (current behavior). Setting to the uv workspace root allows workspace packages to resolve during the build.

A caveat is that a lot more might get copied into the image since we basically add the full content of the build context into the image (`ADD . /app` during build)-- but I think that can be refined later.

## How I Tested These Changes

Manually + existing test suite.