### PR TITLE
[ui] Restore AssetNode status row for OSS users without Health

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -3,15 +3,16 @@ import clsx from 'clsx';
 import isEqual from 'lodash/isEqual';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
+import {observeEnabled} from 'shared/app/observeEnabled.oss';
 import {UserDisplay} from 'shared/runs/UserDisplay.oss';
 import styled, {CSSObject} from 'styled-components';
 
 import {labelForFacet} from './AssetNodeFacets';
 import {AssetNodeFacet} from './AssetNodeFacetsUtil';
-import {AssetNodeFreshnessRow} from './AssetNodeFreshnessRow';
+import {AssetNodeFreshnessRow, AssetNodeFreshnessRowOld} from './AssetNodeFreshnessRow';
 import {AssetNodeHealthRow} from './AssetNodeHealthRow';
 import {AssetNodeMenuProps, useAssetNodeMenu} from './AssetNodeMenu';
-import {assetNodeLatestEventContent} from './AssetNodeStatusContent';
+import {assetNodeLatestEventContent, buildAssetNodeStatusContent} from './AssetNodeStatusContent';
 import {LiveDataForNode, LiveDataForNodeWithStaleData} from './Utils';
 import {gql} from '../apollo-client';
 import {ContextMenuWrapper} from './ContextMenuWrapper';
