### PR TITLE
[For CI] Fix Helm schema URL referencing defunct kubernetesjsonschema.dev

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -1,13 +1,13 @@
 {
     "$defs": {
         "Affinity": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
             "additionalProperties": true,
             "title": "Affinity",
             "type": "object"
         },
         "Annotations": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
             "additionalProperties": {
                 "type": "string"
             },
@@ -15,28 +15,28 @@
             "type": "object"
         },
         "ConfigMapEnvSource": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
             "additionalProperties": true,
             "properties": {},
             "title": "ConfigMapEnvSource",
             "type": "object"
         },
         "Container": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
             "additionalProperties": true,
             "properties": {},
             "title": "Container",
             "type": "object"
         },
         "DeploymentStrategy": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
             "additionalProperties": true,
             "properties": {},
             "title": "DeploymentStrategy",
             "type": "object"
         },
         "EnvVar": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar",
             "additionalProperties": true,
             "properties": {},
             "title": "EnvVar",
@@ -120,14 +120,14 @@
             "type": "object"
         },
         "LivenessProbe": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
             "additionalProperties": true,
             "properties": {},
             "title": "LivenessProbe",
             "type": "object"
         },
         "NodeSelector": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
             "additionalProperties": {
                 "type": "string"
             },
@@ -136,7 +136,7 @@
             "type": "object"
         },
         "PodSecurityContext": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
             "additionalProperties": true,
             "title": "PodSecurityContext",
             "type": "object"
@@ -151,7 +151,7 @@
             "type": "string"
         },
         "ReadinessProbeWithEnabled": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
             "additionalProperties": true,
             "properties": {
                 "enabled": {
@@ -166,27 +166,27 @@
             "type": "object"
         },
         "Resources": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
             "additionalProperties": true,
             "title": "Resources",
             "type": "object"
         },
         "SecretEnvSource": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecretEnvSource",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecretEnvSource",
             "additionalProperties": true,
             "properties": {},
             "title": "SecretEnvSource",
             "type": "object"
         },
         "SecretRef": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference",
             "additionalProperties": true,
             "properties": {},
             "title": "SecretRef",
             "type": "object"
         },
         "SecurityContext": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
             "additionalProperties": true,
             "title": "SecurityContext",
             "type": "object"
@@ -214,7 +214,7 @@
             "type": "object"
         },
         "StartupProbe": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
             "additionalProperties": true,
             "properties": {
                 "enabled": {
@@ -227,7 +227,7 @@
             "type": "object"
         },
         "Tolerations": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
             "items": {
                 "additionalProperties": true,
                 "type": "object"
@@ -583,14 +583,14 @@
             "type": "object"
         },
         "Volume": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume",
             "additionalProperties": true,
             "properties": {},
             "title": "Volume",
             "type": "object"
         },
         "VolumeMount": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount",
             "additionalProperties": true,
             "properties": {},
             "title": "VolumeMount",

--- a/helm/dagster/schema/schema/charts/utils/utils.py
+++ b/helm/dagster/schema/schema/charts/utils/utils.py
@@ -9,7 +9,7 @@ from pydantic import (
 
 
 class SupportedKubernetes(str, Enum):
-    V1_18 = "1.18.0"
+    V1_19 = "1.19.0"
 
 
 class ConfigurableClass(PydanticBaseModel, extra="forbid"):
@@ -44,9 +44,9 @@ class BaseModel(PydanticBaseModel):
                     value["anyOf"].append({"type": "null"})
 
 
-def create_definition_ref(definition: str, version: str = SupportedKubernetes.V1_18.value) -> str:
+def create_definition_ref(definition: str, version: str = SupportedKubernetes.V1_19.value) -> str:
     return (
-        f"https://kubernetesjsonschema.dev/v{version}/_definitions.json#/definitions/{definition}"
+        f"https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v{version}/_definitions.json#/definitions/{definition}"
     )
 
 

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1,13 +1,13 @@
 {
     "$defs": {
         "Affinity": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
             "additionalProperties": true,
             "title": "Affinity",
             "type": "object"
         },
         "Annotations": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
             "additionalProperties": {
                 "type": "string"
             },
@@ -641,7 +641,7 @@
             "type": "string"
         },
         "ConfigMapEnvSource": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
             "additionalProperties": true,
             "properties": {},
             "title": "ConfigMapEnvSource",
@@ -673,7 +673,7 @@
             "type": "object"
         },
         "Container": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
             "additionalProperties": true,
             "properties": {},
             "title": "Container",
