### PR TITLE
Add Lorem ipsum text to CHANGES.md and update Python version requirement to 3.14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6192,3 +6192,5 @@ nux:
 - Asset backfills launched from the asset graph will now only materialize each non-partitioned asset once - after all upstream partitions within the backfill have been materialized.
 - Executors can now be configured with a `tag_concurrency_limits` key that allows you to specify limits on the number of ops with certain tags that can be executing at once within a single run. See the [docs](https://docs.dagster.io/concepts/ops-jobs-graphs/job-execution#op-concurrency-limits) for more information.
 - `ExecuteInProcessResult`, the type returned by `materialize`, `materialize_to_memory`, and `execute_in_process`, now has an `as
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,3 @@
 version = 1
 revision = 3
-requires-python = ">=3.11"
+requires-python = ">=3.14"


### PR DESCRIPTION
This branch updates the CHANGES.md file with Lorem ipsum placeholder text and bumps the minimum Python version requirement from 3.11 to 3.14 in the uv.lock file.

## Files Changed

### Modified (2 files)
- `CHANGES.md` - Added Lorem ipsum placeholder text at end of file
- `uv.lock` - Updated minimum Python version requirement from 3.11 to 3.14

## Key Changes

- Added Lorem ipsum placeholder text to CHANGES.md
- Updated Python version requirement to 3.14 in uv.lock

## Critical Notes

- **⚠️ Breaking Change**: Python 3.11 and 3.12 are no longer supported; minimum version is now 3.14
- Lorem ipsum text in CHANGES.md appears to be placeholder content that should be replaced with actual changelog entries
---


Closes dagster-io/dagster-erk-backing-store#4


To checkout this PR in a fresh worktree and environment locally, run:

```
erk pr checkout 33185 && erk pr sync --dangerous
```
