### PR TITLE
[dagster-dbt] Enable customization of retry policies on dbt components

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/core_models.py
+++ b/python_modules/dagster/dagster/components/resolved/core_models.py
@@ -21,6 +21,7 @@ from dagster._core.definitions.partitions.definition import (
     TimeWindowPartitionsDefinition,
     WeeklyPartitionsDefinition,
 )
+from dagster._core.definitions.policy import Backoff, Jitter, RetryPolicy
 from dagster.components.resolved.base import Resolvable, resolve_fields
 from dagster.components.resolved.context import ResolutionContext
 from dagster.components.resolved.model import Injected, Model, Resolver
@@ -143,6 +144,30 @@ def resolve_backfill_policy(
         )
 
     raise ValueError(f"Invalid backfill policy: {backfill_policy}")
+
+
+class RetryPolicyModel(Resolvable, Model):
+    """Model for configuring retry policy."""
+
+    max_retries: int = 1
+    delay: Optional[Union[float, int]] = None
+    backoff: Optional[Backoff] = None
+    jitter: Optional[Jitter] = None
+
+
+def resolve_retry_policy(
+    context: ResolutionContext, retry_policy: Optional[RetryPolicyModel]
+) -> Optional[RetryPolicy]:
+    """Resolve a RetryPolicyModel to a RetryPolicy instance."""
+    if retry_policy is None:
+        return None
+
+    return RetryPolicy(
+        max_retries=retry_policy.max_retries,
+        delay=retry_policy.delay,
+        backoff=retry_policy.backoff,
+        jitter=retry_policy.jitter,
+    )
 
 
 class OpSpec(Model, Resolvable):

--- a/python_modules/dagster/dagster/components/resolved/core_models.py
+++ b/python_modules/dagster/dagster/components/resolved/core_models.py
@@ -182,6 +182,10 @@ class OpSpec(Model, Resolvable):
             model_field_type=SingleRunBackfillPolicyModel | MultiRunBackfillPolicyModel,
         ),
     ] = None
+    retry_policy: Annotated[
+        Optional[RetryPolicy],
+        Resolver(resolve_retry_policy, model_field_type=RetryPolicyModel),
+    ] = None
 
 
 def _expect_injected(context, val):

--- a/python_modules/dagster/dagster/components/testing/test_cases.py
+++ b/python_modules/dagster/dagster/components/testing/test_cases.py
@@ -182,8 +182,23 @@ class TestOpCustomization:
                 {"backfill_policy": {"type": "single_run"}},
                 lambda op: op.backfill_policy.max_partitions_per_run is None,
             ),
+            (
+                {
+                    "retry_policy": {
+                        "max_retries": 2,
+                        "delay": 10,
+                        "jitter": "PLUS_MINUS",
+                        "backoff": "LINEAR",
+                    }
+                },
+                lambda op: op.retry_policy is not None
+                and op.retry_policy.max_retries == 2
+                and op.retry_policy.delay == 10
+                and op.retry_policy.jitter.name == "PLUS_MINUS"
+                and op.retry_policy.backoff.name == "LINEAR",
+            ),
         ],
-        ids=["name", "tags", "backfill_policy"],
+        ids=["name", "tags", "backfill_policy", "retry_policy"],
     )
     def translation_test_case(self, request):
         return request.param

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -182,6 +182,12 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
                     "name": "some_op",
                     "tags": {"tag1": "value"},
                     "backfill_policy": {"type": "single_run"},
+                    "retry_policy": {
+                        "max_retries": 3,
+                        "delay": 30,
+                        "jitter": "LINEAR",
+                        "backoff": "EXPONENTIAL",
+                    },
                 },
             ],
         ),
@@ -395,6 +401,7 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
             pool=op_spec.pool,
             config_schema=self.config_cls.to_fields_dict() if self.config_cls else None,
             allow_arbitrary_check_specs=self.translator.settings.enable_source_tests_as_checks,
+            retry_policy=op_spec.retry_policy,
         )
         def _fn(context: dg.AssetExecutionContext):
             with _set_resolution_context(res_ctx):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -185,7 +185,7 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
                     "retry_policy": {
                         "max_retries": 3,
                         "delay": 30,
-                        "jitter": "LINEAR",
+                        "jitter": "FULL",
                         "backoff": "EXPONENTIAL",
                     },
                 },


### PR DESCRIPTION
## Summary & Motivation
With the current configuration of dbt components, retry policies are by default set to `None` and can only be changed by overriding the `build_defs_from_state` method. This PR adds support for customizing retry policy by adding `retry_policy` parameters under the `op` attriibute of YAML definition which is especially helpful when needing to define multiple instances of dbt components with different configurations.

Users can now configure retry policies in their dbt component YAML:

<img width="517" height="240" alt="Screenshot 2026-02-01 at 11 08 01 PM" src="https://github.com/user-attachments/assets/3bd2336c-15a7-415a-9230-a60e7dca0a15" />


## How I Tested These Changes
- The TestDbtOpCustomization class now includes a `retry_policy` test case that validates the op spec is properly configured on dbt assets
- Also, verified that yaml is being parsed correctly as `dg check defs` runs without errors
- Retries are also observed when manually testing failing pipelines

Closes #33408 