### PR TITLE
Don't fail a step when check_step_health raises an exception

### DIFF
--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -369,40 +369,14 @@ class StepDelegatingExecutor(Executor):
                                         )
 
                                 except Exception:
-                                    serializable_error = serializable_error_info_from_exc_info(
-                                        sys.exc_info()
-                                    )
-
                                     DagsterEvent.engine_event(
                                         step_context,
-                                        f"Exception while running health check for step {step.key} - terminating and failing the step",
-                                        EngineEventData(error=serializable_error),
-                                    )
-
-                                    # Terminate the step after health check exception
-                                    try:
-                                        list(
-                                            self._step_handler.terminate_step(
-                                                self._get_step_handler_context(
-                                                    plan_context, [step], active_execution
-                                                )
+                                        f"Error while checking health for step {step.key}",
+                                        EngineEventData(
+                                            error=serializable_error_info_from_exc_info(
+                                                sys.exc_info()
                                             )
-                                        )
-                                    except Exception:
-                                        DagsterEvent.engine_event(
-                                            step_context,
-                                            f"Exception while terminating step {step.key} after health check exception",
-                                            EngineEventData(
-                                                error=serializable_error_info_from_exc_info(
-                                                    sys.exc_info()
-                                                )
-                                            ),
-                                        )
-
-                                    self.log_failure_or_retry_event_after_error(
-                                        step_context,
-                                        serializable_error,
-                                        active_execution.get_known_state(),
+                                        ),
                                     )
 
                         if self._max_concurrent is not None:

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_executor.py
@@ -287,7 +287,7 @@ class DockerStepHandler(StepHandler):
             return CheckStepHealthResult.healthy()
 
         try:
-            container_info = container.wait(timeout=0.1)
+            container_info = container.wait(timeout=5)
         except Exception as e:
             raise Exception(
                 f"Container status is {container.status}. Raised exception attempting to get its"


### PR DESCRIPTION
## Summary & Motivation
Transient issues fetching job status should not fail the step - instead, log a warning and carry on.

## How I Tested These Changes
New test cases
Verify that all current check_step_health implementations will fail if the object does not exist at all

## Changelog
Fixed an issue where a step would fail when a transient issue caused a step health check to fail when using the k8s_job_executor.
