### PR TITLE
Ensure dg dev sets per-code-location working directory

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import threading
 from contextlib import AbstractContextManager
@@ -192,6 +193,11 @@ class GrpcServerRegistry(AbstractContextManager):
             active_entry = self._active_entries[origin_id]
             refresh_server = loadable_target_origin != active_entry.loadable_target_origin
 
+        if os.getenv("DAGSTER_IS_DEV_CLI"):
+            cwd = loadable_target_origin.working_directory
+        else:
+            cwd = None
+
         if refresh_server:
             try:
                 server_process = GrpcServerProcess(
@@ -202,6 +208,7 @@ class GrpcServerRegistry(AbstractContextManager):
                     heartbeat=True,
                     heartbeat_timeout=self._heartbeat_ttl,
                     startup_timeout=self._startup_timeout,
+                    cwd=cwd,
                     log_level=self._log_level,
                     inject_env_vars_from_instance=self._inject_env_vars_from_instance,
                     container_image=self._container_image,

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -1610,9 +1610,7 @@ class GrpcServerProcess:
         self._heartbeat_timeout = heartbeat_timeout
         self._fixed_server_id = fixed_server_id
         self._startup_timeout = startup_timeout
-        self._cwd = cwd or (
-            self._loadable_target_origin.working_directory if self._loadable_target_origin else None
-        )
+        self._cwd = cwd
         self._log_level = log_level
         self._inject_env_vars_from_instance = inject_env_vars_from_instance
         self._container_image = container_image


### PR DESCRIPTION
## Summary & Motivation
This PR makes `dg dev` automatically set the current working directory for each project in a workspace's code location. Prevents tooling and APIs from breaking during code location setup, since they normally expect to be called from the project directory.

The change was made by explicitly passing in a cwd from the loadable_target_origin's working directory attribute(taken from the dg.toml in the workspace root) when starting up a GrpcServerProcess for each project through the _get_grpc_server_entry function in the GrpcServerRegistry class. This was the approach I took because this was where each project's cwd was being defined, previously there was no cwd being passed explicitly hence it would default the cwd to None, causing it to use the workspace directory. 

Additionally, from danielgafni's input I made the change only occur when dg dev is ran by checking if the env variable "DAGSTER_IS_DEV_CLI" is truthy.

## How I Tested These Changes
- Checked that current working directory for code location of two projects in a workspace environment is set to the respective project's directory by exposing it in the metadata
- Added Unit Test that simulates a multi-project workspace and asserts that each project has their cwd set to the project's directory

## Changelog
Fixed: dg dev does not set the current working directory for code locations #33428 
