### PR TITLE
Support `function` resource type on dagster-dbt

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -789,7 +789,6 @@ def is_non_asset_node(dbt_resource_props: Mapping[str, Any]):
             resource_type == "metric",
             resource_type == "semantic_model",
             resource_type == "saved_query",
-            resource_type == "function",
             resource_type == "model"
             and dbt_resource_props.get("config", {}).get("materialized") == "ephemeral",
         ]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from dagster_dbt.core.resource import DbtProject
 
 # dbt resource types that may be considered assets
-ASSET_RESOURCE_TYPES = ["model", "seed", "snapshot"]
+ASSET_RESOURCE_TYPES = ["model", "seed", "snapshot", "function"]
 
 clean_name = clean_name_lower
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -1185,7 +1185,7 @@ def test_dbt_with_unit_tests(test_dbt_unit_tests_manifest: dict[str, Any], selec
     DBT_PYTHON_VERSION and DBT_PYTHON_VERSION < version.parse("1.11.0"),
     reason="dbt udf support is only available in `dbt-core>=1.11.0`",
 )
-@pytest.mark.parametrize("select", ["fqn:*", "tag:test"])
+@pytest.mark.parametrize("select", ["fqn:*", "tag:test", "resource_type:function"])
 def test_dbt_with_functions(test_dbt_functions_manifest: dict[str, Any], select: str) -> None:
     @dbt_assets(
         manifest=test_dbt_functions_manifest,


### PR DESCRIPTION
## Summary & Motivation

dbt introduced [User-defined functions](https://docs.getdbt.com/docs/build/udfs?version=2.0) (UDFs) on 1.11+. This allows the developers to create dedicated UDFs files instead of using dbt macros.

The #33245 changed so the UDFs won't cause Dagster exceptions when executing, but it won't allow the UDF to be treated as an asset inside Dagster. This PR change this behavior, allowing the function to be treated as an asset an consequently be materialized.

## How I Tested These Changes

I tested locally creating something like this (similar to seeds):

```python
@dbt_assets(
    manifest=dbt_project.manifest_path,
    select="resource_type:function",
    name="dbt_functions",
    automation_condition=dg.AutomationCondition.code_version_changed(),
)
def dbt_functions(context: dg.AssetExecutionContext, dbt: DbtCliResource):
    yield from dbt.cli(["build"], context=context).stream()
```

## Changelog

* Support dbt UDF (`function`) as Dagster asset
