### PR TITLE
fix(dagster-aws): handle s3_prefix=None in PickledObjectS3IOManager

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/io_manager.py
@@ -32,6 +32,8 @@ class PickledObjectS3IOManager(UPathIOManager):
         self.bucket = check.str_param(s3_bucket, "s3_bucket")
         check.opt_str_param(s3_prefix, "s3_prefix")
         self.s3 = s3_session
+        # boto3 rejects Prefix=None; normalize to empty string
+        s3_prefix = s3_prefix or ""
         self.s3.list_objects(Bucket=s3_bucket, Prefix=s3_prefix, MaxKeys=1)
         base_path = UPath(s3_prefix) if s3_prefix else None
         super().__init__(base_path=base_path)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_io_manager.py
@@ -24,7 +24,11 @@ from dagster._core.definitions.partitions.definition import StaticPartitionsDefi
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 
-from dagster_aws.s3.io_manager import S3PickleIOManager, s3_pickle_io_manager
+from dagster_aws.s3.io_manager import (
+    PickledObjectS3IOManager,
+    S3PickleIOManager,
+    s3_pickle_io_manager,
+)
 from dagster_aws.s3.utils import construct_s3_client
 
 
@@ -110,6 +114,40 @@ def define_multiple_output_job():
         return_two_outputs()
 
     return output_prefix_execution_plan
+
+
+@pytest.mark.parametrize("s3_prefix", [None, ""])
+def test_pickled_object_s3_io_manager_none_and_empty_prefix(mock_s3_bucket, s3_prefix):
+    """Regression test for https://github.com/dagster-io/dagster/issues/33490.
+
+    PickledObjectS3IOManager accepts s3_prefix=None in its signature but previously passed None
+    directly to boto3's list_objects(Prefix=None), which raises ParamValidationError.
+
+    Both None and "" should result in no prefix being applied (base_path=None).
+    """
+    import boto3
+
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    # Should not raise botocore.exceptions.ParamValidationError
+    io_manager = PickledObjectS3IOManager(
+        s3_bucket=mock_s3_bucket.name,
+        s3_session=s3_client,
+        s3_prefix=s3_prefix,
+    )
+    assert io_manager.bucket == mock_s3_bucket.name
+
+
+def test_pickled_object_s3_io_manager_with_valid_prefix(mock_s3_bucket):
+    """Verify PickledObjectS3IOManager correctly stores a valid prefix."""
+    import boto3
+
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    io_manager = PickledObjectS3IOManager(
+        s3_bucket=mock_s3_bucket.name,
+        s3_session=s3_client,
+        s3_prefix="my-prefix",
+    )
+    assert io_manager.bucket == mock_s3_bucket.name
 
 
 def test_s3_pickle_io_manager_prefix(mock_s3_bucket):


### PR DESCRIPTION
> **Reviewers Requested:** @smackesey @gibsondan — domain experts for `dagster-aws` (top committers to this package)
>
> **Note on CI:** Buildkite builds are blocked pending maintainer approval (standard for fork PRs). Tests pass locally — see Test Results below.

## Summary & Motivation

Fixes #33490

`PickledObjectS3IOManager` accepts `s3_prefix=None` in its constructor signature (`s3_prefix: str | None = None`), but it was passed directly to boto3's `list_objects(Prefix=None)`, which raises `botocore.exceptions.ParamValidationError` because boto3 strictly requires the `Prefix` parameter to be a string type.

This affects users who:
- Use the legacy `s3_pickle_io_manager` resource factory (where `s3_prefix` defaults to `None` if not configured)
- Explicitly pass `s3_prefix=None` to `PickledObjectS3IOManager`

### Root Cause

In `PickledObjectS3IOManager.__init__`, line 35 directly passes the unchecked `s3_prefix` value to boto3:

```python
self.s3.list_objects(Bucket=s3_bucket, Prefix=s3_prefix, MaxKeys=1)
```

When `s3_prefix=None`, boto3 raises:
```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter Prefix, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
```

### Fix

Added `s3_prefix = s3_prefix or ""` normalization after the `check.opt_str_param` call and before the boto3 call. An empty string is the correct boto3 equivalent of "no prefix" and is also falsy, so the existing `base_path = UPath(s3_prefix) if s3_prefix else None` logic continues to work correctly.

## Test Plan

| Test | Status |
|------|--------|
| `test_pickled_object_s3_io_manager_none_and_empty_prefix` (parametrized: `None`, `""`) | PASS |
| `test_pickled_object_s3_io_manager_with_valid_prefix` | PASS |
| Full `test_io_manager.py` suite (7 tests) | PASS |
| `make ruff` | PASS |

## Test Results

```
7 passed in 2.23s  (dagster_aws_tests/s3_tests/test_io_manager.py)
```

## Changelog

`PickledObjectS3IOManager` no longer raises `ParamValidationError` when `s3_prefix=None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)