### PR TITLE
fix(daemon): retry job backfills on transient code location unreachable errors

### DIFF
--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -15,6 +15,7 @@ from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.partitions.context import partition_loading_context
 from dagster._core.errors import (
     DagsterCodeLocationLoadError,
+    DagsterCodeLocationNotFoundError,
     DagsterRunAlreadyExists,
     DagsterUserCodeUnreachableError,
 )
@@ -225,6 +226,31 @@ def execute_backfill_iteration_with_instigation_logger(
                     instance.update_backfill(
                         backfill.with_failure_count(backfill.failure_count + 1)
                     )
+            elif (
+                not backfill.is_asset_backfill
+                and backfill.status == BulkActionStatus.REQUESTED
+                and isinstance(
+                    e,
+                    (
+                        DagsterUserCodeUnreachableError,
+                        DagsterCodeLocationLoadError,
+                        DagsterCodeLocationNotFoundError,
+                    ),
+                )
+            ):
+                # Job backfills should also retry transiently when the code server is unreachable,
+                # rather than permanently failing. The daemon will retry on the next tick.
+                try:
+                    raise DagsterUserCodeUnreachableError(
+                        "Unable to reach the code server. Backfill will resume once the code server is available."
+                    ) from e
+                except:
+                    error_info = DaemonErrorCapture.process_exception(
+                        sys.exc_info(),
+                        logger=backfill_logger,
+                        log_message=f"Job backfill failed for {backfill.backfill_id} due to unreachable code server and will retry",
+                    )
+                instance.update_backfill(backfill.with_error(error_info))
             else:
                 error_info = DaemonErrorCapture.process_exception(
                     sys.exc_info(),

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -4245,3 +4245,57 @@ def test_threaded_submit_backfill(
     runs = instance.get_runs()
     partitions = {run.tags[PARTITION_NAME_TAG] for run in runs}
     assert partitions == {"one", "two", "three"}
+
+
+def test_job_backfill_retries_on_unreachable_code_location(
+    instance: DagsterInstance,
+    workspace_context: WorkspaceProcessContext,
+    unloadable_location_workspace_context: WorkspaceProcessContext,
+    remote_repo: RemoteRepository,
+):
+    """Job backfills should stay in REQUESTED state (not move to FAILING) when the code location
+    is temporarily unreachable. This mirrors the retry behavior that already exists for asset
+    backfills (see test_unloadable_backfill_retry for the asset backfill equivalent).
+    """
+    partition_set = remote_repo.get_partition_set("the_job_partition_set")
+    instance.add_backfill(
+        PartitionBackfill(
+            backfill_id="job_retry_backfill",
+            partition_set_origin=partition_set.get_remote_origin(),
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["one", "two", "three"],
+            from_failure=False,
+            reexecution_steps=None,
+            tags=None,
+            backfill_timestamp=get_current_timestamp(),
+        )
+    )
+    assert instance.get_runs_count() == 0
+
+    # First iteration with unreachable code location — backfill should stay REQUESTED, not FAILING
+    list(
+        execute_backfill_iteration(
+            unloadable_location_workspace_context, get_default_daemon_logger("BackfillDaemon")
+        )
+    )
+    backfill = instance.get_backfill("job_retry_backfill")
+    assert backfill
+    assert backfill.status == BulkActionStatus.REQUESTED, (
+        "Job backfill should remain REQUESTED when code location is transiently unreachable"
+    )
+    assert instance.get_runs_count() == 0
+
+    # Second iteration still unreachable — still stays REQUESTED
+    list(
+        execute_backfill_iteration(
+            unloadable_location_workspace_context, get_default_daemon_logger("BackfillDaemon")
+        )
+    )
+    backfill = instance.get_backfill("job_retry_backfill")
+    assert backfill
+    assert backfill.status == BulkActionStatus.REQUESTED
+    assert instance.get_runs_count() == 0
+
+    # Once the code location is reachable again, backfill proceeds normally
+    list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
+    assert instance.get_runs_count() == 3


### PR DESCRIPTION
> **Reviewers Requested:** @gibsondan @jamiedemaria — primary owners of `backfill.py` (11x and 10x commits respectively)
>
> **Note on CI:** Buildkite builds are blocked pending maintainer approval (standard for fork PRs). Tests pass locally — see Test Results below.

## Summary & Motivation

Fixes #33527

Job backfills (non-asset backfills) are permanently cancelled when the code location is temporarily unreachable. Asset backfills already have retry logic for transient code-location errors, but job backfills were excluded from this protection, causing them to be marked as `FAILING` on the first transient error — even if the code server comes back seconds later.

This is especially painful for ECS Fargate, Kubernetes, or any environment where code locations may briefly go offline during rolling deploys, task recycling, or network blips.

### Root Cause

In `backfill.py`, the retry condition is gated on `backfill.is_asset_backfill`:

```python
if (
    backfill.is_asset_backfill        # <-- job backfills always skip this
    and backfill.status == BulkActionStatus.REQUESTED
    and backfill.failure_count < _get_max_asset_backfill_retries()
    and _is_retryable_asset_backfill_error(e)
):
    # retry logic
else:
    # marks FAILING ← job backfills always land here
```

### Fix

Added a new `elif` branch for job backfills that handles three transient code-location errors:
- `DagsterUserCodeUnreachableError` — code server not responding
- `DagsterCodeLocationLoadError` — code location failed to load
- `DagsterCodeLocationNotFoundError` — code location missing from workspace (discovered during testing)

When the backfill is still `REQUESTED`, it's updated with error info but **stays in REQUESTED state**, allowing the daemon to retry on the next tick.

### Key Finding During Testing

Initial implementation only handled `DagsterUserCodeUnreachableError` and `DagsterCodeLocationLoadError`. Testing with the `unloadable_location_workspace_context` fixture revealed the actual error raised is `DagsterCodeLocationNotFoundError` (when the location is missing from the workspace). This was added to the condition.

## Test Plan

| Test | Status |
|------|--------|
| `test_job_backfill_retries_on_unreachable_code_location` (full lifecycle) | PASS |
| All `job_backfill` tests (8 tests) | PASS |
| Existing asset backfill retry tests | PASS |
| `make ruff` | PASS |

## Test Results

```
1 passed in 5.22s   (new integration test)
8 passed in 29.53s  (all job_backfill tests)
```

The integration test verifies:
1. Backfill stays `REQUESTED` across 2 unreachable iterations
2. Proceeds normally once code location is reachable again
3. All 3 partitions are submitted correctly

## Changelog

Job backfills now retry on transient code location errors (unreachable, failed to load, not found) instead of being permanently cancelled. This matches the existing retry behavior for asset backfills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)