### PR TITLE
[pyright] Add pin for types-setuptools

### DIFF
--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -24,13 +24,12 @@ async-lru==2.0.5
 attrs==25.4.0
 babel==2.17.0
 backoff==2.2.1
-backports-tarfile==1.2.0
 beautifulsoup4==4.14.3
 bleach==6.3.0
 boto3==1.41.5
-boto3-stubs-lite==1.42.17
+boto3-stubs-lite==1.42.19
 botocore==1.41.5
-botocore-stubs==1.42.17
+botocore-stubs==1.42.19
 cachetools==6.2.4
 caio==0.9.25
 certifi==2025.1.31
@@ -89,7 +88,7 @@ duckdb==1.4.3
 execnet==2.1.2
 executing==2.2.1
 fastjsonschema==2.21.2
-filelock==3.20.1
+filelock==3.20.2
 flaky==3.8.1
 fonttools==4.61.1
 fqdn==1.5.1
@@ -99,7 +98,7 @@ fsspec==2024.3.0
 gcp-storage-emulator==2024.8.3
 gcsfs==0.8.0
 gitdb==4.0.12
-gitpython==3.1.45
+gitpython==3.1.46
 google-api-core==2.28.1
 google-api-python-client==2.187.0
 google-auth==2.45.0
@@ -144,7 +143,7 @@ jedi==0.19.2
 jinja2==3.1.6
 jmespath==1.0.1
 joblib==1.5.3
-json5==0.12.1
+json5==0.13.0
 jsonpointer==3.0.0
 jsonschema==4.25.1
 jsonschema-specifications==2025.9.1
@@ -161,7 +160,7 @@ keyring==25.7.0
 kiwisolver==1.4.9
 lark==1.3.1
 leather==0.4.1
-librt==0.7.5
+librt==0.7.7
 mako==1.3.10
 markdown-it-py==4.0.0
 markupsafe==3.0.3
@@ -198,7 +197,6 @@ oauthlib==3.3.1
 objgraph==3.6.2
 orderly-set==5.5.0
 orjson==3.11.5
-overrides==7.7.0
 packaging==25.0
 pandas==2.3.3
 pandas-stubs==2.3.3.251219
@@ -208,7 +206,7 @@ parsedatetime==2.6
 parso==0.8.5
 pathspec==0.12.1
 pexpect==4.9.0
-pillow==12.0.0
+pillow==12.1.0
 pip==25.3
 platformdirs==4.5.1
 pluggy==1.6.0
@@ -271,7 +269,7 @@ s3transfer==0.15.0
 scikit-learn==1.8.0
 scipy==1.16.3
 seaborn==0.13.2
-send2trash==1.8.3
+send2trash==2.0.0
 setuptools==80.9.0
 shellingham==1.5.4
 six==1.17.0
@@ -321,7 +319,7 @@ types-pytz==2025.2.0.20251108
 types-pyyaml==6.0.12.20250915
 types-requests==2.32.4.20250913
 types-s3transfer==0.16.0
-types-setuptools==80.9.0.20251223
+types-setuptools==80.9.0.20250822
 types-simplejson==3.20.0.20250822
 types-six==1.17.0.20251009
 types-tabulate==0.9.0.20241207

--- a/pyright/alt-1/requirements.txt
+++ b/pyright/alt-1/requirements.txt
@@ -50,3 +50,10 @@
     -e python_modules/libraries/dagster-snowflake-pandas/
     -e python_modules/libraries/dagster-snowflake-polars/
     -e python_modules/libraries/dagster-snowflake-pyspark/
+
+### CONSTRAINED BEYOND RUNTIME
+# The packages listed here are constrained beyond what is necessary for runtime
+# compatibility. Even though Dagster supports a wider range of versions at
+# runtime, some of these versions have bugged or incomplete type annotations
+# that trigger type errors
+types-setuptools==80.9.0.20250822  # Pinned due to overly strict _DictLike types in newer versions (20251223) causing false positives in setup.py files

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -1,4 +1,4 @@
-acryl-datahub==1.3.1.4
+acryl-datahub==1.3.1.5
 adbc-driver-manager==1.9.0
 adbc-driver-snowflake==1.9.0
 agate==1.9.1
