### PR TITLE
fix: Add regression coverage for hourly cron alignment in non-hour offset timezones

### DIFF
--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -168,7 +168,7 @@ def _find_hourly_schedule_time(
             + (SECONDS_PER_MINUTE - new_timestamp % SECONDS_PER_MINUTE) % SECONDS_PER_MINUTE
         )
 
-        current_minute = (new_timestamp // SECONDS_PER_MINUTE) % SECONDS_PER_MINUTE
+        current_minute = datetime.datetime.fromtimestamp(new_timestamp, tz=date.tzinfo).minute
 
         final_timestamp = None
 
@@ -202,7 +202,7 @@ def _find_hourly_schedule_time(
         new_timestamp = new_timestamp - new_timestamp % SECONDS_PER_MINUTE
 
         # move minutes back to correct place
-        current_minute = (new_timestamp // SECONDS_PER_MINUTE) % SECONDS_PER_MINUTE
+        current_minute = datetime.datetime.fromtimestamp(new_timestamp, tz=date.tzinfo).minute
 
         final_timestamp = None
 


### PR DESCRIPTION
## Summary
Fix and add regression coverage for hourly cron tick alignment in timezones with non-zero minute UTC offsets.

## Problem
In Dagster 1.12.11, for `cron="0 * * * *"` and `execution_timezone="Asia/Kolkata"`, schedule evaluation can yield tick times at `HH:30` local time, while `HourlyPartitionsDefinition(timezone="Asia/Kolkata")` partition keys remain aligned to `HH:00`. This causes schedule tick times and hourly partition boundaries to diverge.

## Fix
Ensure minute calculations during hourly schedule time-finding are performed in the schedule's timezone (timezone-aware `datetime`) rather than via integer modulo arithmetic on epoch seconds.

## Tests
- Added regression tests covering `cron="0 * * * *"` alignment for the following non-hour-offset timezones:
  - Asia/Kolkata, Asia/Kathmandu, Australia/Adelaide, America/St_Johns, Pacific/Chatham
- Validated both ascending and descending iteration paths.
- Added minute-fidelity checks for `cron_minute in {0, 30}` and ensured parity between the fast iterator and the croniter fallback.
- For `cron_minute=0`, also validated that tick timestamps map to the expected `HourlyPartitionsDefinition` partition keys.

## Testing
- `make ruff`
- `uv run python -m pytest`

Closes #33448