@@ -45,7 +46,7 @@ export const ASSET_NODE_HOVER_EXPAND_HEIGHT = 3;
 
 export const AssetNode = React.memo((props: Props2025) => {
   const {liveData} = useAssetLiveData(props.definition.assetKey);
-  return <AssetNodeWithLiveData {...props} liveData={liveData} />;
+  return <AssetNodeWithLiveData {...props} liveData={liveData} hasAssetHealth={observeEnabled()} />;
 }, isEqual);
 
 export const AssetNodeWithLiveData = ({
@@ -55,8 +56,10 @@ export const AssetNodeWithLiveData = ({
   onChangeAssetSelection,
   liveData,
   automationData,
+  hasAssetHealth,
 }: Props2025 & {liveData: LiveDataForNodeWithStaleData | undefined} & {
   automationData?: AssetAutomationFragment | undefined;
+  hasAssetHealth: boolean;
 }) => {
   return (
     <AssetNodeContainer $selected={selected}>
@@ -122,15 +125,21 @@ export const AssetNodeWithLiveData = ({
             <PartitionsFacetContent definition={definition} liveData={liveData} />
           </AssetNodeRow>
         )}
-        {facets.has(AssetNodeFacet.Freshness) && (
-          <AssetNodeFreshnessRow definition={definition} liveData={liveData} />
-        )}
+        {facets.has(AssetNodeFacet.Freshness) &&
+          (hasAssetHealth ? (
+            <AssetNodeFreshnessRow definition={definition} liveData={liveData} />
+          ) : (
+            <AssetNodeFreshnessRowOld liveData={liveData} />
+          ))}
         {facets.has(AssetNodeFacet.Automation) && (
           <AssetNodeAutomationRow definition={definition} automationData={automationData} />
         )}
-        {facets.has(AssetNodeFacet.Status) && (
-          <AssetNodeHealthRow definition={definition} liveData={liveData} />
-        )}
+        {facets.has(AssetNodeFacet.Status) &&
+          (hasAssetHealth ? (
+            <AssetNodeHealthRow definition={definition} liveData={liveData} />
+          ) : (
+            <AssetNodeStatusRow definition={definition} liveData={liveData} />
+          ))}
       </AssetNodeBox>
       {facets.has(AssetNodeFacet.KindTag) && (
         <Box
@@ -148,6 +157,29 @@ export const AssetNodeWithLiveData = ({
         </Box>
       )}
     </AssetNodeContainer>
+  );
+};
+
+const AssetNodeStatusRow = ({
+  definition,
+  liveData,
+}: {
+  definition: AssetNodeFragment;
+  liveData: LiveDataForNode | undefined;
+}) => {
+  const {content, background} = buildAssetNodeStatusContent({
+    assetKey: definition.assetKey,
+    definition,
+    liveData,
+  });
+  return (
+    <AssetNodeRowBox
+      background={background}
+      padding={{horizontal: 8}}
+      flex={{justifyContent: 'space-between', alignItems: 'center', gap: 6}}
+    >
+      {content}
+    </AssetNodeRowBox>
   );
 };
 
@@ -454,7 +486,20 @@ type AssetNodeMinimalProps = {
   height: number;
 };
 
-export const AssetNodeMinimal = ({definition, facets, height, selected}: AssetNodeMinimalProps) => {
+export const AssetNodeMinimal = (props: AssetNodeMinimalProps) => {
+  return observeEnabled() ? (
+    <AssetNodeMinimalWithHealth {...props} />
+  ) : (
+    <AssetNodeMinimalWithoutHealth {...props} />
+  );
+};
+
+export const AssetNodeMinimalWithHealth = ({
+  definition,
+  facets,
+  height,
+  selected,
+}: AssetNodeMinimalProps) => {
   const {isMaterializable, assetKey} = definition;
   const {liveData} = useAssetLiveData(assetKey);
   const {liveData: healthData} = useAssetHealthData(assetKey);
@@ -510,6 +555,75 @@ export const AssetNodeMinimal = ({definition, facets, height, selected}: AssetNo
           $isMaterializable={isMaterializable}
           $background={backgroundColor}
           $border={borderColor}
+          $inProgress={!!inProgressRuns}
+          $isQueued={!!queuedRuns}
+          $height={nodeHeight}
+        >
+          {isChanged ? (
+            <MinimalNodeChangedDot changedReasons={definition.changedReasons} assetKey={assetKey} />
+          ) : null}
+          {isStale ? <MinimalNodeStaleDot assetKey={assetKey} liveData={liveData} /> : null}
+          <MinimalName style={{fontSize: 24}} $isMaterializable={isMaterializable}>
+            {withMiddleTruncation(displayName, {maxLength: 18})}
+          </MinimalName>
+        </MinimalAssetNodeBox>
+      </TooltipStyled>
+    </MinimalAssetNodeContainer>
+  );
+};
+
+export const AssetNodeMinimalWithoutHealth = ({
+  definition,
+  facets,
+  height,
+  selected,
+}: AssetNodeMinimalProps) => {
+  const {isMaterializable, assetKey} = definition;
+  const {liveData} = useAssetLiveData(assetKey);
+
+  const {border, background} = buildAssetNodeStatusContent({assetKey, definition, liveData});
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const displayName = assetKey.path[assetKey.path.length - 1]!;
+
+  const isChanged = definition.changedReasons.length;
+  const isStale = isAssetStale(liveData);
+
+  const queuedRuns = liveData?.unstartedRunIds.length;
+  const inProgressRuns = liveData?.inProgressRunIds.length;
+
+  // old design
+  let paddingTop = height / 2 - 52;
+  let nodeHeight = 86;
+
+  if (facets !== null) {
+    const topTagsPresent = facets.has(AssetNodeFacet.UnsyncedTag);
+    const bottomTagsPresent = facets.has(AssetNodeFacet.KindTag);
+    paddingTop = ASSET_NODE_VERTICAL_MARGIN + (topTagsPresent ? ASSET_NODE_TAGS_HEIGHT : 0);
+    nodeHeight =
+      height -
+      ASSET_NODE_VERTICAL_MARGIN * 2 -
+      (topTagsPresent ? ASSET_NODE_TAGS_HEIGHT : ASSET_NODE_HOVER_EXPAND_HEIGHT) -
+      (bottomTagsPresent ? ASSET_NODE_TAGS_HEIGHT : 0);
+
+    // Ensure that we have room for the label, even if it makes the minimal format larger.
+    if (nodeHeight < 38) {
+      nodeHeight = 38;
+    }
+  }
+
+  return (
+    <MinimalAssetNodeContainer $selected={selected} style={{paddingTop}}>
+      <TooltipStyled
+        content={displayName}
+        canShow={displayName.length > 14}
+        targetTagName="div"
+        position="top"
+      >
+        <MinimalAssetNodeBox
+          $selected={selected}
+          $isMaterializable={isMaterializable}
+          $background={background}
+          $border={border}
           $inProgress={!!inProgressRuns}
           $isQueued={!!queuedRuns}
           $height={nodeHeight}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeFacetSettingsButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeFacetSettingsButton.tsx
@@ -1,5 +1,6 @@
 import {Box, Button, Colors, Dialog, DialogFooter, Icon} from '@dagster-io/ui-components';
 import {useState} from 'react';
+import {observeEnabled} from 'shared/app/observeEnabled.oss';
 
 import {AssetNodeWithLiveData} from './AssetNode';
 import {AssetNodeFacetDefaults} from './AssetNodeFacets';
@@ -182,6 +183,7 @@ export const AssetNodeFacetSettingsButton = ({
                 definition={ExampleAssetNode}
                 liveData={ExampleLiveData}
                 automationData={ExampleAutomationData}
+                hasAssetHealth={observeEnabled()}
               />
             </div>
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
@@ -1,5 +1,5 @@
 import {MockedProvider} from '@apollo/client/testing';
-import {Box} from '@dagster-io/ui-components';
+import {Box, Checkbox} from '@dagster-io/ui-components';
 import {useState} from 'react';
 
 import {AssetBaseData} from '../../asset-data/AssetBaseDataProvider';
@@ -15,7 +15,12 @@ import {
   buildAssetNode,
   buildStaleCause,
 } from '../../graphql/types';
-import {AssetNode, AssetNodeMinimal} from '../AssetNode';
+import {
+  AssetNode,
+  AssetNodeMinimalWithHealth,
+  AssetNodeMinimalWithoutHealth,
+  AssetNodeWithLiveData,
+} from '../AssetNode';
 import {AllAssetNodeFacets} from '../AssetNodeFacets';
 import {AssetNodeFacetsPicker} from '../AssetNodeFacetsPicker';
 import {AssetNodeFacet} from '../AssetNodeFacetsUtil';
@@ -71,6 +76,7 @@ function SetCacheEntry({
 }
 
 export const LiveStates = () => {
+  const [hasAssetHealth, setHasAssetHealth] = useState(true);
   const [facets, setFacets] = useState<Set<AssetNodeFacet>>(new Set(AllAssetNodeFacets));
 
   const caseWithLiveData = (scenario: AssetNodeScenario) => {
@@ -107,7 +113,13 @@ export const LiveStates = () => {
               overflowY: 'hidden',
             }}
           >
-            <AssetNode definition={definitionCopy} selected={false} facets={facets} />
+            <AssetNodeWithLiveData
+              liveData={scenario.liveData}
+              definition={definitionCopy}
+              selected={false}
+              facets={facets}
+              hasAssetHealth={hasAssetHealth}
+            />
           </div>
           <div
             style={{
@@ -118,12 +130,21 @@ export const LiveStates = () => {
             }}
           >
             <div style={{position: 'absolute', width: dimensions.width, transform: 'scale(0.4)'}}>
-              <AssetNodeMinimal
-                definition={definitionCopy}
-                selected={false}
-                height={82}
-                facets={facets}
-              />
+              {hasAssetHealth ? (
+                <AssetNodeMinimalWithHealth
+                  definition={definitionCopy}
+                  selected={false}
+                  height={82}
+                  facets={facets}
+                />
+              ) : (
+                <AssetNodeMinimalWithoutHealth
+                  definition={definitionCopy}
+                  selected={false}
+                  height={82}
+                  facets={facets}
+                />
+              )}
             </div>
           </div>
         </Box>
@@ -134,6 +155,12 @@ export const LiveStates = () => {
   return (
     <MockedProvider>
       <AssetLiveDataProvider>
+        <Checkbox
+          checked={hasAssetHealth}
+          label="Asset Health Available (Cloud)"
+          onChange={() => setHasAssetHealth(!hasAssetHealth)}
+        />
+
         <AssetNodeFacetsPicker value={facets} onChange={setFacets} />
         <h2>Base Assets</h2>
         <Box flex={{gap: 20, wrap: 'wrap', alignItems: 'flex-start'}}>
@@ -186,7 +213,13 @@ export const PartnerTags = () => {
               background: `linear-gradient(to bottom, transparent 49%, gray 50%, transparent 51%)`,
             }}
           >
-            <AssetNode facets={facets} definition={def} selected={false} />
+            <AssetNodeWithLiveData
+              liveData={liveData}
+              facets={facets}
+              definition={def}
+              selected={false}
+              hasAssetHealth
+            />
           </div>
         </Box>
       </>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
@@ -39,13 +39,19 @@ jest.mock('../../assets/useAllAssets', () => ({
   useAllAssetsNodes: () => ({allAssetKeys: mockAllAssetKeys, loading: false}),
 }));
 
+jest.mock('../../app/observeEnabled.oss', () => ({
+  observeEnabled: jest.fn(() => true),
+}));
+
 /** The tests in this file mirror the stories in the storybook. If you've made
  * changes to the AssetNode rendering, consider opening the storybook and updating
  * the `expectedText` for each scenario to match what is rendered. Then these tests
  * should all pass.
  * */
 describe('AssetNode', function () {
-  beforeEach(function () {});
+  afterAll(() => {
+    jest.unmock('../../app/observeEnabled.oss');
+  });
 
   Scenarios.forEach((scenario: AssetNodeScenario) =>
     it(`renders ${scenario.expectedText.join(',')} when ${scenario.title}`, async () => {


### PR DESCRIPTION
## Summary & Motivation

- Restores a few `observeEnabled()` checks in AssetNode, allowing users in OSS to continue getting the "status" row instead of the "health" row

- Updates the storybooks with a checkbox so that you can preview either version

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/ad6db597-abd3-40db-9633-66243e6cf4cb" />

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/feecb581-c06d-48e8-a4a7-ce6af5e05689" />

