### PR TITLE
Fixed partitioning tags with multiple '=' in email id's. 

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -157,7 +157,7 @@ export function runsFilterForSearchTokens(search: TokenizingFieldValue[]) {
     } else if (item.token === 'snapshotId') {
       obj.snapshotId = item.value;
     } else if (item.token === 'tag') {
-      const [key, value = ''] = item.value.split('=');
+      const [key, value = ''] = item.value.split(/=(.+)/);
       if (obj.tags) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         obj.tags.push({key: key!, value});


### PR DESCRIPTION
## Summary & Motivation
Working for Codeday micro-internship with a team of 3 interns. We were assigned to solve issue #32885 where email id's were being displayed incorrectly in the client's filter. We found that the partition of tag "key=value" format was partitioning all '='s in the value which was causing the bug for values that include an '=' in them.
## How I Tested These Changes
We have run out of time after finding this fix. It still needs to be tested! Apologies for the extra time you have to spend on this.

