### PR TITLE
fix(storage): use SAVEPOINT in initialize_concurrency_limit_to_default to fix PostgreSQL crash

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2259,13 +2259,14 @@ class SqlEventLogStorage(EventLogStorage):
                     self._allocate_concurrency_slots(conn, concurrency_key, 0)
                 else:
                     try:
-                        conn.execute(
-                            ConcurrencyLimitsTable.insert().values(
-                                concurrency_key=concurrency_key,
-                                limit=default_limit,
-                                using_default_limit=True,
+                        with conn.begin_nested():
+                            conn.execute(
+                                ConcurrencyLimitsTable.insert().values(
+                                    concurrency_key=concurrency_key,
+                                    limit=default_limit,
+                                    using_default_limit=True,
+                                )
                             )
-                        )
                     except db_exc.IntegrityError:
                         conn.execute(
                             ConcurrencyLimitsTable.update()
@@ -2285,11 +2286,12 @@ class SqlEventLogStorage(EventLogStorage):
 
         with self.index_transaction() as conn:
             try:
-                conn.execute(
-                    ConcurrencyLimitsTable.insert().values(
-                        concurrency_key=concurrency_key, limit=default_limit
+                with conn.begin_nested():
+                    conn.execute(
+                        ConcurrencyLimitsTable.insert().values(
+                            concurrency_key=concurrency_key, limit=default_limit
+                        )
                     )
-                )
             except db_exc.IntegrityError:
                 pass
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -5861,6 +5861,41 @@ class TestEventLogStorage:
 
         assert storage.get_concurrency_info("foo").slot_count == 0
 
+    def test_initialize_concurrency_limit_to_default_idempotent(
+        self, storage: EventLogStorage, instance: DagsterInstance
+    ):
+        """Calling initialize_concurrency_limit_to_default twice for the same key must succeed.
+
+        This verifies the fix for https://github.com/dagster-io/dagster/issues/33552: on
+        PostgreSQL (and other databases that abort a transaction on IntegrityError) the
+        INSERT-then-catch-IntegrityError-then-UPDATE pattern was broken because the failed INSERT
+        aborted the entire transaction, leaving the subsequent UPDATE unable to execute.
+
+        The fix wraps the INSERT in conn.begin_nested() (a SAVEPOINT) so that only the savepoint
+        is rolled back on conflict, not the whole transaction.
+        """
+        if not storage.supports_global_concurrency_limits:
+            pytest.skip("storage does not support global op concurrency")
+
+        if not self.can_set_concurrency_defaults():
+            pytest.skip("storage does not support setting global op concurrency defaults")
+
+        self.set_default_op_concurrency(instance, storage, 5)
+
+        # First call inserts the row
+        assert storage.initialize_concurrency_limit_to_default("bar")
+        assert storage.get_concurrency_info("bar").slot_count == 5
+
+        # Second call for the same key (simulating a race condition or retry) must not crash.
+        # This is the scenario that triggered InFailedSqlTransaction on PostgreSQL.
+        assert storage.initialize_concurrency_limit_to_default("bar")
+        assert storage.get_concurrency_info("bar").slot_count == 5
+
+        # Changing the default and calling again must update the existing row
+        self.set_default_op_concurrency(instance, storage, 3)
+        assert storage.initialize_concurrency_limit_to_default("bar")
+        assert storage.get_concurrency_info("bar").slot_count == 3
+
     def test_asset_checks(
         self,
         storage: EventLogStorage,


### PR DESCRIPTION
> **Reviewers Requested:** @prha @gibsondan — top committers to `sql_event_log.py` (14x and 7x commits respectively)
>
> **Note on CI:** Buildkite builds are blocked pending maintainer approval (standard for fork PRs). Tests pass locally — see Test Results below.

## Summary & Motivation

Fixes #33552

**Production blocker:** `SqlEventLogStorage.initialize_concurrency_limit_to_default()` crashes on PostgreSQL when the concurrency key already exists in the database. This makes it impossible to run any asset that uses the `pool=` parameter on PostgreSQL deployments when a race condition or retry causes the INSERT to find an existing row.

The bug affects all PostgreSQL-backed Dagster deployments (Azure Database for PostgreSQL, AWS RDS, etc.) using pool-based concurrency limits. The only workaround is manually setting pool limits through the UI.

### Root Cause

The method uses an INSERT-then-catch-IntegrityError-then-UPDATE pattern:

```python
try:
    conn.execute(ConcurrencyLimitsTable.insert().values(...))
except db_exc.IntegrityError:
    conn.execute(ConcurrencyLimitsTable.update()...)  # FAILS on PostgreSQL
```

On PostgreSQL, a failed INSERT statement **aborts the entire transaction**. All subsequent statements fail with `InFailedSqlTransaction` until a `ROLLBACK`. This is fundamental PostgreSQL behavior — unlike SQLite where failed statements don't invalidate the transaction.

The bug exists in **both** code paths:
1. `has_default_pool_limit_col=True` — INSERT fails, UPDATE fails
2. `has_default_pool_limit_col=False` — INSERT fails, `_allocate_concurrency_slots` fails

### Trigger Scenario

A race condition (concurrent runs, or retry after partial failure where the row was committed by a different process) causes the INSERT to find the row already present.

### Fix

Wrapped the INSERT in `conn.begin_nested()` (SAVEPOINT). On IntegrityError, only the savepoint is rolled back — the outer transaction proceeds. Applied to both code paths. This pattern is already used elsewhere in the codebase (`store_asset_event`, `add_dynamic_partitions`).

## Test Plan

| Test | Status |
|------|--------|
| `test_initialize_concurrency_limit_to_default_idempotent` (double-call + update) | PASS (runs on PostgreSQL storage) |
| Existing `test_default_concurrency` | PASS |
| Existing `test_changing_default_concurrency_key` | PASS |
| `make ruff` | PASS |

### Error Before Fix

```
sqlalchemy.exc.InternalError: (psycopg2.errors.InFailedSqlTransaction)
current transaction is aborted, commands ignored until end of transaction block

Caused by: psycopg2.errors.UniqueViolation: duplicate key value violates
unique constraint "concurrency_limits_concurrency_key_key"
```

## Changelog

Fixed a crash in `initialize_concurrency_limit_to_default` on PostgreSQL when the concurrency key already exists. The method now uses a SAVEPOINT to handle the INSERT conflict gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)