### PR TITLE
[ui] TextInput: Replace styled-components with CSS

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Suggest.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Suggest.tsx
@@ -15,24 +15,64 @@ import styled, {createGlobalStyle} from 'styled-components';
 import {Box} from './Box';
 import {Colors} from './Color';
 import {Icon, IconName} from './Icon';
-import {TextInputContainerStyles, TextInputStyles} from './TextInput';
 import {Container, Inner, Row} from './VirtualizedTable';
+import {FontFamily} from './styles';
 
 export const GlobalSuggestStyle = createGlobalStyle`
   .dagster-suggest-input.bp5-input-group {
-    ${TextInputContainerStyles}
+    /* Inline TextInputContainerStyles */
+    align-items: center;
+    color: ${Colors.textLight()};
+    display: inline-flex;
+    flex-direction: row;
+    flex: 1;
+    flex-grow: 0;
+    font-family: ${FontFamily.default};
+    font-size: 14px;
+    font-weight: 400;
+    position: relative;
 
     &:disabled .iconGlobal:first-child {
       background-color: ${Colors.accentGray()};
     }
 
     .bp5-input {
-      ${TextInputStyles}
+      /* Inline TextInputStyles */
+      background-color: ${Colors.backgroundDefault()};
+      border: none;
+      box-shadow: ${Colors.borderDefault()} inset 0px 0px 0px 1px;
+      outline: none;
+      border-radius: 8px;
+      color: ${Colors.textDefault()};
+      flex-grow: 1;
+      font-size: 14px;
+      line-height: 20px;
+      padding: 6px 6px 6px 12px;
+      margin: 0;
+      transition: box-shadow 150ms;
 
       height: auto;
 
       ::placeholder {
         color: ${Colors.textDisabled()};
+      }
+
+      :disabled {
+        box-shadow: ${Colors.keylineDefault()} inset 0px 0px 0px 1px;
+        background-color: ${Colors.backgroundLight()};
+        color: ${Colors.textDisabled()};
+      }
+
+      :disabled::placeholder {
+        color: ${Colors.textDisabled()};
+      }
+
+      :focus {
+        box-shadow:
+          ${Colors.borderDefault()} inset 0px 0px 0px 1px,
+          ${Colors.keylineDefault()} inset 2px 2px 1.5px,
+          ${Colors.focusRing()} 0 0 0 2px;
+        outline: none;
       }
     }
 

--- a/js_modules/dagster-ui/packages/ui-components/src/components/TagSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TagSelector.tsx
@@ -10,7 +10,7 @@ import {Icon} from './Icon';
 import {Menu, MenuItem} from './Menu';
 import {MiddleTruncate} from './MiddleTruncate';
 import {Popover} from './Popover';
-import {TextInput, TextInputStyles} from './TextInput';
+import {TextInput} from './TextInput';
 import {Inner, Row, Container as VirtualContainer} from './VirtualizedTable';
 import {useViewport} from './useViewport';
 
@@ -254,7 +254,41 @@ export const TagSelectorContainer = styled.div<{$disabled?: boolean}>`
   flex-direction: row;
   align-items: center;
 
-  ${TextInputStyles}
+  /* Inline TextInputStyles */
+  background-color: ${Colors.backgroundDefault()};
+  border: none;
+  box-shadow: ${Colors.borderDefault()} inset 0px 0px 0px 1px;
+  outline: none;
+  border-radius: 8px;
+  color: ${Colors.textDefault()};
+  flex-grow: 1;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 6px 6px 6px 12px;
+  margin: 0;
+  transition: box-shadow 150ms;
+
+  ::placeholder {
+    color: ${Colors.textLighter()};
+  }
+
+  :disabled {
+    box-shadow: ${Colors.keylineDefault()} inset 0px 0px 0px 1px;
+    background-color: ${Colors.backgroundLight()};
+    color: ${Colors.textDisabled()};
+  }
+
+  :disabled::placeholder {
+    color: ${Colors.textDisabled()};
+  }
+
+  :focus {
+    box-shadow:
+      ${Colors.borderDefault()} inset 0px 0px 0px 1px,
+      ${Colors.keylineDefault()} inset 2px 2px 1.5px,
+      ${Colors.focusRing()} 0 0 0 2px;
+    outline: none;
+  }
 
   min-height: 32px;
   padding: 4px 8px;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/TextArea.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TextArea.tsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx';
