### PR TITLE
[ui] Fix multi-partitioned asset checks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckPartitions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/AssetCheckPartitions.tsx
@@ -1,4 +1,4 @@
-import {Box, Button, Colors, NonIdealState, TextInput} from '@dagster-io/ui-components';
+import {Box, Colors, NonIdealState, TextInput} from '@dagster-io/ui-components';
 import {useCallback, useMemo, useState} from 'react';
 
 import {AssetCheckPartitionDetail} from './AssetCheckPartitionDetail';
@@ -7,14 +7,18 @@ import {
   assetCheckPartitionStatusToText,
   assetCheckPartitionStatusesToStyle,
 } from './AssetCheckPartitionStatus';
-import {AssetCheckPartitionStatusBar} from './AssetCheckPartitionStatusBar';
 import {AssetCheckPartitionData, useAssetCheckPartitionData} from './useAssetCheckPartitionData';
+import {PartitionDefinitionType} from '../../graphql/types';
 import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
+import {DimensionRangeWizard} from '../../partitions/DimensionRangeWizard';
+import {assembleIntoSpans} from '../../partitions/SpanRepresentation';
 import {testId} from '../../testing/testId';
+import {AssetPartitionStatus} from '../AssetPartitionStatus';
 import {PartitionListSelector} from '../PartitionListSelector';
 import {PartitionStatusCheckboxes} from '../PartitionStatusCheckboxes';
 import {getDefaultPartitionSort, sortPartitionKeys} from '../partitionSortUtils';
 import {AssetKey} from '../types';
