### PR TITLE
feat(asset-jobs): support deterministic execution ordering via AssetSelection

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -499,6 +499,34 @@ class AssetSelection(ABC):
 
         return self.resolve_inner(asset_graph, allow_missing=allow_missing)
 
+    def resolve_ordered(
+        self,
+        all_assets: Iterable[AssetsDefinition | SourceAsset] | BaseAssetGraph,
+        allow_missing: bool = False,
+    ) -> Sequence[AssetKey] | None:
+        """Returns the sequence of asset keys in the given graph that match this selection,
+        preserving the order in which they were specified in the selection if possible.
+        If no specific order was specified, returns None.
+
+        Args:
+            all_assets (Union[Iterable[Union[AssetsDefinition, SourceAsset]], AssetGraph]): The
+                assets to select from.
+            allow_missing (bool): Whether to ignore asset keys in the selection that are not
+                present in the asset graph. Defaults to False.
+        """
+        if isinstance(all_assets, BaseAssetGraph):
+            asset_graph = all_assets
+        else:
+            check.iterable_param(all_assets, "all_assets", (AssetsDefinition, SourceAsset))
+            asset_graph = AssetGraph.from_assets(all_assets)
+
+        return self.resolve_ordered_inner(asset_graph, allow_missing=allow_missing)
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None
+
     @abstractmethod
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
@@ -771,6 +799,17 @@ class AndAssetSelection(OperandListAssetSelection):
             ),
         )
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        resolved = self.resolve_inner(asset_graph, allow_missing)
+        # Intersection - take order from the first operand that has it
+        for operand in self.operands:
+            ordered = operand.resolve_ordered_inner(asset_graph, allow_missing)
+            if ordered is not None:
+                return [key for key in ordered if key in resolved]
+        return None
+
     def to_selection_str(self) -> str:
         return " and ".join(f"{operand.operand_to_selection_str()}" for operand in self.operands)
 
@@ -787,6 +826,29 @@ class OrAssetSelection(OperandListAssetSelection):
                 for selection in self.operands
             ),
         )
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        ordered_keys = []
+        seen = set()
+        any_ordered = False
+        for operand in self.operands:
+            operand_ordered = operand.resolve_ordered_inner(asset_graph, allow_missing)
+            if operand_ordered is not None:
+                any_ordered = True
+                for key in operand_ordered:
+                    if key not in seen:
+                        ordered_keys.append(key)
+                        seen.add(key)
+            else:
+                operand_resolved = sorted(list(operand.resolve_inner(asset_graph, allow_missing)))
+                for key in operand_resolved:
+                    if key not in seen:
+                        ordered_keys.append(key)
+                        seen.add(key)
+
+        return ordered_keys if any_ordered else None
 
     def resolve_checks_inner(  # pyright: ignore[reportIncompatibleMethodOverride]
         self, asset_graph: AssetGraph, allow_missing: bool
@@ -823,6 +885,15 @@ class SubtractAssetSelection(AssetSelection):
             asset_graph, allow_missing=allow_missing
         ) - self.right.resolve_checks_inner(asset_graph, allow_missing=allow_missing)
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        resolved = self.resolve_inner(asset_graph, allow_missing)
+        left_ordered = self.left.resolve_ordered_inner(asset_graph, allow_missing)
+        if left_ordered is None:
+            return None
+        return [key for key in left_ordered if key in resolved]
+
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return copy(
             self,
@@ -849,6 +920,24 @@ class ChainedAssetSelection(AssetSelection):
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return copy(self, child=self.child.to_serializable_asset_selection(asset_graph))
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        child_ordered = self.child.resolve_ordered_inner(asset_graph, allow_missing)
+        if child_ordered is None:
+            return None
+
+        full_resolved = self.resolve_inner(asset_graph, allow_missing)
+        returned = []
+        seen = set()
+        for key in child_ordered:
+            if key in full_resolved:
+                returned.append(key)
+                seen.add(key)
+
+        remaining = sorted([key for key in full_resolved if key not in seen])
+        return returned + remaining
 
 
 @whitelist_for_serdes
@@ -949,6 +1038,12 @@ class GroupsAssetSelection(AssetSelection):
                 group, require_materializable=not self.include_sources
             )
         }
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        # Group selection does not imply a specific user-requested execution order.
+        return None
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self
@@ -1232,6 +1327,18 @@ class KeysAssetSelection(AssetSelection):
                 )
 
         return specified_keys - missing_keys
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        resolved = self.resolve_inner(asset_graph, allow_missing)
+        seen = set()
+        ordered = []
+        for key in self.selected_keys:
+            if key in resolved and key not in seen:
+                ordered.append(key)
+                seen.add(key)
+        return ordered
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self

