### PR TITLE
[perf] Faster handling of sentinel values in hashObject

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/asyncGraphLayout.ts
@@ -39,11 +39,10 @@ const asyncGetFullOpLayout = asyncMemoize((ops: ILayoutOp[], opts: LayoutOpGraph
 
 const _assetLayoutCacheKey = weakMapMemoize(
   (graphData: GraphData, opts: LayoutAssetGraphOptions) => {
-    return hashObject({
-      opts,
-      graphData,
-      version: 6,
-    });
+    // IMPORTANT: hashObject internally uses weakmapMemoize to avoid re-calculating
+    // the hash for the same object twice. Hashing individual objects and joining the
+    // strings allows this Weakmap to re-use `graphData` hashes.
+    return hashObject(graphData) + hashObject(opts) + 'version:6';
   },
 );
 


### PR DESCRIPTION
## Summary & Motivation

I'm debugging the asset lineage perf on extremely large graph data (~50MB). It takes about 1 second to hash the graphData object. This PR:

- Changes sentinel value hashing to skip conversion in/out of strings, which Claude flagged as an optimization and makes the hash generate about ~20% faster.

- Avoids creating a new object each time hashObject is called for graph layout. This was busting hashObject's internal WeakMap and resulting in a 1s calculation time on each layout, not just the FIRST layout of the graphData.

## How I Tested These Changes

- Tested manually

