### PR TITLE
Add migration for asset_keys.cached_status_data being longtext on mysql

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/f495c27d5019_use_longtext_on_asset_keys_cached_.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/f495c27d5019_use_longtext_on_asset_keys_cached_.py
@@ -1,19 +1,19 @@
-"""use mediumtext on asset_keys cached_status_data in mysql
+"""use longtext on asset_keys cached_status_data in mysql
 
 Revision ID: f495c27d5019
 Revises: 7e2f3204cf8e
 Create Date: 2026-01-05 12:28:45.417971
 
 """
-from alembic import op
-import sqlalchemy as sa
-from sqlalchemy import inspect
-from sqlalchemy.dialects.mysql import MEDIUMTEXT
 
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+from sqlalchemy.dialects.mysql import LONGTEXT
 
 # revision identifiers, used by Alembic.
-revision = 'f495c27d5019'
-down_revision = '7e2f3204cf8e'
+revision = "f495c27d5019"
+down_revision = "7e2f3204cf8e"
 branch_labels = None
 depends_on = None
 
@@ -27,7 +27,7 @@ def upgrade():
         table_name="asset_keys",
         column_name="cached_status_data",
         nullable=True,
-        type_=sa.types.Text().with_variant(MEDIUMTEXT, "mysql"),
+        type_=sa.types.Text().with_variant(LONGTEXT, "mysql"),
         existing_type=sa.types.Text(),
     )
 
@@ -42,5 +42,5 @@ def downgrade():
         column_name="cached_status_data",
         nullable=True,
         type_=sa.types.Text(),
-        existing_type=sa.types.Text().with_variant(MEDIUMTEXT, "mysql"),
+        existing_type=sa.types.Text().with_variant(LONGTEXT, "mysql"),
     )

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -66,7 +66,7 @@ AssetKeyTable = db.Table(
     ),  # guarded by secondary index check
     db.Column("tags", db.TEXT),  # guarded by secondary index check
     db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
-    db.Column("cached_status_data", db.TEXT),
+    db.Column("cached_status_data", MySQLCompatabilityTypes.LongText),
 )
 
 AssetEventTagsTable = db.Table(


### PR DESCRIPTION
Text field has a length of 65,535 characters which can easily be reached if triggering a backfill with lots of partitions.

This changes the column type to mediumtext which has a character limit of 16,777,215 characters which should be ample (don't think we need to go to longtext just yet).

Sqlite and Postgres do not have a length limit on text, so this will only apply to Mysql.

## Summary & Motivation

Runs page wouldn't load without error, see https://github.com/dagster-io/dagster/issues/33155

Closes https://github.com/dagster-io/dagster/issues/33155

## How I Tested These Changes

I could do with some help with this, I've not really tested it and not quite sure how to.

## Changelog

Added migration to alter asset_keys.cached_status_data column from text to mediumtext for Mysql storage
