### PR TITLE
dagster-dlt: resource.py - Add error handling for row_count

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
@@ -131,6 +131,7 @@ class DagsterDltResource(ConfigurableResource):
             for job in load_package.get("jobs", [])
             if job.get("table_name") == normalized_table_name
         ]
+        rows_loaded = None
         try:
             rows_loaded = dlt_pipeline.last_trace.last_normalize_info.row_counts.get(
                 normalized_table_name


### PR DESCRIPTION
Adds error handling around getting the row_count for a dlt resource. Using a custom dlt destination + write strategy combo means that not all dlt steps will be taken every run. The dlt steps are: extract, normalize and load and the integration library  `dagster_dlt` relies on the normalize step being run for getting the row_count.

## Summary & Motivation

When running my dlt pipeline through dagster, it errors out since I use a custom dlt destination that sometimes skips the normalize step.

## How I Tested These Changes

Manually. I patched dagster_dlt in my venv and re-ran my pipelines. It's a really small patch so it shouldn't affect anything else.
