### PR TITLE
[claude] include dagster-hightouch in .claude/python_packages.md

### DIFF
--- a/.claude/python_packages.md
+++ b/.claude/python_packages.md
@@ -115,6 +115,7 @@ Quick reference for Python packages in the Dagster repository.
 **dagster-github**: `python_modules/libraries/dagster-github`
 **dagster-datahub**: `python_modules/libraries/dagster-datahub`
 **dagster-census**: `python_modules/libraries/dagster-census`
+**dagster-hightouch**: `python_modules/libraries/dagster-hightouch`
 **dagster-managed-elements**: `python_modules/libraries/dagster-managed-elements`
 
 ## cli tools


### PR DESCRIPTION
## Summary & Motivation

Fix failing CI by including `dagster-hightouch` in `.claude/python_packages.md`.

## How I Tested These Changes
