### PR TITLE
Fix KeyError in AssetDefinitionCollisionQuery when asset keys are mis…

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -150,7 +150,11 @@ def get_additional_required_keys(
     graphene_info: "ResolveInfo",
     asset_keys: AbstractSet[AssetKey],
 ) -> list["AssetKey"]:
-    asset_nodes = {graphene_info.context.asset_graph.get(asset_key) for asset_key in asset_keys}
+    asset_nodes = {
+        graphene_info.context.asset_graph.get(asset_key)
+        for asset_key in asset_keys
+        if graphene_info.context.asset_graph.has(asset_key)
+    }
 
     required_asset_keys = set()
     for asset_node in asset_nodes:
@@ -167,6 +171,8 @@ def get_asset_node_definition_collisions(
 
     repos: dict[AssetKey, list[GrapheneRepository]] = defaultdict(list)
     for asset_key in asset_keys:
+        if not graphene_info.context.asset_graph.has(asset_key):
+            continue
         remote_asset_node = graphene_info.context.asset_graph.get(asset_key)
         for info in remote_asset_node.repo_scoped_asset_infos:
             asset_node_snap = info.asset_node.asset_node_snap


### PR DESCRIPTION
…sing from graph

Added has() checks before calling get() on the asset graph in get_asset_node_definition_collisions and get_additional_required_keys. This prevents a KeyError when the UI sends asset keys that no longer exist in the asset graph (e.g. after adding incremental dbt components).

Fixes #33462

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
