### PR TITLE
[dagster-fivetran] Add warning when API call to groups returns an empty list

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -1035,6 +1035,13 @@ class FivetranWorkspace(ConfigurableResource):
         client = self.get_client()
         groups = client.get_groups()["items"]
 
+        if not groups:
+            self._log.warning(
+                "No Fivetran groups found. This may indicate that your API credentials lack "
+                "permission to access any groups. Check your Fivetran RBAC settings "
+                "to ensure your API key has access to the relevant groups."
+            )
+
         for group in groups:
             group_id = group["id"]
 


### PR DESCRIPTION
## Summary & Motivation

Added a warning log message when no Fivetran groups are found during workspace data fetching. This helps users troubleshoot permission issues, as empty results often indicate that the API credentials lack proper RBAC permissions to access groups.

## How I Tested These Changes

New unit test

## Changelog

[dagster-fivetran] Added warning log when no Fivetran groups are found to help users troubleshoot permission issues.