### PR TITLE
[dg] adds `dagster-cloud ci check` validation to `dg plus deploy start`

### DIFF
--- a/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
+++ b/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
@@ -201,8 +201,8 @@ Before following the steps in this section, you must:
 
 :::
 
-{/* Note: Previously this section referenced `dagster-cloud ci check` which is now deprecated.
-The `dg plus deploy start` command (step 2 below) validates configuration during initialization. */}
+{/* Note: The `dg plus deploy start` command now validates configuration including YAML schema,
+build directories, and API connectivity before starting the deploy session. */}
 
 1.  Set the build environment variables. Note that all variables are required:
     - `DAGSTER_CLOUD_ORGANIZATION`: The name of your organization in Dagster+.

--- a/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
+++ b/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
@@ -202,7 +202,7 @@ Before following the steps in this section, you must:
 :::
 
 {/* Note: Previously this section referenced `dagster-cloud ci check` which is now deprecated.
-    The `dg plus deploy start` command (step 2 below) validates configuration during initialization. */}
+The `dg plus deploy start` command (step 2 below) validates configuration during initialization. */}
 
 1.  Set the build environment variables. Note that all variables are required:
     - `DAGSTER_CLOUD_ORGANIZATION`: The name of your organization in Dagster+.

--- a/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
+++ b/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
@@ -201,9 +201,6 @@ Before following the steps in this section, you must:
 
 :::
 
-{/* Note: The `dg plus deploy start` command now validates configuration including YAML schema,
-build directories, and API connectivity before starting the deploy session. */}
-
 1.  Set the build environment variables. Note that all variables are required:
     - `DAGSTER_CLOUD_ORGANIZATION`: The name of your organization in Dagster+.
     - `DAGSTER_CLOUD_API_TOKEN`: A Dagster+ API token. **Note:** This is a sensitive value and should be stored as a CI/CD secret if possible.