+import * as React from 'react';
+
+import styles from './css/TextArea.module.css';
+
+interface TextAreaProps extends React.ComponentPropsWithRef<'textarea'> {
+  resize?: React.CSSProperties['resize'];
+  strokeColor?: string;
+}
+
+export const TextArea = React.forwardRef(
+  (props: TextAreaProps, ref: React.ForwardedRef<HTMLTextAreaElement>) => {
+    const {resize, strokeColor, style, className, ...rest} = props;
+
+    const textareaStyle = {
+      ...style,
+      ...(resize ? {'--text-area-resize': resize} : {}),
+      ...(strokeColor
+        ? {
+            '--text-input-stroke-color': strokeColor,
+            '--text-input-stroke-color-hover': strokeColor,
+          }
+        : {}),
+    } as React.CSSProperties;
+
+    return (
+      <textarea
+        {...rest}
+        ref={ref}
+        className={clsx(styles.textarea, className)}
+        style={textareaStyle}
+      />
+    );
+  },
+);
+
+TextArea.displayName = 'TextArea';

--- a/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
@@ -1,9 +1,9 @@
+import clsx from 'clsx';
 import * as React from 'react';
-import styled, {css} from 'styled-components';
 
 import {Colors} from './Color';
 import {Icon, IconName} from './Icon';
