### PR TITLE
fix(k8s): skip health check failure if STEP_SUCCESS already in event log

### DIFF
--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -255,7 +255,7 @@ class StepDelegatingExecutor(Executor):
                 last_check_step_health_time = get_current_datetime()
 
                 try:
-                    # Order of events is important here. During an interation, we call handle_event, then get_steps_to_execute,
+                    # Order of events is important here. During an iteration, we call handle_event, then get_steps_to_execute,
                     # then is_complete. get_steps_to_execute updates the state of ActiveExecution, and without it
                     # is_complete can return true when we're just between steps.
                     while not active_execution.is_complete:
@@ -353,6 +353,36 @@ class StepDelegatingExecutor(Executor):
                                         )
                                     )
                                     if not health_check_result.is_healthy:
+                                        # Before declaring failure, verify that STEP_SUCCESS
+                                        # hasn't already been written to the event log but not
+                                        # yet consumed by _pop_events. This covers two races:
+                                        #
+                                        # 1. TTL race: the K8s job is deleted by
+                                        #    ttlSecondsAfterFinished before the executor polls
+                                        #    the STEP_SUCCESS event, making get_job_status
+                                        #    return None and check_step_health return unhealthy.
+                                        #
+                                        # 2. OOMKill race: the pod is killed during
+                                        #    post-success cleanup (after writing STEP_SUCCESS
+                                        #    but before the process exits), causing the K8s job
+                                        #    to show status.failed > 0.
+                                        #
+                                        # In both cases the step genuinely succeeded; the next
+                                        # _pop_events call will pick up STEP_SUCCESS and remove
+                                        # the step from running_steps, so we can safely skip
+                                        # the failure here.
+                                        step_already_succeeded = any(
+                                            record.event_log_entry.dagster_event is not None
+                                            and record.event_log_entry.dagster_event.step_key
+                                            == step.key
+                                            for record in plan_context.instance.get_records_for_run(
+                                                plan_context.run_id,
+                                                of_type=DagsterEventType.STEP_SUCCESS,
+                                            ).records
+                                        )
+                                        if step_already_succeeded:
+                                            continue
+
                                         health_check_error = SerializableErrorInfo(
                                             message=f"Step {step.key} failed health check: {health_check_result.unhealthy_reason}",
                                             stack=[],

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -380,7 +380,7 @@ class StepDelegatingExecutor(Executor):
                                                 of_type={DagsterEventType.STEP_SUCCESS, DagsterEventType.STEP_UP_FOR_RETRY},
                                             ).records
                                         )
