### PR TITLE
TELEMETRY_ENABLED uses DAGSTER_DISABLE_TELEMETRY

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -13,6 +13,7 @@ from dagster._core.storage.cloud_storage_compute_log_manager import CloudStorage
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.storage.local_compute_log_manager import LocalComputeLogManager
 from dagster._core.storage.runs.sql_run_storage import SqlRunStorage
+from dagster._core.telemetry_upload import is_running_in_test
 from dagster._core.workspace.context import BaseWorkspaceRequestContext, IWorkspaceProcessContext
 from dagster._utils import Counter, traced_counter
 from dagster_graphql import __version__ as dagster_graphql_version
@@ -227,7 +228,9 @@ class DagsterWebserver(
                         .replace("__INSTANCE_ID__", run_storage_id or "")
                         .replace(
                             '"__TELEMETRY_ENABLED__"',
-                            str(context.instance.telemetry_enabled).lower(),
+                            str(
+                                context.instance.telemetry_enabled and not is_running_in_test()
+                            ).lower(),
                         )
                         .replace("NONCE-PLACEHOLDER", nonce)
                     )


### PR DESCRIPTION
## Summary & Motivation

`__TELEMETRY_ENABLED__` (which sets `export const TELEMETRY_PLACEHOLDER`, which sets `telemetryEnabled`) in the webserver UI code now respects the `DAGSTER_DISABLE_TELEMETRY` environment variable.

The `uploading_logging_thread` in the `telemetry_upload` module will skip uploading logs if the `DAGSTER_DISABLE_TELEMETRY` environment variable is set (or if a CI system is detected). Additionally, there won't be any logs to upload if `instance.telemetry.enabled` is false.

In the current webserver UI code, browser telemetry will always be sent if `instance.telemetry.enabled` is true.

This change matches the behavior of the webserver browser telemetry to match the behavior of the server telemetry: telemetry will only be sent if both `instance.telemetry.enabled` is true and `DAGSTER_DISABLE_TELEMETRY` is unset.

## How I Tested These Changes

```bash
$ dagster-webserver &

$ curl --silent "http://127.0.0.1:3000" | grep "telemetryEnabled"
```
Outputs:
>   "telemetryEnabled": true,

```bash
$ DAGSTER_DISABLE_TELEMETRY=true dagster-webserver

$ curl --silent "http://127.0.0.1:3000" | grep "telemetryEnabled"
```
Outputs:
>   "telemetryEnabled": false,

There do not appear to be any automated tests for this area of code.

## Changelog

> Match the behavior of the webserver browser telemetry to match the behavior of the server telemetry: telemetry will only be sent if both `instance.telemetry.enabled` is true and `DAGSTER_DISABLE_TELEMETRY` is unset.