-import {FontFamily} from './styles';
+import styles from './css/TextInput.module.css';
 
 interface Props extends Omit<React.ComponentPropsWithRef<'input'>, 'onChange'> {
   fill?: boolean;
@@ -15,171 +15,39 @@ interface Props extends Omit<React.ComponentPropsWithRef<'input'>, 'onChange'> {
 
 export const TextInput = React.forwardRef(
   (props: Props, ref: React.ForwardedRef<HTMLInputElement>) => {
-    const {
-      fill,
-      icon,
-      disabled,
-      strokeColor = Colors.borderDefault(),
-      rightElement,
-      type = 'text',
-      ...rest
-    } = props;
+    const {fill, icon, disabled, strokeColor, rightElement, type = 'text', ...rest} = props;
+
+    const containerStyle = fill ? {width: '100%', flex: 1} : undefined;
+
+    const inputStyle = strokeColor
+      ? ({
+          '--text-input-stroke-color': strokeColor,
+          '--text-input-stroke-color-hover': strokeColor,
+        } as React.CSSProperties)
+      : {};
 
     return (
-      <TextInputContainer $disabled={!!disabled} style={fill ? {width: '100%', flex: 1} : {}}>
+      <div className={clsx(styles.container, disabled && styles.disabled)} style={containerStyle}>
         {icon ? (
           <Icon name={icon} color={disabled ? Colors.accentGray() : Colors.accentPrimary()} />
         ) : null}
-        <StyledInput
+        <input
           data-lpignore="true"
           {...rest}
-          $strokeColor={strokeColor}
+          className={clsx(
+            styles.input,
+            icon && styles.hasIcon,
+            rightElement && styles.hasRightElement,
+          )}
           disabled={disabled}
           ref={ref}
-          $hasIcon={!!icon}
-          $hasRightElement={!!rightElement}
           type={type}
+          style={inputStyle}
         />
-        {rightElement ? <RightContainer>{rightElement}</RightContainer> : null}
-      </TextInputContainer>
+        {rightElement ? <div className={styles.rightContainer}>{rightElement}</div> : null}
+      </div>
     );
   },
 );
 
 TextInput.displayName = 'TextInput';
-
-export const TextInputContainerStyles = css`
-  align-items: center;
-  color: ${Colors.textLight()};
-  display: inline-flex;
-  flex-direction: row;
-  flex: 1;
-  flex-grow: 0;
-  font-family: ${FontFamily.default};
-  font-size: 14px;
-  font-weight: 400;
-  position: relative;
-`;
-
-export const TextInputContainer = styled.div<{$disabled?: boolean}>`
-  ${TextInputContainerStyles}
-
-  > .iconGlobal:first-child {
-    position: absolute;
-    left: 8px;
-    top: 8px;
-    ${({$disabled}) =>
-      $disabled
-        ? css`
-            background-color: ${Colors.backgroundDisabled()};
-          `
-        : null};
-  }
-`;
-
-const RightContainer = styled.div`
-  position: absolute;
-  bottom: 0;
-  top: 0;
-  right: 8px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-`;
-
-export const TextInputStyles = css`
-  background-color: ${Colors.backgroundDefault()};
-  border: none;
-  box-shadow: ${Colors.borderDefault()} inset 0px 0px 0px 1px;
-  outline: none;
-  border-radius: 8px;
-  color: ${Colors.textDefault()};
-  flex-grow: 1;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 6px 6px 6px 12px;
-  margin: 0;
-  transition: box-shadow 150ms;
-
-  ::placeholder {
-    color: ${Colors.textLighter()};
-  }
-
-  :disabled {
-    box-shadow: ${Colors.keylineDefault()} inset 0px 0px 0px 1px;
-    background-color: ${Colors.backgroundLight()};
-    color: ${Colors.textDisabled()};
-  }
-
-  :disabled::placeholder {
-    color: ${Colors.textDisabled()};
-  }
-
-  :focus {
-    box-shadow:
-      ${Colors.borderDefault()} inset 0px 0px 0px 1px,
-      ${Colors.keylineDefault()} inset 2px 2px 1.5px,
-      ${Colors.focusRing()} 0 0 0 2px;
-    outline: none;
-  }
-`;
-
-interface StyledInputProps {
-  $hasIcon: boolean;
-  $strokeColor: string;
-  $hasRightElement: boolean;
-}
-
-const StyledInput = styled.input<StyledInputProps>`
-  ${TextInputStyles}
-
-  ${({$hasRightElement}) =>
-    $hasRightElement
-      ? css`
-          & {
-            padding-right: 28px;
-          }
-        `
-      : null}
-
-  box-shadow: ${({$strokeColor}) => $strokeColor || Colors.borderDefault()} inset 0px 0px 0px 1px;
-  padding: ${({$hasIcon}) => ($hasIcon ? '6px 6px 6px 28px' : '6px 6px 6px 12px')};
-
-  :hover:not(:disabled) {
-    box-shadow: ${({$strokeColor}) =>
-        $strokeColor === Colors.borderDefault() ? Colors.borderHover() : $strokeColor}
-      inset 0px 0px 0px 1px;
-  }
-
-  :focus,
-  :hover:focus:not(:disabled) {
-    box-shadow:
-      ${({$strokeColor}) => $strokeColor || Colors.borderHover()} inset 0px 0px 0px 1px,
-      ${Colors.focusRing()} 0 0 0 2px;
-    background-color: ${Colors.backgroundDefaultHover()};
-  }
-`;
-
-interface TextAreaProps {
-  $resize: React.CSSProperties['resize'];
-  $strokeColor?: string;
-}
-
-export const TextArea = styled.textarea<TextAreaProps>`
-  ${TextInputStyles}
-
-  box-shadow: ${({$strokeColor}) => $strokeColor || Colors.borderDefault()} inset 0px 0px 0px 1px;
-
-  :hover {
-    box-shadow: ${({$strokeColor}) => $strokeColor || Colors.borderHover()} inset 0px 0px 0px 1px;
-  }
-
-  :focus {
-    box-shadow:
-      ${({$strokeColor}) => $strokeColor || Colors.borderHover()} inset 0px 0px 0px 1px,
-      ${Colors.focusRing()} 0px 0px 0px 2px;
-    background-color: ${Colors.backgroundDefaultHover()};
-  }
-
-  ${({$resize}) => ($resize ? `resize: ${$resize};` : null)}
-`;

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/TextArea.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/TextArea.stories.tsx
@@ -1,7 +1,7 @@
 import {useState} from 'react';
 
 import {Colors} from '../Color';
-import {TextArea} from '../TextInput';
+import {TextArea} from '../TextArea';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -16,7 +16,7 @@ export const Default = () => {
       placeholder="Type anything…"
       value={value}
       onChange={(e) => setValue(e.target.value)}
-      $resize="none"
+      resize="none"
     />
   );
 };
@@ -28,7 +28,7 @@ export const Resize = () => {
       placeholder="Type anything…"
       value={value}
       onChange={(e) => setValue(e.target.value)}
-      $resize="vertical"
+      resize="vertical"
     />
   );
 };
