### PR TITLE
fix(docs): update telemetry documentation addressing issue 31887

### DIFF
--- a/docs/docs/about/telemetry.md
+++ b/docs/docs/about/telemetry.md
@@ -8,7 +8,7 @@ As open source project maintainers, we collect usage statistics to better unders
 
 We collect telemetry from both the frontend and backend. We do not collect any data processed by Dagster pipelines, and we do not collect any identifiable information about your Dagster definitions, including the names of your assets, ops, or jobs.
 
-Front end telemetry is collected from a JavaScript bundle hosted unminified at `https://dagster.io/oss-telemetry.js`. This bundle may change over time.
+Front end telemetry is collected from a JavaScript bundle hosted unminified at [https://dagster-website.vercel.app/oss-telemetry.js](https://dagster-website.vercel.app/oss-telemetry.js). This bundle may change over time.
 
 Backend telemetry collection is logged at `$DAGSTER_HOME/logs/` if `$DAGSTER_HOME` is set or `~/.dagster/logs/` if not set.
 


### PR DESCRIPTION
## Summary
Updates the telemetry documentation to point to a working frontend telemetry bundle URL.

## Issue
Link in the documentation page is not available and points to a 404 [https://dagster.io/oss-telemetry.js](https://super-duper-waddle-xrrgjj59ww4fp6g9.github.dev/)

Fix
Replace the broken URL in the telemetry docs with the correct, working URL.

Additional Information
Doc: [https://docs.dagster.io/about/telemetry](https://super-duper-waddle-xrrgjj59ww4fp6g9.github.dev/)

Issue Link
[https://github.com/dagster-io/dagster/issues/31887](https://super-duper-waddle-xrrgjj59ww4fp6g9.github.dev/)

Testing
Not required (doc-only change).