### PR TITLE
[ui] Slider: Replace blueprint with radix

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/package.json
+++ b/js_modules/dagster-ui/packages/ui-components/package.json
@@ -34,6 +34,7 @@
     "styled-components": "^5.3.3"
   },
   "dependencies": {
+    "@radix-ui/react-slider": "^1.2.2",
     "@react-hook/resize-observer": "^1.2.6",
     "amator": "^1.1.0",
     "clsx": "^2.1.1",

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Slider.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Slider.tsx
@@ -1,80 +1,58 @@
-// eslint-disable-next-line no-restricted-imports
-import {
-  MultiSlider as BlueprintMultiSlider,
-  MultiSliderProps as BlueprintMultiSliderProps,
-  Slider as BlueprintSlider,
-  SliderProps as BlueprintSliderProps,
-} from '@blueprintjs/core';
+import * as RadixSlider from '@radix-ui/react-slider';
 import * as React from 'react';
-import styled, {css} from 'styled-components';
 
 import {Colors} from './Color';
+import styles from './css/Slider.module.css';
 
-interface SliderProps extends BlueprintSliderProps {
-  fillColor?: string;
+interface Props {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  step: number;
+  orientation?: 'horizontal' | 'vertical';
+  trackColor?: string;
+  rangeColor?: string;
+  disabled?: boolean;
+  name?: string;
 }
 
-export const Slider = ({fillColor = Colors.accentGray(), ...rest}: SliderProps) => {
-  return <StyledSlider {...rest} intent="none" $fillColor={fillColor} />;
+export const Slider = (props: Props) => {
+  const {
+    value,
+    onChange,
+    min = 0,
+    max = 100,
+    step,
+    orientation = 'horizontal',
+    trackColor = Colors.backgroundGray(),
+    rangeColor = Colors.accentGray(),
+    disabled = false,
+    name,
+  } = props;
+
+  const style = {
+    '--slider-track-color': trackColor,
+    '--slider-range-color': rangeColor,
+  } as React.CSSProperties;
+
+  return (
+    <RadixSlider.Root
+      className={styles.slider}
+      style={style}
+      value={[value]}
+      onValueChange={([first]) => first !== undefined && onChange(first)}
+      min={min}
+      max={max}
+      step={step}
+      disabled={disabled}
+      orientation={orientation}
+      name={name}
+    >
+      <RadixSlider.Track className={styles.track}>
+        <RadixSlider.Range className={styles.range} />
+      </RadixSlider.Track>
+      <RadixSlider.Thumb className={styles.thumb} />
+    </RadixSlider.Root>
+  );
 };
-
-interface MultiSliderProps extends BlueprintMultiSliderProps {
-  fillColor?: string;
-  children: React.ReactNode;
-}
-
-export const MultiSlider = ({fillColor = Colors.accentGray(), ...rest}: MultiSliderProps) => {
-  return <StyledMultiSlider {...rest} intent="none" $fillColor={fillColor} />;
-};
-
-MultiSlider.Handle = BlueprintMultiSlider.Handle;
-
-export const SliderStyles = css<{$fillColor: string}>`
-  .bp5-slider-track {
-    height: 8px;
-    .bp5-slider-progress {
-      background-color: ${(p) => p.$fillColor};
-      opacity: 0.4;
-      height: 8px;
-    }
-    .bp5-slider-progress.bp5-intent-primary {
-      background-color: ${(p) => p.$fillColor};
-      opacity: 1;
-      height: 8px;
-    }
-  }
-  &.bp5-vertical {
-    width: 20px;
-    min-width: 20px;
-  }
-  &.bp5-vertical .bp5-slider-track,
-  &.bp5-vertical .bp5-slider-track .bp5-slider-progress {
-    height: initial;
-    width: 8px;
-  }
-  .bp5-slider-handle {
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    border: 2px solid ${Colors.accentGray()};
-    background: ${Colors.backgroundLighter()};
-    box-shadow: none;
-    &:hover {
-      border: 2px solid ${Colors.accentGrayHover()};
-      box-shadow: ${Colors.shadowDefault()} 0px 2px 12px 0px;
-    }
-
-    .bp5-slider-label {
-      background: ${Colors.accentBlue()};
-      box-shadow: 0 1px 4px ${Colors.shadowDefault()};
-      padding: 4px 8px;
-    }
-  }
-`;
-
-const StyledMultiSlider = styled(BlueprintMultiSlider)<{$fillColor: string}>`
-  ${SliderStyles}
-`;
-const StyledSlider = styled(BlueprintSlider)<{$fillColor: string}>`
-  ${SliderStyles}
-`;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/MiddleTruncate.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/MiddleTruncate.stories.tsx
@@ -31,9 +31,8 @@ export const Simple = () => {
       <Slider
         min={200}
         max={600}
-        stepSize={10}
+        step={10}
         value={controlledWidth}
-        labelRenderer={false}
         onChange={(value) => setControlledWidth(value)}
       />
       <div ref={sizer} style={{width: controlledWidth}}>
@@ -147,9 +146,8 @@ export const Containers = () => {
       <Slider
         min={200}
         max={600}
-        stepSize={10}
+        step={10}
         value={controlledWidth}
-        labelRenderer={false}
         onChange={(value) => setControlledWidth(value)}
       />
       <div ref={sizer} style={{width: controlledWidth}}>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Slider.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Slider.stories.tsx
@@ -1,8 +1,7 @@
 import {useState} from 'react';
 
-import {Colors} from '../Color';
-import {Group} from '../Group';
-import {MultiSlider, Slider} from '../Slider';
+import {Box} from '../Box';
+import {Slider} from '../Slider';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -12,58 +11,21 @@ export default {
 
 export const Sizes = () => {
   const [value, setValue] = useState(2);
-  const [minValue, setMinValue] = useState(1);
 
   return (
-    <Group direction="column" spacing={32}>
-      <Slider value={value} onChange={setValue} max={10} labelStepSize={2} />
-
-      <Slider
-        vertical
-        min={0}
-        max={10}
-        stepSize={1}
-        value={value}
-        labelRenderer={false}
-        onChange={setValue}
-      />
-
-      <MultiSlider
-        min={0}
-        max={10}
-        stepSize={0.1}
-        labelRenderer={(value: number) => (
-          <span style={{whiteSpace: 'nowrap'}}>Value: {value.toFixed(1)}</span>
-        )}
-        onChange={(values: number[]) => {
-          const [first] = values;
-          if (typeof first === 'number') {
-            setValue(first);
-          }
-        }}
-      >
-        <MultiSlider.Handle value={value} type="full" intentAfter="primary" />
-      </MultiSlider>
-
-      <MultiSlider
-        min={0}
-        max={10}
-        stepSize={0.01}
-        fillColor={Colors.accentBlue()}
-        labelRenderer={(value: number) => (
-          <span style={{whiteSpace: 'nowrap'}}>Value: {value.toFixed(1)}</span>
-        )}
-        onChange={(values: number[]) => {
-          const [first, second] = values;
-          if (typeof first === 'number' && typeof second === 'number') {
-            setMinValue(Math.min(first, second));
-            setValue(Math.max(first, second));
-          }
-        }}
-      >
-        <MultiSlider.Handle value={minValue} type="full" intentAfter="primary" />
-        <MultiSlider.Handle value={value} type="full" intentBefore="primary" />
-      </MultiSlider>
-    </Group>
+    <Box flex={{direction: 'column', gap: 32}}>
+      <Slider value={value} onChange={setValue} min={0} max={10} step={0.1} />
+      <div style={{height: 200}}>
+        <Slider
+          orientation="vertical"
+          min={0}
+          max={10}
+          step={1}
+          value={value}
+          onChange={setValue}
+        />
+      </div>
+      <Slider disabled value={value} onChange={setValue} min={0} max={10} step={0.01} />
+    </Box>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-components/src/components/css/Slider.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/css/Slider.module.css
@@ -1,0 +1,83 @@
+/* Slider Root */
+.slider {
+  --slider-track-height: 8px;
+  --slider-handle-size: 18px;
+  --slider-track-color: var(--color-background-gray);
+  --slider-range-color: var(--color-accent-gray);
+
+  position: relative;
+  display: flex;
+  align-items: center;
+  user-select: none;
+  touch-action: none;
+  width: 100%;
+}
+
+.slider[data-orientation='vertical'] {
+  flex-direction: column;
+  width: 20px;
+  min-width: 20px;
+  height: 100%;
+}
+
+/* Track - the background rail */
+.track {
+  position: relative;
+  flex-grow: 1;
+  background-color: var(--slider-track-color);
+  height: var(--slider-track-height);
+  border-radius: 4px;
+}
+
+.slider[data-orientation='vertical'] .track {
+  width: var(--slider-track-height);
+}
+
+/* Range - the filled portion */
+.range {
+  position: absolute;
+  background-color: var(--slider-range-color);
+  opacity: 1;
+  height: 100%;
+  border-radius: 4px;
+}
+
+.slider[data-orientation='vertical'] .range {
+  width: 100%;
+  height: auto;
+}
+
+/* Thumb - the draggable handle */
+.thumb {
+  display: block;
+  width: var(--slider-handle-size);
+  height: var(--slider-handle-size);
+  border-radius: 50%;
+  border: 2px solid var(--color-accent-gray);
+  background: var(--color-background-lighter);
+  box-shadow: none;
+  transition:
+    border-color 100ms,
+    box-shadow 150ms;
+  cursor: pointer;
+}
+
+.thumb:hover {
+  border-color: var(--color-accent-gray-hover);
+  box-shadow: var(--color-shadow-default) 0px 2px 12px 0px;
+}
+
+.thumb:focus,
+.thumb:focus-visible {
+  outline: none;
+  box-shadow: var(--color-focus-ring) 0 0 0 2px;
+}
+
+.thumb[data-disabled] {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.slider[data-disabled] {
+  opacity: 0.5;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/ZoomSlider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/ZoomSlider.tsx
@@ -1,58 +1,19 @@
-import {Colors, SliderStyles} from '@dagster-io/ui-components';
+import {Colors, Slider} from '@dagster-io/ui-components';
 import * as React from 'react';
-import styled from 'styled-components';
 
 /**
  * Renders a horizontal slider that lets you adjust the graph's relative zoom from 1-100.
- * It uses Blueprint CSS but not the Slider component, because that renders twice and
- * forces a DOM layout to determine it's size (I think for tick marks, which we aren't using)
  */
 export const ZoomSlider = React.memo((props: {value: number; onChange: (v: number) => void}) => {
   return (
-    <ZoomSliderContainer
-      $fillColor={Colors.accentGray()}
-      className="bp5-slider bp5-slider-unlabeled"
-      onMouseDown={(e: React.MouseEvent) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const rect = e.currentTarget.closest('.bp5-slider')!.getBoundingClientRect();
-
-        let initialX: number;
-        if (e.target instanceof HTMLElement && e.target.classList.contains('bp5-slider-handle')) {
-          initialX = e.pageX;
-        } else {
-          initialX = rect.left + (props.value / 100) * rect.width;
-        }
-
-        const onUpdate = (e: MouseEvent) => {
-          const nextValue = props.value + (e.pageX - initialX) * (100 / rect.width);
-          props.onChange(Math.max(0, Math.min(100, nextValue)));
-        };
-        const onRelease = (e: MouseEvent) => {
-          onUpdate(e);
-          document.removeEventListener('mousemove', onUpdate);
-          document.removeEventListener('mouseup', onRelease);
-        };
-        document.addEventListener('mousemove', onUpdate);
-        document.addEventListener('mouseup', onRelease);
-      }}
-    >
-      <div className="bp5-slider-track">
-        <div className="bp5-slider-progress" style={{left: 0, right: 0, top: 0}} />
-        <div
-          className="bp5-slider-progress bp5-intent-primary"
-          style={{left: 0, right: `${100 - props.value}%`, top: 0}}
-        />
-      </div>
-      <div className="bp5-slider-axis" />
-      <span
-        className="bp5-slider-handle"
-        style={{left: `calc(${props.value}% - 8px)`}}
-        tabIndex={0}
-      />
-    </ZoomSliderContainer>
+    <Slider
+      value={props.value}
+      onChange={props.onChange}
+      min={0}
+      max={100}
+      step={0.1}
+      trackColor={Colors.backgroundGray()}
+      rangeColor={Colors.accentGray()}
+    />
   );
 });
-
-const ZoomSliderContainer = styled.div`
-  ${SliderStyles}
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGViewport.tsx
@@ -648,12 +648,11 @@ const SVGViewportInner = forwardRef<SVGViewportRef, SVGViewportProps>(
               data-testid={testId('zoom-slider')}
             >
               <Slider
-                vertical
+                orientation="vertical"
                 min={getMinZoom()}
                 max={getMaxZoom()}
-                stepSize={0.001}
+                step={0.001}
                 value={scale}
-                labelRenderer={false}
                 onChange={(next: number) => {
                   const el = element.current;
                   if (!el) {

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -2151,6 +2151,7 @@ __metadata:
     "@dagster-io/eslint-config": "workspace:*"
     "@date-fns/tz": "npm:^1.4.1"
     "@mdx-js/react": "npm:^1.6.22"
+    "@radix-ui/react-slider": "npm:^1.2.2"
     "@react-hook/resize-observer": "npm:^1.2.6"
     "@rollup/plugin-babel": "npm:^5.3.1"
     "@rollup/plugin-commonjs": "npm:^21.0.3"
@@ -4531,6 +4532,216 @@ __metadata:
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
   checksum: 10/ddd16090cde777aaf102940f05d0274602079a95ad9805bd20bc55dcc7c3a2ba1b99dd5c73e5cc2753c3d31250ca52a67d58059459d7d27debb983a9f552936c
+  languageName: node
+  linkType: hard
+
+"@radix-ui/number@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/number@npm:1.1.1"
+  checksum: 10/58717faf3f7aa180fdfcde7083cae0bc06677cbd08fd2bed5a3f8820deeb6f514f7d475f1fbb61e1f9a16cb2e7daf1000b2c614b0de3520fccfc04e3576e4566
+  languageName: node
+  linkType: hard
+
+"@radix-ui/primitive@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@radix-ui/primitive@npm:1.1.3"
+  checksum: 10/ee27abbff0d6d305816e9314655eb35e72478ba47416bc9d5cb0581728be35e3408cfc0748313837561d635f0cb7dfaae26e61831f0e16c0fd7d669a612f2cb0
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-collection@npm:1.1.7":
+  version: 1.1.7
+  resolution: "@radix-ui/react-collection@npm:1.1.7"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-slot": "npm:1.2.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/cd53e2a2be82be7bc4014164cac0b42948401a203e5d0294d3947a5193f1d56bd23eb60e878a98dba50d08283254e79c3b873de5f935276b849686a868d51dd5
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-compose-refs@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-compose-refs@npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/9a91f0213014ffa40c5b8aae4debb993be5654217e504e35aa7422887eb2d114486d37e53c482d0fffb00cd44f51b5269fcdf397b280c71666fa11b7f32f165d
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-context@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-context@npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/156088367de42afa3c7e3acf5f0ba7cad6b359f3d17485585e80c2418434a6ed7cac2602eb73bca265d0091a1ad380f9405c069f103983e53497097ff35ba8f2
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-direction@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-direction@npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/8cc330285f1d06829568042ca9aabd3295be4690ae93683033fc8632b5c4dfc60f5c1312f6e2cae27c196189c719de3cfbcf792ff74800f9ccae0ab4abc1bc92
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@radix-ui/react-primitive@npm:2.1.3"
+  dependencies:
+    "@radix-ui/react-slot": "npm:1.2.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/1dbbf932a3527f4e62f210bb72944eff605c3e38c8d3275ed5a5c570c02820ab156169756a65ad9a638d2089a828a04a7903795377384e98c87d0ca456303253
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slider@npm:^1.2.2":
+  version: 1.3.6
+  resolution: "@radix-ui/react-slider@npm:1.3.6"
+  dependencies:
+    "@radix-ui/number": "npm:1.1.1"
+    "@radix-ui/primitive": "npm:1.1.3"
+    "@radix-ui/react-collection": "npm:1.1.7"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-direction": "npm:1.1.1"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+    "@radix-ui/react-use-previous": "npm:1.1.1"
+    "@radix-ui/react-use-size": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/3817eb89cf077bb2610383e3fa1651e624b1638f3a83e464330a6f5cc41cc7c7556a62dda337ece7a80ebde470562669d48a6b014a0b472fc35d608103b9ecbd
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@radix-ui/react-slot@npm:1.2.3"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/fe484c2741e31d9c20a8fb53c5790a73c0664e2bea35e27f4d484a90c42135fcfffe11a08abfcacb7a8ee2faf013471f0e856818f3ddac8ac51ceb8869e0fd08
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-controllable-state@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@radix-ui/react-use-controllable-state@npm:1.2.2"
+  dependencies:
+    "@radix-ui/react-use-effect-event": "npm:0.0.2"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/a100bff3ddecb753dab17444147273c9f70046c5949712c52174b259622eaef12acbf7ebcf289bae4e714eb84d0a7317c1aa44064cd997f327d77b62bc732a7c
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-effect-event@npm:0.0.2":
+  version: 0.0.2
+  resolution: "@radix-ui/react-use-effect-event@npm:0.0.2"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/5a1950a30a399ea7e4b98154da9f536737a610de80189b7aacd4f064a89a3cd0d2a48571d527435227252e72e872bdb544ff6ffcfbdd02de2efd011be4aaa902
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-layout-effect@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-layout-effect@npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/bad2ba4f206e6255263582bedfb7868773c400836f9a1b423c0b464ffe4a17e13d3f306d1ce19cf7a19a492e9d0e49747464f2656451bb7c6a99f5a57bd34de2
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-previous@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-previous@npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/ea6ea13523a0561dda9b14b9d44e299484816a6762d7fb50b91b27b6aec89f78c85245b69d5a904750d43919dbb7ef6ce6d3823639346675aa3a5cb9de32d984
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-size@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-size@npm:1.1.1"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/64e61f65feb67ffc80e1fc4a8d5e32480fb6d68475e2640377e021178dead101568cba5f936c9c33e6c142c7cf2fb5d76ad7b23ef80e556ba142d56cf306147b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

Replace Blueprint-based implementation of `Slider` with a radix-ui one.

The new implementation:
- Uses `@radix-ui/react-slider` for better accessibility and customization
- Simplifies the API by standardizing prop names (e.g., `step` instead of `stepSize`)
- Adds CSS modules for styling instead of styled-components
- Maintains the same visual appearance and functionality
- Eliminates `MultiSlider`, which is not used

## How I Tested These Changes

- Updated all existing usages of the Slider component
- Verified the component works in both horizontal and vertical orientations
- Ensured disabled state works correctly
- Confirmed the component maintains the same visual appearance