### PR TITLE
[Asset Selection] Deterministic execution ordering for AssetJobs via priority tags

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -499,6 +499,38 @@ class AssetSelection(ABC):
 
         return self.resolve_inner(asset_graph, allow_missing=allow_missing)
 
+    def resolve_ordered(
+        self,
+        all_assets: Iterable[AssetsDefinition | SourceAsset] | BaseAssetGraph,
+        allow_missing: bool = False,
+    ) -> Sequence[AssetKey] | None:
+        """Returns the sequence of asset keys in the given graph that match this selection,
+        preserving the order in which they were specified in the selection if possible.
+        If no specific order was specified, returns None.
+
+        Args:
+            all_assets (Union[Iterable[Union[AssetsDefinition, SourceAsset]], AssetGraph]): The
+                assets to select from.
+            allow_missing (bool): Whether to ignore asset keys in the selection that are not
+                present in the asset graph. Defaults to False.
+        """
+        if isinstance(all_assets, BaseAssetGraph):
+            asset_graph = all_assets
+        else:
+            check.iterable_param(all_assets, "all_assets", (AssetsDefinition, SourceAsset))
+            asset_graph = AssetGraph.from_assets(all_assets)
+
+        return self.resolve_ordered_inner(asset_graph, allow_missing=allow_missing)
+
+    @abstractmethod
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        """Return ordered keys if this selection carries explicit ordering, else None.
+        Subclasses that have no intrinsic order must explicitly return None.
+        """
+        ...
+
     @abstractmethod
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
@@ -646,6 +678,11 @@ class AllSelection(AssetSelection):
     def to_selection_str(self) -> str:
         return "*"
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for all selections
+
 
 @whitelist_for_serdes
 @record
@@ -662,6 +699,11 @@ class AllAssetCheckSelection(AssetSelection):
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for check selections
 
 
 @whitelist_for_serdes
@@ -685,6 +727,11 @@ class AssetChecksForAssetKeysSelection(AssetSelection):
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for check selections
 
 
 @whitelist_for_serdes
@@ -714,6 +761,11 @@ class AssetCheckKeysSelection(AssetSelection):
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for check selections
 
 
 @record
@@ -771,6 +823,17 @@ class AndAssetSelection(OperandListAssetSelection):
             ),
         )
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        resolved = self.resolve_inner(asset_graph, allow_missing)
+        # Intersection - take order from the first operand that has it
+        for operand in self.operands:
+            ordered = operand.resolve_ordered_inner(asset_graph, allow_missing)
+            if ordered is not None:
+                return [key for key in ordered if key in resolved]
+        return None
+
     def to_selection_str(self) -> str:
         return " and ".join(f"{operand.operand_to_selection_str()}" for operand in self.operands)
 
@@ -787,6 +850,60 @@ class OrAssetSelection(OperandListAssetSelection):
                 for selection in self.operands
             ),
         )
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        """Merge operand orderings for a union (|) selection.
+
+        Strategy
+        --------
+        Resolve each operand once, tagging whether it carries explicit order.
+        Then merge in two passes:
+
+        Pass 1 - emit all keys from *explicitly-ordered* operands first, in
+                 their declared order.  This guarantees user intent wins over
+                 alphabetical fill-in, regardless of operand position.
+        Pass 2 - append remaining keys from *unordered* operands in stable
+                 alphabetical order (fill-in that never overrides Pass 1).
+
+        Returns None only when no operand carries explicit ordering.
+        """
+        # Resolve each operand once.
+        operand_results: list[tuple[bool, list[AssetKey]]] = []
+        any_ordered = False
+        for operand in self.operands:
+            op_ordered = operand.resolve_ordered_inner(asset_graph, allow_missing)
+            if op_ordered is not None:
+                any_ordered = True
+                operand_results.append((True, list(op_ordered)))
+            else:
+                op_keys = sorted(list(operand.resolve_inner(asset_graph, allow_missing)))
+                operand_results.append((False, op_keys))
+
+        if not any_ordered:
+            return None
+
+        final: list[AssetKey] = []
+        seen: set[AssetKey] = set()
+
+        # Pass 1: explicitly-ordered keys take precedence.
+        for is_ordered, keys in operand_results:
+            if is_ordered:
+                for key in keys:
+                    if key not in seen:
+                        final.append(key)
+                        seen.add(key)
+
+        # Pass 2: alphabetically-sorted fill-in from unordered operands.
+        for is_ordered, keys in operand_results:
+            if not is_ordered:
+                for key in keys:
+                    if key not in seen:
+                        final.append(key)
+                        seen.add(key)
+
+        return final
 
     def resolve_checks_inner(  # pyright: ignore[reportIncompatibleMethodOverride]
         self, asset_graph: AssetGraph, allow_missing: bool
@@ -823,6 +940,15 @@ class SubtractAssetSelection(AssetSelection):
             asset_graph, allow_missing=allow_missing
         ) - self.right.resolve_checks_inner(asset_graph, allow_missing=allow_missing)
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        resolved = self.resolve_inner(asset_graph, allow_missing)
+        left_ordered = self.left.resolve_ordered_inner(asset_graph, allow_missing)
+        if left_ordered is None:
+            return None
+        return [key for key in left_ordered if key in resolved]
+
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return copy(
             self,
@@ -849,6 +975,24 @@ class ChainedAssetSelection(AssetSelection):
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return copy(self, child=self.child.to_serializable_asset_selection(asset_graph))
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        child_ordered = self.child.resolve_ordered_inner(asset_graph, allow_missing)
+        if child_ordered is None:
+            return None
+
+        full_resolved = self.resolve_inner(asset_graph, allow_missing)
+        returned = []
+        seen = set()
+        for key in child_ordered:
+            if key in full_resolved:
+                returned.append(key)
+                seen.add(key)
+
+        remaining = sorted([key for key in full_resolved if key not in seen])
+        return returned + remaining
 
 
 @whitelist_for_serdes
@@ -950,6 +1094,12 @@ class GroupsAssetSelection(AssetSelection):
             )
         }
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        # Group selection does not imply a specific user-requested execution order.
+        return None
+
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self
 
