### PR TITLE
Treat Sequence[str] as multiple assets in AssetSelection.assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_key.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_key.py
@@ -268,6 +268,14 @@ def asset_keys_from_defs_and_coercibles(
     for el in assets:
         if isinstance(el, AssetsDefinition):
             result.extend(el.keys)
+
+        elif (
+            isinstance(el, Sequence)
+            and not isinstance(el, (str, AssetKey))
+            and all(isinstance(x, str) for x in el)
+        ):
+            result.extend(AssetKey.from_user_string(x) for x in el)
+
         else:
             result.append(
                 AssetKey.from_user_string(el)


### PR DESCRIPTION
## Summary & Motivation
Fixes an issue where passing a `Sequence[str]` to `AssetSelection.assets`
(e.g. `AssetSelection.assets(["a", "b"])`) was interpreted as a single
hierarchical `AssetKey` (`a/b`) instead of selecting multiple assets.

## How I Tested These Changes
- Verified locally by defining an asset job with
  `define_asset_job(selection=["asset_a", "asset_b"])` and confirming the code
  location loads successfully.
- Materialized the resulting asset job in Dagster UI and verified that both
  assets are selected and executed without errors.
- Confirmed that existing usages such as `AssetSelection.assets("a", "b")` and
  `AssetSelection.assets(AssetKey(["a", "b"]))` continue to behave as expected.

fixes: #31224 