### PR TITLE
[ui] Some fixes for TextInput and TextArea

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TextInput.tsx
@@ -11,11 +11,21 @@ interface Props extends Omit<React.ComponentPropsWithRef<'input'>, 'onChange'> {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   strokeColor?: string;
   rightElement?: JSX.Element;
+  allowPasswordManagers?: boolean;
 }
 
 export const TextInput = React.forwardRef(
   (props: Props, ref: React.ForwardedRef<HTMLInputElement>) => {
-    const {fill, icon, disabled, strokeColor, rightElement, type = 'text', ...rest} = props;
+    const {
+      fill,
+      icon,
+      disabled,
+      strokeColor,
+      rightElement,
+      type = 'text',
+      allowPasswordManagers = false,
+      ...rest
+    } = props;
 
     const containerStyle = fill ? {width: '100%', flex: 1} : undefined;
 
@@ -26,13 +36,20 @@ export const TextInput = React.forwardRef(
         } as React.CSSProperties)
       : {};
 
+    const passwordManagerProps = allowPasswordManagers
+      ? {}
+      : {
+          'data-lpignore': 'true',
+          'data-1p-ignore': 'true',
+        };
+
     return (
       <div className={clsx(styles.container, disabled && styles.disabled)} style={containerStyle}>
         {icon ? (
           <Icon name={icon} color={disabled ? Colors.accentGray() : Colors.accentPrimary()} />
         ) : null}
         <input
-          data-lpignore="true"
+          {...passwordManagerProps}
           {...rest}
           className={clsx(
             styles.input,

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/TextInput.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/TextInput.stories.tsx
@@ -4,6 +4,7 @@ import {Box} from '../Box';
 import {Button} from '../Button';
 import {Colors} from '../Color';
 import {Icon} from '../Icon';
+import {Caption} from '../Text';
 import {TextInput} from '../TextInput';
 
 // eslint-disable-next-line import/no-default-export
@@ -82,6 +83,37 @@ export const Disabled = () => {
     <Box flex={{direction: 'column', gap: 8}} style={{width: '300px'}}>
       <TextInput icon="layers" placeholder="Disabled input…" value="" disabled />
       <TextInput icon="layers" placeholder="Enabled input…" value="" />
+    </Box>
+  );
+};
+
+export const PasswordManagers = () => {
+  const [value, setValue] = useState('');
+  return (
+    <Box flex={{direction: 'column', gap: 8}} style={{width: '300px'}}>
+      <label htmlFor="username">
+        <Box flex={{direction: 'column', gap: 4}}>
+          <Caption>Username</Caption>
+          <TextInput
+            name="username-1"
+            placeholder="Password managers allowed…"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            allowPasswordManagers
+          />
+        </Box>
+      </label>
+      <label htmlFor="password">
+        <Box flex={{direction: 'column', gap: 4}}>
+          <Caption>Username (no password managers)</Caption>
+          <TextInput
+            name="username-2"
+            placeholder="Password managers not allowed…"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+        </Box>
+      </label>
     </Box>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-components/src/components/css/TextInput.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/css/TextInput.module.css
@@ -23,7 +23,7 @@
 .textInputBase {
   background-color: var(--color-background-default);
   border: none;
-  box-shadow: var(--color-border-default) inset 0px 0px 0px 1px;
+  box-shadow: var(--text-input-stroke-color, var(--color-border-default)) inset 0px 0px 0px 1px;
   outline: none;
   border-radius: 8px;
   color: var(--color-text-default);
@@ -57,6 +57,18 @@
   outline: none;
 }
 
+.textInputBase:hover:not(:disabled) {
+  box-shadow: var(--text-input-stroke-color-hover, var(--color-border-hover)) inset 0px 0px 0px 1px;
+}
+
+.textInputBase:focus,
+.textInputBase:hover:focus:not(:disabled) {
+  box-shadow:
+    var(--text-input-stroke-color, var(--color-border-hover)) inset 0px 0px 0px 1px,
+    var(--color-focus-ring) 0 0 0 2px;
+  background-color: var(--color-background-default-hover);
+}
+
 /* ============================================
    TEXTINPUT COMPONENT CLASSES
    ============================================ */
@@ -79,20 +91,7 @@
   composes: textInputBase;
 
   /* Dynamic values via CSS custom properties */
-  box-shadow: var(--text-input-stroke-color, var(--color-border-default)) inset 0px 0px 0px 1px;
   padding: var(--text-input-padding, 6px 6px 6px 12px);
-}
-
-.input:hover:not(:disabled) {
-  box-shadow: var(--text-input-stroke-color-hover, var(--color-border-hover)) inset 0px 0px 0px 1px;
-}
-
-.input:focus,
-.input:hover:focus:not(:disabled) {
-  box-shadow:
-    var(--text-input-stroke-color, var(--color-border-hover)) inset 0px 0px 0px 1px,
-    var(--color-focus-ring) 0 0 0 2px;
-  background-color: var(--color-background-default-hover);
 }
 
 .input.hasIcon {


### PR DESCRIPTION
## Summary

Added support for password managers in the TextInput component by introducing an `allowPasswordManagers` prop. By default, password managers are disabled with the `data-lpignore` and `data-1p-ignore` attributes, but can now be enabled when needed.

![Screenshot 2026-01-22 at 11.28.58.png](https://app.graphite.com/user-attachments/assets/ee0941b0-9330-4d6d-82ff-cab5f397a70e.png)

Also improved the CSS structure by moving hover and focus styles from the `.input` class to the shared `.textInputBase` class, ensuring consistent styling for both TextInput and TextArea components.

## Test plan

Added a new "PasswordManagers" story to demonstrate and test both configurations - with and without password manager support.

Verified that the TextArea component inherits the correct styling from the shared CSS classes, specifically stroke color.