### PR TITLE
Fix EMR Serverless log group name lookup from cloudWatchLoggingConfiguration

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr_serverless.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/emr_serverless.py
@@ -292,7 +292,10 @@ class PipesEMRServerlessClient(PipesClient, TreatAsResourceParam):
         else:
             output_streams = ["stdout", "stderr"]
 
-        log_group = monitoring_configuration.get("logGroupName") or "/aws/emr-serverless"
+        log_group = (
+            monitoring_configuration.get("cloudWatchLoggingConfiguration", {}).get("logGroupName")
+            or "/aws/emr-serverless"
+        )
 
         attempt = response["jobRun"].get("attempt")
 


### PR DESCRIPTION
## Summary & Motivation
The EMR Serverless Pipes client was reading the CloudWatch log group name from the wrong key in the monitoring configuration. The logGroupName field is nested under cloudWatchLoggingConfiguration in the EMR Serverless API response, but the code was looking for it at the top level of monitoringConfiguration. This caused log streaming to always fall back to the default /aws/emr-serverless log group, even when a custom log group was configured.

## Test Plan
Manual testing against an EMR Serverless job with a custom CloudWatch log group configured.

## Changelog

dagster-aws: Fixed a bug in PipesEMRServerlessClient where a custom CloudWatch log group name configured in monitoringConfiguration.cloudWatchLoggingConfiguration.logGroupName was ignored, causing log streaming to always use the default /aws/emr-serverless log group