### PR TITLE
fix(dbt): make dbt-core optional to avoid shadowing external runtimes like dbt-fusion (#33513)

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -43,8 +43,8 @@ def select_unique_ids(
     elif DBT_PYTHON_VERSION is not None:
         return _select_unique_ids_from_manifest(select, exclude, selector, manifest_json)
     else:
-        # in theory, as long as dbt-core is a dependency of dagster-dbt, this can't happen, but adding
-        # this for now to be safe
+        # dbt-core is optional in dagster-dbt. dbt Cloud users without an adapter package
+        # (which would pull dbt-core transitively) must install dagster-dbt[core] explicitly.
         check.failed(
             "dbt-core is not installed and no `project` was passed to `select_unique_ids`. "
             "This can happen if you are using the dbt Cloud integration without the dbt-core package installed."

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_fusion_support.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_fusion_support.py
@@ -1,10 +1,55 @@
 import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 import dagster as dg
 import pytest
 from dagster_dbt import DbtCliResource, DbtProject, dbt_assets
 
 from dagster_dbt_tests.dbt_projects import test_fusion_compatible_jaffle_shop_path
+
+
+def test_package_root_imports_without_dbt_core() -> None:
+    package_root = Path(__file__).resolve().parents[2]
+    script = """
+import builtins
+
+real_import = builtins.__import__
+
+def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "dbt" or name.startswith("dbt."):
+        raise ModuleNotFoundError(name)
+    return real_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = blocked_import
+
+import dagster_dbt
+from dagster_dbt import DbtCliResource, DbtProject, dbt_assets
+from dagster_dbt.compat import DBT_PYTHON_VERSION
+
+assert dagster_dbt.__version__
+assert DbtCliResource is not None
+assert DbtProject is not None
+assert dbt_assets is not None
+assert DBT_PYTHON_VERSION is None
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(
+                [os.fspath(package_root), os.environ.get("PYTHONPATH", "")]
+            ).rstrip(os.pathsep),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.fixture(name="project", scope="module")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_fusion_support.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_fusion_support.py
@@ -1,8 +1,10 @@
+import importlib
 import json
 import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest import mock
 
 import dagster as dg
 import pytest
@@ -93,3 +95,30 @@ def test_basic(project: DbtProject, fail: bool) -> None:
     else:
         assert n_materializations == n_assets
         assert n_check_evaluations == n_checks
+
+
+def test_select_unique_ids_raises_without_dbt_core_or_project() -> None:
+    """Regression: dbt Cloud users without an adapter package (no dbt-core) must get a clear error."""
+    from dagster_dbt.utils import select_unique_ids
+    from dagster_shared.check import CheckError
+
+    blocked = {
+        "dbt": None,
+        **{k: None for k in list(sys.modules) if k.startswith("dbt.")},
+    }
+    import dagster_dbt.compat as compat_mod
+
+    with mock.patch.dict(sys.modules, blocked):
+        importlib.reload(compat_mod)
+        with mock.patch("dagster_dbt.utils.DBT_PYTHON_VERSION", None):
+            with pytest.raises(CheckError, match="dbt-core is not installed"):
+                select_unique_ids(
+                    select="fqn:*",
+                    exclude="",
+                    selector="",
+                    project=None,
+                    manifest_json={},
+                )
+
+    # Restore compat module state so DBT_PYTHON_VERSION is not permanently None
+    importlib.reload(compat_mod)

--- a/python_modules/libraries/dagster-dbt/pyproject.toml
+++ b/python_modules/libraries/dagster-dbt/pyproject.toml
@@ -19,9 +19,6 @@ classifiers = [
 ]
 dependencies = [
     "dagster==1!0+dev",
-    # Follow the version support constraints for dbt Core:
-    # https://docs.getdbt.com/docs/dbt-versions/core
-    "dbt-core>=1.7,<1.12",
     "gitpython",
     "Jinja2",
     "networkx",
@@ -44,6 +41,11 @@ dagster-dbt = "dagster_dbt.cli.app:app"
 dagster_dbt = "dagster_dbt"
 
 [project.optional-dependencies]
+core = [
+    # Follow the version support constraints for dbt Core:
+    # https://docs.getdbt.com/docs/dbt-versions/core
+    "dbt-core>=1.7,<1.12",
+]
 # used for dbtfusion tests that don't use adapters
 test-bare = [
     "pytest-rerunfailures",

--- a/python_modules/libraries/dagster-dbt/pyproject.toml
+++ b/python_modules/libraries/dagster-dbt/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "sqlglot[rs]<28.1.0",  # FW-731
     "typer>=0.9.0",
     "packaging",
+    "msgpack",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary & Motivation
Fixes #33513

`dagster-dbt` currently declares `dbt-core` as a required dependency. Installing `dbt-core` places a local `dbt` executable wrapper inside the virtual environment (`venv/bin/dbt` or `venv/Scripts/dbt.exe`).

Because virtual environment binaries take precedence in `$PATH`, this local wrapper unintentionally shadows external runtimes such as the Rust-based `dbt-fusion`. As a result, Dagster may resolve the Python `dbt-core` shim (without adapters) instead of the fully configured `dbt-fusion` runtime, leading to runtime failures such as:

> "Could not find adapter type bigquery!"

This PR moves `dbt-core` from required `dependencies` into `optional-dependencies[core]`. This allows users to opt into the Python runtime when needed, while enabling seamless usage of external runtimes like `dbt-fusion`.

## Backward Compatibility
This change is backward compatible:

- Adapter packages (for example `dbt-snowflake`, `dbt-duckdb`, `dbt-sqlite`) already depend on `dbt-core` and continue to pull it transitively.
- Users who explicitly rely on the Python `dbt-core` CLI can install `dagster-dbt[core]`.
- The package root already tolerates missing `dbt-core`; this PR adds regression coverage for that contract.

## How I Tested These Changes
- Added a subprocess regression in `dagster_dbt_tests/core/test_fusion_support.py` that blocks all `dbt.*` imports and verifies `import dagster_dbt` plus key public exports still work when `dbt-core` is absent.
- Verified standard dbt-core behavior with a local `DbtCliResource(...).cli(["parse"])` smoke test against the `jaffle_shop` test project.
- The existing Fusion end-to-end path in `dagster_dbt_tests/core/test_fusion_support.py` still requires the env-backed CI/provisioned test environment.