### PR TITLE
Improve spacing in Asset Catalog Events tab

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventList.tsx
@@ -45,10 +45,7 @@ export const AssetEventList = ({
   }, [focused?.timestamp, focused?.partition]);
 
   return (
-    <Box
-      style={{position: 'relative', flex: 1, minHeight: 0}}
-      padding={{vertical: 12, horizontal: 16}}
-    >
+    <Box style={{position: 'relative', flex: 1, minHeight: 0}}>
       <AssetListContainer
         ref={parentRef}
         onScroll={(e) => {
@@ -83,7 +80,7 @@ export const AssetEventList = ({
                 }}
               >
                 <Box
-                  padding={{left: 12, right: 8, vertical: 5 as any}}
+                  padding={{horizontal: 12, vertical: 8}}
                   flex={{direction: 'column', justifyContent: 'center', gap: 8}}
                   data-index={index}
                   ref={rowVirtualizer.measureElement}
@@ -118,6 +115,7 @@ export const AssetEventList = ({
 
 export const AssetListContainer = styled(Container)`
   outline: none;
+  padding: 8px;
   &:focus {
     box-shadow: 0 -1px ${Colors.accentBlue()};
   }
@@ -165,12 +163,12 @@ const AssetEventListEventRow = ({group}: {group: AssetEventGroup}) => {
 
   return (
     <Box flex={{direction: 'column', gap: 4}}>
-      <Box flex={{gap: 4, direction: 'row', alignItems: 'center'}}>
+      <Box flex={{gap: 8, direction: 'row', alignItems: 'center'}}>
         {icon()}
         <Timestamp timestamp={{ms: Number(timestamp)}} />
       </Box>
       {partition ? (
-        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+        <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
           <Icon name="partition" />
           <MonoSmall color={Colors.textLight()}>{partition}</MonoSmall>
         </Box>


### PR DESCRIPTION
## Summary & Motivation

This PR adjusts the padding and spacing in the `AssetEventList` component to improve visual consistency and readability. The changes include:

- Removing the vertical and horizontal padding from the outer Box component
- Adding padding (8px) to the `AssetListContainer` styled component
- Adjusting the padding in the row items to be more consistent (12px horizontal, 8px vertical)
- Increasing the gap between elements in the event rows from 4px to 8px for better visual separation

These adjustments create a more balanced and visually appealing layout for the asset event list.

Before

![Screenshot 2025-12-31 at 11.49.57.png](https://app.graphite.com/user-attachments/assets/05a8946b-23a9-46a9-aaa3-a798727e3856.png)

After

![Screenshot 2025-12-31 at 11.49.17.png](https://app.graphite.com/user-attachments/assets/41f40589-139c-45c9-96d1-9b3e8e489753.png)

## How I Tested These Changes

I verified the UI appearance in the browser to ensure the padding and spacing changes maintain proper alignment while improving the overall visual design.

## Changelog

Improved spacing and padding in the Asset Event List UI component.