@@ -997,6 +1147,11 @@ class KindAssetSelection(AssetSelection):
             return "kind:<null>"
         return f'kind:"{self.kind_str}"'
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for kind-based selections
+
 
 @whitelist_for_serdes
 @record
@@ -1022,6 +1177,11 @@ class TagAssetSelection(AssetSelection):
         else:
             return f'tag:"{self.key}"'
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for tag-based selections
+
 
 @whitelist_for_serdes
 @record
@@ -1037,6 +1197,11 @@ class OwnerAssetSelection(AssetSelection):
         if self.selected_owner is None:
             return "owner:<null>"
         return f'owner:"{self.selected_owner}"'
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for owner-based selections
 
 
 @whitelist_for_serdes
@@ -1089,6 +1254,11 @@ class CodeLocationAssetSelection(AssetSelection):
             return "code_location:<null>"
         return f'code_location:"{self.selected_code_location}"'
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for code location selections
+
 
 @whitelist_for_serdes
 @record
@@ -1110,6 +1280,11 @@ class ColumnAssetSelection(AssetSelection):
             return "column:<null>"
         return f'column:"{self.selected_column}"'
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for column-based selections
+
 
 @whitelist_for_serdes
 @record
@@ -1130,6 +1305,11 @@ class TableNameAssetSelection(AssetSelection):
         if self.selected_table_name is None:
             return "table_name:<null>"
         return f'table_name:"{self.selected_table_name}"'
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for table-based selections
 
 
 @whitelist_for_serdes
@@ -1154,6 +1334,11 @@ class ColumnTagAssetSelection(AssetSelection):
         else:
             return f'column_tag:"{self.key}"'
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for column tag selections
+
 
 @whitelist_for_serdes
 @record
@@ -1175,6 +1360,11 @@ class ChangedInBranchAssetSelection(AssetSelection):
             return "changed_in_branch:<null>"
         return f'changed_in_branch:"{self.selected_changed_in_branch}"'
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for branch-based selections
+
 
 @whitelist_for_serdes
 @record
@@ -1191,6 +1381,11 @@ class StatusAssetSelection(AssetSelection):
         if self.selected_status is None:
             return "status:<null>"
         return f'status:"{self.selected_status}"'
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for status-based selections
 
 
 @whitelist_for_serdes
@@ -1233,6 +1428,18 @@ class KeysAssetSelection(AssetSelection):
 
         return specified_keys - missing_keys
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        resolved = self.resolve_inner(asset_graph, allow_missing)
+        seen = set()
+        ordered = []
+        for key in self.selected_keys:
+            if key in resolved and key not in seen:
+                ordered.append(key)
+                seen.add(key)
+        return ordered if ordered else None
+
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self
 
@@ -1266,6 +1473,11 @@ class KeyPrefixesAssetSelection(AssetSelection):
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
         return self
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for prefix-based selections
+
 
 @whitelist_for_serdes
 @record
