### PR TITLE
[dagster-dbt] Support --exclude in the temp selector file

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_temp_selector.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_temp_selector.py
@@ -6,6 +6,47 @@ from unittest import mock
 
 import pytest
 from dagster_dbt import DbtCliResource
+from dagster_dbt.asset_utils import _parse_selection_args
+
+
+class TestParseSelectionArgs:
+    """Unit tests for _parse_selection_args helper function."""
+
+    def test_select_only(self):
+        """Test parsing args with only --select."""
+        args = ["--select", "model1 model2 model3"]
+        select, exclude = _parse_selection_args(args)
+        assert select == ["model1", "model2", "model3"]
+        assert exclude is None
+
+    def test_exclude_only(self):
+        """Test parsing args with only --exclude."""
+        args = ["--exclude", "model1 model2"]
+        select, exclude = _parse_selection_args(args)
+        assert select is None
+        assert exclude == ["model1", "model2"]
+
+    def test_select_and_exclude(self):
+        """Test parsing args with both --select and --exclude."""
+        args = ["--select", "model1 model2 model3", "--exclude", "model2"]
+        select, exclude = _parse_selection_args(args)
+        assert select == ["model1", "model2", "model3"]
+        assert exclude == ["model2"]
+
+    def test_empty_args(self):
+        """Test parsing empty args."""
+        args: list[str] = []
+        select, exclude = _parse_selection_args(args)
+        assert select is None
+        assert exclude is None
+
+    def test_selector_arg_ignored(self):
+        """Test that --selector args are ignored (not parsed as select/exclude)."""
+        args = ["--selector", "my_selector"]
+        select, exclude = _parse_selection_args(args)
+        assert select is None
+        assert exclude is None
+
 
 _EXISTING_SELECTORS_CONTENT = textwrap.dedent("""
 selectors:
@@ -138,3 +179,89 @@ def test_temp_selector_file_used_with_many_models(large_dbt_project: tuple[Path,
         assert content == _EXISTING_SELECTORS_CONTENT, (
             "Existing selectors.yml content should be unchanged."
         )
+
+
+def test_temp_selector_file_includes_exclude(large_dbt_project: tuple[Path, dict]):
+    """Test that --exclude arguments are incorporated into the generated selectors.yml.
+
+    This test verifies that when both --select and --exclude are present and exceed
+    the threshold, the exclude is properly included in the selectors.yml definition,
+    and that the excluded model is not actually materialized.
+    """
+    import yaml
+    from dagster import AssetExecutionContext, AssetKey, materialize
+    from dagster_dbt import DbtCliResource, DbtProject, dbt_assets
+
+    project_dir, manifest = large_dbt_project
+
+    # Create DbtProject for metadata
+    dbt_project = DbtProject(project_dir=str(project_dir))
+
+    # Track the selectors.yml content that gets written
+    captured_selectors: list[dict] = []
+    original_write_text = Path.write_text
+
+    def intercepting_write_text(self, content, *args, **kwargs):
+        if self.name == "selectors.yml":
+            captured_selectors.append(yaml.safe_load(content))
+        return original_write_text(self, content, *args, **kwargs)
+
+    # Create a large select expression that exceeds the threshold when combined with exclude
+    # This simulates a user providing a large --select with --exclude
+    model_names = [f"model_{i}" for i in range(_NUM_MODELS)]
+    large_select = " ".join(model_names)
+
+    @dbt_assets(manifest=manifest, project=dbt_project, select=large_select, exclude="model_0")
+    def my_dbt_assets_with_exclude(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["run"], context=context).stream()
+
+    # Materialize all assets (not a subset) - this uses default_dbt_selection
+    # which includes both --select and --exclude from the decorator
+    # Patch selection args threshold to a low value for testing
+    with (
+        mock.patch("dagster_dbt.asset_utils._SELECTION_ARGS_THRESHOLD", 5),
+        mock.patch.object(Path, "write_text", intercepting_write_text),
+    ):
+        result = materialize(
+            [my_dbt_assets_with_exclude],
+            resources={"dbt": DbtCliResource(project_dir=str(project_dir))},
+            raise_on_error=False,
+        )
+
+    assert result.success, "Dbt run with exclude should succeed."
+
+    # Verify that selectors.yml was written with exclude
+    assert len(captured_selectors) > 0, "selectors.yml should have been written"
+    selector_content = captured_selectors[0]
+
+    # Verify structure of generated selectors.yml
+    assert "selectors" in selector_content
+    assert len(selector_content["selectors"]) == 1
+    selector_def = selector_content["selectors"][0]["definition"]
+
+    # Verify union is present (from --select)
+    assert "union" in selector_def, "Selector should have union key"
+    union_items = selector_def["union"]
+
+    # The union should contain all model names plus an exclude dict
+    # _NUM_MODELS items + 1 exclude dict = _NUM_MODELS + 1
+    assert len(union_items) == _NUM_MODELS + 1
+
+    # Verify exclude is present as an item in the union (dbt requires this structure)
+    exclude_item = union_items[-1]
+    assert isinstance(exclude_item, dict), "Last union item should be exclude dict"
+    assert "exclude" in exclude_item, "Should have exclude key"
+    assert exclude_item["exclude"] == ["model_0"]
+
+    # Verify the excluded model was not actually materialized
+    materialized_keys = result.get_asset_materialization_events()
+    materialized_asset_keys = {
+        event.asset_key for event in materialized_keys if event.asset_key is not None
+    }
+    excluded_key = AssetKey(["large_project", "model_0"])
+    assert excluded_key not in materialized_asset_keys, "model_0 should not be materialized"
+
+    # Verify other models were materialized
+    assert len(materialized_asset_keys) == _NUM_MODELS - 1, (
+        f"Expected {_NUM_MODELS - 1} models to be materialized, got {len(materialized_asset_keys)}"
+    )


### PR DESCRIPTION
## Summary & Motivation

#32710 added a workaround to dagster-dbt for when the asset selection is large enough to exceed the OS arg size limit. A temporary selectors.yml file is created. This workaround only incorporates the `--select` argument, however, and the `--exclude` argument is incompatible with a custom `selectors.yml`, leading to the situation where if `--select` and `--exclude` are both passed, `--exclude` is silently ignored.

This PR incorporates `--exclude` into the temporary `selectors.yml`, solving this problem.

## How I Tested These Changes

New unit tests.

## Changelog

- [dagster-dbt] Fixed an issue where the `exclude` parameter of `@dbt_assets` could be ignored if the selection was too large.