@@ -963,14 +963,14 @@
             "type": "object"
         },
         "DeploymentStrategy": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
             "additionalProperties": true,
             "properties": {},
             "title": "DeploymentStrategy",
             "type": "object"
         },
         "EnvVar": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar",
             "additionalProperties": true,
             "properties": {},
             "title": "EnvVar",
@@ -1410,7 +1410,7 @@
             "type": "object"
         },
         "InitContainer": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
             "additionalProperties": true,
             "properties": {},
             "title": "InitContainer",
@@ -1582,14 +1582,14 @@
             "type": "object"
         },
         "Labels": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
             "additionalProperties": true,
             "properties": {},
             "title": "Labels",
             "type": "object"
         },
         "LivenessProbe": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
             "additionalProperties": true,
             "properties": {},
             "title": "LivenessProbe",
@@ -1671,7 +1671,7 @@
             "type": "object"
         },
         "NodeSelector": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
             "additionalProperties": {
                 "type": "string"
             },
@@ -1680,7 +1680,7 @@
             "type": "object"
         },
         "PodSecurityContext": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
             "additionalProperties": true,
             "title": "PodSecurityContext",
             "type": "object"
@@ -1951,14 +1951,14 @@
             "type": "object"
         },
         "ReadinessProbe": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
             "additionalProperties": true,
             "properties": {},
             "title": "ReadinessProbe",
             "type": "object"
         },
         "ReadinessProbeWithEnabled": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
             "additionalProperties": true,
             "properties": {
                 "enabled": {
@@ -2032,14 +2032,14 @@
             "type": "object"
         },
         "ResourceRequirements": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
             "additionalProperties": true,
             "properties": {},
             "title": "ResourceRequirements",
             "type": "object"
         },
         "Resources": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
             "additionalProperties": true,
             "title": "Resources",
             "type": "object"
@@ -2683,21 +2683,21 @@
             "type": "object"
         },
         "SecretEnvSource": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecretEnvSource",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecretEnvSource",
             "additionalProperties": true,
             "properties": {},
             "title": "SecretEnvSource",
             "type": "object"
         },
         "SecretRef": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference",
             "additionalProperties": true,
             "properties": {},
             "title": "SecretRef",
             "type": "object"
         },
         "SecurityContext": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
             "additionalProperties": true,
             "title": "SecurityContext",
             "type": "object"
@@ -2818,7 +2818,7 @@
             "type": "object"
         },
         "StartupProbe": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
             "additionalProperties": true,
             "properties": {
                 "enabled": {
@@ -2942,7 +2942,7 @@
             "type": "object"
         },
         "Tolerations": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
             "items": {
                 "additionalProperties": true,
                 "type": "object"
@@ -3332,14 +3332,14 @@
             "type": "object"
         },
         "Volume": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume",
             "additionalProperties": true,
             "properties": {},
             "title": "Volume",
             "type": "object"
         },
         "VolumeMount": {
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount",
             "additionalProperties": true,
             "properties": {},
             "title": "VolumeMount",


### PR DESCRIPTION
Will land the OSS contribution if this passes, just sending this out separately to run full CI

The kubernetesjsonschema.dev service is no longer available (returns 404).
Updated to use the maintained GitHub-hosted schema from yannh/kubernetes-json-schema
and bumped the Kubernetes version from 1.18.0 to 1.19.0.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
