### PR TITLE
:bug: fix calling __enter__ on nested ResourceDependency during parent resource setup

### DIFF
--- a/js_modules/.gitignore
+++ b/js_modules/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+**/node_modules
 
 # testing
 /coverage

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -934,11 +934,7 @@ def _call_resource_fn_with_default(
     else:
         result = cast("ResourceFunctionWithoutContext", obj.resource_fn)()
 
-    is_fn_generator = (
-        inspect.isgenerator(obj.resource_fn)
-        or isinstance(obj.resource_fn, contextlib.ContextDecorator)
-        or isinstance(result, contextlib.AbstractContextManager)
-    )
+    is_fn_generator = inspect.isgenerator(result) or isinstance(result, contextlib.ContextDecorator)
     if is_fn_generator:
         return stack.enter_context(cast("contextlib.AbstractContextManager", result))
     else:

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -482,6 +482,45 @@ def test_nested_resource_raw_value() -> None:
     assert executed["yes"]
 
 
+def test_nested_resource_dependency_does_not_enter_context_manager() -> None:
+    """Test that Dagster does not call __enter__ on non-resource objects nested via ResourceDependency,
+    even if they implement the context manager protocol.
+
+    Regression test for https://github.com/dagster-io/dagster/issues/33511.
+    """
+
+    class MyObject:
+        def __init__(self) -> None:
+            self.is_open = False
+
+        def __enter__(self) -> "MyObject":
+            self.is_open = True
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            self.is_open = False
+
+    class MyResource(dg.ConfigurableResource):
+        my_object: dg.ResourceDependency[MyObject]
+
+    executed = {}
+
+    @dg.asset
+    def my_asset(my_resource: MyResource) -> None:
+        assert not my_resource.my_object.is_open, (
+            "Dagster should not call __enter__ on nested ResourceDependency objects"
+        )
+        executed["yes"] = True
+
+    my_object = MyObject()
+    defs = dg.Definitions(
+        assets=[my_asset],
+        resources={"my_resource": MyResource(my_object=my_object)},
+    )
+    assert defs.resolve_implicit_global_asset_job_def().execute_in_process().success
+    assert executed["yes"]
+
+
 def test_nested_resource_raw_value_io_manager() -> None:
     class MyMultiwriteIOManager(dg.ConfigurableIOManager):
         base_io_manager: dg.ResourceDependency[dg.IOManager]


### PR DESCRIPTION
## Summary & Motivation

Resolve #33511 

## How I Tested These Changes

Added a test

## Changelog

fixed a bug where Dagster called `__enter__` on nested resource attribute annotated with `dagster.ResourceDependency` during parent resource setup