@@ -56,7 +56,7 @@ avro==1.12.1
 avro-gen3==0.7.16
 aws-sam-translator==1.106.0
 aws-xray-sdk==2.15.0
-azure-ai-ml==1.30.0
+azure-ai-ml==1.31.0
 azure-common==1.1.28
 azure-core==1.37.0
 azure-core-tracing-opentelemetry==1.0.0b12
@@ -69,7 +69,6 @@ azure-storage-file-datalake==12.22.0
 azure-storage-file-share==12.23.1
 babel==2.17.0
 backoff==2.2.1
-backports-tarfile==1.2.0
 bcrypt==5.0.0
 beautifulsoup4==4.14.3
 billiard==4.2.4
@@ -77,9 +76,9 @@ bleach==6.3.0
 blinker==1.9.0
 bokeh==3.8.1
 boto3==1.41.5
-boto3-stubs-lite==1.42.17
+boto3-stubs-lite==1.42.19
 botocore==1.41.5
-botocore-stubs==1.42.17
+botocore-stubs==1.42.19
 build==1.3.0
 cachecontrol==0.14.4
 cached-property==2.0.1
@@ -88,7 +87,7 @@ cachetools==6.2.4
 caio==0.9.25
 callee==0.3.1
 cattrs==23.1.2
-celery==5.6.0
+celery==5.6.1
 certifi==2025.11.12
 cffi==2.0.0
 cfn-lint==1.43.1
@@ -219,9 +218,9 @@ debugpy==1.8.19
 decopatch==1.4.10
 decorator==5.2.1
 deepdiff==7.0.1
-deepeval==3.7.6
+deepeval==3.7.8
 defusedxml==0.7.1
-deltalake==1.2.1
+deltalake==1.3.0
 deprecated==1.3.1
 deprecation==2.1.0
 -e examples/development_to_production
@@ -243,7 +242,6 @@ durationpy==0.10
 ecdsa==0.19.1
 email-validator==2.3.0
 entrypoints==0.4
-exceptiongroup==1.3.1
 execnet==2.1.2
 executing==2.2.1
 expandvars==1.1.2
@@ -252,7 +250,7 @@ fastapi==0.128.0
 fastavro==1.12.1
 fastjsonschema==2.21.2
 -e examples/feature_graph_backed_assets
-filelock==3.20.1
+filelock==3.20.2
 flaky==3.8.1
 flask==2.2.5
 flask-appbuilder==4.5.3
@@ -275,7 +273,7 @@ fsspec==2024.3.0
 gcp-storage-emulator==2024.8.3
 gitdb==4.0.12
 github3-py==4.0.1
-gitpython==3.1.45
+gitpython==3.1.46
 giturlparse==0.14.0
 google-ai-generativelanguage==0.6.15
 google-api-core==2.28.1
@@ -345,7 +343,7 @@ jinja2==3.1.6
 jiter==0.12.0
 jmespath==1.0.1
 joblib==1.5.3
-json5==0.12.1
+json5==0.13.0
 jsondiff==2.2.1
 jsonpatch==1.33
 jsonpath-ng==1.7.0
@@ -367,7 +365,7 @@ jupyterlab-widgets==3.0.16
 keyring==25.7.0
 -e python_modules/libraries/dagster-airlift/kitchen-sink
 kiwisolver==1.4.9
-kombu==5.6.1
+kombu==5.6.2
 kopf==1.39.1
 kubernetes==33.1.0
 kubernetes-asyncio==33.3.0
@@ -376,7 +374,7 @@ langchain-community==0.3.31
 langchain-core==0.3.81
 langchain-openai==0.3.35
 langchain-text-splitters==0.3.11
-langsmith==0.5.1
+langsmith==0.5.2
 lark==1.3.1
 lazy-object-proxy==1.12.0
 leather==0.4.1
