### PR TITLE
[feature] Support of all Datadog init fields

### DIFF
--- a/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/resources.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from dagster import ConfigurableResource, resource
 from dagster._annotations import beta
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
@@ -14,10 +16,47 @@ class DatadogClient:
         DogStatsd.UNKNOWN,
     )
 
-    def __init__(self, api_key: str, app_key: str):
+    def __init__(
+        self,
+        api_key: Optional[str],
+        app_key: Optional[str],
+        host_name: Optional[str] = None,
+        api_host: Optional[str] = None,
+        statsd_host: Optional[str] = None,
+        statsd_port: Optional[int] = None,
+        statsd_disable_aggregation: bool = True,
+        statsd_disable_buffering: bool = True,
+        statsd_aggregation_flush_interval: float = 0.3,
+        statsd_use_default_route: bool = False,
+        statsd_socket_path: Optional[str] = None,
+        statsd_namespace: Optional[str] = None,
+        statsd_max_samples_per_context: Optional[int] = 0,
+        statsd_constant_tags: Optional[List[str]] = None,
+        return_raw_response: bool = False,
+        hostname_from_config: bool = True,
+        cardinality: Optional[str] = None,
+    ):
         self.api_key = api_key
         self.app_key = app_key
-        initialize(api_key=api_key, app_key=app_key)
+        initialize(
+            api_key=api_key,
+            app_key=app_key,
+            host_name=host_name,
+            api_host=api_host,
+            statsd_host=statsd_host,
+            statsd_port=statsd_port,
+            statsd_disable_aggregation=statsd_disable_aggregation,
+            statsd_disable_buffering=statsd_disable_buffering,
+            statsd_aggregation_flush_interval=statsd_aggregation_flush_interval,
+            statsd_use_default_route=statsd_use_default_route,
+            statsd_socket_path=statsd_socket_path,
+            statsd_namespace=statsd_namespace,
+            statsd_max_samples_per_context=statsd_max_samples_per_context,
+            statsd_constant_tags=statsd_constant_tags,
+            return_raw_response=return_raw_response,
+            hostname_from_config=hostname_from_config,
+            cardinality=cardinality,
+        )
 
         # Pull in methods from the dogstatsd library
         for method in [
@@ -92,13 +131,46 @@ class DatadogResource(ConfigurableResource):
             " https://docs.datadoghq.com/account_management/api-app-keys/."
         )
     )
+    host_name: Optional[str] = None
+    api_host: Optional[str] = None
+    statsd_host: Optional[str] = None
+    statsd_port: Optional[int] = None
+    statsd_disable_aggregation: bool = True
+    statsd_disable_buffering: bool = True
+    statsd_aggregation_flush_interval: float = 0.3
+    statsd_use_default_route: bool = False
+    statsd_socket_path: Optional[str] = None
+    statsd_namespace: Optional[str] = None
+    statsd_max_samples_per_context: Optional[int] = 0
+    statsd_constant_tags: Optional[List[str]] = None
+    return_raw_response: bool = False
+    hostname_from_config: bool = True
+    cardinality: Optional[str] = None
 
     @classmethod
     def _is_dagster_maintained(cls) -> bool:
         return True
 
     def get_client(self) -> DatadogClient:
-        return DatadogClient(self.api_key, self.app_key)
+        return DatadogClient(
+            api_key=self.api_key,
+            app_key=self.app_key,
+            host_name=self.host_name,
+            api_host=self.api_host,
+            statsd_host=self.statsd_host,
+            statsd_port=self.statsd_port,
+            statsd_disable_aggregation=self.statsd_disable_aggregation,
+            statsd_disable_buffering=self.statsd_disable_buffering,
+            statsd_aggregation_flush_interval=self.statsd_aggregation_flush_interval,
+            statsd_use_default_route=self.statsd_use_default_route,
+            statsd_socket_path=self.statsd_socket_path,
+            statsd_namespace=self.statsd_namespace,
+            statsd_max_samples_per_context=self.statsd_max_samples_per_context,
+            statsd_constant_tags=self.statsd_constant_tags,
+            return_raw_response=self.return_raw_response,
+            hostname_from_config=self.hostname_from_config,
+            cardinality=self.cardinality,
+        )
 
 
 @beta

--- a/python_modules/libraries/dagster-datadog/dagster_datadog/version.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog/version.py
@@ -1,1 +1,1 @@
-__version__ = "1!0+dev"
+__version__ = "1!0.1+dev"

--- a/python_modules/libraries/dagster-datadog/dagster_datadog_tests/test_resources.py
+++ b/python_modules/libraries/dagster-datadog/dagster_datadog_tests/test_resources.py
@@ -95,6 +95,51 @@ def assert_datadog_client_class(
     timed.assert_called_with("run_fn")
 
 
+@mock.patch("dagster_datadog.resources.initialize")
+def test_datadog_resource_initialize_args(initialize) -> None:
+    resource = DatadogResource(
+        api_key="API_KEY",
+        app_key="APP_KEY",
+        host_name="host",
+        api_host="https://api.datadoghq.com",
+        statsd_host="127.0.0.1",
+        statsd_port=8125,
+        statsd_disable_aggregation=False,
+        statsd_disable_buffering=False,
+        statsd_aggregation_flush_interval=0.5,
+        statsd_use_default_route=True,
+        statsd_socket_path="/tmp/dsd.socket",
+        statsd_namespace="namespace",
+        statsd_max_samples_per_context=5,
+        statsd_constant_tags=["env:dev", "team:platform"],
+        return_raw_response=True,
+        hostname_from_config=False,
+        cardinality="low",
+    )
+    client = resource.get_client()
+    assert client.api_key == "API_KEY"
+    assert client.app_key == "APP_KEY"
+    initialize.assert_called_once_with(
+        api_key="API_KEY",
+        app_key="APP_KEY",
+        host_name="host",
+        api_host="https://api.datadoghq.com",
+        statsd_host="127.0.0.1",
+        statsd_port=8125,
+        statsd_disable_aggregation=False,
+        statsd_disable_buffering=False,
+        statsd_aggregation_flush_interval=0.5,
+        statsd_use_default_route=True,
+        statsd_socket_path="/tmp/dsd.socket",
+        statsd_namespace="namespace",
+        statsd_max_samples_per_context=5,
+        statsd_constant_tags=["env:dev", "team:platform"],
+        return_raw_response=True,
+        hostname_from_config=False,
+        cardinality="low",
+    )
+
+
 @mock.patch("datadog.api.Metadata")
 @mock.patch("datadog.api.ServiceCheck")
 @mock.patch("datadog.api.Metric")


### PR DESCRIPTION
## Summary & Motivation

  - Added full support for all datadog.initialize parameters in the dagster-datadog resource and client wiring.
  - Updated tests to assert initialization args are forwarded correctly.
  - Bumped library version to reflect the expanded configuration surface.

  ## How I Tested These Changes

  - .venv/bin/pytest -q
  - Rolled out into our production and tested

  ## Changelog

  - Added full datadog.initialize configuration support for DatadogResource and DatadogClient.