### PR TITLE
[dagster-ui] Fix partition selector performance for large partition sets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/TagSelector.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/TagSelector.stories.tsx
@@ -104,9 +104,9 @@ export const Styled = () => {
           </Menu>
         );
       }}
-      renderTagList={(tags) => {
-        if (tags.length > 3) {
-          return <span>{tags.length} partitions selected</span>;
+      renderTagList={(tags, totalCount) => {
+        if (totalCount > 3) {
+          return <span>{totalCount} partitions selected</span>;
         }
         return tags;
       }}

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/OrdinalPartitionSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/OrdinalPartitionSelector.tsx
@@ -59,6 +59,12 @@ export const OrdinalPartitionSelector = ({
     [allPartitions, health],
   );
 
+  // Memoize selectedPartitions as a Set for O(1) lookups instead of O(n) includes()
+  const selectedPartitionsSet = React.useMemo(
+    () => new Set(selectedPartitions),
+    [selectedPartitions],
+  );
+
   return (
     <TagSelectorWithSearch
       allTags={allPartitions}
@@ -129,7 +135,8 @@ export const OrdinalPartitionSelector = ({
       )}
       renderDropdown={React.useCallback(
         (dropdown: React.ReactNode, {width, allTags}: TagSelectorDropdownProps) => {
-          const isAllSelected = allTags.every((t) => selectedPartitions.includes(t));
+          // Use Set for O(1) lookup instead of O(n) includes() - critical for 100k+ partitions
+          const isAllSelected = allTags.every((t) => selectedPartitionsSet.has(t));
           return (
             <Menu style={{width}}>
               <Box padding={4}>
@@ -183,11 +190,11 @@ export const OrdinalPartitionSelector = ({
             </Menu>
           );
         },
-        [isDynamic, selectedPartitions, setSelectedPartitions, setShowCreatePartition, mode],
+        [isDynamic, selectedPartitionsSet, setSelectedPartitions, setShowCreatePartition, mode],
       )}
-      renderTagList={(tags) => {
-        if (tags.length > 4) {
-          return <span>{tags.length} partitions selected</span>;
+      renderTagList={(tags, totalCount) => {
+        if (totalCount > 4) {
+          return <span>{totalCount} partitions selected</span>;
         }
         return tags;
       }}


### PR DESCRIPTION
## Summary & Motivation

The materialize modal becomes unresponsive for 30-100 seconds when selecting "All" partitions on assets with 100k+ partitions. This PR fixes two performance bottlenecks in the partition selector:

1. **O(n²) → O(n) lookup optimization**: The `isAllSelected` check used `array.includes()` inside `array.every()`, causing ~10 billion string comparisons for 100k partitions. Changed to use memoized `Set` for O(1) lookups.

2. **Avoided creating 100k React elements**: When >4 partitions are selected, the UI shows "X partitions selected" text, but was still creating React elements for all selected partitions first. Now limits element creation to 100 items and passes `totalCount` to the `renderTagList` callback for accurate display.

Related: #10330

## How I Tested These Changes

1. Created a test asset with 100k static partitions
2. Before fix: Clicking "All" in materialize modal caused 30-100s freeze
3. After fix: Selection is nearly instant

Ran existing tests:
- `yarn jest` in js_modules/dagster-ui - 1201 passed
- `yarn tsgo` and `yarn lint` pass

## Changelog

[dagster-ui] Fixed performance issue where the partition selector would freeze for 30+ seconds when selecting "All" on assets with large (100k+) partition sets.
