### PR TITLE
Fix issue when using asset decorates in pyright strict mode

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -82,11 +82,11 @@ def asset(
     io_manager_def: Optional[object] = ...,
     io_manager_key: Optional[str] = ...,
     dagster_type: Optional[DagsterType] = ...,
-    partitions_def: Optional[PartitionsDefinition] = ...,
+    partitions_def: Optional[PartitionsDefinition[str]] = ...,
     op_tags: Optional[Mapping[str, Any]] = ...,
     group_name: Optional[str] = ...,
     output_required: bool = ...,
-    automation_condition: Optional[AutomationCondition] = ...,
+    automation_condition: Optional[AutomationCondition[AssetKey]] = ...,
     backfill_policy: Optional[BackfillPolicy] = ...,
     retry_policy: Optional[RetryPolicy] = ...,
     code_version: Optional[str] = ...,
@@ -95,14 +95,14 @@ def asset(
     owners: Optional[Sequence[str]] = ...,
     kinds: Optional[AbstractSet[str]] = ...,
     pool: Optional[str] = ...,
-    **kwargs,
+    **kwargs: Any,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]: ...
 
 
 @overload
 def asset(
     compute_fn: Callable[..., Any],
-    **kwargs,
+    **kwargs: Any,
 ) -> AssetsDefinition: ...
 
 
@@ -168,11 +168,11 @@ def asset(
     io_manager_def: Optional[object] = None,
     io_manager_key: Optional[str] = None,
     dagster_type: Optional[DagsterType] = None,
-    partitions_def: Optional[PartitionsDefinition] = None,
+    partitions_def: Optional[PartitionsDefinition[str]] = None,
     op_tags: Optional[Mapping[str, Any]] = None,
     group_name: Optional[str] = None,
     output_required: bool = True,
-    automation_condition: Optional[AutomationCondition] = None,
+    automation_condition: Optional[AutomationCondition[AssetKey]] = None,
     freshness_policy: Optional[FreshnessPolicy] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     retry_policy: Optional[RetryPolicy] = None,
@@ -182,7 +182,7 @@ def asset(
     owners: Optional[Sequence[str]] = None,
     kinds: Optional[AbstractSet[str]] = None,
     pool: Optional[str] = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> Union[AssetsDefinition, Callable[[Callable[..., Any]], AssetsDefinition]]:
     """Create a definition for how to compute an asset.
 
@@ -590,7 +590,7 @@ def multi_asset(
     config_schema: Optional[UserConfigSchema] = None,
     required_resource_keys: Optional[AbstractSet[str]] = None,
     internal_asset_deps: Optional[Mapping[str, set[AssetKey]]] = None,
-    partitions_def: Optional[PartitionsDefinition] = None,
+    partitions_def: Optional[PartitionsDefinition[str]] = None,
     hooks: Optional[AbstractSet[HookDefinition]] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     op_tags: Optional[Mapping[str, Any]] = None,
@@ -769,7 +769,7 @@ def graph_asset(
     config: Optional[Union[ConfigMapping, Mapping[str, Any]]] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     group_name: Optional[str] = None,
-    partitions_def: Optional[PartitionsDefinition] = None,
+    partitions_def: Optional[PartitionsDefinition[str]] = None,
     hooks: Optional[AbstractSet[HookDefinition]] = None,
     metadata: Optional[RawMetadataMapping] = ...,
     tags: Optional[Mapping[str, str]] = ...,
@@ -777,7 +777,7 @@ def graph_asset(
     kinds: Optional[AbstractSet[str]] = None,
     legacy_freshness_policy: Optional[LegacyFreshnessPolicy] = ...,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = ...,
-    automation_condition: Optional[AutomationCondition] = ...,
+    automation_condition: Optional[AutomationCondition[AssetKey]] = ...,
     backfill_policy: Optional[BackfillPolicy] = ...,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = ...,
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
@@ -806,19 +806,19 @@ def graph_asset(
     config: Optional[Union[ConfigMapping, Mapping[str, Any]]] = None,
     key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
     group_name: Optional[str] = None,
-    partitions_def: Optional[PartitionsDefinition] = None,
+    partitions_def: Optional[PartitionsDefinition[str]] = None,
     hooks: Optional[AbstractSet[HookDefinition]] = None,
     metadata: Optional[RawMetadataMapping] = None,
     tags: Optional[Mapping[str, str]] = None,
     owners: Optional[Sequence[str]] = None,
-    automation_condition: Optional[AutomationCondition] = None,
+    automation_condition: Optional[AutomationCondition[AssetKey]] = None,
     backfill_policy: Optional[BackfillPolicy] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
     code_version: Optional[str] = None,
     key: Optional[CoercibleToAssetKey] = None,
     kinds: Optional[AbstractSet[str]] = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> Union[AssetsDefinition, Callable[[Callable[..., Any]], AssetsDefinition]]:
     """Creates a software-defined asset that's computed using a graph of ops.
 


### PR DESCRIPTION
## Summary & Motivation

Fixes #33251

Resolves Pyright strict mode "Type of X is partially unknown" errors when using `@asset`, `@multi_asset`, and `@graph_asset` decorators. This enables developers to use Pyright's strict type checking mode with Dagster asset decorators without encountering type warnings.

## Root Cause

The asset decorators had three missing type annotations that caused Pyright in strict mode to infer "Unknown" types:

1. Missing `Any` type annotation on `**kwargs` parameters
2. Missing generic type parameter on `AutomationCondition` (should be `AutomationCondition[AssetKey]`)
3. Missing generic type parameter on `PartitionsDefinition` (should be `PartitionsDefinition[str]`)

## Changes

Updated type annotations in `/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py`:

### `asset` decorator

- Added `Any` type annotation to `**kwargs` in both overloads and implementation
- Changed `AutomationCondition` to `AutomationCondition[AssetKey]`
- Changed `PartitionsDefinition` to `PartitionsDefinition[str]`

### `multi_asset` decorator

- Changed `PartitionsDefinition` to `PartitionsDefinition[str]`

### `graph_asset` decorator

- Added `Any` type annotation to `**kwargs`
- Changed `AutomationCondition` to `AutomationCondition[AssetKey]`
- Changed `PartitionsDefinition` to `PartitionsDefinition[str]`


## How I Tested These Changes

## Changelog

- [dagster] Fixed Pyright strict mode reporting "Type of 'asset' is partially unknown" errors when using `@asset`, `@multi_asset`, and `@graph_asset` decorators. The decorators now have complete type annotations including proper generic type parameters for `AutomationCondition[AssetKey]` and `PartitionsDefinition[str]`

