### PR TITLE
[dagster-polytomic][5/n] Allow per-object-type customization for Polytomic translation

### DIFF
--- a/python_modules/libraries/dagster-polytomic/dagster_polytomic/component.py
+++ b/python_modules/libraries/dagster-polytomic/dagster_polytomic/component.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import dagster as dg
 from dagster._annotations import preview
-from dagster._core.definitions.metadata.metadata_set import NamespacedMetadataSet, TableMetadataSet
+from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster.components.component.state_backed_component import StateBackedComponent
 from dagster.components.utils.defs_state import (
@@ -14,7 +14,6 @@ from dagster.components.utils.defs_state import (
     ResolvedDefsStateConfig,
 )
 from pydantic import Field
-from typing_extensions import Self
 
 from dagster_polytomic.objects import PolytomicBulkSyncEnrichedSchema, PolytomicWorkspaceData
 from dagster_polytomic.translation import (
@@ -77,7 +76,7 @@ class PolytomicComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             )
         return None
 
-    def get_asset_spec(self, data: PolytomicTranslatorData) -> dg.AssetSpec:
+    def get_asset_spec(self, data: PolytomicTranslatorData) -> Optional[dg.AssetSpec]:
         """Core function for converting a Polytomic object into an AssetSpec object."""
         base_asset_spec = self._get_default_polytomic_spec(data)
         if self.translation and base_asset_spec:

--- a/python_modules/libraries/dagster-polytomic/dagster_polytomic/translation.py
+++ b/python_modules/libraries/dagster-polytomic/dagster_polytomic/translation.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional, Self, TypeAlias, Union
+from typing import Annotated, Optional, TypeAlias, Union
 
 from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
 from dagster._core.definitions.metadata.metadata_set import NamespacedMetadataSet
@@ -9,6 +9,7 @@ from dagster.components.resolved.core_models import AssetSpecUpdateKwargs
 from dagster.components.utils import TranslatorResolvingInfo
 from dagster.components.utils.translation import TranslationFn, TranslationFnResolver
 from dagster_shared.record import record
+from typing_extensions import Self
 
 from dagster_polytomic.objects import PolytomicBulkSyncEnrichedSchema, PolytomicWorkspaceData
 

--- a/python_modules/libraries/dagster-polytomic/dagster_polytomic_tests/test_defs.py
+++ b/python_modules/libraries/dagster-polytomic/dagster_polytomic_tests/test_defs.py
@@ -102,7 +102,7 @@ def test_get_asset_spec_with_translation(component: PolytomicComponent):
         return spec.replace_attributes(key=AssetKey(["custom", *spec.key.path]))
 
     component = PolytomicComponent(
-        workspace=PolytomicWorkspace(token="test-key"),
+        workspace=PolytomicWorkspace(token="test-token"),
         translation=custom_translation,
     )
 


### PR DESCRIPTION
## Summary & Motivation

Implement the per-object-type translation pattern for Polytomic. Currently we only represent bulk sync schemas as assets in Dagster, but I believe we'll want to represent Polytomic models as well in the near future.

## How I Tested These Changes

BK with new unit tests
