### PR TITLE
fix: Allow custom readiness probe

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -178,7 +178,11 @@ spec:
               {{- toYaml $deployment.livenessProbe.failureThreshold | nindent 14 }}
             {{- end }}
           {{- else}}
-          livenessProbe: {{ $deployment.livenessProbe | toYaml | nindent 12 }}
+          livenessProbe:
+            {{- $livenessProbe := omit $deployment.livenessProbe "enabled" }}
+            {{- if $livenessProbe }}
+              {{- $livenessProbe | toYaml | nindent 12 }}
+            {{- end }}
           {{- end }}
         {{- end }}
         {{- if $deployment.startupProbe }}


### PR DESCRIPTION
## Summary & Motivation

Fixes issue #25979 . Following the pattern currently used to render `startupProbe`, this PR omits the `enabled` key during rendering, which is added to the readiness probe by Dagster's custom schema.

## How I Tested These Changes

I rendered a test chart using a custom exec function.