--- a/python_modules/dagster/dagster/_core/definitions/assets/job/asset_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/job/asset_job.py
@@ -208,14 +208,20 @@ class JobScopedAssetGraph(AssetGraph):
         asset_nodes_by_key: Mapping[AssetKey, AssetNode],
         assets_defs_by_check_key: Mapping[AssetCheckKey, AssetsDefinition],
         source_asset_graph: AssetGraph,
+        ordered_asset_keys: Sequence[AssetKey] | None = None,
     ):
         super().__init__(asset_nodes_by_key, assets_defs_by_check_key)
         self._source_asset_graph = source_asset_graph
+        self._ordered_asset_keys = ordered_asset_keys
 
     @property
     def source_asset_graph(self) -> AssetGraph:
         """The source AssetGraph from which this job-scoped graph was created."""
         return self._source_asset_graph
+
+    @property
+    def ordered_asset_keys(self) -> Sequence[AssetKey] | None:
+        return self._ordered_asset_keys
 
 
 def get_asset_graph_for_job(
@@ -238,6 +244,7 @@ def get_asset_graph_for_job(
     )
 
     selected_keys = selection.resolve(parent_asset_graph)
+    selected_keys_ordered = selection.resolve_ordered(parent_asset_graph)
     invalid_keys = selected_keys - parent_asset_graph.executable_asset_keys
     if invalid_keys:
         raise DagsterInvalidDefinitionError(
@@ -284,7 +291,12 @@ def get_asset_graph_for_job(
     asset_nodes_by_key, assets_defs_by_check_key = JobScopedAssetGraph.key_mappings_from_assets(
         [*executable_assets_defs, *unexecutable_assets_defs]
     )
-    return JobScopedAssetGraph(asset_nodes_by_key, assets_defs_by_check_key, parent_asset_graph)
+    return JobScopedAssetGraph(
+        asset_nodes_by_key,
+        assets_defs_by_check_key,
+        parent_asset_graph,
+        ordered_asset_keys=selected_keys_ordered,
+    )
 
 
 def _subset_assets_defs(
@@ -462,7 +474,30 @@ def build_node_deps(
         # the key that we'll use to reference the node inside this AssetsDefinition
         node_def_name = assets_def.node_def.name
         alias = node_handle.name if node_handle.name != node_def_name else None
-        node_key = NodeInvocation(node_def_name, alias=alias)
+
+        tags = {}
+        if (
+            isinstance(asset_graph, JobScopedAssetGraph)
+            and asset_graph.ordered_asset_keys
+            and len(asset_graph.ordered_asset_keys) > 1
+            and list(asset_graph.ordered_asset_keys) != sorted(asset_graph.ordered_asset_keys)
+            and len(assets_defs_by_node_handle) > 1
+        ):
+            asset_to_priority = {
+                key: len(asset_graph.ordered_asset_keys) - i
+                for i, key in enumerate(asset_graph.ordered_asset_keys)
+            }
+            node_priority = max(
+                (asset_to_priority.get(key, 0) for key in assets_def.keys),
+                default=0,
+            )
+            if node_priority > 0:
+                tags = {"dagster/priority": str(node_priority)}
+
+        if tags:
+            node_key = NodeInvocation(node_def_name, alias=alias, tags=tags)
+        else:
+            node_key = NodeInvocation(node_def_name, alias=alias)
         deps[node_key] = {}
 
         # For check-only nodes, we treat additional_deps as execution dependencies regardless

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_selection_ordered.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_selection_ordered.py
@@ -1,0 +1,151 @@
+import dagster as dg
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.assets.graph.asset_graph import AssetGraph
+
+
+@dg.asset(group_name="grp1")
+def a(): ...
+
+
+@dg.asset(group_name="grp1")
+def b(): ...
+
+
+@dg.asset(group_name="grp2")
+def c(): ...
+
+
+@dg.multi_asset(
+    specs=[dg.AssetSpec("m1", group_name="mixed"), dg.AssetSpec("m2", group_name="mixed")]
+)
+def multi_m1_m2():
+    return 1, 2
+
+
+@dg.asset
+def d(m1): ...
+
+
+all_assets = [a, b, c, multi_m1_m2, d]
+asset_graph = AssetGraph.from_assets(all_assets)
+
+
+def test_keys_selection_ordered():
+    # Using AssetKey objects directly to avoid any coercing issues
+    keys = [dg.AssetKey("c"), dg.AssetKey("a"), dg.AssetKey("b")]
+    selection = AssetSelection.assets(*keys)
+
+    # Check if internal storage preserved order
+    # KeysAssetSelection stores selected_keys
+    assert list(selection.selected_keys) == keys
+
+    ordered = selection.resolve_ordered(asset_graph)
+    assert list(ordered) == keys
+
+
+def test_groups_selection_not_ordered():
+    selection = AssetSelection.groups("grp1")
+    ordered = selection.resolve_ordered(asset_graph)
+    assert ordered is None
+
+
+def test_duplicate_keys_in_selection():
+    keys = [dg.AssetKey("c"), dg.AssetKey("a"), dg.AssetKey("c"), dg.AssetKey("b")]
+    selection = AssetSelection.assets(*keys)
+    ordered = selection.resolve_ordered(asset_graph)
+    # Deduplicated, respecting first occurrence
+    assert list(ordered) == [dg.AssetKey("c"), dg.AssetKey("a"), dg.AssetKey("b")]
+
+
+def test_multi_asset_conflicting_order():
+    # m2 (index 0), a (index 1), m1 (index 2)
+    selection = AssetSelection.assets("m2", "a", "m1")
+    job_def = dg.define_asset_job("test_job", selection=selection).resolve(asset_graph=asset_graph)
+
+    node_priorities = {
+        (node_invocation.alias or node_invocation.name): node_invocation.tags.get(
+            "dagster/priority"
+        )
+        for node_invocation in job_def.dependencies.keys()
+    }
+
+    # m2 has index 0 -> priority 3
+    # a has index 1 -> priority 2
+    # m1 has index 2 -> priority 1
+    # node multi_m1_m2 has m1 and m2 -> max(3, 1) = 3
+    assert node_priorities["multi_m1_m2"] == "3"
+    assert node_priorities["a"] == "2"
+
+
+def test_upstream_selection_order():
+    selection = AssetSelection.assets("d").upstream()
+    ordered = selection.resolve_ordered(asset_graph)
+    # d is the 'child_ordered' (base). m1 is remaining.
+    assert list(ordered) == [dg.AssetKey("d"), dg.AssetKey("m1")]
+
+
+def test_subtraction_selection_order():
+    selection = (
+        AssetSelection.assets("a") | AssetSelection.assets("b") | AssetSelection.assets("c")
+    ) - AssetSelection.assets("b")
+    ordered = selection.resolve_ordered(asset_graph)
+    # (a | b | c) resolves as [a, b, c] because they were added in that order to the union
+    # then subtract b -> [a, c]
+    assert list(ordered) == [dg.AssetKey("a"), dg.AssetKey("c")]
+
+
+def test_intersection_complex_order():
+    # Intersection prefers order from first operand if available
+    selection = AssetSelection.assets("c", "b", "a") & AssetSelection.groups("grp1")
+    ordered = selection.resolve_ordered(asset_graph)
+    # grp1 has a, b. c, b, a has c, b, a. Intersection: [b, a]
+    assert list(ordered) == [dg.AssetKey("b"), dg.AssetKey("a")]
+
+
+def test_all_selection_not_ordered():
+    selection = AssetSelection.all()
+    ordered = selection.resolve_ordered(asset_graph)
+    assert ordered is None
+
+
+def test_empty_selection():
+    selection = AssetSelection.assets("non_existent")
+    ordered = selection.resolve_ordered(asset_graph, allow_missing=True)
+    assert list(ordered) == []
+
+
+def test_single_node_job_no_priority_regression():
+    selection = AssetSelection.assets("a")
+    job_def = dg.define_asset_job("test_job", selection=selection).resolve(asset_graph=asset_graph)
+    for node_invocation in job_def.dependencies.keys():
+        assert "dagster/priority" not in (node_invocation.tags or {})
+
+
+def test_alphabetical_job_no_priority_regression():
+    selection = AssetSelection.assets("a", "b", "c")
+    job_def = dg.define_asset_job("test_job", selection=selection).resolve(asset_graph=asset_graph)
+    for node_invocation in job_def.dependencies.keys():
+        assert "dagster/priority" not in (node_invocation.tags or {})
+
+
+def test_mixed_case_alphabetical_guard():
+    @dg.asset
+    def B(): ...
+    @dg.asset
+    def a_low(): ...
+
+    local_graph = AssetGraph.from_assets([a_low, B])
+    # alphabetical: [B, a_low]
+
+    selection = AssetSelection.assets("B", "a_low")
+    job_def = dg.define_asset_job("test_job", selection=selection).resolve(asset_graph=local_graph)
+    for node_invocation in job_def.dependencies.keys():
+        assert "dagster/priority" not in (node_invocation.tags or {})
+
+    # Non-alphabetical: [a_low, B]
+    selection = AssetSelection.assets("a_low", "B")
+    job_def = dg.define_asset_job("test_job", selection=selection).resolve(asset_graph=local_graph)
+
+    priorities = {n.name: n.tags.get("dagster/priority") for n in job_def.dependencies.keys()}
+    assert priorities["a_low"] == "2"
+    assert priorities["B"] == "1"


### PR DESCRIPTION
Summary

This PR enables deterministic execution ordering for AssetJobs based on the explicit order provided in AssetSelection.

Currently, when multiple assets are runnable at the same topological level, execution defaults to alphabetical order. With this change, the resolved selection order is used as a tie-breaker while preserving full topological correctness.

The dependency graph is unchanged.

Implementation

Added resolve_ordered() / resolve_ordered_inner() to the AssetSelection hierarchy to propagate explicit ordering.

Updated build_node_deps() in asset_job.py to translate selection indices into dagster/priority tags.

For multi-asset nodes, priority is computed as the max() of selected assets within that node.

OrAssetSelection performs a stable merge.

AndAssetSelection preserves order from the most specific operand.

KeysAssetSelection deduplicates keys while preserving first occurrence order.

GroupsAssetSelection and AllSelection do not introduce ordering and act purely as filters.

Safeguards

Priority tags are omitted if the resolved order is already alphabetical.

Single-node jobs are excluded from tagging to avoid unnecessary metadata changes.

Topological dependencies always take precedence; ordering acts strictly as a tie-breaker.

Testing

Added test_asset_selection_ordered.py with coverage for:

Multi-asset nodes

Duplicate keys

Nested boolean selections

Upstream/downstream chaining

Confirmed existing test_asset_selection.py and test_asset_job.py pass without regressions.