### PR TITLE
[helm] Add lifecycle, terminationGracePeriodSeconds, minReadySeconds to user deployments

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -18,6 +18,9 @@ spec:
   strategy:
     {{- toYaml $deployment.deploymentStrategy | nindent 4 }}
   {{- end }}
+  {{- if $deployment.minReadySeconds }}
+  minReadySeconds: {{ $deployment.minReadySeconds }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "dagster.selectorLabels" $ | nindent 6 }}
@@ -44,6 +47,9 @@ spec:
       serviceAccountName: {{ include "dagsterUserDeployments.serviceAccountName" $ }}
       automountServiceAccountToken: true
       securityContext: {{ $deployment.podSecurityContext | toYaml | nindent 8 }}
+      {{- if $deployment.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $deployment.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if $deployment.initContainers }}
       initContainers:
         {{- range $container := $deployment.initContainers }}
@@ -101,6 +107,9 @@ spec:
                 optional: true
             {{- end }}
           resources: {{ $deployment.resources | toYaml | nindent 12 }}
+          {{- if $deployment.lifecycle }}
+          lifecycle: {{ $deployment.lifecycle | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
         {{- if $.Values.includeInstance }}
             - name: dagster-instance

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -35,6 +35,13 @@
             "title": "DeploymentStrategy",
             "type": "object"
         },
+        "Lifecycle": {
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Lifecycle",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "Lifecycle",
+            "type": "object"
+        },
         "EnvVar": {
             "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar",
             "additionalProperties": true,
@@ -631,6 +638,41 @@
                     "anyOf": [
                         {
                             "$ref": "#/$defs/DeploymentStrategy"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "minReadySeconds": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Minreadyseconds"
+                },
+                "terminationGracePeriodSeconds": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Terminationgraceperiodseconds"
+                },
+                "lifecycle": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Lifecycle"
                         },
                         {
                             "type": "null"

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -44,6 +44,9 @@ class UserDeployment(BaseModel):
     ] = None
     sidecarContainers: Optional[list[kubernetes.Container]] = None
     deploymentStrategy: Optional[kubernetes.DeploymentStrategy] = None
+    minReadySeconds: Optional[int] = None
+    terminationGracePeriodSeconds: Optional[int] = None
+    lifecycle: Optional[kubernetes.Lifecycle] = None
 
 
 class UserDeployments(BaseModel):

--- a/helm/dagster/schema/schema/charts/utils/kubernetes.py
+++ b/helm/dagster/schema/schema/charts/utils/kubernetes.py
@@ -251,3 +251,12 @@ class DeploymentStrategy(BaseModel):
             "$ref": create_definition_ref("io.k8s.api.apps.v1.DeploymentStrategy")
         },
     }
+
+
+class Lifecycle(BaseModel):
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {
+            "$ref": create_definition_ref("io.k8s.api.core.v1.Lifecycle")
+        },
+    }


### PR DESCRIPTION
## Summary & Motivation

During Kubernetes rolling updates of user code deployments, there is a race between pod termination and kube-proxy endpoint propagation. When SIGTERM arrives, the old pod begins shutting down, but kube-proxy may still route traffic to it for several seconds. The Dagster webserver's gRPC channel hits "Connection refused" on the dying pod and caches the error state without automatically retrying.

A `preStop` lifecycle hook is the standard Kubernetes solution for gRPC services: it delays SIGTERM long enough for kube-proxy to remove the pod from Service endpoints, so in-flight connections drain cleanly and new connections route to the replacement pod. However, the `dagster-user-deployments` subchart does not expose the fields needed to configure this.

This PR adds three opt-in fields to `UserDeployment` values:

- **`lifecycle`** -- container lifecycle hooks (e.g. `preStop: exec: command: ["sleep", "15"]`)
- **`terminationGracePeriodSeconds`** -- pod-level grace period to accommodate the preStop duration
- **`minReadySeconds`** -- ensures the new pod is stable before the old pod is terminated

All fields are optional with no defaults. Fully backwards compatible.

### Related issues

| Issue | Description | Relationship |
|-------|-------------|--------------|
| [#33297](https://github.com/dagster-io/dagster/issues/33297) | Webserver fails to auto-reconnect to code locations after transient gRPC disconnections during rolling updates | **Directly mitigated** -- this PR prevents the disconnection from occurring by keeping the old pod alive until endpoint propagation completes |
| [#24050](https://github.com/dagster-io/dagster/issues/24050) (41 👍) | gRPC subprocess dies and Dagster cannot recover (unix socket `No such file or directory`) | **Different root cause** -- proxy mode subprocess crash, not a rolling update race. Not addressed by this PR |
| [#27266](https://github.com/dagster-io/dagster/issues/27266) (30 👍) | Various gRPC issues with K8s Helm deployments (pods losing readiness, `Connection refused`) | **Partially related** -- some reported symptoms may stem from the rolling update race this PR fixes, but the issue also covers unrelated gRPC stalls |
| [#25116](https://github.com/dagster-io/dagster/issues/25116) (66 👍) | gRPC health check timeouts due to sensor/schedule GIL contention | **Unrelated** -- GIL contention issue, not addressed by this PR |

## How I Tested These Changes

- These fields are live in a production Kubernetes deployment where the rolling update race condition was occurring in ~60% of Helm upgrades. After applying these values, the issue has not recurred.
- New unit test `test_graceful_shutdown_fields` added, verifying all three fields render correctly in the Deployment manifest.
- Full existing helm test suite passes (71/71).