### PR TITLE
[dagster-postgres] Add password_provider for dynamic credential refresh (#33427)

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/config.py
+++ b/python_modules/dagster/dagster/_core/storage/config.py
@@ -1,4 +1,4 @@
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from dagster._config import Field, IntSource, Permissive, Selector, StringSource
 from dagster._config.config_schema import UserConfigSchema
@@ -39,7 +39,8 @@ class PostgresStorageConfig(TypedDict):
 
 class PostgresStorageConfigDb(TypedDict):
     username: str
-    password: str
+    password: NotRequired[str]
+    password_provider: NotRequired[str]
     hostname: str
     db_name: str
     port: int
@@ -53,7 +54,8 @@ def pg_config() -> UserConfigSchema:
         "postgres_db": Field(
             {
                 "username": StringSource,
-                "password": StringSource,
+                "password": Field(StringSource, is_required=False),
+                "password_provider": Field(StringSource, is_required=False),
                 "hostname": StringSource,
                 "db_name": StringSource,
                 "port": Field(IntSource, is_required=False, default_value=5432),

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -37,10 +37,12 @@ from sqlalchemy.engine import Connection
 from dagster_postgres.utils import (
     create_pg_connection,
     pg_alembic_config,
+    pg_config_password_provider,
     pg_url_from_config,
     retry_pg_connection_fn,
     retry_pg_creation_fn,
     set_pg_statement_timeout,
+    setup_pg_password_provider_event,
 )
 
 CHANNEL_NAME = "run_events"
@@ -80,6 +82,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         postgres_url: str,
         should_autocreate_tables: bool = True,
         inst_data: ConfigurableClassData | None = None,
+        password_provider: str | None = None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.postgres_url = check.str_param(postgres_url, "postgres_url")
@@ -91,6 +94,10 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         self._engine = create_engine(
             self.postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
         )
+        self.password_provider = password_provider
+        if self.password_provider:
+            setup_pg_password_provider_event(self._engine, self.password_provider)
+
         self._event_watcher: SqlPollingEventWatcher | None = None
 
         self._secondary_index_cache = {}
@@ -126,6 +133,9 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
         self._engine = create_engine(self.postgres_url, **kwargs)
+        if self.password_provider:
+            setup_pg_password_provider_event(self._engine, self.password_provider)
+
         event.listen(
             self._engine,
             "connect",
@@ -153,21 +163,27 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             inst_data=inst_data,
             postgres_url=pg_url_from_config(config_value),
             should_autocreate_tables=config_value.get("should_autocreate_tables", True),
+            password_provider=pg_config_password_provider(config_value),
         )
 
     @staticmethod
     def create_clean_storage(
-        conn_string: str, should_autocreate_tables: bool = True
+        conn_string: str,
+        should_autocreate_tables: bool = True,
+        password_provider: str | None = None,
     ) -> "PostgresEventLogStorage":
         engine = create_engine(
             conn_string, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
         )
+        if password_provider:
+            setup_pg_password_provider_event(engine, password_provider)
+
         try:
             SqlEventLogStorageMetadata.drop_all(engine)
         finally:
             engine.dispose()
 
-        return PostgresEventLogStorage(conn_string, should_autocreate_tables)
+        return PostgresEventLogStorage(conn_string, should_autocreate_tables, password_provider=password_provider)
 
     def store_event(self, event: EventLogEntry) -> None:
         """Store an event corresponding to a run.

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -32,10 +32,12 @@ from sqlalchemy.engine import Connection
 from dagster_postgres.utils import (
     create_pg_connection,
     pg_alembic_config,
+    pg_config_password_provider,
     pg_url_from_config,
     retry_pg_connection_fn,
     retry_pg_creation_fn,
     set_pg_statement_timeout,
+    setup_pg_password_provider_event,
 )
 
 
@@ -72,6 +74,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         postgres_url: str,
         should_autocreate_tables: bool = True,
         inst_data: ConfigurableClassData | None = None,
+        password_provider: str | None = None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.postgres_url = postgres_url
@@ -85,6 +88,10 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
             isolation_level="AUTOCOMMIT",
             poolclass=db_pool.NullPool,
         )
+
+        self.password_provider = password_provider
+        if self.password_provider:
+            setup_pg_password_provider_event(self._engine, self.password_provider)
 
         self._index_migration_cache = {}
 
@@ -122,6 +129,9 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
         self._engine = create_engine(self.postgres_url, **kwargs)
+        if self.password_provider:
+            setup_pg_password_provider_event(self._engine, self.password_provider)
+
         event.listen(
             self._engine,
             "connect",
@@ -144,20 +154,26 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
             inst_data=inst_data,
             postgres_url=pg_url_from_config(config_value),
             should_autocreate_tables=config_value.get("should_autocreate_tables", True),
+            password_provider=pg_config_password_provider(config_value),
         )
 
     @staticmethod
     def create_clean_storage(
-        postgres_url: str, should_autocreate_tables: bool = True
+        postgres_url: str,
+        should_autocreate_tables: bool = True,
+        password_provider: str | None = None,
     ) -> "PostgresRunStorage":
         engine = create_engine(
             postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
         )
+        if password_provider:
+            setup_pg_password_provider_event(engine, password_provider)
+
         try:
             RunStorageSqlMetadata.drop_all(engine)
         finally:
             engine.dispose()
-        return PostgresRunStorage(postgres_url, should_autocreate_tables)
+        return PostgresRunStorage(postgres_url, should_autocreate_tables, password_provider=password_provider)
 
     def connect(self) -> ContextManager[Connection]:
         return create_pg_connection(self._engine)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -32,10 +32,12 @@ from sqlalchemy.engine import Connection
 from dagster_postgres.utils import (
     create_pg_connection,
     pg_alembic_config,
+    pg_config_password_provider,
     pg_url_from_config,
     retry_pg_connection_fn,
     retry_pg_creation_fn,
     set_pg_statement_timeout,
+    setup_pg_password_provider_event,
 )
 
 
@@ -72,6 +74,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         postgres_url: str,
         should_autocreate_tables: bool = True,
         inst_data: ConfigurableClassData | None = None,
+        password_provider: str | None = None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.postgres_url = postgres_url
@@ -83,6 +86,10 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self._engine = create_engine(
             self.postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
         )
+
+        self.password_provider = password_provider
+        if self.password_provider:
+            setup_pg_password_provider_event(self._engine, self.password_provider)
 
         # Stamp and create tables if the main table does not exist (we can't check alembic
         # revision because alembic config may be shared with other storage classes)
@@ -118,6 +125,9 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
         self._engine = create_engine(self.postgres_url, **kwargs)
+        if self.password_provider:
+            setup_pg_password_provider_event(self._engine, self.password_provider)
+
         event.listen(
             self._engine,
             "connect",
@@ -140,20 +150,26 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             inst_data=inst_data,
             postgres_url=pg_url_from_config(config_value),
             should_autocreate_tables=config_value.get("should_autocreate_tables", True),
+            password_provider=pg_config_password_provider(config_value),
         )
 
     @staticmethod
     def create_clean_storage(
-        postgres_url: str, should_autocreate_tables: bool = True
+        postgres_url: str,
+        should_autocreate_tables: bool = True,
+        password_provider: str | None = None,
     ) -> "PostgresScheduleStorage":
         engine = create_engine(
             postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
         )
+        if password_provider:
+            setup_pg_password_provider_event(engine, password_provider)
+
         try:
             ScheduleStorageSqlMetadata.drop_all(engine)
         finally:
             engine.dispose()
-        return PostgresScheduleStorage(postgres_url, should_autocreate_tables)
+        return PostgresScheduleStorage(postgres_url, should_autocreate_tables, password_provider=password_provider)
 
     def connect(self, run_id: str | None = None) -> ContextManager[Connection]:
         return create_pg_connection(self._engine)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/storage.py
@@ -10,7 +10,7 @@ from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster_postgres.event_log import PostgresEventLogStorage
 from dagster_postgres.run_storage import PostgresRunStorage
 from dagster_postgres.schedule_storage import PostgresScheduleStorage
-from dagster_postgres.utils import pg_url_from_config
+from dagster_postgres.utils import pg_config_password_provider, pg_url_from_config
 
 
 class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
@@ -37,15 +37,23 @@ class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
         postgres_url,
         should_autocreate_tables=True,
         inst_data: ConfigurableClassData | None = None,
+        password_provider: str | None = None,
     ):
         self.postgres_url = postgres_url
         self.should_autocreate_tables = check.bool_param(
             should_autocreate_tables, "should_autocreate_tables"
         )
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
-        self._run_storage = PostgresRunStorage(postgres_url, should_autocreate_tables)
-        self._event_log_storage = PostgresEventLogStorage(postgres_url, should_autocreate_tables)
-        self._schedule_storage = PostgresScheduleStorage(postgres_url, should_autocreate_tables)
+        self.password_provider = password_provider
+        self._run_storage = PostgresRunStorage(
+            postgres_url, should_autocreate_tables, password_provider=password_provider
+        )
+        self._event_log_storage = PostgresEventLogStorage(
+            postgres_url, should_autocreate_tables, password_provider=password_provider
+        )
+        self._schedule_storage = PostgresScheduleStorage(
+            postgres_url, should_autocreate_tables, password_provider=password_provider
+        )
         super().__init__()
 
     @property
@@ -64,6 +72,7 @@ class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
             inst_data=inst_data,
             postgres_url=pg_url_from_config(config_value),
             should_autocreate_tables=config_value.get("should_autocreate_tables", True),
+            password_provider=pg_config_password_provider(config_value),
         )
 
     @property

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 import time
 from collections.abc import Callable, Iterator, Mapping
@@ -13,6 +14,7 @@ import sqlalchemy
 import sqlalchemy.exc
 from dagster import _check as check
 from dagster._core.definitions.policy import Backoff, Jitter, calculate_delay
+from dagster._core.errors import DagsterInvariantViolationError
 
 # re-export
 from dagster._core.storage.config import pg_config as pg_config
@@ -50,16 +52,32 @@ def pg_url_from_config(config_value: Mapping[str, Any]) -> str:
         return get_conn_string(**config_value["postgres_db"])
 
 
+def pg_config_password_provider(config_value: Mapping[str, Any]) -> str | None:
+    if config_value.get("postgres_db"):
+        return config_value["postgres_db"].get("password_provider")
+    return None
+
+
 def get_conn_string(
     username: str,
-    password: str,
-    hostname: str,
-    db_name: str,
+    password: str | None = None,
+    hostname: str = "",
+    db_name: str = "",
     port: str = "5432",
     params: Mapping[str, object] | None = None,
     scheme: str = "postgresql",
+    *,
+    password_provider: str | None = None,
 ) -> str:
-    uri = f"{scheme}://{quote(username)}:{quote(password)}@{hostname}:{port}/{db_name}"
+    has_password = password is not None
+    has_password_provider = password_provider is not None
+    check.invariant(
+        has_password ^ has_password_provider,
+        "postgres storage config must provide exactly one of `password` or `password_provider`",
+    )
+
+    pwd_str = password if password is not None else ""
+    uri = f"{scheme}://{quote(username)}:{quote(pwd_str)}@{hostname}:{port}/{db_name}"
 
     if params:
         query_string = f"{urlencode(params, quote_via=quote)}"
@@ -175,3 +193,57 @@ def set_pg_statement_timeout(conn: psycopg2.extensions.connection, millis: int):
     with conn:
         with conn.cursor() as curs:
             curs.execute(f"SET statement_timeout = {millis};")
+
+
+def setup_pg_password_provider_event(
+    engine: sqlalchemy.engine.Engine, password_provider: str
+) -> None:
+    """
+    Sets up an SQLAlchemy do_connect event listener that dynamically retrieves the password
+    by importing and invoking the callable specified by `password_provider`.
+    
+    The callable returns a string password/token to be injected into the connection params.
+    
+    WARNING: `password_provider` is dynamically imported using `importlib.import_module`.
+             This should only be used with trusted code paths.
+    """
+    parts = password_provider.split(".")
+    if len(parts) < 2:
+        raise DagsterInvariantViolationError(
+            f"password_provider must be a dot-separated string like 'my_module.my_function'. "
+            f"Got: '{password_provider}'"
+        )
+    module_name = ".".join(parts[:-1])
+    callable_name = parts[-1]
+
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as e:
+        raise DagsterInvariantViolationError(
+            f"Could not import module '{module_name}' specified in password_provider: {e}"
+        ) from e
+
+    try:
+        get_password = getattr(module, callable_name)
+    except AttributeError as e:
+        raise DagsterInvariantViolationError(
+            f"Could not find callable '{callable_name}' in module '{module_name}'"
+        ) from e
+
+    check.callable_param(get_password, "password_provider")
+
+    @sqlalchemy.event.listens_for(engine, "do_connect")
+    def receive_do_connect(dialect, conn_rec, cargs, cparams):
+        try:
+            password = get_password()
+        except Exception as e:
+            raise DagsterInvariantViolationError(
+                f"password_provider '{password_provider}' raised an error while "
+                f"fetching credentials: {e}"
+            ) from e
+        if not isinstance(password, str):
+            raise DagsterInvariantViolationError(
+                f"password_provider '{password_provider}' must return a str, "
+                f"got {type(password).__name__}"
+            )
+        cparams["password"] = password

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_password_provider.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_password_provider.py
@@ -1,0 +1,302 @@
+"""Tests for the password_provider feature (issue #33427).
+
+Bug: dagster-postgres bakes the password into the connection URL at startup.
+When using short-lived credentials (Azure AD tokens, AWS IAM tokens), the
+password expires after ~60 minutes, but new connections still use the stale
+token from the URL. Long-running workloads (daemon, sensors, schedules)
+silently fail with authentication errors.
+
+Fix: A `password_provider` config option that hooks into SQLAlchemy's
+`do_connect` event to dynamically inject a fresh password/token on every
+new database connection.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import sqlalchemy
+from dagster import _check as check
+from dagster._core.errors import DagsterInvariantViolationError
+from dagster_postgres.utils import get_conn_string, setup_pg_password_provider_event
+
+
+# ---------------------------------------------------------------------------
+# Helpers: simulate a rotating token provider (like Azure AD / AWS IAM)
+# ---------------------------------------------------------------------------
+
+_call_count = 0
+
+
+def rotating_token_provider():
+    """Simulates a token provider that returns a different token each time,
+    mimicking Azure AD access token refresh behavior."""
+    global _call_count
+    _call_count += 1
+    return f"token_v{_call_count}"
+
+
+def dummy_valid_provider():
+    return "secret123"
+
+
+NON_CALLABLE_VAR = "I am a string, not a function"
+
+
+def failing_provider():
+    """Simulates a provider that fails at runtime (e.g., network error fetching
+    an Azure AD token)."""
+    raise ConnectionError("Azure AD endpoint unreachable")
+
+
+def bad_return_type_provider():
+    """Simulates a provider that returns a non-string value."""
+    return 12345
+
+
+# ---------------------------------------------------------------------------
+# Bug reproduction: prove the problem exists without the fix
+# ---------------------------------------------------------------------------
+
+
+class TestBugReproduction:
+    """Reproduce issue #33427: static passwords become stale."""
+
+    def test_static_password_stays_stale_across_connections(self):
+        """BUG: Without password_provider, the password is baked into the
+        connection URL and never refreshed. Simulates what happens when an
+        Azure AD token expires after the initial connection."""
+        initial_token = "azure_ad_token_that_will_expire"
+        conn_url = get_conn_string(
+            username="dagster",
+            password=initial_token,
+            hostname="pg-host",
+            db_name="dagster_db",
+        )
+
+        engine = sqlalchemy.create_engine(conn_url, poolclass=sqlalchemy.pool.NullPool)
+
+        # The password is permanently embedded in the URL -- there is no
+        # mechanism to update it when the token expires.
+        # Note: str(engine.url) masks the password, so we use render_as_string
+        rendered_url = engine.url.render_as_string(hide_password=False)
+        assert initial_token in rendered_url
+
+        # Simulate multiple connection attempts over time.  Each one would
+        # reuse the same stale token from the URL.
+        for _ in range(3):
+            # The URL never changes, so every new psycopg2.connect() call
+            # would send the original (now-expired) token.
+            current_url = engine.url.render_as_string(hide_password=False)
+            assert initial_token in current_url
+
+    def test_password_provider_injects_fresh_token_every_connection(self):
+        """FIX: With password_provider, the do_connect hook calls the provider
+        on every new connection, injecting a fresh token into cparams."""
+        global _call_count
+        _call_count = 0
+
+        engine = sqlalchemy.create_engine(
+            "postgresql://dagster:placeholder@pg-host:5432/dagster_db",
+            poolclass=sqlalchemy.pool.NullPool,
+        )
+        setup_pg_password_provider_event(
+            engine,
+            "dagster_postgres_tests.test_password_provider.rotating_token_provider",
+        )
+
+        # Mock psycopg2.connect so we don't need a real Postgres server.
+        # The do_connect event fires BEFORE psycopg2.connect is called,
+        # modifying cparams["password"] with the fresh token.
+        captured_passwords = []
+
+        original_connect = sqlalchemy.pool._ConnectionRecord  # noqa
+
+        with patch("psycopg2.connect") as mock_connect:
+            mock_conn = MagicMock()
+            mock_conn.encoding = "utf-8"
+            mock_conn.cursor.return_value.__enter__ = MagicMock()
+            mock_conn.cursor.return_value.__exit__ = MagicMock()
+            mock_connect.return_value = mock_conn
+
+            # Capture the password kwarg passed to psycopg2.connect
+            def capture_connect(*args, **kwargs):
+                captured_passwords.append(kwargs.get("password"))
+                return mock_conn
+
+            mock_connect.side_effect = capture_connect
+
+            # Simulate 3 connection cycles (like a long-running daemon)
+            for _ in range(3):
+                try:
+                    with engine.connect() as conn:
+                        pass
+                except Exception:
+                    # We expect various errors since we're mocking psycopg2
+                    # The important thing is that psycopg2.connect was called
+                    pass
+
+        # The provider should have been called for each connection attempt.
+        # Each call should produce a DIFFERENT token, proving rotation works.
+        assert _call_count >= 3, (
+            f"Expected provider to be called at least 3 times, got {_call_count}"
+        )
+        # Verify ascending token versions were injected
+        for i, pwd in enumerate(captured_passwords):
+            assert pwd == f"token_v{i + 1}", (
+                f"Connection {i + 1} got password '{pwd}', expected 'token_v{i + 1}'"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: setup_pg_password_provider_event validation
+# ---------------------------------------------------------------------------
+
+
+class TestPasswordProviderSetup:
+    """Test validation and error handling in setup_pg_password_provider_event."""
+
+    def test_valid_provider_hooks_into_engine(self):
+        """A valid dotted-path provider should register the do_connect listener."""
+        engine = sqlalchemy.create_engine("sqlite:///:memory:")
+        setup_pg_password_provider_event(
+            engine,
+            "dagster_postgres_tests.test_password_provider.dummy_valid_provider",
+        )
+
+        # The hook should fire and inject "password" into cparams.
+        # SQLite doesn't accept a "password" kwarg, so it raises TypeError.
+        with pytest.raises(TypeError, match="password"):
+            with engine.connect() as conn:
+                pass
+
+    def test_invalid_format_raises_invariant_error(self):
+        """A provider string without dots should raise immediately."""
+        engine = sqlalchemy.create_engine("sqlite:///:memory:")
+        with pytest.raises(
+            DagsterInvariantViolationError,
+            match="password_provider must be a dot-separated string",
+        ):
+            setup_pg_password_provider_event(engine, "invalid_format_no_dots")
+
+    def test_missing_module_raises_invariant_error(self):
+        """An unimportable module should raise with a clear message."""
+        engine = sqlalchemy.create_engine("sqlite:///:memory:")
+        with pytest.raises(
+            DagsterInvariantViolationError,
+            match="Could not import module",
+        ):
+            setup_pg_password_provider_event(
+                engine, "this_module_absolutely_does_not_exist.get_token"
+            )
+
+    def test_missing_attribute_raises_invariant_error(self):
+        """A valid module with a missing attribute should raise clearly."""
+        engine = sqlalchemy.create_engine("sqlite:///:memory:")
+        with pytest.raises(
+            DagsterInvariantViolationError, match="Could not find callable"
+        ):
+            setup_pg_password_provider_event(
+                engine, "dagster.NON_EXISTENT_ATTRIBUTE_DOES_NOT_EXIST"
+            )
+
+    def test_non_callable_attribute_raises_check_error(self):
+        """A valid module.attribute that is not callable should raise CheckError."""
+        engine = sqlalchemy.create_engine("sqlite:///:memory:")
+        with pytest.raises(check.CheckError, match="not callable"):
+            setup_pg_password_provider_event(
+                engine,
+                "dagster_postgres_tests.test_password_provider.NON_CALLABLE_VAR",
+            )
+
+    def test_provider_runtime_error_raises_clear_message(self):
+        """If the provider callable raises at connection time, the error should
+        be wrapped in a DagsterInvariantViolationError with a clear message."""
+        engine = sqlalchemy.create_engine(
+            "postgresql://dagster:placeholder@pg-host:5432/dagster_db",
+            poolclass=sqlalchemy.pool.NullPool,
+        )
+        setup_pg_password_provider_event(
+            engine,
+            "dagster_postgres_tests.test_password_provider.failing_provider",
+        )
+
+        with patch("psycopg2.connect") as mock_connect:
+            mock_connect.return_value = MagicMock()
+            with pytest.raises(
+                DagsterInvariantViolationError,
+                match="raised an error while fetching credentials",
+            ):
+                with engine.connect() as conn:
+                    pass
+
+    def test_provider_bad_return_type_raises_clear_message(self):
+        """If the provider returns a non-string, the error should clearly say so."""
+        engine = sqlalchemy.create_engine(
+            "postgresql://dagster:placeholder@pg-host:5432/dagster_db",
+            poolclass=sqlalchemy.pool.NullPool,
+        )
+        setup_pg_password_provider_event(
+            engine,
+            "dagster_postgres_tests.test_password_provider.bad_return_type_provider",
+        )
+
+        with patch("psycopg2.connect") as mock_connect:
+            mock_connect.return_value = MagicMock()
+            with pytest.raises(
+                DagsterInvariantViolationError,
+                match="must return a str",
+            ):
+                with engine.connect() as conn:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: get_conn_string XOR validation
+# ---------------------------------------------------------------------------
+
+
+class TestGetConnStringValidation:
+    """Test the XOR validation: exactly one of password or password_provider."""
+
+    def test_password_only_builds_valid_uri(self):
+        uri = get_conn_string(
+            username="foo", password="bar", hostname="host", db_name="db"
+        )
+        assert uri == "postgresql://foo:bar@host:5432/db"
+
+    def test_password_provider_only_builds_uri_with_empty_password(self):
+        uri = get_conn_string(
+            username="foo",
+            password_provider="my_module.get_token",
+            hostname="host",
+            db_name="db",
+        )
+        # Password placeholder is empty since the real token is injected at connect time
+        assert uri == "postgresql://foo:@host:5432/db"
+
+    def test_neither_provided_raises(self):
+        with pytest.raises(
+            check.CheckError,
+            match="exactly one of `password` or `password_provider`",
+        ):
+            get_conn_string(username="foo", hostname="host", db_name="db")
+
+    def test_both_provided_raises(self):
+        with pytest.raises(
+            check.CheckError,
+            match="exactly one of `password` or `password_provider`",
+        ):
+            get_conn_string(
+                username="foo",
+                password="bar",
+                hostname="host",
+                db_name="db",
+                password_provider="my_module.get_token",
+            )
+
+    def test_special_characters_in_password_are_url_encoded(self):
+        uri = get_conn_string(
+            username="user", password="p@ss:w0rd", hostname="h", db_name="d"
+        )
+        # quote() encodes @ and : but not /
+        assert "p%40ss%3Aw0rd" in uri


### PR DESCRIPTION
## Summary

Resolves #33427

`dagster-postgres` bakes the database password into the SQLAlchemy connection URL at startup. When using short-lived credentials (Azure AD access tokens, AWS IAM tokens), the password expires after ~60 minutes, but new connections continue to use the stale token from the URL. This causes long-running workloads (daemon, sensors, schedules) to fail with authentication errors.

## Changes

Adds a [password_provider](cci:1://file:///c:/Users/aakas/Documents/Dagster/dagster/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py:54:0-57:15) configuration option that hooks into SQLAlchemy's [do_connect](cci:1://file:///c:/Users/aakas/Documents/Dagster/dagster/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py:234:4-248:38) event to dynamically inject a fresh password/token on every new database connection.

### Configuration

```yaml
# dagster.yaml
storage:
  postgres:
    postgres_db:
      username: dagster
      hostname: my-pg-host
      db_name: dagster
      password_provider: my_package.auth.get_azure_ad_token
