### PR TITLE
fix(dagster-docker): pass auth_config and retry on intermittent GHCR image pull failure

### DIFF
--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -1,4 +1,5 @@
 import json
+import time
 from collections.abc import Mapping
 from typing import Any
 
@@ -23,6 +24,22 @@ from dagster_docker.container_context import DockerContainerContext
 from dagster_docker.utils import DOCKER_CONFIG_SCHEMA, validate_docker_config, validate_docker_image
 
 DOCKER_CONTAINER_ID_TAG = "docker/container_id"
+
+
+def _pull_image_with_retry(
+    client: "docker.DockerClient",
+    docker_image: str,
+    auth_config: "dict | None",
+    max_attempts: int = 3,
+) -> None:
+    for attempt in range(max_attempts):
+        try:
+            client.images.pull(docker_image, auth_config=auth_config)
+            return
+        except docker.errors.APIError:  # pyright: ignore[reportAttributeAccessIssue]
+            if attempt == max_attempts - 1:
+                raise
+            time.sleep(2**attempt)  # 1s, 2s, 4s backoff
 
 
 class DockerRunLauncher(RunLauncher, ConfigurableClass):
@@ -115,6 +132,15 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
         labels["dagster/run_id"] = run.run_id
         labels["dagster/job_name"] = run.job_name
 
+        auth_config = (
+            {
+                "username": container_context.registry["username"],
+                "password": container_context.registry["password"],
+            }
+            if container_context.registry
+            else None
+        )
+
         try:
             container = client.containers.create(
                 image=docker_image,
@@ -127,7 +153,7 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
             )
 
         except docker.errors.ImageNotFound:  # pyright: ignore[reportAttributeAccessIssue]
