### PR TITLE
[dagster-dbt] Fix seeds disappearing from manifest on dagster dev reload (#33471)

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -131,19 +131,25 @@ class DagsterDbtProjectPreparer(DbtProjectPreparer):
             .wait()
         )
 
-        # Remove seed entries from partial_parse to force re-parsing at runtime.
-        # This ensures seeds get correct root_path based on current project location.
-        self._invalidate_seeds_in_partial_parse(project)
+        # Update seed root_path in partial_parse to ensure portability across environments.
+        self._update_seed_paths_in_partial_parse(project)
 
-    def _invalidate_seeds_in_partial_parse(self, project: "DbtProject") -> None:
-        """Remove seed entries from partial_parse.msgpack to force re-parsing.
+    def _update_seed_paths_in_partial_parse(self, project: "DbtProject") -> None:
+        """Update seed root_path entries in partial_parse.msgpack to the current project directory.
 
-        Seeds contain root_path which is an absolute path from build time. When state
-        is generated in one environment (e.g., CI/CD) and used in another (e.g., deployed
-        container), the root_path points to the wrong location and seed loading fails.
+        Seeds store an absolute root_path in partial_parse.msgpack. If the path recorded at
+        parse time differs from the current project directory (e.g., the project was moved or
+        the partial_parse was produced in CI and shipped to a container), dbt will fail to
+        locate seed files when executing ``dbt seed``.
 
