### PR TITLE
[dagster-aws] Default S3 prefix to empty string in `PickledObjectS3IOManager`

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -30,7 +30,7 @@ class PickledObjectS3IOManager(UPathIOManager):
         s3_prefix: str | None = None,
     ):
         self.bucket = check.str_param(s3_bucket, "s3_bucket")
-        check.opt_str_param(s3_prefix, "s3_prefix")
+        s3_prefix = check.opt_str_param(s3_prefix, "s3_prefix", default="")
         self.s3 = s3_session
         self.s3.list_objects(Bucket=s3_bucket, Prefix=s3_prefix, MaxKeys=1)
         base_path = UPath(s3_prefix) if s3_prefix else None

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
@@ -1,6 +1,7 @@
 import pickle
 from collections.abc import Callable
 from typing import Any
+from unittest import mock
 
 import pytest
 from dagster import (
@@ -26,7 +27,11 @@ from dagster._core.definitions.partitions.definition import StaticPartitionsDefi
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 
-from dagster_aws.s3.io_manager import S3PickleIOManager, s3_pickle_io_manager
+from dagster_aws.s3.io_manager import (
+    PickledObjectS3IOManager,
+    S3PickleIOManager,
+    s3_pickle_io_manager,
+)
 from dagster_aws.s3.utils import construct_s3_client
 
 
@@ -268,3 +273,10 @@ def test_s3_pickle_io_manager_dynamic_output(mock_s3_bucket, s3_and_io_manager):
 
     assert any("return_value--foo" in key for key in keys)
     assert any("return_value--bar" in key for key in keys)
+
+
+@pytest.mark.parametrize("s3_prefix", ["", None])
+def test_pickled_object_s3_io_manager_init_with_none_prefix(s3_prefix: str | None):
+    mock_session = mock.Mock()
+    PickledObjectS3IOManager(s3_bucket="test-bucket", s3_session=mock_session, s3_prefix=s3_prefix)
+    mock_session.list_objects.assert_called_once_with(Bucket="test-bucket", Prefix="", MaxKeys=1)


### PR DESCRIPTION
Closes #33490.

## Summary & Motivation
Fix bug (see issue).

The `PickledObjectS3IOManager`'s behavior stays exactly the same, since the base path is determined on the truthyness of the `s3_prefix`.

## How I Tested These Changes
With a test, and verified that the boto3 S3 client returns the same response on no prefix, and empty prefix.

## Changelog

> Default S3 prefix to empty string in `PickledObjectS3IOManager`.