### PR TITLE
[dagster-dlt] fix typing error introduced in recent PR

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/asset_decorator.py
@@ -1,8 +1,7 @@
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence, Set
 from typing import Any, Optional
 
 from dagster import (
-    AbstractSet,
     AssetsDefinition,
     AssetSpec,
     BackfillPolicy,
@@ -64,7 +63,7 @@ def dlt_assets(
     dagster_dlt_translator: Optional[DagsterDltTranslator] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
-    hooks: Optional[AbstractSet[HookDefinition]] = None,
+    hooks: Optional[Set[HookDefinition]] = None,
     op_tags: Optional[Mapping[str, Any]] = None,
     pool: Optional[str] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:


### PR DESCRIPTION
## Summary & Motivation

Note: diverging from `AbstractSet` usage elsewhere due to warning:
```
python_modules/libraries/dagster-dlt/dagster_dlt/asset_decorator.py:2:1: UP035 `typing.AbstractSet` is deprecated, use `collections.abc.Set` instead
  |
1 | from collections.abc import Callable, Mapping, Sequence
2 | from typing import AbstractSet, Any, Optional
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP035
```

## How I Tested These Changes

## Changelog

NOCHANGELOG
