### PR TITLE
[telemetry] Add anonymous user id to telemetry payload

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver_tests/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/test_app.py
@@ -337,6 +337,7 @@ def test_dagster_webserver_logs(_, telemetry_caplog):
                         "elapsed_time",
                         "event_id",
                         "instance_id",
+                        "user_id",
                         "python_version",
                         "run_storage_id",
                         "metadata",

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -25,6 +25,7 @@ from dagster_shared.telemetry import (
     TelemetrySettings,
     dagster_home_if_set,
     get_or_set_instance_id,
+    get_or_set_user_id,
     log_telemetry_action,
     write_telemetry_log_line,
 )
@@ -379,6 +380,7 @@ def log_remote_repo_stats(
                 client_time=str(datetime.datetime.now()),
                 event_id=str(uuid.uuid4()),
                 instance_id=instance_id,
+                user_id=get_or_set_user_id(),
                 metadata={
                     **get_stats_from_remote_repo(remote_repo),
                     "source": source,
@@ -450,6 +452,7 @@ def log_repo_stats(
                 client_time=str(datetime.datetime.now()),
                 event_id=str(uuid.uuid4()),
                 instance_id=instance_id,
+                user_id=get_or_set_user_id(),
                 metadata={
                     "source": source,
                     "pipeline_name_hash": job_name_hash,

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/telemetry.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/telemetry.py
@@ -27,20 +27,16 @@ def _get_project_telemetry_metadata(start_path: Optional[Path] = None) -> dict[s
     import yaml
 
     project_telemetry_data = {}
-    try:
-        path = start_path or Path.cwd()
-        while path != path.parent:
-            telemetry_file = path / ".dg" / "telemetry.yaml"
-            if telemetry_file.exists():
-                data = yaml.safe_load(telemetry_file.read_text())
-                if data and isinstance(data, dict):
-                    if "project_id" in data:
-                        project_telemetry_data["project_id"] = str(data["project_id"])
-                break
-            path = path.parent
-    except Exception:
-        # Silently ignore errors - telemetry metadata is optional
-        pass
+    path = start_path or Path.cwd()
+    while path != path.parent:
+        telemetry_file = path / ".dg" / "telemetry.yaml"
+        if telemetry_file.exists():
+            data = yaml.safe_load(telemetry_file.read_text())
+            if data and isinstance(data, dict):
+                if "project_id" in data:
+                    project_telemetry_data["project_id"] = str(data["project_id"])
+            break
+        path = path.parent
     return project_telemetry_data
 
 


### PR DESCRIPTION
## Summary & Motivation

This adds an anonymous user id to every uploaded telemetry event. The id is stored at `~/.dagster/.telemetry/user_id.yaml`, alongside the "default" instance id for a machine. The ID is generated automatically if it does not exist.

Unlike the instance id, the user id is _always_ read from `~/.dagster`. It does not depend on `$DAGSTER_HOME`. This allows more stable identification of OSS users.

## How I Tested These Changes

New unit tests.