### PR TITLE
[ui] Remove Blueprint from Menu, MenuItem

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/Menu.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Menu.tsx
@@ -1,180 +1,289 @@
-/* eslint-disable no-restricted-imports */
+import clsx from 'clsx';
 import {
-  Menu as BlueprintMenu,
-  MenuDivider as BlueprintMenuDivider,
-  MenuItem as BlueprintMenuItem,
-  Intent,
-} from '@blueprintjs/core';
-import * as React from 'react';
-import styled from 'styled-components';
+  CSSProperties,
+  FocusEventHandler,
+  HTMLProps,
+  KeyboardEvent,
+  MouseEvent,
+  ReactNode,
+  forwardRef,
+} from 'react';
 
-import {Colors} from './Color';
 import {Icon, IconName} from './Icon';
+import {Intent} from './Intent';
+import styles from './css/Menu.module.css';
 
-interface Props extends React.ComponentProps<typeof BlueprintMenu> {}
-
-export const Menu = (props: Props) => {
-  return <StyledMenu {...props} />;
-};
-
-const intentToTextColor = (intent: React.ComponentProps<typeof BlueprintMenuItem>['intent']) => {
-  switch (intent) {
-    case 'primary':
-      return Colors.accentBlue();
-    case 'danger':
-      return Colors.accentRed();
-    case 'success':
-      return Colors.accentGreen();
-    case 'warning':
-      return Colors.accentYellow();
-    case 'none':
-    default:
-      return Colors.textDefault();
-  }
-};
-
-const intentToIconColor = (intent: React.ComponentProps<typeof BlueprintMenuItem>['intent']) => {
-  switch (intent) {
-    case 'primary':
-      return Colors.accentBlue();
-    case 'danger':
-      return Colors.accentRed();
-    case 'success':
-      return Colors.accentGreen();
-    case 'warning':
-      return Colors.accentYellow();
-    case 'none':
-    default:
-      return Colors.textDefault();
-  }
-};
-
-export const iconWithColor = (icon?: IconName | JSX.Element, intent?: Intent) => {
-  if (icon) {
-    if (typeof icon === 'string') {
-      return <Icon name={icon} color={intentToIconColor(intent)} />;
-    }
-    return icon;
-  }
-  return null;
-};
-
-export interface CommonMenuItemProps {
-  icon?: IconName | JSX.Element;
-}
-
-interface ItemProps
-  extends CommonMenuItemProps,
-    Omit<React.ComponentProps<typeof BlueprintMenuItem>, 'ref' | 'href' | 'icon'> {}
-
-export const MenuItem = (props: ItemProps) => {
-  const {icon, intent, ...rest} = props;
-  return (
-    <StyledMenuItem
-      {...rest}
-      $textColor={intentToTextColor(intent)}
-      icon={iconWithColor(icon, intent)}
-      tabIndex={0}
-    />
+const intentToClassName = (intent: Intent) => {
+  return clsx(
+    intent === 'primary' && styles.primary,
+    intent === 'danger' && styles.danger,
+    intent === 'success' && styles.success,
+    intent === 'warning' && styles.warning,
+    intent === 'none' && styles.none,
   );
 };
 
-interface MenuExternalLinkProps
-  extends CommonMenuItemProps,
-    Omit<React.ComponentProps<typeof BlueprintMenuItem>, 'ref' | 'href' | 'icon'> {
-  href: string;
+// ===== MENU =====
+
+export const Menu = forwardRef<HTMLUListElement, HTMLProps<HTMLUListElement>>((props, ref) => {
+  const {className, children, ...rest} = props;
+  return (
+    <ul {...rest} role="menu" ref={ref} className={clsx(styles.menu, className)}>
+      {children}
+    </ul>
+  );
+});
+
+Menu.displayName = 'Menu';
+
+export interface MenuItemContentsProps {
+  icon?: IconName | ReactNode;
+  intent?: Intent;
+  text?: ReactNode;
+  right?: string | ReactNode;
+  className?: string;
+  active?: boolean;
+  disabled?: boolean;
+  style?: CSSProperties;
+}
+
+export const MenuItemContents = (props: MenuItemContentsProps) => {
+  const {
+    icon,
+    intent = 'none',
+    text,
+    right,
+    className,
+    active = false,
+    disabled = false,
+    style,
+  } = props;
+
+  const iconElement = () => {
+    if (typeof icon === 'string') {
+      return <Icon name={icon as IconName} className={styles.menuItemIcon} />;
+    }
+    return icon;
+  };
+
+  return (
+    <div
+      className={clsx(
+        styles.menuItem,
+        active && styles.menuItemActive,
+        disabled && styles.menuItemDisabled,
+        intentToClassName(intent),
+        className,
+      )}
+      style={style}
+    >
+      {icon ? iconElement() : null}
+      <span className={styles.menuItemText}>{text}</span>
+      {right ? <span className={styles.menuItemRight}>{right}</span> : null}
+    </div>
+  );
+};
+
+// ===== MENUITEM =====
+
+export interface CommonMenuItemProps {
+  icon?: IconName | ReactNode;
+  intent?: Intent;
+  style?: CSSProperties;
+  className?: string;
+}
+
+interface MenuItemProps extends CommonMenuItemProps {
+  text: ReactNode;
+  disabled?: boolean;
+  active?: boolean;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+  onMouseDown?: (e: MouseEvent<HTMLButtonElement>) => void;
+  onFocus?: FocusEventHandler<HTMLButtonElement>;
+  right?: string | ReactNode;
+  shouldDismissPopover?: boolean;
+  tabIndex?: number;
+}
+
+export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>((props, ref) => {
+  const {
+    text,
+    icon,
+    intent = 'none',
+    disabled = false,
+    active = false,
+    onClick,
+    onMouseDown,
+    onFocus,
+    right,
+    shouldDismissPopover = true,
+    style,
+    tabIndex = 0,
+    className,
+    ...rest
+  } = props;
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (disabled) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+    onClick?.(e);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault();
+      e.currentTarget.click();
+    }
+  };
+
+  return (
+    <li {...rest} role="none" ref={ref} className={styles.menuItemWrapper}>
+      <button
+        type="button"
+        role="menuitem"
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : tabIndex}
+        data-active={active}
+        disabled={disabled}
+        className={clsx(
+          styles.menuItemButton,
+          // Below is a Blueprint hack to close `Popover` on click, until we've refactored
+          // away from using Blueprint `Popover`.
+          shouldDismissPopover ? 'bp5-popover-dismiss' : null,
+        )}
+        onClick={handleClick}
+        onMouseDown={onMouseDown}
+        onKeyDown={handleKeyDown}
+        onFocus={onFocus}
+      >
+        <MenuItemContents
+          icon={icon}
+          intent={intent}
+          text={text}
+          right={right}
+          className={className}
+          active={active}
+          disabled={disabled}
+          style={style}
+        />
+      </button>
+    </li>
+  );
+});
+
+MenuItem.displayName = 'MenuItem';
+
+// ===== MENUITEMFORINTERACTIVECONTENT =====
+
+interface MenuItemForInteractiveContentProps extends CommonMenuItemProps {
+  children: ReactNode;
 }
 
 /**
- * If you want to use a menu item as a link, use `MenuLink` and provide a `to` prop.
+ * Use MenuItemForInteractiveContent when you need to include interactive elements
+ * (like checkboxes, radio buttons, or other inputs) within a menu item.
+ * This component renders as a div instead of a button to support nested interactive content.
+ *
+ * For standard menu actions, use MenuItem instead.
+ *
+ * Example:
+ * <MenuItemForInteractiveContent>
+ *   <Checkbox label="Show completed" />
+ * </MenuItemForInteractiveContent>
  */
-export const MenuExternalLink = (props: MenuExternalLinkProps) => {
-  const {icon, intent = 'none', ...rest} = props;
+export const MenuItemForInteractiveContent = forwardRef<
+  HTMLLIElement,
+  MenuItemForInteractiveContentProps
+>((props, ref) => {
+  const {children, intent = 'none', style, className, ...rest} = props;
   return (
-    <StyledMenuItem
-      {...rest}
-      target="_blank"
-      rel="noreferrer nofollow"
-      $textColor={intentToTextColor(intent)}
-      icon={iconWithColor(icon, intent)}
-    />
+    <li {...rest} role="none" ref={ref} className={styles.menuItemWrapper}>
+      <div
+        role="menuitem"
+        className={clsx(styles.menuItem, intentToClassName(intent), className)}
+        style={style}
+      >
+        {children}
+      </div>
+    </li>
   );
-};
+});
 
