### PR TITLE
dagster-k8s: fix UTF-8 decoding when sequences span log chunks

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -1,3 +1,4 @@
+import codecs
 import logging
 import os
 import random
@@ -731,34 +732,48 @@ def _process_log_stream(stream: Iterator[bytes]) -> Iterator[LogItem]:
     timestamp = ""
     log = ""
 
-    for log_chunk in stream:
-        for line in log_chunk.decode("utf-8").split("\n"):
-            maybe_timestamp, _, tail = line.partition(" ")
-            if not timestamp:
-                # The first item in the stream will always have a timestamp.
-                timestamp = maybe_timestamp
-                log = tail
-            elif maybe_timestamp == timestamp:
-                # We have multiple messages with the same timestamp in this chunk, add them separated
-                # with a new line
-                log += f"\n{tail}"
-            elif not (
-                len(maybe_timestamp) == len(timestamp) and _is_kube_timestamp(maybe_timestamp)
-            ):
-                # The line is continuation of a long line that got truncated and thus doesn't
-                # have a timestamp in the beginning of the line.
-                # Since all timestamps in the RFC format returned by Kubernetes have the same
-                # length (when represented as strings) we know that the value won't be a timestamp
-                # if the string lengths differ, however if they do not differ, we need to parse the
-                # timestamp.
-                log += line
-            else:
-                # New log line has been observed, send in the next cycle
-                yield LogItem(timestamp=timestamp, log=log)
-                timestamp = maybe_timestamp
-                log = tail
+    # Incremental decoder: supports UTF-8 sequences split across chunks.
+    # errors="replace" prevents crashing if a container emits invalid bytes.
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
 
-    # Send the last message that we were building
+    def handle_line(line: str) -> Iterator[LogItem]:
+        nonlocal timestamp, log
+
+        if not line:
+            return
+
+        maybe_timestamp, _, tail = line.partition(" ")
+
+        if not timestamp:
+            # First item must begin with a timestamp.
+            timestamp = maybe_timestamp
+            log = tail
+        elif maybe_timestamp == timestamp:
+            # Some runtimes can emit multiple lines sharing the same timestamp.
+            log += f"\n{tail}"
+        elif not (len(maybe_timestamp) == len(timestamp) and _is_kube_timestamp(maybe_timestamp)):
+            # Continuation of a long line that got split across chunks (no timestamp prefix).
+            log += line
+        else:
+            # New timestamp => finalize previous log item.
+            yield LogItem(timestamp=timestamp, log=log)
+            timestamp = maybe_timestamp
+            log = tail
+
+    for log_chunk in stream:
+        text = decoder.decode(log_chunk, final=False)
+
+        # Keep original behavior: split *within the chunk*, but if there is no "\n"
+        # we still treat it as a single "line" candidate.
+        for line in text.split("\n"):
+            yield from handle_line(line)
+
+    # Flush any buffered bytes from the decoder (e.g. when stream ends cleanly).
+    tail = decoder.decode(b"", final=True)
+    for line in tail.split("\n"):
+        yield from handle_line(line)
+
+    # Emit the last in-progress log item (if any).
     if log or timestamp:
         yield LogItem(timestamp=timestamp, log=log)
 


### PR DESCRIPTION
## Summary & Motivation
Fix pod log decoding when a multi-byte UTF-8 character is split across k8s log chunks by using an incremental decoder.