-                                        if step_already_succeeded:
+                                        if step_already_handled:
                                             continue
 
                                         health_check_error = SerializableErrorInfo(

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -371,13 +371,13 @@ class StepDelegatingExecutor(Executor):
                                         # _pop_events call will pick up STEP_SUCCESS and remove
                                         # the step from running_steps, so we can safely skip
                                         # the failure here.
-                                        step_already_succeeded = any(
+                                        step_already_handled = any(
                                             record.event_log_entry.dagster_event is not None
                                             and record.event_log_entry.dagster_event.step_key
                                             == step.key
                                             for record in plan_context.instance.get_records_for_run(
                                                 plan_context.run_id,
-                                                of_type=DagsterEventType.STEP_SUCCESS,
+                                                of_type={DagsterEventType.STEP_SUCCESS, DagsterEventType.STEP_UP_FOR_RETRY},
                                             ).records
                                         )
                                         if step_already_succeeded:

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -371,13 +371,24 @@ class StepDelegatingExecutor(Executor):
                                         # _pop_events call will pick up STEP_SUCCESS and remove
                                         # the step from running_steps, so we can safely skip
                                         # the failure here.
+                                        #
+                                        # Only events not yet consumed by _pop_events (storage_id
+                                        # not in seen_storage_ids) count: a consumed
+                                        # STEP_UP_FOR_RETRY belongs to a prior attempt of this
+                                        # step and must not suppress a genuine failure of the
+                                        # current attempt, which would otherwise leave the step
+                                        # in running_steps forever and hang the run.
                                         step_already_handled = any(
-                                            record.event_log_entry.dagster_event is not None
+                                            record.storage_id not in seen_storage_ids
+                                            and record.event_log_entry.dagster_event is not None
                                             and record.event_log_entry.dagster_event.step_key
                                             == step.key
                                             for record in plan_context.instance.get_records_for_run(
                                                 plan_context.run_id,
-                                                of_type={DagsterEventType.STEP_SUCCESS, DagsterEventType.STEP_UP_FOR_RETRY},
+                                                of_type={
+                                                    DagsterEventType.STEP_SUCCESS,
+                                                    DagsterEventType.STEP_UP_FOR_RETRY,
+                                                },
                                             ).records
                                         )
                                         if step_already_handled:

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -3,6 +3,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from unittest.mock import MagicMock
 
 import dagster as dg
 import pytest
@@ -12,6 +13,7 @@ from dagster._core.definitions.assets.definition.cacheable_assets_definition imp
     CacheableAssetsDefinition,
 )
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
+from dagster._core.event_api import EventLogRecord
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.step_delegating import (
@@ -20,6 +22,7 @@ from dagster._core.executor.step_delegating import (
     StepHandler,
 )
 from dagster._core.instance import DagsterInstance
+from dagster._core.storage.event_log.base import EventLogConnection
 from dagster._core.test_utils import environ, poll_for_pool_pending_step
 from dagster._utils.merger import merge_dicts
 from dagster._utils.test.definitions import scoped_definitions_load_context
@@ -661,3 +664,103 @@ def test_check_step_health_unhealthy_fails_step():
         event for event in result.all_events if event.event_type == DagsterEventType.STEP_FAILURE
     ]
     assert len(failure_events) > 0, "Expected step failure events"
+
+
+def test_check_step_health_unhealthy_with_unconsumed_step_success_skips_failure(monkeypatch):
+    """If STEP_SUCCESS exists but is not yet tailed, unhealthy checks should not emit STEP_FAILURE."""
+    TestStepHandler.reset()
+    TestStepHandler.should_return_unhealthy = True
+
+    with dg.instance_for_test() as instance:
+        original_get_records_for_run = instance.get_records_for_run
+
+        def _get_records_for_run(run_id, cursor=None, of_type=None, limit=None, ascending=True):
+            conn = original_get_records_for_run(
+                run_id,
+                cursor=cursor,
+                of_type=of_type,
+                limit=limit,
+                ascending=ascending,
+            )
+            if of_type == {DagsterEventType.STEP_SUCCESS, DagsterEventType.STEP_UP_FOR_RETRY}:
+                # Mimic an event written to storage that the event tailer has not consumed yet.
+                unconsumed_success_record = EventLogRecord(
+                    storage_id=10**12,
+                    event_log_entry=MagicMock(
+                        dagster_event=MagicMock(step_key="slow_op_0"),
+                    ),
+                )
+                return EventLogConnection(
+                    records=[*conn.records, unconsumed_success_record],
+                    cursor=conn.cursor,
+                    has_more=conn.has_more,
+                )
+            return conn
+
+        monkeypatch.setattr(instance, "get_records_for_run", _get_records_for_run)
+
+        result = dg.execute_job(
+            dg.reconstructable(three_op_job),
+            instance=instance,
+            run_config={
+                "execution": {
+                    "config": {
+                        "check_step_health_interval_seconds": 0,
+                        "sleep_seconds": 0.01,
+                    }
+                }
+            },
+        )
+        TestStepHandler.wait_for_processes()
+
+    assert result.success
+    failure_events = [
+        event for event in result.all_events if event.event_type == DagsterEventType.STEP_FAILURE
+    ]
+    assert len(failure_events) == 0, "Did not expect STEP_FAILURE events"
+
+
+@dg.op(retry_policy=dg.RetryPolicy(max_retries=1))
+def retry_then_sleep_op(context):
+    if context.retry_number == 0:
+        raise Exception("Fail first attempt so STEP_UP_FOR_RETRY is consumed")
+
+    time.sleep(2)
+
+
+@dg.job(executor_def=test_step_delegating_executor)
+def retry_then_sleep_job():
+    retry_then_sleep_op()
+
+
+def test_check_step_health_unhealthy_with_consumed_step_up_for_retry_emits_failure():
+    """A consumed STEP_UP_FOR_RETRY from a prior attempt must not suppress current-attempt failure."""
+    TestStepHandler.reset()
+    TestStepHandler.should_return_unhealthy = True
+
+    with dg.instance_for_test() as instance:
+        result = dg.execute_job(
+            dg.reconstructable(retry_then_sleep_job),
+            instance=instance,
+            run_config={
+                "execution": {
+                    "config": {
+                        "check_step_health_interval_seconds": 0,
+                        "sleep_seconds": 0.01,
+                    }
+                }
+            },
+        )
+        TestStepHandler.wait_for_processes()
+
+    assert not result.success
+    retry_events = [
+        event
+        for event in result.all_events
+        if event.event_type == DagsterEventType.STEP_UP_FOR_RETRY
+    ]
+    assert len(retry_events) == 1
+    failure_events = [
+        event for event in result.all_events if event.event_type == DagsterEventType.STEP_FAILURE
+    ]
+    assert len(failure_events) > 0, "Expected STEP_FAILURE for unhealthy second attempt"


### PR DESCRIPTION
## Summary & Motivation

Fixes a race condition in the K8s executor ([#22565](https://github.com/dagster-io/dagster/issues/22565)) where a step could be marked as failed even though it had already emitted `STEP_SUCCESS`.

The `StepDelegatingExecutor` runs two concurrent concerns in the same polling loop: tailing the event log via `_pop_events` (every ~1s) and running a K8s job health check via `check_step_health` (every 20s). A step is only removed from `running_steps` once `_pop_events` returns a `STEP_SUCCESS` event. This creates a window where the health check fires, finds the K8s job gone or failed, and emits `STEP_FAILURE` — even though `STEP_SUCCESS` is already in the database, just not yet consumed by the tailer.

Two concrete triggers:

1. **TTL race** — `ttlSecondsAfterFinished` is short enough that Kubernetes deletes the job between the pod writing `STEP_SUCCESS` and the executor polling it. `get_job_status` returns 404, health check returns unhealthy.

2. **OOMKill race** — the pod is killed during post-success cleanup (IO manager teardown, connection closing, etc.) after writing `STEP_SUCCESS` but before the process exits. Kubernetes marks the job as failed (`status.failed > 0`), health check returns unhealthy.

The fix is in `StepDelegatingExecutor.execute`: when a health check returns unhealthy, query the event log directly for a `STEP_SUCCESS` event matching the step key. If one exists, skip emitting the failure — the next `_pop_events` iteration will consume the success event and cleanly remove the step from `running_steps`.

## How I Tested These Changes

Manually traced the race condition through the executor polling loop. The query uses `of_type=DagsterEventType.STEP_SUCCESS`, which is indexed in the event log schema, so the overhead on the genuine-failure path is one narrow DB query before the failure is emitted.

## Changelog

Fixed an intermittent false `STEP_FAILURE` on the K8s executor where a step that had already succeeded could be marked as failed if the Kubernetes job was deleted (via `ttlSecondsAfterFinished`) or killed (OOMKill during cleanup) before the executor's event tailer processed the `STEP_SUCCESS` event.