+import {Range} from '../usePartitionHealthData';
 
 interface AssetCheckPartitionsProps {
   assetKey: AssetKey;
@@ -38,6 +42,56 @@ const STATUS_ORDER: AssetCheckPartitionStatus[] = [
   AssetCheckPartitionStatus.IN_PROGRESS,
   AssetCheckPartitionStatus.SUCCEEDED,
 ];
+
+/** Map check partition statuses to asset partition statuses for the status bar display */
+function checkStatusToAssetStatus(status: AssetCheckPartitionStatus): AssetPartitionStatus {
+  switch (status) {
+    case AssetCheckPartitionStatus.SUCCEEDED:
+      return AssetPartitionStatus.MATERIALIZED;
+    case AssetCheckPartitionStatus.FAILED:
+    case AssetCheckPartitionStatus.EXECUTION_FAILED:
+    case AssetCheckPartitionStatus.SKIPPED:
+      return AssetPartitionStatus.FAILED;
+    case AssetCheckPartitionStatus.IN_PROGRESS:
+      return AssetPartitionStatus.MATERIALIZING;
+    case AssetCheckPartitionStatus.MISSING:
+      return AssetPartitionStatus.MISSING;
+  }
+}
+
+/** Build Range[] (asset health format) from check data for a given dimension */
+function buildHealthRangesForDim(partitionData: AssetCheckPartitionData, dimIdx: number): Range[] {
+  const dim = partitionData.dimensions[dimIdx];
+  if (!dim) {
+    return [];
+  }
+  const keys = dim.partitionKeys;
+
+  // Get serialized status set for each key, then assemble into spans
+  const statusesCache = new Map<string, AssetPartitionStatus[]>();
+  const spans = assembleIntoSpans(keys, (key) => {
+    const checkStatuses = partitionData.statusesForDimAggregate(dimIdx, key);
+    const assetStatuses = [...new Set(checkStatuses.map(checkStatusToAssetStatus))].sort();
+    const serialized = assetStatuses.join(',');
+    statusesCache.set(serialized, assetStatuses);
+    return serialized;
+  });
+
+  return spans
+    .map((span) => {
+      const startKey = keys[span.startIdx];
+      const endKey = keys[span.endIdx];
+      if (!startKey || !endKey) {
+        return null;
+      }
+      return {
+        start: {key: startKey, idx: span.startIdx},
+        end: {key: endKey, idx: span.endIdx},
+        value: statusesCache.get(span.status) ?? [AssetPartitionStatus.MISSING],
+      };
+    })
+    .filter((r): r is Range => r !== null);
+}
 
 export const AssetCheckPartitions = ({assetKey, checkName}: AssetCheckPartitionsProps) => {
   const {data: partitionData, loading} = useAssetCheckPartitionData(assetKey, checkName);
@@ -94,8 +148,10 @@ const AssetCheckSinglePartitions = ({
   partitionData: AssetCheckPartitionData;
 }) => {
   const [focusedPartitionKey, setFocusedPartitionKey] = useState<string | undefined>();
-  const [selectedPartitionKeys, setSelectedPartitionKeys] = useState<string[]>([]);
   const [searchValue, setSearchValue] = useState('');
+
+  // Selection for the DimensionRangeWizard (matching asset behavior)
+  const [selectedKeys, setSelectedKeys] = useState<string[]>(() => partitionData.partitions);
 
   const [statusFilters, setStatusFilters] = useQueryPersistedState<AssetCheckPartitionStatus[]>({
     defaults: {status: [...DISPLAYED_STATUSES].sort().join(',')},
@@ -113,6 +169,8 @@ const AssetCheckSinglePartitions = ({
     },
   });
 
+  const healthRanges = useMemo(() => buildHealthRangesForDim(partitionData, 0), [partitionData]);
+
   const {filteredPartitions, countsByStatus} = useMemo(() => {
     const counts: {[key: string]: number} = {
       [AssetCheckPartitionStatus.MISSING]: 0,
@@ -123,9 +181,10 @@ const AssetCheckSinglePartitions = ({
       [AssetCheckPartitionStatus.EXECUTION_FAILED]: 0,
     };
 
+    const selectedSet = new Set(selectedKeys);
     const allPartitions = partitionData.partitions;
     const filtered = allPartitions.filter((partition) => {
-      if (selectedPartitionKeys.length > 0 && !selectedPartitionKeys.includes(partition)) {
+      if (!selectedSet.has(partition)) {
         return false;
       }
 
@@ -140,7 +199,7 @@ const AssetCheckSinglePartitions = ({
     });
 
     return {filteredPartitions: filtered, countsByStatus: counts};
-  }, [partitionData, statusFilters, searchValue, selectedPartitionKeys]);
+  }, [partitionData, statusFilters, searchValue, selectedKeys]);
 
   const sortedAndFilteredPartitions = useMemo(() => {
     if (partitionData.dimensions.length === 0) {
@@ -153,7 +212,7 @@ const AssetCheckSinglePartitions = ({
     }
 
     const dimensionType = firstDimension.type;
-    const sortType = getDefaultPartitionSort(dimensionType as any);
+    const sortType = getDefaultPartitionSort(dimensionType as PartitionDefinitionType);
     return sortPartitionKeys(filteredPartitions, sortType);
   }, [filteredPartitions, partitionData]);
 
@@ -161,32 +220,30 @@ const AssetCheckSinglePartitions = ({
     return [partitionData.statusForPartition(dimensionKey)];
   };
 
+  const firstDimension = partitionData.dimensions[0];
+
   return (
     <>
+      {firstDimension && (
+        <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
+          <DimensionRangeWizard
+            dimensionType={firstDimension.type as PartitionDefinitionType}
+            partitionKeys={firstDimension.partitionKeys}
+            health={{ranges: healthRanges}}
+            selected={selectedKeys}
+            setSelected={setSelectedKeys}
+            showQuickSelectOptionsForStatuses={false}
+          />
+        </Box>
+      )}
       <Box
         padding={{vertical: 16, horizontal: 24}}
         flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
         border="bottom"
       >
-        <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-          <div data-testid={testId('partitions-selected')}>
-            {sortedAndFilteredPartitions.length.toLocaleString()}{' '}
-            {selectedPartitionKeys.length > 0 ? 'of' : 'Partitions'}
-            {selectedPartitionKeys.length > 0 && (
-              <> {partitionData.partitions.length.toLocaleString()} partitions</>
-            )}
-          </div>
-          {selectedPartitionKeys.length > 0 && (
-            <Button
-              onClick={() => {
-                setSelectedPartitionKeys([]);
-                setFocusedPartitionKey(undefined);
-              }}
-            >
-              Clear selection
-            </Button>
-          )}
-        </Box>
+        <div data-testid={testId('partitions-selected')}>
+          {sortedAndFilteredPartitions.length.toLocaleString()} Partitions Selected
+        </div>
         <PartitionStatusCheckboxes
           counts={countsByStatus}
           allowed={DISPLAYED_STATUSES}
@@ -195,23 +252,6 @@ const AssetCheckSinglePartitions = ({
           statusToText={assetCheckPartitionStatusToText}
         />
       </Box>
-
-      {partitionData.partitions.length > 0 && partitionData.dimensions.length > 0 && (
-        <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
-          <AssetCheckPartitionStatusBar
-            partitionKeys={partitionData.partitions}
-            statusForPartition={partitionData.statusForPartition}
-            selected={selectedPartitionKeys}
-            onSelect={(selectedKeys) => {
-              setSelectedPartitionKeys(selectedKeys);
-              if (selectedKeys.length > 0) {
-                setFocusedPartitionKey(selectedKeys[0]);
-              }
-            }}
-            splitPartitions={partitionData.dimensions[0]?.type !== 'TIME_WINDOW'}
-          />
-        </Box>
-      )}
 
       <Box style={{flex: 1, minHeight: 0, outline: 'none'}} flex={{direction: 'row'}} tabIndex={-1}>
         <Box
@@ -276,8 +316,19 @@ const AssetCheckMultiPartitions = ({
   checkName: string;
   partitionData: AssetCheckPartitionData;
 }) => {
+  // Find the time dimension index (prefer it as the primary/status-bar dimension)
+  const timeDimensionIdx = partitionData.dimensions.findIndex(
+    (d) => d.type === PartitionDefinitionType.TIME_WINDOW,
+  );
+
   const [focusedDimensionKeys, setFocusedDimensionKeys] = useState<(string | undefined)[]>([]);
   const [searchValues, setSearchValues] = useState<string[]>([]);
+
+  // Selection for the time dimension (DimensionRangeWizard), matching asset behavior
+  const timeDim = timeDimensionIdx !== -1 ? partitionData.dimensions[timeDimensionIdx] : undefined;
+  const [selectedTimeKeys, setSelectedTimeKeys] = useState<string[]>(
+    () => timeDim?.partitionKeys ?? [],
+  );
 
   const [statusFilters, setStatusFilters] = useQueryPersistedState<AssetCheckPartitionStatus[]>({
     defaults: {status: [...DISPLAYED_STATUSES].sort().join(',')},
@@ -306,20 +357,32 @@ const AssetCheckMultiPartitions = ({
     });
   }, []);
 
-  const setFocusedDimensionKey = useCallback((idx: number, key: string | undefined) => {
-    setFocusedDimensionKeys((prev) => {
-      const next = [...prev];
-      while (next.length <= idx) {
-        next.push(undefined);
-      }
-      next[idx] = key;
-      // Clear downstream selections when an upstream dimension changes
-      for (let i = idx + 1; i < next.length; i++) {
-        next[i] = undefined;
-      }
-      return next;
-    });
-  }, []);
+  const setFocusedDimensionKey = useCallback(
+    (idx: number, key: string | undefined) => {
+      setFocusedDimensionKeys((prev) => {
+        // Auto-fill upstream dimensions with defaults (matching asset behavior)
+        const next: (string | undefined)[] = [];
+        for (let ii = 0; ii < idx; ii++) {
+          const existing = prev[ii];
+          const dim = partitionData.dimensions[ii];
+          next.push(existing ?? dim?.partitionKeys[0]);
+        }
+        if (key) {
+          next.push(key);
+        }
+        return next;
+      });
+    },
+    [partitionData],
+  );
+
+  // Build health ranges for the time dimension status bar
+  const timeHealthRanges = useMemo(() => {
+    if (timeDimensionIdx === -1) {
+      return [];
+    }
+    return buildHealthRangesForDim(partitionData, timeDimensionIdx);
+  }, [partitionData, timeDimensionIdx]);
 
   // Count statuses across all 2D cells for the status filter checkboxes
   const countsByStatus = useMemo(() => {
@@ -356,42 +419,59 @@ const AssetCheckMultiPartitions = ({
       const searchLower = searchValues[idx]?.toLowerCase().trim() || '';
       let keys = dimension.partitionKeys;
 
+      // For time dimension, filter to selected keys from DimensionRangeWizard
+      if (
+        idx === timeDimensionIdx &&
+        selectedTimeKeys.length < (timeDim?.partitionKeys.length ?? 0)
+      ) {
+        const selectedSet = new Set(selectedTimeKeys);
+        keys = keys.filter((k) => selectedSet.has(k));
+      }
+
       if (searchLower) {
         keys = keys.filter((k) => k.toLowerCase().includes(searchLower));
       }
 
-      // For dim1, only show keys that match the status filters when scoped to selected dim0
-      if (idx === 1 && focusedDimensionKeys[0]) {
-        const dim0Key = focusedDimensionKeys[0];
-        keys = keys.filter((k1) => {
-          const status = partitionData.statusForPartitionKeys([dim0Key, k1]);
+      // When the other dimension has a focused key, filter by specific cell status
+      const otherIdx = idx === 0 ? 1 : 0;
+      const otherFocusedKey = focusedDimensionKeys[otherIdx];
+      if (otherFocusedKey) {
+        keys = keys.filter((k) => {
+          const cellKeys = idx === 0 ? [k, otherFocusedKey] : [otherFocusedKey, k];
+          const status = partitionData.statusForPartitionKeys(cellKeys);
           return statusFilters.includes(status);
         });
-      }
-
-      // For dim0, filter by aggregate status
-      if (idx === 0) {
-        keys = keys.filter((k0) => {
-          const aggStatus = partitionData.statusForDim0Aggregate(k0);
+      } else {
+        // No focused key in other dimension - filter by aggregate status
+        keys = keys.filter((k) => {
+          const aggStatus = partitionData.statusForDimAggregate(idx, k);
           return statusFilters.includes(aggStatus);
         });
       }
 
-      const sortType = getDefaultPartitionSort(dimension.type as any);
+      const sortType = getDefaultPartitionSort(dimension.type as PartitionDefinitionType);
       return sortPartitionKeys(keys, sortType);
     },
-    [partitionData, searchValues, statusFilters, focusedDimensionKeys],
+    [
+      partitionData,
+      searchValues,
+      statusFilters,
+      focusedDimensionKeys,
+      selectedTimeKeys,
+      timeDimensionIdx,
+      timeDim,
+    ],
   );
 
   const statusForPartitionInDim = useCallback(
     (idx: number, key: string): AssetCheckPartitionStatus[] => {
-      if (idx === 0) {
-        return [partitionData.statusForDim0Aggregate(key)];
+      const otherIdx = idx === 0 ? 1 : 0;
+      const otherFocusedKey = focusedDimensionKeys[otherIdx];
+      if (otherFocusedKey) {
+        const cellKeys = idx === 0 ? [key, otherFocusedKey] : [otherFocusedKey, key];
+        return [partitionData.statusForPartitionKeys(cellKeys)];
       }
-      if (idx === 1 && focusedDimensionKeys[0]) {
-        return [partitionData.statusForPartitionKeys([focusedDimensionKeys[0], key])];
-      }
-      return [AssetCheckPartitionStatus.MISSING];
+      return [partitionData.statusForDimAggregate(idx, key)];
     },
     [partitionData, focusedDimensionKeys],
   );
@@ -403,6 +483,18 @@ const AssetCheckMultiPartitions = ({
 
   return (
     <>
+      {timeDim && (
+        <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
+          <DimensionRangeWizard
+            dimensionType={timeDim.type as PartitionDefinitionType}
+            partitionKeys={timeDim.partitionKeys}
+            health={{ranges: timeHealthRanges}}
+            selected={selectedTimeKeys}
+            setSelected={setSelectedTimeKeys}
+            showQuickSelectOptionsForStatuses={false}
+          />
+        </Box>
+      )}
       <Box
         padding={{vertical: 16, horizontal: 24}}
         flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
@@ -475,11 +567,11 @@ const AssetCheckMultiPartitions = ({
               flex={{direction: 'column', justifyContent: 'center', alignItems: 'center'}}
               style={{height: '100%'}}
             >
-              <Box style={{color: Colors.textLight()}}>
+              <span style={{color: Colors.textLight()}}>
                 {focusedDimensionKeys[0]
                   ? 'Select a partition in the second dimension to view details'
                   : 'Select a partition to view details'}
-              </Box>
+              </span>
             </Box>
           )}
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatus.tsx
@@ -135,6 +135,7 @@ export const PartitionStatus = React.memo(
                 position: 'absolute',
                 zIndex: s.start.idx === 0 || s.end.idx === highestIndex ? 3 : 2,
                 top: 0,
+                height,
               }}
             >
               {hideStatusTooltip || tooltipMessage ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatusBar.module.css
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatusBar.module.css
@@ -11,7 +11,7 @@
   position: absolute;
   top: 0;
   height: 8px;
-  border: 2px solid var(--color-blue500);
+  border: 2px solid var(--color-accent-blue);
   border-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary & Motivation

Previously, the UI would not work for asset checks with a multi-partitions definition, this fixes that

Before:

<img width="1909" height="918" alt="Screenshot 2026-02-17 at 1 32 26 PM" src="https://github.com/user-attachments/assets/e2669068-8a05-46f2-bdfd-6b190788ecba" />


After:

<img width="1908" height="869" alt="Screenshot 2026-02-17 at 1 31 03 PM" src="https://github.com/user-attachments/assets/e039b5f4-629b-41ed-8ea3-593976bbca15" />


## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