@@ -40,8 +40,21 @@ export const StrokeColor = () => {
       placeholder="Type anything…"
       value={value}
       onChange={(e) => setValue(e.target.value)}
-      $resize="none"
-      $strokeColor={Colors.accentRed()}
+      resize="none"
+      strokeColor={Colors.accentRed()}
+    />
+  );
+};
+
+export const Disabled = () => {
+  const [value, setValue] = useState('This textarea is disabled');
+  return (
+    <TextArea
+      placeholder="Type anything…"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      resize="vertical"
+      disabled
     />
   );
 };

--- a/js_modules/dagster-ui/packages/ui-components/src/components/css/TextArea.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/css/TextArea.module.css
@@ -1,0 +1,4 @@
+.textarea {
+  composes: textInputBase from './TextInput.module.css';
+  resize: var(--text-area-resize, vertical);
+}

--- a/js_modules/dagster-ui/packages/ui-components/src/components/css/TextInput.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/css/TextInput.module.css
@@ -1,0 +1,114 @@
+/* ============================================
+   BASE CLASSES (for composition)
+   ============================================ */
+
+/* Base container styles that can be composed by other CSS modules */
+.textInputContainer {
+  align-items: center;
+  color: var(--color-text-light);
+  display: inline-flex;
+  flex-direction: row;
+  flex: 1;
+  flex-grow: 0;
+  font-family: var(--font-family);
+  font-size: 14px;
+  font-weight: 400;
+  position: relative;
+
+  --text-input-stroke-color: var(--color-border-default);
+  --text-input-stroke-color-hover: var(--color-border-hover);
+}
+
+/* Base input styles that can be composed by other CSS modules */
+.textInputBase {
+  background-color: var(--color-background-default);
+  border: none;
+  box-shadow: var(--color-border-default) inset 0px 0px 0px 1px;
+  outline: none;
+  border-radius: 8px;
+  color: var(--color-text-default);
+  flex-grow: 1;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 6px 6px 6px 12px;
+  margin: 0;
+  transition: box-shadow 150ms;
+}
+
+.textInputBase::placeholder {
+  color: var(--color-text-lighter);
+}
+
+.textInputBase:disabled {
+  box-shadow: var(--color-keyline-default) inset 0px 0px 0px 1px;
+  background-color: var(--color-background-light);
+  color: var(--color-text-disabled);
+}
+
+.textInputBase:disabled::placeholder {
+  color: var(--color-text-disabled);
+}
+
+.textInputBase:focus {
+  box-shadow:
+    var(--color-border-default) inset 0px 0px 0px 1px,
+    var(--color-keyline-default) inset 2px 2px 1.5px,
+    var(--color-focus-ring) 0 0 0 2px;
+  outline: none;
+}
+
+/* ============================================
+   TEXTINPUT COMPONENT CLASSES
+   ============================================ */
+
+.container {
+  composes: textInputContainer;
+}
+
+.container > :global(.iconGlobal):first-child {
+  position: absolute;
+  left: 8px;
+  top: 8px;
+}
+
+.container.disabled > :global(.iconGlobal):first-child {
+  background-color: var(--color-background-disabled);
+}
+
+.input {
+  composes: textInputBase;
+
+  /* Dynamic values via CSS custom properties */
+  box-shadow: var(--text-input-stroke-color, var(--color-border-default)) inset 0px 0px 0px 1px;
+  padding: var(--text-input-padding, 6px 6px 6px 12px);
+}
+
+.input:hover:not(:disabled) {
+  box-shadow: var(--text-input-stroke-color-hover, var(--color-border-hover)) inset 0px 0px 0px 1px;
+}
+
+.input:focus,
+.input:hover:focus:not(:disabled) {
+  box-shadow:
+    var(--text-input-stroke-color, var(--color-border-hover)) inset 0px 0px 0px 1px,
+    var(--color-focus-ring) 0 0 0 2px;
+  background-color: var(--color-background-default-hover);
+}
+
+.input.hasIcon {
+  --text-input-padding: 6px 6px 6px 28px;
+}
+
+.input.hasRightElement {
+  padding-right: 28px;
+}
+
+.rightContainer {
+  position: absolute;
+  bottom: 0;
+  top: 0;
+  right: 8px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}

