### PR TITLE
[dg] fix issue where dg-cli failing launch when partition-ranges used, but works with partition argument

### DIFF
--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -405,11 +405,16 @@ def execute_execute_command(
             for asset_key in job_def.asset_layer.executable_asset_keys:
                 backfill_policy = job_def.asset_layer.get(asset_key).backfill_policy
                 if (
-                    backfill_policy is not None
-                    and backfill_policy.policy_type != BackfillPolicyType.SINGLE_RUN
+                    backfill_policy is None
+                    or backfill_policy.policy_type != BackfillPolicyType.SINGLE_RUN
                 ):
                     check.failed(
-                        "Provided partition range, but not all assets have a single-run backfill policy."
+                        "Partition ranges with the CLI require all selected assets to have a "
+                        "BackfillPolicy.single_run() policy. This allows the partition range to be "
+                        "executed in a single run. Assets without this policy would require creating "
+                        "a backfill with separate runs per partition, which needs a running daemon "
+                        "process. Consider using the Dagster UI or a running daemon to execute "
+                        "partition ranges for assets without a single-run backfill policy."
                     )
             try:
                 job_def.validate_partition_key(

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_launch_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_launch_commands.py
@@ -11,13 +11,14 @@ from dagster_test.dg_utils.utils import ProxyRunner, isolated_example_project_fo
 
 
 def _sample_defs():
-    from dagster import DailyPartitionsDefinition, asset, schedule, sensor
+    from dagster import BackfillPolicy, DailyPartitionsDefinition, asset, schedule, sensor
 
     @asset
     def my_asset_1(): ...
 
     @asset(
         partitions_def=DailyPartitionsDefinition(start_date="2024-01-01"),
+        backfill_policy=BackfillPolicy.single_run(),
     )
     def my_asset_2(): ...
 


### PR DESCRIPTION
## Summary & Motivation

Resolves #31055 

When using `--partition-range` with assets that don't have an explicit `BackfillPolicy.single_run()`, the CLI would fail with unclear errors. The validation logic had a bug where it only rejected assets with a multi-run policy but allowed assets with no policy at all, leading to runtime failures.


## How I Tested These Changes

## Changelog

- [dg] Fixed dg launch --partition-range failing for assets without BackfillPolicy.single_run()