### PR TITLE
Use google artifact registry or public aws ecr for dind

### DIFF
--- a/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
+++ b/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
@@ -385,8 +385,7 @@ class CommandStepBuilder:
             if "gke" in queue:
                 docker_image = "us-central1-docker.pkg.dev/dagster-production/buildkite-images/docker:20.10.16-dind"
             else:
-                # Use ECR pull-through cache for Docker Hub images in AWS
-                docker_image = "968703565975.dkr.ecr.us-west-2.amazonaws.com/dockerhub/library/docker:20.10.16-dind"
+                docker_image = "public.ecr.aws/docker/library/docker:20.10.16-dind"
 
             sidecars.append(
                 {


### PR DESCRIPTION
## Summary & Motivation

Loading the dind image from ecr fails with 429 when running in gke.

## How I Tested These Changes
Will look in gke buildkite after landing.
