### PR TITLE
[ui] ProgressBar: Replace blueprint with radix

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/package.json
+++ b/js_modules/dagster-ui/packages/ui-components/package.json
@@ -34,6 +34,7 @@
     "styled-components": "^5.3.3"
   },
   "dependencies": {
+    "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-slider": "^1.2.2",
     "@react-hook/resize-observer": "^1.2.6",
     "amator": "^1.1.0",

--- a/js_modules/dagster-ui/packages/ui-components/src/components/ProgressBar.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/ProgressBar.tsx
@@ -1,38 +1,27 @@
-// eslint-disable-next-line no-restricted-imports
-import {ProgressBar as BlueprintProgressBar, ProgressBarProps} from '@blueprintjs/core';
-import styled from 'styled-components';
+import * as Progress from '@radix-ui/react-progress';
+import clsx from 'clsx';
 
 import {Colors} from './Color';
+import styles from './css/ProgressBar.module.css';
 
-interface Props extends ProgressBarProps {
+interface ProgressBarProps {
+  value: number; // 0-100
+  animate?: boolean;
   fillColor?: string;
 }
 
-export const ProgressBar = ({fillColor = Colors.accentGray(), ...rest}: Props) => {
+export const ProgressBar = (props: ProgressBarProps) => {
+  const {value, animate = false, fillColor = Colors.accentBlue()} = props;
+
+  const radixValue = Math.round(Math.max(0, Math.min(100, value)));
+  const style = {
+    '--progress-fill-color': fillColor,
+    '--progress-value': radixValue,
+  } as React.CSSProperties;
+
   return (
-    <StyledProgressBar
-      {...rest}
-      intent="none"
-      $fillColor={fillColor}
-      stripes={rest.animate ? true : false}
-    />
+    <Progress.Root className={styles.root} style={style} value={radixValue} max={100}>
+      <Progress.Indicator className={clsx(styles.indicator, animate && styles.animated)} />
+    </Progress.Root>
   );
 };
-
-const StyledProgressBar = styled(BlueprintProgressBar)<{$fillColor: string}>`
-  &.bp5-progress-bar {
-    background: transparent;
-
-    ::before {
-      content: '';
-      background: ${(p) => p.$fillColor};
-      position: absolute;
-      inset: 0;
-      opacity: 0.25;
-    }
-
-    .bp5-progress-meter {
-      background-color: ${(p) => p.$fillColor};
-    }
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/ProgressBar.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/ProgressBar.stories.tsx
@@ -1,6 +1,7 @@
+import {useEffect, useState} from 'react';
+
 import {Box} from '../Box';
 import {Colors} from '../Color';
-import {Group} from '../Group';
 import {ProgressBar} from '../ProgressBar';
 
 // eslint-disable-next-line import/no-default-export
@@ -10,25 +11,34 @@ export default {
 };
 
 export const Sizes = () => {
+  const [value, setValue] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setValue((value) => (value < 100 ? value + 1 : value));
+    }, 200);
+    return () => clearInterval(interval);
+  }, []);
+
   return (
-    <Group direction="column" spacing={32}>
+    <Box flex={{direction: 'column', gap: 32}}>
       <Box padding={20} border="all">
-        <Group direction="column" spacing={16}>
-          <ProgressBar intent="primary" value={0.1} animate={true} />
-          <ProgressBar intent="primary" value={0.7} />
-        </Group>
+        <Box flex={{direction: 'column', gap: 16}}>
+          <ProgressBar value={10} animate fillColor={Colors.accentGray()} />
+          <ProgressBar value={70} fillColor={Colors.accentGray()} />
+        </Box>
       </Box>
       <Box padding={20} border="all">
-        <Group direction="column" spacing={16}>
-          <ProgressBar
-            intent="primary"
-            value={0.1}
-            animate={true}
-            fillColor={Colors.accentBlue()}
-          />
-          <ProgressBar intent="primary" value={0.7} fillColor={Colors.accentBlue()} />
-        </Group>
+        <Box flex={{direction: 'column', gap: 16}}>
+          <ProgressBar value={10} animate />
+          <ProgressBar value={70} />
+        </Box>
       </Box>
-    </Group>
+      <Box padding={20} border="all">
+        <Box flex={{direction: 'column', gap: 16}}>
+          <ProgressBar value={value} animate fillColor={Colors.accentGreen()} />
+        </Box>
+      </Box>
+    </Box>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-components/src/components/css/ProgressBar.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/css/ProgressBar.module.css
@@ -1,0 +1,69 @@
+.root {
+  --progress-fill-color: var(--color-accent-blue);
+  --progress-value: 0;
+  --progress-height: 8px;
+
+  position: relative;
+  overflow: hidden;
+  background: transparent;
+  height: var(--progress-height);
+  border-radius: 4px;
+  width: 100%;
+
+  /* Fix overflow clipping in Safari */
+  /* https://gist.github.com/domske/b66047671c780a238b51c51ffde8d3a0 */
+  transform: translateZ(0);
+}
+
+/* 25% opacity background layer */
+.root::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--progress-fill-color);
+  opacity: 0.25;
+  border-radius: 4px;
+}
+
+/* Progress indicator - the filled portion */
+.indicator {
+  background-color: var(--progress-fill-color);
+  height: 100%;
+  border-radius: 4px;
+  transition: width 300ms ease;
+  position: relative;
+  transition: transform 660ms cubic-bezier(0.65, 0, 0.35, 1);
+  transform: translateX(calc((100 - var(--progress-value)) * -1%));
+}
+
+/* Animated stripes */
+.animated {
+  background-image: linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.15) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.15) 50%,
+    rgba(255, 255, 255, 0.15) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 30px 30px;
+  animation: progress-stripes 1s linear infinite;
+}
+
+@keyframes progress-stripes {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 30px 0;
+  }
+}
+
+/* Respect user motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .animated {
+    animation: none;
+  }
+}

--- a/js_modules/dagster-ui/packages/ui-components/src/index.ts
+++ b/js_modules/dagster-ui/packages/ui-components/src/index.ts
@@ -31,6 +31,7 @@ export * from './components/Page';
 export * from './components/PageHeader';
 export * from './components/Popover';
 export * from './components/ProductTour';
+export * from './components/ProgressBar';
 export * from './components/Radio';
 export * from './components/RefreshableCountdown';
 export * from './components/RoundedButton';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetWipeDialog.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetWipeDialog.oss.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {ProgressBar} from '@blueprintjs/core';
 import {
   Body1,
   Box,
@@ -8,6 +6,7 @@ import {
   DialogBody,
   DialogFooter,
   Group,
+  ProgressBar,
   ifPlural,
 } from '@dagster-io/ui-components';
 import {memo, useMemo} from 'react';
@@ -88,7 +87,7 @@ export const AssetWipeDialogInner = memo(
       return (
         <Box flex={{gap: 8, direction: 'column'}}>
           <div>Wiping...</div>
-          <ProgressBar intent="primary" value={Math.max(0.1, value)} animate={value < 1} />
+          <ProgressBar value={Math.max(0.1, value) * 100} animate={value < 100} />
           <NavigationBlock message="Wiping in progress, please do not navigate away yet." />
         </Box>
       );

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationStateChangeDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationStateChangeDialog.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {ProgressBar} from '@blueprintjs/core';
 import {
   Button,
   Colors,
@@ -8,6 +6,7 @@ import {
   DialogFooter,
   Group,
   Icon,
+  ProgressBar,
 } from '@dagster-io/ui-components';
 import {useEffect} from 'react';
 
@@ -223,7 +222,7 @@ export const AutomationStateChangeDialog = (props: Props) => {
         const value = count > 0 ? state.completion.completed / count : 1;
         return (
           <Group direction="column" spacing={8}>
-            <ProgressBar intent="primary" value={Math.max(0.1, value)} animate={value < 1} />
+            <ProgressBar value={Math.max(0.1, value) * 100} animate={value < 100} />
             {state.step === 'updating' ? (
               <NavigationBlock message="Automations are being updated, please do not navigate away yet." />
             ) : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/DeletionDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/DeletionDialog.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {ProgressBar} from '@blueprintjs/core';
 import {
   Button,
   Colors,
@@ -9,6 +7,7 @@ import {
   Group,
   Icon,
   Mono,
+  ProgressBar,
 } from '@dagster-io/ui-components';
 import {useEffect, useReducer, useRef} from 'react';
 
@@ -172,7 +171,7 @@ export const DeletionDialog = (props: Props) => {
         return (
           <Group direction="column" spacing={8}>
             <div>Deleting…</div>
-            <ProgressBar intent="primary" value={Math.max(0.1, value)} animate={value < 1} />
+            <ProgressBar value={Math.max(0.1, value) * 100} animate={value < 100} />
             {state.step === 'deleting' ? (
               <NavigationBlock message="Deletion in progress, please do not navigate away yet." />
             ) : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/ReexecutionDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/ReexecutionDialog.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {ProgressBar} from '@blueprintjs/core';
 import {
   Button,
   Colors,
@@ -9,6 +7,7 @@ import {
   Group,
   Icon,
   Mono,
+  ProgressBar,
 } from '@dagster-io/ui-components';
 import {useEffect, useReducer, useRef} from 'react';
 import {Link} from 'react-router-dom';
@@ -275,7 +274,7 @@ export const ReexecutionDialog = (props: ReexecutionDialogProps) => {
         const value = count > 0 ? state.reexecution.completed / count : 1;
         return (
           <Group direction="column" spacing={8}>
-            <ProgressBar intent="primary" value={Math.max(0.1, value)} animate={value < 1} />
+            <ProgressBar value={Math.max(0.1, value) * 100} animate={value < 100} />
             {state.step === 'reexecuting' ? (
               <NavigationBlock message="Re-execution in progress, please do not navigate away yet." />
             ) : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/TerminationDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/TerminationDialog.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {ProgressBar} from '@blueprintjs/core';
 import {
   Box,
   Button,
@@ -11,6 +9,7 @@ import {
   Group,
   Icon,
   Mono,
+  ProgressBar,
   showToast,
 } from '@dagster-io/ui-components';
 import chunk from 'lodash/chunk';
@@ -244,7 +243,7 @@ export const TerminationDialog = (props: Props) => {
         return (
           <Group direction="column" spacing={8}>
             <div>{force ? 'Forcing termination…' : 'Terminating…'}</div>
-            <ProgressBar intent="primary" value={Math.max(0.1, value)} animate={value < 1} />
+            <ProgressBar value={Math.max(0.1, value) * 100} animate={value < 100} />
             {state.step === 'terminating' ? (
               <NavigationBlock message="Termination in progress, please do not navigate away yet." />
             ) : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleStateChangeDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleStateChangeDialog.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {ProgressBar} from '@blueprintjs/core';
 import {
   Button,
   Colors,
@@ -8,6 +6,7 @@ import {
   DialogFooter,
   Group,
   Icon,
+  ProgressBar,
 } from '@dagster-io/ui-components';
 import {useEffect} from 'react';
 
@@ -156,7 +155,7 @@ export const ScheduleStateChangeDialog = (props: Props) => {
         const value = count > 0 ? state.completion.completed / count : 1;
         return (
           <Group direction="column" spacing={8}>
-            <ProgressBar intent="primary" value={Math.max(0.1, value)} animate={value < 1} />
+            <ProgressBar value={Math.max(0.1, value) * 100} animate={value < 100} />
             {state.step === 'updating' ? (
               <NavigationBlock message="Schedules are being updated, please do not navigate away yet." />
             ) : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorStateChangeDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorStateChangeDialog.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {ProgressBar} from '@blueprintjs/core';
 import {
   Button,
   Colors,
@@ -8,6 +6,7 @@ import {
   DialogFooter,
   Group,
   Icon,
+  ProgressBar,
 } from '@dagster-io/ui-components';
 import {useEffect} from 'react';
 
@@ -156,7 +155,7 @@ export const SensorStateChangeDialog = (props: Props) => {
         const value = count > 0 ? state.completion.completed / count : 1;
         return (
           <Group direction="column" spacing={8}>
-            <ProgressBar intent="primary" value={Math.max(0.1, value)} animate={value < 1} />
+            <ProgressBar value={Math.max(0.1, value) * 100} animate={value < 100} />
             {state.step === 'updating' ? (
               <NavigationBlock message="Sensors are being updated, please do not navigate away yet." />
             ) : null}

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -1938,6 +1938,7 @@ __metadata:
     "@dagster-io/eslint-config": "workspace:*"
     "@date-fns/tz": "npm:^1.4.1"
     "@mdx-js/react": "npm:^1.6.22"
+    "@radix-ui/react-progress": "npm:^1.1.8"
     "@radix-ui/react-slider": "npm:^1.2.2"
     "@react-hook/resize-observer": "npm:^1.2.6"
     "@rollup/plugin-babel": "npm:^5.3.1"
@@ -4202,6 +4203,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-context@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@radix-ui/react-context@npm:1.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/65199507b3c626dcc535aabd972c127eb233d8f60bb13e3784e9fcf5dff06377ff033a8e794841a555267c3fb72bda93fea92fa3f612936e181dfb7902ae0ae2
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-direction@npm:1.1.1":
   version: 1.1.1
   resolution: "@radix-ui/react-direction@npm:1.1.1"
@@ -4231,6 +4245,45 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10/1dbbf932a3527f4e62f210bb72944eff605c3e38c8d3275ed5a5c570c02820ab156169756a65ad9a638d2089a828a04a7903795377384e98c87d0ca456303253
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:2.1.4":
+  version: 2.1.4
+  resolution: "@radix-ui/react-primitive@npm:2.1.4"
+  dependencies:
+    "@radix-ui/react-slot": "npm:1.2.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/a718537c2e66d541e72cc6b92bcf8ba6a7a0b4a30072efadeac0a517eb36f8acc55f2983cc1e345dc0eae18166ebcace4dab0299ed87a79e8ac3f653df9ee437
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-progress@npm:^1.1.8":
+  version: 1.1.8
+  resolution: "@radix-ui/react-progress@npm:1.1.8"
+  dependencies:
+    "@radix-ui/react-context": "npm:1.1.3"
+    "@radix-ui/react-primitive": "npm:2.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/0d42bfcae4b6aebfa5ec5b54b79e1ed50e00080ff38dff116c7f78bbd0be9f50cc6ea99d89accbebcba643de4f51c866878fc8e57b961681c3f73608cf02e1ba
   languageName: node
   linkType: hard
 
@@ -4275,6 +4328,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/fe484c2741e31d9c20a8fb53c5790a73c0664e2bea35e27f4d484a90c42135fcfffe11a08abfcacb7a8ee2faf013471f0e856818f3ddac8ac51ceb8869e0fd08
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@radix-ui/react-slot@npm:1.2.4"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/b37e37455b92789758980359d73ab5a5f5d1c12af480c775519bd15c556b891642d472accf05b30d520751489ca74cdb8fd7866064abc7942f0437371be28e51
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

It turns out we haven't even been using `ProgressBar` from `ui-components`!

Replaced the Blueprint.js ProgressBar component with a custom implementation using Radix UI's Progress component. This change:

- Adds `@radix-ui/react-progress` as a dependency
- Creates a new CSS module for styling the progress bar
- Updates the ProgressBar API to use a 0-100 value range instead of 0-1
- Maintains backward compatibility by scaling the input values
- Adds proper accessibility features and respects user motion preferences
- Exports the ProgressBar component from the ui-components package

![Screenshot 2025-12-26 at 15.52.19.png](https://app.graphite.com/user-attachments/assets/79d5d733-28dc-4f84-9011-5503c56cdb1e.png)

## How I Tested These Changes

- Updated the Storybook stories to showcase different progress bar states
- Added an animated example that increments over time
- Verified that all existing usages of ProgressBar across the codebase work correctly with the new implementation
- Confirmed that the component respects reduced motion preferences