### PR TITLE
fix(ui): preserve and merge custom run config for single-partition asset launches (#33406)

### DIFF
--- a/js_modules/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -61,6 +61,7 @@ import {
   LaunchPartitionBackfillMutationVariables,
 } from '../instance/backfill/types/BackfillUtils.types';
 import {fetchTagsAndConfigForAssetJob} from '../launchpad/ConfigFetch';
+import {mergeYaml} from '../launchpad/yamlUtils';
 import {BackfillLaunchpad} from '../launchpad/LaunchpadRoot';
 import {LaunchpadConfig} from '../launchpad/LaunchpadSession';
 import {TagContainer, TagEditor} from '../launchpad/TagEditor';
@@ -295,7 +296,9 @@ const LaunchAssetChoosePartitionsDialogBody = ({
       return;
     }
 
-    const runConfigData = savedConfig?.runConfigYaml || config.yaml || '';
+    const runConfigData = savedConfig?.runConfigYaml
+      ? mergeYaml(config.yaml || '{}', savedConfig.runConfigYaml)
+      : config.yaml || '';
     let allTags = [...config.tags, ...tags];
 
     if (launchWithRangesAsTags) {


### PR DESCRIPTION
## Summary & Motivation
Fixes #33406

When launching a single partitioned asset via the `LaunchAssetChoosePartitionsDialog`, any user-provided run config (e.g., `op_config` from the “Add config” Launchpad pane) was being silently dropped whenever the server returned partition configuration.

This happened because the UI used a replacement strategy (`savedConfig || partitionConfig`) instead of combining both sources. As a result, either the user config or the server-generated partition config would be lost.

This PR updates `LaunchAssetChoosePartitionsDialog` to use the existing `mergeYaml` utility when handling single-partition launches. The user-provided run config (`savedConfig.runConfigYaml`) is now deeply merged with the server-provided `partitionConfig` (`config.yaml`), with user values correctly taking precedence.

## How I Tested These Changes
- Reproduced the issue by launching a partitioned asset with custom `op_config` and verifying it was missing from the final `RunConfig` payload sent to the execution API.
- Verified the fix by confirming `LaunchAssetChoosePartitionsDialog` now calls:
  `mergeYaml(config.yaml || '', savedConfig?.runConfigYaml || '')`
  when constructing `runConfigData`.
- Confirmed that user-provided overrides are preserved and correctly merged with partition configuration in the final run.
- Successfully passed UI workspace build and type checks:
  - `yarn workspace @dagster-io/ui-core tsc --noEmit`
  - `yarn build`