### PR TITLE
docs: Add missing .env.example file to project_dbt example

### DIFF
--- a/examples/docs_projects/project_dbt/.env.example
+++ b/examples/docs_projects/project_dbt/.env.example
@@ -1,0 +1,10 @@
+# Dagster Configuration
+DAGSTER_HOME=/tmp/dagster_home
+
+# Optional: Dagster Webserver Configuration
+# DAGSTER_HOST=localhost
+# DAGSTER_PORT=3000
+
+# Optional: Database Configuration (defaults to DuckDB)
+# For production, you may want to configure a different database
+# DATABASE_URL=duckdb://path/to/your/database.duckdb


### PR DESCRIPTION
Fixes #33415

The documentation for the dbt example project references an .env.example file
for configuration setup, but this file was missing from the project directory.

This PR adds a basic .env.example with common Dagster environment variables
that users can copy and customize for their setup.

## Changes
- Added examples/docs_projects/project_dbt/.env.example with standard Dagster environment variables

## Testing
- Verified the file follows the same format as other project examples
- Confirmed the documentation instructions now work correctly