### PR TITLE
[dagster-mysql] fix examples per community member feedback

### DIFF
--- a/python_modules/libraries/dagster-mysql/dagster_mysql/resources.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/resources.py
@@ -24,8 +24,9 @@ class MySQLResource(ConfigurableResource):
                 with mysql.get_connection() as conn:
                     with conn.cursor() as cur:
                         cur.execute("SELECT * FROM table;")
+                        results = cur.fetchall()
 
-            Definitions(
+            defs = Definitions(
                 assets=[my_table],
                 resources={
                     "mysql": MySQLResource(


### PR DESCRIPTION
## Summary & Motivation

Feedback from message: https://dagster.slack.com/archives/C08A2Q09X5F/p1769440361649479

> The Definitions section should start with defs = Definitions. Without the defs = part you get errors about how the resource mysql does not exist. For someone new to Dagster, it took a bit of work to figure out this incorrect line of code.

> The asset my_table is not defined correctly. The cur.execute() needs another line of code to fetchall(). Without the fetchall() you get errors about how there is an unused result set.