### PR TITLE
[dagster-ui] use deployment icon in sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/navigation/mainNavigationItems.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/navigation/mainNavigationItems.tsx
@@ -171,7 +171,7 @@ export const getTopGroups = (config: NavigationGroupConfig): NavigationGroup[] =
           },
           element: (
             <NavItemWithLink
-              icon={<Icon name="settings" />}
+              icon={<Icon name="deployment" />}
               label="Deployment"
               href="/deployment"
               isActive={deploymentPathMatcher}


### PR DESCRIPTION
## Summary & Motivation

Fixes #33249.

The change updates `mainNavigationItems.tsx`, changing the Deployment icon from `settings` to `deployment` to differentiate from settings.


After update:

<img width="444" height="562" alt="image" src="https://github.com/user-attachments/assets/fb2adf0a-7c14-4731-9d93-4865b8e89397" />

## How I Tested These Changes

## Changelog

NOCHANGELOG
