### PR TITLE
Consolidate python versions in dg cli, add python 3.14

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/util.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/util.py
@@ -11,10 +11,10 @@ import click
 from packaging import version
 
 from dagster_cloud_cli.core.pex_builder.platforms import COMPLETE_PLATFORMS
-from dagster_cloud_cli.utils import DEFAULT_PYTHON_VERSION
+from dagster_cloud_cli.utils import DEFAULT_PYTHON_VERSION, SUPPORTED_PYTHON_VERSIONS
 
 TARGET_PYTHON_VERSIONS = [
-    version.Version(python_version) for python_version in ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    version.Version(python_version) for python_version in SUPPORTED_PYTHON_VERSIONS
 ]
 
 
@@ -142,7 +142,7 @@ def python_version_option():
     """Reusable click.option."""
     return click.option(
         "--python-version",
-        type=click.Choice([str(v) for v in TARGET_PYTHON_VERSIONS]),
+        type=click.Choice(SUPPORTED_PYTHON_VERSIONS),
         default=DEFAULT_PYTHON_VERSION,
         show_default=True,
         help="Target Python version.",

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/utils.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/utils.py
@@ -3,17 +3,21 @@ import functools
 import inspect
 import math
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import typer
-from typer.models import OptionInfo
+if TYPE_CHECKING:
+    from typer import Typer
+    from typer.models import OptionInfo
 
-from dagster_cloud_cli import ui
 
 DEFAULT_PYTHON_VERSION = "3.11"
 
+SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
-def create_stub_app(package_name: str) -> typer.Typer:
+
+def create_stub_app(package_name: str) -> "Typer":
+    import typer
+
     return typer.Typer(
         help=f"This command is not available unless you install the {package_name} package.",
         hidden=True,
@@ -21,6 +25,8 @@ def create_stub_app(package_name: str) -> typer.Typer:
 
 
 def create_stub_command(package_name: str):
+    from dagster_cloud_cli import ui
+
     def fn():
         ui.print(f"This command is not available unless you install the {package_name} package.")
 
@@ -48,7 +54,7 @@ def without_params(signature: inspect.Signature, to_remove: list[str]) -> inspec
     return signature.replace(parameters=list(params.values()))
 
 
-def add_options(options: dict[str, tuple[Any, OptionInfo]]):
+def add_options(options: dict[str, tuple[Any, "OptionInfo"]]):
     """Decorator to add Options to a particular command."""
 
     def decorator(to_wrap):

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Optional
 
 import click
 from dagster_cloud_cli.types import SnapshotBaseDeploymentCondition
+from dagster_cloud_cli.utils import SUPPORTED_PYTHON_VERSIONS
 from dagster_dg_core.config import DgRawCliConfig, normalize_cli_config
 from dagster_dg_core.context import DgContext
 from dagster_dg_core.shared_options import (
@@ -95,7 +96,7 @@ org_and_deploy_option_group = make_option_group(
 @click.option(
     "--python-version",
     "python_version",
-    type=click.Choice(["3.9", "3.10", "3.11", "3.12"]),
+    type=click.Choice(SUPPORTED_PYTHON_VERSIONS),
     help=(
         "Python version used to deploy the project. If not set, defaults to the calling process's Python minor version."
     ),
@@ -341,7 +342,7 @@ def start_deploy_session_command(
 @click.option(
     "--python-version",
     "python_version",
-    type=click.Choice(["3.9", "3.10", "3.11", "3.12"]),
+    type=click.Choice(SUPPORTED_PYTHON_VERSIONS),
     help=(
         "Python version used to deploy the project. If not set, defaults to the calling process's Python minor version."
     ),

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/configure/commands.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Optional
 
 import click
+from dagster_cloud_cli.utils import SUPPORTED_PYTHON_VERSIONS
 from dagster_dg_core.config import normalize_cli_config
 from dagster_dg_core.context import DgContext
 from dagster_dg_core.shared_options import dg_editable_dagster_options, dg_global_options
@@ -296,7 +297,7 @@ def deploy_configure_group(
 )
 @click.option(
     "--python-version",
-    type=click.Choice(["3.9", "3.10", "3.11", "3.12", "3.13"]),
+    type=click.Choice(SUPPORTED_PYTHON_VERSIONS),
     help="Python version used to deploy the project",
 )
 @click.option(
@@ -384,7 +385,7 @@ def deploy_configure_serverless(
 )
 @click.option(
     "--python-version",
-    type=click.Choice(["3.9", "3.10", "3.11", "3.12", "3.13"]),
+    type=click.Choice(SUPPORTED_PYTHON_VERSIONS),
     help="Python version used to deploy the project",
 )
 @click.option(

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/build_artifacts.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/scaffold/build_artifacts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 import click
+from dagster_cloud_cli.utils import SUPPORTED_PYTHON_VERSIONS
 from dagster_dg_core.config import normalize_cli_config
 from dagster_dg_core.context import DgContext
 from dagster_dg_core.shared_options import dg_editable_dagster_options, dg_global_options
@@ -76,7 +77,7 @@ def _resolve_config_for_build_artifacts(
 @click.option(
     "--python-version",
     "python_version",
-    type=click.Choice(["3.9", "3.10", "3.11", "3.12", "3.13"]),
+    type=click.Choice(SUPPORTED_PYTHON_VERSIONS),
     help=(
         "Python version used to deploy the project. If not set, defaults to the calling process's Python minor version."
     ),

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/import_perf_tests/test_import_perf.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/import_perf_tests/test_import_perf.py
@@ -58,8 +58,8 @@ def test_import_perf():
     # if `tuna` output is unfriendly, another way to debug imports is to open `/tmp/import.txt`
     # using https://kmichel.github.io/python-importtime-graph/
     assert not expensive_imports, (
-        "The following expensive libraries were imported with the top-level `dagster` module, "
-        f"slowing down any process that imports Dagster: {', '.join(expensive_imports)}; to debug, "
+        "The following expensive libraries were imported with the top-level `dagster_dg_cli` module, "
+        f"slowing down any process that imports dg: {', '.join(expensive_imports)}; to debug, "
         "`pip install tuna`, then run "
         "`python -X importtime python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/import_perf_tests/simple_import.py noop &> /tmp/import.txt && tuna /tmp/import.txt`."
     )


### PR DESCRIPTION
## Summary & Motivation
There were a bunch of different places we list out valid python versions, and one was missing python 3.13. Consolidate them into a constant and add python 3.14 now that we have serverless support for that as well.

## How I Tested These Changes
BK, deploy a dg project to python 3.13

## Changelog
Added support for using python version 3.13 when running `dg plus deploy`.