### PR TITLE
`inspect.iscoroutinefunction` instead of `asyncio.iscoroutinefunction`

### DIFF
--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/cached_method.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/cached_method.py
@@ -1,6 +1,6 @@
-import asyncio
 from collections.abc import Callable, Hashable, Mapping
 from functools import wraps
+from inspect import iscoroutinefunction
 from typing import Any, Concatenate, TypeVar, cast
 
 from typing_extensions import ParamSpec
@@ -93,7 +93,7 @@ def cached_method(method: Callable[Concatenate[S, P], T]) -> Callable[Concatenat
 
         return canonical_kwargs
 
-    if asyncio.iscoroutinefunction(method):
+    if iscoroutinefunction(method):
 
         @wraps(method)
         async def _async_cached_method_wrapper(self: S, *args: P.args, **kwargs: P.kwargs) -> T:


### PR DESCRIPTION
Running tests on python 3.14 warns that the `asyncio` function should be replaced with the `inspect` one. A lot of the dagster code is already using inspect.iscoroutinefunction instead of the asyncio one.
