### PR TITLE
fix: remove dead code in time_window.py

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/subset/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/subset/time_window.py
@@ -33,12 +33,6 @@ def _attempt_coerce_to_time_window_subset(subset: "PartitionsSubset") -> "Partit
 
     if isinstance(subset, TimeWindowPartitionsSubset):
         return subset
-    elif isinstance(subset, TimeWindowPartitionsSubset):
-        return TimeWindowPartitionsSubset(
-            partitions_def=subset.partitions_def,
-            num_partitions=subset.num_partitions,
-            included_time_windows=subset.included_time_windows,
-        )
     elif isinstance(subset, AllPartitionsSubset) and isinstance(
         subset.partitions_def, TimeWindowPartitionsDefinition
     ):


### PR DESCRIPTION
This PR removes unreachable dead code in the _attempt_coerce_to_time_window_subset function.

## Problem
The second elif branch checking for TimeWindowPartitionsSubset was unreachable because the first if statement already handles that type and returns.

## Solution
Removed the redundant elif branch that was identified as dead code in issue #33379.

## Changes
- Removed 6 lines of unreachable code in time_window.py

Fixes #33379