### PR TITLE
[dg] fix automation condition labels in dg list command

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/automation_condition.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/automation_condition.py
@@ -1,9 +1,9 @@
 import graphene
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionSnapshot,
+    get_expanded_label,
 )
 
-from dagster_graphql.schema.asset_condition_evaluations import get_expanded_label
 from dagster_graphql.schema.util import non_null_list
 
 

--- a/python_modules/dagster/dagster/components/list/list.py
+++ b/python_modules/dagster/dagster/components/list/list.py
@@ -28,6 +28,7 @@ from dagster._cli.workspace.cli_target import get_repository_python_origin_from_
 from dagster._config.pythonic_config.resource import get_resource_type_name
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets.job.asset_job import is_reserved_asset_job_name
+from dagster._core.definitions.declarative_automation.serialized_objects import get_expanded_label
 from dagster._core.definitions.definitions_load_context import (
     DefinitionsLoadContext,
     DefinitionsLoadType,
@@ -177,7 +178,9 @@ def list_definitions(
                     group=node.group_name,
                     kinds=sorted(list(node.kinds)),
                     description=node.description,
-                    automation_condition=node.automation_condition.get_label()
+                    automation_condition=" ".join(
+                        get_expanded_label(node.automation_condition.get_snapshot())
+                    )
                     if node.automation_condition
                     else None,
                     tags=sorted(f'"{k}"="{v}"' for k, v in node.tags.items() if _tag_filter(k)),


### PR DESCRIPTION
## Summary & MotivationA

Resolves FW-453.

The `dg list` command was displaying `None` for automation conditions without explicit labels (e.g., conditions created via `&` or `|` operators).

Changes:
- Moved `get_expanded_label` function from dagster-graphql to core dagster (serialized_objects.py) to make it accessible to both graphql and components
- Updated `dg list` to use `get_expanded_label()` instead of `get_label()`, which recursively builds meaningful labels from condition tree structure
- Updated dagster-graphql imports to use the relocated function

## How I Tested These Changes

## Changelog

- [dg] improved `dg list defs` to adequately show labels for automation conditions