### PR TITLE
fix: create local copy for dep keys

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -163,7 +163,7 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     def _get_dep_keys(
         self, key: T_EntityKey, asset_graph: BaseAssetGraph[BaseAssetNode]
     ) -> AbstractSet[AssetKey]:
-        dep_keys = asset_graph.get(key).parent_entity_keys
+        dep_keys = set(asset_graph.get(key).parent_entity_keys)
         if self.allow_selection is not None:
             dep_keys &= self.allow_selection.resolve(asset_graph, allow_missing=True)
         if self.ignore_selection is not None:


### PR DESCRIPTION
## Summary & Motivation

`DepsAutomationCondition._get_dep_keys` applies in-place set operations (`&=`, `-=`) directly on the mutable set returned by `asset_graph.get(key).parent_entity_keys` when `allow_selection` or `ignore_selection` is set:

https://github.com/dagster-io/dagster/blob/51bedbb1e18b1d842636a3130a0687af37a35c82/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py#L163-L171

Since `parent_entity_keys` returns the asset graph's own internal set (not a copy), these operations permanently remove dependency edges from the graph. Any subsequent evaluation — including by other automation conditions on other assets — sees a corrupted DAG with missing edges.

**Fix:** Copy the set before mutating:

```python
dep_keys = set(asset_graph.get(key).parent_entity_keys)  # copy first
```

The `&=` and `-=` then operate on the local copy, leaving the asset graph intact.

## How I Tested These Changes

**To reproduce the bug:**

1. Define a DAG with assets A → B → C
2. Apply `.allow(selection_that_excludes_A)` on a `any_deps_match()` condition for C
3. After evaluation, inspect `asset_graph.get(B).parent_entity_keys` — A is permanently removed
4. Any other automation condition that checks B's parents now sees an incomplete graph

The one-line fix (copying the set before mutating) prevents the in-place mutation from escaping into the asset graph.

## Changelog

- `bugfix` `DepsAutomationCondition._get_dep_keys` no longer permanently removes dependency edges from the asset graph when `allow_selection` or `ignore_selection` is set. The set is now copied before applying `&=` / `-=`, so filtering is local to each evaluation.

## Note

This bug was found by the dagster-expert Claude plugin while I was working on a new automation condition for dbt assets: https://github.com/TEAMSchools/teamster/blob/5d62ee4e7eb833fac48c4a241cfe64a7d7172908/src/teamster/core/automation_conditions.py