-            client.images.pull(docker_image)
+            _pull_image_with_retry(client, docker_image, auth_config)
             container = client.containers.create(
                 image=docker_image,
                 command=command,

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -379,6 +379,7 @@ from unittest import mock
 
 from dagster._core.launcher.base import WorkerStatus
 from dagster._core.test_utils import create_run_for_test, instance_for_test
+from dagster_docker.docker_run_launcher import _pull_image_with_retry
 
 
 def test_check_run_health():
@@ -530,3 +531,120 @@ def _test_launch(
 
                 # termination is a no-op once run is finished
                 assert not launcher.terminate(run.run_id)
+
+
+# Unit tests for _pull_image_with_retry and auth_config handling (no Docker required)
+
+
+def test_pull_with_auth_config_on_image_not_found():
+    """When ImageNotFound is raised, images.pull is called with the registry auth_config."""
+    with (
+        instance_for_test(
+            {
+                "run_launcher": {
+                    "class": "DockerRunLauncher",
+                    "module": "dagster_docker",
+                    "config": {
+                        "registry": {
+                            "url": "ghcr.io",
+                            "username": "testuser",
+                            "password": "testtoken",
+                        }
+                    },
+                },
+            }
+        ) as instance,
+        mock.patch("docker.client.from_env") as mock_from_env,
+    ):
+        mock_client = mock.MagicMock()
+        mock_from_env.return_value = mock_client
+
+        mock_container = mock.MagicMock()
+        mock_container.id = "container123"
+        mock_client.containers.create.side_effect = [
+            docker.errors.ImageNotFound("not found"),
+            mock_container,
+        ]
+
+        run_launcher = instance.run_launcher
+
+        run = create_run_for_test(instance, "test_job")
+        run_launcher._launch_container_with_command(  # noqa: SLF001
+            run,
+            "ghcr.io/myorg/myimage:sha-abc123",
+            ["dagster", "api", "execute_run"],
+        )
+
+        mock_client.images.pull.assert_called_once_with(
+            "ghcr.io/myorg/myimage:sha-abc123",
+            auth_config={"username": "testuser", "password": "testtoken"},
+        )
+
+
+def test_pull_retries_on_api_error():
+    """_pull_image_with_retry retries up to max_attempts on APIError."""
+    mock_client = mock.MagicMock()
+    mock_client.images.pull.side_effect = [
+        docker.errors.APIError("server error"),
+        docker.errors.APIError("server error"),
+        None,  # succeeds on 3rd attempt
+    ]
+
+    with mock.patch("time.sleep"):
+        _pull_image_with_retry(mock_client, "myimage:latest", auth_config=None, max_attempts=3)
+
+    assert mock_client.images.pull.call_count == 3
+
+
+def test_pull_raises_after_max_retries():
+    """_pull_image_with_retry raises after exhausting all retry attempts."""
+    mock_client = mock.MagicMock()
+    mock_client.images.pull.side_effect = docker.errors.APIError("server error")
+
+    with mock.patch("time.sleep"), pytest.raises(docker.errors.APIError):
+        _pull_image_with_retry(mock_client, "myimage:latest", auth_config=None, max_attempts=3)
+
+    assert mock_client.images.pull.call_count == 3
+
+
+def test_pull_without_registry_uses_no_auth_config():
+    """When no registry is configured, images.pull is called with auth_config=None."""
+    mock_client = mock.MagicMock()
+    mock_client.images.pull.return_value = None
+
+    with mock.patch("time.sleep"):
+        _pull_image_with_retry(mock_client, "myimage:latest", auth_config=None)
+
+    mock_client.images.pull.assert_called_once_with("myimage:latest", auth_config=None)
+
+
+def test_no_pull_when_image_exists_locally():
+    """When containers.create() succeeds immediately, images.pull is never called."""
+    with (
+        instance_for_test(
+            {
+                "run_launcher": {
+                    "class": "DockerRunLauncher",
+                    "module": "dagster_docker",
+                    "config": {},
+                },
+            }
+        ) as instance,
+        mock.patch("docker.client.from_env") as mock_from_env,
+    ):
+        mock_client = mock.MagicMock()
+        mock_from_env.return_value = mock_client
+
+        mock_container = mock.MagicMock()
+        mock_container.id = "container456"
+        mock_client.containers.create.return_value = mock_container
+
+        run_launcher = instance.run_launcher
+        run = create_run_for_test(instance, "test_job")
+        run_launcher._launch_container_with_command(  # noqa: SLF001
+            run,
+            "localimage:latest",
+            ["dagster", "api", "execute_run"],
+        )
+
+        mock_client.images.pull.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes intermittent `DockerRunLauncher` failures when pulling private GHCR images in docker-compose deployments (closes #17814). 

**Root cause:** `containers.create()` triggers an implicit pull at the Docker daemon level using the daemon's own cached credential store — not the Python SDK session established by `client.login()`. When the daemon's short-lived GHCR token expires between runs, the implicit pull fails with `unauthorized`, raising `ImageNotFound`. The fallback `images.pull()` call also had no `auth_config` passed, so it too failed if the daemon's credential cache was stale.

**Fix:**
- Extract `auth_config` from `container_context.registry` before creating the container
- Replace the bare `images.pull()` call with a new `_pull_image_with_retry()` helper that passes explicit `auth_config` and retries up to 3 times with exponential backoff (1s / 2s / 4s) on `docker.errors.APIError`

## How I Tested These Changes

Added 5 unit tests to `test_launch_docker.py` (no Docker daemon required):
- `test_pull_with_auth_config_on_image_not_found` — verifies `auth_config` is passed on `ImageNotFound`
- `test_pull_retries_on_api_error` — verifies retry fires 3 times on `APIError`
- `test_pull_raises_after_max_retries` — verifies exception propagates after exhausting retries
- `test_pull_without_registry_uses_no_auth_config` — verifies no regression when no registry configured
- `test_no_pull_when_image_exists_locally` — verifies `images.pull` not called when image already present

## Changelog

- `dagster-docker`: Fixed intermittent `unauthorized` failures when `DockerRunLauncher` pulls private registry images by passing explicit `auth_config` to `images.pull()` and adding retry with exponential backoff.
