### PR TITLE
[dagster-dbt] Added support for passing dbt CLI arguments during manifest generation

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -205,6 +205,11 @@ class DbtProject(IHaveNew):
             like when deploying using PEX.
         state_path (Optional[Union[str, Path]]):
             The path, relative to the project directory, to reference artifacts from another run.
+        generate_cli_args (Optional[Sequence[str]]):
+            The arguments to pass to the dbt cli to generate a manifest.json during
+            development time preparation. If omitted, ["parse", "--quiet"] is used.
+            Example: ["parse", "--quiet", "--vars", "{'my_variable': 'my_value'}"]
+
 
     Examples:
         Creating a DbtProject with by referencing the dbt project directory:
@@ -240,6 +245,20 @@ class DbtProject(IHaveNew):
                 target=get_env(),
             )
 
+        Creating a DbtProject that passes dbt variables during manifest generation:
+
+        .. code-block:: python
+            from pathlib import Path
+            from dagster_dbt import DbtProject
+            my_project = DbtProject(
+                project_dir=Path("path/to/dbt_project"),
+                generate_cli_args=[
+                    "parse",
+                    "--quiet",
+                    "--vars",
+                    "{'my_variable': 'my_value'}"
+                ],
+            )
     """
 
     name: str
@@ -253,6 +272,7 @@ class DbtProject(IHaveNew):
     state_path: Optional[Path]
     has_uninstalled_deps: bool
     preparer: DbtProjectPreparer
+    generate_cli_args: Optional[Sequence[str]]
 
     def __new__(
         cls,
@@ -264,6 +284,7 @@ class DbtProject(IHaveNew):
         target: Optional[str] = None,
         packaged_project_dir: Optional[Union[Path, str]] = None,
         state_path: Optional[Union[Path, str]] = None,
+        generate_cli_args: Optional[Sequence[str]] = None,
     ) -> "DbtProject":
         project_dir = Path(project_dir)
         if not project_dir.exists():
@@ -280,7 +301,10 @@ class DbtProject(IHaveNew):
                 f"profiles {profiles_dir} does not exist."
             )
 
-        preparer = DagsterDbtProjectPreparer()
+        if generate_cli_args:
+            preparer = DagsterDbtProjectPreparer(generate_cli_args=generate_cli_args)
+        else:
+            preparer = DagsterDbtProjectPreparer()
 
         manifest_path = project_dir.joinpath(target_path, "manifest.json")
 
@@ -321,6 +345,7 @@ class DbtProject(IHaveNew):
             packaged_project_dir=packaged_project_dir,
             has_uninstalled_deps=has_uninstalled_deps,
             preparer=preparer,
+            generate_cli_args=generate_cli_args,
         )
 
     @public


### PR DESCRIPTION
## Summary & Motivation
`dagster_dbt.DbtProject` has a new a new optional argument `generate_cli_args`.

It allows the user to specify the `dbt` command used when generating the dbt `manifest.json`.

### Use case
We have a need to pass a dbt `var` that control whether dbt models were enabled.

Before, these could be passed during dbt runtime, but not during manifest generation. This  led to situations where dagster assets were generated for dynamically disabled dbt models. When materializing the dbt models would be skipped and dagster would stop the materialization of assets it thinks are downstream of the disabled dbt models.

The issue https://github.com/dagster-io/dagster/issues/33270 illustrates this scenario in more detail.

## How I Tested These Changes

### Enabling a model after it was initially disabled (gif)
![Kapture 2026-01-20 at 17 45 42](https://github.com/user-attachments/assets/b45e662d-64d7-42fe-a7e5-efbf8ce1e6fa)

### Disabling a model after it was initially enabled (gif)
![Kapture 2026-01-20 at 17 48 05](https://github.com/user-attachments/assets/6dd6ea1b-9276-4e5d-8f31-9a25aa6fd99f)

### Testing that original interface still works
Here, the manifest is generated with default vars when you don't supply the argument, just like before.
![Kapture 2026-01-20 at 17 50 27](https://github.com/user-attachments/assets/5fa3e29e-ea2c-46ef-93c4-95f25ffcc1be)

## Changelog
Added support for passing custom dbt CLI arguments during manifest generation
