### PR TITLE
postgres event log retry connection

### DIFF
--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -344,7 +344,8 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     yield conn
 
     def has_table(self, table_name: str) -> bool:
-        return bool(self._engine.dialect.has_table(self._engine.connect(), table_name))
+        with self._connect() as conn:
+            return bool(self._engine.dialect.has_table(conn, table_name))
 
     def has_secondary_index(self, name: str) -> bool:
         if name not in self._secondary_index_cache:
@@ -370,7 +371,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         self._event_watcher.watch_run(run_id, cursor, callback)
 
     def _gen_event_log_entry_from_cursor(self, cursor) -> EventLogEntry:
-        with self._engine.connect() as conn:
+        with self._connect() as conn:
             cursor_res = conn.execute(
                 db_select([SqlEventLogStorageTable.c.event]).where(
                     SqlEventLogStorageTable.c.id == cursor


### PR DESCRIPTION
closes #33886 

## Summary & Motivation

in the postgres event log, has_table() and _gen_event_log_entry_from_cursor() do not use the available retry wrapper for connecting to postgres. this means if postgres temporarily drops out, the asset will fail immediately. 

a truncated stack trace, after a dagster asset successfully materializes but fails due to postgres error:
```
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) could not translate host name "dataeng-postgres-pgbouncer" to address: Temporary failure in name resolution

(Background on this error at: https://sqlalche.me/e/14/e3q8)

  File "/usr/local/lib/python3.12/site-packages/dagster_postgres/event_log/event_log.py", line 208, in store_event
    self.store_asset_event_tags([event], [event_id])
  File "/usr/local/lib/python3.12/site-packages/dagster/_core/storage/event_log/sql_event_log.py", line 354, in store_asset_event_tags
    if len(all_values) > 0 and self.has_table(AssetEventTagsTable.name):
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dagster_postgres/event_log/event_log.py", line 347, in has_table
    return bool(self._engine.dialect.has_table(self._engine.connect(), table_name))
                                               ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 3325, in connect
    return self._connection_cls(self, close_with_result=close_with_result)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## How I Tested These Changes

ran python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py

## Changelog

dagster postgres event log retry connection
