### PR TITLE
fix(multi-asset): scope entity_partitions_def to selected specs only in mixed multi-assets

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -970,13 +970,26 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         """If the current step is executing a partitioned asset, returns the PartitionsDefinition
         for that asset. If there are one or more partitioned assets executing in the step, they're
         expected to all have the same PartitionsDefinition.
+
+        Only considers the specs and check specs that are actually selected for execution in this
+        step. This matters for can_subset=True multi-assets that mix partitioned and non-partitioned
+        specs: when only non-partitioned specs are selected, this returns None.
         """
         if self.assets_def is not None:
+            computation = self.assets_def.computation
+            selected_asset_keys = (
+                computation.selected_asset_keys if computation is not None else self.assets_def.keys
+            )
+            selected_check_keys = (
+                computation.selected_asset_check_keys
+                if computation is not None
+                else set(self.assets_def.check_keys)
+            )
             for spec in self.assets_def.specs:
-                if spec.partitions_def is not None:
+                if spec.key in selected_asset_keys and spec.partitions_def is not None:
                     return spec.partitions_def
             for check_spec in self.assets_def.check_specs:
-                if check_spec.partitions_def is not None:
+                if check_spec.key in selected_check_keys and check_spec.partitions_def is not None:
                     return check_spec.partitions_def
         return None
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -524,6 +524,121 @@ def test_multi_asset_with_different_partitions_defs():
     )
 
 
+def test_non_partitioned_spec_in_mixed_multi_asset_does_not_raise_partition_key_error():
+    """Regression test for https://github.com/dagster-io/dagster/issues/33584.
+
+    A non-partitioned AssetSpec inside a can_subset=True @multi_asset that also contains
+    a partitioned spec must be materializable without raising
+    "Cannot access partition_key for a non-partitioned run".
+
+    This was a regression introduced in 1.12.14 where entity_partitions_def iterated all specs
+    (including unselected partitioned ones), making has_partitions return True for a run that was
+    not partitioned.
+    """
+    partitions_def = dg.StaticPartitionsDefinition(["a", "b", "c"])
+
+    @dg.multi_asset(
+        specs=[
+            dg.AssetSpec("partitioned_asset", partitions_def=partitions_def),
+            dg.AssetSpec("non_partitioned_asset"),
+        ],
+        can_subset=True,
+    )
+    def mixed_multi_asset(context: AssetExecutionContext):
+        for asset_key in context.selected_asset_keys:
+            yield dg.MaterializeResult(asset_key=asset_key)
+
+    # Materializing only the non-partitioned spec must NOT raise DagsterInvariantViolationError
+    result = dg.materialize(
+        assets=[mixed_multi_asset],
+        selection=["non_partitioned_asset"],
+    )
+    assert result.success
+    assert_namedtuple_lists_equal(
+        result.asset_materializations_for_node("mixed_multi_asset"),
+        [dg.AssetMaterialization(asset_key=dg.AssetKey(["non_partitioned_asset"]))],
+        exclude_fields=["tags"],
+    )
+
+    # Materializing only the partitioned spec with a partition key still works correctly
+    result = dg.materialize(
+        assets=[mixed_multi_asset],
+        selection=["partitioned_asset"],
+        partition_key="a",
+    )
+    assert result.success
+
+
+def test_mixed_multi_asset_partition_key_accessible_for_partitioned_selection():
+    """Verify that context.partition_key is accessible when selecting only the partitioned spec
+    in a mixed (partitioned + non-partitioned) can_subset multi-asset.
+
+    This tests the other direction of #33584: the partitioned path must still expose partition_key.
+    """
+    partitions_def = dg.StaticPartitionsDefinition(["x", "y", "z"])
+
+    @dg.multi_asset(
+        specs=[
+            dg.AssetSpec("partitioned_out", partitions_def=partitions_def),
+            dg.AssetSpec("unpartitioned_out"),
+        ],
+        can_subset=True,
+    )
+    def my_mixed(context: AssetExecutionContext):
+        if dg.AssetKey("partitioned_out") in context.selected_asset_keys:
+            # This must NOT raise "Cannot access partition_key for a non-partitioned run"
+            assert context.partition_key == "y"
+        for key in context.selected_asset_keys:
+            yield dg.MaterializeResult(asset_key=key)
+
+    result = dg.materialize(
+        assets=[my_mixed],
+        selection=["partitioned_out"],
+        partition_key="y",
+    )
+    assert result.success
+
+    assert_namedtuple_lists_equal(
+        result.asset_materializations_for_node("my_mixed"),
+        [dg.AssetMaterialization(asset_key=dg.AssetKey(["partitioned_out"]), partition="y")],
+        exclude_fields=["tags"],
+    )
+
+
+def test_mixed_multi_asset_multiple_non_partitioned_specs():
+    """When a can_subset multi-asset has multiple non-partitioned specs alongside a partitioned
+    one, materializing any combination of the non-partitioned specs must succeed without partition
+    errors.
+    """
+    partitions_def = dg.StaticPartitionsDefinition(["1", "2"])
+
+    @dg.multi_asset(
+        specs=[
+            dg.AssetSpec("p_asset", partitions_def=partitions_def),
+            dg.AssetSpec("np_asset_a"),
+            dg.AssetSpec("np_asset_b"),
+        ],
+        can_subset=True,
+    )
+    def triple_mixed(context: AssetExecutionContext):
+        for key in context.selected_asset_keys:
+            yield dg.MaterializeResult(asset_key=key)
+
+    # Materialize both non-partitioned at once
+    result = dg.materialize(
+        assets=[triple_mixed],
+        selection=["np_asset_a", "np_asset_b"],
+    )
+    assert result.success
+
+    # Materialize just one non-partitioned
+    result = dg.materialize(
+        assets=[triple_mixed],
+        selection=["np_asset_a"],
+    )
+    assert result.success
+
+
 def test_multi_asset_with_differrent_partitions_def_and_top_level_group_name():
     partitions_def1 = dg.DailyPartitionsDefinition(start_date="2020-01-01")
     partitions_def2 = dg.StaticPartitionsDefinition(["1", "2", "3"])