@@ -1289,6 +1501,11 @@ class KeySubstringAssetSelection(AssetSelection):
     def to_selection_str(self) -> str:
         return f'key_substring:"{self.selected_key_substring}"'
 
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for substring-based selections
+
 
 @whitelist_for_serdes
 @record
@@ -1305,6 +1522,11 @@ class KeyWildCardAssetSelection(AssetSelection):
 
     def to_selection_str(self) -> str:
         return f'key:"{self.selected_key_wildcard}"'
+
+    def resolve_ordered_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> Sequence[AssetKey] | None:
+        return None  # No intrinsic ordering for wildcard-based selections
 
 
 def _fetch_all_upstream(

--- a/python_modules/dagster/dagster/_core/definitions/assets/job/asset_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/job/asset_job.py
@@ -208,14 +208,20 @@ class JobScopedAssetGraph(AssetGraph):
         asset_nodes_by_key: Mapping[AssetKey, AssetNode],
         assets_defs_by_check_key: Mapping[AssetCheckKey, AssetsDefinition],
         source_asset_graph: AssetGraph,
+        ordered_asset_keys: Sequence[AssetKey] | None = None,
     ):
         super().__init__(asset_nodes_by_key, assets_defs_by_check_key)
         self._source_asset_graph = source_asset_graph
+        self._ordered_asset_keys = ordered_asset_keys
 
     @property
     def source_asset_graph(self) -> AssetGraph:
         """The source AssetGraph from which this job-scoped graph was created."""
         return self._source_asset_graph