--- a/js_modules/dagster-ui/packages/ui-components/src/index.ts
+++ b/js_modules/dagster-ui/packages/ui-components/src/index.ts
@@ -47,6 +47,7 @@ export * from './components/Tabs';
 export * from './components/Tag';
 export * from './components/TagSelector';
 export * from './components/Text';
+export * from './components/TextArea';
 export * from './components/TextInput';
 export * from './components/Toaster';
 export * from './components/TokenizingField';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -8,7 +8,6 @@ import {
   NonIdealState,
   Spinner,
   SplitPanelContainer,
-  TextInputContainer,
   Tooltip,
 } from '@dagster-io/ui-components';
 import pickBy from 'lodash/pickBy';
@@ -934,9 +933,6 @@ const GraphQueryInputFlexWrap = styled.div`
   flex: 1;
 
   > div {
-    ${TextInputContainer} {
-      width: 100%;
-    }
     > * {
       display: block;
       width: 100%;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSubsetList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSubsetList.tsx
@@ -6,7 +6,6 @@ import {
   MiddleTruncate,
   SpinnerWithText,
   TextInput,
-  TextInputContainer,
 } from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import {useMemo, useRef, useState} from 'react';
@@ -184,7 +183,7 @@ const statusToColors: Record<AssetConditionEvaluationStatus, ColorConfig> = {
 
 const SearchContainer = styled(Box)`
   display: flex;
-  ${TextInputContainer} {
+  > * {
     flex: 1;
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputHighlighter.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/selection/SelectionInputHighlighter.ts
@@ -1,4 +1,4 @@
-import {Colors, FontFamily, TextInputStyles} from '@dagster-io/ui-components';
+import {Colors, FontFamily} from '@dagster-io/ui-components';
 import {ParserRuleContext} from 'antlr4ts';
 import {AbstractParseTreeVisitor} from 'antlr4ts/tree/AbstractParseTreeVisitor';
 import CodeMirror from 'codemirror';
@@ -240,7 +240,43 @@ export const SelectionAutoCompleteInputCSS = css`
     padding: 0;
   }
   width: 100%;
-  ${TextInputStyles}
+
+  /* Inline TextInputStyles */
+  background-color: ${Colors.backgroundDefault()};
+  border: none;
+  box-shadow: ${Colors.borderDefault()} inset 0px 0px 0px 1px;
+  outline: none;
+  border-radius: 8px;
+  color: ${Colors.textDefault()};
+  flex-grow: 1;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 6px 6px 6px 12px;
+  margin: 0;
+  transition: box-shadow 150ms;
+
+  ::placeholder {
+    color: ${Colors.textLighter()};
+  }
+
+  :disabled {
+    box-shadow: ${Colors.keylineDefault()} inset 0px 0px 0px 1px;
+    background-color: ${Colors.backgroundLight()};
+    color: ${Colors.textDisabled()};
+  }
+
+  :disabled::placeholder {
+    color: ${Colors.textDisabled()};
+  }
+
+  :focus {
+    box-shadow:
+      ${Colors.borderDefault()} inset 0px 0px 0px 1px,
+      ${Colors.keylineDefault()} inset 2px 2px 1.5px,
+      ${Colors.focusRing()} 0 0 0 2px;
+    outline: none;
+  }
+
   flex-shrink: 1;
   overflow: auto;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/EditCursorDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/EditCursorDialog.tsx
@@ -92,7 +92,7 @@ export const EditCursorDialog = ({
       <DialogBody>
         <TextArea
           value={cursorValue}
-          $resize="vertical"
+          resize="vertical"
           onChange={(e) => setCursorValue(e.target.value)}
           style={{width: '100%'}}
         />


### PR DESCRIPTION
## Summary & Motivation

This PR refactors the text input components to use CSS modules instead of styled-components. It extracts the TextArea component into its own file and converts the styling approach from styled-components to CSS modules with global classes for cross-component usage.

The main changes include:
- Converting TextInput from styled-components to CSS modules
- Creating a separate TextArea component file
- Adding global CSS classes for text input styling that can be used across components
- Inlining previously imported styles in components that depended on TextInput styles
- Updating prop names (e.g., `$resize` to `resize`, `$strokeColor` to `strokeColor`)

## How I Tested These Changes

I verified that all text input components render correctly with the new styling approach. I tested various states including:
- Default state
- Focus state
- Hover state
- Disabled state
- With icons and right elements
- With custom stroke colors
- TextArea with different resize options