### PR TITLE
[gitignore] remove data rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,11 +138,6 @@ docs/gatsby/**/public
 # Next stuff
 docs/next/.mdx-data
 docs/next/public/sitemap.xml
-# Data
-data
-# Don't ignore data folders in examples
-!examples/*/data
-!examples/**/**/data
 
 # Dask
 dask-worker-space


### PR DESCRIPTION
og blame is super old https://github.com/dagster-io/dagster/commit/014e264035e33d2d89c6acef96bc6c6030b00bba
and we have already had to work around it a few times as seen in the exception cases 
we also have files that would be ignored if they were not checked in before the rule
https://github.com/dagster-io/dagster/blame/master/python_modules/dagster-graphql/dagster_graphql_tests/data/num.csv

## How I Tested These Changes

bk

