### PR TITLE
[ui] Restore observeEnabled checks for Cloud behavior

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/observeEnabled.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/observeEnabled.oss.tsx
@@ -1,0 +1,3 @@
+export const observeEnabled = (): boolean => {
+  return false;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -15,6 +15,7 @@ import uniq from 'lodash/uniq';
 import without from 'lodash/without';
 import * as React from 'react';
 import {useCallback, useMemo, useRef, useState} from 'react';
+import {observeEnabled} from 'shared/app/observeEnabled.oss';
 import {AssetSelectionInput} from 'shared/asset-selection/input/AssetSelectionInput.oss';
 import {CreateCatalogViewButton} from 'shared/assets/CreateCatalogViewButton.oss';
 import {useCatalogExtraDropdownOptions} from 'shared/assets/catalog/useCatalogExtraDropdownOptions.oss';
@@ -765,7 +766,9 @@ const AssetGraphExplorerWithData = ({
                       />
                     </Tooltip>
                   )}
-                  {viewType !== AssetGraphViewType.CATALOG ? toggleFullScreenButton : null}
+                  {viewType !== AssetGraphViewType.CATALOG && observeEnabled()
+                    ? toggleFullScreenButton
+                    : null}
                   {viewType === AssetGraphViewType.CATALOG ? (
                     <>
                       {toggleFullScreenButton}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
@@ -4,6 +4,7 @@ import {Box, Colors, Icon, MiddleTruncate, PageHeader, Subtitle1} from '@dagster
 import * as React from 'react';
 import {useContext} from 'react';
 import {Link, useHistory, useLocation} from 'react-router-dom';
+import {observeEnabled} from 'shared/app/observeEnabled.oss';
 import {
   getAssetSelectionQueryString,
   useAssetSelectionState,
@@ -43,7 +44,10 @@ export const AssetPageHeader = ({
     const keyPathItems: BreadcrumbProps[] = [];
     assetKey.path.reduce((accum: string, elem: string) => {
       const nextAccum = `${accum ? `${accum}/` : ''}${encodeURIComponent(elem)}`;
-      const href = `/assets?asset-selection=key:"${nextAccum}/*"`;
+      let href = `/assets/${nextAccum}?view=folder`;
+      if (observeEnabled()) {
+        href = `/assets?asset-selection=key:"${nextAccum}/*"`;
+      }
       keyPathItems.push({text: elem, href});
       return nextAccum;
     }, '');

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -4,6 +4,8 @@ import {Alert, Box, ErrorBoundary, Spinner, Tag} from '@dagster-io/ui-components
 import React, {useContext, useEffect, useMemo} from 'react';
 import {Link, Redirect, useLocation, useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
+import {observeEnabled} from 'shared/app/observeEnabled.oss';
+import {getAssetSelectionQueryString} from 'shared/asset-selection/useAssetSelectionState.oss';
 import {AssetPageHeader} from 'shared/assets/AssetPageHeader.oss';
 
 import {ASSET_NODE_CONFIG_FRAGMENT} from './AssetConfig';
@@ -269,8 +271,12 @@ const AssetViewImpl = ({assetKey, headerBreadcrumbs, writeAssetVisit, currentPat
     (definitionQueryResult.data?.assetOrError.__typename === 'Asset' &&
       !definitionQueryResult.data.assetOrError.hasDefinitionOrRecord)
   ) {
-    // Set the asset selection to filter to assets prefixed with the current path.
-    const nextPath = `/assets?asset-selection=key:"${currentPath.join('/')}/*"`;
+    const assetSelection = getAssetSelectionQueryString();
+    let nextPath = `/assets/${currentPath.join('/')}?view=folder${assetSelection ? `&asset-selection=${assetSelection}` : ''}`;
+    if (observeEnabled()) {
+      // The new UI doesn't have folders. So instead set the asset selection to filter to assets prefixed with the current path.
+      nextPath = `/assets?asset-selection=key:"${currentPath.join('/')}/*"`;
+    }
     // Redirect to the asset catalog
     return <Redirect to={nextPath} />;
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -13,6 +13,7 @@ import pick from 'lodash/pick';
 import uniq from 'lodash/uniq';
 import React, {useContext, useMemo, useState} from 'react';
 import {Link} from 'react-router-dom';
+import {observeEnabled} from 'shared/app/observeEnabled.oss';
 import {useLaunchWithTelemetry} from 'shared/launchpad/useLaunchWithTelemetry.oss';
 
 import {ASSET_NODE_CONFIG_FRAGMENT} from './AssetConfig';
@@ -191,7 +192,7 @@ export function optionsForExecuteButton(
     materializeOption: {
       assetKeys: materializable.map((a) => a.assetKey),
       disabledReason: materializationDisabledReason(assets, materializable, isSingle),
-      icon: <Icon name="execute" />,
+      icon: <Icon name={observeEnabled() ? 'execute' : 'materialization'} />,
       label: isSelection
         ? `Materialize selected${countIfPluralOrNotAll(materializable, assets)}${ellipsis}`
         : materializable.length > 1 && !skipAllTerm
@@ -275,7 +276,7 @@ export const LaunchAssetExecutionButton = ({
   ) {
     // If all options are disabled, just show the button with no dropdown.
     return (
-      <Tooltip content={firstOption.disabledReason} placement="bottom-end">
+      <Tooltip content={firstOption.disabledReason} position="bottom-end">
         <Button
           intent={primary ? 'primary' : undefined}
           icon={firstOption.icon}
@@ -326,7 +327,13 @@ export const LaunchAssetExecutionButton = ({
                 borderRight: `1px solid rgba(255,255,255,0.2)`,
               }}
               disabled={!canLaunch}
-              icon={loading ? <Spinner purpose="body-text" /> : <Icon name="execute" />}
+              icon={
+                loading ? (
+                  <Spinner purpose="body-text" />
+                ) : (
+                  <Icon name={observeEnabled() ? 'execute' : 'materialization'} />
+                )
+              }
             >
               {firstOption.label}
             </Button>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewActivityRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewActivityRoot.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import {Redirect, Switch} from 'react-router-dom';
 
 import {OverviewAssetsRoot} from './OverviewAssetsRoot';
+import {OverviewPageHeader} from './OverviewPageHeader';
+import {OverviewTabs} from './OverviewTabs';
 import {OverviewTimelineRoot} from './OverviewTimelineRoot';
 import {Route} from '../app/Route';
 import {AssetFeatureContext} from '../assets/AssetFeatureContext';
@@ -12,6 +14,13 @@ import {ActivatableButton} from '../runs/ActivatableButton';
 
 export const OverviewActivityRoot = () => {
   useDocumentTitle('Overview | Activity');
+
+  const header = React.useCallback(
+    ({refreshState}: {refreshState: React.ComponentProps<typeof OverviewTabs>['refreshState']}) => (
+      <OverviewPageHeader tab="activity" refreshState={refreshState} />
+    ),
+    [],
+  );
 
   const [_defaultTab, setDefaultTab] = useStateWithStorage<'timeline' | 'assets'>(
     'overview-activity-tab',
@@ -48,11 +57,11 @@ export const OverviewActivityRoot = () => {
       <Switch>
         {!enableAssetHealthOverviewPreview && (
           <Route path="/overview/activity/assets">
-            <OverviewAssetsRoot TabButton={tabButton} />
+            <OverviewAssetsRoot Header={header} TabButton={tabButton} />
           </Route>
         )}
         <Route path="/overview/activity/timeline">
-          <OverviewTimelineRoot />
+          <OverviewTimelineRoot Header={header} TabButton={tabButton} />
         </Route>
         <Route
           path="*"

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -17,6 +17,7 @@ import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
+import {FIFTEEN_SECONDS, RefreshState, useRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useAssetsBaseData} from '../asset-data/AssetBaseDataProvider';
 import {StatusCase, buildAssetNodeStatusContent} from '../asset-graph/AssetNodeStatusContent';
@@ -34,14 +35,19 @@ import {Container, HeaderCell, HeaderRow, Inner, Row, RowCell} from '../ui/Virtu
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 type Props = {
+  Header: React.ComponentType<{refreshState: RefreshState}>;
   TabButton: React.ComponentType<{selected: 'timeline' | 'assets'}>;
 };
-
-export const OverviewAssetsRoot = ({TabButton}: Props) => {
+export const OverviewAssetsRoot = ({Header, TabButton}: Props) => {
   useTrackPageView();
   useDocumentTitle('Overview | Assets');
 
-  const {assets, error, loading} = useAllAssets();
+  const {assets, query, error, loading} = useAllAssets();
+  const refreshState = useRefreshAtInterval<any>({
+    refresh: query,
+    intervalMs: FIFTEEN_SECONDS,
+    leading: true,
+  });
 
   const groupedAssetsUnfiltered = React.useMemo(() => {
     if (assets) {
@@ -134,6 +140,7 @@ export const OverviewAssetsRoot = ({TabButton}: Props) => {
   return (
     <>
       <div style={{position: 'sticky', top: 0, zIndex: 1}}>
+        <Header refreshState={refreshState} />
         <Box
           padding={{horizontal: 24, vertical: 16}}
           flex={{alignItems: 'center', gap: 12, grow: 0}}

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageHeader.tsx
@@ -1,0 +1,33 @@
+import {Box, PageHeader} from '@dagster-io/ui-components';
+import React from 'react';
+import {observeEnabled} from 'shared/app/observeEnabled.oss';
+import {ObserveRolloutBanner} from 'shared/overview/ObserveRolloutBanner.oss';
+
+import {OverviewTabs} from './OverviewTabs';
+
+export const OverviewPageHeader = ({
+  tab,
+  queryData,
+  refreshState,
+  ...rest
+}: React.ComponentProps<typeof OverviewTabs> &
+  Omit<React.ComponentProps<typeof PageHeader>, 'title'>) => {
+  const observeUIEnabled = observeEnabled();
+  if (observeUIEnabled) {
+    return null;
+  }
+
+  return (
+    <div>
+      <ObserveRolloutBanner />
+      <PageHeader
+        tabs={
+          <Box flex={{direction: 'column', gap: 8}}>
+            <OverviewTabs tab={tab} queryData={queryData} refreshState={refreshState} />
+          </Box>
+        }
+        {...rest}
+      />
+    </div>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesRoot.tsx
@@ -1,6 +1,7 @@
 import {Box, Colors, NonIdealState, Spinner, TextInput} from '@dagster-io/ui-components';
 import {useContext, useMemo} from 'react';
 
+import {OverviewPageHeader} from './OverviewPageHeader';
 import {OverviewResourcesTable} from './OverviewResourcesTable';
 import {sortRepoBuckets} from './sortRepoBuckets';
 import {
@@ -10,6 +11,7 @@ import {
 import {visibleRepoKeys} from './visibleRepoKeys';
 import {gql, useQuery} from '../apollo-client';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
@@ -48,6 +50,7 @@ export const OverviewResourcesRoot = () => {
     },
   );
   const {data, loading: queryLoading} = queryResultOverview;
+  const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   // Batch up the data and bucket by repo.
   const repoBuckets = useMemo(() => {
@@ -142,6 +145,7 @@ export const OverviewResourcesRoot = () => {
 
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+      <OverviewPageHeader tab="resources" refreshState={refreshState} />
       <Box
         padding={{horizontal: 24, vertical: 16}}
         flex={{direction: 'row', alignItems: 'center', gap: 12, grow: 0}}

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
@@ -1,0 +1,68 @@
+import {Box, Colors, Spinner, Tabs} from '@dagster-io/ui-components';
+import {useContext} from 'react';
+import {observeEnabled} from 'shared/app/observeEnabled.oss';
+
+import {QueryResult} from '../apollo-client';
+import {QueryRefreshCountdown, RefreshState} from '../app/QueryRefresh';
+import {AssetFeatureContext} from '../assets/AssetFeatureContext';
+import {useAutoMaterializeSensorFlag} from '../assets/AutoMaterializeSensorFlag';
+import {useAutomaterializeDaemonStatus} from '../assets/useAutomaterializeDaemonStatus';
+import {TabLink} from '../ui/TabLink';
+
+interface Props<TData> {
+  refreshState?: RefreshState;
+  queryData?: QueryResult<TData, any>;
+  tab: string;
+}
+
+export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
+  const {refreshState, tab} = props;
+
+  const automaterialize = useAutomaterializeDaemonStatus();
+  const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
+  const {enableAssetHealthOverviewPreview} = useContext(AssetFeatureContext);
+  const hideAMPTab = observeEnabled();
+
+  return (
+    <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
+      <Tabs selectedTabId={tab}>
+        <TabLink id="activity" title="Timeline" to="/overview/activity" />
+        {enableAssetHealthOverviewPreview && (
+          <TabLink id="asset-health" title="Asset health" to="/overview/asset-health" />
+        )}
+        {automaterializeSensorsFlagState === 'has-global-amp' && !hideAMPTab ? (
+          <TabLink
+            id="amp"
+            title={
+              <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+                <div>Auto-materialize</div>
+                {automaterialize.loading ? (
+                  <Spinner purpose="body-text" />
+                ) : (
+                  <div
+                    style={{
+                      width: '10px',
+                      height: '10px',
+                      borderRadius: '50%',
+                      backgroundColor:
+                        automaterialize.paused === false
+                          ? Colors.accentBlue()
+                          : Colors.accentGray(),
+                    }}
+                  />
+                )}
+              </Box>
+            }
+            to="/overview/automation"
+          />
+        ) : null}
+        <TabLink id="resources" title="Resources" to="/overview/resources" />
+      </Tabs>
+      {refreshState ? (
+        <Box style={{alignSelf: 'center'}}>
+          <QueryRefreshCountdown refreshState={refreshState} />
+        </Box>
+      ) : null}
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -5,6 +5,7 @@ import {useDeferredValue, useMemo} from 'react';
 import {GroupTimelineRunsBySelect} from './GroupTimelineRunsBySelect';
 import {groupRunsByAutomation} from './groupRunsByAutomation';
 import {useGroupTimelineRunsBy} from './useGroupTimelineRunsBy';
+import {RefreshState} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {usePrefixedCacheKey} from '../app/usePrefixedCacheKey';
 import {useAutomations} from '../automation/useAutomations';
@@ -34,6 +35,11 @@ const hourWindowToOffset = (hourWindow: HourWindow) => {
     case '24':
       return 24 * ONE_HOUR;
   }
+};
+
+type Props = {
+  Header: React.ComponentType<{refreshState: RefreshState}>;
+  TabButton: React.ComponentType<{selected: 'timeline' | 'assets'}>;
 };
 
 export function useTimelineRange({
@@ -84,7 +90,7 @@ export function useTimelineRange({
   return {rangeMs, hourWindow, setHourWindow, onPageEarlier, onPageLater, onPageNow};
 }
 
-export const OverviewTimelineRoot = () => {
+export const OverviewTimelineRoot = ({Header}: Props) => {
   useTrackPageView();
   useDocumentTitle('Overview | Timeline');
   const {rangeMs, hourWindow, setHourWindow, onPageEarlier, onPageLater, onPageNow} =
@@ -111,7 +117,7 @@ export const OverviewTimelineRoot = () => {
   const runsForTimelineRet = useRunsForTimeline({rangeMs});
 
   // Use deferred value to allow paginating quickly with the UI feeling more responsive.
-  const {jobs: jobsUnmapped, loading} = useDeferredValue(runsForTimelineRet);
+  const {jobs: jobsUnmapped, loading, refreshState} = useDeferredValue(runsForTimelineRet);
 
   const automationRows = useMemo(() => {
     const sensors = Object.fromEntries(
@@ -155,6 +161,7 @@ export const OverviewTimelineRoot = () => {
 
   return (
     <>
+      <Header refreshState={refreshState} />
       <Box padding={{horizontal: 24, vertical: 12}} flex={{alignItems: 'center', gap: 16}}>
         <GroupTimelineRunsBySelect value={groupRunsBy} onSelect={setGroupRunsBy} />
         <div style={{flex: 1, display: 'flex', alignItems: 'center'}}>


### PR DESCRIPTION
## Summary & Motivation

This is a partial revert of https://github.com/dagster-io/dagster/pull/33125, which I put together under the assumption that "observe enabled" was a flag that no longer needed to be checked, as it was used for gating and rolling out features on the Cloud side.

Unfortunately, it's actually more an internal vs. OSS check on the OSS side, and it needs to remain in place and `false`.

## How I Tested These Changes

dagster dev, load the app. Verify that asset catalog and overview are back to normal.

## Changelog

[ui] Fix broken asset catalog and overview page.