### PR TITLE
feat: Improve the default configuration for the locally deployed Docker based `dagster.yaml`

### DIFF
--- a/examples/deploy_docker/dagster.yaml
+++ b/examples/deploy_docker/dagster.yaml
@@ -23,7 +23,7 @@ run_launcher:
     env_vars:
       - DAGSTER_POSTGRES_USER
       - DAGSTER_POSTGRES_PASSWORD
-      - DAGSTER_POSTGRES_DB      
+      - DAGSTER_POSTGRES_DB
     network: docker_example_network
     container_kwargs:
       auto_remove: True


### PR DESCRIPTION
## Summary & Motivation

The locally deployed Docker `dagster.yaml` configuration can be improved by exposing more configuration parameters to be tweaked by users which are buried in the documentation.

## Changelog
- Add config for `dequeue_use_threads`, `dequeue_num_workers`, `dequeue_interval_seconds` to speed-up the throughput of short running by numerous parallel tasks
- Add `auto_remove` to Docker `container_kwargs` to clean-up completed job containers, without this config unused containers simply hang around and on large backfills can quickly fill up disk space.
- Expose DNS config to allow users to disable ipv6 by default which massively speeds up name resolution.
- Add retention schedule
- Disable telemetry by default, if deploying Docker privately - likely do not want this on by default.
- Expose run-monitoring config to speedup task state resolution.