+
+    @property
+    def ordered_asset_keys(self) -> Sequence[AssetKey] | None:
+        return self._ordered_asset_keys
 
 
 def get_asset_graph_for_job(
@@ -238,6 +244,7 @@ def get_asset_graph_for_job(
     )
 
     selected_keys = selection.resolve(parent_asset_graph)
+    selected_keys_ordered = selection.resolve_ordered(parent_asset_graph)
     invalid_keys = selected_keys - parent_asset_graph.executable_asset_keys
     if invalid_keys:
         raise DagsterInvalidDefinitionError(
@@ -284,7 +291,12 @@ def get_asset_graph_for_job(
     asset_nodes_by_key, assets_defs_by_check_key = JobScopedAssetGraph.key_mappings_from_assets(
         [*executable_assets_defs, *unexecutable_assets_defs]
     )
-    return JobScopedAssetGraph(asset_nodes_by_key, assets_defs_by_check_key, parent_asset_graph)
+    return JobScopedAssetGraph(
+        asset_nodes_by_key,
+        assets_defs_by_check_key,
+        parent_asset_graph,
+        ordered_asset_keys=selected_keys_ordered,
+    )
 
 
 def _subset_assets_defs(
@@ -457,12 +469,45 @@ def build_node_deps(
         )
     )
 
+    def _step_key_str(key: AssetKey) -> str:
+        """Map an AssetKey to the step-key string Dagster's executor uses."""
+        return "__".join(key.path)
+
+    _use_priorities: bool = False
+    _asset_to_priority: dict[AssetKey, int] = {}
+
+    if (
+        isinstance(asset_graph, JobScopedAssetGraph)
+        and asset_graph.ordered_asset_keys
+        and len(asset_graph.ordered_asset_keys) > 1
+        and len(assets_defs_by_node_handle) > 1
+    ):
+        _ordered = list(asset_graph.ordered_asset_keys)
+        # Natural executor order uses step keys (components joined with __)
+        _natural = sorted(_ordered, key=_step_key_str)
+        if _ordered != _natural:
+            _use_priorities = True
+            _asset_to_priority = {key: len(_ordered) - i for i, key in enumerate(_ordered)}
+
     deps: dict[NodeInvocation, dict[str, IDependencyDefinition]] = {}
     for node_handle, assets_def in assets_defs_by_node_handle.items():
         # the key that we'll use to reference the node inside this AssetsDefinition
         node_def_name = assets_def.node_def.name
         alias = node_handle.name if node_handle.name != node_def_name else None
-        node_key = NodeInvocation(node_def_name, alias=alias)
+
+        tags: dict[str, str] = {}
+        if _use_priorities:
+            node_priority = max(
+                (_asset_to_priority.get(key, 0) for key in assets_def.keys),
+                default=0,
+            )
+            if node_priority > 0:
+                tags = {"dagster/priority": str(node_priority)}
+
+        if tags:
+            node_key = NodeInvocation(node_def_name, alias=alias, tags=tags)
+        else:
+            node_key = NodeInvocation(node_def_name, alias=alias)
         deps[node_key] = {}
 
         # For check-only nodes, we treat additional_deps as execution dependencies regardless

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_selection_ordered.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_selection_ordered.py
@@ -1,0 +1,253 @@
+import dagster as dg
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.assets.graph.asset_graph import AssetGraph
+
+
+@dg.asset(group_name="grp1")
+def a(): ...
+
+
+@dg.asset(group_name="grp1")
+def b(): ...
+
+
+@dg.asset(group_name="grp2")
+def c(): ...
+
+
+@dg.multi_asset(
+    specs=[dg.AssetSpec("m1", group_name="mixed"), dg.AssetSpec("m2", group_name="mixed")]
+)
+def multi_m1_m2():
+    return 1, 2
+
+
+@dg.asset
+def d(m1): ...
+
+
+all_assets = [a, b, c, multi_m1_m2, d]
+asset_graph = AssetGraph.from_assets(all_assets)
+
+
+def test_keys_selection_ordered():
+    # Using AssetKey objects directly to avoid any coercing issues
+    keys = [dg.AssetKey("c"), dg.AssetKey("a"), dg.AssetKey("b")]
+    selection = AssetSelection.assets(*keys)
+
+    # Check if internal storage preserved order
+    # KeysAssetSelection stores selected_keys
+    assert list(selection.selected_keys) == keys
+
+    ordered = selection.resolve_ordered(asset_graph)
+    assert list(ordered) == keys
+
+
+def test_groups_selection_not_ordered():
+    selection = AssetSelection.groups("grp1")
+    ordered = selection.resolve_ordered(asset_graph)
+    assert ordered is None
+
+
+def test_duplicate_keys_in_selection():
+    keys = [dg.AssetKey("c"), dg.AssetKey("a"), dg.AssetKey("c"), dg.AssetKey("b")]
+    selection = AssetSelection.assets(*keys)
+    ordered = selection.resolve_ordered(asset_graph)
+    # Deduplicated, respecting first occurrence
+    assert list(ordered) == [dg.AssetKey("c"), dg.AssetKey("a"), dg.AssetKey("b")]
+
+
+def test_multi_asset_conflicting_order():
+    # m2 (index 0), a (index 1), m1 (index 2)
+    selection = AssetSelection.assets("m2", "a", "m1")
+    job_def = dg.define_asset_job("test_job", selection=selection).resolve(asset_graph=asset_graph)
+
+    node_priorities = {
+        (node_invocation.alias or node_invocation.name): node_invocation.tags.get(
+            "dagster/priority"
+        )
+        for node_invocation in job_def.dependencies.keys()
+    }
+
+    # m2 has index 0 -> priority 3
+    # a has index 1 -> priority 2
+    # m1 has index 2 -> priority 1
+    # node multi_m1_m2 has m1 and m2 -> max(3, 1) = 3
+    assert node_priorities["multi_m1_m2"] == "3"
+    assert node_priorities["a"] == "2"
+
+
+def test_upstream_selection_order():
+    selection = AssetSelection.assets("d").upstream()
+    ordered = selection.resolve_ordered(asset_graph)
+    # d is the 'child_ordered' (base). m1 is remaining.
+    assert list(ordered) == [dg.AssetKey("d"), dg.AssetKey("m1")]
+
+
+def test_subtraction_selection_order():
+    selection = (
+        AssetSelection.assets("a") | AssetSelection.assets("b") | AssetSelection.assets("c")
+    ) - AssetSelection.assets("b")
+    ordered = selection.resolve_ordered(asset_graph)
+    # (a | b | c) resolves as [a, b, c] because they were added in that order to the union
+    # then subtract b -> [a, c]
+    assert list(ordered) == [dg.AssetKey("a"), dg.AssetKey("c")]
+
+
+def test_intersection_complex_order():
+    # Intersection prefers order from first operand if available
+    selection = AssetSelection.assets("c", "b", "a") & AssetSelection.groups("grp1")
+    ordered = selection.resolve_ordered(asset_graph)
+    # grp1 has a, b. c, b, a has c, b, a. Intersection: [b, a]
+    assert list(ordered) == [dg.AssetKey("b"), dg.AssetKey("a")]
+
+
+def test_all_selection_not_ordered():
+    selection = AssetSelection.all()
+    ordered = selection.resolve_ordered(asset_graph)
+    assert ordered is None
+
+
+def test_empty_selection():
+    selection = AssetSelection.assets("non_existent")
+    ordered = selection.resolve_ordered(asset_graph, allow_missing=True)
+    assert ordered is None  # empty selection carries no ordering information
+
+
+def test_single_node_job_no_priority_regression():
+    selection = AssetSelection.assets("a")
+    job_def = dg.define_asset_job("test_job", selection=selection).resolve(asset_graph=asset_graph)
+    for node_invocation in job_def.dependencies.keys():
+        assert "dagster/priority" not in (node_invocation.tags or {})
+
+
+def test_alphabetical_job_no_priority_regression():
+    selection = AssetSelection.assets("a", "b", "c")
+    job_def = dg.define_asset_job("test_job", selection=selection).resolve(asset_graph=asset_graph)
+    for node_invocation in job_def.dependencies.keys():
+        assert "dagster/priority" not in (node_invocation.tags or {})
+
+
+def test_mixed_case_alphabetical_guard():
+    @dg.asset
+    def B(): ...
+    @dg.asset
+    def a_low(): ...
+
+    local_graph = AssetGraph.from_assets([a_low, B])
+    # alphabetical: [B, a_low]
+
+    selection = AssetSelection.assets("B", "a_low")
+    job_def = dg.define_asset_job("test_job", selection=selection).resolve(asset_graph=local_graph)
+    for node_invocation in job_def.dependencies.keys():
+        assert "dagster/priority" not in (node_invocation.tags or {})
+
+    # Non-alphabetical: [a_low, B]
+    selection = AssetSelection.assets("a_low", "B")
+    job_def = dg.define_asset_job("test_job", selection=selection).resolve(asset_graph=local_graph)
+
+    priorities = {n.name: n.tags.get("dagster/priority") for n in job_def.dependencies.keys()}
+    assert priorities["a_low"] == "2"
+    assert priorities["B"] == "1"
+
+
+def test_union_order_precedence():
+    # grp1 has a, b. alphabetical is [a, b]
+    # assets("c", "a") is ordered [c, a]
+
+    # Case 1: Unordered | Ordered
+    # User intent (c before a) should win even though grp1 comes first.
+    selection = AssetSelection.groups("grp1") | AssetSelection.assets("c", "a")
+    ordered = selection.resolve_ordered(asset_graph)
+    # [c, a] from assets win precedence. then "b" from grp1 is filled in.
+    assert list(ordered) == [dg.AssetKey("c"), dg.AssetKey("a"), dg.AssetKey("b")]
+
+    # Case 2: Ordered | Unordered
+    selection = AssetSelection.assets("c", "a") | AssetSelection.groups("grp1")
+    ordered = selection.resolve_ordered(asset_graph)
+    assert list(ordered) == [dg.AssetKey("c"), dg.AssetKey("a"), dg.AssetKey("b")]
+
+
+def test_multi_component_key_alphabetical_guard():
+    @dg.asset
+    def a_b(): ...  # step key "a_b"
+
+    @dg.asset(key_prefix="a")
+    def b(): ...  # step key "a__b"
+
+    # Natural executor order: "a__b" then "a_b" (because '_' < 'b')
+    # Wait, ASCII: '_' is 95, 'b' is 98.
+    # a__b -> [97, 95, 95, 98]
+    # a_b  -> [97, 95, 98]
+    # Index 2: 95 ('_') vs 98 ('b'). So "a__b" < "a_b".
+
+    local_graph = AssetGraph.from_assets([a_b, b])
+
+    # natural [a__b, a_b]
+    selection = AssetSelection.assets(dg.AssetKey(["a", "b"]), dg.AssetKey(["a_b"]))
+    job_def = dg.define_asset_job("test", selection=selection).resolve(asset_graph=local_graph)
+    for node in job_def.dependencies.keys():
+        assert "dagster/priority" not in (node.tags or {})
+
+    # non-natural [a_b, a__b]
+    selection = AssetSelection.assets(dg.AssetKey(["a_b"]), dg.AssetKey(["a", "b"]))
+    job_def = dg.define_asset_job("test", selection=selection).resolve(asset_graph=local_graph)
+    priorities = {n.name: n.tags.get("dagster/priority") for n in job_def.dependencies.keys()}
+    assert priorities["a_b"] == "2"
+    assert priorities["a__b"] == "1"
+
+
+def test_execution_priority_e2e():
+    materialization_order = []
+
+    @dg.asset
+    def asset_1():
+        materialization_order.append("asset_1")
+
+    @dg.asset
+    def asset_2():
+        materialization_order.append("asset_2")
+
+    @dg.asset
+    def asset_3():
+        materialization_order.append("asset_3")
+
+    # Topological level 0: all three.
+    # Default order: 1, 2, 3.
+    # Request order: 3, 1, 2.
+    selection = AssetSelection.assets("asset_3", "asset_1", "asset_2")
+    job_def = dg.define_asset_job("ordered_job", selection=selection).resolve(
+        asset_graph=AssetGraph.from_assets([asset_1, asset_2, asset_3])
+    )
+
+    result = job_def.execute_in_process()
+    # NOTE: The in-process executor does not honour dagster/priority for
+    # tiebreak ordering, so we only verify the job completes successfully.
+    # Actual priority-driven ordering is verified at the unit level via
+    # NodeInvocation tag assertions in the tests above.
+    assert result.success
+
+
+def test_all_subclasses_implement_resolve_ordered_inner():
+    """Ensures no concrete AssetSelection subclass silently inherits None."""
+    from dagster._core.definitions.asset_selection import AssetSelection
+
+    def get_all_subclasses(cls):
+        all_subclasses = []
+        for subclass in cls.__subclasses__():
+            all_subclasses.append(subclass)
+            all_subclasses.extend(get_all_subclasses(subclass))
+        return all_subclasses
+
+    # Recursively find all subclasses of AssetSelection currently loaded
+    all_selections = get_all_subclasses(AssetSelection)
+
+    for cls in all_selections:
+        import inspect
+
+        if not inspect.isabstract(cls):
+            # We exclude AssetSelection from the walk to ensure some intermediate
+            # or leaf class provides the implementation.
+            assert "resolve_ordered_inner" in {
+                m for c in cls.__mro__ if c is not AssetSelection for m in c.__dict__
+            }, f"{cls.__name__} must explicitly implement resolve_ordered_inner"


### PR DESCRIPTION
## Summary

Allows developers to control asset execution order within an `AssetJob` by
specifying assets in the desired sequence via `AssetSelection`. The declared
order is resolved at job construction time and translated into `dagster/priority`
tags on `NodeInvocation` objects, so the executor respects developer intent
without breaking topological guarantees.
```python
# Assets will be prioritised in the order declared: C → A → B
job = define_asset_job("my_job", selection=AssetSelection.assets("C", "A", "B"))
```

---

## Changes

### 1. `AssetSelection` hierarchy

- Added `resolve_ordered()` public entry point and `@abstractmethod
  resolve_ordered_inner()` to the base class, forcing all subclasses to
  declare intent explicitly.
- **Ordered subclasses** — `KeysAssetSelection` preserves the user-declared
  sequence; `OrAssetSelection` and `ChainedAssetSelection` implement stable
  merge logic.
- **Unordered subclasses** — metadata-based selections (`groups`, `tags`,
  `owner`, etc.) explicitly return `None`.
- **Two-pass union merge** — the `|` operator now emits explicitly ordered
  keys first, then fills in unordered keys alphabetically. This ensures
  developer intent wins regardless of operand position.
- **Empty selection fix** — `KeysAssetSelection.resolve_ordered_inner` returns
  `None` instead of `[]`, aligning with the "no ordering available" protocol.

### 2. `build_node_deps` optimisation

- Hoisted priority computation outside the per-node loop: `asset_to_priority`
  and the alphabetical guard are now computed once per job build — O(N) instead
  of O(N × K log K).
- Alphabetical guard now compares by `step_key` string (`prefix__name`) rather
  than `AssetKey` tuple, matching the executor's actual tiebreak ordering and
  preventing redundant tag generation for multi-component keys.

### 3. Tests

- 16 new tests in `test_asset_selection_ordered.py` covering deduplication,
  complex union/intersection/subtraction logic, multi-component key guards,
  and cross-group ordering.
- Recursive `__subclasses__()` meta-test verifies every concrete
  `AssetSelection` in the codebase implements the ordering interface,
  preventing silent regressions from future subclasses.
- E2E test verifies jobs with priority tags materialise successfully.
  Runtime ordering is validated at the unit level via `NodeInvocation` tag
  assertions; the in-process executor does not honour `dagster/priority` for
  tiebreak ordering.

---

## Test results
```
pytest python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_asset_selection_ordered.py -vv
16 passed in 1.02s
```

---

## Notes

- Non-breaking: priorities are only assigned when the declared order differs
  from the executor's natural step-key order. Single-node jobs are excluded.
  Topological dependencies always take full precedence over priority hints.