### PR TITLE
[perf] Bring back a more sophisticated “graph too large” warning

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -13,6 +13,7 @@ import {
 import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
 import without from 'lodash/without';
+import {ParsedQs} from 'qs';
 import * as React from 'react';
 import {useCallback, useMemo, useRef, useState} from 'react';
 import {observeEnabled} from 'shared/app/observeEnabled.oss';
@@ -37,7 +38,6 @@ import {
   AssetGraphViewType,
   GraphData,
   GraphNode,
-  graphHasCycles,
   groupIdForNode,
   isGroupId,
   tokenForAssetKey,
@@ -64,9 +64,11 @@ import {
   RightInfoPanelContent,
 } from '../pipelines/GraphExplorer';
 import {
+  CycleDetectedNotice,
   EmptyDAGNotice,
   EntirelyFilteredDAGNotice,
   InvalidSelectionQueryNotice,
+  LargeDAGNotice,
   LoadingContainer,
   LoadingNotice,
 } from '../pipelines/GraphNotices';
@@ -127,12 +129,6 @@ export const AssetGraphExplorer = React.memo((props: Props) => {
     return <NonIdealState icon="error" title="Query Error" />;
   }
 
-  const hasCycles = graphHasCycles(assetGraphData);
-
-  if (hasCycles) {
-    return <NonIdealState icon="error" title="Cycle detected" />;
-  }
-
   return (
     <AssetGraphExplorerWithData
       key={props.explorerPath.pipelineName}
@@ -190,6 +186,7 @@ const AssetGraphExplorerWithData = ({
 
   const [direction, setDirection] = useLayoutDirectionState();
   const [facets, setFacets] = useSavedAssetNodeFacets();
+  const [forceLargeGraph, setForceLargeGraph] = useState(false);
 
   const {flagAssetGraphGroupsPerCodeLocation} = useFeatureFlags();
 
@@ -204,11 +201,13 @@ const AssetGraphExplorerWithData = ({
     },
     isEmptyState: (val) => val.length === 0,
   });
+
   const focusGroupIdAfterLayoutRef = React.useRef('');
 
   const {
     layout,
     loading: layoutLoading,
+    error,
     async,
   } = useAssetLayout(
     assetGraphData,
@@ -216,10 +215,11 @@ const AssetGraphExplorerWithData = ({
     useMemo(
       () => ({
         direction,
+        forceLargeGraph,
         flagAssetGraphGroupsPerCodeLocation,
         facets: Array.from(facets),
       }),
-      [direction, facets, flagAssetGraphGroupsPerCodeLocation],
+      [direction, facets, forceLargeGraph, flagAssetGraphGroupsPerCodeLocation],
     ),
     dataLoading,
   );
@@ -690,6 +690,47 @@ const AssetGraphExplorerWithData = ({
     );
   }, [toggleFullScreen, isFullScreen]);
 
+  const renderNotice = () => {
+    if (graphQueryItems.length === 0) {
+      return <EmptyDAGNotice nodeType="asset" isGraph />;
+    }
+    if (Object.keys(assetGraphData.nodes).length === 0) {
+      if (errorState.length > 0) {
+        return <InvalidSelectionQueryNotice errors={errorState} />;
+      }
+      return <EntirelyFilteredDAGNotice nodeType="asset" />;
+    }
+    if (error === 'cycles') {
+      return <CycleDetectedNotice />;
+    }
+    if (error === 'too-large') {
+      return <LargeDAGNotice nodeType="asset" setForceLargeGraph={setForceLargeGraph} />;
+    }
+    return null;
+  };
+
+  const renderContent = () => {
+    if (error) {
+      return null;
+    }
+    if (loading && !layout) {
+      return <LoadingNotice async={async} nodeType="asset" />;
+    }
+    return (
+      <AssetGraphBackgroundContextMenu
+        direction={direction}
+        setDirection={setDirection}
+        allGroups={allGroups}
+        expandedGroups={expandedGroups}
+        setExpandedGroups={setExpandedGroups}
+        hideEdgesToNodesOutsideQuery={fetchOptions.hideEdgesToNodesOutsideQuery}
+        setHideEdgesToNodesOutsideQuery={setHideEdgesToNodesOutsideQuery}
+      >
+        {svgViewport}
+      </AssetGraphBackgroundContextMenu>
+    );
+  };
+
   const explorer = (
     <SplitPanelContainer
       key="explorer"
@@ -705,30 +746,8 @@ const AssetGraphExplorerWithData = ({
           </LoadingContainer>
         ) : (
           <ErrorBoundary region="graph">
-            {!loading && graphQueryItems.length === 0 ? (
-              <EmptyDAGNotice nodeType="asset" isGraph />
-            ) : !loading && Object.keys(assetGraphData.nodes).length === 0 ? (
-              errorState.length > 0 ? (
-                <InvalidSelectionQueryNotice errors={errorState} />
-              ) : (
-                <EntirelyFilteredDAGNotice nodeType="asset" />
-              )
-            ) : undefined}
-            {loading && !layout ? (
-              <LoadingNotice async={async} nodeType="asset" />
-            ) : (
-              <AssetGraphBackgroundContextMenu
-                direction={direction}
-                setDirection={setDirection}
-                allGroups={allGroups}
-                expandedGroups={expandedGroups}
-                setExpandedGroups={setExpandedGroups}
-                hideEdgesToNodesOutsideQuery={fetchOptions.hideEdgesToNodesOutsideQuery}
-                setHideEdgesToNodesOutsideQuery={setHideEdgesToNodesOutsideQuery}
-              >
-                {svgViewport}
-              </AssetGraphBackgroundContextMenu>
-            )}
+            {renderNotice()}
+            {renderContent()}
             {setOptions && (
               <OptionsOverlay>
                 <Checkbox

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -59,6 +59,7 @@ export type LayoutAssetGraphOptions = {
   flagAssetGraphGroupsPerCodeLocation: boolean;
   overrides?: Partial<LayoutAssetGraphConfig>;
   facets: AssetNodeFacet[];
+  forceLargeGraph?: boolean;
 };
 
 export const Config = {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -1,4 +1,4 @@
-import {Box, Spinner} from '@dagster-io/ui-components';
+import {Body2, Box, Button, NonIdealState, Spinner} from '@dagster-io/ui-components';
 import React, {useMemo, useRef, useState} from 'react';
 import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
@@ -55,19 +55,21 @@ const AssetNodeLineageGraphInner = ({
   const [highlighted, setHighlighted] = useState<string[] | null>(null);
   const [direction, setDirection] = useLayoutDirectionState();
   const [facets, setFacets] = useSavedAssetNodeFacets();
+  const [forceLargeGraph, setForceLargeGraph] = useState(false);
 
   const {flagAssetGraphGroupsPerCodeLocation} = useFeatureFlags();
 
-  const {layout, loading} = useAssetLayout(
+  const {layout, loading, error} = useAssetLayout(
     assetGraphData,
     allGroups,
     useMemo(
       () => ({
         direction,
         flagAssetGraphGroupsPerCodeLocation,
+        forceLargeGraph,
         facets: Array.from(facets),
       }),
-      [direction, facets, flagAssetGraphGroupsPerCodeLocation],
+      [direction, facets, forceLargeGraph, flagAssetGraphGroupsPerCodeLocation],
     ),
   );
   const viewportEl = useRef<SVGViewportRef>();
@@ -87,6 +89,38 @@ const AssetNodeLineageGraphInner = ({
   };
 
   useLastSavedZoomLevel(viewportEl, layout, assetGraphId);
+
+  if (error === 'cycles') {
+    return (
+      <Box style={{flex: 1}} flex={{alignItems: 'center', justifyContent: 'center'}}>
+        <NonIdealState
+          icon="error"
+          title="Cycle detected"
+          description="This graph contains a cycle and cannot be displayed. Check your asset dependencies for circular references."
+        />
+      </Box>
+    );
+  }
+
+  if (error === 'too-large') {
+    return (
+      <Box style={{flex: 1}} flex={{alignItems: 'center', justifyContent: 'center'}}>
+        <NonIdealState
+          icon="error"
+          title="Lineage graph too large"
+          description={
+            <Box flex={{direction: 'column', gap: 16, alignItems: 'flex-start'}}>
+              <Body2>
+                This asset has too many upstream or downstream dependencies to render. Try reducing
+                the lineage depth or click below to render anyway.
+              </Body2>
+              <Button onClick={() => setForceLargeGraph(true)}>Show Lineage Graph</Button>
+            </Box>
+          }
+        />
+      </Box>
+    );
+  }
 
   if (!layout || loading) {
     return (

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryAndLocalStoragePersistedState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryAndLocalStoragePersistedState.tsx
@@ -18,9 +18,11 @@ export const useQueryAndLocalStoragePersistedState = <T extends QueryPersistedDa
 ): [T, (setterOrState: React.SetStateAction<T>) => void] => {
   const {localStorageKey, isEmptyState, decode, encode} = props;
 
+  const decoder = React.useCallback((json: any) => (decode ? decode(json ?? {}) : json), [decode]);
+
   const [valueFromLocalStorage, setValueFromLocalStorage] = useStateWithStorage(
     localStorageKey,
-    (json) => (decode ? decode(json ?? {}) : json),
+    decoder,
   );
 
   const [state, setter] = useQueryPersistedState(props);

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphNotices.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/GraphNotices.tsx
@@ -1,4 +1,12 @@
-import {Box, Colors, MonoSmall, NonIdealState, Spinner} from '@dagster-io/ui-components';
+import {
+  Body2,
+  Box,
+  Button,
+  Colors,
+  MonoSmall,
+  NonIdealState,
+  Spinner,
+} from '@dagster-io/ui-components';
 import capitalize from 'lodash/capitalize';
 import styled from 'styled-components';
 
@@ -94,3 +102,46 @@ const CenteredContainer = styled.div`
   transform: translate(-50%, -50%);
   z-index: 2;
 `;
+
+export const LargeDAGNotice = ({
+  nodeType,
+  setForceLargeGraph,
+}: {
+  nodeType: 'op' | 'asset';
+  setForceLargeGraph: (enabled: boolean) => void;
+}) => {
+  return (
+    <CenteredContainer>
+      <NonIdealState
+        icon="graph_vertical"
+        title="Large graph"
+        description={
+          <Box flex={{direction: 'column', gap: 16, alignItems: 'flex-start'}}>
+            <Body2>
+              This graph may be too large to display. Build an {nodeType} filter above to render a
+              portion of the graph, or click below to attempt to render it in full.
+            </Body2>
+            <Button onClick={() => setForceLargeGraph(true)}>Show Lineage Graph</Button>
+          </Box>
+        }
+      />
+    </CenteredContainer>
+  );
+};
+
+export const CycleDetectedNotice = () => {
+  return (
+    <CenteredContainer>
+      <NonIdealState
+        icon="error"
+        title="Cycle detected"
+        description={
+          <div>
+            This graph contains a cycle and cannot be displayed. Check your asset dependencies for
+            circular references.
+          </div>
+        }
+      />
+    </CenteredContainer>
+  );
+};


### PR DESCRIPTION
## Summary & Motivation

This PR brings back an escape hatch for extremely large asset graphs. We detect that the graph is large using several heuristics and display an empty state with instructions to filter to a subset or type "*" to render the entire graph.

We used to do this back in 2021-2023, and our previous version of this idea set the cap quite low (I think ~1000 assets). We can now handle much larger graphs gracefully, but there are still extreme cases (> 10,000 nodes, > 30,000 edges, or a graph depth of more than 300) where we've observed that the `dagre` layout algorithm still becomes extremely slow. 

This PR introduces the concept of graph "pre-flight checks" which combines our old "cycles" check with a graph depth calculation and uses a much faster algorithm (thanks Claude). The pre-flight checks provide stats to `renderingModeForGraph` which allows it to determine if we should render sync / async / not at all.

Even on a very large test graph I have not observed `runPreflightChecks` taking meaningful time.

The graph depth check is a new one, and is based on the observation that Dagre internally fans out and performs a ton of work as the graph depth increases. Even a flat graph with just 500 nodes in a line is extremely slow and necessitates this additional detection method.

## How I Tested These Changes

- Tested manually against a large test asset graph

