### PR TITLE
[ui] Split assetHealthEnabled from observeEnabled

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/assetHealthEnabled.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/assetHealthEnabled.oss.tsx
@@ -1,0 +1,3 @@
+export const assetHealthEnabled = (): boolean => {
+  return false;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetHealthDataProvider.tsx
@@ -1,5 +1,5 @@
 import {useMemo} from 'react';
-import {observeEnabled} from 'shared/app/observeEnabled.oss';
+import {assetHealthEnabled} from 'shared/app/assetHealthEnabled.oss';
 
 import {ApolloClient, gql, useApolloClient} from '../apollo-client';
 import {showCustomAlert} from '../app/CustomAlertProvider';
@@ -11,12 +11,12 @@ import {AssetKeyInput} from '../graphql/types';
 import {liveDataFactory} from '../live-data-provider/Factory';
 import {LiveDataThreadID} from '../live-data-provider/LiveDataThread';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
+import {weakMapMemoize} from '../util/weakMapMemoize';
 import {
   AssetHealthFragment,
   AssetHealthQuery,
   AssetHealthQueryVariables,
 } from './types/AssetHealthDataProvider.types';
-import {weakMapMemoize} from '../util/weakMapMemoize';
 
 const BATCH_SIZE = 250;
 const PARALLEL_FETCHES = 4;
@@ -189,12 +189,12 @@ function shouldBlockTrace(
   return currentDataCount === expectedDataCount;
 }
 
-// Get assets health data, with an `observeEnabled` check included to effectively no-op any users
+// Get assets health data, with an `assetHealthEnabled` check included to effectively no-op any users
 // who are not gated in.
 export function useAssetsHealthData({assetKeys, ...rest}: AssetsHealthDataConfig) {
   return useAssetsHealthDataWithoutGateCheck({
     ...rest,
-    assetKeys: observeEnabled() ? assetKeys : EMPTY_ARRAY,
+    assetKeys: assetHealthEnabled() ? assetKeys : EMPTY_ARRAY,
   });
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeFacetSettingsButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeFacetSettingsButton.tsx
@@ -1,6 +1,6 @@
 import {Box, Button, Colors, Dialog, DialogFooter, Icon} from '@dagster-io/ui-components';
 import {useState} from 'react';
-import {observeEnabled} from 'shared/app/observeEnabled.oss';
+import {assetHealthEnabled} from 'shared/app/assetHealthEnabled.oss';
 
 import {AssetNodeWithLiveData} from './AssetNode';
 import {AssetNodeFacetDefaults} from './AssetNodeFacets';
@@ -184,7 +184,7 @@ export const AssetNodeFacetSettingsButton = ({
                 definition={ExampleAssetNode}
                 liveData={ExampleLiveData}
                 automationData={ExampleAutomationData}
-                hasAssetHealth={observeEnabled()}
+                assetHealthEnabled={assetHealthEnabled()}
               />
             </div>
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/CollapsedGroupNode.tsx
@@ -11,7 +11,7 @@ import {
   ifPlural,
 } from '@dagster-io/ui-components';
 import React, {useContext} from 'react';
-import {observeEnabled} from 'shared/app/observeEnabled.oss';
+import {assetHealthEnabled} from 'shared/app/assetHealthEnabled.oss';
 import styled from 'styled-components';
 
 import {AssetDescription, NameTooltipCSS} from './AssetNode';
@@ -132,7 +132,7 @@ const GroupNodeAssetStatusCounts = ({
 }: {
   group: GroupLayout & {assetCount: number; assets: GraphNode[]};
 }) => {
-  if (observeEnabled()) {
+  if (assetHealthEnabled()) {
     return <GroupNodeAssetStatusCountsAssetHealth group={group} />;
   }
   return <GroupNodeAssetStatusCountsNonAssetHealth group={group} />;

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__stories__/AssetNode.stories.tsx
@@ -76,7 +76,7 @@ function SetCacheEntry({
 }
 
 export const LiveStates = () => {
-  const [hasAssetHealth, setHasAssetHealth] = useState(true);
+  const [assetHealthEnabled, setAssetHealthEnabled] = useState(true);
   const [facets, setFacets] = useState<Set<AssetNodeFacet>>(new Set(AllAssetNodeFacets));
 
   const caseWithLiveData = (scenario: AssetNodeScenario) => {
@@ -118,7 +118,7 @@ export const LiveStates = () => {
               definition={definitionCopy}
               selected={false}
               facets={facets}
-              hasAssetHealth={hasAssetHealth}
+              assetHealthEnabled={assetHealthEnabled}
             />
           </div>
           <div
@@ -130,7 +130,7 @@ export const LiveStates = () => {
             }}
           >
             <div style={{position: 'absolute', width: dimensions.width, transform: 'scale(0.4)'}}>
-              {hasAssetHealth ? (
+              {assetHealthEnabled ? (
                 <AssetNodeMinimalWithHealth
                   definition={definitionCopy}
                   selected={false}
@@ -156,9 +156,9 @@ export const LiveStates = () => {
     <MockedProvider>
       <AssetLiveDataProvider>
         <Checkbox
-          checked={hasAssetHealth}
+          checked={assetHealthEnabled}
           label="Asset Health Available (Cloud)"
-          onChange={() => setHasAssetHealth(!hasAssetHealth)}
+          onChange={() => setAssetHealthEnabled(!assetHealthEnabled)}
         />
 
         <AssetNodeFacetsPicker value={facets} onChange={setFacets} />
@@ -218,7 +218,7 @@ export const PartnerTags = () => {
               facets={facets}
               definition={def}
               selected={false}
-              hasAssetHealth
+              assetHealthEnabled
             />
           </div>
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
@@ -39,8 +39,8 @@ jest.mock('../../assets/useAllAssets', () => ({
   useAllAssetsNodes: () => ({allAssetKeys: mockAllAssetKeys, loading: false}),
 }));
 
-jest.mock('../../app/observeEnabled.oss', () => ({
-  observeEnabled: jest.fn(() => true),
+jest.mock('../../app/assetHealthEnabled.oss', () => ({
+  assetHealthEnabled: jest.fn(() => true),
 }));
 
 /** The tests in this file mirror the stories in the storybook. If you've made
@@ -50,7 +50,7 @@ jest.mock('../../app/observeEnabled.oss', () => ({
  * */
 describe('AssetNode', function () {
   afterAll(() => {
-    jest.unmock('../../app/observeEnabled.oss');
+    jest.unmock('../../app/assetHealthEnabled.oss');
   });
 
   Scenarios.forEach((scenario: AssetNodeScenario) =>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/AssetSidebarNode.tsx
@@ -1,6 +1,6 @@
 import {Box, Colors, Icon, UnstyledButton} from '@dagster-io/ui-components';
 import * as React from 'react';
-import {observeEnabled} from 'shared/app/observeEnabled.oss';
+import {assetHealthEnabled} from 'shared/app/assetHealthEnabled.oss';
 import styled from 'styled-components';
 
 import {StatusDot, StatusDotNode} from './StatusDot';
@@ -109,7 +109,7 @@ const AssetSidebarAssetLabel = ({
         isSelected={isSelected}
         isLastSelected={isLastSelected}
         icon={
-          observeEnabled() ? (
+          assetHealthEnabled() ? (
             <div style={{marginLeft: -8, marginRight: -8}}>
               <AssetHealthSummary iconOnly assetKey={node.assetKey} />
             </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/__tests__/util.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/__tests__/util.test.tsx
@@ -1,15 +1,15 @@
-import {observeEnabled} from 'shared/app/observeEnabled.oss';
+import {assetHealthEnabled} from 'shared/app/assetHealthEnabled.oss';
 
 import {AssetGraphQueryItem} from '../../../asset-graph/types';
 import {AssetHealthStatus} from '../../../graphql/types';
 import {SUB_STATUSES, getAttributesMap} from '../util';
 
 // Mock the observeEnabled function
-jest.mock('shared/app/observeEnabled.oss', () => ({
-  observeEnabled: jest.fn(),
+jest.mock('shared/app/assetHealthEnabled.oss', () => ({
+  assetHealthEnabled: jest.fn(),
 }));
 
-const mockObserveEnabled = observeEnabled as jest.MockedFunction<typeof observeEnabled>;
+const mockAssetHealthEnabled = assetHealthEnabled as jest.MockedFunction<typeof assetHealthEnabled>;
 
 describe('getAttributesMap', () => {
   const mockAssets: AssetGraphQueryItem[] = [
@@ -52,7 +52,7 @@ describe('getAttributesMap', () => {
   });
 
   it('should not include status attribute when observeEnabled is false', () => {
-    mockObserveEnabled.mockReturnValue(false);
+    mockAssetHealthEnabled.mockReturnValue(false);
 
     const result = getAttributesMap(mockAssets);
 
@@ -67,8 +67,8 @@ describe('getAttributesMap', () => {
     });
   });
 
-  it('should include status attribute when observeEnabled is true', () => {
-    mockObserveEnabled.mockReturnValue(true);
+  it('should include status attribute when assetHealthEnabled is true', () => {
+    mockAssetHealthEnabled.mockReturnValue(true);
 
     const result = getAttributesMap(mockAssets);
 
@@ -76,7 +76,7 @@ describe('getAttributesMap', () => {
   });
 
   it('should handle empty assets array', () => {
-    mockObserveEnabled.mockReturnValue(true);
+    mockAssetHealthEnabled.mockReturnValue(true);
 
     const result = getAttributesMap([]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/input/util.ts
@@ -1,5 +1,5 @@
 import {IconName} from '@dagster-io/ui-components';
-import {observeEnabled} from 'shared/app/observeEnabled.oss';
+import {assetHealthEnabled} from 'shared/app/assetHealthEnabled.oss';
 
 import {assertUnreachable} from '../../app/Util';
 import {AssetGraphQueryItem} from '../../asset-graph/types';
@@ -81,7 +81,7 @@ export const getAttributesMap = (assets: AssetGraphQueryItem[]) => {
     kind: kinds,
     code_location: codeLocations,
   };
-  if (observeEnabled()) {
+  if (assetHealthEnabled()) {
     const statuses = [
       AssetHealthStatus.HEALTHY,
       AssetHealthStatus.DEGRADED,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetHealthSummary.tsx
@@ -15,7 +15,7 @@ import {
 } from '@dagster-io/ui-components';
 import React, {useCallback, useMemo} from 'react';
 import {Link} from 'react-router-dom';
-import {observeEnabled} from 'shared/app/observeEnabled.oss';
+import {assetHealthEnabled} from 'shared/app/assetHealthEnabled.oss';
 
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {useAllAssetsNodes} from './useAllAssets';
@@ -41,7 +41,7 @@ import {numberFormatter} from '../ui/formatters';
 
 export const AssetHealthSummary = React.memo(
   ({assetKey, iconOnly}: {assetKey: {path: string[]}; iconOnly?: boolean}) => {
-    if (!observeEnabled()) {
+    if (!assetHealthEnabled()) {
       return null;
     }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetCatalogTablev2.test.tsx
@@ -33,8 +33,8 @@ import {AssetCatalogV2VirtualizedTable} from '../catalog/AssetCatalogV2Virtualiz
 import {AssetRecordsQuery, AssetRecordsQueryVariables} from '../types/useAllAssets.types';
 import {ASSET_RECORDS_QUERY, AssetRecord} from '../useAllAssets';
 
-jest.mock('../../app/observeEnabled.oss', () => ({
-  observeEnabled: jest.fn(() => true),
+jest.mock('../../app/assetHealthEnabled.oss', () => ({
+  assetHealthEnabled: jest.fn(() => true),
 }));
 
 jest.mock('../../util/idb-lru-cache', () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetEventsFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetEventsFilters.tsx
@@ -1,6 +1,6 @@
 import {Box, Icon} from '@dagster-io/ui-components';
 import React, {useCallback, useMemo} from 'react';
-import {observeEnabled} from 'shared/app/observeEnabled.oss';
+import {assetHealthEnabled} from 'shared/app/assetHealthEnabled.oss';
 
 import {AssetKey} from './types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
@@ -187,7 +187,7 @@ export const useAssetEventsFilters = ({assetKey, assetNode}: Config) => {
       // No need to show the type filter for assets with only observations
       // No need to show the status filter, only failed materializations count as Failure
       filters.push(typeFilter);
-      if (observeEnabled()) {
+      if (assetHealthEnabled()) {
         filters.push(statusFilter);
       }
     }


### PR DESCRIPTION
[INTERNAL_BRANCH=bengotow/assetnode-2025-fix-2]

## Summary & Motivation

Internal PR: https://github.com/dagster-io/internal/pull/19726

observeEnabled will be going away, but asset health is not available in OSS and this flag still needs to exist. I reviewed all the observeEnabled() callsites in OSS and split them based on whether it was a health-related feature being gated. 