--- a/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
+++ b/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
@@ -162,7 +162,7 @@ If you don't want to use our automated GitHub/GitLab process, you can use the [`
    dagster-cloud configure
    ```
 
-You can also configure the `dagster-cloud` tool non-interactively; for more information, see [the `dagster-cloud` installation and configuration docs](/api/clis/dagster-cloud-cli/installing-and-configuring). For new projects, consider using the `dg` CLI command `dg plus login` instead.
+You can also configure the `dagster-cloud` tool non-interactively; for more information, see [the `dagster-cloud` installation and configuration docs](/api/clis/dagster-cloud-cli/installing-and-configuring). For new projects, consider using the `dg` CLI instead via `dg plus login`.
 
 3. Finally, deploy your project to Dagster+ using the `serverless` command, replacing `YOUR_PACKAGE_NAME` with the name of your Dagster package:
 
@@ -200,6 +200,9 @@ Before following the steps in this section, you must:
 - Log in to your Dagster organization with `dg plus login`
 
 :::
+
+{/* Note: Previously this section referenced `dagster-cloud ci check` which is now deprecated.
+    The `dg plus deploy start` command (step 2 below) validates configuration during initialization. */}
 
 1.  Set the build environment variables. Note that all variables are required:
     - `DAGSTER_CLOUD_ORGANIZATION`: The name of your organization in Dagster+.

--- a/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
+++ b/docs/docs/deployment/dagster-plus/deploying-code/configuring-ci-cd.md
@@ -162,7 +162,7 @@ If you don't want to use our automated GitHub/GitLab process, you can use the [`
    dagster-cloud configure
    ```
 
-You can also configure the `dagster-cloud` tool non-interactively; for more information, see [the `dagster-cloud` installation and configuration docs](/api/clis/dagster-cloud-cli/installing-and-configuring). For new projects, consider using the `dg` CLI instead via `dg plus login`.
+You can also configure the `dagster-cloud` tool non-interactively; for more information, see [the `dagster-cloud` installation and configuration docs](/api/clis/dagster-cloud-cli/installing-and-configuring). For new projects, consider using the `dg` CLI command `dg plus login` instead.
 
 3. Finally, deploy your project to Dagster+ using the `serverless` command, replacing `YOUR_PACKAGE_NAME` with the name of your Dagster package:
 

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/conftest.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/conftest.py
@@ -23,9 +23,7 @@ def create_template_file(tmpdir: str, filename: str, text: str) -> Generator[str
 
 @pytest.fixture
 def empty_config(monkeypatch):
-    # ensure no defaults are read from the local config
     monkeypatch.setenv("DAGSTER_CLOUD_CLI_CONFIG", "/tmp/nosuchpath")
-    # also clear any environment variables that might be set
     monkeypatch.delenv("DAGSTER_CLOUD_ORGANIZATION", raising=False)
     monkeypatch.delenv("DAGSTER_CLOUD_API_TOKEN", raising=False)
     monkeypatch.delenv("DAGSTER_CLOUD_DEPLOYMENT", raising=False)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/commands.py
@@ -141,6 +141,11 @@ org_and_deploy_option_group = make_option_group(
         ]
     ),
 )
+@click.option(
+    "--skip-validation",
+    is_flag=True,
+    help="Skip configuration validation checks (not recommended).",
+)
 @dg_editable_dagster_options
 @dg_path_options
 @dg_global_options
@@ -159,6 +164,7 @@ def deploy_group(
     target_path: Path,
     status_url: Optional[str],
     snapshot_base_condition_str: Optional[str],
+    skip_validation: bool,
     **global_options: object,
 ) -> None:
     """Deploy a project or workspace to Dagster Plus. Handles all state management for the deploy
@@ -211,6 +217,7 @@ def deploy_group(
         location_names,
         status_url,
         snapshot_base_condition,
+        skip_validation,
     )
 
     build_artifact(
@@ -281,6 +288,11 @@ def _validate_location_names(
         ]
     ),
 )
+@click.option(
+    "--skip-validation",
+    is_flag=True,
+    help="Skip configuration validation checks (not recommended).",
+)
 @dg_global_options
 @cli_telemetry_wrapper
 def start_deploy_session_command(
@@ -294,6 +306,7 @@ def start_deploy_session_command(
     target_path: Path,
     status_url: Optional[str],
     snapshot_base_condition_str: Optional[str],
+    skip_validation: bool,
     **global_options: object,
 ) -> None:
     """Start a new deploy session. Determines which code locations will be deployed and what
@@ -329,6 +342,7 @@ def start_deploy_session_command(
         location_names,
         status_url,
         snapshot_base_condition,
+        skip_validation,
     )
 
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/deploy_session.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/deploy_session.py
@@ -147,16 +147,11 @@ def init_deploy_session(
 
     from dagster_dg_cli.cli.plus.deploy.validation import validate_deploy_configuration
 
-    try:
+    if not skip_validation:
         validate_deploy_configuration(
             dagster_cloud_yaml_path=dagster_cloud_yaml_file,
             organization=organization,
-            skip_validation=skip_validation,
         )
-    except click.ClickException:
-        if os.path.exists(statedir):
-            shutil.rmtree(statedir, ignore_errors=True)
-        raise
 
     from dagster_cloud_cli.commands.ci import init_impl
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/validation.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/validation.py
@@ -26,7 +26,6 @@ def _extract_dagster_env_from_url(url: Optional[str]) -> Optional[str]:
 def validate_deploy_configuration(
     dagster_cloud_yaml_path: str,
     organization: str,
-    skip_validation: bool = False,
 ) -> None:
     """Validate deployment configuration before starting deploy session.
 
@@ -37,14 +36,10 @@ def validate_deploy_configuration(
     Args:
         dagster_cloud_yaml_path: Path to the dagster_cloud.yaml file to validate
         organization: Dagster Cloud organization name
-        skip_validation: If True, skip all validation checks
 
     Raises:
         click.ClickException: If validation fails
     """
-    if skip_validation:
-        return
-
     yaml_path = pathlib.Path(dagster_cloud_yaml_path)
 
     yaml_result = checks.check_dagster_cloud_yaml(yaml_path)

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/validation.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/deploy/validation.py
@@ -1,0 +1,73 @@
+"""Validation for dg plus deploy commands."""
+
+import pathlib
+from typing import Optional
+
+import click
+from dagster_cloud_cli.commands.ci import checks
+from dagster_cloud_cli.config_utils import get_org_url
+from dagster_shared.plus.config import DagsterPlusCliConfig
+
+
+def _extract_dagster_env_from_url(url: Optional[str]) -> Optional[str]:
+    """Extract dagster_env from a DagsterPlusCliConfig URL.
+
+    Args:
+        url: Base URL like "https://eu.dagster.cloud" or None
+
+    Returns:
+        "eu" if EU region, None otherwise
+    """
+    if url and "eu.dagster.cloud" in url:
+        return "eu"
+    return None
+
+
+def validate_deploy_configuration(
+    dagster_cloud_yaml_path: str,
+    organization: str,
+    skip_validation: bool = False,
+) -> None:
+    """Validate deployment configuration before starting deploy session.
+
+    Performs:
+    - YAML schema validation (structure, required fields, build directories)
+    - API connectivity check (token + GraphQL query)
+
+    Args:
+        dagster_cloud_yaml_path: Path to the dagster_cloud.yaml file to validate
+        organization: Dagster Cloud organization name
+        skip_validation: If True, skip all validation checks
+
+    Raises:
+        click.ClickException: If validation fails
+    """
+    if skip_validation:
+        return
+
+    yaml_path = pathlib.Path(dagster_cloud_yaml_path)
+
+    yaml_result = checks.check_dagster_cloud_yaml(yaml_path)
+
+    dagster_env = None
+    if DagsterPlusCliConfig.exists():
+        config = DagsterPlusCliConfig.get()
+        dagster_env = _extract_dagster_env_from_url(config.url)
+
+    url = get_org_url(organization, dagster_env)
+    connect_result = checks.check_connect_dagster_cloud(url)
+
+    all_errors = yaml_result.errors + connect_result.errors
+
+    if all_errors:
+        click.echo(click.style("\nConfiguration validation failed:", fg="red", bold=True))
+        click.echo()
+        for error in all_errors:
+            click.echo(f"  • {error}")
+        click.echo()
+        click.echo(
+            click.style("Fix the errors above or use --skip-validation to bypass.", dim=True)
+        )
+        raise click.ClickException("Deploy configuration validation failed")
+
+    click.echo("Configuration validated")

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/plus_tests/test_plus_deploy_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/plus_tests/test_plus_deploy_command.py
@@ -226,9 +226,14 @@ def mock_external_dagster_cloud_cli_command() -> Generator[MockedCloudCliCommand
         patch(
             "dagster_cloud_cli.commands.ci.set_build_output",
         ) as mock_set_build_output_command,
+        patch(
+            "dagster_dg_cli.cli.plus.deploy.validation.validate_deploy_configuration",
+        ) as mock_validation,
     ):
         # Ensure deploy_impl mock returns successfully without checking build state
         mock_deploy_command.return_value = None
+        # Skip validation in tests
+        mock_validation.return_value = None
         yield MockedCloudCliCommands(
             init=mock_init_command,
             build=mock_build_command,

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/plus_tests/test_plus_deploy_validation.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/plus_tests/test_plus_deploy_validation.py
@@ -1,0 +1,192 @@
+"""Tests for validation in dg plus deploy commands."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import responses
+from dagster_shared.plus.config import DagsterPlusCliConfig
+from dagster_test.dg_utils.utils import ProxyRunner, isolated_example_project_foo_bar
+
+
+@pytest.fixture
+def logged_in_dg_cli_config(empty_dg_cli_config, monkeypatch):
+    """Config with organization and token set."""
+    config = DagsterPlusCliConfig(
+        organization="hooli",
+        user_token="fake-user-token",
+        default_deployment="prod",
+    )
+    config.write()
+    monkeypatch.setenv("DAGSTER_CLOUD_API_TOKEN", "fake-api-token")
+    yield
+
+
+@pytest.fixture
+def empty_dg_cli_config(monkeypatch):
+    """Empty config with no credentials."""
+    with tempfile.TemporaryDirectory() as tmp_dg_dir:
+        config_path = Path(tmp_dg_dir) / "dg.toml"
+        monkeypatch.setenv("DG_CLI_CONFIG", config_path)
+        monkeypatch.delenv("DG_USE_EDITABLE_DAGSTER", raising=False)
+        monkeypatch.delenv("DAGSTER_CLOUD_ORGANIZATION", raising=False)
+        monkeypatch.delenv("DAGSTER_CLOUD_API_TOKEN", raising=False)
+        monkeypatch.delenv("DAGSTER_CLOUD_DEPLOYMENT", raising=False)
+        yield
+
+
+@pytest.fixture(scope="module")
+def runner():
+    """CLI test runner."""
+    with ProxyRunner.test(use_fixed_test_components=True) as the_runner:
+        yield the_runner
+
+
+@pytest.fixture
+def project(runner):
+    """Create an isolated test project."""
+    with isolated_example_project_foo_bar(runner) as project_dir:
+        yield project_dir
+
+
+@responses.activate
+def test_deploy_start_validates_yaml_schema(logged_in_dg_cli_config, project: Path, runner):
+    """Test that valid configuration passes validation."""
+    # Mock successful API connectivity check
+    responses.add(
+        responses.POST,
+        "https://hooli.dagster.cloud/graphql",
+        json={"data": {"organizationSettings": {"settings": "{}"}}},
+    )
+
+    # Mock init_impl to avoid actual deployment
+    with patch("dagster_cloud_cli.commands.ci.init_impl"):
+        result = runner.invoke("plus", "deploy", "start", "--yes")
+        assert result.exit_code == 0, result.output
+        assert "Configuration validated" in result.output
+
+
+@responses.activate
+def test_deploy_start_fails_on_invalid_yaml(logged_in_dg_cli_config, project: Path, runner):
+    """Test that invalid YAML schema fails validation."""
+    # Mock the temp YAML generation to create invalid YAML
+    with patch(
+        "dagster_dg_cli.cli.utils.create_temp_dagster_cloud_yaml_file",
+        side_effect=lambda ctx, statedir: _create_invalid_yaml(statedir),
+    ):
+        result = runner.invoke("plus", "deploy", "start", "--yes")
+        assert result.exit_code != 0
+        assert "Configuration validation failed" in result.output
+
+
+def test_deploy_start_fails_on_missing_api_token(empty_dg_cli_config, project: Path, runner):
+    """Test that missing API token fails validation."""
+    result = runner.invoke(
+        "plus", "deploy", "start", "--organization=hooli", "--deployment=prod", "--yes"
+    )
+    assert result.exit_code != 0
+    assert "Configuration validation failed" in result.output
+    assert "DAGSTER_CLOUD_API_TOKEN" in result.output
+
+
+@responses.activate
+def test_deploy_start_fails_on_invalid_api_token(logged_in_dg_cli_config, project: Path, runner):
+    """Test that invalid API token fails validation."""
+    # Mock API returning authentication error
+    responses.add(
+        responses.POST,
+        "https://hooli.dagster.cloud/graphql",
+        json={"errors": [{"message": "Unauthorized"}]},
+        status=401,
+    )
+
+    result = runner.invoke("plus", "deploy", "start", "--yes")
+    assert result.exit_code != 0
+    assert "Configuration validation failed" in result.output
+
+
+@responses.activate
+def test_deploy_start_succeeds_with_valid_config(logged_in_dg_cli_config, project: Path, runner):
+    """Test that valid configuration passes all checks."""
+    responses.add(
+        responses.POST,
+        "https://hooli.dagster.cloud/graphql",
+        json={"data": {"organizationSettings": {"settings": "{}"}}},
+    )
+
+    with patch("dagster_cloud_cli.commands.ci.init_impl"):
+        result = runner.invoke("plus", "deploy", "start", "--yes")
+        assert result.exit_code == 0, result.output
+        assert "Configuration validated" in result.output
+
+
+@responses.activate
+def test_deploy_start_eu_region_url(empty_dg_cli_config, project: Path, runner, monkeypatch):
+    """Test that EU region uses correct URL format."""
+    config = DagsterPlusCliConfig(
+        organization="hooli",
+        user_token="fake-user-token",
+        default_deployment="prod",
+        url="https://eu.dagster.cloud",
+    )
+    config.write()
+    monkeypatch.setenv("DAGSTER_CLOUD_API_TOKEN", "fake-api-token")
+
+    responses.add(
+        responses.POST,
+        "https://hooli.eu.dagster.cloud/graphql",
+        json={"data": {"organizationSettings": {"settings": "{}"}}},
+    )
+
+    with patch("dagster_cloud_cli.commands.ci.init_impl"):
+        result = runner.invoke("plus", "deploy", "start", "--yes")
+        assert result.exit_code == 0, result.output
+        assert "Configuration validated" in result.output
+
+
+@responses.activate
+def test_deploy_start_skip_validation_bypasses_checks(
+    logged_in_dg_cli_config, project: Path, runner
+):
+    """Test that --skip-validation bypasses all validation checks."""
+    with patch("dagster_cloud_cli.commands.ci.init_impl"):
+        result = runner.invoke("plus", "deploy", "start", "--yes", "--skip-validation")
+        assert result.exit_code == 0, result.output
+        assert "Configuration validated" not in result.output
+
+
+def test_deploy_start_skip_validation_with_missing_token(
+    empty_dg_cli_config, project: Path, runner
+):
+    """Test that --skip-validation works even with missing API token."""
+    with patch("dagster_cloud_cli.commands.ci.init_impl"):
+        result = runner.invoke(
+            "plus",
+            "deploy",
+            "start",
+            "--organization=hooli",
+            "--deployment=prod",
+            "--yes",
+            "--skip-validation",
+        )
+        assert result.exit_code == 0, result.output
+
+
+def test_validation_errors_are_actionable(empty_dg_cli_config, project: Path, runner):
+    """Test that error messages provide clear guidance."""
+    result = runner.invoke(
+        "plus", "deploy", "start", "--organization=hooli", "--deployment=prod", "--yes"
+    )
+    assert result.exit_code != 0
+    assert "Configuration validation failed:" in result.output
+    assert "DAGSTER_CLOUD_API_TOKEN" in result.output
+    assert "--skip-validation" in result.output
+
+
+def _create_invalid_yaml(statedir: str) -> str:
+    """Create an invalid dagster_cloud.yaml file."""
+    yaml_path = Path(statedir) / "dagster_cloud.yaml"
+    # Write YAML with invalid structure (missing required 'locations' field)
+    yaml_path.write_text("invalid: yaml\nstructure: true\n")
+    return str(yaml_path)


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Changelog

- [dg] `dg plus deploy start` now validates deployment akin to `dagster-cloud ci check`
