### PR TITLE
docs: clarify grpc_server configuration (workspace.yaml vs dg.toml)

### DIFF
--- a/docs/docs/guides/build/projects/workspaces/dg-toml.md
+++ b/docs/docs/guides/build/projects/workspaces/dg-toml.md
@@ -22,6 +22,20 @@ To create Dagster projects that can be loaded by Dagster, see [Creating Dagster 
 
 :::
 
+:::note
+
+`dg.toml` workspaces load local `dg` projects listed under `[[workspace.projects]]`. There isn't an equivalent `grpc_server` entry in `dg.toml`.
+
+If you need to connect to an already-running gRPC code server, configure it in a `workspace.yaml` file and start Dagster with:
+
+```bash
+dg dev -w path/to/workspace.yaml
+```
+
+See the [`workspace.yaml` reference](/guides/build/projects/workspaces/workspace-yaml#grpc-server) for the `grpc_server` configuration options.
+
+:::
+
 ## Location of the `dg.toml` file
 
 Dagster command line tools (like [`dg`](/api/clis/dg-cli/dg-cli-reference)) look for the `dg.toml` file in the current directory when invoked. This allows you to launch the Dagster webserver/UI and load your projects from the current directory without command line arguments:

--- a/docs/docs/guides/build/projects/workspaces/workspace-yaml.md
+++ b/docs/docs/guides/build/projects/workspaces/workspace-yaml.md
@@ -8,6 +8,8 @@ title: workspace.yaml reference (Dagster OSS)
 
 If you are just getting started with Dagster OSS, use a [workspace](/guides/build/projects/workspaces/creating-workspaces) with a `dg.toml` configuration file instead of a `workspace.yaml` file. If you have an older setup with a workspace.yaml file, we recommend [migrating to a workspace](/guides/build/projects/workspaces/migrating-workspace-yaml) with a `dg.toml` file.
 
+If you need to connect to an already-running code server (for example, using a `grpc_server` code location), continue to use `workspace.yaml`. See the [gRPC server](#grpc-server) section below.
+
 :::
 
 import DagsterOSS from '@site/docs/partials/\_DagsterOSS.md';


### PR DESCRIPTION
## Summary & Motivation
This PR clarifies where `grpc_server` code locations should be configured.
- Adds a note to the `dg.toml` reference explaining that `dg.toml` workspaces load local `[[workspace.projects]]` and do not support a `grpc_server` entry.
- Updates the `workspace.yaml` reference to note that `workspace.yaml` should be used when connecting to an already running gRPC code server, and links to the relevant section.

This addresses common confusion from users looking for a `grpc_server` equivalent in `dg.toml`.

Fixes #33222

## How I Tested These Changes
- Ran `yarn build-api-docs`
- Ran `yarn start` and verified:
  - The new notes render correctly on both pages
  - The link to the `workspace.yaml` gRPC section works

## Changelog
N/A (docs-only)
