### PR TITLE
[ui] Align escaping in partition syntax with the allowed un-quoted characters

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/SpanRepresentation.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/SpanRepresentation.tsx
@@ -10,15 +10,11 @@ export type {ParsedPartitionTerm as ParsedSpanTerm} from './AntlrPartitionSelect
 
 /**
  * Regular expression matching characters that require quoting in partition keys.
- * These characters have special meaning in the partition selection syntax:
- * - , (comma): separates partition items
- * - [ ] (brackets): range delimiters
- * - . (dot): part of range delimiter ...
- * - * (asterisk): wildcard character
- * - " (quote): string delimiter
- * - \ (backslash): escape character
+ * This matches any character NOT allowed in unquoted partition keys per the grammar.
+ * The grammar's UNQUOTED_CHAR fragment allows: [-a-zA-Z0-9_:/@]
+ * Any other character (whitespace, punctuation, special chars) requires quoting.
  */
-const SPECIAL_CHARS = /[,[\].*"\\]/;
+const REQUIRES_QUOTING = /[^-a-zA-Z0-9_:/@]/;
 
 /**
  * Escape a partition key for serialization.
@@ -40,7 +36,7 @@ const SPECIAL_CHARS = /[,[\].*"\\]/;
  * // => '"key\\"with\\"quotes"'
  */
 export function escapePartitionKey(key: string): string {
-  if (!SPECIAL_CHARS.test(key)) {
+  if (!REQUIRES_QUOTING.test(key)) {
     return key;
   }
   // Escape backslashes first (so we don't double-escape), then quotes

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/SpanRepresentation.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/SpanRepresentation.test.tsx
@@ -58,6 +58,16 @@ describe('SpanRepresentation', () => {
       });
     });
 
+    describe('quotes keys with spaces (datetime partitions)', () => {
+      it('quotes keys with spaces', () => {
+        expect(escapePartitionKey('2025-09-01 00:00')).toBe('"2025-09-01 00:00"');
+      });
+
+      it('quotes keys with multiple spaces', () => {
+        expect(escapePartitionKey('hello world foo')).toBe('"hello world foo"');
+      });
+    });
+
     describe('quotes keys with special characters', () => {
       it('quotes keys with commas', () => {
         expect(escapePartitionKey('my,key')).toBe('"my,key"');
@@ -788,6 +798,40 @@ describe('SpanRepresentation', () => {
         expect(parsed).not.toBeInstanceOf(Error);
         if (!(parsed instanceof Error)) {
           expect(parsed.selectedKeys).toEqual(['2024-01-01', 'data,file', '2024-01-02']);
+        }
+      });
+    });
+
+    describe('datetime partitions with spaces', () => {
+      it('handles single datetime key with space', () => {
+        const allKeys = ['2025-09-01 00:00', '2025-09-01 01:00', '2025-09-01 02:00'];
+        const selected = ['2025-09-01 00:00'];
+
+        const text = partitionsToText(selected, allKeys);
+        expect(text).toBe('"2025-09-01 00:00"');
+
+        const parsed = spanTextToSelectionsOrError(allKeys, text);
+        expect(parsed).not.toBeInstanceOf(Error);
+        if (!(parsed instanceof Error)) {
+          expect(parsed.selectedKeys).toEqual(['2025-09-01 00:00']);
+        }
+      });
+
+      it('handles range of datetime keys with spaces', () => {
+        const allKeys = ['2025-09-01 00:00', '2025-09-01 01:00', '2025-09-01 02:00'];
+        const selected = ['2025-09-01 00:00', '2025-09-01 01:00', '2025-09-01 02:00'];
+
+        const text = partitionsToText(selected, allKeys);
+        expect(text).toBe('["2025-09-01 00:00"..."2025-09-01 02:00"]');
+
+        const parsed = spanTextToSelectionsOrError(allKeys, text);
+        expect(parsed).not.toBeInstanceOf(Error);
+        if (!(parsed instanceof Error)) {
+          expect(parsed.selectedKeys).toEqual([
+            '2025-09-01 00:00',
+            '2025-09-01 01:00',
+            '2025-09-01 02:00',
+          ]);
         }
       });
     });

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/parsePartitionSelection.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/parsePartitionSelection.test.ts
@@ -94,6 +94,11 @@ describe('parsePartitionSelection', () => {
       const result = parsePartitionSelection('["start...value"..."end...value"]');
       expect(result).toEqual([{type: 'range', start: 'start...value', end: 'end...value'}]);
     });
+
+    it('parses range with spaces in keys (datetime partitions)', () => {
+      const result = parsePartitionSelection('["2025-09-01 00:00"..."2026-01-14 20:00"]');
+      expect(result).toEqual([{type: 'range', start: '2025-09-01 00:00', end: '2026-01-14 20:00'}]);
+    });
   });
 
   describe('wildcards', () => {


### PR DESCRIPTION
## Summary & Motivation

Fix for https://linear.app/dagster-labs/issue/FE-1034/partition-name-syntax-error


## How I Tested These Changes

```
hourly_partitions_def2 = HourlyPartitionsDefinition(
    start_date="2025-09-01 00:00",
     fmt="%Y-%m-%d %H:%M",
)


@asset(
    partitions_def=hourly_partitions_def2,
)
def test_hourly_march8_2(context):
    time.sleep(1)
```
