### PR TITLE
 [dagster-aws] Add multi-region task orchestration for ECS tasks

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -693,10 +693,15 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         arn = task["taskArn"]
         cluster_arn = task["clusterArn"]
 
-        if tags.cluster is not None and tags.cluster != cluster_arn:
-            warnings.warn(
-                f"Run cluster ARN {cluster_arn} does not match run tag cluster {tags.cluster}. "
+        if tags.cluster is not None:
+            cluster_name_from_arn = (
+                cluster_arn.split("/")[-1] if "/" in cluster_arn else cluster_arn
             )
+            tags_cluster_name = tags.cluster.split("/")[-1] if "/" in tags.cluster else tags.cluster
+            if cluster_name_from_arn != tags_cluster_name:
+                warnings.warn(
+                    f"Run cluster ARN {cluster_arn} does not match run tag cluster {tags.cluster}. "
+                )
 
         self._set_run_tags(run.run_id, cluster=cluster_arn, task_arn=arn)
         self.report_launch_events(run, arn, cluster_arn)


### PR DESCRIPTION
## Summary
 
 - Related issue: https://github.com/dagster-io/dagster/issues/28035
 - Demo repository for the feature: https://github.com/BehavixOy/dagster-ecs-multi-region-example
 - Adds multi-region support to `EcsRunLauncher` so a single Dagster cluster can orchestrate ECS tasks across multiple AWS regions -- no need to deploy Dagster-specific services (webserver, daemon,
 code locations) in each target region
 - Primary use case: data proximity and legal/regulatory compliance -- run compute where the data lives while keeping a single control plane
 - All cross-region configuration is specified via `ecs/*` job/run tags, requiring zero changes to `dagster.yaml`
 - Production-proven: proudly contributed by [Behavix.io](https://behavix.io) where the feature has been used in production for over six months

Note, the first approach to the feature was attempted in [PR 30635](https://github.com/dagster-io/dagster/pull/30635), however somewhat usable it was finished.

 ## Motivation

Running ECS tasks in a different region currently requires standing up a full Dagster deployment in that region. This is operationally expensive and unnecessary when the only requirement is to run compute near the data. With this change, a single Dagster cluster can dispatch tasks to any region by simply tagging jobs with the target region's network details.

 ## Approach

 Tag-based configuration (no new config schema):

 | Tag | Required | Description |
 |-----|----------|-------------|
 | `ecs/region` | Yes | Target AWS region (e.g. `eu-north-1`) |
 | `ecs/cluster` | Yes | ECS cluster name/ARN in target region |
 | `ecs/security_groups` | Yes | Comma-separated security group IDs |
 | `ecs/subnets` | Yes | Comma-separated subnet IDs |
 | `ecs/assign_public_ip` | No | `ENABLED` or `DISABLED` (default: `DISABLED`) |
 | `ecs/image` | No | Docker image override (e.g. region-specific ECR) |
 | `ecs/task_definition_arn` | No | Base task definition to clone with new image |
 | `ecs/cpu` | No | CPU override |
 | `ecs/memory` | No | Memory override |

 Example usage:

 ```python
 @job(tags={
     "ecs/region": "eu-north-1",
     "ecs/cluster": "my-eu-cluster",
     "ecs/security_groups": "sg-abc123",
     "ecs/subnets": "subnet-111,subnet-222",
 })
 def my_cross_region_job(): ...
```
 Key implementation details:

 - Region-specific ECS clients are cached per-region via _get_ecs_client(region) and reused across launches
 - Tag validation: setting ecs/region without the three required companion tags raises CheckError at launch time
 - Task definition registration happens in the target region automatically
 - Termination and health checks use the region-specific ECS/CloudWatch clients (region is persisted in run tags)
 - CloudWatch Logs: awslogs-region is overwritten to the target region; awslogs-create-group is set to "true" for auto-creation
 - Full backward compatibility: without ecs/region tag, behavior is completely unchanged
 
## Other
### Implementors:
Vladimir Grigor (@behavix-vladimir, @voukka) and Dmitry Tikhonov (@tikhdm)