### PR TITLE
[ui] Prevent menu item text wrapping

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/css/Menu.module.css
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/css/Menu.module.css
@@ -47,6 +47,7 @@
   width: 100%;
   text-align: left;
   font-family: var(--font-family--default);
+  overflow: hidden;
 }
 
 /* Remove underline from all link states */
@@ -211,6 +212,9 @@
 .menuItemText {
   flex: 1;
   min-width: 0; /* Allow text truncation */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .menuItemRight {


### PR DESCRIPTION
## Summary & Motivation

Menu item text should not be allowed to wrap. Truncate it by default.

![Screenshot 2026-01-22 at 12.09.48.png](https://app.graphite.com/user-attachments/assets/90d3ab55-de00-48c5-8d6e-c173070d4ab8.png)

In the attached issue, there is a specific internal callsite in the audit log filters that needs a separate change to ensure that truncation and hover-text appear.

## How I Tested These Changes

Storybook examples. Set menu item text to be very long, verify that it truncates properly and does not wrap.