### PR TITLE
Enhance DataFrame validation logic

### DIFF
--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -181,12 +181,12 @@ def _pandera_schema_to_type_check_fn(
             try:
                 # `lazy` instructs pandera to capture every (not just the first) validation error
                 # TODO: pending alternative dataframe support
+                
+                # don't re-validate a dataframe that contains the same exact schema
                 if (
-                    not hasattr(value, "pandera")
-                    or value.pandera.schema is None
-                    # don't re-validate a dataframe that contains the same
-                    # exact schema
-                    or value.pandera.schema != schema
+                    hasattr(value, "pandera")
+                    and value.pandera.schema is not None
+                    and value.pandera.schema == schema
                     ):
                     pass
                 elif isinstance(schema, pa_pd.DataFrameSchema):


### PR DESCRIPTION
Add checks to avoid re-validation of DataFrames with the same schema.

## Summary & Motivation

Pandera code in the `pandera.decorators.check_types` has a step which checks if a dataframe already has a schema which matches the one being validated, avoids revalidation overhead:

https://github.com/unionai-oss/pandera/blob/main/pandera/decorators.py#713

## How I Tested These Changes


