### PR TITLE
Fix PostgreSQL concurrency init: transaction abort and using_default_limit flag corruption

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2258,6 +2258,12 @@ class SqlEventLogStorage(EventLogStorage):
                     )
                     self._allocate_concurrency_slots(conn, concurrency_key, 0)
                 else:
+                    # PostgresEventLogStorage overrides this entire method to use
+                    # INSERT ... ON CONFLICT syntax.  On PostgreSQL, a UniqueViolation
+                    # inside a transaction aborts the whole transaction (InFailedSqlTransaction),
+                    # so the UPDATE below would also fail.  This INSERT-then-catch pattern is
+                    # only safe for SQLite, which does not abort the transaction on an
+                    # IntegrityError.
                     try:
                         conn.execute(
                             ConcurrencyLimitsTable.insert().values(
@@ -2269,11 +2275,14 @@ class SqlEventLogStorage(EventLogStorage):
                     except db_exc.IntegrityError:
                         conn.execute(
                             ConcurrencyLimitsTable.update()
-                            .values(limit=default_limit)
+                            .values(limit=default_limit, using_default_limit=True)
                             .where(
                                 db.and_(
                                     ConcurrencyLimitsTable.c.concurrency_key == concurrency_key,
-                                    ConcurrencyLimitsTable.c.limit != default_limit,
+                                    db.or_(
+                                        ConcurrencyLimitsTable.c.limit != default_limit,
+                                        ConcurrencyLimitsTable.c.using_default_limit == False,  # noqa: E712
+                                    ),
                                 )
                             )
                         )
@@ -2292,8 +2301,7 @@ class SqlEventLogStorage(EventLogStorage):
                 )
             except db_exc.IntegrityError:
                 pass
-
-        self._allocate_concurrency_slots(conn, concurrency_key, default_limit)
+            self._allocate_concurrency_slots(conn, concurrency_key, default_limit)
         return True
 
     def _upsert_and_lock_limit_row(

--- a/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
@@ -86,6 +86,18 @@ class TestSqliteEventLogStorage(TestEventLogStorage):
     def can_wipe_asset_partitions(self) -> bool:
         return False
 
+    def can_set_concurrency_defaults(self) -> bool:
+        return True
+
+    def set_default_op_concurrency(self, instance, storage, limit) -> None:
+        if instance is None:
+            return
+        if "concurrency" not in instance._settings:  # noqa: SLF001
+            instance._settings["concurrency"] = {}  # noqa: SLF001
+        if "pools" not in instance._settings["concurrency"]:  # noqa: SLF001
+            instance._settings["concurrency"]["pools"] = {}  # noqa: SLF001
+        instance._settings["concurrency"]["pools"]["default_limit"] = limit  # noqa: SLF001
+
     def test_filesystem_event_log_storage_run_corrupted(self, storage):
         # URL begins sqlite:///
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -5861,6 +5861,45 @@ class TestEventLogStorage:
 
         assert storage.get_concurrency_info("foo").slot_count == 0
 
+    def test_default_concurrency_idempotent(
+        self,
+        storage: EventLogStorage,
+        instance: DagsterInstance,
+    ):
+        assert storage
+        if not storage.supports_global_concurrency_limits:
+            pytest.skip("storage does not support global op concurrency")
+
+        if not self.can_set_concurrency_defaults():
+            pytest.skip("storage does not support setting global op concurrency defaults")
+
+        self.set_default_op_concurrency(instance, storage, 2)
+
+        # First call creates the row
+        assert storage.initialize_concurrency_limit_to_default("foo")
+        assert storage.get_concurrency_info("foo").slot_count == 2
+
+        # Second call with same key and same default must not raise and must be a no-op
+        assert storage.initialize_concurrency_limit_to_default("foo")
+        assert storage.get_concurrency_info("foo").slot_count == 2
+
+        # Third call still idempotent
+        assert storage.initialize_concurrency_limit_to_default("foo")
+        assert storage.get_concurrency_info("foo").slot_count == 2
+
+        # Changing the default must propagate on the next call
+        self.set_default_op_concurrency(instance, storage, 3)
+        assert storage.initialize_concurrency_limit_to_default("foo")
+        assert storage.get_concurrency_info("foo").slot_count == 3
+
+        # A user-managed row (using_default_limit=False) must be re-marked as
+        # default-managed after initialize_concurrency_limit_to_default is called.
+        storage.set_concurrency_slots("bar", 5)
+        assert storage.get_concurrency_info("bar").using_default_limit is False
+        assert storage.initialize_concurrency_limit_to_default("bar")
+        assert storage.get_concurrency_info("bar").using_default_limit is True
+        assert storage.get_concurrency_info("bar").slot_count == 3
+
     def test_asset_checks(
         self,
         storage: EventLogStorage,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -22,6 +22,7 @@ from dagster._core.storage.event_log import (
 from dagster._core.storage.event_log.base import EventLogCursor
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.event_log.polling_event_watcher import SqlPollingEventWatcher
+from dagster._core.storage.event_log.schema import ConcurrencyLimitsTable, ConcurrencySlotsTable
 from dagster._core.storage.sql import (
     AlembicVersion,
     check_alembic_revision,
@@ -322,6 +323,102 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 )
                 .on_conflict_do_nothing(),
             )
+
+    def _reconcile_concurrency_limits_from_slots(self) -> None:
+        """PostgreSQL override: replaces the base-class bare INSERT with ON CONFLICT DO NOTHING
+        so that two workers racing to populate an empty limits table during the one-time
+        migration from the slots-only schema do not cause a UniqueViolation / transaction abort.
+        """
+        if not self.has_concurrency_limits_table:
+            return
+
+        if not self._has_rows(ConcurrencySlotsTable) or self._has_rows(ConcurrencyLimitsTable):
+            return
+
+        with self.index_transaction() as conn:
+            rows = conn.execute(
+                db_select(
+                    [
+                        ConcurrencySlotsTable.c.concurrency_key,
+                        db.func.count().label("count"),
+                    ]
+                )
+                .where(ConcurrencySlotsTable.c.deleted == False)  # noqa: E712
+                .group_by(ConcurrencySlotsTable.c.concurrency_key)
+            ).fetchall()
+            if rows:
+                conn.execute(
+                    db_dialects.postgresql.insert(ConcurrencyLimitsTable)
+                    .values([{"concurrency_key": row[0], "limit": row[1]} for row in rows])
+                    .on_conflict_do_nothing()
+                )
+
+    def initialize_concurrency_limit_to_default(self, concurrency_key: str) -> bool:
+        """Override of SqlEventLogStorage.initialize_concurrency_limit_to_default that uses
+        INSERT ... ON CONFLICT syntax instead of the INSERT-then-catch-IntegrityError pattern.
+
+        PostgreSQL differs from SQLite in that a failed statement inside a transaction (e.g. a
+        UniqueViolation on INSERT) aborts the *entire* transaction, putting it into an
+        InFailedSqlTransaction state. The base-class approach of catching IntegrityError and then
+        issuing an UPDATE on the same connection therefore always fails on PostgreSQL.  Using
+        ON CONFLICT DO UPDATE keeps the upsert as a single atomic statement that never raises.
+        """
+        if not self.has_concurrency_limits_table:
+            return False
+
+        self._reconcile_concurrency_limits_from_slots()
+
+        if not self.has_instance:
+            return False
+
+        default_limit = self._instance.global_op_concurrency_default_limit
+        # initialize outside of connection context
+        has_default_pool_limit_col = self.has_default_pool_limit_col
+
+        if has_default_pool_limit_col:
+            with self.index_transaction() as conn:
+                if default_limit is None:
+                    conn.execute(
+                        ConcurrencyLimitsTable.delete().where(
+                            ConcurrencyLimitsTable.c.concurrency_key == concurrency_key,
+                        )
+                    )
+                    self._allocate_concurrency_slots(conn, concurrency_key, 0)
+                else:
+                    insert_stmt = db_dialects.postgresql.insert(ConcurrencyLimitsTable).values(
+                        concurrency_key=concurrency_key,
+                        limit=default_limit,
+                        using_default_limit=True,
+                    )
+                    conn.execute(
+                        insert_stmt.on_conflict_do_update(
+                            index_elements=[ConcurrencyLimitsTable.c.concurrency_key],
+                            set_={
+                                "limit": insert_stmt.excluded.limit,
+                                "using_default_limit": insert_stmt.excluded.using_default_limit,
+                            },
+                            where=db.or_(
+                                ConcurrencyLimitsTable.c.limit != insert_stmt.excluded.limit,
+                                ConcurrencyLimitsTable.c.using_default_limit
+                                != insert_stmt.excluded.using_default_limit,
+                            ),
+                        )
+                    )
+                    self._allocate_concurrency_slots(conn, concurrency_key, default_limit)
+            return True
+
+        if default_limit is None:
+            return False
+
+        with self.index_transaction() as conn:
+            result = conn.execute(
+                db_dialects.postgresql.insert(ConcurrencyLimitsTable)
+                .values(concurrency_key=concurrency_key, limit=default_limit)
+                .on_conflict_do_nothing()
+            )
+            if result.rowcount > 0:
+                self._allocate_concurrency_slots(conn, concurrency_key, default_limit)
+        return True
 
     def _connect(self) -> ContextManager[Connection]:
         return create_pg_connection(self._engine)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -48,6 +48,20 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
     def can_wipe_asset_partitions(self) -> bool:
         return False
 
+    def can_set_concurrency_defaults(self) -> bool:
+        return True
+
+    def set_default_op_concurrency(self, instance, storage, limit) -> None:
+        if instance is None:
+            return
+        # Patch the in-memory settings dict so get_concurrency_config() returns the
+        # expected default_pool_limit without needing to recreate the instance.
+        if "concurrency" not in instance._settings:  # noqa: SLF001
+            instance._settings["concurrency"] = {}  # noqa: SLF001
+        if "pools" not in instance._settings["concurrency"]:  # noqa: SLF001
+            instance._settings["concurrency"]["pools"] = {}  # noqa: SLF001
+        instance._settings["concurrency"]["pools"]["default_limit"] = limit  # noqa: SLF001
+
     def test_event_log_storage_two_watchers(self, conn_string):
         with _clean_storage(conn_string) as storage:
             run_id = make_new_run_id()


### PR DESCRIPTION
## Summary & Motivation

`initialize_concurrency_limit_to_default` could silently corrupt concurrency state on PostgreSQL in multiple ways.

**Bug 1 — Transaction abort on duplicate key**

The base-class implementation uses an INSERT-then-catch-`IntegrityError`-then-UPDATE pattern. On PostgreSQL, a `UniqueViolation` aborts the entire transaction. Any subsequent statement on the same connection — including the corrective UPDATE — silently no-ops, leaving the row with its stale `limit` value. SQLite does not have this behavior.

Fixed by overriding `initialize_concurrency_limit_to_default` in `PostgresEventLogStorage` to use `INSERT ... ON CONFLICT DO UPDATE`, following the same pattern already used by `add_dynamic_partitions` in the same class.

**Bug 2 — `_reconcile_concurrency_limits_from_slots` race on PostgreSQL**

The one-time migration helper that populates `ConcurrencyLimitsTable` from `ConcurrencySlotsTable` does a bare bulk INSERT. Two workers racing during startup (limits table empty, slots table populated) both attempt the insert; the second gets a `UniqueViolation` that aborts its transaction and leaves its connection in a broken state.

Fixed by overriding `_reconcile_concurrency_limits_from_slots` in `PostgresEventLogStorage` to use `INSERT ... ON CONFLICT DO NOTHING`.

**Bug 3 — `using_default_limit` flag not reset for user-managed rows**

When a row previously set via `set_concurrency_slots` (`using_default_limit=False`) is later reclaimed by `initialize_concurrency_limit_to_default`, the flag remained `False`. The PostgreSQL ON CONFLICT SET clause was missing `using_default_limit`, and the SQLite fallback UPDATE omitted it as well.

Fixed in both paths: SET clause now includes `using_default_limit=True`, and the WHERE guard fires when either `limit` differs or `using_default_limit` is `False`.

**Bug 4 — Legacy schema path allocates slots unconditionally**

In the legacy (pre-limits-table) code path, `_allocate_concurrency_slots` was called even when the INSERT was a no-op (row already existed), silently overwriting the slot count.

Fixed by gating `_allocate_concurrency_slots` on `result.rowcount > 0`.

## How I Tested These Changes

Extended the shared `test_default_concurrency_idempotent` test (runs against both SQLite and PostgreSQL) to cover:
- Same-value idempotency (no spurious update)
- Default limit propagation (2 → 3)
- User-managed row reclaim: `set_concurrency_slots` marks a key as user-managed (`using_default_limit=False`), then `initialize_concurrency_limit_to_default` correctly resets the flag to `True` and updates the slot count

Enabled `can_set_concurrency_defaults` on `TestSqliteEventLogStorage` so all three default-concurrency tests now run on SQLite in addition to PostgreSQL.

## Changelog

- `[dagster]` Fixed `initialize_concurrency_limit_to_default` silently no-oping on PostgreSQL due to transaction abort after `UniqueViolation`
- `[dagster]` Fixed `using_default_limit` flag not being reset when a user-managed concurrency row is reclaimed by the default pool
- `[dagster-postgres]` Fixed `_reconcile_concurrency_limits_from_slots` causing a transaction abort on PostgreSQL when two workers race during the one-time slots→limits migration
