### PR TITLE
Handle non-float max_runtime tag values without erroring the daemon

### DIFF
--- a/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
+++ b/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
@@ -235,7 +235,11 @@ def check_run_timeout(
         MAX_RUNTIME_SECONDS_TAG, run_record.dagster_run.tags.get("dagster/max_runtime_seconds")
     )
     if max_time_str:
-        max_time = float(max_time_str)
+        try:
+            max_time = float(max_time_str)
+        except ValueError:
+            logger.warning(f"Invalid max runtime value: {max_time_str}")
+            max_time = None
     else:
         max_time = default_timeout_seconds
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -519,3 +519,46 @@ def test_long_running_termination_failure(
             event.message == "This job is being forcibly marked as failed. The "
             "computational resources created by the run may not have been fully cleaned up."
         )
+
+
+def test_invalid_max_runtime_tag_value(
+    instance: DagsterInstance,
+    workspace_context: WorkspaceProcessContext,
+    logger: Logger,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that invalid (non-float) max_runtime tag values are handled gracefully."""
+    with environ({"DAGSTER_TEST_RUN_HEALTH_CHECK_RESULT": "healthy"}):
+        initial = create_datetime(2021, 1, 1)
+        with freeze_time(initial):
+            invalid_tag_run = create_run_for_test(
+                instance,
+                job_name="foo",
+                status=DagsterRunStatus.STARTING,
+                tags={dg.MAX_RUNTIME_SECONDS_TAG: "invalid"},
+            )
+        started_time = initial + datetime.timedelta(seconds=1)
+        with freeze_time(started_time):
+            report_started_event(instance, invalid_tag_run, started_time.timestamp())
+
+        invalid_tag_record = instance.get_run_record_by_id(invalid_tag_run.run_id)
+        assert invalid_tag_record is not None
+        assert invalid_tag_record.dagster_run.status == DagsterRunStatus.STARTED
+
+        workspace = workspace_context.create_request_context()
+        run_launcher = cast("TestRunLauncher", instance.run_launcher)
+
+        # Advance time well past what would be a typical timeout
+        eval_time = started_time + datetime.timedelta(seconds=10000)
+        with freeze_time(eval_time):
+            with caplog.at_level(logging.WARNING):
+                monitor_started_run(instance, workspace, invalid_tag_record, logger)
+
+            # Run should NOT be terminated - invalid tag value is ignored
+            run = instance.get_run_by_id(invalid_tag_record.dagster_run.run_id)
+            assert run
+            assert run.status == DagsterRunStatus.STARTED
+            assert not run_launcher.termination_calls
+
+            # Verify warning was logged
+            assert "Invalid max runtime value: invalid" in caplog.text


### PR DESCRIPTION
## Summary & Motivation
This should be logged and proceed, not raise an exception that potentially affects other monitoring operation.

## How I Tested These Changes
New test case
