### PR TITLE
Better handling for health check failures in StepDelegatingExecutor

### DIFF
--- a/python_modules/dagster/dagster/_core/executor/base.py
+++ b/python_modules/dagster/dagster/_core/executor/base.py
@@ -79,12 +79,12 @@ class Executor(ABC):
         else:
             return original_event
 
-    def get_failure_or_retry_event_after_error(
+    def log_failure_or_retry_event_after_error(
         self,
         step_context: "IStepContext",
         err_info: SerializableErrorInfo,
         known_state: "KnownExecutionState",
-    ):
+    ) -> "DagsterEvent":
         from dagster._core.events import DagsterEvent
 
         # determine the retry policy for the step if needed

--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -285,7 +285,7 @@ class MultiprocessExecutor(Executor):
                                 )
 
                                 failure_or_retry_event = (
-                                    self.get_failure_or_retry_event_after_error(
+                                    self.log_failure_or_retry_event_after_error(
                                         step_context,
                                         event_or_none.engine_event_data.error,
                                         active_execution.get_known_state(),
@@ -309,7 +309,7 @@ class MultiprocessExecutor(Executor):
                                 ),
                                 EngineEventData.engine_error(serializable_error),
                             )
-                            failure_or_retry_event = self.get_failure_or_retry_event_after_error(
+                            failure_or_retry_event = self.log_failure_or_retry_event_after_error(
                                 step_context, serializable_error, active_execution.get_known_state()
                             )
 


### PR DESCRIPTION
## Summary & Motivation
Before, if a health check failure failed due to some transient issue in the health check itself, it was possible for the step to keep going even after the run fails. Now, the executor will terminate the step when this occurs to ensure that if the run stops, each of its constituent steps will also stop. Additionally, if the step is set up to retry, retry the step when this occurs rather than always failing it.

## How I Tested These Changes
New test cases


## Changelog
Fixed an issue where a health check failure while using the k8s_job_executor could result in a step continuing to run after the run failed.
