### PR TITLE
[ui] Jest test patterns: use findBy and userEvent.setup()

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/__tests__/actWarnings.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__tests__/actWarnings.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, waitFor} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {useState} from 'react';
 
@@ -18,6 +18,6 @@ describe('Act warnings', () => {
     render(<Counter />);
     const button = await screen.findByRole('button');
     await user.click(button);
-    await waitFor(() => expect(screen.getByText(/count: 1/i)).toBeVisible());
+    expect(await screen.findByText(/count: 1/i)).toBeVisible();
   });
 });

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__tests__/useSuggestionsForString.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__tests__/useSuggestionsForString.test.tsx
@@ -48,8 +48,9 @@ describe('useSuggestionsForString', () => {
   });
 
   it('determines suggestions for query', async () => {
+    const user = userEvent.setup();
     render(<Test />);
-    await userEvent.type(screen.getByRole('textbox'), 'pr');
+    await user.type(screen.getByRole('textbox'), 'pr');
     expect(screen.getByText('prez:')).toBeVisible();
     expect(screen.getByText('prez:washington')).toBeVisible();
     expect(screen.getByText('prez:adams')).toBeVisible();
@@ -57,8 +58,9 @@ describe('useSuggestionsForString', () => {
   });
 
   it('determines suggestions when querystring matches a suggestion exactly', async () => {
+    const user = userEvent.setup();
     render(<Test />);
-    await userEvent.type(screen.getByRole('textbox'), 'prez:');
+    await user.type(screen.getByRole('textbox'), 'prez:');
     expect(screen.getByText('prez:')).toBeVisible();
     expect(screen.getByText('prez:washington')).toBeVisible();
     expect(screen.getByText('prez:adams')).toBeVisible();
@@ -66,32 +68,36 @@ describe('useSuggestionsForString', () => {
   });
 
   it('determines suggestions only for the last segment of the string', async () => {
+    const user = userEvent.setup();
     render(<Test />);
-    await userEvent.type(screen.getByRole('textbox'), 'query pr');
+    await user.type(screen.getByRole('textbox'), 'query pr');
     expect(screen.getByText('prez:')).toBeVisible();
     expect(screen.getByText('prez:washington')).toBeVisible();
     expect(screen.queryByText('query:')).toBeNull();
   });
 
   it('trims the input string when determining suggestions', async () => {
+    const user = userEvent.setup();
     render(<Test />);
-    await userEvent.type(screen.getByRole('textbox'), '     pr     ');
+    await user.type(screen.getByRole('textbox'), '     pr     ');
     expect(screen.getByText('prez:')).toBeVisible();
     expect(screen.getByText('prez:washington')).toBeVisible();
   });
 
   it('replaces the last segment with the suggestion, if selected', async () => {
+    const user = userEvent.setup();
     render(<Test />);
-    await userEvent.type(screen.getByRole('textbox'), 'pre');
+    await user.type(screen.getByRole('textbox'), 'pre');
     expect(screen.getByText('prez:')).toBeVisible();
     expect(screen.getByText('prez:washington')).toBeVisible();
   });
 
   it('replaces only the last segment with the suggestion', async () => {
+    const user = userEvent.setup();
     render(<Test />);
-    await userEvent.type(screen.getByRole('textbox'), 'query pre');
+    await user.type(screen.getByRole('textbox'), 'query pre');
     const prez = screen.getByText('prez:');
-    await userEvent.click(prez);
+    await user.click(prez);
     const input = screen.getByRole('textbox');
     expect(input).toHaveValue('query prez:');
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/CustomConfirmationProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/CustomConfirmationProvider.test.tsx
@@ -33,6 +33,7 @@ describe('CustomConfirmationProvider', () => {
   });
 
   it('must render a Dialog when `confirm` is executed', async () => {
+    const user = userEvent.setup();
     render(
       <CustomConfirmationProvider>
         <Test />
@@ -40,12 +41,13 @@ describe('CustomConfirmationProvider', () => {
     );
 
     const button = screen.queryByRole('button', {name: /terminate/i}) as HTMLButtonElement;
-    await userEvent.click(button);
+    await user.click(button);
 
     expect(screen.queryByText(/r u sure about this/i)).toBeVisible();
   });
 
   it('must perform confirmation correctly', async () => {
+    const user = userEvent.setup();
     render(
       <CustomConfirmationProvider>
         <Test />
@@ -53,14 +55,14 @@ describe('CustomConfirmationProvider', () => {
     );
 
     const button = screen.queryByRole('button', {name: /terminate/i}) as HTMLButtonElement;
-    await userEvent.click(button);
+    await user.click(button);
 
     const confirmationButton = screen.queryByRole('button', {
       name: /confirm/i,
     }) as HTMLButtonElement;
 
     // Resolves the promise.
-    await userEvent.click(confirmationButton);
+    await user.click(confirmationButton);
 
     expect(screen.queryByText(/confirmed\? true/i)).toBeVisible();
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
@@ -118,9 +118,9 @@ describe('launchAssetChoosePartitionsDialog', () => {
       expect(assetBQueryMockResult).toHaveBeenCalled();
     });
 
-    const link = await waitFor(() => screen.getByTestId('add-partition-link'));
+    const link = await screen.findByTestId('add-partition-link');
     userEvent.click(link);
-    const partitionInput = await waitFor(() => screen.getByTestId('partition-input'));
+    const partitionInput = await screen.findByTestId('partition-input');
     await userEvent.type(partitionInput, 'test2');
     expect(assetASecondQueryMockResult).not.toHaveBeenCalled();
     expect(assetBSecondQueryMockResult).not.toHaveBeenCalled();

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -315,7 +315,7 @@ describe('LaunchAssetExecutionButton', () => {
         preferredJobName: undefined,
       });
       await clickMaterializeButton();
-      await waitFor(() => expect(screen.getByText('Launchpad (configure assets)')).toBeVisible());
+      expect(await screen.findByText('Launchpad (configure assets)')).toBeVisible();
     });
 
     it('should show an error if the assets do not share a code location', async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/usePartitionKeyInParams.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/usePartitionKeyInParams.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, waitFor} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 
 import {usePartitionKeyInParams} from '../usePartitionKeyInParams';
 
@@ -20,7 +20,7 @@ describe('usePartitionKeyInParams', () => {
     };
 
     render(<HookUse />);
-    await waitFor(() => expect(screen.getByText('Done')).toBeVisible());
+    expect(await screen.findByText('Done')).toBeVisible();
   });
 
   it('should default to no value for a one-dimensional partition key', async () => {
@@ -36,7 +36,7 @@ describe('usePartitionKeyInParams', () => {
     };
 
     render(<HookUse />);
-    await waitFor(() => expect(screen.getByText('Done')).toBeVisible());
+    expect(await screen.findByText('Done')).toBeVisible();
   });
 
   it('should parse and set a two-dimensional partition key', async () => {
@@ -64,7 +64,7 @@ describe('usePartitionKeyInParams', () => {
     };
 
     render(<HookUse />);
-    await waitFor(() => expect(screen.getByText('Done')).toBeVisible());
+    expect(await screen.findByText('Done')).toBeVisible();
   });
 
   it('should allow a partial selection of just the first partition key', async () => {
@@ -83,7 +83,7 @@ describe('usePartitionKeyInParams', () => {
     };
 
     render(<HookUse />);
-    await waitFor(() => expect(screen.getByText('Done')).toBeVisible());
+    expect(await screen.findByText('Done')).toBeVisible();
   });
 
   it('should default to no values for a two-dimensional partition key', async () => {
@@ -100,7 +100,7 @@ describe('usePartitionKeyInParams', () => {
     };
 
     render(<HookUse />);
-    await waitFor(() => expect(screen.getByText('Done')).toBeVisible());
+    expect(await screen.findByText('Done')).toBeVisible();
   });
 
   it('should default to the 1st key of dimension 1 if dimension 2 is selected first', async () => {
@@ -120,6 +120,6 @@ describe('usePartitionKeyInParams', () => {
     };
 
     render(<HookUse />);
-    await waitFor(() => expect(screen.getByText('Done')).toBeVisible());
+    expect(await screen.findByText('Done')).toBeVisible();
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/__tests__/AutomationStateChangeDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/__tests__/AutomationStateChangeDialog.test.tsx
@@ -202,6 +202,7 @@ describe('AutomationStateChangeDialog', () => {
 
   describe('Mutation: start', () => {
     it('starts sensors', async () => {
+      const user = userEvent.setup();
       const mocks = [buildStartKansasSuccess(100), buildStartLouisianaSuccess(100)];
 
       render(
@@ -215,7 +216,7 @@ describe('AutomationStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /start/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /starting/i});
@@ -229,6 +230,7 @@ describe('AutomationStateChangeDialog', () => {
     });
 
     it('shows error when starting a sensor fails', async () => {
+      const user = userEvent.setup();
       const mocks = [buildStartKansasSuccess(100), buildStartLouisianaError(100)];
 
       render(
@@ -242,7 +244,7 @@ describe('AutomationStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /start/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /starting/i});
@@ -262,6 +264,7 @@ describe('AutomationStateChangeDialog', () => {
     });
 
     it('starts schedules', async () => {
+      const user = userEvent.setup();
       const mocks = [buildStartColoradoSuccess(100), buildStartAlaskaSuccess(100)];
 
       render(
@@ -275,7 +278,7 @@ describe('AutomationStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /start/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /starting/i});
@@ -289,6 +292,7 @@ describe('AutomationStateChangeDialog', () => {
     });
 
     it('shows error when starting a schedule fails', async () => {
+      const user = userEvent.setup();
       const mocks = [buildStartAlaskaSuccess(100), buildStartColoradoError(100)];
 
       render(
@@ -302,7 +306,7 @@ describe('AutomationStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /start/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /starting/i});
@@ -322,6 +326,7 @@ describe('AutomationStateChangeDialog', () => {
     });
 
     it('starts a combination of schedules and sensors', async () => {
+      const user = userEvent.setup();
       const mocks = [
         buildStartKansasSuccess(100),
         buildStartLouisianaSuccess(100),
@@ -345,7 +350,7 @@ describe('AutomationStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /start/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /starting/i});
@@ -359,6 +364,7 @@ describe('AutomationStateChangeDialog', () => {
     });
 
     it('shows errors when starting a combination of schedules and sensors', async () => {
+      const user = userEvent.setup();
       const mocks = [
         buildStartKansasSuccess(100),
         buildStartLouisianaError(100),
@@ -382,7 +388,7 @@ describe('AutomationStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /start/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /starting/i});
@@ -409,6 +415,7 @@ describe('AutomationStateChangeDialog', () => {
 
   describe('Mutation: stop', () => {
     it('stops sensors', async () => {
+      const user = userEvent.setup();
       const mocks = [buildStopMinnesotaSuccess(100), buildStopOregonSuccess(100)];
 
       render(
@@ -422,7 +429,7 @@ describe('AutomationStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /stop/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /stopping/i});
@@ -436,6 +443,7 @@ describe('AutomationStateChangeDialog', () => {
     });
 
     it('shows error when stopping a sensor fails', async () => {
+      const user = userEvent.setup();
       const mocks = [buildStopMinnesotaSuccess(100), buildStopOregonError(100)];
 
       render(
@@ -449,7 +457,7 @@ describe('AutomationStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /stop/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /stopping/i});
@@ -469,6 +477,7 @@ describe('AutomationStateChangeDialog', () => {
     });
 
     it('stops schedules', async () => {
+      const user = userEvent.setup();
       const mocks = [buildStopDelawareSuccess(100), buildStopHawaiiSuccess(100)];
 
       render(
@@ -482,7 +491,7 @@ describe('AutomationStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /stop/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /stopping/i});
@@ -496,6 +505,7 @@ describe('AutomationStateChangeDialog', () => {
     });
 
     it('shows error when stopping a schedule fails', async () => {
+      const user = userEvent.setup();
       const mocks = [buildStopDelawareSuccess(100), buildStopHawaiiError(100)];
 
       render(
@@ -509,7 +519,7 @@ describe('AutomationStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /stop/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /stopping/i});
@@ -529,6 +539,7 @@ describe('AutomationStateChangeDialog', () => {
     });
 
     it('stops a combination of sensors and schedules', async () => {
+      const user = userEvent.setup();
       const mocks = [
         buildStopMinnesotaSuccess(100),
         buildStopOregonSuccess(100),
@@ -552,7 +563,7 @@ describe('AutomationStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /stop/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /stopping/i});
@@ -566,6 +577,7 @@ describe('AutomationStateChangeDialog', () => {
     });
 
     it('shows errors when stopping a combination of schedules and sensors', async () => {
+      const user = userEvent.setup();
       const mocks = [
         buildStopMinnesotaSuccess(100),
         buildStopOregonError(100),
@@ -589,7 +601,7 @@ describe('AutomationStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /stop/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /stopping/i});

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useQueryPersistedState.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useQueryPersistedState.test.tsx
@@ -40,6 +40,7 @@ describe('useQueryPersistedState', () => {
   });
 
   it('updates the URL query string when its exposed setter is called', async () => {
+    const user = userEvent.setup();
     // from https://reactrouter.com/web/guides/testing/checking-location-in-tests
     let querySearch: string | undefined;
 
@@ -53,13 +54,14 @@ describe('useQueryPersistedState', () => {
       expect(querySearch).toEqual('?q=B');
     });
 
-    await userEvent.click(screen.getByText(`[B]`));
+    await user.click(screen.getByText(`[B]`));
 
     expect(screen.getByText(`[Navigated]`)).toBeVisible();
     expect(querySearch).toEqual('?q=Navigated');
   });
 
   it('ignores and preserves other params present in the query string', async () => {
+    const user = userEvent.setup();
     // from https://reactrouter.com/web/guides/testing/checking-location-in-tests
     let querySearch: string | undefined;
     render(
@@ -69,13 +71,14 @@ describe('useQueryPersistedState', () => {
       </MemoryRouter>,
     );
 
-    await userEvent.click(screen.getByText(`[B]`));
+    await user.click(screen.getByText(`[B]`));
     await waitFor(() => {
       expect(querySearch).toEqual('?q=Navigated&cursor=basdasd&limit=100');
     });
   });
 
   it('omits query params when their values are set to the default', async () => {
+    const user = userEvent.setup();
     // from https://reactrouter.com/web/guides/testing/checking-location-in-tests
     let querySearch: string | undefined;
 
@@ -86,13 +89,14 @@ describe('useQueryPersistedState', () => {
       </MemoryRouter>,
     );
 
-    await userEvent.click(screen.getByText(`[B]`));
+    await user.click(screen.getByText(`[B]`));
     await waitFor(() => {
       expect(querySearch).toEqual('?cursor=basdasd&limit=100');
     });
   });
 
   it('can coexist with other instances of the same hook', async () => {
+    const user = userEvent.setup();
     let querySearch: string | undefined;
 
     render(
@@ -106,11 +110,11 @@ describe('useQueryPersistedState', () => {
     await waitFor(() => {
       expect(querySearch).toEqual('?param1=A1&param2=A2');
     });
-    await userEvent.click(screen.getByText(`[A1]`));
+    await user.click(screen.getByText(`[A1]`));
     await waitFor(() => {
       expect(querySearch).toEqual('?param1=Navigated&param2=A2');
     });
-    await userEvent.click(screen.getByText(`[A2]`));
+    await user.click(screen.getByText(`[A2]`));
     await waitFor(() => {
       expect(querySearch).toEqual('?param1=Navigated&param2=Navigated');
     });
@@ -118,6 +122,7 @@ describe('useQueryPersistedState', () => {
   });
 
   it('can coexist, even if you errantly retain the setter (just like setState)', async () => {
+    const user = userEvent.setup();
     const TestWithBug = () => {
       const [word, setWord] = useQueryPersistedState({queryKey: 'word'});
       const onCapturedForever = useCallback(() => {
@@ -138,17 +143,18 @@ describe('useQueryPersistedState', () => {
       </MemoryRouter>,
     );
 
-    await userEvent.click(screen.getByText(`[A]`));
+    await user.click(screen.getByText(`[A]`));
     await waitFor(() => {
       expect(querySearch).toEqual('?word=hello&param1=Navigated');
     });
-    await userEvent.click(screen.getByText(`[hello]`));
+    await user.click(screen.getByText(`[hello]`));
     await waitFor(() => {
       expect(querySearch).toEqual('?word=world&param1=Navigated'); // would reset param1=A in case of bug
     });
   });
 
   it('can be used to represent arbitrary state shapes via custom encode/decode methods', async () => {
+    const user = userEvent.setup();
     const TestEncoding = () => {
       const [items, setItems] = useQueryPersistedState<string[]>({
         encode: (items) => ({value: items.join(',')}),
@@ -176,18 +182,19 @@ describe('useQueryPersistedState', () => {
       </MemoryRouter>,
     );
 
-    await userEvent.click(screen.getByText(`[]`));
+    await user.click(screen.getByText(`[]`));
     await waitFor(() => {
       expect(querySearch).toEqual('?value=Added0');
     });
-    await userEvent.click(screen.getByText(`["Added0"]`));
-    await userEvent.click(screen.getByText(`["Added0","Added1"]`));
+    await user.click(screen.getByText(`["Added0"]`));
+    await user.click(screen.getByText(`["Added0","Added1"]`));
     await waitFor(() => {
       expect(querySearch).toEqual('?value=Added0%2CAdded1%2CAdded2');
     });
   });
 
   it('can be used to represent objects with optional / non-optional keys', async () => {
+    const user = userEvent.setup();
     const TestWithObject = () => {
       const [filters, setFilters] = useQueryPersistedState<{
         pipeline?: string;
@@ -211,12 +218,13 @@ describe('useQueryPersistedState', () => {
       </MemoryRouter>,
     );
 
-    await userEvent.click(screen.getByText(`{"view":"grid"}`));
-    await userEvent.click(screen.getByText(`{"view":"grid","pipeline":"my_pipeline"}`));
+    await user.click(screen.getByText(`{"view":"grid"}`));
+    await user.click(screen.getByText(`{"view":"grid","pipeline":"my_pipeline"}`));
     expect(querySearch).toEqual('?pipeline=my_pipeline');
   });
 
   it('automatically coerces true/false if no encode/decode methods are provided', async () => {
+    const user = userEvent.setup();
     const TestWithObject = () => {
       const [filters, setFilters] = useQueryPersistedState<{
         enableA?: boolean;
@@ -238,17 +246,18 @@ describe('useQueryPersistedState', () => {
       </MemoryRouter>,
     );
 
-    await userEvent.click(screen.getByText(`{"enableA":true,"enableB":false}`));
+    await user.click(screen.getByText(`{"enableA":true,"enableB":false}`));
     await waitFor(() => {
       expect(querySearch).toEqual('?enableA=false&enableB=true');
     });
-    await userEvent.click(screen.getByText(`{"enableA":false,"enableB":true}`));
+    await user.click(screen.getByText(`{"enableA":false,"enableB":true}`));
     await waitFor(() => {
       expect(querySearch).toEqual('?enableA=true&enableB=false');
     });
   });
 
   it('emits the same setFilters on each render if memoized options are provided, matching React.useState', async () => {
+    const user = userEvent.setup();
     let firstSetFunction: (v: any) => void;
 
     const TestWithObject = () => {
@@ -279,9 +288,9 @@ describe('useQueryPersistedState', () => {
       </MemoryRouter>,
     );
 
-    await userEvent.click(screen.getByText(`Functions Same: true`));
+    await user.click(screen.getByText(`Functions Same: true`));
     expect(screen.getByText(`Functions Same: true`)).toBeVisible();
-    await userEvent.click(screen.getByText(`Functions Same: true`));
+    await user.click(screen.getByText(`Functions Same: true`));
     expect(screen.getByText(`Functions Same: true`)).toBeVisible();
   });
 
@@ -296,6 +305,7 @@ describe('useQueryPersistedState', () => {
     });
 
     it('correctly encodes arrays, using `indices` syntax', async () => {
+      const user = userEvent.setup();
       const TestArray = () => {
         const [state, setState] = useQueryPersistedState<{value: string[]}>({
           defaults: {value: []},
@@ -315,18 +325,19 @@ describe('useQueryPersistedState', () => {
         </MemoryRouter>,
       );
 
-      await userEvent.click(screen.getByText(`[]`));
+      await user.click(screen.getByText(`[]`));
       await waitFor(() => {
         expect(querySearch).toEqual('?value%5B0%5D=Added0');
       });
-      await userEvent.click(screen.getByText(`["Added0"]`));
-      await userEvent.click(screen.getByText(`["Added0","Added1"]`));
+      await user.click(screen.getByText(`["Added0"]`));
+      await user.click(screen.getByText(`["Added0","Added1"]`));
       await waitFor(() => {
         expect(querySearch).toEqual('?value%5B0%5D=Added0&value%5B1%5D=Added1&value%5B2%5D=Added2');
       });
     });
 
     it('correctly encodes arrays of objects, using `indices` syntax', async () => {
+      const user = userEvent.setup();
       const TestArray = () => {
         const [state, setState] = useQueryPersistedState<{value: {foo: string; bar: string}[]}>({
           defaults: {value: []},
@@ -353,14 +364,12 @@ describe('useQueryPersistedState', () => {
         </MemoryRouter>,
       );
 
-      await userEvent.click(screen.getByText(`[]`));
+      await user.click(screen.getByText(`[]`));
       await waitFor(() => {
         expect(querySearch).toEqual('?value%5B0%5D%5Bfoo%5D=len0&value%5B0%5D%5Bbar%5D=baz');
       });
-      await userEvent.click(screen.getByText(`[{"foo":"len0","bar":"baz"}]`));
-      await userEvent.click(
-        screen.getByText(`[{"foo":"len0","bar":"baz"},{"foo":"len1","bar":"baz"}]`),
-      );
+      await user.click(screen.getByText(`[{"foo":"len0","bar":"baz"}]`));
+      await user.click(screen.getByText(`[{"foo":"len0","bar":"baz"},{"foo":"len1","bar":"baz"}]`));
       await waitFor(() => {
         expect(querySearch).toEqual(
           '?value%5B0%5D%5Bfoo%5D=len0&value%5B0%5D%5Bbar%5D=baz&value%5B1%5D%5Bfoo%5D=len1&value%5B1%5D%5Bbar%5D=baz&value%5B2%5D%5Bfoo%5D=len2&value%5B2%5D%5Bbar%5D=baz',
@@ -369,6 +378,7 @@ describe('useQueryPersistedState', () => {
     });
 
     it('correctly encodes arrays alongside other values, using `indices` syntax', async () => {
+      const user = userEvent.setup();
       const TestArray = () => {
         const [state, setState] = useQueryPersistedState<{hello: boolean; items: string[]}>({
           defaults: {hello: 'false', items: []},
@@ -393,13 +403,13 @@ describe('useQueryPersistedState', () => {
         </MemoryRouter>,
       );
 
-      await userEvent.click(screen.getByText(`{"hello":false,"items":[]}`));
+      await user.click(screen.getByText(`{"hello":false,"items":[]}`));
 
       await waitFor(() => {
         expect(querySearch).toEqual('?hello=true&items%5B0%5D=Added0');
       });
-      await userEvent.click(screen.getByText(`{"hello":true,"items":["Added0"]}`));
-      await userEvent.click(screen.getByText(`{"hello":true,"items":["Added0","Added1"]}`));
+      await user.click(screen.getByText(`{"hello":true,"items":["Added0"]}`));
+      await user.click(screen.getByText(`{"hello":true,"items":["Added0","Added1"]}`));
 
       await waitFor(() => {
         expect(querySearch).toEqual(
@@ -409,6 +419,7 @@ describe('useQueryPersistedState', () => {
     });
 
     it('correctly handles very large arrays', async () => {
+      const user = userEvent.setup();
       /**
        * Note that this test checks an extreme case, and GET requests will not really be able to support
        * query strings of this length.
@@ -433,7 +444,7 @@ describe('useQueryPersistedState', () => {
         </MemoryRouter>,
       );
 
-      await userEvent.click(screen.getByText(`{"hello":false,"items":[]}`));
+      await user.click(screen.getByText(`{"hello":false,"items":[]}`));
 
       // Fire a console error so that we can track this. We will still allow the parse to proceed.
       expect(console.error).toHaveBeenCalledWith(
@@ -450,6 +461,7 @@ describe('useQueryPersistedState', () => {
     });
 
     it('correctly handles sparse array with very large indices', async () => {
+      const user = userEvent.setup();
       const arr = new Array(1001);
       arr[1000] = 'Added1000';
 
@@ -471,7 +483,7 @@ describe('useQueryPersistedState', () => {
         </MemoryRouter>,
       );
 
-      await userEvent.click(await findByText(`{"hello":false,"items":[]}`));
+      await user.click(await findByText(`{"hello":false,"items":[]}`));
 
       // High index is present in stringified parameter.
       await waitFor(() => {
@@ -484,6 +496,7 @@ describe('useQueryPersistedState', () => {
   });
 
   it('supports push behavior', async () => {
+    const user = userEvent.setup();
     let querySearch: string | undefined;
 
     let goback: () => void;
@@ -508,17 +521,17 @@ describe('useQueryPersistedState', () => {
       </MemoryRouter>,
     );
 
-    await userEvent.click(screen.getByText(`one`));
+    await user.click(screen.getByText(`one`));
     await waitFor(() => {
       expect(querySearch).toEqual('?q=one');
     });
 
-    await userEvent.click(screen.getByText(`two`));
+    await user.click(screen.getByText(`two`));
     await waitFor(() => {
       expect(querySearch).toEqual('?q=two');
     });
 
-    await userEvent.click(screen.getByText(`three`));
+    await user.click(screen.getByText(`three`));
     await waitFor(() => {
       expect(querySearch).toEqual('?q=three');
     });
@@ -541,6 +554,7 @@ describe('useQueryPersistedState', () => {
   });
 
   it('supports replace behavior', async () => {
+    const user = userEvent.setup();
     let querySearch: string | undefined;
 
     let goback: () => void;
@@ -572,17 +586,17 @@ describe('useQueryPersistedState', () => {
       push!('/page?');
     });
 
-    await userEvent.click(screen.getByText(`one`));
+    await user.click(screen.getByText(`one`));
     await waitFor(() => {
       expect(querySearch).toEqual('?q=one');
     });
 
-    await userEvent.click(screen.getByText(`two`));
+    await user.click(screen.getByText(`two`));
     await waitFor(() => {
       expect(querySearch).toEqual('?q=two');
     });
 
-    await userEvent.click(screen.getByText(`three`));
+    await user.click(screen.getByText(`three`));
     await waitFor(() => {
       expect(querySearch).toEqual('?q=three');
     });

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/__tests__/DaemonList.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/__tests__/DaemonList.test.tsx
@@ -110,6 +110,7 @@ describe('DaemonList', () => {
   });
 
   it('turns off Auto-materializing', async () => {
+    const user = userEvent.setup();
     const setAutoMaterializePausedMock = {
       request: {
         query: SET_AUTOMATERIALIZE_PAUSED_MUTATION,
@@ -141,16 +142,17 @@ describe('DaemonList', () => {
     expect(switchButton).toBeChecked();
     expect(switchButton).toBeEnabled();
 
-    await userEvent.click(switchButton);
+    await user.click(switchButton);
     expect(setAutoMaterializePausedMock.result).not.toHaveBeenCalled();
 
     const confirmButton = await screen.findByRole('button', {name: /confirm/i});
-    await userEvent.click(confirmButton);
+    await user.click(confirmButton);
 
     await waitFor(() => expect(setAutoMaterializePausedMock.result).toHaveBeenCalled());
   });
 
   it('turns on Auto-materializing', async () => {
+    const user = userEvent.setup();
     const setAutoMaterializePausedMock = {
       request: {
         query: SET_AUTOMATERIALIZE_PAUSED_MUTATION,
@@ -182,7 +184,7 @@ describe('DaemonList', () => {
     expect(switchButton).not.toBeChecked();
     expect(switchButton).toBeEnabled();
 
-    await userEvent.click(switchButton);
+    await user.click(switchButton);
     await waitFor(() => expect(setAutoMaterializePausedMock.result).toHaveBeenCalled());
   });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/RunsFeedBackfillPage.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/RunsFeedBackfillPage.test.tsx
@@ -1,5 +1,5 @@
 import {MockedProvider} from '@apollo/client/testing';
-import {getAllByText, getByText, getByTitle, render, screen, waitFor} from '@testing-library/react';
+import {getAllByText, getByText, getByTitle, render, screen} from '@testing-library/react';
 import {MemoryRouter} from 'react-router-dom';
 import {RecoilRoot} from 'recoil';
 
@@ -125,7 +125,7 @@ describe('BackfillPage', () => {
       }),
     ];
 
-    const {getByText} = render(
+    const {findByText} = render(
       <RecoilRoot>
         <AnalyticsContext.Provider value={{page: () => {}} as any}>
           <MemoryRouter initialEntries={[`/runs/b/${mockBackfillId}`]}>
@@ -139,7 +139,7 @@ describe('BackfillPage', () => {
       </RecoilRoot>,
     );
 
-    await waitFor(() => expect(getByText('An error occurred')).toBeVisible());
+    expect(await findByText('An error occurred')).toBeVisible();
   });
 
   it('renders the loaded state', async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/useRepositoryLocationReload.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/useRepositoryLocationReload.test.tsx
@@ -49,6 +49,7 @@ describe('useRepositoryReloadLocation', () => {
   };
 
   it('reloads successfully if there are no errors', async () => {
+    const user = userEvent.setup();
     render(
       <TestProvider apolloProps={{mocks: [defaultMocks]}}>
         <Test />
@@ -61,7 +62,7 @@ describe('useRepositoryReloadLocation', () => {
     });
 
     const tryButton = screen.getByRole('button', {name: /try/i});
-    await userEvent.click(tryButton);
+    await user.click(tryButton);
 
     await waitFor(() => {
       expect(screen.queryByText(/Reloading: true/)).toBeVisible();
@@ -75,6 +76,7 @@ describe('useRepositoryReloadLocation', () => {
   });
 
   it('surfaces mutation errors', async () => {
+    const user = userEvent.setup();
     const mocks = {
       ReloadRepositoryLocationMutationResult: () => ({
         __typename: 'RepositoryLocationNotFound',
@@ -94,7 +96,7 @@ describe('useRepositoryReloadLocation', () => {
     });
 
     const tryButton = screen.getByRole('button', {name: /try/i});
-    await userEvent.click(tryButton);
+    await user.click(tryButton);
 
     await waitFor(() => {
       expect(screen.queryByText(/Reloading: false/)).toBeVisible();
@@ -103,6 +105,7 @@ describe('useRepositoryReloadLocation', () => {
   });
 
   it('surfaces code location errors', async () => {
+    const user = userEvent.setup();
     const mocks = {
       RepositoryLocationOrLoadError: () => ({
         __typename: 'PythonError',
@@ -121,7 +124,7 @@ describe('useRepositoryReloadLocation', () => {
       expect(screen.queryByText(/Has error: false/)).toBeVisible();
     });
 
-    await userEvent.click(screen.getByText(/Try/));
+    await user.click(screen.getByText(/Try/));
 
     await waitFor(() => {
       expect(screen.queryByText(/Reloading: true/)).toBeVisible();
@@ -136,6 +139,7 @@ describe('useRepositoryReloadLocation', () => {
 
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('waits for polling when attempting reload', async () => {
+    const user = userEvent.setup();
     const mocks = {
       WorkspaceLocationEntry: () => ({
         id: () => LOCATION,
@@ -150,7 +154,7 @@ describe('useRepositoryReloadLocation', () => {
       </TestProvider>,
     );
 
-    await userEvent.click(screen.getByText(/Try/));
+    await user.click(screen.getByText(/Try/));
 
     // Still considered reloading while polling occurs.
     await waitFor(() => {
@@ -178,6 +182,7 @@ describe('useRepositoryReloadLocation', () => {
   });
 
   it('stops polling when attempting reload when `LOADED` and there are errors', async () => {
+    const user = userEvent.setup();
     const mocks = {
       WorkspaceLocationEntry: () => ({
         id: () => LOCATION,
@@ -192,7 +197,7 @@ describe('useRepositoryReloadLocation', () => {
       </TestProvider>,
     );
 
-    await userEvent.click(screen.getByText(/Try/));
+    await user.click(screen.getByText(/Try/));
 
     // Still considered reloading while polling occurs.
     await waitFor(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/CreatePartitionDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/CreatePartitionDialog.test.tsx
@@ -44,14 +44,15 @@ describe('CreatePartitionDialog', () => {
   });
 
   it('Submits mutation with correct variables and calls setSelected and onClose', async () => {
+    const user = userEvent.setup();
     const createFixture = buildCreatePartitionFixture({
       partitionsDefName: 'testPartitionDef',
       partitionKey: 'testPartitionName',
     });
     render(<Test mocks={[createFixture]} />);
     const partitionInput = await screen.findByTestId('partition-input');
-    await userEvent.type(partitionInput, 'testPartitionName');
-    await userEvent.click(screen.getByTestId('save-partition-button'));
+    await user.type(partitionInput, 'testPartitionName');
+    await user.click(screen.getByTestId('save-partition-button'));
     await waitFor(() => {
       expect(onCloseMock).toHaveBeenCalled();
       expect(onCreatedMock).toHaveBeenCalledWith('testPartitionName');
@@ -60,18 +61,20 @@ describe('CreatePartitionDialog', () => {
   });
 
   it('Shows error state', async () => {
+    const user = userEvent.setup();
     render(<Test mocks={[]} />);
     const partitionInput = await screen.findByTestId('partition-input');
     expect(screen.queryByTestId('warning-icon')).toBeNull();
-    await userEvent.type(partitionInput, 'invalidname\n\r\t');
+    await user.type(partitionInput, 'invalidname\n\r\t');
     expect(screen.getByTestId('warning-icon')).toBeVisible();
-    await userEvent.clear(partitionInput);
+    await user.clear(partitionInput);
     expect(screen.queryByTestId('warning-icon')).toBeNull();
-    await userEvent.type(partitionInput, 'validname');
+    await user.type(partitionInput, 'validname');
     expect(screen.queryByTestId('warning-icon')).toBeNull();
   });
 
   it('Shows error state when mutation fails', async () => {
+    const user = userEvent.setup();
     const createFixture = buildCreatePartitionMutation({
       variables: {
         partitionsDefName: 'testPartitionDef',
@@ -87,8 +90,8 @@ describe('CreatePartitionDialog', () => {
     });
     render(<Test mocks={[createFixture]} />);
     const partitionInput = await screen.findByTestId('partition-input');
-    await userEvent.type(partitionInput, 'testPartitionName');
-    await userEvent.click(screen.getByTestId('save-partition-button'));
+    await user.type(partitionInput, 'testPartitionName');
+    await user.click(screen.getByTestId('save-partition-button'));
     await waitFor(() => {
       expect(createFixture.result).toHaveBeenCalled();
       expect(showCustomAlertSpy).toHaveBeenCalledWith({

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/ReexecutionDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/ReexecutionDialog.test.tsx
@@ -44,6 +44,7 @@ describe('ReexecutionDialog', () => {
   });
 
   it('allows you to specify one or more extra tags which are sent in the re-execute mutation', async () => {
+    const user = userEvent.setup();
     render(
       <Test
         strategy={ReexecutionStrategy.FROM_FAILURE}
@@ -56,13 +57,13 @@ describe('ReexecutionDialog', () => {
       />,
     );
 
-    await userEvent.click(await screen.findByText('Add custom tag'));
-    await userEvent.type(await screen.findByPlaceholderText('Tag Key'), 'test_key');
-    await userEvent.type(await screen.findByPlaceholderText('Tag Value'), 'test_value');
+    await user.click(await screen.findByText('Add custom tag'));
+    await user.type(await screen.findByPlaceholderText('Tag Key'), 'test_key');
+    await user.type(await screen.findByPlaceholderText('Tag Value'), 'test_value');
 
     await waitFor(async () => {
       const button = screen.getByText(/re\-execute 3 runs/i);
-      await userEvent.click(button);
+      await user.click(button);
     });
 
     await waitFor(() => {
@@ -71,6 +72,7 @@ describe('ReexecutionDialog', () => {
   });
 
   it('moves into loading state upon re-execution', async () => {
+    const user = userEvent.setup();
     render(
       <Test
         strategy={ReexecutionStrategy.FROM_FAILURE}
@@ -87,7 +89,7 @@ describe('ReexecutionDialog', () => {
     });
 
     const button = screen.getByText(/re\-execute 3 runs/i);
-    await userEvent.click(button);
+    await user.click(button);
 
     await waitFor(() => {
       expect(
@@ -98,6 +100,7 @@ describe('ReexecutionDialog', () => {
   });
 
   it('displays success message if mutations are successful', async () => {
+    const user = userEvent.setup();
     render(
       <Test
         strategy={ReexecutionStrategy.FROM_FAILURE}
@@ -112,7 +115,7 @@ describe('ReexecutionDialog', () => {
 
     await waitFor(async () => {
       const button = screen.getByText(/re\-execute 3 runs/i);
-      await userEvent.click(button);
+      await user.click(button);
     });
 
     await waitFor(() => {
@@ -121,6 +124,7 @@ describe('ReexecutionDialog', () => {
   });
 
   it('displays python errors', async () => {
+    const user = userEvent.setup();
     render(
       <Test
         strategy={ReexecutionStrategy.FROM_FAILURE}
@@ -143,7 +147,7 @@ describe('ReexecutionDialog', () => {
 
     await waitFor(async () => {
       const button = screen.getByText(/re\-execute 3 runs/i);
-      await userEvent.click(button);
+      await user.click(button);
     });
 
     await waitFor(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunFilterInput.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunFilterInput.test.tsx
@@ -169,6 +169,7 @@ describe('<RunFilterInput  />', () => {
   // b. Test rendering with all enabledFilters
   // (Include tests for rendering with different combinations of enabledFilters)
   it('should call onChange with updated tokens when created DATE filter is updated', async () => {
+    const user = userEvent.setup();
     const onChange = jest.fn();
     const tokens: RunFilterToken[] = [
       {token: 'created_date_before', value: '1609459200'}, // 1/1/2021
@@ -181,9 +182,9 @@ describe('<RunFilterInput  />', () => {
     expect(getByText('1/1/2020')).toBeVisible();
     expect(getByText('1/1/2021')).toBeVisible();
 
-    await userEvent.click(getByText('Filter'));
-    await userEvent.click(getByText('Created date'));
-    await userEvent.click(getByText('Today'));
+    await user.click(getByText('Filter'));
+    await user.click(getByText('Created date'));
+    await user.click(getByText('Today'));
 
     const todayRange = calculateTimeRanges('UTC').timeRanges.TODAY.range;
 
@@ -197,6 +198,7 @@ describe('<RunFilterInput  />', () => {
   });
 
   it('should call onChange with updated tokens when JOB filter is updated', async () => {
+    const user = userEvent.setup();
     const onChange = jest.fn();
     const tokens: RunFilterToken[] = [];
     const {getByText} = render(
@@ -210,17 +212,18 @@ describe('<RunFilterInput  />', () => {
 
     onChange.mockClear();
 
-    await userEvent.click(getByText('Filter'));
-    await userEvent.click(getByText('Job'));
+    await user.click(getByText('Filter'));
+    await user.click(getByText('Job'));
 
     await waitFor(async () => {
-      await userEvent.click(getByText('some_job'));
+      await user.click(getByText('some_job'));
     });
 
     expect(onChange).toHaveBeenCalledWith([{token: 'job', value: 'some_job'}]);
   });
 
   it('should call onChange with updated tokens when BACKFILL filter is updated', async () => {
+    const user = userEvent.setup();
     const onChange = jest.fn();
     const tokens: RunFilterToken[] = [];
     const {getByText} = render(
@@ -234,17 +237,18 @@ describe('<RunFilterInput  />', () => {
 
     onChange.mockClear();
 
-    await userEvent.click(getByText('Filter'));
-    await userEvent.click(getByText('Backfill ID'));
+    await user.click(getByText('Filter'));
+    await user.click(getByText('Backfill ID'));
 
     await waitFor(async () => {
-      await userEvent.click(getByText('value1'));
+      await user.click(getByText('value1'));
     });
 
     expect(onChange).toHaveBeenCalledWith([{token: 'tag', value: 'dagster/backfill=value1'}]);
   });
 
   it('should call onChange with updated tokens when TAG filter is updated', async () => {
+    const user = userEvent.setup();
     const onChange = jest.fn();
     const tokens: RunFilterToken[] = [];
     const {getByText} = render(
@@ -260,15 +264,15 @@ describe('<RunFilterInput  />', () => {
 
     onChange.mockClear();
 
-    await userEvent.click(getByText('Filter'));
-    await userEvent.click(getByText('Tag'));
+    await user.click(getByText('Filter'));
+    await user.click(getByText('Tag'));
 
     await waitFor(async () => {
-      await userEvent.click(getByText(DagsterTag.PartitionSet));
+      await user.click(getByText(DagsterTag.PartitionSet));
     });
 
     await waitFor(async () => {
-      await userEvent.click(getByText('set1'));
+      await user.click(getByText('set1'));
     });
 
     expect(onChange).toHaveBeenCalledWith([

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useJobReExecution.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useJobReExecution.test.tsx
@@ -27,6 +27,7 @@ describe('useJobReexecution', () => {
   const PARENT_RUN = {id: '1', pipelineName: 'abc', tags: []};
 
   it('creates the correct mutation for FROM_FAILURE', async () => {
+    const user = userEvent.setup();
     const {findByText, findByTestId} = render(
       <MockedProvider
         addTypename={false}
@@ -44,12 +45,13 @@ describe('useJobReexecution', () => {
       </MockedProvider>,
     );
 
-    await userEvent.click(await findByText('Re-execute'));
+    await user.click(await findByText('Re-execute'));
 
     expect((await findByTestId('location')).textContent).toEqual('/runs/1234');
   });
 
   it('shows the re-execute dialog so you can provide tags if requested', async () => {
+    const user = userEvent.setup();
     const {findByText} = render(
       <MockedProvider
         addTypename={false}
@@ -66,15 +68,15 @@ describe('useJobReexecution', () => {
       </MockedProvider>,
     );
 
-    await userEvent.click(await findByText('Re-execute'));
+    await user.click(await findByText('Re-execute'));
 
-    await userEvent.click(await screen.findByText('Add custom tag'));
-    await userEvent.type(await screen.findByPlaceholderText('Tag Key'), 'test_key');
-    await userEvent.type(await screen.findByPlaceholderText('Tag Value'), 'test_value');
+    await user.click(await screen.findByText('Add custom tag'));
+    await user.type(await screen.findByPlaceholderText('Tag Key'), 'test_key');
+    await user.type(await screen.findByPlaceholderText('Tag Value'), 'test_value');
 
     await waitFor(async () => {
       const button = screen.getByText(/re\-execute 1 run/i);
-      await userEvent.click(button);
+      await user.click(button);
     });
 
     await waitFor(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/__tests__/ScheduleBulkActionMenu.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/__tests__/ScheduleBulkActionMenu.test.tsx
@@ -23,6 +23,7 @@ describe('ScheduleBulkActionMenu', () => {
   };
 
   it('renders button and menu items for stopped schedules', async () => {
+    const user = userEvent.setup();
     render(
       <ScheduleBulkActionMenu
         schedules={[scheduleAlaskaCurrentlyStopped, scheduleColoradoCurrentlyStopped]}
@@ -34,7 +35,7 @@ describe('ScheduleBulkActionMenu', () => {
     expect(button).toBeVisible();
     expect(button).toBeEnabled();
 
-    await userEvent.click(button);
+    await user.click(button);
 
     const startItem = screen.getByRole('menuitem', {name: /start 2 schedules/i});
     expectAriaEnabled(startItem);
@@ -43,6 +44,7 @@ describe('ScheduleBulkActionMenu', () => {
   });
 
   it('renders button and menu items for running schedules', async () => {
+    const user = userEvent.setup();
     render(
       <ScheduleBulkActionMenu
         schedules={[scheduleDelawareCurrentlyRunning, scheduleHawaiiCurrentlyRunning]}
@@ -54,7 +56,7 @@ describe('ScheduleBulkActionMenu', () => {
     expect(button).toBeVisible();
     expect(button).toBeEnabled();
 
-    await userEvent.click(button);
+    await user.click(button);
 
     const startItem = screen.getByRole('menuitem', {name: /start 2 schedules/i});
     expectAriaDisabled(startItem);
@@ -63,6 +65,7 @@ describe('ScheduleBulkActionMenu', () => {
   });
 
   it('renders button and menu items for mixture of statuses', async () => {
+    const user = userEvent.setup();
     render(
       <ScheduleBulkActionMenu
         schedules={[
@@ -79,7 +82,7 @@ describe('ScheduleBulkActionMenu', () => {
     expect(button).toBeVisible();
     expect(button).toBeEnabled();
 
-    await userEvent.click(button);
+    await user.click(button);
 
     // Both options enabled
     const startItem = screen.getByRole('menuitem', {name: /start 4 schedules/i});

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/__tests__/ScheduleStateChangeDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/__tests__/ScheduleStateChangeDialog.test.tsx
@@ -101,6 +101,7 @@ describe('ScheduleStateChangeDialog', () => {
 
   describe('Mutation: start', () => {
     it('starts schedules', async () => {
+      const user = userEvent.setup();
       const mocks = [buildStartAlaskaSuccess(100), buildStartColoradoSuccess(100)];
 
       render(
@@ -115,7 +116,7 @@ describe('ScheduleStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /start/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /starting/i});
@@ -129,6 +130,7 @@ describe('ScheduleStateChangeDialog', () => {
     });
 
     it('shows error when starting a schedule fails', async () => {
+      const user = userEvent.setup();
       const mocks = [buildStartAlaskaSuccess(100), buildStartColoradoError(100)];
 
       render(
@@ -143,7 +145,7 @@ describe('ScheduleStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /start/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /starting/i});
@@ -165,6 +167,7 @@ describe('ScheduleStateChangeDialog', () => {
 
   describe('Mutation: stop', () => {
     it('stops schedules', async () => {
+      const user = userEvent.setup();
       const mocks = [buildStopDelawareSuccess(100), buildStopHawaiiSuccess(100)];
 
       render(
@@ -179,7 +182,7 @@ describe('ScheduleStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /stop/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /stopping/i});
@@ -193,6 +196,7 @@ describe('ScheduleStateChangeDialog', () => {
     });
 
     it('shows error when stopping a schedule fails', async () => {
+      const user = userEvent.setup();
       const mocks = [buildStopDelawareSuccess(100), buildStopHawaiiError(100)];
 
       render(
@@ -207,7 +211,7 @@ describe('ScheduleStateChangeDialog', () => {
       );
 
       const confirmButton = screen.getByRole('button', {name: /stop/i});
-      await userEvent.click(confirmButton);
+      await user.click(confirmButton);
 
       await waitFor(() => {
         const button = screen.getByRole('button', {name: /stopping/i});

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/EvaluateScheduleDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/EvaluateScheduleDialog.test.tsx
@@ -55,32 +55,34 @@ function Test({mocks, resolvers}: {mocks?: MockedResponse[]; resolvers?: Resolve
 
 describe('EvaluateScheduleTest', () => {
   it('submits evaluateSchedule mutation with cursor variable and renders successful result and persists cursor', async () => {
+    const user = userEvent.setup();
     render(<Test mocks={[GetScheduleQueryMock, ScheduleDryRunMutationRunRequests]} />);
     const selectButton = await screen.findByTestId('tick-selection');
-    await userEvent.click(selectButton);
+    await user.click(selectButton);
     await waitFor(() => {
       expect(screen.getByTestId('tick-5')).toBeVisible();
     });
-    await userEvent.click(screen.getByTestId('tick-5'));
-    await userEvent.click(screen.getByTestId('continue'));
+    await user.click(screen.getByTestId('tick-5'));
+    await user.click(screen.getByTestId('continue'));
     await waitFor(() => {
       expect(screen.getByText(/1\s+run request/i)).toBeVisible();
     });
   });
 
   it('renders errors', async () => {
+    const user = userEvent.setup();
     render(<Test mocks={[GetScheduleQueryMock, ScheduleDryRunMutationError]} />);
     const tickSelection = await screen.findByTestId('tick-selection');
     expect(tickSelection).toBeVisible();
-    await userEvent.click(tickSelection);
+    await user.click(tickSelection);
     await waitFor(() => {
       expect(screen.getByTestId('tick-5')).toBeVisible();
     });
-    await userEvent.click(screen.getByTestId('tick-5'));
+    await user.click(screen.getByTestId('tick-5'));
     await waitFor(() => {
       expect(screen.getByTestId('continue')).not.toBeDisabled();
     });
-    await userEvent.click(screen.getByTestId('continue'));
+    await user.click(screen.getByTestId('continue'));
     await waitFor(() => {
       expect(screen.getByText('Failed')).toBeVisible();
       expect(screen.queryByText('Skipped')).toBe(null);
@@ -88,37 +90,40 @@ describe('EvaluateScheduleTest', () => {
   });
 
   it('renders skip reason', async () => {
+    const user = userEvent.setup();
     render(<Test mocks={[GetScheduleQueryMock, ScheduleDryRunMutationSkipped]} />);
     const selectButton = await screen.findByTestId('tick-selection');
-    await userEvent.click(selectButton);
+    await user.click(selectButton);
     await waitFor(() => {
       expect(screen.getByTestId('tick-5')).toBeVisible();
     });
-    await userEvent.click(screen.getByTestId('tick-5'));
-    await userEvent.click(screen.getByTestId('continue'));
+    await user.click(screen.getByTestId('tick-5'));
+    await user.click(screen.getByTestId('continue'));
     await waitFor(() => {
       expect(screen.getByText('Skipped')).toBeVisible();
     });
   });
 
   it('allows you to test again', async () => {
+    const user = userEvent.setup();
     render(<Test mocks={[GetScheduleQueryMock, ScheduleDryRunMutationSkipped]} />);
     const selectButton = await screen.findByTestId('tick-selection');
-    await userEvent.click(selectButton);
+    await user.click(selectButton);
     await waitFor(() => {
       expect(screen.getByTestId('tick-5')).toBeVisible();
     });
-    await userEvent.click(screen.getByTestId('tick-5'));
-    await userEvent.click(screen.getByTestId('continue'));
+    await user.click(screen.getByTestId('tick-5'));
+    await user.click(screen.getByTestId('continue'));
     await waitFor(() => {
       expect(screen.getByText('Skipped')).toBeVisible();
     });
-    await userEvent.click(screen.getByTestId('try-again'));
+    await user.click(screen.getByTestId('try-again'));
     expect(screen.queryByText('Failed')).toBe(null);
     expect(screen.queryByText('Skipped')).toBe(null);
   });
 
   it('launches all runs', async () => {
+    const user = userEvent.setup();
     const pushSpy = jest.fn();
     const createHrefSpy = jest.fn();
 
@@ -141,18 +146,18 @@ describe('EvaluateScheduleTest', () => {
       </MemoryRouter>,
     );
     const selectButton = await screen.findByTestId('tick-selection');
-    await userEvent.click(selectButton);
+    await user.click(selectButton);
     await waitFor(() => {
       expect(screen.getByTestId('tick-5')).toBeVisible();
     });
-    await userEvent.click(screen.getByTestId('tick-5'));
-    await userEvent.click(screen.getByTestId('continue'));
+    await user.click(screen.getByTestId('tick-5'));
+    await user.click(screen.getByTestId('continue'));
     await waitFor(() => {
       expect(screen.getByText(/1\s+run request/i)).toBeVisible();
       expect(screen.getByTestId('launch-all')).not.toBeDisabled();
     });
 
-    userEvent.click(screen.getByTestId('launch-all'));
+    user.click(screen.getByTestId('launch-all'));
 
     await waitFor(() => {
       expect(screen.getByText(/Launching runs/i)).toBeVisible();
@@ -164,6 +169,7 @@ describe('EvaluateScheduleTest', () => {
   });
 
   it('launches all runs for 1 runrequest with undefined job name in the runrequest', async () => {
+    const user = userEvent.setup();
     const pushSpy = jest.fn();
     const createHrefSpy = jest.fn();
 
@@ -186,18 +192,18 @@ describe('EvaluateScheduleTest', () => {
       </MemoryRouter>,
     );
     const selectButton = await screen.findByTestId('tick-selection');
-    await userEvent.click(selectButton);
+    await user.click(selectButton);
     await waitFor(() => {
       expect(screen.getByTestId('tick-5')).toBeVisible();
     });
-    await userEvent.click(screen.getByTestId('tick-5'));
-    await userEvent.click(screen.getByTestId('continue'));
+    await user.click(screen.getByTestId('tick-5'));
+    await user.click(screen.getByTestId('continue'));
     await waitFor(() => {
       expect(screen.getByText(/1\s+run request/i)).toBeVisible();
       expect(screen.getByTestId('launch-all')).not.toBeDisabled();
     });
 
-    userEvent.click(screen.getByTestId('launch-all'));
+    user.click(screen.getByTestId('launch-all'));
 
     await waitFor(() => {
       expect(screen.getByText(/Launching runs/i)).toBeVisible();

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
@@ -48,10 +48,11 @@ function Test({mocks, resolvers}: {mocks?: MockedResponse[]; resolvers?: Resolve
 
 describe('SensorDryRunTest', () => {
   it('submits sensorDryRun mutation with cursor variable and renders successful result and persists cursor', async () => {
+    const user = userEvent.setup();
     render(<Test mocks={[Mocks.SensorDryRunMutationRunRequests, Mocks.PersistCursorValueMock]} />);
     const cursorInput = await screen.findByTestId('cursor-input');
-    await userEvent.type(cursorInput, 'testing123');
-    await userEvent.click(screen.getByTestId('continue'));
+    await user.type(cursorInput, 'testing123');
+    await user.click(screen.getByTestId('continue'));
     await waitFor(() => {
       expect(screen.getByText(/3\srun requests/g)).toBeVisible();
       expect(screen.queryByText('Skipped')).toBe(null);
@@ -60,10 +61,11 @@ describe('SensorDryRunTest', () => {
   });
 
   it('renders errors', async () => {
+    const user = userEvent.setup();
     render(<Test mocks={[Mocks.SensorDryRunMutationError]} />);
     const cursorInput = await screen.findByTestId('cursor-input');
-    await userEvent.type(cursorInput, 'testing123');
-    await userEvent.click(screen.getByTestId('continue'));
+    await user.type(cursorInput, 'testing123');
+    await user.click(screen.getByTestId('continue'));
     await waitFor(() => {
       expect(screen.getByText('Failed')).toBeVisible();
       expect(screen.queryByText('Skipped')).toBe(null);
@@ -71,31 +73,34 @@ describe('SensorDryRunTest', () => {
   });
 
   it('renders skip reason', async () => {
+    const user = userEvent.setup();
     render(<Test mocks={[Mocks.SensorDryRunMutationSkipped]} />);
     const cursorInput = await screen.findByTestId('cursor-input');
-    await userEvent.type(cursorInput, 'testing123');
-    await userEvent.click(screen.getByTestId('continue'));
+    await user.type(cursorInput, 'testing123');
+    await user.click(screen.getByTestId('continue'));
     await waitFor(() => {
       expect(screen.getByText('Skipped')).toBeVisible();
     });
   });
 
   it('allows you to test again', async () => {
+    const user = userEvent.setup();
     render(<Test mocks={[Mocks.SensorDryRunMutationError]} />);
     const cursorInput = await screen.findByTestId('cursor-input');
-    await userEvent.type(cursorInput, 'testing123');
-    await userEvent.click(screen.getByTestId('continue'));
+    await user.type(cursorInput, 'testing123');
+    await user.click(screen.getByTestId('continue'));
     await waitFor(() => {
       expect(screen.getByText('Failed')).toBeVisible();
       expect(screen.queryByText('Skipped')).toBe(null);
     });
-    await userEvent.click(screen.getByTestId('try-again'));
+    await user.click(screen.getByTestId('try-again'));
     expect(screen.queryByText('Failed')).toBe(null);
     expect(screen.queryByText('Skipped')).toBe(null);
     expect(screen.getByTestId('cursor-input')).toBeVisible();
   });
 
   it('launches all runs with well defined job names', async () => {
+    const user = userEvent.setup();
     const pushSpy = jest.fn();
     const createHrefSpy = jest.fn();
 
@@ -118,8 +123,8 @@ describe('SensorDryRunTest', () => {
       </MemoryRouter>,
     );
     const cursorInput = await screen.findByTestId('cursor-input');
-    await userEvent.type(cursorInput, 'testing123');
-    await userEvent.click(screen.getByTestId('continue'));
+    await user.type(cursorInput, 'testing123');
+    await user.click(screen.getByTestId('continue'));
     await waitFor(() => {
       expect(screen.getByText(/3\srun requests/g)).toBeVisible();
       expect(screen.queryByText('Skipped')).toBe(null);
@@ -130,7 +135,7 @@ describe('SensorDryRunTest', () => {
       expect(screen.getByTestId('launch-all')).not.toBeDisabled();
     });
 
-    userEvent.click(screen.getByTestId('launch-all'));
+    user.click(screen.getByTestId('launch-all'));
 
     await waitFor(() => {
       expect(screen.getByText(/Launching runs/i)).toBeVisible();
@@ -142,6 +147,7 @@ describe('SensorDryRunTest', () => {
   });
 
   it('launches all runs for 1 runrequest with undefined job name in the runrequest', async () => {
+    const user = userEvent.setup();
     const pushSpy = jest.fn();
     const createHrefSpy = jest.fn();
 
@@ -164,8 +170,8 @@ describe('SensorDryRunTest', () => {
       </MemoryRouter>,
     );
     const cursorInput = await screen.findByTestId('cursor-input');
-    await userEvent.type(cursorInput, 'testing123');
-    await userEvent.click(screen.getByTestId('continue'));
+    await user.type(cursorInput, 'testing123');
+    await user.click(screen.getByTestId('continue'));
     await waitFor(() => {
       expect(screen.getByText(/1\srun requests/g)).toBeVisible();
       expect(screen.queryByText('Skipped')).toBe(null);
@@ -176,7 +182,7 @@ describe('SensorDryRunTest', () => {
       expect(screen.getByTestId('launch-all')).not.toBeDisabled();
     });
 
-    userEvent.click(screen.getByTestId('launch-all'));
+    user.click(screen.getByTestId('launch-all'));
 
     await waitFor(() => {
       expect(screen.getByText(/Launching runs/i)).toBeVisible();

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/__tests__/FilterDropdown.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/__tests__/FilterDropdown.test.tsx
@@ -68,8 +68,8 @@ describe('FilterDropdown', () => {
     );
     const searchInput = screen.getByPlaceholderText('Search filters...');
     await userEvent.type(searchInput, 'type');
-    await waitFor(() => expect(screen.getByText('Type 1')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByText('Type 2')).toBeInTheDocument());
+    expect(await screen.findByText('Type 1')).toBeInTheDocument();
+    expect(await screen.findByText('Type 2')).toBeInTheDocument();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await waitFor(() => expect(mockFilters[0]!.getResults).toHaveBeenCalledWith('type'));
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -86,7 +86,7 @@ describe('FilterDropdown', () => {
     );
     const searchInput = screen.getByPlaceholderText('Search filters...');
     await userEvent.type(searchInput, 'nonexistent');
-    await waitFor(() => expect(screen.getByText('No results')).toBeInTheDocument());
+    expect(await screen.findByText('No results')).toBeInTheDocument();
   });
 });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/__tests__/useRepoExpansionState.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/__tests__/useRepoExpansionState.test.tsx
@@ -69,36 +69,39 @@ describe('useRepoExpansionState', () => {
   });
 
   it('toggles a key to expanded', async () => {
+    const user = userEvent.setup();
     const fullCollapsedKey = buildStorageKey('', COLLAPSED_STORAGE_KEY);
     window.localStorage.setItem(fullCollapsedKey, JSON.stringify(['ipsum:lorem']));
     render(<Test />);
 
     const button = await screen.findByRole('button', {name: 'toggle ipsum:lorem'});
-    await userEvent.click(button);
+    await user.click(button);
 
     expect(screen.getByText('ipsum:lorem expanded')).toBeVisible();
     expect(window.localStorage.getItem(fullCollapsedKey)).toEqual('[]');
   });
 
   it('toggles a key to collapsed', async () => {
+    const user = userEvent.setup();
     const fullCollapsedKey = buildStorageKey('', COLLAPSED_STORAGE_KEY);
     window.localStorage.setItem(fullCollapsedKey, JSON.stringify([]));
     render(<Test />);
 
     const button = await screen.findByRole('button', {name: 'toggle ipsum:lorem'});
-    await userEvent.click(button);
+    await user.click(button);
 
     expect(screen.getByText('ipsum:lorem collapsed')).toBeVisible();
     expect(window.localStorage.getItem(fullCollapsedKey)).toEqual(JSON.stringify(['ipsum:lorem']));
   });
 
   it('toggles all to expanded', async () => {
+    const user = userEvent.setup();
     const fullCollapsedKey = buildStorageKey('', COLLAPSED_STORAGE_KEY);
     window.localStorage.setItem(fullCollapsedKey, JSON.stringify(['ipsum:lorem', 'amet:dolorsit']));
     render(<Test />);
 
     const button = await screen.findByRole('button', {name: 'expand all'});
-    await userEvent.click(button);
+    await user.click(button);
 
     // Everything expanded!
     expect(screen.getByText('ipsum:lorem expanded')).toBeVisible();
@@ -107,12 +110,13 @@ describe('useRepoExpansionState', () => {
   });
 
   it('toggles all to collapsed', async () => {
+    const user = userEvent.setup();
     const fullCollapsedKey = buildStorageKey('', COLLAPSED_STORAGE_KEY);
     window.localStorage.setItem(fullCollapsedKey, JSON.stringify(['ipsum:lorem']));
     render(<Test />);
 
     const button = await screen.findByRole('button', {name: 'collapse all'});
-    await userEvent.click(button);
+    await user.click(button);
 
     // Everything collapsed!
     expect(screen.getByText('ipsum:lorem collapsed')).toBeVisible();


### PR DESCRIPTION
## Summary & Motivation

This PR updates React Testing Library usage across the codebase by:

1. Replacing `waitFor(() => expect(...))` with `await screen.findBy...` where appropriate
2. Using `userEvent.setup()` pattern instead of directly importing `userEvent`
3. Removing unused imports of `waitFor` where it's no longer needed

## How I Tested These Changes

BK