### PR TITLE
[dagster-cloud] deprecate `dg ci check`

### DIFF
--- a/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
+++ b/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
@@ -201,8 +201,8 @@ Before following the steps in this section, you must:
 
 :::
 
-{/* Note: Previously this section referenced `dagster-cloud ci check` which is now deprecated.
-The `dg plus deploy start` command (step 2 below) validates configuration during initialization. */}
+{/* Note: The `dg plus deploy start` command now validates configuration including YAML schema,
+build directories, and API connectivity before starting the deploy session. */}
 
 1.  Set the build environment variables. Note that all variables are required:
     - `DAGSTER_CLOUD_ORGANIZATION`: The name of your organization in Dagster+.

--- a/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
+++ b/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
@@ -202,7 +202,7 @@ Before following the steps in this section, you must:
 :::
 
 {/* Note: Previously this section referenced `dagster-cloud ci check` which is now deprecated.
-    The `dg plus deploy start` command (step 2 below) validates configuration during initialization. */}
+The `dg plus deploy start` command (step 2 below) validates configuration during initialization. */}
 
 1.  Set the build environment variables. Note that all variables are required:
     - `DAGSTER_CLOUD_ORGANIZATION`: The name of your organization in Dagster+.

--- a/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
+++ b/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
@@ -201,9 +201,6 @@ Before following the steps in this section, you must:
 
 :::
 
-{/* Note: The `dg plus deploy start` command now validates configuration including YAML schema,
-build directories, and API connectivity before starting the deploy session. */}
-
 1.  Set the build environment variables. Note that all variables are required:
     - `DAGSTER_CLOUD_ORGANIZATION`: The name of your organization in Dagster+.
     - `DAGSTER_CLOUD_API_TOKEN`: A Dagster+ API token. **Note:** This is a sensitive value and should be stored as a CI/CD secret if possible.

--- a/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
+++ b/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
@@ -162,7 +162,7 @@ If you don't want to use our automated GitHub/GitLab process, you can use the [`
    dagster-cloud configure
    ```
 
-You can also configure the `dagster-cloud` tool non-interactively; for more information, see [the `dagster-cloud` installation and configuration docs](/api/clis/dagster-cloud-cli/installing-and-configuring). For new projects, consider using the `dg` CLI instead via `dg plus login`.
+You can also configure the `dagster-cloud` tool non-interactively; for more information, see [the `dagster-cloud` installation and configuration docs](/api/clis/dagster-cloud-cli/installing-and-configuring). For new projects, consider using the `dg` CLI command `dg plus login` instead.
 
 3. Finally, deploy your project to Dagster+ using the `serverless` command, replacing `YOUR_PACKAGE_NAME` with the name of your Dagster package:
 

--- a/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
+++ b/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
@@ -162,7 +162,7 @@ If you don't want to use our automated GitHub/GitLab process, you can use the [`
    dagster-cloud configure
    ```
 
-You can also configure the `dagster-cloud` tool non-interactively; for more information, see [the `dagster-cloud` installation and configuration docs](/api/clis/dagster-cloud-cli/installing-and-configuring). {/* TODO - replace with `dg` equivalent */}
+You can also configure the `dagster-cloud` tool non-interactively; for more information, see [the `dagster-cloud` installation and configuration docs](/api/clis/dagster-cloud-cli/installing-and-configuring). For new projects, consider using the `dg` CLI instead via `dg plus login`.
 
 3. Finally, deploy your project to Dagster+ using the `serverless` command, replacing `YOUR_PACKAGE_NAME` with the name of your Dagster package:
 
@@ -201,7 +201,8 @@ Before following the steps in this section, you must:
 
 :::
 
-{/* TODO add step 2 below for running `dg` equivalent of `dagster-cloud ci check --project-dir=. */}
+{/* Note: Previously this section referenced `dagster-cloud ci check` which is now deprecated.
+    The `dg plus deploy start` command (step 2 below) validates configuration during initialization. */}
 
 1.  Set the build environment variables. Note that all variables are required:
     - `DAGSTER_CLOUD_ORGANIZATION`: The name of your organization in Dagster+.

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/ci/__init__.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/ci/__init__.py
@@ -249,6 +249,11 @@ def check_command(
     dagster_cloud_yaml_check: checks.Check = typer.Option("error"),
     dagster_cloud_connect_check: checks.Check = typer.Option("error"),
 ):
+    ui.warn(
+        "The 'dagster-cloud ci check' command is deprecated and will be removed in a future release. "
+        "Use 'dg plus deploy start' instead, which validates configuration during deployment initialization."
+    )
+
     project_path = pathlib.Path(project_dir)
 
     verdicts = []

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/conftest.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/conftest.py
@@ -25,3 +25,7 @@ def create_template_file(tmpdir: str, filename: str, text: str) -> Generator[str
 def empty_config(monkeypatch):
     # ensure no defaults are read from the local config
     monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", "/tmp/nosuchpath")
+    # also clear any environment variables that might be set
+    monkeypatch.delenv("DAGSTER_CLOUD_ORGANIZATION", raising=False)
+    monkeypatch.delenv("DAGSTER_CLOUD_API_TOKEN", raising=False)
+    monkeypatch.delenv("DAGSTER_CLOUD_DEPLOYMENT", raising=False)

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/test_check.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/test_check.py
@@ -123,6 +123,8 @@ def test_dagster_cloud_yaml_check() -> None:
 
     result = check_yaml(LONG_VALID_DAGSTER_CLOUD_YAML)
     assert not result.exit_code, result.output
+    assert "deprecated" in result.output.lower()
+    assert "dg plus deploy start" in result.output
 
 
 def test_dagster_cloud_connect_check(empty_config, monkeypatch, mocker) -> None:
@@ -149,4 +151,6 @@ def test_dagster_cloud_connect_check(empty_config, monkeypatch, mocker) -> None:
     result = run_connect_check()
     assert "Able to connect to dagster.cloud" in result.output
     assert not result.exit_code
+    assert "deprecated" in result.output.lower()
+    assert "dg plus deploy start" in result.output
     get_organization_settings.assert_called_once()


### PR DESCRIPTION
## Summary & Motivation

Closes FW-408.

## How I Tested These Changes

## Changelog

- [dagster-cloud-cli] The `dagster-cloud ci check` command is now deprecated. Use `dg plus deploy start` instead, which validates configuration during deployment initialization. The deprecated command will be removed in a future release.

