### PR TITLE
[dagster-dbt] coerce target_path to Path object

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -269,6 +269,8 @@ class DbtProject(IHaveNew):
         if not project_dir.exists():
             raise DagsterDbtProjectNotFoundError(f"project_dir {project_dir} does not exist.")
 
+        target_path = Path(target_path)
+
         packaged_project_dir = Path(packaged_project_dir) if packaged_project_dir else None
         if not using_dagster_dev() and packaged_project_dir and packaged_project_dir.exists():
             project_dir = packaged_project_dir

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -221,6 +221,20 @@ def test_dbt_subclass_additional_scope_fn(dbt_path: Path) -> None:
     assert assets_def.get_asset_spec(AssetKey("stg_customers")).tags["model_id"] == "stg-customers"
 
 
+def test_target_path_from_component_string(dbt_path: Path) -> None:
+    component = load_component_for_test(
+        DbtProjectComponent,
+        {
+            "project": {
+                "project_dir": str(dbt_path),
+                "target_path": "tmp_dbt_target",
+            }
+        },
+    )
+    assert isinstance(component.dbt_project.target_path, Path)
+    assert component.dbt_project.target_path == Path("tmp_dbt_target")
+
+
 class TestDbtTranslation(TestTranslation):
     def test_translation(
         self,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
@@ -1,4 +1,5 @@
 import multiprocessing
+from pathlib import Path
 
 import msgpack
 import pytest
@@ -111,6 +112,14 @@ def test_invalidate_seeds_handles_missing_partial_parse() -> None:
         # Should not raise an error
         preparer = DagsterDbtProjectPreparer()
         preparer._invalidate_seeds_in_partial_parse(my_project)  # noqa: SLF001
+
+
+def test_accepts_string_target_path(project_dir) -> None:
+    project_dir_path = Path(project_dir)
+    string_target_path = str(project_dir_path / "dbt_target")
+    my_project = DbtProject(project_dir_path, target_path=string_target_path)
+    assert isinstance(my_project.target_path, Path)
+    assert my_project.target_path == Path(string_target_path)
 
 
 def test_seed_command_succeeds_after_invalidation() -> None:


### PR DESCRIPTION
## Summary & Motivation

Resolves #33433.

## How I Tested These Changes

## Changelog

- [dagster-dbt] Coerce `DbtProject.target_path` to `Path` in constructor to accept string component inputs and add targeted regression tests for direct/component config path handling.

