### PR TITLE
Fix extracting table name from assets with otherwise invalid metadata

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/remote_asset_graph.py
@@ -520,7 +520,7 @@ class RemoteAssetGraph(BaseAssetGraph[TRemoteAssetNode], ABC, Generic[TRemoteAss
 
         by_table_name = defaultdict(set)
         for node in self.asset_nodes:
-            normalized_table_name = TableMetadataSet.extract(node.metadata).normalized_table_name
+            normalized_table_name = TableMetadataSet.extract_normalized_table_name(node.metadata)
             if normalized_table_name:
                 by_table_name[normalized_table_name.lower()].add(node.key)
 
@@ -547,7 +547,7 @@ class RemoteAssetGraph(BaseAssetGraph[TRemoteAssetNode], ABC, Generic[TRemoteAss
         from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
 
         input_node = self.get(asset_key)
-        input_table_name = TableMetadataSet.extract(input_node.metadata).normalized_table_name
+        input_table_name = TableMetadataSet.extract_normalized_table_name(input_node.metadata)
 
         if not input_table_name:
             return set()

--- a/python_modules/dagster/dagster/_core/definitions/metadata/metadata_set.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/metadata_set.py
@@ -197,9 +197,20 @@ class TableMetadataSet(NamespacedMetadataSet):
     def current_key_by_legacy_key(cls) -> Mapping[str, str]:
         return {"relation_identifier": "table_name"}
 
-    @property
-    def normalized_table_name(self) -> Optional[str]:
-        return self.table_name.lower() if self.table_name else None
+    @classmethod
+    def extract_normalized_table_name(cls, metadata: Mapping[str, Any]) -> Optional[str]:
+        from pydantic import ValidationError
+
+        metadata_subset = {
+            key: metadata[key]
+            for key in {"dagster/table_name", "dagster/relation_identifier"}
+            if key in metadata
+        }
+        try:
+            table_name = TableMetadataSet.extract(metadata_subset).table_name
+            return table_name.lower() if table_name else None
+        except ValidationError:
+            return None
 
 
 class UriMetadataSet(NamespacedMetadataSet):


### PR DESCRIPTION
## Summary & Motivation
Pydantic validation on other fields was preventing us from extracting the table name from assets in certain cases. Use a helper method that:
- only applies the validation to the subset of the dict that we actually care about (might be some small perf benefits here too)
- doesn't die on a validation error on that field, just returns None

## How I Tested These Changes
New test cases

