### PR TITLE
Fix cursor ID collisions in DepsAutomationCondition when using allow/ignore filters

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -123,16 +123,19 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     def requires_cursor(self) -> bool:
         return False
 
-    def get_node_unique_id(
+    def get_backcompat_node_unique_ids(
         self,
         *,
-        parent_unique_id: str | None,
-        index: int | None,
-        target_key: EntityKey | None,
-    ) -> str:
-        """Ignore allow_selection / ignore_selection for the cursor hash."""
-        parts = [str(parent_unique_id), str(index), self.base_name]
-        return non_secure_md5_hash_str("".join(parts).encode())
+        parent_unique_id: str | None = None,
+        index: int | None = None,
+        target_key: EntityKey | None = None,
+    ) -> Sequence[str]:
+        # backcompat for previous cursors where the allow/ignore selection was ignored
+        return [
+            non_secure_md5_hash_str(
+                f"{parent_unique_id}{index}{self.base_name}".encode()
+            )
+        ]
 
     @public
     def allow(self, selection: "AssetSelection") -> "DepsAutomationCondition":

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
@@ -137,14 +137,52 @@ def test_node_unique_id() -> None:
         .allow(AssetSelection.keys("a"))
         .ignore(AssetSelection.keys("b"))
     )
+    # Current ID includes allow/ignore selections in the hash (fixes cursor collisions)
     assert (
         condition.get_node_unique_id(parent_unique_id=None, index=None, target_key=None)
-        == "80f87fb32baaf7ce3f65f68c12d3eb11"
+        == "35b152923d1d99348e85c3cbe426bcb7"
     )
-    assert (
-        condition.get_backcompat_node_unique_ids(parent_unique_id=None, index=None, target_key=None)
-        == []
-    )
+    # Backcompat ID is the old format (base_name only, ignoring allow/ignore selections)
+    assert condition.get_backcompat_node_unique_ids(
+        parent_unique_id=None, index=None, target_key=None
+    ) == ["80f87fb32baaf7ce3f65f68c12d3eb11"]
+
+
+@pytest.mark.parametrize(
+    "make_cond",
+    [
+        pytest.param(AC.any_deps_match, id="any_deps_match"),
+        pytest.param(AC.all_deps_match, id="all_deps_match"),
+    ],
+)
+def test_dep_condition_id_collision_fix(make_cond) -> None:
+    """Verify that any_deps_match and all_deps_match conditions with different allow() or
+    ignore() selections get different unique IDs (the original bug: they used to hash
+    identically, causing cursor state to be shared or corrupted).
+    Also verify they share the same backcompat ID (the old base-name-only format).
+    """
+    cond_a = make_cond(AC.missing()).allow(AssetSelection.keys("assetA"))
+    cond_b = make_cond(AC.missing()).allow(AssetSelection.keys("assetB"))
+
+    id_a = cond_a.get_node_unique_id(parent_unique_id=None, index=0, target_key=None)
+    id_b = cond_b.get_node_unique_id(parent_unique_id=None, index=0, target_key=None)
+    assert id_a != id_b, "Conditions with different allow() selections must have different unique IDs"
+
+    bc_a = cond_a.get_backcompat_node_unique_ids(parent_unique_id=None, index=0, target_key=None)
+    bc_b = cond_b.get_backcompat_node_unique_ids(parent_unique_id=None, index=0, target_key=None)
+    assert bc_a == bc_b, "Backcompat IDs (old pre-fix format) should be the same when only filter differs"
+
+    # Also verify ignore() produces the same behavior
+    cond_c = make_cond(AC.missing()).ignore(AssetSelection.keys("assetC"))
+    cond_d = make_cond(AC.missing()).ignore(AssetSelection.keys("assetD"))
+
+    id_c = cond_c.get_node_unique_id(parent_unique_id=None, index=0, target_key=None)
+    id_d = cond_d.get_node_unique_id(parent_unique_id=None, index=0, target_key=None)
+    assert id_c != id_d, "Conditions with different ignore() selections must have different unique IDs"
+
+    bc_c = cond_c.get_backcompat_node_unique_ids(parent_unique_id=None, index=0, target_key=None)
+    bc_d = cond_d.get_backcompat_node_unique_ids(parent_unique_id=None, index=0, target_key=None)
+    assert bc_c == bc_d, "Backcompat IDs (old pre-fix format) should be the same when only filter differs"
 
 
 def test_since_condition_cursor_backcompat() -> None:


### PR DESCRIPTION
Fixes #32999

## Summary

Fixes a bug where two `any_deps_match()` (or `all_deps_match()`) conditions with
different `.allow()` or `.ignore()` selections were assigned **the same cursor unique ID**
when combined in the same condition tree (e.g., with `&` or `|`).

### Root cause

`DepsAutomationCondition.get_node_unique_id` computed its hash using only `self.base_name`
(`"ANY_DEPS_MATCH"` or `"ALL_DEPS_MATCH"`), completely ignoring `allow_selection` and
`ignore_selection`. Two conditions at the same position in the tree with different filters
therefore hashed identically.

**Example (broken before this fix):**
```python
cond_a = AC.any_deps_match(AC.data_version_changed()).allow(AssetSelection.assets("upstream_a"))
cond_b = AC.any_deps_match(AC.data_version_changed()).allow(AssetSelection.assets("upstream_b"))

# Both returned the same ID — cursor state was shared/corrupted
assert cond_a.get_node_unique_id(...) == cond_b.get_node_unique_id(...)  # True (wrong!)


Fix
Removed the get_node_unique_id override in DepsAutomationCondition. The base
AutomationCondition.get_node_unique_id uses self.name, which already includes the
serialized allow_selection / ignore_selection — so different filters now produce
different IDs automatically.

Added get_backcompat_node_unique_ids returning the old base-name-only hash.
This ensures existing cursors stored under the old format are found and migrated
gracefully on upgrade, rather than being silently dropped (which would cause
unintended re-evaluation from scratch).

Test Plan
test_node_unique_id: updated expected hash values (current ID now reflects filters; backcompat ID is the old base-name-only hash)
test_dep_condition_id_collision_fix (new): explicitly asserts that two any_deps_match conditions with different .allow() selections get different unique IDs, and that they share the same backcompat ID (old format)
test_since_condition_cursor_backcompat / test_since_condition_cursor_forwardscompat: both continue to pass — cursor migration logic is unaffected

pytest python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py -v -k "not test_value_hash"
# 7 passed