@@ -490,7 +488,7 @@ pendulum==3.1.0
 -e python_modules/libraries/dagster-airlift/perf-harness
 pex==2.59.5
 pexpect==4.9.0
-pillow==12.0.0
+pillow==12.1.0
 pip==25.3
 platformdirs==4.5.1
 plotly==6.5.0
@@ -527,8 +525,8 @@ pyfiglet==1.0.4
 pyflakes==3.4.0
 pygments==2.19.2
 pyjwt==2.10.1
-pymdown-extensions==10.19.1
-pynacl==1.6.1
+pymdown-extensions==10.20
+pynacl==1.6.2
 pyopenssl==25.3.0
 pyparsing==3.3.1
 pypd==1.1.0
@@ -595,7 +593,7 @@ scipy==1.16.3
 scrapbook==0.5.0
 seaborn==0.13.2
 semver==3.0.4
-send2trash==1.8.3
+send2trash==2.0.0
 sentry-sdk==2.48.0
 setproctitle==1.3.7
 setuptools==70.3.0
@@ -617,12 +615,12 @@ snowflake-sqlalchemy==1.8.2
 snowplow-tracker==1.1.0
 sortedcontainers==2.4.0
 soupsieve==2.8.1
-sphinx==9.0.4
-sphinx-autodoc-typehints==3.6.0
+sphinx==9.1.0
+sphinx-autodoc-typehints==3.6.1
 sphinx-jinja2-compat==0.4.1
 sphinx-prompt==1.10.2
 sphinx-tabs==3.4.5
-sphinx-toolbox==4.1.0
+sphinx-toolbox==4.1.1
 sphinxcontrib-applehelp==2.0.0
 sphinxcontrib-devhelp==2.0.0
 sphinxcontrib-htmlhelp==2.1.0
@@ -635,7 +633,7 @@ sqlalchemy-utils==0.42.1
 sqlglot==28.0.0
 sqlglotrs==0.7.3
 sqlparse==0.5.5
-sse-starlette==3.1.1
+sse-starlette==3.1.2
 sshpubkeys==3.3.1
 sshtunnel==0.4.0
 stack-data==0.6.3
@@ -691,7 +689,7 @@ types-pytz==2025.2.0.20251108
 types-pyyaml==6.0.12.20250915
 types-requests==2.32.4.20250913
 types-s3transfer==0.16.0
-types-setuptools==80.9.0.20251223
+types-setuptools==80.9.0.20250822
 types-simplejson==3.20.0.20250822
 types-six==1.17.0.20251009
 types-sqlalchemy==1.4.53.34
@@ -719,7 +717,7 @@ wandb==0.23.1
 watchdog==6.0.0
 watchfiles==1.1.1
 wcwidth==0.2.14
-weaviate-client==4.19.0
+weaviate-client==4.19.2
 webcolors==25.10.0
 webencodings==0.5.1
 websocket-client==1.9.0

--- a/pyright/master/requirements.txt
+++ b/pyright/master/requirements.txt
@@ -115,6 +115,7 @@ wordcloud  # (quickstart-*)
 apache-airflow>2.7
 types-sqlalchemy==1.4.53.34
 fastapi>=0.115.6 # producing a bizarrely early version of fastapi without this
+types-setuptools==80.9.0.20250822  # Pinned due to overly strict _DictLike types in newer versions (20251223) causing false positives in setup.py files
 
 ### EXAMPLES
 


### PR DESCRIPTION
## Summary & Motivation

1. Added constraint to pyright/master/requirements.txt (line 118)
2. Added constraint to pyright/alt-1/requirements.txt (line 59)
3. Regenerated pinned requirements

The newer version of types-setuptools (80.9.0.20251223) introduced overly strict _DictLike[Incomplete, Incomplete] type definitions that incorrectly rejected valid dict types in ~80 setup.py files. By pinning to the previous working version, we avoided having to modify 80+ files with workarounds for what is likely a type stub bug.

## How I Tested These Changes

## Changelog

NOCHANGELOG
