### PR TITLE
[dg] Allow region to be specified during login

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/login.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/login.py
@@ -1,4 +1,5 @@
 import webbrowser
+from typing import Optional
 
 import click
 from dagster_dg_core.utils import DgClickCommand
@@ -8,15 +9,30 @@ from dagster_shared.plus.config import DagsterPlusCliConfig
 from dagster_dg_cli.utils.plus.gql import FULL_DEPLOYMENTS_QUERY
 from dagster_dg_cli.utils.plus.gql_client import DagsterPlusGraphQLClient
 
+EU_DAGSTER_CLOUD_URL = "https://eu.dagster.cloud"
+
 
 @click.command(name="login", cls=DgClickCommand)
+@click.option(
+    "--region",
+    type=click.Choice(["us", "eu"]),
+    default=None,
+    help="Dagster Cloud region to login to. Use 'eu' for European region.",
+)
 @cli_telemetry_wrapper
-def login_command() -> None:
+def login_command(region: Optional[str]) -> None:
     """Login to Dagster Plus."""
     # Import login server only when the command is actually used
     from dagster_shared.plus.login_server import start_login_server
 
-    org_url = DagsterPlusCliConfig.get().url if DagsterPlusCliConfig.exists() else None
+    # Determine the base URL based on region
+    if region == "eu":
+        org_url = EU_DAGSTER_CLOUD_URL
+    elif DagsterPlusCliConfig.exists():
+        org_url = DagsterPlusCliConfig.get().url
+    else:
+        org_url = None
+
     server, url = start_login_server(org_url)
 
     try:


### PR DESCRIPTION
## Summary & Motivation

We need to allow users to use the dg plus login command if they're in the eu region, but right now we direct people to the main us site for initial auth

## How I Tested These Changes

## Changelog

`dg plus login` now supports a `region` flag for eu-based users: `dg plus login --region eu`