-        By removing seed entries from the cache, dbt will re-parse them at runtime with
-        the correct current project path. Models keep their cached data for fast loading.
+        Updating root_path in-place — rather than deleting seed entries — also ensures that
+        seeds remain visible in the dbt manifest on subsequent ``dbt parse`` invocations.
+        Deleting seed entries from partial_parse causes dbt to omit them from the manifest,
+        making seeds invisible as Dagster assets in ``dagster dev`` (see issue #33471).
+
+        This method is a no-op when the partial_parse was produced on the same machine and
+        project directory has not changed (the common case). It corrects stale paths when
+        the project directory differs from what was recorded at parse time.
         """
         import msgpack
 
@@ -154,18 +160,26 @@ class DagsterDbtProjectPreparer(DbtProjectPreparer):
         with open(partial_parse_path, "rb") as f:
             data = msgpack.unpack(f, raw=False, strict_map_key=False)
 
-        # Remove seed nodes
-        seed_node_ids = [k for k in data.get("nodes", {}).keys() if k.startswith("seed.")]
-        for seed_id in seed_node_ids:
-            del data["nodes"][seed_id]
+        current_project_dir = str(project.project_dir.resolve())
+        modified = False
 
-        # Remove seed file entries (CSVs)
-        seed_file_ids = [k for k in data.get("files", {}).keys() if k.lower().endswith(".csv")]
-        for file_id in seed_file_ids:
-            del data["files"][file_id]
+        # Update root_path for seed nodes to the current project directory
+        for key, node in data.get("nodes", {}).items():
+            if key.startswith("seed.") and isinstance(node, dict):
+                if node.get("root_path") != current_project_dir:
+                    node["root_path"] = current_project_dir
+                    modified = True
 
-        with open(partial_parse_path, "wb") as f:
-            msgpack.pack(data, f)
+        # Update root_path for seed file entries (CSVs)
+        for key, file_entry in data.get("files", {}).items():
+            if key.lower().endswith(".csv") and isinstance(file_entry, dict):
+                if file_entry.get("root_path") != current_project_dir:
+                    file_entry["root_path"] = current_project_dir
+                    modified = True
+
+        if modified:
+            with open(partial_parse_path, "wb") as f:
+                msgpack.pack(data, f)
 
 
 @record_custom

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
@@ -57,15 +57,16 @@ def test_concurrent_processes(project_dir):
         assert my_project.manifest_path.exists()
 
 
-def test_invalidate_seeds_in_partial_parse(project_dir) -> None:
-    """Test that seed entries are removed from partial_parse.msgpack after preparation.
+def test_update_seed_paths_in_partial_parse(project_dir) -> None:
+    """Test that seed root_path entries are updated in partial_parse.msgpack after preparation.
 
     Seeds contain root_path which is an absolute path from build time. When state
     is generated in one environment (CI/CD) and used in another (deployed container),
     the root_path points to the wrong location and seed loading fails.
 
-    By removing seed entries from the cache, dbt will re-parse them at runtime with
-    the correct current project path. Models keep their cached data for fast loading.
+    By updating root_path for seed entries to the current project directory, seeds
+    remain in the manifest (and visible in dagster-dev) while using the correct path.
+    jaffle_shop has 3 seed CSVs: raw_customers, raw_orders, raw_payments.
     """
     my_project = DbtProject(project_dir)
     partial_parse_path = my_project.project_dir / my_project.target_path / "partial_parse.msgpack"
@@ -76,17 +77,33 @@ def test_invalidate_seeds_in_partial_parse(project_dir) -> None:
 
     assert partial_parse_path.exists(), "partial_parse.msgpack should exist after preparation"
 
-    # Read the partial_parse and verify seeds were removed
+    # Read the partial_parse and verify seeds are present with updated root_path
     with open(partial_parse_path, "rb") as f:
         data = msgpack.unpack(f, raw=False, strict_map_key=False)
 
-    # Check that no seed nodes remain
-    seed_node_ids = [k for k in data.get("nodes", {}).keys() if k.startswith("seed.")]
-    assert len(seed_node_ids) == 0, f"Expected no seed nodes, but found: {seed_node_ids}"
+    current_project_dir = str(my_project.project_dir.resolve())
 
-    # Check that no seed files remain (CSVs)
-    seed_file_ids = [k for k in data.get("files", {}).keys() if k.lower().endswith(".csv")]
-    assert len(seed_file_ids) == 0, f"Expected no seed files, but found: {seed_file_ids}"
+    # Check that seed nodes are still present and have the correct root_path
+    seed_nodes = {k: v for k, v in data.get("nodes", {}).items() if k.startswith("seed.")}
+    assert len(seed_nodes) > 0, (
+        "jaffle_shop dbt project should have seed nodes in partial_parse after prepare_if_dev()"
+    )
+    for seed_id, node in seed_nodes.items():
+        assert node.get("root_path") == current_project_dir, (
+            f"Seed node {seed_id} has incorrect root_path: {node.get('root_path')!r}, "
+            f"expected: {current_project_dir!r}"
+        )
+
+    # Check that seed file entries (CSVs) are still present and have the correct root_path
+    seed_files = {k: v for k, v in data.get("files", {}).items() if k.lower().endswith(".csv")}
+    assert len(seed_files) > 0, (
+        "jaffle_shop dbt project should have seed file entries in partial_parse after prepare_if_dev()"
+    )
+    for file_id, file_entry in seed_files.items():
+        assert file_entry.get("root_path") == current_project_dir, (
+            f"Seed file {file_id} has incorrect root_path: {file_entry.get('root_path')!r}, "
+            f"expected: {current_project_dir!r}"
+        )
 
     # Check that model nodes are preserved
     model_node_ids = [k for k in data.get("nodes", {}).keys() if k.startswith("model.")]
@@ -97,8 +114,62 @@ def test_invalidate_seeds_in_partial_parse(project_dir) -> None:
     assert len(model_file_ids) > 0, "Model files should be preserved"
 
 
-def test_invalidate_seeds_handles_missing_partial_parse() -> None:
-    """Test that _invalidate_seeds_in_partial_parse handles missing file gracefully."""
+def test_update_seed_paths_corrects_stale_root_path(project_dir) -> None:
+    """Test that _update_seed_paths_in_partial_parse corrects a stale root_path.
+
+    Simulates the cross-environment portability scenario: a partial_parse produced in
+    CI (with path /ci/workspace) is shipped to a container (with path /app). The method
+    must detect the stale path and overwrite it with the current project directory.
+    """
+    my_project = DbtProject(project_dir)
+    partial_parse_path = my_project.project_dir / my_project.target_path / "partial_parse.msgpack"
+
+    # Generate a real partial_parse first
+    with environ({"DAGSTER_IS_DEV_CLI": "1"}):
+        my_project.prepare_if_dev()
+
+    assert partial_parse_path.exists()
+
+    # Inject a stale root_path into all seed nodes and seed file entries
+    stale_path = "/stale/ci/workspace/project"
+    with open(partial_parse_path, "rb") as f:
+        data = msgpack.unpack(f, raw=False, strict_map_key=False)
+
+    seed_node_keys = [k for k in data.get("nodes", {}) if k.startswith("seed.")]
+    seed_file_keys = [k for k in data.get("files", {}) if k.lower().endswith(".csv")]
+
+    assert len(seed_node_keys) > 0, "Need seed nodes in partial_parse to run this test"
+    assert len(seed_file_keys) > 0, "Need seed file entries in partial_parse to run this test"
+
+    for key in seed_node_keys:
+        data["nodes"][key]["root_path"] = stale_path
+    for key in seed_file_keys:
+        data["files"][key]["root_path"] = stale_path
+
+    with open(partial_parse_path, "wb") as f:
+        msgpack.pack(data, f)
+
+    # Now call the method and verify it corrects the stale paths
+    preparer = DagsterDbtProjectPreparer()
+    preparer._update_seed_paths_in_partial_parse(my_project)  # noqa: SLF001
+
+    with open(partial_parse_path, "rb") as f:
+        corrected = msgpack.unpack(f, raw=False, strict_map_key=False)
+
+    current_project_dir = str(my_project.project_dir.resolve())
+
+    for key in seed_node_keys:
+        assert corrected["nodes"][key]["root_path"] == current_project_dir, (
+            f"Seed node {key} still has stale root_path after correction"
+        )
+    for key in seed_file_keys:
+        assert corrected["files"][key]["root_path"] == current_project_dir, (
+            f"Seed file {key} still has stale root_path after correction"
+        )
+
+
+def test_update_seed_paths_handles_missing_partial_parse() -> None:
+    """Test that _update_seed_paths_in_partial_parse handles missing file gracefully."""
     with copy_directory(test_jaffle_shop_path) as project_dir:
         my_project = DbtProject(project_dir)
         partial_parse_path = (
@@ -111,7 +182,7 @@ def test_invalidate_seeds_handles_missing_partial_parse() -> None:
 
         # Should not raise an error
         preparer = DagsterDbtProjectPreparer()
-        preparer._invalidate_seeds_in_partial_parse(my_project)  # noqa: SLF001
+        preparer._update_seed_paths_in_partial_parse(my_project)  # noqa: SLF001
 
 
 def test_accepts_string_target_path(project_dir) -> None:
@@ -122,23 +193,23 @@ def test_accepts_string_target_path(project_dir) -> None:
     assert my_project.target_path == Path(string_target_path)
 
 
-def test_seed_command_succeeds_after_invalidation() -> None:
-    """Test that dbt seed command works after seed entries are invalidated.
+def test_seed_command_succeeds_after_path_update() -> None:
+    """Test that dbt seed command works after seed root_path entries are updated.
 
-    This is the end-to-end validation that removing seed entries from
-    partial_parse.msgpack allows dbt to correctly re-parse and load seeds.
+    This is the end-to-end validation that keeping seed entries in partial_parse
+    (with corrected root_path) allows dbt to correctly locate and load seeds.
     """
     from dagster_dbt import DbtCliResource
 
     with copy_directory(test_jaffle_shop_path) as project_dir:
         my_project = DbtProject(project_dir)
 
-        # Prepare the project (which invalidates seeds in partial_parse)
+        # Prepare the project (which updates seed paths in partial_parse)
         with environ({"DAGSTER_IS_DEV_CLI": "1"}):
             my_project.prepare_if_dev()
 
-        # Run dbt seed - this should succeed because dbt will re-parse
-        # the seed files with correct paths
+        # Run dbt seed - this should succeed because seeds remain in partial_parse
+        # with the correct root_path for the current project directory
         dbt = DbtCliResource(project_dir=my_project)
         result = dbt.cli(["seed"]).wait()
 


### PR DESCRIPTION
## Summary & Motivation

Fixes #33471.

Seeds were becoming invisible as Dagster assets in `dagster dev` after commit
`740cbc2` (#33074). That commit deleted seed entries from `partial_parse.msgpack`
to work around a `root_path` portability issue. The deletion had an unintended
side effect: dbt treats missing partial_parse entries as deleted nodes rather than
cache misses, so the regenerated `manifest.json` on the next reload contains no
seeds.

**Fix:** Update `root_path` in seed entries in-place to
`str(project.project_dir.resolve())` rather than deleting them.
- Seeds stay in partial_parse → stay in manifest → visible in `dagster dev` ✅
- Corrects stale CI paths when partial_parse is shipped to a different environment ✅
- No-op (skips file write) when paths already match ✅

## Changes

- Rename `_invalidate_seeds_in_partial_parse` → `_update_seed_paths_in_partial_parse`
- Update implementation to patch `root_path` in-place; use `.resolve()` for normalization; add `modified` guard
- Add `test_update_seed_paths_corrects_stale_root_path`: injects stale `/stale/ci/workspace/project` path, verifies method corrects it

## How I Tested These Changes

Four tests: presence+path correctness post-`prepare_if_dev`, stale-path
portability round-trip, missing-file no-crash, end-to-end `dbt seed` success.

## Changelog

- `dagster-dbt`: Fixed a bug where seeds disappeared from the Dagster asset
  graph in `dagster dev` after the first reload. Seeds are now preserved in
  `partial_parse.msgpack` with a corrected `root_path`.
