### PR TITLE
toys asset with custom metadata

### DIFF
--- a/python_modules/dagster-test/dagster_test/toys/alert_helpers.py
+++ b/python_modules/dagster-test/dagster_test/toys/alert_helpers.py
@@ -1,5 +1,6 @@
 import random
 import time
+from typing import Any
 
 import dagster as dg
 
@@ -40,5 +41,14 @@ def schema_change_asset(context):
     )
 
 
+class CustomMetadataConfig(dg.Config):
+    custom_metadata: dict[str, Any]
+
+
+@dg.asset
+def custom_metadata_asset(config: CustomMetadataConfig):
+    return dg.MaterializeResult(metadata={**config.custom_metadata})
+
+
 def get_assets_and_checks():
-    return [schema_change_asset]
+    return [schema_change_asset, custom_metadata_asset]


### PR DESCRIPTION
New asset in `toys` repo that lets you emit custom metadata. This will help with asset metrics alert testing because we can emit custom metadata like row_count on demand 