### PR TITLE
FE-990: Fix propagation of events in Launchpad opened from context menu

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ContextMenuWrapper.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ContextMenuWrapper.tsx
@@ -96,6 +96,18 @@ export const ContextMenuWrapper = ({
                 zIndex: 10,
                 borderRadius: '4px',
               }}
+              onKeyDown={(e) => {
+                /**
+                 * React's synthetic event system is designed to treat events from portals as
+                 * if they originated from their logical location within the React component tree,
+                 * not their physical location in the DOM. This means that onKeyDown handlers in the
+                 * parent code could receive key events that happened within the menu.
+                 */
+                e.stopPropagation();
+              }}
+              onKeyUp={(e) => {
+                e.stopPropagation();
+              }}
               onClick={(e) => {
                 e.stopPropagation();
               }}


### PR DESCRIPTION
## Summary & Motivation

This one is a bit subtle. If you open the Launchpad by right-clicking an asset on the asset graph and choosing Materialize, the launch pad appears within the context menu’s React portal. Even though the DOM element is mounted to the document body, the events propagate up the React component tree, and key up events within the launchpad trigger the key event handling on the asset graph.

I don't think we have any cases where we want key events to propagate out of a context menu portal, and I want this to also apply to modals like the wipe materializations modal, the choose partitions modal, etc. so I’ve put the fix in the context menu wrapper itself.

## How I Tested These Changes

Tested by manually right-clicking assets and observing that the asset graph no longer updates beneath the launchpad modal. 

## Changelog

[ui] Entering the asset launchpad by right-clicking on the asset graph no longer causes keyboard navigation issues. 
