### PR TITLE
Fix timezone double-offset in Automation page evaluation timestamps (#32901)

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -487,6 +487,7 @@ class SqlScheduleStorage(ScheduleStorage):
                             "asset_key": evaluation.key.to_db_string(),
                             "asset_evaluation_body": serialize_value(evaluation),
                             "num_requested": evaluation.num_requested,
+                            "create_timestamp": get_current_datetime(),
                         }
                     ]
                 )

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -997,3 +997,54 @@ class TestScheduleStorage:
 
         res = storage.get_auto_materialize_asset_evaluations(key=AssetKey("asset_one"), limit=100)
         assert len(res) == 0
+
+    def test_auto_materialize_asset_evaluations_timestamp_uses_python_utc_clock(
+        self, storage
+    ) -> None:
+        """Regression test for https://github.com/dagster-io/dagster/issues/32901.
+
+        On PostgreSQL with a non-UTC server timezone (e.g. IST, UTC+5:30), the DB's
+        CURRENT_TIMESTAMP returns local time. If that value is then stamped as UTC by
+        utc_datetime_from_naive(), the resulting Unix epoch is offset by the full UTC
+        difference, and the frontend doubles it when converting back to local time.
+
+        The fix is to pass create_timestamp=get_current_datetime() explicitly in the
+        INSERT so the Python process always controls the timestamp in UTC.
+
+        This test verifies the fix by pinning the Python clock with freeze_time and
+        asserting that the stored record's timestamp exactly matches the frozen time,
+        not a DB-derived value.
+        """
+        if not self.can_store_auto_materialize_asset_evaluations():
+            pytest.skip("Storage cannot store auto materialize asset evaluations")
+
+        condition_snapshot = AutomationConditionNodeSnapshot(
+            class_name="foo", description="bar", unique_id=""
+        )
+        freeze_datetime = get_current_datetime()
+
+        with freeze_time(freeze_datetime):
+            storage.add_auto_materialize_asset_evaluations(
+                evaluation_id=42,
+                asset_evaluations=[
+                    AutomationConditionEvaluation(
+                        condition_snapshot=condition_snapshot,
+                        true_subset=SerializableEntitySubset(
+                            key=AssetKey("ts_asset"), value=False
+                        ),
+                        candidate_subset=SerializableEntitySubset(
+                            key=AssetKey("ts_asset"), value=False
+                        ),
+                        start_timestamp=0,
+                        end_timestamp=1,
+                        subsets_with_metadata=[],
+                        child_evaluations=[],
+                    ).with_run_ids(set()),
+                ],
+            )
+
+        res = storage.get_auto_materialize_asset_evaluations(key=AssetKey("ts_asset"), limit=100)
+        assert len(res) == 1
+        # timestamp must equal the Python-side UTC clock at insert time, not whatever
+        # the DB's CURRENT_TIMESTAMP would return (which varies with server timezone).
+        assert res[0].timestamp == freeze_datetime.timestamp()


### PR DESCRIPTION
## Summary

Fixes #32901.

On PostgreSQL deployments where the DB server is configured with a non-UTC timezone
(e.g. IST, UTC+5:30), the Automation page shows evaluation timestamps that are
offset by an additional UTC+5:30, displaying time as IST + 5:30 = UTC+11 instead
of the correct local time. The Runs page was unaffected.

**Root cause (double-offset):**

The `asset_daemon_asset_evaluations` INSERT did not set `create_timestamp`
explicitly, so it fell back to `server_default = CURRENT_TIMESTAMP`. On PostgreSQL,
`CURRENT_TIMESTAMP` returns the server's local time. When read back, the naive
datetime is passed to `utc_datetime_from_naive()` (which blindly stamps it as UTC
via `.replace(tzinfo=timezone.utc)`), creating a Unix epoch that is one full UTC
offset too far in the future. The frontend then applies the user's timezone offset
on top — producing a double-offset equal to the UTC difference.

SQLite users were never affected because SQLite's `CURRENT_TIMESTAMP` always returns UTC.

**Fix:**

Pass `"create_timestamp": get_current_datetime()` explicitly in the INSERT so the
Python process controls the timestamp using UTC, bypassing the DB's local clock.
`get_current_datetime` was already imported in the file.

## Test Plan

- Existing `test_auto_materialize_asset_evaluations` and related storage tests pass (8/8)
- To reproduce before fix: run Dagster with PostgreSQL on a non-UTC system timezone,
  observe Automation page timestamps ahead by the UTC offset vs. the Runs page
