### PR TITLE
Fix TypeError when re-validating Discriminated Unions in Pythonic Config

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -230,7 +230,6 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
                     discriminator_key: discriminated_value,
                 }
                 continue 
-           
             elif (
                 field
                 and safe_is_subclass(field.annotation, Enum)

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_union_serialization_fix.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_union_serialization_fix.py
@@ -1,6 +1,8 @@
+from typing import Literal, Union
+
 import dagster as dg
 from pydantic import Field
-from typing import Union, Literal
+
 
 def test_union_config_revalidation_fix():
     class ConfigA(dg.Config):
@@ -13,10 +15,8 @@ def test_union_config_revalidation_fix():
     class MasterConfig(dg.Config):
         union_field: Union[ConfigA, ConfigB] = Field(discriminator="t")
 
-    # דימוי של המרת אובייקט למילון (כמו שקורה ב-dump)
     data = {"union_field": {"t": "a", "v": 10}}
     
-    # לפני התיקון שלך - השורה הזו קרסה
     revalidated = MasterConfig(**data)
     
     assert revalidated.union_field.t == "a"


### PR DESCRIPTION
Summary
This PR fixes a TypeError: 'str' object is not a mapping that occurs when a dg.Config object containing a discriminated union is re-instantiated from a flattened dictionary (for example, after calling model_dump()).

Root Cause
In Config.__init__, the code previously assumed that union data would always be in Dagster's nested selector format. When provided with a standard dictionary that already included the discriminator key, it failed to parse it correctly.

Changes
Updated dagster/_config/pythonic_config/config.py to detect if the input dictionary already contains the discriminator key.

Added a regression test in pythonic_config_tests/test_union_serialization_fix.py to ensure this use case is supported and doesn't break in the future.

Fixes #32008