### PR TITLE
Fix PostgreSQL transaction abort in initialize_concurrency_limit_to_default 

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2258,6 +2258,12 @@ class SqlEventLogStorage(EventLogStorage):
                     )
                     self._allocate_concurrency_slots(conn, concurrency_key, 0)
                 else:
+                    # PostgresEventLogStorage overrides this entire method to use
+                    # INSERT ... ON CONFLICT syntax.  On PostgreSQL, a UniqueViolation
+                    # inside a transaction aborts the whole transaction (InFailedSqlTransaction),
+                    # so the UPDATE below would also fail.  This INSERT-then-catch pattern is
+                    # only safe for SQLite, which does not abort the transaction on an
+                    # IntegrityError.
                     try:
                         conn.execute(
                             ConcurrencyLimitsTable.insert().values(
@@ -2292,8 +2298,7 @@ class SqlEventLogStorage(EventLogStorage):
                 )
             except db_exc.IntegrityError:
                 pass
-
-        self._allocate_concurrency_slots(conn, concurrency_key, default_limit)
+            self._allocate_concurrency_slots(conn, concurrency_key, default_limit)
         return True
 
     def _upsert_and_lock_limit_row(

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -5861,6 +5861,32 @@ class TestEventLogStorage:
 
         assert storage.get_concurrency_info("foo").slot_count == 0
 
+    def test_default_concurrency_idempotent(
+        self,
+        storage: EventLogStorage,
+        instance: DagsterInstance,
+    ):
+        assert storage
+        if not storage.supports_global_concurrency_limits:
+            pytest.skip("storage does not support global op concurrency")
+
+        if not self.can_set_concurrency_defaults():
+            pytest.skip("storage does not support setting global op concurrency defaults")
+
+        self.set_default_op_concurrency(instance, storage, 2)
+
+        # First call creates the row
+        assert storage.initialize_concurrency_limit_to_default("foo")
+        assert storage.get_concurrency_info("foo").slot_count == 2
+
+        # Second call with same key and same default must not raise and must be a no-op
+        assert storage.initialize_concurrency_limit_to_default("foo")
+        assert storage.get_concurrency_info("foo").slot_count == 2
+
+        # Third call still idempotent
+        assert storage.initialize_concurrency_limit_to_default("foo")
+        assert storage.get_concurrency_info("foo").slot_count == 2
+
     def test_asset_checks(
         self,
         storage: EventLogStorage,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -22,6 +22,7 @@ from dagster._core.storage.event_log import (
 from dagster._core.storage.event_log.base import EventLogCursor
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.event_log.polling_event_watcher import SqlPollingEventWatcher
+from dagster._core.storage.event_log.schema import ConcurrencyLimitsTable
 from dagster._core.storage.sql import (
     AlembicVersion,
     check_alembic_revision,
@@ -322,6 +323,65 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 )
                 .on_conflict_do_nothing(),
             )
+
+    def initialize_concurrency_limit_to_default(self, concurrency_key: str) -> bool:
+        """Override of SqlEventLogStorage.initialize_concurrency_limit_to_default that uses
+        INSERT ... ON CONFLICT syntax instead of the INSERT-then-catch-IntegrityError pattern.
+
+        PostgreSQL differs from SQLite in that a failed statement inside a transaction (e.g. a
+        UniqueViolation on INSERT) aborts the *entire* transaction, putting it into an
+        InFailedSqlTransaction state. The base-class approach of catching IntegrityError and then
+        issuing an UPDATE on the same connection therefore always fails on PostgreSQL.  Using
+        ON CONFLICT DO UPDATE keeps the upsert as a single atomic statement that never raises.
+        """
+        if not self.has_concurrency_limits_table:
+            return False
+
+        self._reconcile_concurrency_limits_from_slots()
+
+        if not self.has_instance:
+            return False
+
+        default_limit = self._instance.global_op_concurrency_default_limit
+        # initialize outside of connection context
+        has_default_pool_limit_col = self.has_default_pool_limit_col
+
+        if has_default_pool_limit_col:
+            with self.index_transaction() as conn:
+                if default_limit is None:
+                    conn.execute(
+                        ConcurrencyLimitsTable.delete().where(
+                            ConcurrencyLimitsTable.c.concurrency_key == concurrency_key,
+                        )
+                    )
+                    self._allocate_concurrency_slots(conn, concurrency_key, 0)
+                else:
+                    insert_stmt = db_dialects.postgresql.insert(ConcurrencyLimitsTable).values(
+                        concurrency_key=concurrency_key,
+                        limit=default_limit,
+                        using_default_limit=True,
+                    )
+                    conn.execute(
+                        insert_stmt.on_conflict_do_update(
+                            index_elements=[ConcurrencyLimitsTable.c.concurrency_key],
+                            set_={"limit": insert_stmt.excluded.limit},
+                            where=(ConcurrencyLimitsTable.c.limit != insert_stmt.excluded.limit),
+                        )
+                    )
+                    self._allocate_concurrency_slots(conn, concurrency_key, default_limit)
+            return True
+
+        if default_limit is None:
+            return False
+
+        with self.index_transaction() as conn:
+            conn.execute(
+                db_dialects.postgresql.insert(ConcurrencyLimitsTable)
+                .values(concurrency_key=concurrency_key, limit=default_limit)
+                .on_conflict_do_nothing()
+            )
+            self._allocate_concurrency_slots(conn, concurrency_key, default_limit)
+        return True
 
     def _connect(self) -> ContextManager[Connection]:
         return create_pg_connection(self._engine)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -48,6 +48,20 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
     def can_wipe_asset_partitions(self) -> bool:
         return False
 
+    def can_set_concurrency_defaults(self) -> bool:
+        return True
+
+    def set_default_op_concurrency(self, instance, storage, limit) -> None:
+        if instance is None:
+            return
+        # Patch the in-memory settings dict so get_concurrency_config() returns the
+        # expected default_pool_limit without needing to recreate the instance.
+        if "concurrency" not in instance._settings:  # noqa: SLF001
+            instance._settings["concurrency"] = {}  # noqa: SLF001
+        if "pools" not in instance._settings["concurrency"]:  # noqa: SLF001
+            instance._settings["concurrency"]["pools"] = {}  # noqa: SLF001
+        instance._settings["concurrency"]["pools"]["default_limit"] = limit  # noqa: SLF001
+
     def test_event_log_storage_two_watchers(self, conn_string):
         with _clean_storage(conn_string) as storage:
             run_id = make_new_run_id()


### PR DESCRIPTION
 ## Summary



  `initialize_concurrency_limit_to_default` has always been broken on PostgreSQL. PostgreSQL aborts the **entire transaction**  
  when any statement raises `UniqueViolation` (the connection enters `InFailedSqlTransaction` state). The base-class
  implementation:

  1. Does an `INSERT` that raises `UniqueViolation` on a duplicate key
  2. Catches `IntegrityError` and falls through
  3. Tries to issue follow-up statements on the **same already-aborted connection**

  Those follow-up statements always fail. SQLite doesn't have this behavior, so the bug never surfaced in local tests.

  ### Changes

  | File | What changed |
  |------|-------------|
  | `dagster_postgres/event_log/event_log.py` | New `initialize_concurrency_limit_to_default` override using `INSERT ... ON     
  CONFLICT`, matching the existing pattern already used by `store_asset_event` and `add_dynamic_partitions` in the same class | 
  | `dagster/_core/storage/event_log/sql_event_log.py` | Fix use-after-close bug in legacy Path B: `_allocate_concurrency_slots`
   was called **outside** the `with self.index_transaction()` block; added comment explaining why the base-class pattern is     
  SQLite-only |
  | `dagster_tests/storage_tests/utils/event_log_storage.py` | New `test_default_concurrency_idempotent` test |
  | `dagster_postgres_tests/test_event_log.py` | Implement `can_set_concurrency_defaults` / `set_default_op_concurrency` hooks  
  so default-concurrency tests actually run against Postgres instead of being permanently skipped |

  ## Test plan

  - [x] `pytest python_modules/dagster/dagster_tests/storage_tests/ -k "concurrency"` — 18 passed, 28 skipped
  - [ ] `pytest python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py -k "concurrency"` — requires 
  running Postgres; `test_default_concurrency_idempotent` and all default-concurrency tests now enabled for Postgres
  - [x] `ruff check` + `ruff format` — clean
