### PR TITLE
Resume job backfills when code location is temporarily unavailable

### DIFF
--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -148,7 +148,7 @@ def execute_backfill_iteration(
     )
 
 
-def _is_retryable_asset_backfill_error(e: Exception):
+def _is_retryable_backfill_error(e: Exception):
     # Retry on issues reaching or loading user code, or transient race conditions submitting runs.
     if isinstance(
         e, (DagsterUserCodeUnreachableError, DagsterCodeLocationLoadError, DagsterRunAlreadyExists)
@@ -203,7 +203,8 @@ def execute_backfill_iteration_with_instigation_logger(
                 e, (DagsterUserCodeUnreachableError, DagsterCodeLocationLoadError)
             ):
                 # Both asset and job backfills retry indefinitely on unreachable code server;
-                # failure_count is not incremented so as not to exhaust the retry budget.
+                # failure_count is not incremented and there is no retry-budget gate, so a
+                # code-server outage can never permanently consume the retry budget.
                 try:
                     raise DagsterUserCodeUnreachableError(
                         "Unable to reach the code server. Backfill will resume once the code server is available."
@@ -216,10 +217,9 @@ def execute_backfill_iteration_with_instigation_logger(
                     )
                     instance.update_backfill(backfill.with_error(error_info))
             elif (
-                backfill.is_asset_backfill
-                and backfill.status == BulkActionStatus.REQUESTED
+                backfill.status == BulkActionStatus.REQUESTED
                 and backfill.failure_count < _get_max_asset_backfill_retries()
-                and _is_retryable_asset_backfill_error(e)
+                and _is_retryable_backfill_error(e)
             ):
                 error_info = DaemonErrorCapture.process_exception(
                     sys.exc_info(),

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1196,7 +1196,7 @@ def test_job_backfill_code_server_unreachable_is_retried(
     assert backfill
     # Backfill must stay REQUESTED, not be moved to FAILING
     assert backfill.status == BulkActionStatus.REQUESTED
-    # failure_count must not be incremented — code server outages don't burn the retry budget
+    # failure_count must not be incremented — code server outages don't consume the retry budget
     assert backfill.failure_count == 0
     assert isinstance(backfill.error, SerializableErrorInfo)
 
@@ -1205,6 +1205,85 @@ def test_job_backfill_code_server_unreachable_is_retried(
     assert instance.get_runs_count() == 3
     backfill = instance.get_backfill(backfill_id)
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+
+
+def test_job_backfill_retryable_error_increments_failure_count(
+    instance, workspace_context, remote_repo
+):
+    """Job backfills should retry on transient (non-DagsterError) exceptions, incrementing
+    failure_count each time, and move to FAILING once the retry budget is exhausted — the same
+    behaviour as asset backfills.
+    """
+    partition_set = remote_repo.get_partition_set("comp_always_succeed_partition_set")
+    partition_keys = my_config.partitions_def.get_partition_keys()
+    backfill_id = "job_backfill_retryable_error"
+    instance.add_backfill(
+        PartitionBackfill(
+            backfill_id=backfill_id,
+            partition_set_origin=partition_set.get_remote_origin(),
+            status=BulkActionStatus.REQUESTED,
+            partition_names=partition_keys[:3],
+            from_failure=False,
+            reexecution_steps=None,
+            tags=None,
+            backfill_timestamp=get_current_timestamp(),
+        )
+    )
+    assert instance.get_runs_count() == 0
+
+    def raise_transient_error(*args, **kwargs):
+        raise Exception("transient non-DagsterError")
+
+    with mock.patch(
+        "dagster._daemon.backfill.execute_job_backfill_iteration",
+        side_effect=raise_transient_error,
+    ):
+        with environ({"DAGSTER_MAX_ASSET_BACKFILL_RETRIES": "2"}):
+            # First retry: failure_count → 1, stays REQUESTED
+            errors = [
+                e
+                for e in execute_backfill_iteration(
+                    workspace_context, get_default_daemon_logger("BackfillDaemon")
+                )
+                if e
+            ]
+            assert len(errors) == 1
+            backfill = instance.get_backfill(backfill_id)
+            assert backfill.status == BulkActionStatus.REQUESTED
+            assert backfill.failure_count == 1
+
+            # Second retry: failure_count → 2, stays REQUESTED
+            errors = [
+                e
+                for e in execute_backfill_iteration(
+                    workspace_context, get_default_daemon_logger("BackfillDaemon")
+                )
+                if e
+            ]
+            assert len(errors) == 1
+            backfill = instance.get_backfill(backfill_id)
+            assert backfill.status == BulkActionStatus.REQUESTED
+            assert backfill.failure_count == 2
+
+            # Budget exhausted (failure_count == max): moves to FAILING
+            errors = [
+                e
+                for e in execute_backfill_iteration(
+                    workspace_context, get_default_daemon_logger("BackfillDaemon")
+                )
+                if e
+            ]
+            assert len(errors) == 1
+            backfill = instance.get_backfill(backfill_id)
+            assert backfill.status == BulkActionStatus.FAILING
+            assert backfill.failure_count == 3
+            assert backfill.backfill_end_timestamp is None
+
+    # One more iteration (no mock) to cancel runs and finalize as FAILED
+    list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
+    backfill = instance.get_backfill(backfill_id)
+    assert backfill.status == BulkActionStatus.FAILED
+    assert backfill.backfill_end_timestamp is not None
 
 
 def test_unloadable_asset_backfill(instance, workspace_context):


### PR DESCRIPTION
## Summary & Motivation

Job backfills are cancelled when the daemon loses contact with the code location. Asset backfills are given opportunities to resume. This PR aims to treat them the same when this happens.

Addresses [Issue #33527](https://github.com/dagster-io/dagster/issues/33527)

## How I Tested These Changes

Built locally, ran tests.

## Changelog
