### PR TITLE
[pac] reverse order of check event / asset event creation

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -97,9 +97,6 @@ def _process_user_event(
         asset_key = _resolve_asset_result_asset_key(user_event, assets_def)
         output_name = assets_def.get_output_name_for_asset_key(asset_key)
 
-        for check_result in user_event.check_results or []:
-            yield from _process_user_event(step_context, check_result)
-
         with disable_dagster_warnings():
             if isinstance(user_event, MaterializeResult):
                 value = user_event.value
@@ -112,6 +109,10 @@ def _process_user_event(
                 data_version=user_event.data_version,
                 tags=user_event.tags,
             )
+
+        for check_result in user_event.check_results or []:
+            yield from _process_user_event(step_context, check_result)
+
     elif isinstance(user_event, AssetCheckResult):
         asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
         assets_def = _get_assets_def_for_step(step_context, user_event)


### PR DESCRIPTION
## Summary & Motivation

Fixes a pre-existing bug that would result in check events getting the wrong target materialization data if they were created from a MaterializeResult object.

The check events should target the brand-new materialization but because they were created before the materialization, that would not be the case.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
