### PR TITLE
[helm] adds support for configuring pools/concurrency

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/__init__.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/__init__.py
@@ -2,6 +2,7 @@ from schema.charts.dagster.subschema.busybox import Busybox as Busybox
 from schema.charts.dagster.subschema.compute_log_manager import (
     ComputeLogManager as ComputeLogManager,
 )
+from schema.charts.dagster.subschema.concurrency import Concurrency as Concurrency
 from schema.charts.dagster.subschema.daemon import Daemon as Daemon
 from schema.charts.dagster.subschema.flower import Flower as Flower
 from schema.charts.dagster.subschema.global_ import Global as Global

--- a/helm/dagster/schema/schema/charts/dagster/subschema/concurrency.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/concurrency.py
@@ -1,0 +1,26 @@
+from typing import Any, Optional, Union
+
+from pydantic import BaseModel
+
+
+class ConcurrencyPools(BaseModel, extra="forbid"):
+    defaultLimit: Optional[int] = None
+    granularity: Optional[str] = None  # "run" or "op"
+    opGranularityRunBuffer: Optional[int] = None
+
+
+class TagConcurrencyLimit(BaseModel, extra="forbid"):
+    key: str
+    value: Optional[Union[str, dict[str, Any]]] = None
+    limit: int
+
+
+class ConcurrencyRuns(BaseModel, extra="forbid"):
+    maxConcurrentRuns: Optional[int] = None
+    tagConcurrencyLimits: list[TagConcurrencyLimit] = []
+
+
+class Concurrency(BaseModel, extra="forbid"):
+    enabled: bool = False
+    pools: ConcurrencyPools = ConcurrencyPools()
+    runs: ConcurrencyRuns = ConcurrencyRuns()

--- a/helm/dagster/schema/schema/charts/dagster/values.py
+++ b/helm/dagster/schema/schema/charts/dagster/values.py
@@ -36,4 +36,5 @@ class DagsterHelmValues(BaseModel, extra="allow"):
     serviceAccount: subschema.ServiceAccount
     global_: subschema.Global = Field(..., alias="global")
     retention: subschema.Retention
+    concurrency: subschema.Concurrency = subschema.Concurrency()
     additionalInstanceConfig: Optional[Mapping[str, Any]] = None

