### PR TITLE
Docs/image zoom

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -69,7 +69,7 @@ const config: Config = {
       additionalLanguages: ['diff', 'json', 'bash', 'docker'],
     },
     zoom: {
-      selector: '.theme-doc-markdown :not(a) > img, .tabs-container img',
+      selector: '.markdown > img, .tabs-container img ',
       config: {
         // options you can specify via https://github.com/francoischalifour/medium-zoom#usage
         background: {

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -69,7 +69,7 @@ const config: Config = {
       additionalLanguages: ['diff', 'json', 'bash', 'docker'],
     },
     zoom: {
-      selector: '.markdown > img, .tabs-container img ',
+      selector: '.theme-doc-markdown :not(a) > img, .tabs-container img',
       config: {
         // options you can specify via https://github.com/francoischalifour/medium-zoom#usage
         background: {


### PR DESCRIPTION
## Summary & Motivation

Make images in the Getting Started Quickstart expandable on click using the existing image zoom plugin.

## How I Tested These Changes

Quickstart screenshots often contain small UI details. Enabling click-to-zoom improves readability without requiring browser zoom.

## Changelog

- Ran `yarn start` from `docs/`
- Navigated to the Quickstart page locally
- Verified clicking screenshots opens the zoom overlay

Fixed: #33384 