### PR TITLE
Pass through ignore_containers correctly in pipes client (#20337)

### DIFF
--- a/examples/temp_pins.txt
+++ b/examples/temp_pins.txt
@@ -1,6 +1,6 @@
 # Temporary pins for example projects that install from PyPI.
 
-# Dagster aims to take a minimalist approach to pinning. Occassionally,
+# Dagster aims to take a minimalist approach to pinning. Occasionally,
 # dependencies will release breaking changes. When this happens, we
 # typically don't patch previously released versions of Dagster to
 # introduce a pin. Instead, we aim to introduce a pin or a backward

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -527,6 +527,7 @@ class PipesK8sClient(PipesClient, TreatAsResourceParam):
                     namespace=namespace,
                     pod_name=pod_name,
                     enable_multi_container_logs=enable_multi_container_logs,
+                    ignore_containers=ignore_containers,
                 ):
                     # wait until the pod is fully terminated (or raise an exception if it failed)
                     client.wait_for_pod(
@@ -550,6 +551,7 @@ class PipesK8sClient(PipesClient, TreatAsResourceParam):
         namespace: str,
         pod_name: str,
         enable_multi_container_logs: bool = False,
+        ignore_containers: Optional[set] = None,
     ) -> Iterator:
         """Consume pod logs in the background if possible simple context manager to setup pod log consumption.
 
@@ -574,6 +576,7 @@ class PipesK8sClient(PipesClient, TreatAsResourceParam):
                 # the ready state in the second while loop, which respects the below timeout only.
                 # Very rarely, the pod will be Evicted there and we have to wait the default, unless set.
                 wait_timeout=WAIT_TIMEOUT_FOR_READY,
+                ignore_containers=ignore_containers,
             )
 
             if enable_multi_container_logs:


### PR DESCRIPTION
This was causing pipes clients to sometimes fail when reading logs when a container that was supposed to have been ignored failed.

New test case

[dagster-k8s] Fixed an issue where `PipesK8sClient` would sometimes fail when containers in the `ignored_containers` list failed.

Synced-From-Internal

GitOrigin-RevId: d039e85c050fd4c60dca02822c045b7dd78058bc

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