--- a/helm/dagster/schema/schema_tests/test_concurrency.py
+++ b/helm/dagster/schema/schema_tests/test_concurrency.py
@@ -1,0 +1,295 @@
+import subprocess
+
+import pytest
+import yaml
+from kubernetes.client import models
+from schema.charts.dagster.subschema.concurrency import (
+    Concurrency,
+    ConcurrencyPools,
+    ConcurrencyRuns,
+    TagConcurrencyLimit,
+)
+from schema.charts.dagster.subschema.daemon import (
+    BlockOpConcurrencyLimitedRuns,
+    Daemon,
+    QueuedRunCoordinatorConfig,
+    RunCoordinator,
+    RunCoordinatorConfig,
+    RunCoordinatorType,
+)
+from schema.charts.dagster.values import DagsterHelmValues
+from schema.utils.helm_template import HelmTemplate
+
+
+@pytest.fixture(name="template")
+def helm_template() -> HelmTemplate:
+    return HelmTemplate(
+        helm_dir_path="helm/dagster",
+        subchart_paths=["charts/dagster-user-deployments"],
+        output="templates/configmap-instance.yaml",
+        model=models.V1ConfigMap,
+        namespace="test-namespace",
+    )
+
+
+def test_concurrency_disabled_by_default(template: HelmTemplate):
+    """Concurrency block should not render when disabled (default)."""
+    helm_values = DagsterHelmValues.construct()
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert "concurrency" not in instance
+
+
+def test_concurrency_enabled_empty(template: HelmTemplate):
+    """Concurrency block renders when enabled, even with default values."""
+    helm_values = DagsterHelmValues.construct(
+        concurrency=Concurrency(enabled=True),
+    )
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    # With all None values, the concurrency block should be empty (but present)
+    assert "concurrency" in instance
+
+
+def test_concurrency_pools_config(template: HelmTemplate):
+    """Test pools configuration renders correctly."""
+    helm_values = DagsterHelmValues.construct(
+        concurrency=Concurrency(
+            enabled=True,
+            pools=ConcurrencyPools(
+                defaultLimit=10,
+                granularity="op",
+                opGranularityRunBuffer=2,
+            ),
+        ),
+    )
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert "concurrency" in instance
+    concurrency = instance["concurrency"]
+    assert concurrency["pools"]["default_limit"] == 10
+    assert concurrency["pools"]["granularity"] == "op"
+    assert concurrency["pools"]["op_granularity_run_buffer"] == 2
+
+
+def test_concurrency_runs_config(template: HelmTemplate):
+    """Test runs configuration renders correctly."""
+    helm_values = DagsterHelmValues.construct(
+        concurrency=Concurrency(
+            enabled=True,
+            runs=ConcurrencyRuns(
+                maxConcurrentRuns=25,
+            ),
+        ),
+    )
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert "concurrency" in instance
+    concurrency = instance["concurrency"]
+    assert concurrency["runs"]["max_concurrent_runs"] == 25
+
+
+def test_concurrency_tag_concurrency_limits(template: HelmTemplate):
+    """Test tag_concurrency_limits renders correctly."""
+    helm_values = DagsterHelmValues.construct(
+        concurrency=Concurrency(
+            enabled=True,
+            runs=ConcurrencyRuns(
+                tagConcurrencyLimits=[
+                    TagConcurrencyLimit(key="database", limit=1),
+                    TagConcurrencyLimit(
+                        key="team",
+                        value={"applyLimitPerUniqueValue": True},
+                        limit=2,
+                    ),
+                ],
+            ),
+        ),
+    )
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert "concurrency" in instance
+    concurrency = instance["concurrency"]
+    tag_limits = concurrency["runs"]["tag_concurrency_limits"]
+    assert len(tag_limits) == 2
+    assert tag_limits[0]["key"] == "database"
+    assert tag_limits[0]["limit"] == 1
+    assert tag_limits[1]["key"] == "team"
+    assert tag_limits[1]["value"] == {"applyLimitPerUniqueValue": True}
+    assert tag_limits[1]["limit"] == 2
+
+
+def test_concurrency_full_config(template: HelmTemplate):
+    """Test full concurrency configuration renders correctly."""
+    helm_values = DagsterHelmValues.construct(
+        concurrency=Concurrency(
+            enabled=True,
+            pools=ConcurrencyPools(
+                defaultLimit=5,
+                granularity="run",
+                opGranularityRunBuffer=1,
+            ),
+            runs=ConcurrencyRuns(
+                maxConcurrentRuns=50,
+                tagConcurrencyLimits=[
+                    TagConcurrencyLimit(key="env", value="prod", limit=10),
+                ],
+            ),
+        ),
+    )
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    concurrency = instance["concurrency"]
+    assert concurrency["pools"]["default_limit"] == 5
+    assert concurrency["pools"]["granularity"] == "run"
+    assert concurrency["pools"]["op_granularity_run_buffer"] == 1
+    assert concurrency["runs"]["max_concurrent_runs"] == 50
+    assert len(concurrency["runs"]["tag_concurrency_limits"]) == 1
+
+
+def test_concurrency_conflict_max_concurrent_runs(template: HelmTemplate):
+    """Should fail if both concurrency and run_coordinator have maxConcurrentRuns."""
+    helm_values = DagsterHelmValues.construct(
+        concurrency=Concurrency(
+            enabled=True,
+            runs=ConcurrencyRuns(maxConcurrentRuns=25),
+        ),
+        dagsterDaemon=Daemon.construct(
+            runCoordinator=RunCoordinator.construct(
+                enabled=True,
+                type=RunCoordinatorType.QUEUED,
+                config=RunCoordinatorConfig.construct(
+                    queuedRunCoordinator=QueuedRunCoordinatorConfig.construct(
+                        maxConcurrentRuns=10,
+                    ),
+                ),
+            ),
+        ),
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        template.render(helm_values)
+
+
+def test_concurrency_conflict_tag_concurrency_limits(template: HelmTemplate):
+    """Should fail if both concurrency and run_coordinator have tagConcurrencyLimits."""
+    helm_values = DagsterHelmValues.construct(
+        concurrency=Concurrency(
+            enabled=True,
+            runs=ConcurrencyRuns(
+                tagConcurrencyLimits=[TagConcurrencyLimit(key="test", limit=1)],
+            ),
+        ),
+        dagsterDaemon=Daemon.construct(
+            runCoordinator=RunCoordinator.construct(
+                enabled=True,
+                type=RunCoordinatorType.QUEUED,
+                config=RunCoordinatorConfig.construct(
+                    queuedRunCoordinator=QueuedRunCoordinatorConfig.construct(
+                        tagConcurrencyLimits=[{"key": "other", "limit": 2}],
+                    ),
+                ),
+            ),
+        ),
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        template.render(helm_values)
+
+
+def test_concurrency_conflict_op_granularity_run_buffer(template: HelmTemplate):
+    """Should fail if both concurrency and run_coordinator have op slot buffer config."""
+    helm_values = DagsterHelmValues.construct(
+        concurrency=Concurrency(
+            enabled=True,
+            pools=ConcurrencyPools(opGranularityRunBuffer=2),
+        ),
+        dagsterDaemon=Daemon.construct(
+            runCoordinator=RunCoordinator.construct(
+                enabled=True,
+                type=RunCoordinatorType.QUEUED,
+                config=RunCoordinatorConfig.construct(
+                    queuedRunCoordinator=QueuedRunCoordinatorConfig.construct(
+                        blockOpConcurrencyLimitedRuns=BlockOpConcurrencyLimitedRuns(
+                            enabled=True,
+                            opConcurrencySlotBuffer=1,
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        template.render(helm_values)
+
+
+def test_concurrency_no_conflict_when_run_coordinator_disabled(template: HelmTemplate):
+    """Should not conflict when run_coordinator is disabled."""
+    helm_values = DagsterHelmValues.construct(
+        concurrency=Concurrency(
+            enabled=True,
+            runs=ConcurrencyRuns(maxConcurrentRuns=25),
+        ),
+        dagsterDaemon=Daemon.construct(
+            runCoordinator=RunCoordinator.construct(
+                enabled=False,
+            ),
+        ),
+    )
+    # Should not raise
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+    assert instance["concurrency"]["runs"]["max_concurrent_runs"] == 25
+
+
+def test_concurrency_no_conflict_when_only_one_set(template: HelmTemplate):
+    """Should not conflict when concurrency is set but run_coordinator fields are not."""
+    helm_values = DagsterHelmValues.construct(
+        concurrency=Concurrency(
+            enabled=True,
+            runs=ConcurrencyRuns(maxConcurrentRuns=25),
+        ),
+        dagsterDaemon=Daemon.construct(
+            runCoordinator=RunCoordinator.construct(
+                enabled=True,
+                type=RunCoordinatorType.QUEUED,
+                config=RunCoordinatorConfig.construct(
+                    queuedRunCoordinator=QueuedRunCoordinatorConfig.construct(
+                        # maxConcurrentRuns is not set (None)
+                        dequeueIntervalSeconds=30,
+                    ),
+                ),
+            ),
+        ),
+    )
+    # Should not raise
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+    assert instance["concurrency"]["runs"]["max_concurrent_runs"] == 25
+
+
+def test_concurrency_zero_values(template: HelmTemplate):
+    """Test that zero values render correctly (not treated as falsey)."""
+    helm_values = DagsterHelmValues.construct(
+        concurrency=Concurrency(
+            enabled=True,
+            pools=ConcurrencyPools(
+                defaultLimit=0,
+                opGranularityRunBuffer=0,
+            ),
+            runs=ConcurrencyRuns(
+                maxConcurrentRuns=0,
+            ),
+        ),
+    )
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    concurrency = instance["concurrency"]
+    assert concurrency["pools"]["default_limit"] == 0
+    assert concurrency["pools"]["op_granularity_run_buffer"] == 0
+    assert concurrency["runs"]["max_concurrent_runs"] == 0

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -176,6 +176,11 @@ data:
       {{- end }}
     {{- end }}
 
+    {{- if .Values.concurrency.enabled }}
+    concurrency:
+      {{- include "dagsterYaml.concurrency" . | indent 6 }}
+    {{- end }}
+
     {{- if .Values.additionalInstanceConfig }}
     {{- .Values.additionalInstanceConfig | toYaml | nindent 4}}
     {{- end }}

--- a/helm/dagster/templates/helpers/instance/_concurrency.tpl
+++ b/helm/dagster/templates/helpers/instance/_concurrency.tpl
@@ -1,0 +1,53 @@
+{{- define "dagsterYaml.concurrency" }}
+{{- $concurrencyConfig := .Values.concurrency }}
+{{- $pools := $concurrencyConfig.pools }}
+{{- $runs := $concurrencyConfig.runs }}
+
+{{- /* Validate no conflicts with run_coordinator config */ -}}
+{{- if and .Values.dagsterDaemon.runCoordinator.enabled (eq .Values.dagsterDaemon.runCoordinator.type "QueuedRunCoordinator") }}
+  {{- $qrc := .Values.dagsterDaemon.runCoordinator.config.queuedRunCoordinator }}
+  {{- if and (not (kindIs "invalid" $runs.maxConcurrentRuns)) (not (kindIs "invalid" $qrc.maxConcurrentRuns)) }}
+    {{- fail "Cannot set both concurrency.runs.maxConcurrentRuns and dagsterDaemon.runCoordinator.config.queuedRunCoordinator.maxConcurrentRuns" }}
+  {{- end }}
+  {{- if and (gt (len $runs.tagConcurrencyLimits) 0) (gt (len $qrc.tagConcurrencyLimits) 0) }}
+    {{- fail "Cannot set both concurrency.runs.tagConcurrencyLimits and dagsterDaemon.runCoordinator.config.queuedRunCoordinator.tagConcurrencyLimits" }}
+  {{- end }}
+  {{- if and (not (kindIs "invalid" $pools.opGranularityRunBuffer)) $qrc.blockOpConcurrencyLimitedRuns }}
+    {{- if not (kindIs "invalid" $qrc.blockOpConcurrencyLimitedRuns.opConcurrencySlotBuffer) }}
+      {{- fail "Cannot set both concurrency.pools.opGranularityRunBuffer and dagsterDaemon.runCoordinator.config.queuedRunCoordinator.blockOpConcurrencyLimitedRuns.opConcurrencySlotBuffer" }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- /* Render pools config */ -}}
+{{- if or (not (kindIs "invalid" $pools.defaultLimit)) $pools.granularity (not (kindIs "invalid" $pools.opGranularityRunBuffer)) }}
+pools:
+  {{- if not (kindIs "invalid" $pools.defaultLimit) }}
+  default_limit: {{ $pools.defaultLimit }}
+  {{- end }}
+  {{- if $pools.granularity }}
+  granularity: {{ $pools.granularity }}
+  {{- end }}
+  {{- if not (kindIs "invalid" $pools.opGranularityRunBuffer) }}
+  op_granularity_run_buffer: {{ $pools.opGranularityRunBuffer }}
+  {{- end }}
+{{- end }}
+
+{{- /* Render runs config */ -}}
+{{- if or (not (kindIs "invalid" $runs.maxConcurrentRuns)) (gt (len $runs.tagConcurrencyLimits) 0) }}
+runs:
+  {{- if not (kindIs "invalid" $runs.maxConcurrentRuns) }}
+  max_concurrent_runs: {{ $runs.maxConcurrentRuns }}
+  {{- end }}
+  {{- if gt (len $runs.tagConcurrencyLimits) 0 }}
+  tag_concurrency_limits:
+    {{- range $runs.tagConcurrencyLimits }}
+    - key: {{ .key | quote }}
+      {{- if .value }}
+      value: {{ .value | toYaml | nindent 8 }}
+      {{- end }}
+      limit: {{ .limit }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -640,6 +640,103 @@
             "title": "ComputeLogManagerType",
             "type": "string"
         },
+        "Concurrency": {
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "default": false,
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "pools": {
+                    "$ref": "#/$defs/ConcurrencyPools",
+                    "default": {
+                        "defaultLimit": null,
+                        "granularity": null,
+                        "opGranularityRunBuffer": null
+                    }
+                },
+                "runs": {
+                    "$ref": "#/$defs/ConcurrencyRuns",
+                    "default": {
+                        "maxConcurrentRuns": null,
+                        "tagConcurrencyLimits": []
+                    }
+                }
+            },
+            "title": "Concurrency",
+            "type": "object"
+        },
+        "ConcurrencyPools": {
+            "additionalProperties": false,
+            "properties": {
+                "defaultLimit": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Defaultlimit"
+                },
+                "granularity": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Granularity"
+                },
+                "opGranularityRunBuffer": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Opgranularityrunbuffer"
+                }
+            },
+            "title": "ConcurrencyPools",
+            "type": "object"
+        },
+        "ConcurrencyRuns": {
+            "additionalProperties": false,
+            "properties": {
+                "maxConcurrentRuns": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Maxconcurrentruns"
+                },
+                "tagConcurrencyLimits": {
+                    "default": [],
+                    "items": {
+                        "$ref": "#/$defs/schema__charts__dagster__subschema__concurrency__TagConcurrencyLimit"
+                    },
+                    "title": "Tagconcurrencylimits",
+                    "type": "array"
+                }
+            },
+            "title": "ConcurrencyRuns",
+            "type": "object"
+        },
         "ConfigMapEnvSource": {
             "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
             "additionalProperties": true,
@@ -1835,7 +1932,7 @@
                     "anyOf": [
                         {
                             "items": {
-                                "$ref": "#/$defs/TagConcurrencyLimit"
+                                "$ref": "#/$defs/schema__charts__dagster__subschema__daemon__TagConcurrencyLimit"
                             },
                             "type": "array"
                         },
@@ -2830,40 +2927,6 @@
             "title": "StartupProbe",
             "type": "object"
         },
-        "TagConcurrencyLimit": {
-            "additionalProperties": false,
-            "properties": {
-                "key": {
-                    "title": "Key",
-                    "type": "string"
-                },
-                "value": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/$defs/TagConcurrencyLimitConfig"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "title": "Value"
-                },
-                "limit": {
-                    "title": "Limit",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "key",
-                "limit"
-            ],
-            "title": "TagConcurrencyLimit",
-            "type": "object"
-        },
         "TagConcurrencyLimitConfig": {
             "additionalProperties": false,
             "properties": {
@@ -3731,6 +3794,75 @@
             "title": "Workspace",
             "type": "object"
         },
+        "schema__charts__dagster__subschema__concurrency__TagConcurrencyLimit": {
+            "additionalProperties": false,
+            "properties": {
+                "key": {
+                    "title": "Key",
+                    "type": "string"
+                },
+                "value": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "additionalProperties": true,
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Value"
+                },
+                "limit": {
+                    "title": "Limit",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "key",
+                "limit"
+            ],
+            "title": "TagConcurrencyLimit",
+            "type": "object"
+        },
+        "schema__charts__dagster__subschema__daemon__TagConcurrencyLimit": {
+            "additionalProperties": false,
+            "properties": {
+                "key": {
+                    "title": "Key",
+                    "type": "string"
+                },
+                "value": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/TagConcurrencyLimitConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Value"
+                },
+                "limit": {
+                    "title": "Limit",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "key",
+                "limit"
+            ],
+            "title": "TagConcurrencyLimit",
+            "type": "object"
+        },
         "schema__charts__dagster__subschema__postgresql__Service": {
             "properties": {
                 "port": {
@@ -3859,6 +3991,21 @@
         },
         "retention": {
             "$ref": "#/$defs/Retention"
+        },
+        "concurrency": {
+            "$ref": "#/$defs/Concurrency",
+            "default": {
+                "enabled": false,
+                "pools": {
+                    "defaultLimit": null,
+                    "granularity": null,
+                    "opGranularityRunBuffer": null
+                },
+                "runs": {
+                    "maxConcurrentRuns": null,
+                    "tagConcurrencyLimits": []
+                }
+            }
         },
         "additionalInstanceConfig": {
             "anyOf": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1457,6 +1457,41 @@ retention:
       skipped: 7
       started: -1
       success: -1
+
+####################################################################################################
+# Concurrency
+# Configure concurrency limits for runs and ops/assets. This is the recommended way to configure
+# concurrency settings. Do NOT set these values if you are also configuring maxConcurrentRuns,
+# tagConcurrencyLimits, or blockOpConcurrencyLimitedRuns in dagsterDaemon.runCoordinator.config.
+####################################################################################################
+concurrency:
+  # Set to true to enable the concurrency configuration block
+  enabled: false
+
+  # Pool-level concurrency settings (for op/asset-level concurrency)
+  pools:
+    # Default max concurrent operations for an unconfigured pool (0 to max limit)
+    defaultLimit: ~
+    # Granularity of concurrency enforcement: "run" or "op"
+    granularity: ~
+    # When granularity is "op", number of runs allowed to block waiting for pool slots
+    opGranularityRunBuffer: ~
+
+  # Run-level concurrency settings
+  runs:
+    # Max runs in progress at once (-1 to disable, 0 to stop launches, default 10)
+    maxConcurrentRuns: ~
+    # Tag-based concurrency limits
+    # Example:
+    # tagConcurrencyLimits:
+    #   - key: "database"
+    #     limit: 1
+    #   - key: "team"
+    #     value:
+    #       applyLimitPerUniqueValue: true
+    #     limit: 2
+    tagConcurrencyLimits: []
+
 ####################################################################################################
 # Additional fields on the instance to configure that aren't already determined by a key above.
 # See https://docs.dagster.io/deployment/dagster-instance for the full set of available fields.


### PR DESCRIPTION
## Summary & Motivation

Another attempt at solving https://github.com/dagster-io/dagster/issues/31086.

Makes it possible to configure pools in the helm chart at the top level with validation to ensure no conflicts occur with the run coordinator.

- concurrency.enabled: false by default, block does not render
- concurrency.enabled: true with pools config renders correctly
- concurrency.enabled: true with runs config renders correctly
- tagConcurrencyLimits renders with proper YAML structure
- Conflict with queuedRunCoordinator.maxConcurrentRuns fails helm render
- Conflict with queuedRunCoordinator.tagConcurrencyLimits fails helm render
- Conflict with queuedRunCoordinator.blockOpConcurrencyLimitedRuns.opConcurrencySlotBuffer fails helm render
- No conflict when using only one config method

## How I Tested These Changes

## Changelog

- [helm] Made it possible to configure concurrency pools in the helm chart as a top level setting
