### PR TITLE
[dagster-dbt] Validate mixed partition defs and op-name collisions in DbtProjectComponent (fixes #33441)

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -19,6 +19,7 @@ from dagster_dbt.asset_utils import (
     DBT_DEFAULT_EXCLUDE,
     DBT_DEFAULT_SELECT,
     DBT_DEFAULT_SELECTOR,
+    _validate_no_mixed_partitions_defs,
     build_dbt_specs,
 )
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_translator
@@ -322,6 +323,8 @@ def dbt_assets(
         io_manager_key=io_manager_key,
         project=project,
     )
+
+    _validate_no_mixed_partitions_defs(specs)
 
     if op_tags and DAGSTER_DBT_SELECT_METADATA_KEY in op_tags:
         raise DagsterInvalidDefinitionError(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -22,6 +22,7 @@ from dagster import (
     DagsterInvariantViolationError,
     DefaultScheduleStatus,
     OpExecutionContext,
+    PartitionsDefinition,
     RunConfig,
     ScheduleDefinition,
     TableColumn,
@@ -844,6 +845,41 @@ def _build_child_map(manifest: Mapping[str, Any]) -> Mapping[str, AbstractSet[st
         for upstream_unique_id in get_upstream_unique_ids(manifest, node):
             child_map[upstream_unique_id].add(unique_id)
     return child_map
+
+
+def _validate_no_mixed_partitions_defs(specs: Sequence[AssetSpec]) -> None:
+    """Raise DagsterInvalidDefinitionError if specs contain two or more distinct non-None partitions_defs.
+
+    dbt's execution model uses a single op with a single execution context and a single
+    partition_key. It cannot simultaneously satisfy two incompatible partition key formats within
+    the same op run, so mixed partitions definitions are not supported within a single
+    @dbt_assets decorator or DbtProjectComponent.
+    """
+    partitions_defs_by_key: dict[AssetKey, PartitionsDefinition] = {
+        spec.key: spec.partitions_def for spec in specs if spec.partitions_def is not None
+    }
+    unique_partitions_defs = set(partitions_defs_by_key.values())
+    if len(unique_partitions_defs) <= 1:
+        return
+
+    assets_by_partitions_def: dict[PartitionsDefinition, list[str]] = defaultdict(list)
+    for key, partitions_def in partitions_defs_by_key.items():
+        assets_by_partitions_def[partitions_def].append(key.to_user_string())
+
+    details = "\n".join(
+        f"  {partitions_def!r}: {asset_keys}"
+        for partitions_def, asset_keys in assets_by_partitions_def.items()
+    )
+    raise DagsterInvalidDefinitionError(
+        "dbt assets cannot include assets with more than one distinct partitions definition."
+        " dbt's execution model uses a single op context with a single partition key, which"
+        " cannot simultaneously satisfy incompatible partition key formats.\n\n"
+        f"Detected {len(unique_partitions_defs)} distinct partitions definitions:\n{details}\n\n"
+        "To resolve this, split the assets into separate @dbt_assets decorators or"
+        " DbtProjectComponent instances — one per partitions definition. When using"
+        " DbtProjectComponent, set a unique `op.name` on each component to avoid op-name"
+        " collisions."
+    )
 
 
 def build_dbt_specs(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -33,6 +33,7 @@ from dagster_dbt.asset_utils import (
     DBT_DEFAULT_EXCLUDE,
     DBT_DEFAULT_SELECT,
     DBT_DEFAULT_SELECTOR,
+    _validate_no_mixed_partitions_defs,
     build_dbt_specs,
     get_node,
 )
@@ -230,9 +231,13 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
     ] = True
 
     @property
+    def defs_state_discriminator(self) -> str:
+        return self._project_manager.defs_state_discriminator
+
+    @property
     def defs_state_config(self) -> DefsStateConfig:
         return DefsStateConfig(
-            key=f"DbtProjectComponent[{self._project_manager.defs_state_discriminator}]",
+            key=f"DbtProjectComponent[{self.defs_state_discriminator}]",
             management_type=DefsStateManagementType.LOCAL_FILESYSTEM,
             refresh_if_dev=self.prepare_if_dev,
         )
@@ -263,6 +268,40 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
                 }
             )
         )
+
+    def validate_no_op_name_collision(self, context: dg.ComponentLoadContext) -> None:
+        """Raise DagsterInvalidDefinitionError if a sibling DbtProjectComponent targets the
+        same dbt project and also uses the default op name.
+
+        When two components share the same dbt project but select different model subsets,
+        the default op name (project.name) is identical for both. This causes build_node_deps
+        to silently rename one op with a ``_2`` suffix, breaking cross-component dependency
+        wiring.
+        """
+        has_explicit_name = self.op is not None and self.op.name is not None
+        if has_explicit_name:
+            return
+
+        my_discriminator = self.defs_state_discriminator
+
+        siblings = context.component_tree.get_all_components(type(self))
+        for sibling in siblings:
+            if sibling is self:
+                continue
+            sibling_has_explicit_name = sibling.op is not None and sibling.op.name is not None
+            if sibling_has_explicit_name:
+                continue
+            if sibling.defs_state_discriminator != my_discriminator:
+                continue
+
+            raise dg.DagsterInvalidDefinitionError(
+                f"Two DbtProjectComponent instances target the same dbt project"
+                f" ({my_discriminator!r}) and neither sets an explicit op name. This causes"
+                f" op-name collisions that break cross-component dependency wiring.\n\n"
+                f"Set a unique `op.name` on each component in your defs.yaml:\n\n"
+                f"    op:\n"
+                f"      name: {my_discriminator}_<unique_suffix>"
+            )
 
     @cached_property
     def translator(self) -> "DagsterDbtTranslator":
@@ -383,7 +422,12 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
             project=project,
             io_manager_key=None,
         )
+
+        _validate_no_mixed_partitions_defs(asset_specs)
+
         op_spec = self._get_op_spec(project)
+
+        self.validate_no_op_name_collision(context)
 
         @dg.multi_asset(
             specs=asset_specs,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import dagster as dg
 import pytest
@@ -798,3 +798,48 @@ def test_upstream_source_metadata_flows_to_stub_asset() -> None:
     assert len(deps) == 1
     assert deps[0].asset_key == AssetKey("foo_upstream_defined")
     assert deps[0].metadata["dagster/table_name"] == table_name
+
+
+def test_op_name_collision_same_project_raises(dbt_path: Path) -> None:
+    """Two DbtProjectComponent instances on the same project with no explicit op.name
+    must raise DagsterInvalidDefinitionError (issue #33441, Bug B).
+    """
+    comp_a = DbtProjectComponent(project=DbtProject(dbt_path))
+    comp_b = DbtProjectComponent(project=DbtProject(dbt_path))
+
+    mock_context = MagicMock()
+    mock_context.component_tree.get_all_components.return_value = [comp_a, comp_b]
+
+    with pytest.raises(dg.DagsterInvalidDefinitionError):
+        comp_a.validate_no_op_name_collision(mock_context)
+
+
+def test_op_name_collision_explicit_name_ok(dbt_path: Path) -> None:
+    """If one component sets an explicit op.name, no collision error is raised."""
+    comp_a = DbtProjectComponent(project=DbtProject(dbt_path))
+    comp_b = DbtProjectComponent(project=DbtProject(dbt_path), op=OpSpec(name="my_unique_op"))
+
+    mock_context = MagicMock()
+    mock_context.component_tree.get_all_components.return_value = [comp_a, comp_b]
+
+    # comp_a has no explicit name but sibling comp_b does → no collision
+    comp_a.validate_no_op_name_collision(mock_context)
+
+    # comp_b has explicit name → skips validation entirely
+    comp_b.validate_no_op_name_collision(mock_context)
+
+
+def test_op_name_collision_different_projects_ok(dbt_path: Path) -> None:
+    """Two components on different projects with no explicit op.name is fine."""
+    comp_a = DbtProjectComponent(project=DbtProject(dbt_path))
+
+    # Create a mock component with a different project discriminator
+    comp_b = MagicMock(spec=DbtProjectComponent)
+    comp_b.op = None
+    type(comp_b).defs_state_discriminator = PropertyMock(return_value="different_project")
+
+    mock_context = MagicMock()
+    mock_context.component_tree.get_all_components.return_value = [comp_a, comp_b]
+
+    # Different projects → no collision
+    comp_a.validate_no_op_name_collision(mock_context)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -842,6 +842,39 @@ def test_with_varying_partitions_defs(test_jaffle_shop_manifest: dict[str, Any])
             assert partitions_def is None, spec.key
 
 
+def test_with_mixed_distinct_partitions_defs_raises(
+    test_jaffle_shop_manifest: dict[str, Any],
+) -> None:
+    """Two distinct non-None partitions defs in the same @dbt_assets must raise a clear error.
+
+    dbt's execution model uses a single op context with a single partition_key and cannot
+    simultaneously satisfy incompatible partition key formats (issue #33441).
+    """
+    daily_partitions = DailyPartitionsDefinition(start_date="2023-01-01")
+    static_partitions = StaticPartitionsDefinition(partition_keys=["a", "b"])
+    keys_with_daily = {AssetKey("customers"), AssetKey("orders")}
+    keys_with_static = {AssetKey("stg_orders")}
+
+    class MixedPartitionsTranslator(DagsterDbtTranslator):
+        def get_partitions_def(
+            self, dbt_resource_props: Mapping[str, Any]
+        ) -> PartitionsDefinition | None:
+            asset_key = super().get_asset_key(dbt_resource_props)
+            if asset_key in keys_with_daily:
+                return daily_partitions
+            if asset_key in keys_with_static:
+                return static_partitions
+            return None
+
+    with pytest.raises(DagsterInvalidDefinitionError):
+
+        @dbt_assets(
+            manifest=test_jaffle_shop_manifest,
+            dagster_dbt_translator=MixedPartitionsTranslator(),
+        )
+        def my_dbt_assets(): ...
+
+
 def test_dbt_meta_auto_materialize_policy(test_meta_config_manifest: dict[str, Any]) -> None:
     expected_auto_materialize_policy = AutoMaterializePolicy.eager()
     expected_specs_by_key = {


### PR DESCRIPTION
## Summary & Motivation

Fixes #33441. Two independent bugs appear in sequence when users try to use `DbtProjectComponent` with partitioned assets that require different partition definitions.

---

**Bug A: mixed partition definitions within a single component**

Tracing the execution path: when a `DagsterDbtTranslator.get_partitions_def()` returns different `PartitionsDefinition` types for different models (e.g. `MultiPartitionsDefinition` for some, `TimeWindowPartitionsDefinition` for others), the definition layer accepts it fine because `can_subset=True` and `allow_different_partitions_defs=True`. The failure is deferred to runtime.

At runtime, all selected models execute inside a single op with a single `AssetExecutionContext`. When the job runs the multi-partition subset, `context.partition_key` is a composite string like `2026-02-09|XRP/USDT`. The component's [`get_cli_args`](https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py#L456) tries `context.partition_time_window`, which internally calls `TimeWindowPartitionsDefinition.time_window_for_partition_key` on that composite string and raises `ValueError: time data '2026-02-09|XRP/USDT' does not match format '%Y-%m-%d%z'`. The traceback points at the partition parsing internals with no mention of the translator or which asset caused it.

Fix: `_validate_no_mixed_partitions_defs()` in `asset_utils.py`. It collects distinct non-`None` `PartitionsDefinition` values across all `AssetSpec` objects returned by `build_dbt_specs()` and raises `DagsterInvalidDefinitionError` at definition time if there are two or more, listing each partition definition and the assets using it, and pointing to the split-component workaround. Called from both `@dbt_assets` and `DbtProjectComponent.build_defs_from_state` immediately after `build_dbt_specs()`.

---

**Bug B: op-name collision when splitting into two components**

The recommended workaround for Bug A is to split the assets across two `DbtProjectComponent` instances, one per partition definition. But when both components point to the same dbt project, their default op name is `project.name`, so both resolve to the same string.

Tracing into [`build_node_deps`](https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_core/definitions/assets/job/asset_job.py#L425): it iterates over all `AssetsDefinition` objects, tracks name collisions in a `dict[str, int]`, and silently renames the second op to `<name>_2` ([line 444](https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_core/definitions/assets/job/asset_job.py#L444)). Cross-component dependency lookups then try to find a specific asset key as an output of `<name>_2`, which does not have it, producing `DagsterInvalidDefinitionError: node "<name>_2" does not have output "<asset>"`. The fact that explicitly setting `op.name` on both components (the user-discovered workaround) immediately fixes it confirms the diagnosis.

Fix: `validate_no_op_name_collision()` on `DbtProjectComponent`. It calls `context.component_tree.get_all_components(type(self))` to enumerate sibling components of the same concrete type at load time, and raises `DagsterInvalidDefinitionError` if any sibling shares the same `defs_state_discriminator` (the lightweight project identity string on `DbtProjectManager`: directory stem for `DbtProjectArgsManager`, repo URL for `RemoteGitDbtProjectManager`, project name for `NoopDbtProjectManager`) without an explicit `op.name` set. The error message includes a concrete `defs.yaml` snippet.

A public `defs_state_discriminator` property is added to `DbtProjectComponent` so the validation can compare siblings via `sibling.defs_state_discriminator` without reaching into `sibling._project_manager` (a private attribute on another instance).

**Note on a related TODO in `asset_job.py`:** while tracing Bug B, the `other_keys` block at [line 273](https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_core/definitions/assets/job/asset_job.py#L273) also stood out. It forces all op output keys into the job graph because [`compute.py:69`](https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_core/execution/plan/compute.py#L69) calls `asset_graph.get()` unconditionally, which hard-crashes on a missing key. Guarding that call looks like a clean fix but it touches core execution machinery, so leaving it for a separate issue.

## How I Tested These Changes

Four new unit tests:

- `test_with_mixed_distinct_partitions_defs_raises` in `test_asset_decorator.py`: uses `@dbt_assets` with a custom translator that returns `DailyPartitionsDefinition` for some models and `StaticPartitionsDefinition` for others; asserts `DagsterInvalidDefinitionError` is raised at decoration time, before any op is created.
- `test_op_name_collision_same_project_raises` in `test_dbt_project_component.py`: two `DbtProjectComponent` instances pointing at the same project path, no explicit `op.name`; asserts the new validation raises.
- `test_op_name_collision_explicit_name_ok`: same setup but one component carries an explicit `op.name`; asserts no error for either component.
- `test_op_name_collision_different_projects_ok`: two components on different projects, no explicit `op.name`; asserts no error.

## Changelog

- [dagster-dbt] Fixed a cryptic `ValueError` raised at runtime when a `DagsterDbtTranslator` returns distinct `PartitionsDefinition` values for different models within the same `@dbt_assets` or `DbtProjectComponent`; a clear `DagsterInvalidDefinitionError` is now raised at definition time with the conflicting assets named.
- [dagster-dbt] Fixed a `DagsterInvalidDefinitionError` about a missing op output when two `DbtProjectComponent` instances target the same dbt project without an explicit `op.name`; a clear error is now raised at component load time with a `defs.yaml` fix snippet.