-export const MenuDivider = styled(BlueprintMenuDivider)`
-  border-top: 1px solid ${Colors.keylineDefault()};
-  margin: 2px 0;
+MenuItemForInteractiveContent.displayName = 'MenuItemForInteractiveContent';
 
-  :focus {
-    outline: none;
-  }
+// ===== MENUEXTERNALLINK =====
 
-  && h6 {
-    color: ${Colors.textLight()};
-    padding: 8px 6px 2px;
-    font-size: 12px;
-    font-weight: 300;
-    user-select: none;
-  }
-`;
-
-const StyledMenu = styled(BlueprintMenu)`
-  background-color: ${Colors.popoverBackground()};
-  border-radius: 4px;
-  padding: 8px 4px;
-`;
-
-interface StyledMenuItemProps extends React.ComponentProps<typeof BlueprintMenuItem> {
-  $textColor: string;
+interface MenuExternalLinkProps extends CommonMenuItemProps {
+  href: string;
+  text: ReactNode;
+  right?: string | ReactNode;
+  tabIndex?: number;
+  download?: boolean | string;
+  onClick?: (e: MouseEvent<HTMLAnchorElement>) => void;
 }
 
-const StyledMenuItem = styled(BlueprintMenuItem)<StyledMenuItemProps>`
-  border-radius: 4px;
-  color: ${({$textColor}) => $textColor};
-  line-height: 20px;
-  padding: 6px 8px 6px 12px;
-  transition:
-    background-color 50ms,
-    box-shadow 150ms;
-  align-items: flex-start;
-  font-size: 14px;
+/**
+ * If you want to use a menu item as an external link, use `MenuExternalLink` and provide an `href` prop.
+ * For internal links with react-router, use `MenuLink` from ui-core.
+ */
+export const MenuExternalLink = forwardRef<HTMLLIElement, MenuExternalLinkProps>((props, ref) => {
+  const {
+    href,
+    text,
+    icon,
+    intent = 'none',
+    right = '',
+    style,
+    tabIndex = 0,
+    className,
+    download,
+    onClick,
+    ...rest
+  } = props;
 
-  /**
-   * Use margin instead of align-items: center because the contents of the menu item may wrap 
-   * in unusual circumstances.
-   */
-  .iconGlobal {
-    margin-top: 2px;
-  }
+  return (
+    <li {...rest} role="none" ref={ref} className={styles.menuItemWrapper}>
+      <a
+        href={href}
+        role="menuitem"
+        tabIndex={tabIndex}
+        className={styles.menuItemAnchor}
+        onClick={onClick}
+        download={download}
+        target="_blank"
+        rel="noreferrer nofollow"
+      >
+        <MenuItemContents
+          icon={icon}
+          intent={intent}
+          text={text}
+          right={right}
+          className={className}
+          style={style}
+        />
+      </a>
+    </li>
+  );
+});
 
-  &.bp5-active,
-  &.bp5-active:hover {
-    background-color: ${Colors.backgroundBlue()};
-    color: ${Colors.textDefault()};
+MenuExternalLink.displayName = 'MenuExternalLink';
 
-    .iconGlobal {
-      background-color: ${Colors.textDefault()};
-    }
-  }
+// ===== MENUDIVIDER =====
 
-  &.bp5-disabled .iconGlobal {
-    opacity: 0.5;
-  }
+interface MenuDividerProps {
+  title?: ReactNode;
+  className?: string;
+}
 
-  &.bp5-active .iconGlobal {
-    color: ${Colors.textDefault()};
-  }
-
-  .iconGlobal:first-child {
-    margin-left: -4px;
-  }
-
-  &:hover {
-    background: ${Colors.popoverBackgroundHover()};
-    color: ${({$textColor}) => $textColor};
-  }
-
-  &:focus-visible {
-    z-index: 1;
-  }
-`;
+export const MenuDivider = (props: MenuDividerProps) => {
+  const {title, className} = props;
+  const allClassNames = clsx(title ? styles.menuHeader : styles.menuDivider, className);
+  return (
+    <li role="separator" className={allClassNames}>
+      {title ? <h6 className={styles.menuHeaderTitle}>{title}</h6> : null}
+    </li>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-components/src/components/TagSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TagSelector.tsx
@@ -7,7 +7,7 @@ import {Box} from './Box';
 import {Checkbox} from './Checkbox';
 import {Colors} from './Color';
 import {Icon} from './Icon';
-import {Menu, MenuItem} from './Menu';
+import {Menu, MenuItemForInteractiveContent} from './Menu';
 import {MiddleTruncate} from './MiddleTruncate';
 import {Popover} from './Popover';
 import {TextInput} from './TextInput';
@@ -83,17 +83,15 @@ const defaultRenderDropdownItem = (
   dropdownItemProps: TagSelectorDropdownItemProps,
 ) => {
   return (
-    <label>
-      <MenuItem
-        text={
-          <Box flex={{alignItems: 'center', gap: 8}}>
-            <Checkbox checked={dropdownItemProps.selected} onChange={dropdownItemProps.toggle} />
-            <span>{tag}</span>
-          </Box>
-        }
-        tagName="div"
-      />
-    </label>
+    <MenuItemForInteractiveContent>
+      <Box flex={{alignItems: 'center', gap: 8}}>
+        <Checkbox
+          checked={dropdownItemProps.selected}
+          onChange={dropdownItemProps.toggle}
+          label={<span>{tag}</span>}
+        />
+      </Box>
+    </MenuItemForInteractiveContent>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Menu.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Menu.stories.tsx
@@ -1,8 +1,18 @@
+import {useCallback, useState} from 'react';
 import styled from 'styled-components';
 
 import {Box} from '../Box';
+import {Checkbox} from '../Checkbox';
 import {Colors} from '../Color';
-import {Menu, MenuDivider, MenuItem} from '../Menu';
+import {
+  Menu,
+  MenuDivider,
+  MenuExternalLink,
+  MenuItem,
+  MenuItemForInteractiveContent,
+} from '../Menu';
+import {Spinner} from '../Spinner';
+import {Tooltip} from '../Tooltip';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -12,7 +22,7 @@ export default {
 
 export const Default = () => {
   return (
-    <Box flex={{direction: 'column', gap: 8, alignItems: 'flex-start'}} padding={8}>
+    <Box flex={{direction: 'column', gap: 8}} padding={8}>
       <Container style={{width: '180px'}}>
         <Menu>
           <MenuItem text="Item 01" />
@@ -44,6 +54,193 @@ export const Default = () => {
           <MenuItem icon="attach_file" text="Attach" />
           <MenuDivider title="Here you can delete" />
           <MenuItem intent="danger" icon="delete" text="Delete" />
+        </Menu>
+      </Container>
+    </Box>
+  );
+};
+
+export const AllIntents = () => {
+  return (
+    <Box flex={{direction: 'column', gap: 8}} padding={8}>
+      <Container style={{width: '200px'}}>
+        <Menu>
+          <MenuItem icon="check_circle" intent="success" text="Success Action" />
+          <MenuItem icon="info" intent="primary" text="Primary Action" />
+          <MenuItem icon="warning" intent="warning" text="Warning Action" />
+          <MenuItem icon="error" intent="danger" text="Danger Action" />
+          <MenuItem icon="settings" intent="none" text="Default Action" />
+        </Menu>
+      </Container>
+    </Box>
+  );
+};
+
+export const DisabledStates = () => {
+  return (
+    <Box flex={{direction: 'column', gap: 8}} padding={8}>
+      <Container style={{width: '220px'}}>
+        <Menu>
+          <MenuItem
+            icon="download_for_offline"
+            text="Save (enabled)"
+            onClick={() => alert('Saved!')} // eslint-disable-line no-alert
+          />
+          <MenuItem icon="download_for_offline" text="Save (disabled)" disabled />
+          <Tooltip content="You don't have permission to delete" placement="left">
+            <MenuItem icon="delete" intent="danger" text="Delete (disabled)" disabled />
+          </Tooltip>
+          <MenuItem icon="download" text="Download (enabled)" />
+        </Menu>
+      </Container>
+    </Box>
+  );
+};
+
+export const ActiveState = () => {
+  return (
+    <Box flex={{direction: 'column', gap: 8}} padding={8}>
+      <Container style={{width: '200px'}}>
+        <Menu>
+          <MenuItem icon="check_circle" text="Selected Item" active />
+          <MenuItem icon="settings" text="Normal Item" />
+          <MenuItem icon="info" text="Another Item" />
+        </Menu>
+      </Container>
+    </Box>
+  );
+};
+
+export const WithLabels = () => {
+  return (
+    <Box flex={{direction: 'column', gap: 8}} padding={8}>
+      <Container style={{width: '250px'}}>
+        <Menu>
+          <MenuItem icon="download_for_offline" text="Save" right="⌘S" />
+          <MenuItem icon="content_copy" text="Copy" right="⌘C" />
+          <MenuItem icon="copy_to_clipboard" text="Paste" right="⌘V" />
+          <MenuDivider />
+          <MenuItem icon="search" text="Find" right="⌘F" />
+          <MenuItem icon="refresh" text="Reload" right="⌘R" />
+        </Menu>
+      </Container>
+    </Box>
+  );
+};
+
+export const ExternalLinks = () => {
+  return (
+    <Box flex={{direction: 'column', gap: 8}} padding={8}>
+      <Container style={{width: '250px'}}>
+        <Menu>
+          <MenuExternalLink
+            icon="open_in_new"
+            text="Open Documentation"
+            href="https://docs.dagster.io"
+          />
+          <MenuExternalLink icon="github" text="View on GitHub" href="https://github.com" />
+          <MenuDivider />
+          <MenuItem icon="info" text="About" />
+        </Menu>
+      </Container>
+    </Box>
+  );
+};
+
+export const ComplexContent = () => {
+  const [checkedItems, setCheckedItems] = useState<Set<string>>(() => new Set());
+  const onChange = useCallback((item: string, checked: boolean) => {
+    setCheckedItems((current) => {
+      const copy = new Set(current);
+      if (checked) {
+        copy.add(item);
+      } else {
+        copy.delete(item);
+      }
+      return copy;
+    });
+  }, []);
+
+  return (
+    <Box flex={{direction: 'column', gap: 8}} padding={8}>
+      <Container style={{width: '280px'}}>
+        <Menu>
+          <MenuItemForInteractiveContent>
+            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+              <Checkbox
+                checked={checkedItems.has('completed')}
+                label="Show completed items"
+                onChange={(e) => onChange('completed', e.target.checked)}
+                style={{width: '100%'}}
+              />
+            </Box>
+          </MenuItemForInteractiveContent>
+          <MenuItemForInteractiveContent>
+            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+              <Checkbox
+                checked={checkedItems.has('archived')}
+                label="Show archived items"
+                onChange={(e) => onChange('archived', e.target.checked)}
+              />
+            </Box>
+          </MenuItemForInteractiveContent>
+          <MenuDivider />
+          <MenuItem
+            icon={<Spinner purpose="body-text" />}
+            text={
+              <Box flex={{direction: 'row', gap: 4}}>
+                <span>Loading latest data...</span>
+              </Box>
+            }
+            disabled
+          />
+        </Menu>
+      </Container>
+    </Box>
+  );
+};
+
+export const ButtonsAndLinks = () => {
+  return (
+    <Box flex={{direction: 'column', gap: 8}} padding={8}>
+      <Container style={{width: '250px'}}>
+        <Menu>
+          <MenuExternalLink
+            icon="link"
+            text="External link"
+            href="https://example.com"
+            onClick={() => alert('Link clicked!')} // eslint-disable-line no-alert
+          />
+          <MenuItem
+            icon="toggle_on"
+            text="Button (MenuItem)"
+            onClick={() => alert('Button clicked!')} // eslint-disable-line no-alert
+          />
+          <MenuItem text="Disabled item" icon="info" disabled />
+        </Menu>
+      </Container>
+    </Box>
+  );
+};
+
+export const InteractiveMenu = () => {
+  return (
+    <Box flex={{direction: 'column', gap: 8}} padding={8}>
+      <Container style={{width: '220px'}}>
+        <Menu>
+          {/* eslint-disable-next-line no-alert */}
+          <MenuItem icon="execute" text="Run Job" onClick={() => alert('Running job...')} />
+          {/* eslint-disable-next-line no-alert */}
+          <MenuItem icon="pause" text="Pause Job" onClick={() => alert('Pausing job...')} />
+          <MenuItem
+            icon="cancel"
+            intent="danger"
+            text="Stop Job"
+            onClick={() => alert('Stopped!')} // eslint-disable-line no-alert
+          />
+          <MenuDivider />
+          {/* eslint-disable-next-line no-alert */}
+          <MenuItem icon="settings" text="Configure" onClick={() => alert('Opening settings...')} />
         </Menu>
       </Container>
     </Box>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/TagSelector.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/TagSelector.stories.tsx
@@ -5,7 +5,7 @@ import {Box} from '../Box';
 import {Checkbox} from '../Checkbox';
 import {Colors} from '../Color';
 import {Icon} from '../Icon';
-import {Menu, MenuDivider, MenuItem} from '../Menu';
+import {Menu, MenuDivider, MenuItemForInteractiveContent} from '../Menu';
 import {TagSelector, TagSelectorWithSearch} from '../TagSelector';
 
 // eslint-disable-next-line import/no-default-export
@@ -45,7 +45,8 @@ export const WithSearch = () => {
 
 export const Styled = () => {
   const [selectedTags, setSelectedTags] = useState<string[]>(allTags.slice(0, 2));
-  const isAllSelected = selectedTags.length === 6;
+  const isAllSelected = selectedTags.length === allTags.length;
+
   return (
     <TagSelector
       allTags={allTags}
@@ -54,21 +55,20 @@ export const Styled = () => {
       placeholder="Select a partition or create one"
       renderDropdownItem={(tag, dropdownItemProps) => {
         return (
-          <label>
-            <MenuItem
-              tagName="div"
-              text={
-                <Box flex={{alignItems: 'center', gap: 12}}>
-                  <Checkbox
-                    checked={dropdownItemProps.selected}
-                    onChange={dropdownItemProps.toggle}
-                  />
-                  <Dot color={Math.random() > 0.5 ? Colors.accentGreen() : Colors.accentGray()} />
-                  <span>{tag}</span>
-                </Box>
-              }
-            />
-          </label>
+          <MenuItemForInteractiveContent>
+            <Box flex={{alignItems: 'center', gap: 12}}>
+              <Checkbox
+                checked={dropdownItemProps.selected}
+                onChange={dropdownItemProps.toggle}
+                label={
+                  <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+                    <Dot color={Math.random() > 0.5 ? Colors.accentGreen() : Colors.accentGray()} />
+                    <span>{tag}</span>
+                  </Box>
+                }
+              />
+            </Box>
+          </MenuItemForInteractiveContent>
         );
       }}
       renderDropdown={(dropdown) => {
@@ -79,6 +79,7 @@ export const Styled = () => {
             setSelectedTags(allTags);
           }
         };
+
         return (
           <Menu>
             <Box padding={4}>
@@ -89,17 +90,15 @@ export const Styled = () => {
                 </Box>
               </Box>
               <MenuDivider />
-              <label>
-                <MenuItem
-                  tagName="div"
-                  text={
-                    <Box flex={{alignItems: 'center', gap: 8}}>
-                      <Checkbox checked={isAllSelected} onChange={toggleAll} />
-                      <span>Select All ({allTags.length})</span>
-                    </Box>
-                  }
-                />
-              </label>
+              <MenuItemForInteractiveContent>
+                <Box flex={{alignItems: 'center', gap: 8}}>
+                  <Checkbox
+                    checked={isAllSelected}
+                    onChange={toggleAll}
+                    label={<span>Select all ({allTags.length})</span>}
+                  />
+                </Box>
+              </MenuItemForInteractiveContent>
               {dropdown}
             </Box>
           </Menu>

--- a/js_modules/dagster-ui/packages/ui-components/src/components/css/Menu.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/css/Menu.module.css
@@ -1,0 +1,255 @@
+/* ============================================
+   MENU
+   ============================================ */
+
+.menu {
+  background-color: var(--color-popover-background);
+  border-radius: 4px;
+  padding: 4px;
+  margin: 0;
+  min-width: 180px;
+  list-style: none;
+}
+
+/* ============================================
+   MENUITEM WRAPPER (LI)
+   ============================================ */
+
+.menuItemWrapper {
+  list-style: none;
+}
+
+/* ============================================
+   MENUITEM (A/BUTTON/DIV)
+   ============================================ */
+
+.menuItem {
+  --menu-item-text-color: var(--color-text-default);
+  --menu-item-icon-color: var(--color-text-default);
+
+  border-radius: 4px;
+  color: var(--menu-item-text-color);
+  line-height: 20px;
+  padding: 6px 8px 6px 12px;
+  transition:
+    background-color 10ms linear,
+    box-shadow 150ms;
+  align-items: flex-start;
+  font-size: 14px;
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  text-decoration: none;
+  cursor: pointer;
+  user-select: none;
+  border: none;
+  background: transparent;
+  width: 100%;
+  text-align: left;
+  font-family: var(--font-family--default);
+}
+
+/* Remove underline from all link states */
+.menuItem:link,
+.menuItem:visited,
+.menuItem:hover,
+.menuItem:active {
+  text-decoration: none;
+}
+
+/* Icon alignment - use margin instead of align-items: center
+   because content may wrap */
+.menuItem :global(.iconGlobal) {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.menuItem :global(.iconGlobal):first-child {
+  margin-left: -4px;
+}
+
+/* Hover state */
+.menuItem:hover:not(.menuItemDisabled) {
+  background: var(--color-popover-background-hover);
+  color: var(--menu-item-text-color);
+}
+
+/* Pressed/clicked state */
+.menuItem:active:not(.menuItemDisabled) {
+  background: var(--color-background-lighter-hover);
+  color: var(--menu-item-text-color);
+}
+
+/* Active state (selected item) */
+.menuItemActive,
+.menuItemActive:hover {
+  background-color: var(--color-background-blue);
+  color: var(--color-text-default);
+}
+
+.menuItemActive :global(.iconGlobal) {
+  background-color: var(--color-text-default);
+  color: var(--color-text-default);
+}
+
+/* Disabled state */
+.menuItemDisabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.menuItemDisabled :global(.iconGlobal) {
+  opacity: 0.5;
+}
+
+.menuItem.primary {
+  --menu-item-text-color: var(--color-accent-blue);
+  --menu-item-icon-color: var(--color-accent-blue);
+}
+
+.menuItem.danger {
+  --menu-item-text-color: var(--color-accent-red);
+  --menu-item-icon-color: var(--color-accent-red);
+}
+
+.menuItem.success {
+  --menu-item-text-color: var(--color-accent-green);
+  --menu-item-icon-color: var(--color-accent-green);
+}
+
+.menuItem.warning {
+  --menu-item-text-color: var(--color-accent-yellow);
+  --menu-item-icon-color: var(--color-accent-yellow);
+}
+
+.menuItem .menuItemIcon {
+  color: var(--menu-item-icon-color);
+  background-color: var(--menu-item-icon-color);
+}
+
+/* ============================================
+   WRAPPER CLASSES (BUTTON/ANCHOR/DIV)
+   ============================================ */
+
+/* Unstyled button wrapper */
+.menuItemButton {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  text-align: left;
+  box-sizing: border-box;
+}
+
+.menuItemButton:focus {
+  outline: none;
+}
+
+.menuItemButton:focus-visible .menuItem {
+  box-shadow: var(--color-focus-ring) 0 0 0 2px;
+  outline: none;
+  z-index: 1;
+  position: relative;
+}
+
+/* Unstyled anchor wrapper */
+.menuItemAnchor {
+  background: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+.menuItemAnchor:link,
+.menuItemAnchor:visited,
+.menuItemAnchor:hover,
+.menuItemAnchor:active {
+  text-decoration: none;
+}
+
+.menuItemAnchor:focus {
+  outline: none;
+}
+
+.menuItemAnchor:focus-visible .menuItem {
+  box-shadow: var(--color-focus-ring) 0 0 0 2px;
+  outline: none;
+  z-index: 1;
+  position: relative;
+}
+
+/* Unstyled div wrapper */
+.menuItemDiv {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.menuItemDiv:focus {
+  outline: none;
+}
+
+.menuItemDiv:focus-visible .menuItem {
+  box-shadow: var(--color-focus-ring) 0 0 0 2px;
+  outline: none;
+  z-index: 1;
+  position: relative;
+}
+
+/* Text container */
+.menuItemText {
+  flex: 1;
+  min-width: 0; /* Allow text truncation */
+}
+
+.menuItemRight {
+  margin-left: auto;
+  padding-left: 16px;
+  color: var(--color-text-light);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+/* ============================================
+   MENUDIVIDER
+   ============================================ */
+
+.menuDivider {
+  border-top: 1px solid var(--color-keyline-default);
+  margin: 2px 0;
+  list-style: none;
+}
+
+.menuDivider:focus {
+  outline: none;
+}
+
+/* ============================================
+   MENUHEADER (Divider with title)
+   ============================================ */
+
+.menuHeader {
+  list-style: none;
+}
+
+.menuHeaderTitle {
+  color: var(--color-text-light);
+  padding: 8px 6px 2px;
+  font-size: 12px;
+  font-weight: 300;
+  user-select: none;
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/HourCycleSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/HourCycleSelect.tsx
@@ -82,7 +82,7 @@ export const HourCycleSelect = () => {
           <MenuItem
             active={props.modifiers.active}
             onClick={props.handleClick}
-            label={item.label}
+            right={item.label}
             key={item.key}
             text={item.text}
             style={{width: '300px'}}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/TimezoneSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/TimezoneSelect.tsx
@@ -165,7 +165,7 @@ export const TimezoneSelect = ({
           <MenuItem
             active={props.modifiers.active}
             onClick={props.handleClick}
-            label={tz.offsetLabel}
+            right={tz.offsetLabel}
             key={tz.key}
             text={tz.key}
           />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetPartitions.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetPartitions.test.tsx
@@ -172,6 +172,7 @@ describe('AssetPartitions', () => {
   });
 
   it('should support reverse sorting individual dimensions', async () => {
+    const user = userEvent.setup();
     const Component = () => {
       const [params, setParams] = useState<AssetViewParams>({});
       return (
@@ -193,62 +194,29 @@ describe('AssetPartitions', () => {
 
     render(<Component />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('partitions-date')).toBeVisible();
-      expect(screen.getByTestId('partitions-zstate')).toBeVisible();
-    });
+    expect(await screen.findByTestId('partitions-date')).toBeVisible();
+    expect(await screen.findByTestId('partitions-zstate')).toBeVisible();
 
-    await waitFor(() => {
-      expect(
-        getByTestId(
-          screen.getByTestId('partitions-date'),
-          'asset-partition-row-2023-02-05-index-0',
-        ),
-      ).toBeVisible();
-      expect(
-        getByTestId(screen.getByTestId('partitions-zstate'), 'asset-partition-row-TN-index-0'),
-      ).toBeVisible();
-    });
+    expect(await screen.findByTestId('asset-partition-row-2023-02-05-index-0')).toBeVisible();
+    expect(await screen.findByTestId('asset-partition-row-TN-index-0')).toBeVisible();
 
-    await userEvent.click(screen.getByTestId('sort-0'));
-    await userEvent.click(screen.getByTestId('sort-creation'));
+    await user.click(await screen.findByTestId('sort-0'));
+    await user.click(await screen.findByRole('menuitem', {name: /^creation sort/i}));
 
-    await waitFor(() => {
-      expect(
-        getByTestId(
-          screen.getByTestId('partitions-date'),
-          'asset-partition-row-2021-05-06-index-0',
-        ),
-      ).toBeVisible();
-      expect(
-        getByTestId(screen.getByTestId('partitions-zstate'), 'asset-partition-row-TN-index-0'),
-      ).toBeVisible();
-    });
+    expect(await screen.findByTestId('asset-partition-row-2021-05-06-index-0')).toBeVisible();
+    expect(await screen.findByTestId('asset-partition-row-TN-index-0')).toBeVisible();
 
-    await userEvent.click(screen.getByTestId('sort-1'));
-    await waitFor(async () => {
-      await userEvent.click(screen.getByTestId('sort-reverse-creation'));
-    });
-    await waitFor(() => {
-      expect(
-        getByTestId(screen.getByTestId('partitions-zstate'), 'asset-partition-row-WV-index-0'),
-      ).toBeVisible();
-    });
+    await user.click(await screen.findByTestId('sort-1'));
+    await user.click(await screen.findByRole('menuitem', {name: /^reverse creation sort/i}));
+    expect(await screen.findByTestId('asset-partition-row-WV-index-0')).toBeVisible();
 
-    await userEvent.click(screen.getByTestId('sort-1'));
-    await waitFor(async () => {
-      await userEvent.click(screen.getByTestId('sort-alphabetical'));
-    });
-    expect(
-      getByTestId(screen.getByTestId('partitions-zstate'), 'asset-partition-row-FL-index-0'),
-    ).toBeVisible();
+    await user.click(await screen.findByTestId('sort-1'));
+    await user.click(await screen.findByRole('menuitem', {name: /^alphabetical sort/i}));
+    expect(await screen.findByTestId('asset-partition-row-FL-index-0')).toBeVisible();
 
-    await waitFor(async () => {
-      await userEvent.click(screen.getByTestId('sort-reverse-alphabetical'));
-    });
-    expect(
-      getByTestId(screen.getByTestId('partitions-zstate'), 'asset-partition-row-WV-index-0'),
-    ).toBeVisible();
+    await user.click(await screen.findByTestId('sort-1'));
+    await user.click(await screen.findByRole('menuitem', {name: /^reverse alphabetical sort/i}));
+    expect(await screen.findByTestId('asset-partition-row-WV-index-0')).toBeVisible();
   });
 
   it('should set the focused partition when you click a list element', async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -137,15 +137,15 @@ describe('LaunchAssetExecutionButton', () => {
 
   describe('observable assets', () => {
     it('should disable the sub-menu item if the selection includes no observable assets', async () => {
+      const user = userEvent.setup();
       renderButton({
         scope: {selected: [ASSET_DAILY]},
       });
 
-      await userEvent.click(await screen.findByTestId('materialize-button-dropdown'));
-
-      const observeOption = await screen.findByTestId('materialize-secondary-option');
-      expect(observeOption.textContent).toEqual('Observe selected');
-      expect(observeOption).toHaveClass('bp5-disabled');
+      await user.click(await screen.findByTestId('materialize-button-dropdown'));
+      const secondaryOption = await screen.findByRole('menuitem', {name: /observe selected/i});
+      expect(secondaryOption).toBeVisible();
+      expect(secondaryOption).toBeDisabled();
     });
 
     it('should enable the sub-menu item if the selection includes observable assets', async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLinkProtocol.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLinkProtocol.tsx
@@ -68,7 +68,7 @@ export const CodeLinkProtocolSelect = ({}) => {
           <MenuItem
             active={props.modifiers.active}
             onClick={props.handleClick}
-            label={protocol}
+            right={protocol}
             key={protocol}
             text={POPULAR_PROTOCOLS[protocol]}
           />

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
@@ -127,7 +127,6 @@ export const BackfillActionsMenu = ({
           >
             <MenuItem
               icon="refresh"
-              tagName="button"
               text="Re-execute"
               disabled={reexecutionDisabledState.disabled}
               onClick={() => reexecute(ReexecutionStrategy.ALL_STEPS)}
@@ -142,7 +141,6 @@ export const BackfillActionsMenu = ({
           >
             <MenuItem
               icon="refresh"
-              tagName="button"
               text="Re-execute from failure"
               disabled={reexecutionFromFailureDisabledState.disabled}
               onClick={() => reexecute(ReexecutionStrategy.FROM_FAILURE)}

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -340,7 +340,7 @@ const ConfigEditorConfigGeneratorPicker = React.memo(
                 renderedPresetItems.length > 0 && renderedPartitionSetItems.length > 0;
 
               return (
-                <Menu ulRef={itemsParentRef}>
+                <Menu ref={itemsParentRef}>
                   {bothTypesPresent && <MenuItem disabled={true} text="Presets" />}
                   {renderedPresetItems}
                   {bothTypesPresent && <MenuDivider />}

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/OrdinalPartitionSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/OrdinalPartitionSelector.tsx
@@ -6,6 +6,7 @@ import {
   Menu,
   MenuDivider,
   MenuItem,
+  MenuItemForInteractiveContent,
   MiddleTruncate,
   TagSelectorDropdownItemProps,
   TagSelectorDropdownProps,
@@ -47,14 +48,13 @@ export const OrdinalPartitionSelector = ({
       const index = allPartitions.indexOf(partitionKey);
       if ('ranges' in health) {
         return <AssetPartitionStatusDot status={partitionStatusAtIndex(health.ranges, index)} />;
-      } else {
-        return (
-          <RunStatusDot
-            size={10}
-            status={health.runStatusForPartitionKey(partitionKey, index) || RunStatus.NOT_STARTED}
-          />
-        );
       }
+      return (
+        <RunStatusDot
+          size={10}
+          status={health.runStatusForPartitionKey(partitionKey, index) || RunStatus.NOT_STARTED}
+        />
+      );
     },
     [allPartitions, health],
   );
@@ -70,34 +70,55 @@ export const OrdinalPartitionSelector = ({
       }
       renderDropdownItem={React.useCallback(
         (tag: string, dropdownItemProps: TagSelectorDropdownItemProps) => {
-          return (
-            <label>
-              <MenuItem
-                tagName="div"
-                data-testid={testId(`menu-item-${tag}`)}
-                onClick={dropdownItemProps.toggle}
-                text={
+          const sharedContent = (
+            <>
+              {dotForPartitionKey(tag)}
+              <div data-tooltip={tag} data-tooltip-style={DropdownItemTooltipStyle}>
+                <MiddleTruncate text={tag} />
+              </div>
+            </>
+          );
+
+          if (mode === 'multiple') {
+            return (
+              <label key={tag}>
+                <MenuItemForInteractiveContent data-testid={testId(`menu-item-${tag}`)}>
                   <div
                     style={{
                       display: 'grid',
-                      gridTemplateColumns:
-                        mode === 'multiple' ? 'auto auto minmax(0, 1fr)' : 'auto minmax(0, 1fr)',
+                      gridTemplateColumns: 'auto auto minmax(0, 1fr)',
                       alignItems: 'center',
                       gap: 12,
                     }}
                   >
-                    {mode === 'multiple' && (
-                      <Checkbox
-                        checked={dropdownItemProps.selected}
-                        onChange={() => {
-                          // no-op, handled by click on parent, this just silences React warning
-                        }}
-                      />
-                    )}
-                    {dotForPartitionKey(tag)}
-                    <div data-tooltip={tag} data-tooltip-style={DropdownItemTooltipStyle}>
-                      <MiddleTruncate text={tag} />
-                    </div>
+                    <Checkbox
+                      checked={dropdownItemProps.selected}
+                      onChange={() => {
+                        dropdownItemProps.toggle();
+                      }}
+                    />
+                    {sharedContent}
+                  </div>
+                </MenuItemForInteractiveContent>
+              </label>
+            );
+          }
+
+          return (
+            <label key={tag}>
+              <MenuItem
+                onClick={() => dropdownItemProps.toggle()}
+                data-testid={testId(`menu-item-${tag}`)}
+                text={
+                  <div
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: 'auto auto minmax(0, 1fr)',
+                      alignItems: 'center',
+                      gap: 12,
+                    }}
+                  >
+                    {sharedContent}
                   </div>
                 }
               />
@@ -116,7 +137,6 @@ export const OrdinalPartitionSelector = ({
                   <>
                     <Box flex={{direction: 'column'}}>
                       <MenuItem
-                        tagName="div"
                         text={
                           <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
                             <StyledIcon name="add" size={24} />
@@ -135,24 +155,21 @@ export const OrdinalPartitionSelector = ({
                   <>
                     {mode === 'multiple' && (
                       <label>
-                        <MenuItem
-                          tagName="div"
-                          text={
-                            <Box flex={{alignItems: 'center', gap: 12}}>
-                              <Checkbox
-                                checked={isAllSelected}
-                                onChange={() => {
-                                  if (isAllSelected) {
-                                    setSelectedPartitions([]);
-                                  } else {
-                                    setSelectedPartitions(allTags);
-                                  }
-                                }}
-                              />
-                              <span>Select all ({allTags.length})</span>
-                            </Box>
-                          }
-                        />
+                        <MenuItemForInteractiveContent>
+                          <Box flex={{alignItems: 'center', gap: 12}}>
+                            <Checkbox
+                              checked={isAllSelected}
+                              onChange={() => {
+                                if (isAllSelected) {
+                                  setSelectedPartitions([]);
+                                } else {
+                                  setSelectedPartitions(allTags);
+                                }
+                              }}
+                            />
+                            <span>Select all ({allTags.length})</span>
+                          </Box>
+                        </MenuItemForInteractiveContent>
                       </label>
                     )}
                     {dropdown}

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/__stories__/OrdinalPartitionSelector.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/__stories__/OrdinalPartitionSelector.stories.tsx
@@ -1,0 +1,344 @@
+import {Box} from '@dagster-io/ui-components';
+import {useState} from 'react';
+
+import {AssetPartitionStatus} from '../../assets/AssetPartitionStatus';
+import {Range} from '../../assets/usePartitionHealthData';
+import {RunStatus} from '../../graphql/types';
+import {OrdinalPartitionSelector} from '../OrdinalPartitionSelector';
+import {PartitionStatusHealthSource} from '../PartitionStatus';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Partitions/OrdinalPartitionSelector',
+  component: OrdinalPartitionSelector,
+};
+
+// Mock partition keys for testing
+const smallPartitionList = ['2024-01-01', '2024-01-02', '2024-01-03', '2024-01-04', '2024-01-05'];
+
+const mediumPartitionList = Array.from({length: 20}, (_, i) => {
+  const date = new Date('2024-01-01');
+  date.setDate(date.getDate() + i);
+  const isoDate = date.toISOString().split('T')[0];
+  return isoDate || '';
+});
+
+const largePartitionList = Array.from(
+  {length: 100},
+  (_, i) => `partition_${i.toString().padStart(3, '0')}`,
+);
+
+// Health sources for different scenarios
+const createAssetHealthSource = (ranges: Range[]): PartitionStatusHealthSource => ({
+  ranges,
+});
+
+const createOpHealthSource = (
+  statusMap: Record<string, RunStatus>,
+): PartitionStatusHealthSource => ({
+  runStatusForPartitionKey: (key: string) => statusMap[key] || RunStatus.NOT_STARTED,
+});
+
+// Healthy partitions (all materialized)
+const allHealthyRanges: Range[] = [
+  {
+    start: {idx: 0, key: '2024-01-01'},
+    end: {
+      idx: smallPartitionList.length - 1,
+      key: '2024-01-05',
+    },
+    value: [AssetPartitionStatus.MATERIALIZED],
+  },
+];
+
+// Mixed health status
+const mixedHealthRanges: Range[] = [
+  {
+    start: {idx: 0, key: '2024-01-01'},
+    end: {idx: 4, key: '2024-01-05'},
+    value: [AssetPartitionStatus.MATERIALIZED],
+  },
+  {
+    start: {idx: 5, key: '2024-01-06'},
+    end: {idx: 9, key: '2024-01-10'},
+    value: [AssetPartitionStatus.MISSING],
+  },
+  {
+    start: {idx: 10, key: '2024-01-11'},
+    end: {idx: 14, key: '2024-01-15'},
+    value: [AssetPartitionStatus.FAILED],
+  },
+  {
+    start: {idx: 15, key: '2024-01-16'},
+    end: {idx: 19, key: '2024-01-20'},
+    value: [AssetPartitionStatus.MATERIALIZING],
+  },
+];
+
+// Op health with run statuses
+const opRunStatusMap: Record<string, RunStatus> = {
+  '2024-01-01': RunStatus.SUCCESS,
+  '2024-01-02': RunStatus.SUCCESS,
+  '2024-01-03': RunStatus.FAILURE,
+  '2024-01-04': RunStatus.STARTED,
+  '2024-01-05': RunStatus.NOT_STARTED,
+};
+
+export const MultipleSelectionDefault = () => {
+  const [selectedPartitions, setSelectedPartitions] = useState<string[]>([]);
+
+  return (
+    <Box padding={20} style={{maxWidth: 600}}>
+      <OrdinalPartitionSelector
+        allPartitions={mediumPartitionList}
+        selectedPartitions={selectedPartitions}
+        setSelectedPartitions={setSelectedPartitions}
+        health={createAssetHealthSource(mixedHealthRanges)}
+        isDynamic={false}
+        mode="multiple"
+      />
+      <Box margin={{top: 12}} style={{fontSize: 14, color: '#666'}}>
+        Selected: {selectedPartitions.length > 0 ? selectedPartitions.join(', ') : 'None'}
+      </Box>
+    </Box>
+  );
+};
+
+export const SingleSelectionMode = () => {
+  const [selectedPartition, setSelectedPartition] = useState<string | undefined>(undefined);
+
+  return (
+    <Box padding={20} style={{maxWidth: 600}}>
+      <OrdinalPartitionSelector
+        allPartitions={smallPartitionList}
+        selectedPartitions={selectedPartition ? [selectedPartition] : []}
+        setSelectedPartitions={(partitions) => {
+          setSelectedPartition(partitions[partitions.length - 1]);
+        }}
+        health={createAssetHealthSource(allHealthyRanges)}
+        isDynamic={false}
+        mode="single"
+      />
+      <Box margin={{top: 12}} style={{fontSize: 14, color: '#666'}}>
+        Selected: {selectedPartition || 'None'}
+      </Box>
+    </Box>
+  );
+};
+
+export const DynamicPartitionsWithAddButton = () => {
+  const [selectedPartitions, setSelectedPartitions] = useState<string[]>([]);
+  const [showCreatePartition, setShowCreatePartition] = useState(false);
+
+  return (
+    <Box padding={20} style={{maxWidth: 600}}>
+      <OrdinalPartitionSelector
+        allPartitions={smallPartitionList}
+        selectedPartitions={selectedPartitions}
+        setSelectedPartitions={setSelectedPartitions}
+        health={createAssetHealthSource(allHealthyRanges)}
+        isDynamic={true}
+        setShowCreatePartition={setShowCreatePartition}
+        mode="multiple"
+      />
+      <Box margin={{top: 12}} style={{fontSize: 14, color: '#666'}}>
+        Selected: {selectedPartitions.length > 0 ? selectedPartitions.join(', ') : 'None'}
+      </Box>
+      {showCreatePartition && (
+        <Box
+          margin={{top: 12}}
+          padding={12}
+          style={{
+            background: '#f0f0f0',
+            borderRadius: 4,
+            fontSize: 14,
+          }}
+        >
+          Create partition dialog would appear here
+          <button onClick={() => setShowCreatePartition(false)} style={{marginLeft: 12}}>
+            Close
+          </button>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export const WithRunStatusHealth = () => {
+  const [selectedPartitions, setSelectedPartitions] = useState<string[]>(['2024-01-01']);
+
+  return (
+    <Box padding={20} style={{maxWidth: 600}}>
+      <OrdinalPartitionSelector
+        allPartitions={smallPartitionList}
+        selectedPartitions={selectedPartitions}
+        setSelectedPartitions={setSelectedPartitions}
+        health={createOpHealthSource(opRunStatusMap)}
+        isDynamic={false}
+        mode="multiple"
+      />
+      <Box margin={{top: 12}} style={{fontSize: 14, color: '#666'}}>
+        Selected: {selectedPartitions.join(', ')}
+      </Box>
+      <Box margin={{top: 8}} style={{fontSize: 12, color: '#999'}}>
+        Shows run status dots: Success (green), Failure (red), Started (blue), Not Started (gray)
+      </Box>
+    </Box>
+  );
+};
+
+export const ManyPartitionsSelected = () => {
+  const [selectedPartitions, setSelectedPartitions] = useState<string[]>(
+    mediumPartitionList.slice(0, 15),
+  );
+
+  return (
+    <Box padding={20} style={{maxWidth: 600}}>
+      <OrdinalPartitionSelector
+        allPartitions={mediumPartitionList}
+        selectedPartitions={selectedPartitions}
+        setSelectedPartitions={setSelectedPartitions}
+        health={createAssetHealthSource(mixedHealthRanges)}
+        isDynamic={false}
+        mode="multiple"
+      />
+      <Box margin={{top: 12}} style={{fontSize: 14, color: '#666'}}>
+        When more than 4 partitions are selected, it shows a count instead of listing them
+      </Box>
+    </Box>
+  );
+};
+
+export const LargePartitionList = () => {
+  const [selectedPartitions, setSelectedPartitions] = useState<string[]>([]);
+
+  const largeHealthRanges: Range[] = [
+    {
+      start: {idx: 0, key: 'partition_000'},
+      end: {idx: 29, key: 'partition_029'},
+      value: [AssetPartitionStatus.MATERIALIZED],
+    },
+    {
+      start: {idx: 30, key: 'partition_030'},
+      end: {idx: 59, key: 'partition_059'},
+      value: [AssetPartitionStatus.MISSING],
+    },
+    {
+      start: {idx: 60, key: 'partition_060'},
+      end: {idx: 99, key: 'partition_099'},
+      value: [AssetPartitionStatus.FAILED],
+    },
+  ];
+
+  return (
+    <Box padding={20} style={{maxWidth: 600}}>
+      <OrdinalPartitionSelector
+        allPartitions={largePartitionList}
+        selectedPartitions={selectedPartitions}
+        setSelectedPartitions={setSelectedPartitions}
+        health={createAssetHealthSource(largeHealthRanges)}
+        isDynamic={false}
+        mode="multiple"
+        placeholder="Select from 100 partitions"
+      />
+      <Box margin={{top: 12}} style={{fontSize: 14, color: '#666'}}>
+        Selected: {selectedPartitions.length} partitions
+      </Box>
+    </Box>
+  );
+};
+
+export const CustomPlaceholder = () => {
+  const [selectedPartitions, setSelectedPartitions] = useState<string[]>([]);
+
+  return (
+    <Box padding={20} style={{maxWidth: 600}}>
+      <OrdinalPartitionSelector
+        allPartitions={mediumPartitionList}
+        selectedPartitions={selectedPartitions}
+        setSelectedPartitions={setSelectedPartitions}
+        health={createAssetHealthSource(mixedHealthRanges)}
+        isDynamic={false}
+        mode="multiple"
+        placeholder="Choose date partitions to materialize"
+      />
+      <Box margin={{top: 12}} style={{fontSize: 14, color: '#666'}}>
+        Custom placeholder text example
+      </Box>
+    </Box>
+  );
+};
+
+export const DisabledState = () => {
+  const [selectedPartitions, setSelectedPartitions] = useState<string[]>([
+    '2024-01-01',
+    '2024-01-02',
+  ]);
+
+  return (
+    <Box padding={20} style={{maxWidth: 600}}>
+      <OrdinalPartitionSelector
+        allPartitions={smallPartitionList}
+        selectedPartitions={selectedPartitions}
+        setSelectedPartitions={setSelectedPartitions}
+        health={createAssetHealthSource(allHealthyRanges)}
+        isDynamic={false}
+        mode="multiple"
+        disabled={true}
+      />
+      <Box margin={{top: 12}} style={{fontSize: 14, color: '#666'}}>
+        Disabled state - selector is not interactive
+      </Box>
+    </Box>
+  );
+};
+
+export const EmptyPartitionList = () => {
+  const [selectedPartitions, setSelectedPartitions] = useState<string[]>([]);
+
+  return (
+    <Box padding={20} style={{maxWidth: 600}}>
+      <OrdinalPartitionSelector
+        allPartitions={[]}
+        selectedPartitions={selectedPartitions}
+        setSelectedPartitions={setSelectedPartitions}
+        health={createAssetHealthSource([])}
+        isDynamic={true}
+        setShowCreatePartition={() => {}}
+        mode="multiple"
+      />
+      <Box margin={{top: 12}} style={{fontSize: 14, color: '#666'}}>
+        No partitions available - shows &ldquo;No matching partitions found&rdquo; in dropdown
+      </Box>
+    </Box>
+  );
+};
+
+export const WithSearchFiltering = () => {
+  const [selectedPartitions, setSelectedPartitions] = useState<string[]>([]);
+
+  return (
+    <Box padding={20} style={{maxWidth: 600}}>
+      <OrdinalPartitionSelector
+        allPartitions={largePartitionList}
+        selectedPartitions={selectedPartitions}
+        setSelectedPartitions={setSelectedPartitions}
+        health={createAssetHealthSource([
+          {
+            start: {idx: 0, key: 'partition_000'},
+            end: {
+              idx: largePartitionList.length - 1,
+              key: 'partition_099',
+            },
+            value: [AssetPartitionStatus.MATERIALIZED],
+          },
+        ])}
+        isDynamic={false}
+        mode="multiple"
+      />
+      <Box margin={{top: 12}} style={{fontSize: 14, color: '#666'}}>
+        Click to open and try the search/filter functionality with 100 partitions
+      </Box>
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogFilterSelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogFilterSelect.tsx
@@ -5,7 +5,7 @@ import {
   Colors,
   Icon,
   Menu,
-  MenuItem,
+  MenuItemForInteractiveContent,
   Popover,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
@@ -51,34 +51,26 @@ export const LogFilterSelect = ({options, onSetFilter}: Props) => {
             const optionForLevel = options[level as keyof typeof options];
             const {label, count, enabled} = optionForLevel;
             return (
-              <MenuItem
-                key={level}
-                tagName="div"
-                shouldDismissPopover={false}
-                text={
-                  <Box flex={{direction: 'row', alignItems: 'center'}} padding={{horizontal: 2}}>
-                    <MenuCheckbox
-                      id={`menu-check-${level}`}
-                      checked={enabled}
-                      size="small"
-                      onChange={onChange(level)}
-                      label={
-                        <Box
-                          flex={{
-                            direction: 'row',
-                            justifyContent: 'space-between',
-                            alignItems: 'center',
-                          }}
-                          style={{flex: 1}}
-                        >
-                          <div>{label}</div>
-                          <div style={{color: Colors.textLight()}}>{compactNumber(count)}</div>
-                        </Box>
-                      }
-                    />
-                  </Box>
-                }
-              />
+              <MenuItemForInteractiveContent key={level}>
+                <MenuCheckbox
+                  id={`menu-check-${level}`}
+                  checked={enabled}
+                  onChange={onChange(level)}
+                  label={
+                    <Box
+                      flex={{
+                        direction: 'row',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                      }}
+                      style={{flex: 1}}
+                    >
+                      <div>{label}</div>
+                      <div style={{color: Colors.textLight()}}>{compactNumber(count)}</div>
+                    </Box>
+                  }
+                />
+              </MenuItemForInteractiveContent>
             );
           })}
         </Menu>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
@@ -192,7 +192,6 @@ export const ComputeLogToolbar = ({
                     onClick={(e) => itemProps.handleClick(e)}
                     text={text}
                     key={item}
-                    title={text}
                   />
                 );
               }}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
@@ -125,7 +125,6 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
             <Menu>
               <AISummaryForRunMenuItem run={run} />
               <MenuItem
-                tagName="button"
                 style={{minWidth: 200}}
                 text={loading ? 'Loading configuration...' : 'View configuration...'}
                 disabled={!runConfigYaml}
@@ -133,7 +132,6 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
                 onClick={() => setVisibleDialog('config')}
               />
               <MenuItem
-                tagName="button"
                 text={
                   <div style={{display: 'contents'}}>
                     View all tags
@@ -158,7 +156,6 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
                   to={getPipelineSnapshotLink(run.pipelineName, run.pipelineSnapshotId)}
                 >
                   <MenuItem
-                    tagName="button"
                     icon="history"
                     text="View snapshot"
                     onClick={() => setVisibleDialog('tags')}
@@ -184,7 +181,6 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
                   position="left"
                 >
                   <MenuItem
-                    tagName="button"
                     text="Re-execute"
                     disabled={reexecutionDisabledState.disabled}
                     icon="refresh"
@@ -195,7 +191,6 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
                 </Tooltip>
                 {isFinished || !run.hasTerminatePermission ? null : (
                   <MenuItem
-                    tagName="button"
                     icon="cancel"
                     text="Terminate"
                     onClick={() => setVisibleDialog('terminate')}
@@ -211,7 +206,6 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
               />
               {runMetricsEnabled && RunMetricsDialog ? (
                 <MenuItem
-                  tagName="button"
                   icon="asset_plot"
                   text="View container metrics"
                   intent="none"
@@ -220,7 +214,6 @@ export const RunActionsMenu = React.memo(({run, onAddTag, anchorLabel}: Props) =
               ) : null}
               {run.hasDeletePermission ? (
                 <MenuItem
-                  tagName="button"
                   icon="delete"
                   text="Delete"
                   intent="danger"

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
@@ -110,7 +110,6 @@ export const RunHeaderActions = ({run, isJob}: {run: RunFragment; isJob: boolean
                     </Tooltip>
                     {run.status === RunStatus.QUEUED ? (
                       <MenuItem
-                        tagName="button"
                         icon="history_toggle_off"
                         text="View queue criteria"
                         intent="none"
@@ -119,7 +118,6 @@ export const RunHeaderActions = ({run, isJob}: {run: RunFragment; isJob: boolean
                     ) : null}
                     {runMetricsEnabled && RunMetricsDialog ? (
                       <MenuItem
-                        tagName="button"
                         icon="asset_plot"
                         text="View container metrics"
                         intent="none"

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunActionsMenu.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunActionsMenu.test.tsx
@@ -14,6 +14,7 @@ import {
 describe('RunActionsMenu', () => {
   describe('Permissions', () => {
     it('renders menu when open', async () => {
+      const user = userEvent.setup();
       render(
         <MockedProvider
           mocks={[
@@ -32,16 +33,17 @@ describe('RunActionsMenu', () => {
       const button = await screen.findByRole('button');
       expect(button).toBeVisible();
 
-      await userEvent.click(button);
+      await user.click(button);
 
-      expect(screen.queryByRole('menuitem', {name: /view configuration/i})).toBeVisible();
-      expect(screen.queryByRole('link', {name: /open in launchpad/i})).toBeVisible();
-      expect(screen.queryByRole('menuitem', {name: /re\-execute/i})).toBeVisible();
-      expect(screen.queryByRole('menuitem', {name: /download debug file/i})).toBeVisible();
-      expect(screen.queryByRole('menuitem', {name: /delete/i})).toBeVisible();
+      expect(await screen.findByRole('menuitem', {name: /view configuration/i})).toBeVisible();
+      expect(await screen.findByRole('menuitem', {name: /open in launchpad/i})).toBeVisible();
+      expect(await screen.findByRole('menuitem', {name: /re\-execute/i})).toBeVisible();
+      expect(await screen.findByRole('menuitem', {name: /download debug file/i})).toBeVisible();
+      expect(await screen.findByRole('menuitem', {name: /delete/i})).toBeVisible();
     });
 
     it('disables re-execution if no permission', async () => {
+      const user = userEvent.setup();
       render(
         <MockedProvider
           mocks={[
@@ -60,14 +62,14 @@ describe('RunActionsMenu', () => {
       const button = await screen.findByRole('button');
       expect(button).toBeVisible();
 
-      await userEvent.click(button);
+      await user.click(button);
 
       const reExecutionButton = await screen.findByRole('menuitem', {
         name: /re\-execute/i,
       });
 
       // Blueprint doesn't actually set `disabled` on the button element.
-      expect(reExecutionButton.classList.contains('bp5-disabled')).toBe(true);
+      expect(reExecutionButton).toBeDisabled();
     });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/SchedulesNextTicks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/SchedulesNextTicks.tsx
@@ -313,7 +313,6 @@ const NextTickMenuItems = ({
     <MenuItem
       text={`View ${evaluationResult.runRequests.length} run requests...`}
       icon="edit"
-      target="_blank"
       onClick={() => onItemOpen(true)}
     />
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/FilterDropdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/FilterDropdown.tsx
@@ -413,7 +413,7 @@ type FilterDropdownMenuItemProps = React.ComponentProps<typeof MenuItem> & {
   index: number;
 };
 const FilterDropdownMenuItem = React.memo(
-  ({menuKey, index, ...rest}: FilterDropdownMenuItemProps) => {
+  ({menuKey, index, ref: _ref, ...rest}: FilterDropdownMenuItemProps) => {
     const divRef = React.useRef<HTMLDivElement | null>(null);
     React.useLayoutEffect(() => {
       if (rest.active) {

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/__tests__/FilterDropdown.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/__tests__/FilterDropdown.test.tsx
@@ -46,7 +46,7 @@ afterAll(() => {
 });
 
 describe('FilterDropdown', () => {
-  test('displays filter categories initially', () => {
+  it('displays filter categories initially', () => {
     render(
       <FilterDropdown
         filters={mockFilters}
@@ -58,7 +58,7 @@ describe('FilterDropdown', () => {
     expect(screen.getByText('Status')).toBeInTheDocument();
   });
 
-  test('searches and displays matching filters', async () => {
+  it('searches and displays matching filters', async () => {
     render(
       <FilterDropdown
         filters={mockFilters}
@@ -76,7 +76,7 @@ describe('FilterDropdown', () => {
     await waitFor(() => expect(mockFilters[1]!.getResults).toHaveBeenCalledWith('type'));
   });
 
-  test('displays no results when no filters match', async () => {
+  it('displays no results when no filters match', async () => {
     render(
       <FilterDropdown
         filters={mockFilters}
@@ -91,7 +91,7 @@ describe('FilterDropdown', () => {
 });
 
 describe('FilterDropdownButton', () => {
-  test('opens and closes the dropdown on click', async () => {
+  it('opens and closes the dropdown on click', async () => {
     render(<FilterDropdownButton filters={mockFilters} />);
     const button = screen.getByRole('button');
     await userEvent.click(button);
@@ -104,7 +104,7 @@ describe('FilterDropdownButton', () => {
     });
   });
 
-  test('closes the dropdown when clicking outside', async () => {
+  it('closes the dropdown when clicking outside', async () => {
     render(<FilterDropdownButton filters={mockFilters} />);
     const button = screen.getByRole('button');
     await userEvent.click(button);
@@ -120,76 +120,90 @@ describe('FilterDropdownButton', () => {
 
 describe('FilterDropdown Accessibility', () => {
   const testKeyboardNavigation = async (nextKey: any, prevKey: any, enterKey: any) => {
+    const user = userEvent.setup();
     render(<FilterDropdownButton filters={mockFilters} />);
 
-    await userEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(screen.getByRole('menu')).toBeInTheDocument();
 
     const input = screen.getByLabelText('Search filters');
     expect(input).toHaveFocus();
 
-    await userEvent.keyboard(nextKey);
+    await user.keyboard(nextKey);
     await waitFor(() => {
-      expect(screen.getByText('Type').closest('a')).toHaveClass('bp5-active');
+      expect(screen.getByRole('menuitem', {name: /type/i}).getAttribute('data-active')).toBe(
+        'true',
+      );
     });
 
-    await userEvent.keyboard(nextKey);
+    await user.keyboard(nextKey);
     await waitFor(() => {
-      expect(screen.getByText('Status').closest('a')).toHaveClass('bp5-active');
+      expect(screen.getByRole('menuitem', {name: /status/i}).getAttribute('data-active')).toBe(
+        'true',
+      );
     });
 
-    await userEvent.keyboard(prevKey);
+    await user.keyboard(prevKey);
     await waitFor(() => {
-      expect(screen.getByText('Type').closest('a')).toHaveClass('bp5-active');
+      expect(screen.getByRole('menuitem', {name: /type/i}).getAttribute('data-active')).toBe(
+        'true',
+      );
     });
 
-    await userEvent.keyboard(nextKey);
+    await user.keyboard(nextKey);
     await waitFor(() => {
-      expect(screen.getByText('Status').closest('a')).toHaveClass('bp5-active');
+      expect(screen.getByRole('menuitem', {name: /status/i}).getAttribute('data-active')).toBe(
+        'true',
+      );
     });
 
-    await userEvent.keyboard(nextKey);
+    await user.keyboard(nextKey);
     expect(input).toHaveFocus();
 
-    await userEvent.keyboard(nextKey);
+    await user.keyboard(nextKey);
     await waitFor(() => {
-      expect(screen.getByText('Type').closest('a')).toHaveClass('bp5-active');
+      expect(screen.getByRole('menuitem', {name: /type/i}).getAttribute('data-active')).toBe(
+        'true',
+      );
     });
 
-    await userEvent.keyboard(nextKey);
+    await user.keyboard(nextKey);
     await waitFor(() => {
-      expect(screen.getByText('Status').closest('a')).toHaveClass('bp5-active');
+      expect(screen.getByRole('menuitem', {name: /status/i}).getAttribute('data-active')).toBe(
+        'true',
+      );
     });
 
-    await userEvent.keyboard(enterKey);
+    await user.keyboard(enterKey);
 
     await waitFor(() => {
       expect(input).toHaveFocus();
     });
 
-    await userEvent.keyboard(nextKey);
-    await userEvent.keyboard(nextKey);
+    await user.keyboard(nextKey);
+    await user.keyboard(nextKey);
 
-    expect(screen.getByText('Inactive').closest('a')).toHaveClass('bp5-active');
-    await userEvent.keyboard(enterKey);
+    expect(screen.getByRole('menuitem', {name: /inactive/i}).getAttribute('data-active')).toBe(
+      'true',
+    );
+    await user.keyboard(enterKey);
 
     await waitFor(() => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(mockFilters[1]!.onSelect).toHaveBeenCalled();
+      expect(mockFilters[1]?.onSelect).toHaveBeenCalled();
     });
   };
 
   // eslint-disable-next-line jest/expect-expect
-  test('keyboard navigation and selection with arrow keys', async () => {
+  it('keyboard navigation and selection with arrow keys', async () => {
     await testKeyboardNavigation('{ArrowDown}', '{ArrowUp}', '{Enter}');
   });
 
   // eslint-disable-next-line jest/expect-expect
-  test('keyboard navigation and selection with Tab and Shift+Tab keys', async () => {
+  it('keyboard navigation and selection with Tab and Shift+Tab keys', async () => {
     await testKeyboardNavigation('{Tab}', '{Shift}{Tab}', ' ');
   });
 
-  test('escape key behavior', async () => {
+  it('escape key behavior', async () => {
     render(<FilterDropdownButton filters={mockFilters} />);
 
     await userEvent.click(screen.getByRole('button'));

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/MenuLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/MenuLink.tsx
@@ -1,66 +1,38 @@
-import {Box, Colors, CommonMenuItemProps, MenuItem, iconWithColor} from '@dagster-io/ui-components';
-import * as React from 'react';
+import {
+  CommonMenuItemProps,
+  MenuExternalLink,
+  MenuItem,
+  MenuItemContents,
+} from '@dagster-io/ui-components';
 import {Link, LinkProps} from 'react-router-dom';
-import styled from 'styled-components';
+
+import styles from './css/MenuLink.module.css';
 
 interface MenuLinkProps
   extends CommonMenuItemProps,
-    Omit<React.ComponentProps<typeof MenuItem>, 'icon' | 'onClick' | 'onFocus' | 'target' | 'ref'>,
-    LinkProps {}
+    Omit<
+      React.ComponentProps<typeof MenuExternalLink>,
+      'onClick' | 'onFocus' | 'target' | 'ref' | 'href' | 'download'
+    >,
+    LinkProps {
+  disabled?: boolean;
+}
 
 /**
  * If you want to use a menu item as a link, use `MenuLink` and provide a `to` prop.
  */
 export const MenuLink = (props: MenuLinkProps) => {
-  const {icon, intent, text, disabled, ...rest} = props;
+  const {icon, intent = 'none', disabled = false, text, to, ...rest} = props;
 
   if (disabled) {
-    return <MenuItem disabled icon={icon} intent={intent} text={text} />;
+    return <MenuItem icon={icon} text={text} disabled />;
   }
+
   return (
-    <StyledMenuLink {...rest}>
-      <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-        {iconWithColor(icon, intent)}
-        <div>{text}</div>
-      </Box>
-    </StyledMenuLink>
+    <li role="none" className="popover-dismiss" style={{listStyle: 'none'}}>
+      <Link {...rest} to={to} role="menuitem" tabIndex={0} className={styles.menuLink}>
+        <MenuItemContents icon={icon} intent={intent} text={text} />
+      </Link>
+    </li>
   );
 };
-
-const StyledMenuLink = styled(Link)`
-  text-decoration: none;
-
-  border-radius: 4px;
-  display: block;
-  line-height: 20px;
-  padding: 6px 8px 6px 12px;
-  transition:
-    background-color 50ms,
-    box-shadow 150ms;
-  align-items: flex-start;
-  user-select: none;
-
-  /**
-   * Use margin instead of align-items: center because the contents of the menu item may wrap 
-   * in unusual circumstances.
-   */
-  .iconGlobal {
-    margin-top: 2px;
-  }
-
-  .iconGlobal:first-child {
-    margin-left: -4px;
-  }
-
-  &&&:link,
-  &&&:visited,
-  &&&:hover,
-  &&&:active {
-    color: ${Colors.textDefault()};
-    text-decoration: none;
-  }
-
-  &&&:hover {
-    background: ${Colors.backgroundLighter()};
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/css/MenuLink.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/css/MenuLink.module.css
@@ -1,0 +1,6 @@
+.menuLink:link,
+.menuLink:visited,
+.menuLink:hover,
+.menuLink:active {
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary & Motivation

Corresponds to internal https://github.com/dagster-io/internal/pull/19884.

This PR replaces the Blueprint Menu component with a custom implementation that uses CSS modules instead of styled-components. The new implementation provides better accessibility, more consistent styling, and improved performance.

## How I Tested These Changes

- Verified all menu functionality in Storybook
- Ran existing tests to ensure they pass with the new implementation
- Manually tested dropdown menus throughout the application

## Changelog

Replaced Blueprint Menu component with a custom implementation using CSS modules for better accessibility and performance.