### PR TITLE
Update Kubernetes JSON schema references to v1.19.0

### DIFF
--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1,13 +1,13 @@
 {
     "$defs": {
         "Affinity": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
             "additionalProperties": true,
             "title": "Affinity",
             "type": "object"
         },
         "Annotations": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
             "additionalProperties": {
                 "type": "string"
             },
@@ -641,7 +641,7 @@
             "type": "string"
         },
         "ConfigMapEnvSource": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
             "additionalProperties": true,
             "properties": {},
             "title": "ConfigMapEnvSource",
@@ -673,7 +673,7 @@
             "type": "object"
         },
         "Container": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
             "additionalProperties": true,
             "properties": {},
             "title": "Container",
@@ -963,14 +963,14 @@
             "type": "object"
         },
         "DeploymentStrategy": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
             "additionalProperties": true,
             "properties": {},
             "title": "DeploymentStrategy",
             "type": "object"
         },
         "EnvVar": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar",
             "additionalProperties": true,
             "properties": {},
             "title": "EnvVar",
@@ -1410,7 +1410,7 @@
             "type": "object"
         },
         "InitContainer": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
             "additionalProperties": true,
             "properties": {},
             "title": "InitContainer",
@@ -1582,14 +1582,14 @@
             "type": "object"
         },
         "Labels": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
             "additionalProperties": true,
             "properties": {},
             "title": "Labels",
             "type": "object"
         },
         "LivenessProbe": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
             "additionalProperties": true,
             "properties": {},
             "title": "LivenessProbe",
@@ -1671,7 +1671,7 @@
             "type": "object"
         },
         "NodeSelector": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
             "additionalProperties": {
                 "type": "string"
             },
@@ -1680,7 +1680,7 @@
             "type": "object"
         },
         "PodSecurityContext": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
             "additionalProperties": true,
             "title": "PodSecurityContext",
             "type": "object"
@@ -1951,14 +1951,14 @@
             "type": "object"
         },
         "ReadinessProbe": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
             "additionalProperties": true,
             "properties": {},
             "title": "ReadinessProbe",
             "type": "object"
         },
         "ReadinessProbeWithEnabled": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
             "additionalProperties": true,
             "properties": {
                 "enabled": {
@@ -2032,14 +2032,14 @@
             "type": "object"
         },
         "ResourceRequirements": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
             "additionalProperties": true,
             "properties": {},
             "title": "ResourceRequirements",
             "type": "object"
         },
         "Resources": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
             "additionalProperties": true,
             "title": "Resources",
             "type": "object"
@@ -2683,21 +2683,21 @@
             "type": "object"
         },
         "SecretEnvSource": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecretEnvSource",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecretEnvSource",
             "additionalProperties": true,
             "properties": {},
             "title": "SecretEnvSource",
             "type": "object"
         },
         "SecretRef": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference",
             "additionalProperties": true,
             "properties": {},
             "title": "SecretRef",
             "type": "object"
         },
         "SecurityContext": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
             "additionalProperties": true,
             "title": "SecurityContext",
             "type": "object"
@@ -2818,7 +2818,7 @@
             "type": "object"
         },
         "StartupProbe": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
             "additionalProperties": true,
             "properties": {
                 "enabled": {
@@ -2942,7 +2942,7 @@
             "type": "object"
         },
         "Tolerations": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
             "items": {
                 "additionalProperties": true,
                 "type": "object"
@@ -3332,14 +3332,14 @@
             "type": "object"
         },
         "Volume": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume",
             "additionalProperties": true,
             "properties": {},
             "title": "Volume",
             "type": "object"
         },
         "VolumeMount": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount",
             "additionalProperties": true,
             "properties": {},
             "title": "VolumeMount",


### PR DESCRIPTION
## Summary & Motivation

  The Helm chart's `values.schema.json` references `kubernetesjsonschema.dev` which returns 404, causing schema validation to fail:

  Error: values don't meet the specifications of the schema(s)
  failing loading "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json": HTTP request returned status 404

  The site is backed by `instrumenta/kubernetes-json-schema` which was last updated in 2020 and is no longer maintained.

  **Fix:** Replace with `yannh/kubernetes-json-schema` - an actively maintained fork. Used v1.19.0 as it's the earliest available version in that repo.

  Fixes #5517

  ## How I Tested These Changes

  - Verified old URL returns 404
  - Verified new URL returns 200 and contains all required definitions (Affinity, Container, Probe, PodSecurityContext, etc.)
  - Ran `helm upgrade --dry-run` successfully without `--skip-schema-validation`

  ## Changelog

  - [helm] Fixed broken schema validation by updating `values.schema.json` to use maintained kubernetes-json-schema source