### PR TITLE
Remove pins in dagster-dbt/kitchen-sink

### DIFF
--- a/python_modules/libraries/dagster-dbt/kitchen-sink/setup.py
+++ b/python_modules/libraries/dagster-dbt/kitchen-sink/setup.py
@@ -1,26 +1,11 @@
-from pathlib import Path
-
 from setuptools import find_packages, setup
-
-
-def get_version() -> str:
-    version: dict[str, str] = {}
-    with open(Path(__file__).parent / ".." / "dagster_dbt/version.py", encoding="utf8") as fp:
-        exec(fp.read(), version)
-
-    return version["__version__"]
-
-
-ver = get_version()
-# dont pin dev installs to avoid pip dep resolver issues
-pin = "" if ver == "1!0+dev" else f"=={ver}"
 
 setup(
     name="dagster-dbt-cloud-kitchen-sink",
     packages=find_packages(),
     install_requires=[
-        f"dagster{pin}",
-        f"dagster-webserver{pin}",
+        "dagster",
+        "dagster-webserver",
         "dagster-dbt",
         "dbt-core>=1.4.0",
     ],


### PR DESCRIPTION
Summary:
We don't publish this module so there is no reason we need these pins (and they are messing up builds on the release branch)

Test Plan:
BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