### PR DESCRIPTION
> **Reviewers Requested:** @OwenKephart @smackesey — @OwenKephart authored the original regression commit (#20493), @smackesey is the second-most active contributor to `execution/context/system.py`
>
> **Note on CI:** Buildkite builds are blocked pending maintainer approval (standard for fork PRs). Tests pass locally — see Test Results below.

## Summary & Motivation

Fixes #33584

**Regression in 1.12.14:** Materializing a non-partitioned `AssetSpec` inside a `can_subset=True` `@multi_asset` that also contains partitioned specs raises `DagsterInvariantViolationError: Cannot access partition_key for a non-partitioned run`.

This is the exact pattern produced by `@dbt_assets` with a `DagsterDbtTranslator` that assigns `partitions_def` to some models but not others, where a non-partitioned model references a partitioned source. The issue is reproducible both locally and on Dagster Cloud, and worked correctly in 1.12.13 and earlier.

### Root Cause

Commit 177042857b (#20493, landed in 1.12.14) — "Fix issue with partitioned asset checks that use IOManagers for input loading" — changed `entity_partitions_def` to iterate ALL `self.assets_def.specs`:

```python
for spec in self.assets_def.specs:
    if spec.partitions_def is not None:
        return spec.partitions_def  # Returns partitioned spec even when NOT selected
```

In a mixed multi-asset with `can_subset=True`, this finds the **other** partitioned specs not being executed. When only non-partitioned specs are selected:
1. `entity_partitions_def` returns a partitions_def from an unselected spec
2. `has_partitions` returns `True`
3. `partition_key` access fails — no partition tags on the run

### Fix

Filter `specs` and `check_specs` by `computation.selected_asset_keys` / `selected_asset_check_keys` before checking `partitions_def`. Only specs actually selected for execution in this step contribute to `entity_partitions_def`:

```python
selected_asset_keys = computation.selected_asset_keys if computation else self.assets_def.keys
for spec in self.assets_def.specs:
    if spec.key in selected_asset_keys and spec.partitions_def is not None:
        return spec.partitions_def
```

**This fix does NOT regress the original PR #20493** — all 12 `test_partitioned_asset_check_status.py` tests pass.

## Test Plan

| Test | Status |
|------|--------|
| `test_non_partitioned_spec_in_mixed_multi_asset_does_not_raise_partition_key_error` | PASS |
| `test_mixed_multi_asset_partition_key_accessible_for_partitioned_selection` | PASS |
| `test_mixed_multi_asset_multiple_non_partitioned_specs` | PASS |
| Full `test_partitioned_assets.py` (31 tests) | PASS |
| `test_partitioned_asset_check_status.py` (12 tests, original #20493) | PASS |
| Broader asset execution tests (159 tests) | PASS |
| All partition-related tests (260 tests) | PASS |
| `make ruff` | PASS |

## Test Results

```
31 passed in 3.82s    (test_partitioned_assets.py — full suite)
12 passed in 17.13s   (test_partitioned_asset_check_status.py — original #20493 tests)
159 passed in 61.97s  (broader asset defs + asset job test suite)
260 passed in 37.57s  (all partition-related asset tests)
```

### Regression Introduced By
Commit `177042857b` — `[pac] Fix issue with partitioned asset checks that use IOManagers for input loading (#20493)` by @OwenKephart

## Changelog

Fixed a regression introduced in 1.12.14 where materializing a non-partitioned asset spec inside a mixed (partitioned + non-partitioned) `can_subset=True` multi-asset would raise "Cannot access partition_key for a non-partitioned run".

🤖 Generated with [Claude Code](https://claude.com/claude-code)