### PR TITLE
Source row count section in the UI from observation or asset metadata when it is not set by a materialization

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/overview/AssetNodeOverview.tsx
@@ -100,9 +100,21 @@ export const AssetNodeOverview = ({
     definitionLoadTimestamp: assetNodeLoadTimestamp,
   });
 
-  const rowCountMeta: IntMetadataEntry | undefined = materialization?.metadataEntries.find(
-    (entry) => isCanonicalRowCountMetadataEntry(entry),
+  let rowCountMeta: IntMetadataEntry | undefined = materialization?.metadataEntries.find((entry) =>
+    isCanonicalRowCountMetadataEntry(entry),
   ) as IntMetadataEntry | undefined;
+
+  if (!rowCountMeta && observation) {
+    rowCountMeta = observation.metadataEntries.find((entry) =>
+      isCanonicalRowCountMetadataEntry(entry),
+    ) as IntMetadataEntry | undefined;
+  }
+
+  if (!rowCountMeta) {
+    rowCountMeta = assetNode?.metadataEntries.find((entry) =>
+      isCanonicalRowCountMetadataEntry(entry),
+    ) as IntMetadataEntry | undefined;
+  }
 
   // The live data does not include a partition, but the timestamp on the live data triggers
   // an update of `observation` and `materialization`, so they should be in sync. To make sure


### PR DESCRIPTION
## Summary & Motivation
Currently if an asset node has row count set in its graph metadata or from an observation, but there is no materializaton with that field, we remove it from the list of metadata in the table view. Instead, show it in these cases.

## How I Tested These Changes
Load an asset created by a warehouse connection - row count is now populated at the top

## Changelog
[ui] Fixed an issue where `dagster/row_count` metadata was sometimes not displayed on the Asset Overview page if it was being set by an asset observation rather than a materialization.
