### PR TITLE
dagster-dbt: Surface dbt CLI failures during selection (prevents StopIteration in multiprocess) Fixes #33380

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -423,7 +423,13 @@ def get_manifest_and_translator_from_dbt_assets(
     check.invariant(len(dbt_assets) == 1, "Exactly one dbt AssetsDefinition is required")
     dbt_assets_def = dbt_assets[0]
     metadata_by_key = dbt_assets_def.metadata_by_key or {}
-    first_asset_key = next(iter(dbt_assets_def.metadata_by_key.keys()))
+    first_asset_key = next(iter(metadata_by_key.keys()), None)
+    if first_asset_key is None:
+        raise DagsterInvariantViolationError(
+            "Expected dbt_assets to have at least one asset with metadata, but found none."
+            " Did you pass in an empty dbt_assets?"
+        )
+
     first_metadata = metadata_by_key.get(first_asset_key, {})
     manifest_wrapper: DbtManifestWrapper | None = first_metadata.get(
         DAGSTER_DBT_MANIFEST_METADATA_KEY

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -423,13 +423,7 @@ def get_manifest_and_translator_from_dbt_assets(
     check.invariant(len(dbt_assets) == 1, "Exactly one dbt AssetsDefinition is required")
     dbt_assets_def = dbt_assets[0]
     metadata_by_key = dbt_assets_def.metadata_by_key or {}
-    first_asset_key = next(iter(metadata_by_key.keys()), None)
-    if first_asset_key is None:
-        raise DagsterInvariantViolationError(
-            "Expected dbt_assets to have at least one asset with metadata, but found none."
-            " Did you pass in an empty dbt_assets?"
-        )
-
+    first_asset_key = next(iter(dbt_assets_def.metadata_by_key.keys()))
     first_metadata = metadata_by_key.get(first_asset_key, {})
     manifest_wrapper: DbtManifestWrapper | None = first_metadata.get(
         DAGSTER_DBT_MANIFEST_METADATA_KEY

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -73,7 +73,8 @@ def _select_unique_ids_from_cli(
         cmd.append("--selector")
         cmd.append(selector)
 
-    raw_events = DbtCliResource(project_dir=project).cli(cmd)._stream_stdout()  # noqa
+    invocation = DbtCliResource(project_dir=project).cli(cmd)
+    raw_events = invocation._stream_stdout()  # noqa
     unique_ids = set()
     for event in raw_events:
         if isinstance(event, dict):
@@ -82,6 +83,10 @@ def _select_unique_ids_from_cli(
             except orjson.JSONDecodeError:
                 continue
             unique_ids.add(msg.get("unique_id"))
+
+    if not invocation.is_successful():
+        err = invocation.get_error()
+        raise err or RuntimeError("dbt invocation failed but no error was captured")
 
     return unique_ids - {None}
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_utils.py
@@ -1,0 +1,87 @@
+import orjson
+import pytest
+
+from dagster_dbt.utils import _select_unique_ids_from_cli
+
+
+def _mock_invocation(mocker):
+    mock_dbt_cli_resource_class = mocker.patch("dagster_dbt.utils.DbtCliResource")
+    mock_dbt_cli_resource = mock_dbt_cli_resource_class.return_value
+    mock_invocation = mock_dbt_cli_resource.cli.return_value
+    return mock_dbt_cli_resource, mock_invocation
+
+
+def test_select_unique_ids_from_cli_success(mocker):
+    mock_dbt_cli_resource, mock_invocation = _mock_invocation(mocker)
+
+    mock_invocation._stream_stdout.return_value = [
+        {"info": {"msg": orjson.dumps({"unique_id": "model.my_project.my_model"}).decode()}},
+        {"info": {"msg": orjson.dumps({"unique_id": "model.my_project.another_model"}).decode()}},
+        {"info": {"msg": orjson.dumps({"unique_id": None}).decode()}},
+        {"info": {"msg": "random non-json log"}},
+        "string log",
+    ]
+    mock_invocation.is_successful.return_value = True
+
+    unique_ids = _select_unique_ids_from_cli("my_model", "", "", "fake_project")
+    assert unique_ids == {"model.my_project.my_model", "model.my_project.another_model"}
+
+    mock_dbt_cli_resource.cli.assert_called_once()
+    mock_invocation._stream_stdout.assert_called_once()
+    mock_invocation.is_successful.assert_called_once()
+    mock_invocation.get_error.assert_not_called()
+
+
+def test_select_unique_ids_from_cli_success_empty_events(mocker):
+    mock_dbt_cli_resource, mock_invocation = _mock_invocation(mocker)
+
+    mock_invocation._stream_stdout.return_value = [
+        {"info": {"msg": "{}"}},         # valid json but no unique_id
+        {"info": {"msg": ""}},           # invalid json
+        {"info": {"msg": "not json"}},   # invalid json
+        {},                              # missing info/msg
+        "string log",
+    ]
+    mock_invocation.is_successful.return_value = True
+
+    unique_ids = _select_unique_ids_from_cli("my_model", "", "", "fake_project")
+    assert unique_ids == set()
+
+    mock_dbt_cli_resource.cli.assert_called_once()
+    mock_invocation._stream_stdout.assert_called_once()
+    mock_invocation.is_successful.assert_called_once()
+    mock_invocation.get_error.assert_not_called()
+
+
+def test_select_unique_ids_from_cli_failure_with_error(mocker):
+    mock_dbt_cli_resource, mock_invocation = _mock_invocation(mocker)
+
+    mock_invocation._stream_stdout.return_value = []
+    mock_invocation.is_successful.return_value = False
+    err = RuntimeError("dbt invocation failed explicitly")
+    mock_invocation.get_error.return_value = err
+
+    with pytest.raises(RuntimeError) as e:
+        _select_unique_ids_from_cli("my_model", "", "", "fake_project")
+    assert e.value is err
+
+    mock_dbt_cli_resource.cli.assert_called_once()
+    mock_invocation._stream_stdout.assert_called_once()
+    mock_invocation.is_successful.assert_called_once()
+    mock_invocation.get_error.assert_called_once()
+
+
+def test_select_unique_ids_from_cli_failure_without_error(mocker):
+    mock_dbt_cli_resource, mock_invocation = _mock_invocation(mocker)
+
+    mock_invocation._stream_stdout.return_value = []
+    mock_invocation.is_successful.return_value = False
+    mock_invocation.get_error.return_value = None
+
+    with pytest.raises(RuntimeError, match="dbt invocation failed but no error was captured"):
+        _select_unique_ids_from_cli("my_model", "", "", "fake_project")
+
+    mock_dbt_cli_resource.cli.assert_called_once()
+    mock_invocation._stream_stdout.assert_called_once()
+    mock_invocation.is_successful.assert_called_once()
+    mock_invocation.get_error.assert_called_once()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_utils.py
@@ -1,17 +1,18 @@
 import orjson
 import pytest
+from pytest_mock import MockerFixture
 
 from dagster_dbt.utils import _select_unique_ids_from_cli
 
 
-def _mock_invocation(mocker):
+def _mock_invocation(mocker: MockerFixture):
     mock_dbt_cli_resource_class = mocker.patch("dagster_dbt.core.resource.DbtCliResource")
     mock_dbt_cli_resource = mock_dbt_cli_resource_class.return_value
     mock_invocation = mock_dbt_cli_resource.cli.return_value
     return mock_dbt_cli_resource, mock_invocation
 
 
-def test_select_unique_ids_from_cli_success(mocker):
+def test_select_unique_ids_from_cli_success(mocker: MockerFixture) -> None:
     mock_dbt_cli_resource, mock_invocation = _mock_invocation(mocker)
 
     mock_invocation._stream_stdout.return_value = [
@@ -32,14 +33,14 @@ def test_select_unique_ids_from_cli_success(mocker):
     mock_invocation.get_error.assert_not_called()
 
 
-def test_select_unique_ids_from_cli_success_empty_events(mocker):
+def test_select_unique_ids_from_cli_success_empty_events(mocker: MockerFixture) -> None:
     mock_dbt_cli_resource, mock_invocation = _mock_invocation(mocker)
 
     mock_invocation._stream_stdout.return_value = [
-        {"info": {"msg": "{}"}},         # valid json but no unique_id
-        {"info": {"msg": ""}},           # invalid json
-        {"info": {"msg": "not json"}},   # invalid json
-        {},                              # missing info/msg
+        {"info": {"msg": "{}"}},
+        {"info": {"msg": ""}},
+        {"info": {"msg": "not json"}},
+        {},
         "string log",
     ]
     mock_invocation.is_successful.return_value = True
@@ -53,7 +54,7 @@ def test_select_unique_ids_from_cli_success_empty_events(mocker):
     mock_invocation.get_error.assert_not_called()
 
 
-def test_select_unique_ids_from_cli_failure_with_error(mocker):
+def test_select_unique_ids_from_cli_failure_with_error(mocker: MockerFixture) -> None:
     mock_dbt_cli_resource, mock_invocation = _mock_invocation(mocker)
 
     mock_invocation._stream_stdout.return_value = []
@@ -71,7 +72,7 @@ def test_select_unique_ids_from_cli_failure_with_error(mocker):
     mock_invocation.get_error.assert_called_once()
 
 
-def test_select_unique_ids_from_cli_failure_without_error(mocker):
+def test_select_unique_ids_from_cli_failure_without_error(mocker: MockerFixture) -> None:
     mock_dbt_cli_resource, mock_invocation = _mock_invocation(mocker)
 
     mock_invocation._stream_stdout.return_value = []
@@ -80,6 +81,29 @@ def test_select_unique_ids_from_cli_failure_without_error(mocker):
 
     with pytest.raises(RuntimeError, match="dbt invocation failed but no error was captured"):
         _select_unique_ids_from_cli("my_model", "", "", "fake_project")
+
+    mock_dbt_cli_resource.cli.assert_called_once()
+    mock_invocation._stream_stdout.assert_called_once()
+    mock_invocation.is_successful.assert_called_once()
+    mock_invocation.get_error.assert_called_once()
+
+
+def test_select_unique_ids_from_cli_partial_stdout_still_raises(
+    mocker: MockerFixture,
+) -> None:
+    mock_dbt_cli_resource, mock_invocation = _mock_invocation(mocker)
+
+    mock_invocation._stream_stdout.return_value = [
+        {"info": {"msg": orjson.dumps({"unique_id": "model.my_project.partial_model"}).decode()}},
+        {"info": {"msg": "not json"}},
+    ]
+    mock_invocation.is_successful.return_value = False
+    err = RuntimeError("dbt invocation failed after emitting partial stdout")
+    mock_invocation.get_error.return_value = err
+
+    with pytest.raises(RuntimeError) as e:
+        _select_unique_ids_from_cli("my_model", "", "", "fake_project")
+    assert e.value is err
 
     mock_dbt_cli_resource.cli.assert_called_once()
     mock_invocation._stream_stdout.assert_called_once()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_utils.py
@@ -5,7 +5,7 @@ from dagster_dbt.utils import _select_unique_ids_from_cli
 
 
 def _mock_invocation(mocker):
-    mock_dbt_cli_resource_class = mocker.patch("dagster_dbt.utils.DbtCliResource")
+    mock_dbt_cli_resource_class = mocker.patch("dagster_dbt.core.resource.DbtCliResource")
     mock_dbt_cli_resource = mock_dbt_cli_resource_class.return_value
     mock_invocation = mock_dbt_cli_resource.cli.return_value
     return mock_dbt_cli_resource, mock_invocation


### PR DESCRIPTION
Fixes #33380

## Summary
Fixes an issue where dbt CLI failures during `_select_unique_ids_from_cli` were silently swallowed, leading to empty metadata and downstream `StopIteration` / `RuntimeError` during multiprocess execution.

## Root cause
When `DbtCliInvocation` failed (non-zero exit), the code continued processing `_stream_stdout()` without checking `is_successful()`. This produced incomplete/empty `unique_id` sets, causing failures later in repository reconstruction under `multiprocess_executor`.

## Fix
- After consuming `_stream_stdout()`, explicitly check `invocation.is_successful()`
- If the invocation failed:
  - raise `invocation.get_error()` when available
  - otherwise raise a fallback `RuntimeError("dbt invocation failed but no error was captured")`

## Tests
Added comprehensive unit tests covering:
- successful parsing with mixed stdout events
- empty / malformed stdout events
- failure with explicit error from dbt CLI
- failure without error object

## Impact
- Prevents misleading `StopIteration` / generator errors
- Surfaces true dbt CLI failures during concurrent execution
- Improves debuggability in `dagster dev` with `multiprocess_executor`