### PR TITLE
[dagster-fivetran] Add exponential backoff option to FivetranClient/FivetranWorkspace

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_example
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_example
@@ -7,6 +7,7 @@ attributes:
     snapshot_path: "example_string"
     request_max_retries: 1
     request_retry_delay: 1.0
+    request_backoff_factor: 1.0
     disable_schedule_on_trigger: true
   connector_selector:
     by_name:

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_output.yaml.template
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_output.yaml.template
@@ -8,6 +8,7 @@ attributes:  # Optional: Component attributes
     snapshot_path: <string>  # Optional: Path to a snapshot file to load Fivetran data from,rather than fetching it from the Fivetran API.
     request_max_retries: <integer>  # Optional: The maximum number of times requests to the Fivetran API should be retried before failing.
     request_retry_delay: <number>  # Optional: Time (in seconds) to wait between each request retry.
+    request_backoff_factor: <number>  # Optional: Multiplier applied to the delay between retries. Set to >1 for exponential backoff.
     disable_schedule_on_trigger: <boolean>  # Optional: Whether to disable the schedule of a connector when it is synchronized using this resource.Defaults to True.
   connector_selector:  # Optional: 
     by_name:  # Required: List of string items
@@ -43,6 +44,7 @@ attributes:
     snapshot_path: "example_string"
     request_max_retries: 1
     request_retry_delay: 1.0
+    request_backoff_factor: 1.0
     disable_schedule_on_trigger: true
   connector_selector:
     by_name:

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_schema
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/yaml_template/test_data/account/expected_schema
@@ -8,6 +8,7 @@ attributes:  # Optional: Attributes details
     snapshot_path: <string>  # Optional: Path to a snapshot file to load Fivetran data from,rather than fetching it from the Fivetran API.
     request_max_retries: <integer>  # Optional: The maximum number of times requests to the Fivetran API should be retried before failing.
     request_retry_delay: <number>  # Optional: Time (in seconds) to wait between each request retry.
+    request_backoff_factor: <number>  # Optional: Multiplier applied to the delay between retries. Set to >1 for exponential backoff.
     disable_schedule_on_trigger: <boolean>  # Optional: Whether to disable the schedule of a connector when it is synchronized using this resource.Defaults to True.
   connector_selector:  # Optional: 
     # Choose one of the following types:


### PR DESCRIPTION
## Summary & Motivation

see changelog

## How I Tested These Changes

## Changelog

[dagster-fivetrna] FivetranWorkspace now supports a `request_backoff_factor` parameter for enabling exponential backoff on request failures.
