### PR TITLE
Add validation when a default partition subset is matched with a time window partitions definition

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/serializable_entity_subset.py
@@ -132,6 +132,10 @@ class SerializableEntitySubset(Generic[T_EntityKey]):
     def is_compatible_with_partitions_def(
         self, partitions_def: Optional[PartitionsDefinition]
     ) -> bool:
+        from dagster._core.definitions.partitions.definition.time_window import (
+            TimeWindowPartitionsDefinition,
+        )
+
         if self.is_partitioned:
             # for some PartitionSubset types, we have access to the underlying partitions
             # definitions, so we can ensure those are identical
@@ -150,6 +154,11 @@ class SerializableEntitySubset(Generic[T_EntityKey]):
                     and partitions_def.has_partition_key(r.end)
                     for r in self.value.key_ranges
                 )
+            elif isinstance(self.value, DefaultPartitionsSubset) and isinstance(
+                partitions_def, TimeWindowPartitionsDefinition
+            ):
+                return all(partitions_def.has_partition_key(k) for k in self.value.subset)
+
             else:
                 return partitions_def is not None
         else:


### PR DESCRIPTION
Fix a validation issue when a non-time-window parittion subset is moved over to a time window partition subset and there are lingering keys from the old key format.

## How I Tested These Changes
New tests, dry run
