### PR TITLE
Include FAILURE in the set of statuses that can trigger a run 'cancellation' thread to trigger

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/run_cancellation_thread.py
+++ b/python_modules/dagster/dagster/_core/execution/run_cancellation_thread.py
@@ -21,6 +21,7 @@ def _kill_on_cancel(instance_ref: InstanceRef, run_id, shutdown_event):
             if run.status in [
                 DagsterRunStatus.CANCELING,
                 DagsterRunStatus.CANCELED,
+                DagsterRunStatus.FAILURE,
             ]:
                 print(  # noqa: T201
                     f"Detected run status {run.status}, sending interrupt to main thread"

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_run_cancellation_thread.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_run_cancellation_thread.py
@@ -1,0 +1,36 @@
+import threading
+from unittest import mock
+
+import pytest
+from dagster._core.execution.run_cancellation_thread import _kill_on_cancel
+from dagster._core.instance_for_test import instance_for_test
+from dagster._core.storage.dagster_run import DagsterRunStatus
+from dagster._core.test_utils import create_run_for_test
+
+
+@pytest.mark.parametrize(
+    "run_status",
+    [
+        DagsterRunStatus.CANCELING,
+        DagsterRunStatus.CANCELED,
+        DagsterRunStatus.FAILURE,
+    ],
+)
+def test_kill_on_cancel_sends_interrupt_for_terminal_statuses(run_status: DagsterRunStatus):
+    with instance_for_test(
+        overrides={"run_monitoring": {"cancellation_thread_poll_interval_seconds": 0}}
+    ) as instance:
+        # Create a run with the target status
+        dagster_run = create_run_for_test(instance, status=run_status)
+        run_id = dagster_run.run_id
+
+        shutdown_event = threading.Event()
+
+        with mock.patch(
+            "dagster._core.execution.run_cancellation_thread.send_interrupt"
+        ) as mock_send_interrupt:
+            # Run the cancellation thread function directly
+            _kill_on_cancel(instance.get_ref(), run_id, shutdown_event)
+
+            # Verify send_interrupt was called
+            mock_send_interrupt.assert_called_once()


### PR DESCRIPTION
Summary:
This situation can happen when a daemon starts canceling a run and then immediately moves it into a failure state (e.g. for exceeding max runtime). Before a race condition here could result in no termination signal firing.

## How I Tested These Changes
New test cases, terminate a run locally with this background thread running and see it always eventually terminate now

## Changelog
Fixed an issue while using the 'isolated_agents' configuration parameter in Dagster+ where runs that were terminated due to exceeding a maximum runtime would sometimes fail to terminate the run worker process after the run was marked as failed.