### PR TITLE
[pac] Add partitions_subset to AssetCheckEvaluationPlanned, partition to AssetCheckEvaluation/AssetCheckEvaluationRecord

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
@@ -51,6 +51,12 @@ class SerializableEntitySubset(Generic[T_EntityKey]):
     value: EntitySubsetValue
 
     @classmethod
+    def empty(
+        cls, key: T_EntityKey, partitions_def: Optional[PartitionsDefinition]
+    ) -> "SerializableEntitySubset[T_EntityKey]":
+        return cls(key=key, value=partitions_def.empty_subset() if partitions_def else False)
+
+    @classmethod
     def from_coercible_value(
         cls,
         key: T_EntityKey,

--- a/python_modules/dagster/dagster/_core/definitions/asset_checks/asset_check_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_checks/asset_check_evaluation.py
@@ -10,6 +10,7 @@ from dagster._core.definitions.asset_checks.asset_check_spec import (
 )
 from dagster._core.definitions.events import AssetKey, MetadataValue, RawMetadataValue
 from dagster._core.definitions.metadata import normalize_metadata
+from dagster._core.definitions.partitions.subset import PartitionsSubset
 from dagster._serdes import whitelist_for_serdes
 
 
@@ -20,6 +21,7 @@ class AssetCheckEvaluationPlanned:
 
     asset_key: AssetKey
     check_name: str
+    partitions_subset: Optional[PartitionsSubset] = None
 
     @property
     def asset_check_key(self) -> AssetCheckKey:
@@ -60,6 +62,8 @@ class AssetCheckEvaluation(IHaveNew):
             A text description of the result of the check evaluation.
         blocking (Optional[bool]):
             Whether the check is blocking.
+        partition (Optional[str]):
+            The partition that the check was evaluated on, if applicable.
     """
 
     asset_key: AssetKey
@@ -70,6 +74,7 @@ class AssetCheckEvaluation(IHaveNew):
     severity: AssetCheckSeverity
     description: Optional[str]
     blocking: Optional[bool]
+    partition: Optional[str]
 
     def __new__(
         cls,
@@ -81,6 +86,7 @@ class AssetCheckEvaluation(IHaveNew):
         severity: AssetCheckSeverity = AssetCheckSeverity.ERROR,
         description: Optional[str] = None,
         blocking: Optional[bool] = None,
+        partition: Optional[str] = None,
     ):
         return super().__new__(
             cls,
@@ -94,6 +100,7 @@ class AssetCheckEvaluation(IHaveNew):
             severity=severity,
             description=description,
             blocking=blocking,
+            partition=partition,
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/remote_asset_graph.py
@@ -744,12 +744,13 @@ class RemoteWorkspaceAssetGraph(RemoteAssetGraph[RemoteWorkspaceAssetNode]):
     def get_repo_scoped_node(
         self, key: EntityKey, repository_selector: "RepositorySelector"
     ) -> Optional[Union[RemoteRepositoryAssetNode, RemoteAssetCheckNode]]:
-        if isinstance(key, AssetKey):
-            if not self.has(key):
-                return None
-            return self.get(key).resolve_to_repo_scoped_node(repository_selector)
+        if not self.has(key):
+            return None
+        node = self.get(key)
+        if isinstance(node, RemoteWorkspaceAssetNode):
+            return node.resolve_to_repo_scoped_node(repository_selector)
         else:
-            raise Exception("Key must be an asset key for get_repo_scoped_node")
+            return node  # type: ignore
 
     def split_entity_keys_by_repository(
         self, keys: AbstractSet[EntityKey]

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/valid_asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/valid_asset_subset.py
@@ -98,14 +98,14 @@ class ValidAssetSubset(SerializableEntitySubset[AssetKey]):
                     key=asset_key, value=AllPartitionsSubset(partitions_def, ctx)
                 )
 
-    @staticmethod
+    @classmethod
     def empty(
-        asset_key: AssetKey, partitions_def: Optional[PartitionsDefinition]
+        cls, key: AssetKey, partitions_def: Optional[PartitionsDefinition]
     ) -> "ValidAssetSubset":
         if partitions_def is None:
-            return ValidAssetSubset(key=asset_key, value=False)
+            return cls(key=key, value=False)
         else:
-            return ValidAssetSubset(key=asset_key, value=partitions_def.empty_subset())
+            return cls(key=key, value=partitions_def.empty_subset())
 
     @staticmethod
     def from_asset_partitions_set(

--- a/python_modules/dagster/dagster/_core/instance/runs/run_domain.py
+++ b/python_modules/dagster/dagster/_core/instance/runs/run_domain.py
@@ -2,7 +2,7 @@ import logging
 import os
 import warnings
 from collections.abc import Mapping, Sequence, Set
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast, overload
 
 import dagster._check as check
 from dagster._core.definitions.asset_checks.asset_check_evaluation import (
@@ -50,10 +50,13 @@ from dagster._utils.warnings import disable_dagster_warnings
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_checks.asset_check_spec import AssetCheckKey
     from dagster._core.definitions.assets.graph.base_asset_graph import (
+        AssetCheckNode,
         BaseAssetGraph,
         BaseAssetNode,
+        BaseEntityNode,
     )
     from dagster._core.definitions.job_definition import JobDefinition
+    from dagster._core.definitions.partitions.definition import PartitionsDefinition
     from dagster._core.definitions.repository_definition.repository_definition import (
         RepositoryLoadData,
     )
@@ -66,10 +69,7 @@ if TYPE_CHECKING:
     from dagster._core.remote_representation.code_location import CodeLocation
     from dagster._core.remote_representation.external import RemoteJob
     from dagster._core.snap import ExecutionPlanSnapshot, JobSnap
-    from dagster._core.snap.execution_plan_snapshot import (
-        ExecutionStepOutputSnap,
-        ExecutionStepSnap,
-    )
+    from dagster._core.snap.execution_plan_snapshot import ExecutionStepSnap
     from dagster._core.workspace.context import BaseWorkspaceRequestContext
 
 
@@ -108,6 +108,7 @@ class RunDomain:
         """Create a run with the given parameters."""
         from dagster._core.definitions.asset_key import AssetCheckKey
         from dagster._core.definitions.assets.graph.remote_asset_graph import RemoteAssetGraph
+        from dagster._core.definitions.partitions.context import partition_loading_context
         from dagster._core.remote_origin import RemoteJobOrigin
         from dagster._core.snap import ExecutionPlanSnapshot, JobSnap
         from dagster._utils.tags import normalize_tags
@@ -256,7 +257,8 @@ class RunDomain:
         dagster_run = self._instance.run_storage.add_run(dagster_run)
 
         if execution_plan_snapshot and not assets_are_externally_managed(dagster_run):
-            self._log_asset_planned_events(dagster_run, execution_plan_snapshot, asset_graph)
+            with partition_loading_context(dynamic_partitions_store=self._instance):
+                self._log_asset_planned_events(dagster_run, execution_plan_snapshot, asset_graph)
 
         return dagster_run
 
@@ -315,8 +317,8 @@ class RunDomain:
                     adjusted_output = output
 
                     if asset_key:
-                        asset_node = self._get_repo_scoped_asset_node(
-                            asset_graph, asset_key, remote_job_origin
+                        asset_node = self._get_repo_scoped_entity_node(
+                            asset_key, asset_graph, remote_job_origin
                         )
                         if asset_node:
                             partitions_definition = asset_node.partitions_def
@@ -767,12 +769,28 @@ class RunDomain:
             {key for key in to_reexecute if isinstance(key, AssetCheckKey)},
         )
 
-    def _get_repo_scoped_asset_node(
+    @overload
+    def _get_repo_scoped_entity_node(
         self,
+        key: AssetKey,
         asset_graph: "BaseAssetGraph",
-        asset_key: AssetKey,
         remote_job_origin: Optional["RemoteJobOrigin"] = None,
-    ) -> Optional["BaseAssetNode"]:
+    ) -> Optional["BaseAssetNode"]: ...
+
+    @overload
+    def _get_repo_scoped_entity_node(
+        self,
+        key: "AssetCheckKey",
+        asset_graph: "BaseAssetGraph",
+        remote_job_origin: Optional["RemoteJobOrigin"] = None,
+    ) -> Optional["AssetCheckNode"]: ...
+
+    def _get_repo_scoped_entity_node(
+        self,
+        key: "EntityKey",
+        asset_graph: "BaseAssetGraph",
+        remote_job_origin: Optional["RemoteJobOrigin"] = None,
+    ) -> Optional["BaseEntityNode"]:
         from dagster._core.definitions.assets.graph.remote_asset_graph import (
             RemoteWorkspaceAssetGraph,
         )
@@ -783,16 +801,29 @@ class RunDomain:
         # in all cases, return the BaseAssetNode for the supplied asset key if it exists.
         if isinstance(asset_graph, RemoteWorkspaceAssetGraph):
             return cast(
-                "Optional[BaseAssetNode]",
+                "Optional[BaseEntityNode]",
                 asset_graph.get_repo_scoped_node(
-                    asset_key, check.not_none(remote_job_origin).repository_origin.get_selector()
+                    key, check.not_none(remote_job_origin).repository_origin.get_selector()
                 ),
             )
 
-        if not asset_graph.has(asset_key):
+        if not asset_graph.has(key):
             return None
 
-        return asset_graph.get(asset_key)
+        return asset_graph.get(key)
+
+    def _get_partitions_def(
+        self,
+        key: "EntityKey",
+        asset_graph: "BaseAssetGraph",
+        remote_job_origin: Optional["RemoteJobOrigin"],
+        run: "DagsterRun",
+    ) -> Optional["PartitionsDefinition"]:
+        # don't fetch the partitions def if the run is not partitioned
+        if not run.is_partitioned:
+            return None
+        entity_node = self._get_repo_scoped_entity_node(key, asset_graph, remote_job_origin)
+        return entity_node.partitions_def if entity_node else None
 
     def _log_asset_planned_events(
         self,
@@ -819,7 +850,7 @@ class RunDomain:
                     if asset_key:
                         events.extend(
                             self.get_materialization_planned_events_for_asset(
-                                dagster_run, asset_key, job_name, step, output, asset_graph
+                                dagster_run, asset_key, job_name, step, asset_graph
                             )
                         )
 
@@ -829,6 +860,13 @@ class RunDomain:
                         )
                         target_asset_key = asset_check_key.asset_key
                         check_name = asset_check_key.name
+
+                        partitions_def = self._get_partitions_def(
+                            asset_check_key, asset_graph, dagster_run.remote_job_origin, dagster_run
+                        )
+                        partitions_subset = dagster_run.get_resolved_partitions_subset_for_events(
+                            partitions_def
+                        )
 
                         event = DagsterEvent(
                             event_type_value=DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED.value,
@@ -840,6 +878,7 @@ class RunDomain:
                             event_specific_data=AssetCheckEvaluationPlanned(
                                 asset_key=target_asset_key,
                                 check_name=check_name,
+                                partitions_subset=partitions_subset,
                             ),
                             step_key=step.key,
                         )
@@ -878,94 +917,26 @@ class RunDomain:
         asset_key: AssetKey,
         job_name: str,
         step: "ExecutionStepSnap",
-        output: "ExecutionStepOutputSnap",
         asset_graph: "BaseAssetGraph[BaseAssetNode]",
     ) -> Sequence["DagsterEvent"]:
         """Moved from DagsterInstance._log_materialization_planned_event_for_asset."""
-        from dagster._core.definitions.partitions.context import partition_loading_context
-        from dagster._core.definitions.partitions.definition import DynamicPartitionsDefinition
         from dagster._core.events import AssetMaterializationPlannedData, DagsterEvent
 
         events = []
 
-        partition_tag = dagster_run.tags.get(PARTITION_NAME_TAG)
-        partition_range_start, partition_range_end = (
-            dagster_run.tags.get(ASSET_PARTITION_RANGE_START_TAG),
-            dagster_run.tags.get(ASSET_PARTITION_RANGE_END_TAG),
+        partitions_def = self._get_partitions_def(
+            asset_key, asset_graph, dagster_run.remote_job_origin, dagster_run
         )
 
-        if partition_tag and (partition_range_start or partition_range_end):
-            raise DagsterInvariantViolationError(
-                f"Cannot have {ASSET_PARTITION_RANGE_START_TAG} or"
-                f" {ASSET_PARTITION_RANGE_END_TAG} set along with"
-                f" {PARTITION_NAME_TAG}"
-            )
-
-        partitions_subset = None
-        individual_partitions = None
-        if partition_range_start or partition_range_end:
-            if not partition_range_start or not partition_range_end:
-                raise DagsterInvariantViolationError(
-                    f"Cannot have {ASSET_PARTITION_RANGE_START_TAG} or"
-                    f" {ASSET_PARTITION_RANGE_END_TAG} set without the other"
-                )
-
-            asset_node = check.not_none(
-                self._get_repo_scoped_asset_node(
-                    asset_graph, asset_key, dagster_run.remote_job_origin
-                )
-            )
-
-            partitions_def = asset_node.partitions_def
-            if (
-                isinstance(partitions_def, DynamicPartitionsDefinition)
-                and partitions_def.name is None
-            ):
-                raise DagsterInvariantViolationError(
-                    "Creating a run targeting a partition range is not supported for assets partitioned with function-based dynamic partitions"
-                )
-
-            if partitions_def is not None:
-                with partition_loading_context(dynamic_partitions_store=self._instance):
-                    if self._instance.event_log_storage.supports_partition_subset_in_asset_materialization_planned_events:
-                        partitions_subset = partitions_def.subset_with_partition_keys(
-                            partitions_def.get_partition_keys_in_range(
-                                PartitionKeyRange(partition_range_start, partition_range_end),
-                            )
-                        ).to_serializable_subset()
-                        individual_partitions = []
-                    else:
-                        individual_partitions = partitions_def.get_partition_keys_in_range(
-                            PartitionKeyRange(partition_range_start, partition_range_end),
-                        )
-        elif check.not_none(output.properties).is_asset_partitioned and partition_tag:
-            individual_partitions = [partition_tag]
-
-        assert not (individual_partitions and partitions_subset), (
-            "Should set either individual_partitions or partitions_subset, but not both"
-        )
-
-        if not individual_partitions and not partitions_subset:
+        partitions_subset = dagster_run.get_resolved_partitions_subset_for_events(partitions_def)
+        if partitions_subset is None:
             materialization_planned = DagsterEvent.build_asset_materialization_planned_event(
                 job_name,
                 step.key,
                 AssetMaterializationPlannedData(asset_key, partition=None, partitions_subset=None),
             )
             events.append(materialization_planned)
-        elif individual_partitions:
-            for individual_partition in individual_partitions:
-                materialization_planned = DagsterEvent.build_asset_materialization_planned_event(
-                    job_name,
-                    step.key,
-                    AssetMaterializationPlannedData(
-                        asset_key,
-                        partition=individual_partition,
-                        partitions_subset=partitions_subset,
-                    ),
-                )
-                events.append(materialization_planned)
-
-        else:
+        elif self._instance.event_log_storage.supports_partition_subset_in_asset_materialization_planned_events:
             materialization_planned = DagsterEvent.build_asset_materialization_planned_event(
                 job_name,
                 step.key,
@@ -974,6 +945,18 @@ class RunDomain:
                 ),
             )
             events.append(materialization_planned)
+        else:
+            for partition_key in partitions_subset.get_partition_keys():
+                materialization_planned = DagsterEvent.build_asset_materialization_planned_event(
+                    job_name,
+                    step.key,
+                    AssetMaterializationPlannedData(
+                        asset_key,
+                        partition=partition_key,
+                        partitions_subset=None,
+                    ),
+                )
+                events.append(materialization_planned)
 
         return events
 

--- a/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
@@ -60,6 +60,7 @@ class AssetCheckExecutionRecord(
             # Old records won't have an event if the status is PLANNED.
             ("event", Optional[EventLogEntry]),
             ("create_timestamp", float),
+            ("partition", Optional[str]),
         ],
     ),
     LoadableBy[AssetCheckKey],
@@ -72,6 +73,7 @@ class AssetCheckExecutionRecord(
         status: AssetCheckExecutionRecordStatus,
         event: Optional[EventLogEntry],
         create_timestamp: float,
+        partition: Optional[str],
     ):
         check.inst_param(key, "key", AssetCheckKey)
         check.int_param(id, "id")
@@ -79,6 +81,7 @@ class AssetCheckExecutionRecord(
         check.inst_param(status, "status", AssetCheckExecutionRecordStatus)
         check.opt_inst_param(event, "event", EventLogEntry)
         check.float_param(create_timestamp, "create_timestamp")
+        check.opt_str_param(partition, "partition")
 
         event_type = event.dagster_event_type if event else None
         if status == AssetCheckExecutionRecordStatus.PLANNED:
@@ -105,6 +108,7 @@ class AssetCheckExecutionRecord(
             status=status,
             event=event,
             create_timestamp=create_timestamp,
+            partition=partition,
         )
 
     @property
@@ -129,6 +133,7 @@ class AssetCheckExecutionRecord(
                 else None
             ),
             create_timestamp=utc_datetime_from_naive(row["create_timestamp"]).timestamp(),
+            partition=row["partition"],
         )
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -41,6 +41,9 @@ from dagster._utils.tags import get_boolean_tag_value
 
 if TYPE_CHECKING:
     from dagster._core.definitions.assets.graph.base_asset_graph import EntityKey
+    from dagster._core.definitions.partitions.definition.partitions_definition import (
+        PartitionsDefinition,
+    )
     from dagster._core.definitions.schedule_definition import ScheduleDefinition
     from dagster._core.definitions.sensor_definition import SensorDefinition
     from dagster._core.remote_representation.external import RemoteSchedule, RemoteSensor
@@ -371,6 +374,80 @@ class DagsterRun(
 
     def get_parent_run_id(self) -> Optional[str]:
         return self.tags.get(PARENT_RUN_ID_TAG)
+
+    @property
+    def is_partitioned(self) -> bool:
+        from dagster._core.storage.tags import (
+            ASSET_PARTITION_RANGE_END_TAG,
+            ASSET_PARTITION_RANGE_START_TAG,
+            PARTITION_NAME_TAG,
+        )
+
+        has_partition_tags = any(
+            self.tags.get(tag) is not None
+            for tag in [
+                PARTITION_NAME_TAG,
+                ASSET_PARTITION_RANGE_START_TAG,
+                ASSET_PARTITION_RANGE_END_TAG,
+            ]
+        )
+        return has_partition_tags or self.partitions_subset is not None
+
+    def get_resolved_partitions_subset_for_events(
+        self, partitions_def: Optional["PartitionsDefinition"]
+    ) -> Optional[PartitionsSubset]:
+        """Get the partitions subset targeted by a run based on its partition tags. Does not always use the
+        partition_subset that is directly stored on the run as this can contain a KeyRangesPartitionSubset
+        which can not be deserialized without additional information.
+        """
+        from dagster._core.definitions.partitions.definition import DynamicPartitionsDefinition
+        from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
+        from dagster._core.errors import DagsterInvariantViolationError
+        from dagster._core.storage.tags import (
+            ASSET_PARTITION_RANGE_END_TAG,
+            ASSET_PARTITION_RANGE_START_TAG,
+            PARTITION_NAME_TAG,
+        )
+
+        # KeyRangesPartitionsSubset cannot be deserialized without access to the instance, so ignore it for now.
+        if self.partitions_subset is not None and not isinstance(
+            self.partitions_subset, KeyRangesPartitionsSubset
+        ):
+            return self.partitions_subset
+
+        # fetch information from the tags
+        partition_tag = self.tags.get(PARTITION_NAME_TAG)
+        partition_range_start = self.tags.get(ASSET_PARTITION_RANGE_START_TAG)
+        partition_range_end = self.tags.get(ASSET_PARTITION_RANGE_END_TAG)
+
+        if partition_range_start or partition_range_end:
+            if not partition_range_start or not partition_range_end:
+                raise DagsterInvariantViolationError(
+                    f"Cannot have {ASSET_PARTITION_RANGE_START_TAG} or"
+                    f" {ASSET_PARTITION_RANGE_END_TAG} set without the other"
+                )
+
+            if (
+                isinstance(partitions_def, DynamicPartitionsDefinition)
+                and partitions_def.name is None
+            ):
+                raise DagsterInvariantViolationError(
+                    "Creating a run targeting a partition range is not supported for assets "
+                    "partitioned with function-based dynamic partitions"
+                )
+
+            if partitions_def is not None:
+                return partitions_def.subset_with_partition_keys(
+                    partitions_def.get_partition_keys_in_range(
+                        PartitionKeyRange(partition_range_start, partition_range_end),
+                    )
+                ).to_serializable_subset()
+        elif partition_tag and partitions_def is not None:
+            return partitions_def.subset_with_partition_keys(
+                [partition_tag]
+            ).to_serializable_subset()
+
+        return None
 
     @cached_property
     def dagster_execution_info(self) -> Mapping[str, str]:

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -1,6 +1,7 @@
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence, Set
+from types import EllipsisType
 from typing import TYPE_CHECKING, Annotated, NamedTuple, Optional, Union
 
 from dagster_shared.record import ImportFrom, record
@@ -633,13 +634,16 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         limit: int,
         cursor: Optional[int] = None,
         status: Optional[Set[AssetCheckExecutionRecordStatus]] = None,
+        partition: Union[str, None, EllipsisType] = ...,
     ) -> Sequence[AssetCheckExecutionRecord]:
         """Get executions for one asset check, sorted by recency."""
         pass
 
     @abstractmethod
     def get_latest_asset_check_execution_by_key(
-        self, check_keys: Sequence[AssetCheckKey]
+        self,
+        check_keys: Sequence[AssetCheckKey],
+        partition: Union[str, None, EllipsisType] = ...,
     ) -> Mapping[AssetCheckKey, AssetCheckExecutionRecord]:
         """Get the latest executions for a list of asset checks."""
         pass

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime
+from types import EllipsisType
 from typing import TYPE_CHECKING, AbstractSet, Optional, Union  # noqa: UP035
 
 from dagster import _check as check
@@ -745,19 +746,24 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         limit: int,
         cursor: Optional[int] = None,
         status: Optional[AbstractSet[AssetCheckExecutionRecordStatus]] = None,
+        partition: Union[str, None, EllipsisType] = ...,
     ) -> Sequence[AssetCheckExecutionRecord]:
         return self._storage.event_log_storage.get_asset_check_execution_history(
             check_key=check_key,
             limit=limit,
             cursor=cursor,
             status=status,
+            partition=partition,
         )
 
-    def get_latest_asset_check_execution_by_key(  # pyright: ignore[reportIncompatibleMethodOverride]
+    def get_latest_asset_check_execution_by_key(
         self,
         check_keys: Sequence["AssetCheckKey"],
-    ) -> Mapping["AssetCheckKey", Optional[AssetCheckExecutionRecord]]:
-        return self._storage.event_log_storage.get_latest_asset_check_execution_by_key(check_keys)
+        partition: Union[str, None, EllipsisType] = ...,
+    ) -> Mapping["AssetCheckKey", AssetCheckExecutionRecord]:
+        return self._storage.event_log_storage.get_latest_asset_check_execution_by_key(
+            check_keys, partition=partition
+        )
 
 
 class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -2201,7 +2201,7 @@ def test_targets_asset_selection_sensor(executor, instance, workspace_context, r
 
 
 def test_partitioned_asset_selection_sensor(executor, instance, workspace_context, remote_repo):
-    freeze_datetime = create_datetime(year=2019, month=2, day=27)
+    freeze_datetime = create_datetime(year=2023, month=2, day=27)
     with freeze_time(freeze_datetime):
         sensor = remote_repo.get_sensor("partitioned_asset_selection_sensor")
         remote_origin_id = sensor.get_remote_origin_id()

--- a/python_modules/dagster/dagster_tests/storage_tests/test_dagster_run.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_dagster_run.py
@@ -5,6 +5,10 @@ import dagster._check as check
 import pytest
 from dagster._check import CheckError
 from dagster._core.code_pointer import ModuleCodePointer
+from dagster._core.definitions.partitions.definition import (
+    HourlyPartitionsDefinition,
+    StaticPartitionsDefinition,
+)
 from dagster._core.origin import (
     DEFAULT_DAGSTER_ENTRY_POINT,
     JobPythonOrigin,
@@ -19,6 +23,11 @@ from dagster._core.storage.dagster_run import (
     IN_PROGRESS_RUN_STATUSES,
     NON_IN_PROGRESS_RUN_STATUSES,
     DagsterRunStatus,
+)
+from dagster._core.storage.tags import (
+    ASSET_PARTITION_RANGE_END_TAG,
+    ASSET_PARTITION_RANGE_START_TAG,
+    PARTITION_NAME_TAG,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 
@@ -79,3 +88,57 @@ def test_runs_filter_supports_nonempty_run_ids():
 
     with pytest.raises(CheckError):
         dg.RunsFilter(run_ids=[])
+
+
+@pytest.mark.parametrize(
+    "test_case, partitions_def, run_kwargs, expected_keys",
+    [
+        # Case 1: stored subset - directly stored partitions_subset returns stored subset
+        (
+            "stored_subset",
+            HourlyPartitionsDefinition(start_date="2024-01-01-00:00"),
+            {
+                "partitions_subset": HourlyPartitionsDefinition(start_date="2024-01-01-00:00")
+                .subset_with_partition_keys(["2024-01-01-00:00", "2024-01-01-02:00"])
+                .to_serializable_subset()
+            },
+            ["2024-01-01-00:00", "2024-01-01-02:00"],
+        ),
+        # Case 2: single tag - PARTITION_NAME_TAG returns single partition
+        (
+            "single_tag",
+            StaticPartitionsDefinition(["a", "b", "c"]),
+            {"tags": {PARTITION_NAME_TAG: "b"}},
+            ["b"],
+        ),
+        # Case 3: range tags - ASSET_PARTITION_RANGE_START_TAG + END_TAG returns range
+        (
+            "range_tags",
+            StaticPartitionsDefinition(["a", "b", "c", "d"]),
+            {
+                "tags": {
+                    ASSET_PARTITION_RANGE_START_TAG: "b",
+                    ASSET_PARTITION_RANGE_END_TAG: "d",
+                }
+            },
+            ["b", "c", "d"],
+        ),
+        # Case 4: unpartitioned - no partition info returns None
+        (
+            "unpartitioned",
+            StaticPartitionsDefinition(["a", "b", "c"]),
+            {},
+            None,
+        ),
+    ],
+)
+def test_get_resolved_partitions_subset(test_case, partitions_def, run_kwargs, expected_keys):
+    """Test that get_resolved_partitions_subset correctly resolves partitions from various sources."""
+    run = dg.DagsterRun(job_name="test", **run_kwargs)
+    result = run.get_resolved_partitions_subset_for_events(partitions_def)
+
+    if expected_keys is None:
+        assert result is None
+    else:
+        assert result is not None
+        assert set(result.get_partition_keys()) == set(expected_keys)

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -6991,3 +6991,355 @@ class TestEventLogStorage:
         assert storage.get_paginated_dynamic_partitions(
             partitions_def_name="foo", limit=1, ascending=True
         ).results == ["baz"]
+
+    @pytest.mark.parametrize(
+        "partitions_def_type, partition_keys",
+        [
+            ("static", ["a", "b", "c"]),
+            ("dynamic", ["x", "y", "z"]),
+            ("time_window", ["2023-01-01", "2023-01-02", "2023-01-03"]),
+        ],
+        ids=["static", "dynamic", "time_window"],
+    )
+    def test_asset_check_partitioned_planned_and_evaluation(
+        self,
+        storage: EventLogStorage,
+        partitions_def_type: str,
+        partition_keys: list,
+    ):
+        """Test that a planned event with multiple partitions creates isolated execution records,
+        and evaluations update the correct partition independently.
+        """
+        run_id = make_new_run_id()
+        asset_key = dg.AssetKey(["my_partitioned_asset"])
+        check_key = dg.AssetCheckKey(asset_key, "my_partitioned_check")
+
+        # Create partitions def based on type
+        if partitions_def_type == "static":
+            partitions_def = dg.StaticPartitionsDefinition(partition_keys)
+        elif partitions_def_type == "dynamic":
+            partitions_def = dg.DynamicPartitionsDefinition(name="test_dynamic_partitions")
+            storage.add_dynamic_partitions(
+                partitions_def_name="test_dynamic_partitions", partition_keys=partition_keys
+            )
+        elif partitions_def_type == "time_window":
+            partitions_def = dg.DailyPartitionsDefinition(start_date="2023-01-01")
+        else:
+            raise ValueError(f"Unknown partitions_def_type: {partitions_def_type}")
+
+        partitions_subset = partitions_def.subset_with_partition_keys(
+            partition_keys
+        ).to_serializable_subset()
+
+        key_a, key_b, key_c = partition_keys
+
+        # Store planned event with partitions_subset containing all 3 partitions
+        storage.store_event(
+            _create_check_planned_event(run_id, check_key, partitions_subset=partitions_subset)
+        )
+
+        # Query each partition individually - verify each returns 1 PLANNED record
+        for partition_key in partition_keys:
+            checks = storage.get_asset_check_execution_history(
+                check_key, limit=10, partition=partition_key
+            )
+            assert len(checks) == 1, f"Expected 1 record for partition {partition_key}"
+            assert checks[0].status == AssetCheckExecutionRecordStatus.PLANNED
+            assert checks[0].run_id == run_id
+            assert checks[0].partition == partition_key
+
+        # Verify partition=None returns empty (no unpartitioned checks)
+        checks_unpartitioned = storage.get_asset_check_execution_history(
+            check_key, limit=10, partition=None
+        )
+        assert len(checks_unpartitioned) == 0
+
+        # Store evaluation for first partition with passed=True
+        storage.store_event(
+            _create_check_evaluation_event(run_id, check_key, passed=True, partition=key_a)
+        )
+
+        # Verify first partition is SUCCEEDED, other partitions are still PLANNED
+        checks_a = storage.get_asset_check_execution_history(check_key, limit=10, partition=key_a)
+        assert len(checks_a) == 1
+        assert checks_a[0].status == AssetCheckExecutionRecordStatus.SUCCEEDED
+
+        checks_b = storage.get_asset_check_execution_history(check_key, limit=10, partition=key_b)
+        assert len(checks_b) == 1
+        assert checks_b[0].status == AssetCheckExecutionRecordStatus.PLANNED
+
+        checks_c = storage.get_asset_check_execution_history(check_key, limit=10, partition=key_c)
+        assert len(checks_c) == 1
+        assert checks_c[0].status == AssetCheckExecutionRecordStatus.PLANNED
+
+        # Store evaluation for second partition with passed=False
+        storage.store_event(
+            _create_check_evaluation_event(run_id, check_key, passed=False, partition=key_b)
+        )
+
+        # Verify second partition is FAILED, third is still PLANNED, first unchanged
+        checks_a = storage.get_asset_check_execution_history(check_key, limit=10, partition=key_a)
+        assert len(checks_a) == 1
+        assert checks_a[0].status == AssetCheckExecutionRecordStatus.SUCCEEDED
+
+        checks_b = storage.get_asset_check_execution_history(check_key, limit=10, partition=key_b)
+        assert len(checks_b) == 1
+        assert checks_b[0].status == AssetCheckExecutionRecordStatus.FAILED
+
+        checks_c = storage.get_asset_check_execution_history(check_key, limit=10, partition=key_c)
+        assert len(checks_c) == 1
+        assert checks_c[0].status == AssetCheckExecutionRecordStatus.PLANNED
+
+        # Test get_latest_asset_check_execution_by_key with partition parameter
+        # partition=... (default) returns latest overall (most recent by id)
+        latest_overall = storage.get_latest_asset_check_execution_by_key([check_key])
+        assert check_key in latest_overall
+
+        # partition=None returns empty (no unpartitioned checks exist)
+        latest_unpartitioned = storage.get_latest_asset_check_execution_by_key(
+            [check_key], partition=None
+        )
+        assert check_key not in latest_unpartitioned
+
+        # first partition returns latest for that partition
+        latest_a = storage.get_latest_asset_check_execution_by_key([check_key], partition=key_a)
+        assert check_key in latest_a
+        assert latest_a[check_key].partition == key_a
+        assert latest_a[check_key].status == AssetCheckExecutionRecordStatus.SUCCEEDED
+
+        # second partition returns latest for that partition
+        latest_b = storage.get_latest_asset_check_execution_by_key([check_key], partition=key_b)
+        assert check_key in latest_b
+        assert latest_b[check_key].partition == key_b
+        assert latest_b[check_key].status == AssetCheckExecutionRecordStatus.FAILED
+
+        # third partition returns latest for that partition (still PLANNED)
+        latest_c = storage.get_latest_asset_check_execution_by_key([check_key], partition=key_c)
+        assert check_key in latest_c
+        assert latest_c[check_key].partition == key_c
+        assert latest_c[check_key].status == AssetCheckExecutionRecordStatus.PLANNED
+
+    def test_asset_check_partitioned_multiple_runs_same_partition(
+        self,
+        storage: EventLogStorage,
+    ):
+        """Test that multiple check executions on the same partition are tracked correctly
+        in history, with correct run_id association and ordering.
+        """
+        run_id_1 = make_new_run_id()
+        run_id_2 = make_new_run_id()
+        asset_key = dg.AssetKey(["my_partitioned_asset_multi"])
+        check_key = dg.AssetCheckKey(asset_key, "my_partitioned_check_multi")
+
+        partitions_def = dg.StaticPartitionsDefinition(["a"])
+        partitions_subset = partitions_def.subset_with_partition_keys(["a"])
+
+        # Run 1: Store planned + evaluation for partition "a" with passed=True
+        storage.store_event(
+            _create_check_planned_event(run_id_1, check_key, partitions_subset=partitions_subset)
+        )
+        storage.store_event(
+            _create_check_evaluation_event(run_id_1, check_key, passed=True, partition="a")
+        )
+
+        # Run 2: Store planned + evaluation for partition "a" with passed=False
+        storage.store_event(
+            _create_check_planned_event(run_id_2, check_key, partitions_subset=partitions_subset)
+        )
+        storage.store_event(
+            _create_check_evaluation_event(run_id_2, check_key, passed=False, partition="a")
+        )
+
+        # Verify get_asset_check_execution_history returns 2 records for partition "a"
+        checks = storage.get_asset_check_execution_history(check_key, limit=10, partition="a")
+        assert len(checks) == 2
+
+        # Verify ordering is reverse chronological (Run 2 first)
+        assert checks[0].run_id == run_id_2
+        assert checks[0].status == AssetCheckExecutionRecordStatus.FAILED
+        assert checks[1].run_id == run_id_1
+        assert checks[1].status == AssetCheckExecutionRecordStatus.SUCCEEDED
+
+        # Verify each record has correct partition
+        assert checks[0].partition == "a"
+        assert checks[1].partition == "a"
+
+        # Test get_latest_asset_check_execution_by_key returns the most recent for partition "a"
+        latest_a = storage.get_latest_asset_check_execution_by_key([check_key], partition="a")
+        assert check_key in latest_a
+        assert latest_a[check_key].run_id == run_id_2
+        assert latest_a[check_key].status == AssetCheckExecutionRecordStatus.FAILED
+        assert latest_a[check_key].partition == "a"
+
+        # partition=... (default) should also return run_id_2 as it's the latest overall
+        latest_overall = storage.get_latest_asset_check_execution_by_key([check_key])
+        assert check_key in latest_overall
+        assert latest_overall[check_key].run_id == run_id_2
+
+    def test_asset_check_partitioned_with_target_materialization(
+        self,
+        storage: EventLogStorage,
+        test_run_id: str,
+    ):
+        """Test that target_materialization_data is correctly stored and can be used
+        to detect stale checks when new materializations occur.
+        """
+        run_id_1 = test_run_id
+        run_id_2 = make_new_run_id()
+        asset_key = dg.AssetKey(["my_partitioned_asset_mat"])
+        check_key = dg.AssetCheckKey(asset_key, "my_partitioned_check_mat")
+
+        partitions_def = dg.StaticPartitionsDefinition(["a"])
+        partitions_subset = partitions_def.subset_with_partition_keys(["a"])
+
+        # Store materialization M1 for partition "a"
+        storage.store_event(_create_materialization_event(run_id_1, asset_key, partition="a"))
+
+        # Get M1's storage_id
+        mat_records = storage.get_event_records(
+            dg.EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                asset_key=asset_key,
+            ),
+            limit=1,
+            ascending=False,
+        )
+        assert len(mat_records) == 1
+        m1_storage_id = mat_records[0].storage_id
+        m1_timestamp = mat_records[0].timestamp
+
+        # Store planned event for partition "a"
+        storage.store_event(
+            _create_check_planned_event(run_id_1, check_key, partitions_subset=partitions_subset)
+        )
+
+        # Store evaluation for partition "a" with target_materialization_data pointing to M1
+        storage.store_event(
+            _create_check_evaluation_event(
+                run_id_1,
+                check_key,
+                passed=True,
+                partition="a",
+                target_materialization_data=AssetCheckEvaluationTargetMaterializationData(
+                    storage_id=m1_storage_id,
+                    run_id=run_id_1,
+                    timestamp=m1_timestamp,
+                ),
+            )
+        )
+
+        # Verify check record has target_materialization_data.storage_id == M1.storage_id
+        checks = storage.get_asset_check_execution_history(check_key, limit=10, partition="a")
+        assert len(checks) == 1
+        assert checks[0].event
+        assert checks[0].event.dagster_event
+        check_data = checks[0].event.dagster_event.asset_check_evaluation_data
+        assert check_data.target_materialization_data
+        assert check_data.target_materialization_data.storage_id == m1_storage_id
+
+        # Store materialization M2 for partition "a"
+        storage.store_event(_create_materialization_event(run_id_2, asset_key, partition="a"))
+
+        # Get M2's storage_id
+        mat_records = storage.get_event_records(
+            dg.EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                asset_key=asset_key,
+            ),
+            limit=1,
+            ascending=False,
+        )
+        assert len(mat_records) == 1
+        m2_storage_id = mat_records[0].storage_id
+        assert m2_storage_id != m1_storage_id, "M2 should have different storage_id than M1"
+
+        # Verify check's target_materialization_data.storage_id still equals M1 (not M2)
+        # This means the check now targets an older materialization
+        checks = storage.get_asset_check_execution_history(check_key, limit=10, partition="a")
+        assert len(checks) == 1
+        assert checks[0].event
+        assert checks[0].event.dagster_event
+        check_data = checks[0].event.dagster_event.asset_check_evaluation_data
+        assert check_data.target_materialization_data
+        assert check_data.target_materialization_data.storage_id == m1_storage_id
+        assert check_data.target_materialization_data.storage_id != m2_storage_id
+
+
+def _create_check_planned_event(
+    run_id: str,
+    check_key: dg.AssetCheckKey,
+    partitions_subset: Optional["dg.PartitionsSubset"] = None,
+) -> dg.EventLogEntry:
+    """Helper to create an ASSET_CHECK_EVALUATION_PLANNED event."""
+    return dg.EventLogEntry(
+        error_info=None,
+        user_message="",
+        level="debug",
+        run_id=run_id,
+        timestamp=time.time(),
+        dagster_event=dg.DagsterEvent(
+            DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED.value,
+            "nonce",
+            event_specific_data=AssetCheckEvaluationPlanned(
+                asset_key=check_key.asset_key,
+                check_name=check_key.name,
+                partitions_subset=partitions_subset,
+            ),
+        ),
+    )
+
+
+def _create_check_evaluation_event(
+    run_id: str,
+    check_key: dg.AssetCheckKey,
+    passed: bool,
+    partition: Optional[str] = None,
+    target_materialization_data: Optional[AssetCheckEvaluationTargetMaterializationData] = None,
+) -> dg.EventLogEntry:
+    """Helper to create an ASSET_CHECK_EVALUATION event."""
+    return dg.EventLogEntry(
+        error_info=None,
+        user_message="",
+        level="debug",
+        run_id=run_id,
+        timestamp=time.time(),
+        dagster_event=dg.DagsterEvent(
+            DagsterEventType.ASSET_CHECK_EVALUATION.value,
+            "nonce",
+            event_specific_data=dg.AssetCheckEvaluation(
+                asset_key=check_key.asset_key,
+                check_name=check_key.name,
+                passed=passed,
+                metadata={},
+                target_materialization_data=target_materialization_data,
+                severity=AssetCheckSeverity.ERROR,
+                partition=partition,
+            ),
+        ),
+    )
+
+
+def _create_materialization_event(
+    run_id: str,
+    asset_key: dg.AssetKey,
+    partition: Optional[str] = None,
+) -> dg.EventLogEntry:
+    """Helper to create an ASSET_MATERIALIZATION event."""
+    return dg.EventLogEntry(
+        error_info=None,
+        user_message="",
+        level="debug",
+        run_id=run_id,
+        timestamp=time.time(),
+        dagster_event=dg.DagsterEvent(
+            DagsterEventType.ASSET_MATERIALIZATION.value,
+            "nonce",
+            event_specific_data=StepMaterializationData(
+                materialization=dg.AssetMaterialization(
+                    asset_key=asset_key,
+                    partition=partition,
+                ),
+                asset_lineage=[],
+            ),
+        ),
+    )


### PR DESCRIPTION
## Summary & Motivation

As title. This is a minimally-invasive change that updates the storage method for getting asset check execution records to take into account partition information.

There is some minor refactoring happening in run_domain.py/dagster_run.py to allow me to reuse logic from the ASSET_MATERIALIZATION_PLANNED side of the world for creating planned events for partitioned asset checks.

On the storage side of the world, we update sql_event_log.py such that we start writing one execution record per partition in subset, and add partition-related parameters to the relevant storage methods.

This PR does NOT include any changes allowing us to efficiently fetch status for multiple partition keys at once, as this will happen in later PRs.

## How I Tested These Changes

## Changelog

NOCHANGELOG
