### PR TITLE
docs: fix CodeExample trimming main block in external pipelines guide (#33468)

### DIFF
--- a/docs/docs/integrations/external-pipelines/index.md
+++ b/docs/docs/integrations/external-pipelines/index.md
@@ -29,6 +29,7 @@ In the following example, our external code is in a Python script that we invoke
   path="docs_snippets/docs_snippets/guides/external-systems/pipes/external_code_opaque.py"
   language="python"
   title="/usr/bin/external_code.py"
+  trimMain={false}
 />
 <CodeExample
   path="docs_snippets/docs_snippets/guides/external-systems/pipes/asset_wrapper.py"
@@ -46,6 +47,7 @@ Dagster Pipes also establishes a protocol for external code to optionally send b
   path="docs_snippets/docs_snippets/guides/external-systems/pipes/external_code_data_passing.py"
   language="python"
   title="/usr/bin/external_code.py"
+  trimMain={false}
 />
 
 The logs sent back using the `PipesContext` will be visible in the structured logs of that asset materialization's run, and the materialization metadata will be reflected in the asset history.


### PR DESCRIPTION
## Summary & Motivation

The `CodeExample` component trims the `if __name__ == "__main__":` block by default, which causes confusion in examples intended to be executed directly.

In the **External pipelines (Dagster Pipes)** guide, this results in incomplete Python snippets being displayed in the documentation, even though the full scripts in the repo include the required `__main__` block.

This PR updates the affected `CodeExample` usages to explicitly set `trimMain={false}` so the full runnable scripts are shown.

## Changes

Updated `docs/docs/guides/build/external-pipelines/index.md` to add:

- `trimMain={false}` for:
  - `external_code_opaque.py`
  - `external_code_data_passing.py`

## How I Tested These Changes

- Verified the referenced source files contain the `if __name__ == "__main__":` block
- Confirmed the documentation now renders full runnable scripts instead of truncated snippets

## Changelog

- Docs: Fix missing `__main__` block in external pipelines guide examples

Fixes #33468