### PR TITLE
[pac] Add get_asset_check_partition_info storage method

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -16,6 +16,7 @@ from dagster._core.event_api import EventHandlerFn
 from dagster._core.storage.asset_check_execution_record import (
     AssetCheckExecutionRecord,
     AssetCheckExecutionRecordStatus,
+    AssetCheckPartitionInfo,
 )
 from dagster._core.storage.base_storage import DagsterStorage
 from dagster._core.storage.event_log.base import (
@@ -763,6 +764,16 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     ) -> Mapping["AssetCheckKey", AssetCheckExecutionRecord]:
         return self._storage.event_log_storage.get_latest_asset_check_execution_by_key(
             check_keys, partition=partition
+        )
+
+    def get_asset_check_partition_info(
+        self,
+        keys: Sequence["AssetCheckKey"],
+        after_storage_id: Optional[int] = None,
+        partition_keys: Optional[Sequence[str]] = None,
+    ) -> Sequence[AssetCheckPartitionInfo]:
+        return self._storage.event_log_storage.get_asset_check_partition_info(
+            keys=keys, after_storage_id=after_storage_id, partition_keys=partition_keys
         )
 
 


### PR DESCRIPTION
## Summary & Motivation

This PR adds a new storage method for fetching a summary record about the status of multiple partitions (of multiple checks) at once.

The current implementation relies on a series of explicit queries against the asset check executions table, but one could imagine a world in which a separate summary table was created and updated on event store, which would result in faster queries.

## How I Tested These Changes

## Changelog

NOCHANGELOG
