### PR TITLE
fix(dbt): correctly treat dbt-fusion test status pass as successful in asset checks (#33512)

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -33,7 +33,7 @@ from dagster_dbt.asset_utils import (
     get_asset_check_key_for_test,
     get_checks_on_sources_upstream_of_selected_assets,
 )
-from dagster_dbt.compat import REFABLE_NODE_TYPES, NodeStatus, NodeType, TestStatus
+from dagster_dbt.compat import REFABLE_NODE_TYPES, NodeType
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_translator
 from dagster_dbt.dbt_manifest import DbtManifestParam, validate_manifest
 from dagster_dbt.dbt_project import DbtProject
@@ -43,6 +43,23 @@ logger = get_dagster_logger()
 # depending on the specific dbt version, any of these values
 # may be used to indicate an empty value in a log message
 _EMPTY_VALUES = {"", "None", None}
+_STATUS_PASS = "pass"
+_STATUS_SKIPPED = "skipped"
+_STATUS_SUCCESS = "success"
+_STATUS_WARN = "warn"
+
+
+def _normalize_status(status: Any) -> str:
+    while hasattr(status, "value"):
+        next_status = status.value
+        if next_status is status:
+            break
+        status = next_status
+
+    if isinstance(status, str):
+        return status.strip().lower()
+
+    return str(status).strip().lower()
 
 
 class EventHistoryMetadata(NamedTuple):
@@ -269,14 +286,14 @@ class DbtCliEventMessage(ABC):
         return (
             resource_props["resource_type"] in REFABLE_NODE_TYPES
             and materialized_type != "ephemeral"
-            and self._get_node_status() == NodeStatus.Success
+            and self._get_node_status() == _STATUS_SUCCESS
         )
 
     def _is_test_execution_event(self, manifest: Mapping[str, Any]) -> bool:
         resource_props = self._get_resource_props(self._unique_id, manifest)
         return (
             resource_props["resource_type"] == NodeType.Test
-            and self._get_node_status() != NodeStatus.Skipped
+            and self._get_node_status() != _STATUS_SKIPPED
         )
 
     def _get_resource_props(self, unique_id: str, manifest: Mapping[str, Any]) -> dict[str, Any]:
@@ -331,11 +348,12 @@ class DbtCliEventMessage(ABC):
         # if model materialization is incremental microbatch, node_status
         # property is "None", hence fall back to status
         raw_node_status = self._raw_node_info.get("node_status")
-        return (
+        status = (
             raw_node_status
             if raw_node_status and raw_node_status not in _EMPTY_VALUES
-            else self._raw_data["status"].lower()
+            else self._raw_data["status"]
         )
+        return _normalize_status(status)
 
     def _get_lineage_metadata(
         self,
@@ -591,13 +609,11 @@ class DbtCoreCliEventMessage(DbtCliEventMessage):
         ) and not unique_id.startswith("unit_test")
 
     def _get_check_passed(self) -> bool:
-        return self._get_node_status() == TestStatus.Pass
+        return self._get_node_status() == _STATUS_PASS
 
     def _get_check_severity(self) -> AssetCheckSeverity:
         node_status = self._get_node_status()
-        return (
-            AssetCheckSeverity.WARN if node_status == NodeStatus.Warn else AssetCheckSeverity.ERROR
-        )
+        return AssetCheckSeverity.WARN if node_status == _STATUS_WARN else AssetCheckSeverity.ERROR
 
 
 class DbtFusionCliEventMessage(DbtCliEventMessage):
@@ -608,10 +624,8 @@ class DbtFusionCliEventMessage(DbtCliEventMessage):
         return self.raw_event["info"]["name"] == "NodeFinished"
 
     def _get_check_passed(self) -> bool:
-        return self._get_node_status() in (NodeStatus.Success, TestStatus.Pass)
+        return self._get_node_status() in (_STATUS_SUCCESS, _STATUS_PASS)
 
     def _get_check_severity(self) -> AssetCheckSeverity:
         node_status = self._get_node_status()
-        return (
-            AssetCheckSeverity.WARN if node_status == NodeStatus.Warn else AssetCheckSeverity.ERROR
-        )
+        return AssetCheckSeverity.WARN if node_status == _STATUS_WARN else AssetCheckSeverity.ERROR

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_dbt_cli_event.py
@@ -1,44 +1,150 @@
-from dagster_dbt.core.dbt_cli_event import DbtFusionCliEventMessage
+from dagster import AssetCheckEvaluation, AssetMaterialization, IntMetadataValue, TextMetadataValue
+from dagster_dbt.core.dbt_cli_event import DbtCoreCliEventMessage, DbtFusionCliEventMessage
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+
+MANIFEST = {
+    "metadata": {"adapter_type": "duckdb", "project_name": "my_project"},
+    "nodes": {
+        "model.my_project.my_model": {
+            "unique_id": "model.my_project.my_model",
+            "name": "my_model",
+            "resource_type": "model",
+            "depends_on": {"nodes": []},
+            "config": {"materialized": "table"},
+            "meta": {},
+            "description": "",
+            "package_name": "my_project",
+            "path": "models/my_model.sql",
+            "original_file_path": "models/my_model.sql",
+        },
+        "test.my_project.my_test": {
+            "unique_id": "test.my_project.my_test",
+            "name": "my_test",
+            "resource_type": "test",
+            "depends_on": {"nodes": ["model.my_project.my_model"]},
+            "attached_node": "model.my_project.my_model",
+            "config": {},
+            "meta": {},
+            "description": "",
+            "package_name": "my_project",
+            "path": "tests/my_test.sql",
+            "original_file_path": "tests/my_test.sql",
+        },
+    },
+}
 
 
-def test_dbt_fusion_cli_event_message_get_check_passed():
-    # 1. Success test event (what dbt-fusion emits: "pass")
-    success_test_event = {
-        "info": {"name": "NodeFinished", "msg": "Test passed", "invocation_id": "1"},
+def _build_core_test_event(node_status: str, status: str | None = None) -> dict[str, object]:
+    return {
+        "info": {"name": "LogTestResult", "msg": "Core test event", "invocation_id": "core-1"},
         "data": {
-            "node_info": {"unique_id": "test.my_project.my_test", "node_status": "pass"},
-            "status": "pass",
-            "num_failures": 0,
+            "node_info": {"unique_id": "test.my_project.my_test", "node_status": node_status},
+            "status": status or node_status,
+            "num_failures": 0 if node_status == "pass" else 1,
         },
     }
 
-    # 2. Failed test event
-    failed_test_event = {
-        "info": {"name": "NodeFinished", "msg": "Test failed", "invocation_id": "2"},
+
+def _build_fusion_event(unique_id: str, node_status: str, status: str | None = None) -> dict[str, object]:
+    return {
+        "info": {"name": "NodeFinished", "msg": "Fusion event", "invocation_id": "fusion-1"},
         "data": {
-            "node_info": {"unique_id": "test.my_project.my_test", "node_status": "fail"},
-            "status": "fail",
-            "num_failures": 1,
+            "node_info": {"unique_id": unique_id, "node_status": node_status},
+            "status": status or node_status,
+            "num_failures": 0 if node_status in {"pass", "success"} else 1,
         },
     }
 
-    # 3. Model success event (not a test, e.g. a model run that emits "success")
-    success_model_event = {
-        "info": {"name": "NodeFinished", "msg": "Model successful", "invocation_id": "3"},
-        "data": {
-            "node_info": {"unique_id": "model.my_project.my_model", "node_status": "success"},
-            "status": "success",
-        },
-    }
 
-    # Test 1: dbt-fusion test passing
-    msg1 = DbtFusionCliEventMessage(raw_event=success_test_event, event_history_metadata={})
-    assert msg1._get_check_passed() is True
+def _assert_check_evaluation(
+    event: object, *, passed: bool, check_name: str, asset_key_path: list[str], status: str, failed_row_count: int
+) -> None:
+    assert isinstance(event, AssetCheckEvaluation)
+    assert event.passed is passed
+    assert event.check_name == check_name
+    assert event.asset_key.path == asset_key_path
+    assert event.metadata["status"] == TextMetadataValue(text=status)
+    assert event.metadata["dagster_dbt/failed_row_count"] == IntMetadataValue(
+        value=failed_row_count
+    )
 
-    # Test 2: dbt-fusion test failing
-    msg2 = DbtFusionCliEventMessage(raw_event=failed_test_event, event_history_metadata={})
-    assert msg2._get_check_passed() is False
 
-    # Test 3: dbt-fusion model success
-    msg3 = DbtFusionCliEventMessage(raw_event=success_model_event, event_history_metadata={})
-    assert msg3._get_check_passed() is True
+def test_dbt_core_cli_event_to_default_asset_events_emits_expected_check_evaluation():
+    passing_test_event = _build_core_test_event("pass")
+    failing_test_event = _build_core_test_event("fail")
+
+    passing_events = list(
+        DbtCoreCliEventMessage(
+            raw_event=passing_test_event, event_history_metadata={}
+        ).to_default_asset_events(MANIFEST, DagsterDbtTranslator())
+    )
+    assert len(passing_events) == 1
+    _assert_check_evaluation(
+        passing_events[0],
+        passed=True,
+        check_name="my_test",
+        asset_key_path=["my_model"],
+        status="pass",
+        failed_row_count=0,
+    )
+
+    failing_events = list(
+        DbtCoreCliEventMessage(
+            raw_event=failing_test_event, event_history_metadata={}
+        ).to_default_asset_events(MANIFEST, DagsterDbtTranslator())
+    )
+    assert len(failing_events) == 1
+    _assert_check_evaluation(
+        failing_events[0],
+        passed=False,
+        check_name="my_test",
+        asset_key_path=["my_model"],
+        status="fail",
+        failed_row_count=1,
+    )
+
+
+def test_dbt_fusion_cli_event_to_default_asset_events_emits_expected_events():
+    success_test_event = _build_fusion_event("test.my_project.my_test", "pass")
+    failed_test_event = _build_fusion_event("test.my_project.my_test", "fail")
+    success_model_event = _build_fusion_event("model.my_project.my_model", "success")
+
+    passing_events = list(
+        DbtFusionCliEventMessage(
+            raw_event=success_test_event, event_history_metadata={}
+        ).to_default_asset_events(MANIFEST, DagsterDbtTranslator())
+    )
+    assert len(passing_events) == 1
+    _assert_check_evaluation(
+        passing_events[0],
+        passed=True,
+        check_name="my_test",
+        asset_key_path=["my_model"],
+        status="pass",
+        failed_row_count=0,
+    )
+
+    failing_events = list(
+        DbtFusionCliEventMessage(
+            raw_event=failed_test_event, event_history_metadata={}
+        ).to_default_asset_events(MANIFEST, DagsterDbtTranslator())
+    )
+    assert len(failing_events) == 1
+    _assert_check_evaluation(
+        failing_events[0],
+        passed=False,
+        check_name="my_test",
+        asset_key_path=["my_model"],
+        status="fail",
+        failed_row_count=1,
+    )
+
+    successful_model_events = list(
+        DbtFusionCliEventMessage(
+            raw_event=success_model_event, event_history_metadata={}
+        ).to_default_asset_events(MANIFEST, DagsterDbtTranslator())
+    )
+    assert len(successful_model_events) == 1
+    model_event = successful_model_events[0]
+    assert isinstance(model_event, AssetMaterialization)
+    assert model_event.asset_key.path == ["my_model"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_fusion_support.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_fusion_support.py
@@ -48,3 +48,4 @@ def test_basic(project: DbtProject, fail: bool) -> None:
     else:
         assert n_materializations == n_assets
         assert n_check_evaluations == n_checks
+        assert all(check_evaluation.passed for check_evaluation in result.get_asset_check_evaluations())


### PR DESCRIPTION
## Summary & Motivation
Fixes #33512

When using `dbt-fusion` (dbt CLI v2.x) with `dagster-dbt`, dbt tests that successfully complete are incorrectly reported as failed asset checks (`passed=False`) in the Dagster UI.

This happens because `DbtFusionCliEventMessage._get_check_passed()` currently determines success using a strict comparison against `NodeStatus.Success` (`"success"`). While model executions emit `"success"`, dbt tests in `dbt-fusion` emit a `"pass"` status.

Since `"pass" != "success"`, all successful test nodes are incorrectly marked as failed.

This PR updates `_get_check_passed()` to treat both:
- `NodeStatus.Success` (`"success"`) and  
- `TestStatus.Pass` (`"pass"`)

as successful outcomes when evaluating asset checks.

## Impact
- Fixes incorrect failure reporting for dbt test checks in Dagster UI
- Restores parity with `DbtCoreCliEventMessage`, which already handles `TestStatus.Pass` correctly
- Ensures consistent behavior across dbt runtimes (dbt-core and dbt-fusion)

## How I Tested These Changes
- Reviewed the existing `DbtCoreCliEventMessage` pipeline to confirm that `TestStatus.Pass` is treated as a success case.
- Created simulated `dbt-fusion` `NodeFinished` JSON payloads for:
  - `"pass"` (test success)
  - `"fail"` (test failure)
  - `"success"` (model execution)
- Verified that `msg._get_check_passed()` now evaluates to:
  - `True` for `"pass"`
  - `False` for `"fail"`
  - `True` for `"success"`
- Confirmed no changes to other execution paths or dependencies.