### PR TITLE
[ui] Fix Asset catalog in OSS

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetRecentUpdatesTrend.tsx
@@ -19,21 +19,12 @@ export const AssetRecentUpdatesTrend = React.memo(({latestInfo, events}: Props) 
   const states = allItems.map((event, index) => {
     const opacity = calculatePezOpacity(index, 5);
 
-    const key = () => {
-      switch (event?.__typename) {
-        case 'AssetLatestInfo':
-          return event.latestRun?.id ?? index;
-        case 'FailedToMaterializeEvent':
-        case 'ObservationEvent':
-        case 'MaterializationEvent':
-          return event.runId;
-        default:
-          return index;
-      }
-    };
+    // Not sufficient to use run ID here, since there could be multiple events for the
+    // same run.
+    const key = event?.timestamp ?? index;
 
     if (!event) {
-      return <PezItem key={key()} opacity={opacity} color={Colors.backgroundDisabled()} />;
+      return <PezItem key={key} opacity={opacity} color={Colors.backgroundDisabled()} />;
     }
 
     const color = () => {
@@ -48,7 +39,7 @@ export const AssetRecentUpdatesTrend = React.memo(({latestInfo, events}: Props) 
     };
 
     return (
-      <EventPopover key={key()} event={event}>
+      <EventPopover key={key} event={event}>
         <PezItem opacity={opacity} color={color()} />
       </EventPopover>
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AssetCatalogTableV2.tsx
@@ -20,6 +20,7 @@ import {
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
+import {assetHealthEnabled} from 'shared/app/assetHealthEnabled.oss';
 import {CreateCatalogViewButton} from 'shared/assets/CreateCatalogViewButton.oss';
 import {AssetCatalogAlerts} from 'shared/assets/catalog/AssetCatalogAlerts.oss';
 import {AssetCatalogTabs} from 'shared/assets/catalog/AssetCatalogTabs.oss';
@@ -62,6 +63,7 @@ export const AssetCatalogTableV2 = React.memo(() => {
   useBlockTraceUntilTrue('useAllAssets', !assetsLoading);
   const trackEvent = useTrackEvent();
 
+  const hasAssetHealth = assetHealthEnabled();
   const {favorites, loading: favoritesLoading} = useFavoriteAssets();
 
   const penultimateAssets = useMemo(() => {
@@ -99,8 +101,8 @@ export const AssetCatalogTableV2 = React.memo(() => {
   });
 
   const healthDataLoading = useMemo(() => {
-    return Object.values(liveDataByNode).length !== filtered.length;
-  }, [liveDataByNode, filtered]);
+    return hasAssetHealth && Object.values(liveDataByNode).length !== filtered.length;
+  }, [liveDataByNode, filtered, hasAssetHealth]);
 
   const {assetsByAssetKey: unfilteredAssetsByAssetKey} = useAllAssets();
   const filteredKeys = useMemo(

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AttributeStatusHeaderRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/AttributeStatusHeaderRow.tsx
@@ -1,5 +1,6 @@
 import {Icon, IconName} from '@dagster-io/ui-components';
 import React from 'react';
+import {assetHealthEnabled} from 'shared/app/assetHealthEnabled.oss';
 
 import {AssetCatalogTableGroupHeaderRow} from './AssetCatalogTableGroupHeaderRow';
 
@@ -57,8 +58,7 @@ export const ASSET_HEALTH_GROUP_BY_META: Record<
   },
 };
 
-export const GROUP_BY = [
-  AssetHealthGroupBy.health_status,
+const SHARED_GROUP_BY: AssetHealthGroupBy[] = [
   AssetHealthGroupBy.freshness_status,
   AssetHealthGroupBy.check_status,
   AssetHealthGroupBy.materialization_status,
@@ -68,6 +68,10 @@ export const GROUP_BY = [
   AssetHealthGroupBy.kind,
   AssetHealthGroupBy.tags,
 ] as const;
+
+export const GROUP_BY = assetHealthEnabled()
+  ? [AssetHealthGroupBy.health_status, ...SHARED_GROUP_BY]
+  : SHARED_GROUP_BY;
 
 export const GROUP_BY_ITEMS = GROUP_BY.map((key) => ({
   key,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/useAssetCatalogGroupAndSortBy.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/catalog/useAssetCatalogGroupAndSortBy.tsx
@@ -1,5 +1,6 @@
 import {ParsedQs} from 'qs';
 import {useCallback, useMemo} from 'react';
+import {assetHealthEnabled} from 'shared/app/assetHealthEnabled.oss';
 
 import {Grouped} from './AssetCatalogV2VirtualizedTable';
 import {
@@ -81,7 +82,7 @@ export const useAssetCatalogGroupAndSortBy = ({
       if (qs.groupBy && GROUP_BY.includes(qs.groupBy as AssetHealthGroupBy)) {
         return qs.groupBy as AssetHealthGroupBy;
       }
-      return AssetHealthGroupBy.health_status;
+      return assetHealthEnabled() ? AssetHealthGroupBy.health_status : AssetHealthGroupBy.group;
     }, []),
     encode: useCallback((b: AssetHealthGroupBy) => ({groupBy: b}), []),
   });


### PR DESCRIPTION
## Summary & Motivation

The asset catalog is failing to load in OSS. This is because we have places in catalog code that are assuming that asset health is present, which in OSS it is not.

If no asset health is available:

- Don't show asset health as loading
- Use `group` as the group-by value.
- Don't include asset health in the group-by list at all.

I also fixed a duplicate-key warning on the asset trend pez component.

## How I Tested These Changes

dagster dev, view catalog. Verify that it loads and renders assets correctly, and that group-by behavior is correct.

## Changelog

[ui] Fix asset catalog loading and rendering.
