### PR TITLE
[dagster] fix: entity_partitions_def respects selected keys for can_subset multi-assets

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -969,11 +969,22 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         """If the current step is executing a partitioned asset, returns the PartitionsDefinition
         for that asset. If there are one or more partitioned assets executing in the step, they're
         expected to all have the same PartitionsDefinition.
+
+        For can_subset=True multi-assets that mix partitioned and non-partitioned specs, only
+        specs that are selected for this execution are considered. This prevents a non-partitioned
+        spec from inheriting the PartitionsDefinition of a sibling partitioned spec that is not
+        being materialized in the current run.
         """
         if self.assets_def is not None:
+            computation = self.assets_def.computation
+            selected_keys = computation.selected_asset_keys if computation is not None else None
             for spec in self.assets_def.specs:
+                if selected_keys is not None and spec.key not in selected_keys:
+                    continue
                 if spec.partitions_def is not None:
                     return spec.partitions_def
+            # AssetsDefinition.check_specs already filters to only selected check specs via
+            # check_specs_by_output_name, so no additional filtering is needed here.
             for check_spec in self.assets_def.check_specs:
                 if check_spec.partitions_def is not None:
                     return check_spec.partitions_def

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -1116,3 +1116,60 @@ def test_time_partitioned_asset_get_partition_key():
             resources={"io_manager": IOManagerDefinition.hardcoded_io_manager(CustomIOManager())},
             partition_key=daily_partition_definition.get_partition_key(None),  # pyright: ignore[reportArgumentType]
         )
+
+
+def test_multi_asset_can_subset_mixed_partitioned_non_partitioned_no_partition_key():
+    """Regression test for issue #33584.
+
+    When a @multi_asset(can_subset=True) has mixed partitioned and non-partitioned specs,
+    materializing only the non-partitioned spec (without a partition_key) should succeed.
+    Previously, entity_partitions_def would iterate ALL specs and return the PartitionsDefinition
+    of the partitioned sibling, causing a DagsterInvariantViolationError when the step context
+    tried to access partition_key on a non-partitioned run.
+    """
+    partitions_def = dg.StaticPartitionsDefinition(["a", "b", "c"])
+
+    @dg.multi_asset(
+        specs=[
+            dg.AssetSpec("partitioned_asset", partitions_def=partitions_def),
+            dg.AssetSpec("non_partitioned_asset"),
+        ],
+        can_subset=True,
+    )
+    def my_mixed_assets(context: AssetExecutionContext):
+        for asset_key in context.selected_asset_keys:
+            yield dg.MaterializeResult(asset_key=asset_key)
+
+    # Materializing only the non-partitioned spec without a partition_key should succeed
+    result = dg.materialize(
+        assets=[my_mixed_assets],
+        selection=["non_partitioned_asset"],
+    )
+    assert result.success
+    assert_namedtuple_lists_equal(
+        result.asset_materializations_for_node("my_mixed_assets"),
+        [dg.AssetMaterialization(asset_key=dg.AssetKey(["non_partitioned_asset"]))],
+        exclude_fields=["tags"],
+    )
+
+    # Materializing the partitioned spec with a partition_key should also still work
+    result = dg.materialize(
+        assets=[my_mixed_assets],
+        partition_key="a",
+        selection=["partitioned_asset"],
+    )
+    assert result.success
+    assert_namedtuple_lists_equal(
+        result.asset_materializations_for_node("my_mixed_assets"),
+        [dg.AssetMaterialization(asset_key=dg.AssetKey(["partitioned_asset"]), partition="a")],
+        exclude_fields=["tags"],
+    )
+
+    # Materializing BOTH specs together with a partition_key should also work — verifies no
+    # regression in the all-selected path where entity_partitions_def must return the
+    # partitioned spec's PartitionsDefinition.
+    result = dg.materialize(
+        assets=[my_mixed_assets],
+        partition_key="a",
+    )
+    assert result.success


### PR DESCRIPTION
Summary
Fixes a regression introduced in 1.12.14 where materializing a non-partitioned spec from a @multi_asset(can_subset=True) that also contains partitioned sibling specs raises:


DagsterInvariantViolationError: Cannot access partition_key for a non-partitioned run
The entity_partitions_def cached property on StepExecutionContext was iterating all specs of the AssetsDefinition and returning the first PartitionsDefinition found — including from unselected sibling specs. When only a non-partitioned spec is selected, this caused the step context to believe the run was partitioned, leading to a crash when no partition_key was present in the run tags.

The fix filters specs by computation.selected_asset_keys so that unselected partitioned specs do not bleed their PartitionsDefinition into an otherwise non-partitioned execution.

Motivation
Closes https://github.com/dagster-io/dagster/issues/33584

Users with @multi_asset(can_subset=True) assets mixing partitioned and non-partitioned specs — a documented and supported pattern — experienced a 100% failure rate when materializing only the non-partitioned spec after upgrading to 1.12.14. No workaround was available short of restructuring the asset definition or pinning to 1.12.13.

Tests
Added test_multi_asset_can_subset_mixed_partitioned_non_partitioned_no_partition_key in dagster_tests/asset_defs_tests/test_partitioned_assets.py covering three scenarios:

Regression case — select only the non-partitioned spec with no partition_key → succeeds
Partitioned path — select only the partitioned spec with partition_key="a" → succeeds
All-selected path — select both specs with partition_key="a" → succeeds
Existing test test_multi_asset_with_different_partitions_defs verified still passing.

Changelog
dagster

bugfix Fixed a regression where @multi_asset(can_subset=True) assets with mixed partitioned and non-partitioned specs would raise DagsterInvariantViolationError when materializing only the non-partitioned spec.