### PR TITLE
[dagster-aws] Add EMR step failure diagnostics with automatic log retrieval

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/emr/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/emr/__init__.py
@@ -1,6 +1,8 @@
 from dagster_aws.emr.emr import (
     EmrError as EmrError,
     EmrJobRunner as EmrJobRunner,
+    FailureLogConfig as FailureLogConfig,
+    StepFailureDiagnostics as StepFailureDiagnostics,
 )
 from dagster_aws.emr.pyspark_step_launcher import (
     emr_pyspark_step_launcher as emr_pyspark_step_launcher,


### PR DESCRIPTION
## Summary & Motivation

EMR step failures previously only showed `"EMR step s-XXX failed"` with no context. Users had to manually find logs in S3 via the AWS console. This PR makes failures self-diagnosing by automatically retrieving stdout/stderr excerpts from S3 and including them in the error message.

**What changed:**
- `FailureLogConfig` — controls how many log lines to retrieve, timeouts, and whether to fetch logs at all
- `StepFailureDiagnostics` — structured container for step ID, cluster ID, failure reason, log excerpts, and S3 URI
- `EmrError` — now includes formatted diagnostics (cluster ID, reason, log excerpts) when available
- `EmrJobRunner.is_emr_step_complete()` — retrieves diagnostics on failure via new `_retrieve_step_failure_diagnostics()`
- `PipesEMRClient` — new `_get_step_failure_details()` surfaces step-level errors when clusters terminate

Closes #1954

## How I Tested These Changes

All 12 EMR tests pass (`pytest dagster_aws_tests/emr_tests/test_emr.py -v`):
- `test_emr_step_failure_diagnostics_with_config` — log truncation
- `test_emr_step_failure_logs_disabled` — config disables retrieval
- `test_emr_error_message_formatting` — error message structure
- `test_is_emr_step_complete` — diagnostics on failure

## Changelog

- [dagster-aws] EMR step failures now include stdout/stderr excerpts from S3 in error messages. Added `FailureLogConfig` and `StepFailureDiagnostics` for configurable, structured failure diagnostics.