### PR TITLE
Add psycopg2-binary as a dependency of dagster-postgres

### DIFF
--- a/python_modules/libraries/dagster-postgres/pyproject.toml
+++ b/python_modules/libraries/dagster-postgres/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "dagster==1!0+dev",
+    "psycopg2-binary",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Re-add psycopg2-binary to the main dependencies of dagster-postgres. The prior removal broke many OSS test suites that depend on psycopg2 being available.

https://claude.ai/code/session_01BrV7epZpMhzTwGe1pS6TvZ

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
