### PR TITLE
fix(dagster-dlt): use resource.table_name directly in extract_resource_metadata (fixes #33573)

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
@@ -121,26 +121,27 @@ class DagsterDltResource(ConfigurableResource):
         # shared metadata that is displayed for all assets
         base_metadata = {k: v for k, v in load_info_dict.items() if k in dlt_base_metadata_types}
         default_schema = dlt_pipeline.default_schema
-        normalized_table_name = default_schema.naming.normalize_table_identifier(
-            str(resource.table_name)
-        )
-        # job metadata for specific target `normalized_table_name`
+        # Use the resource's table name directly — dlt stores tables by their original name,
+        # not by the output of normalize_table_identifier. For resource names that contain
+        # double-underscores (e.g. "my__test__resource"), the normalizer returns a different
+        # string, causing all per-table lookups to silently fail. See:
+        # https://github.com/dagster-io/dagster/issues/33573
+        table_name_str = str(resource.table_name)
+        # job metadata for specific target `table_name_str`
         base_metadata["jobs"] = [
             job
             for load_package in load_info_dict.get("load_packages", [])
             for job in load_package.get("jobs", [])
-            if job.get("table_name") == normalized_table_name
+            if job.get("table_name") == table_name_str
         ]
-        rows_loaded = dlt_pipeline.last_trace.last_normalize_info.row_counts.get(
-            normalized_table_name
-        )
+        rows_loaded = dlt_pipeline.last_trace.last_normalize_info.row_counts.get(table_name_str)
         if rows_loaded:
             base_metadata["rows_loaded"] = MetadataValue.int(rows_loaded)
 
         schema: str | None = None
         for load_package in load_info_dict.get("load_packages", []):
             for table in load_package.get("tables", []):
-                if table.get("name") == normalized_table_name:
+                if table.get("name") == table_name_str:
                     schema = table.get("schema_name")
                     break
             if schema:
@@ -149,18 +150,18 @@ class DagsterDltResource(ConfigurableResource):
         destination_name: str | None = base_metadata.get("destination_name")
         table_name = None
         if destination_name and schema:
-            table_name = ".".join([destination_name, schema, normalized_table_name])
+            table_name = ".".join([destination_name, schema, table_name_str])
 
         child_table_names = [
             name
             for name in default_schema.data_table_names()
-            if name.startswith(f"{normalized_table_name}__")
+            if name.startswith(f"{table_name_str}__")
         ]
         child_table_schemas = {
             table_name: self._extract_table_schema_metadata(table_name, default_schema)
             for table_name in child_table_names
         }
-        table_schema = self._extract_table_schema_metadata(normalized_table_name, default_schema)
+        table_schema = self._extract_table_schema_metadata(table_name_str, default_schema)
 
         base_metadata = {
             **child_table_schemas,

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/dlt_test_sources/double_underscore_resource.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/dlt_test_sources/double_underscore_resource.py
@@ -1,0 +1,27 @@
+"""Test dlt source with a resource name containing double underscores.
+
+Used to reproduce https://github.com/dagster-io/dagster/issues/33573, where
+extract_resource_metadata silently returns empty metadata for resource names that
+contain ``__`` because normalize_table_identifier transforms them to a different string.
+"""
+
+import dlt
+
+MOCK_DATA = [
+    {"id": 1, "value": "alpha"},
+    {"id": 2, "value": "beta"},
+    {"id": 3, "value": "gamma"},
+]
+
+
+@dlt.source
+def pipeline_double_underscore():
+    @dlt.resource(
+        name="my__test__resource",
+        primary_key="id",
+        write_disposition="merge",
+    )
+    def my__test__resource():
+        yield from MOCK_DATA
+
+    return (my__test__resource,)

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_asset_decorator.py
@@ -877,3 +877,56 @@ def test_translator_invariant_group_name_with_asset_decorator(dlt_pipeline: Pipe
             dagster_dlt_translator=CustomDagsterDltTranslator(),
         )
         def my_dlt_assets(dlt_pipeline_resource: DagsterDltResource): ...
+
+
+def test_resource_name_with_double_underscores(dlt_pipeline: Pipeline) -> None:
+    """Regression test for https://github.com/dagster-io/dagster/issues/33573.
+
+    extract_resource_metadata was calling normalize_table_identifier() on the resource's
+    table name. For names that contain double-underscores (e.g. "my__test__resource"), the
+    normalizer collapses them to a different string, so all per-table lookups silently
+    returned empty results (empty jobs list, no rows_loaded, empty column_schema).
+
+    The fix is to use str(resource.table_name) directly, which matches how dlt stores
+    tables internally.
+    """
+    from dagster_dlt_tests.dlt_test_sources.double_underscore_resource import (
+        pipeline_double_underscore,
+    )
+
+    @dlt_assets(dlt_source=pipeline_double_underscore(), dlt_pipeline=dlt_pipeline)
+    def example_pipeline_assets(
+        context: AssetExecutionContext, dlt_pipeline_resource: DagsterDltResource
+    ):
+        yield from dlt_pipeline_resource.run(context=context)
+
+    res = materialize(
+        [example_pipeline_assets],
+        resources={"dlt_pipeline_resource": DagsterDltResource()},
+    )
+    assert res.success
+
+    materializations = [event.materialization for event in res.get_asset_materialization_events()]
+    assert len(materializations) == 1
+    metadata = materializations[0].metadata
+
+    # jobs list must be non-empty — this was the primary symptom of the bug
+    assert "jobs" in metadata
+    assert len(metadata["jobs"].value) > 0, (
+        "jobs metadata is empty: normalize_table_identifier likely still being called"
+    )
+
+    # rows_loaded must be present and non-zero
+    assert "rows_loaded" in metadata, (
+        "rows_loaded missing: row_counts lookup failed (double-underscore name mismatch)"
+    )
+    assert metadata["rows_loaded"].value == 3
+
+    # column_schema must be populated
+    assert "dagster/column_schema" in metadata, (
+        "column_schema missing: get_table_columns lookup failed (double-underscore name mismatch)"
+    )
+    columns = metadata["dagster/column_schema"].schema.columns
+    column_names = [col.name for col in columns]
+    assert "id" in column_names
+    assert "value" in column_names


### PR DESCRIPTION
## Summary

Fixes #33573.

### Root cause

`extract_resource_metadata` (in `python_modules/libraries/dagster-dlt/dagster_dlt/resource.py`) called `default_schema.naming.normalize_table_identifier(str(resource.table_name))` to derive the key used for every per-table lookup.

For resource names that contain double-underscores (e.g. `my__test__resource`), dlt's snake_case normalizer collapses consecutive underscores, returning a *different* string (e.g. `my_test_resource`). However, dlt stores tables internally under the **original** name, so all lookups silently fail:

| Lookup | Effect before fix |
|---|---|
| `jobs` filter in load packages | returns `[]` |
| `row_counts.get(table_name)` | returns `None` |
| `get_table_columns(table_name)` | raises `KeyError`, caught silently → empty `TableSchema` |
| `tables` filter for `schema_name` | no match → no `dagster/table_name` metadata |

### Fix

Remove the `normalize_table_identifier()` call and use `str(resource.table_name)` directly — which is the key dlt already uses internally for all schema bookkeeping.

```python
# Before
normalized_table_name = default_schema.naming.normalize_table_identifier(
    str(resource.table_name)
)

# After
table_name_str = str(resource.table_name)
```

### Tests

- Added `dagster_dlt_tests/dlt_test_sources/double_underscore_resource.py` — a minimal dlt source with a resource named `my__test__resource`.
- Added `test_resource_name_with_double_underscores` to `test_asset_decorator.py` — asserts that after materialization the metadata contains a non-empty `jobs` list, a non-zero `rows_loaded` value, and a populated `dagster/column_schema`. This test **fails before the fix and passes after**.

Full suite: **42 passed, 0 failed**.

## How I Tested This

```
pytest python_modules/libraries/dagster-dlt/dagster_dlt_tests/ -x -v
# 42 passed in 3.28s
```