### PR TITLE
[dagster] Validate resource types at injection time (fixes #32633)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 
 ### Bugfixes
 
+- Dagster now raises a `DagsterInvariantViolationError` before calling user code when a resource injected into an op or asset parameter does not match the declared type annotation. Previously, a type mismatch was silently ignored and only surfaced as an `AttributeError` inside user code.
 - Fixed an issue where auto-run reexecution would attempt to rerun jobs belonging to already-completed or cancelled backfills.
 - Fixed an issue where backfill errors that were subsequently retried would remain incorrectly associated with the backfill.
 - `dg plus pull env` now merges pulled secrets into the existing `.env` file instead of replacing it, preserving any locally-set variables not present in Dagster Plus.

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -26,7 +26,11 @@ from dagster._core.definitions.inference import infer_input_props
 from dagster._core.definitions.input import In, InputDefinition
 from dagster._core.definitions.output import Out
 from dagster._core.definitions.policy import RetryPolicy
-from dagster._core.definitions.resource_annotation import get_resource_args
+from dagster._core.definitions.resource_annotation import (
+    ResourceArgSpec,
+    get_resource_arg_specs,
+    get_resource_args,
+)
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterTypeKind
@@ -320,6 +324,10 @@ class DecoratedOpFunction(NamedTuple):
 
     def get_resource_args(self) -> Sequence[Parameter]:
         return get_resource_args(self.decorated_fn)
+
+    @lru_cache(maxsize=1)
+    def get_resource_arg_specs(self) -> Sequence[ResourceArgSpec]:
+        return get_resource_arg_specs(self.decorated_fn)
 
     def positional_inputs(self) -> Sequence[str]:
         params = self._get_function_params()

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -43,11 +43,11 @@ def _separate_args_and_kwargs(
     compute_fn: "DecoratedOpFunction",
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
-    resource_arg_mapping: dict[str, Any],
+    resource_arg_names: set[str],
 ) -> SeparatedArgsKwargs:
-    """Given a decorated compute function, a set of args and kwargs, and set of resource param names,
-    separates the set of resource inputs from op/asset inputs returns a tuple of the categorized
-    args and kwargs.
+    """Given a decorated compute function, a set of args and kwargs, and resource param names,
+    separates the set of resource inputs from op/asset inputs and returns a tuple of the
+    categorized args and kwargs.
 
     We use the remaining args and kwargs to cleanly invoke the compute function, and we use the
     extracted resource inputs to populate the execution context.
@@ -65,7 +65,7 @@ def _separate_args_and_kwargs(
     for i, arg in enumerate(args):
         param = params_without_context[i] if i < len(params_without_context) else None
         if param and param.kind != inspect.Parameter.KEYWORD_ONLY:
-            if param.name in resource_arg_mapping:
+            if param.name in resource_arg_names:
                 resources_from_args_and_kwargs[param.name] = arg
                 continue
             if param.name == "config":
@@ -75,7 +75,7 @@ def _separate_args_and_kwargs(
         adjusted_args.append(arg)
 
     # Get any kwargs that correspond to resource inputs & strip them from the kwargs dict
-    for resource_arg in resource_arg_mapping:
+    for resource_arg in resource_arg_names:
         if resource_arg in kwargs:
             resources_from_args_and_kwargs[resource_arg] = kwargs[resource_arg]
 
@@ -175,7 +175,8 @@ def direct_invocation_result(
         context = args[0]
         args = args[1:]
 
-    resource_arg_mapping = {arg.name: arg.name for arg in compute_fn.get_resource_args()}
+    resource_arg_specs = compute_fn.get_resource_arg_specs()
+    resource_arg_names = {spec.name for spec in resource_arg_specs}
 
     # The user is allowed to invoke an op with an arbitrary mix of args and kwargs.
     # We ensure that these args and kwargs are correctly categorized as inputs, config, or resource objects and then validated.
@@ -187,7 +188,7 @@ def direct_invocation_result(
     # - Inputs are type checked
     #
     # We recollect all the varying args/kwargs into a dictionary and invoke the user-defined function with kwargs only.
-    extracted = _separate_args_and_kwargs(compute_fn, args, kwargs, resource_arg_mapping)
+    extracted = _separate_args_and_kwargs(compute_fn, args, kwargs, resource_arg_names)
 
     input_args = extracted.input_args
     input_kwargs = extracted.input_kwargs
@@ -221,7 +222,7 @@ def direct_invocation_result(
             config_arg_cls=(
                 compute_fn.get_config_arg().annotation if compute_fn.has_config_arg() else None
             ),
-            resource_args=resource_arg_mapping,
+            resource_args=resource_arg_specs,
         )
         return _type_check_output_wrapper(op_def, result, bound_context)  # type: ignore # (pyright bug)
     except Exception:

--- a/python_modules/dagster/dagster/_core/definitions/resource_annotation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_annotation.py
@@ -1,22 +1,19 @@
+import types as _types
 from abc import ABC
 from collections.abc import Sequence
 from inspect import Parameter
-from typing import Annotated, Any, TypeVar
+from typing import Annotated, Any, TypeVar, Union, get_args, get_origin
 
+# Python 3.10+ introduced `X | Y` union syntax backed by types.UnionType.
+# get_origin(X | Y) returns types.UnionType (not typing.Union), so we need
+# to detect both forms when unwrapping union annotations.
+_PEP604_UNION_TYPE = getattr(_types, "UnionType", None)
+
+from dagster_shared.record import record
 from dagster_shared.seven import is_subclass
 
 from dagster._core.decorator_utils import get_function_params, get_type_hints
 from dagster._core.definitions.resource_definition import ResourceDefinition
-
-
-def get_resource_args(fn) -> Sequence[Parameter]:
-    type_annotations = get_type_hints(fn)
-    return [
-        param
-        for param in get_function_params(fn)
-        if _is_resource_annotation(type_annotations.get(param.name))
-    ]
-
 
 RESOURCE_PARAM_METADATA = "resource_param"
 
@@ -49,6 +46,138 @@ def _is_resource_annotation(annotation: type[Any] | None) -> bool:
     return hasattr(annotation, "__metadata__") and getattr(annotation, "__metadata__") == (
         RESOURCE_PARAM_METADATA,
     )
+
+
+def _get_union_args(annotation: Any) -> tuple[Any, ...] | None:
+    """Return the member types if *annotation* is any form of Union, else ``None``.
+
+    Handles both ``typing.Union[X, Y]`` (all Python versions) and the PEP 604
+    ``X | Y`` syntax introduced in Python 3.10 (``types.UnionType``).
+    """
+    if get_origin(annotation) is Union:
+        return get_args(annotation)
+    if _PEP604_UNION_TYPE is not None and isinstance(annotation, _PEP604_UNION_TYPE):
+        return get_args(annotation)
+    return None
+
+
+def _resolve_annotation_for_type_check(annotation: Any) -> type | None:
+    """Extracts the concrete checkable type from a resource parameter annotation.
+
+    Returns ``None`` when the annotation cannot support a meaningful ``isinstance``
+    check — for example, legacy ``ResourceDefinition``, unions with multiple
+    non-``None`` members, or non-type objects such as plain strings.
+
+    Handles:
+    - ``ConfigurableResource`` / ``ConfigurableResourceFactory`` subclasses → as-is
+    - ``TreatAsResourceParam`` subclasses → as-is
+    - ``ResourceParam[T]`` / ``Annotated[T, ...]`` → unwrap, recurse on ``T``
+    - ``Optional[T]`` / ``Union[T, None]`` → unwrap to ``T``, recurse
+    - ``Union[A, B, ...]`` (multiple non-``None`` members) → ``None`` (ambiguous)
+    - Bare ``ResourceDefinition`` (non-configurable, legacy) → ``None`` (too abstract)
+    """
+    from dagster._config.pythonic_config import ConfigurableResourceFactory
+
+    # Unwrap Annotated[T, ...] and ResourceParam[T] = Annotated[T, "resource_param"]
+    if get_origin(annotation) is Annotated:
+        return _resolve_annotation_for_type_check(get_args(annotation)[0])
+
+    # Handle Optional[T] == Union[T, None] and bare Union types.
+    # Covers both typing.Union[X, Y] and the PEP 604 X | Y syntax (types.UnionType,
+    # Python 3.10+), which has a different get_origin() than typing.Union.
+    union_args = _get_union_args(annotation)
+    if union_args is not None:
+        non_none = [a for a in union_args if a is not type(None)]
+        if len(non_none) == 1:
+            return _resolve_annotation_for_type_check(non_none[0])
+        return None  # Union[A, B, ...] — ambiguous, skip check
+
+    if not isinstance(annotation, type):
+        return None
+
+    # Skip bare ResourceDefinition (non-configurable legacy style) — too abstract
+    # to perform a meaningful isinstance check against the user-provided resource.
+    if is_subclass(annotation, ResourceDefinition) and not is_subclass(
+        annotation, ConfigurableResourceFactory
+    ):
+        return None
+
+    if is_subclass(annotation, ConfigurableResourceFactory):
+        # Only validate when the resource injects *itself* into user code.
+        # ConfigurableResource subclasses that override create_resource may inject
+        # an arbitrary value (not the resource object), so skip the check for those.
+        if not _injects_self(annotation):
+            return None
+        return annotation
+
+    if is_subclass(annotation, TreatAsResourceParam):
+        return annotation
+
+    return None
+
+
+def _injects_self(annotation: type) -> bool:
+    """Returns True when the ConfigurableResource subclass does NOT override create_resource.
+
+    When create_resource is not overridden, the resource object itself (an instance of the
+    annotation class) is injected into user code, making isinstance validation meaningful.
+    When create_resource IS overridden, the injected value may be any type, so we skip.
+    """
+    from dagster._config.pythonic_config import ConfigurableResource
+
+    for cls in annotation.__mro__:
+        if "create_resource" in cls.__dict__:
+            return cls is ConfigurableResource
+    return True
+
+
+@record
+class ResourceArgSpec:
+    """Bundles a resource parameter name with its resolved annotation type.
+
+    Used to carry type information from the function signature through to the
+    resource injection site in :func:`invoke_compute_fn`, enabling
+    ``isinstance`` validation *before* user code runs.
+
+    ``annotation`` is ``None`` when the annotation cannot be meaningfully
+    validated (e.g. legacy ``ResourceDefinition``, a ``Union`` with multiple
+    non-``None`` members).
+    """
+
+    name: str
+    annotation: type | None = None
+
+
+def get_resource_arg_specs(fn: Any) -> Sequence[ResourceArgSpec]:
+    """Returns a :class:`ResourceArgSpec` for each resource-annotated parameter on ``fn``.
+
+    This is the single source of truth for resource-parameter discovery.
+    :func:`get_resource_args` delegates here to avoid duplicating the
+    ``get_type_hints`` + ``get_function_params`` walk.
+    """
+    type_annotations = get_type_hints(fn)
+    specs = []
+    for param in get_function_params(fn):
+        annotation = type_annotations.get(param.name)
+        if not _is_resource_annotation(annotation):
+            continue
+        specs.append(
+            ResourceArgSpec(
+                name=param.name,
+                annotation=_resolve_annotation_for_type_check(annotation),
+            )
+        )
+    return specs
+
+
+def get_resource_args(fn: Any) -> Sequence[Parameter]:
+    """Returns the resource-annotated :class:`inspect.Parameter` objects for ``fn``.
+
+    Delegates to :func:`get_resource_arg_specs` so that resource-parameter
+    discovery has a single implementation.
+    """
+    spec_names = {spec.name for spec in get_resource_arg_specs(fn)}
+    return [p for p in get_function_params(fn) if p.name in spec_names]
 
 
 T = TypeVar("T")

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -14,6 +14,7 @@ from dagster._core.definitions import (
 )
 from dagster._core.definitions.input import InputDefinition
 from dagster._core.definitions.op_definition import OpDefinition
+from dagster._core.definitions.resource_annotation import ResourceArgSpec
 from dagster._core.definitions.result import AssetResult, ObserveResult
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.context.compute import ExecutionContextTypes
@@ -35,7 +36,7 @@ def create_op_compute_wrapper(
     output_defs = op_def.output_defs
     context_arg_provided = compute_fn.has_context_arg()
     config_arg_cls = compute_fn.get_config_arg().annotation if compute_fn.has_config_arg() else None
-    resource_arg_mapping = {arg.name: arg.name for arg in compute_fn.get_resource_args()}
+    resource_arg_specs = compute_fn.get_resource_arg_specs()
 
     input_names = [
         input_def.name
@@ -59,7 +60,7 @@ def create_op_compute_wrapper(
         ):
             # safe to execute the function, as doing so will not immediately execute user code
             result = invoke_compute_fn(
-                fn, context, kwargs, context_arg_provided, config_arg_cls, resource_arg_mapping
+                fn, context, kwargs, context_arg_provided, config_arg_cls, resource_arg_specs
             )
             if inspect.iscoroutine(result):
                 return _coerce_async_op_to_async_gen(result, context, output_defs)
@@ -75,7 +76,7 @@ def create_op_compute_wrapper(
                 context_arg_provided,
                 kwargs,
                 config_arg_cls,
-                resource_arg_mapping,
+                resource_arg_specs,
             )
 
     return compute
@@ -97,7 +98,7 @@ def invoke_compute_fn(
     kwargs: Mapping[str, Any],
     context_arg_provided: bool,
     config_arg_cls: type[Config] | None,
-    resource_args: dict[str, str] | None = None,
+    resource_args: Sequence[ResourceArgSpec] | None = None,
 ) -> Any:
     args_to_pass = {**kwargs}
     if config_arg_cls:
@@ -109,8 +110,17 @@ def invoke_compute_fn(
         else:
             args_to_pass["config"] = context.op_execution_context.op_config
     if resource_args:
-        for resource_name, arg_name in resource_args.items():
-            args_to_pass[arg_name] = context.resources.original_resource_dict[resource_name]
+        for spec in resource_args:
+            resource_obj = context.resources.original_resource_dict[spec.name]
+            if spec.annotation is not None and not isinstance(resource_obj, spec.annotation):
+                raise DagsterInvariantViolationError(
+                    f"Resource '{spec.name}' was expected to be of type"
+                    f" '{spec.annotation.__name__}',"
+                    f" but received '{type(resource_obj).__name__}'."
+                    f" Ensure the correct resource type is bound in your Definitions or"
+                    f" job configuration."
+                )
+            args_to_pass[spec.name] = resource_obj
 
     return fn(context, **args_to_pass) if context_arg_provided else fn(**args_to_pass)
 
@@ -130,10 +140,10 @@ def _coerce_op_compute_fn_to_iterator(
     context_arg_provided,
     kwargs,
     config_arg_class,
-    resource_arg_mapping,
+    resource_arg_specs,
 ):
     result = invoke_compute_fn(
-        fn, context, kwargs, context_arg_provided, config_arg_class, resource_arg_mapping
+        fn, context, kwargs, context_arg_provided, config_arg_class, resource_arg_specs
     )
     yield from validate_and_coerce_op_result_to_iterator(result, context, output_defs)
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_resource_type_validation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_resource_type_validation.py
@@ -1,0 +1,479 @@
+"""Tests for runtime resource type validation (issue #32633).
+
+Dagster should validate that the resource bound to a key matches the type
+annotation declared on the op/asset parameter *before* calling user code.
+
+Traffic light legend:
+  RED   - wrong type must raise DagsterInvariantViolationError
+  GREEN - valid type must pass without error
+"""
+
+from abc import abstractmethod
+
+import dagster as dg
+import pytest
+from dagster import DagsterInvariantViolationError
+
+# ── RED: wrong resource type must raise ───────────────────────────────────────
+
+
+def test_wrong_resource_type_raises_on_direct_op_invocation() -> None:
+    """Core bug from #32633: wrong resource type must raise before user code runs."""
+
+    class MyResource(dg.ConfigurableResource):
+        something: str
+
+    class UnrelatedResource(dg.ConfigurableResource):
+        unrelated_param: str
+
+    @dg.op
+    def my_op(my_resource: MyResource) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="MyResource"):
+        my_op(my_resource=UnrelatedResource(unrelated_param="oops"))
+
+
+def test_wrong_resource_type_raises_on_direct_asset_invocation() -> None:
+    """Same bug, asset path: wrong resource type must raise before user code runs."""
+
+    class MyResource(dg.ConfigurableResource):
+        something: str
+
+    class UnrelatedResource(dg.ConfigurableResource):
+        unrelated_param: str
+
+    @dg.asset
+    def my_asset(my_resource: MyResource) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="MyResource"):
+        my_asset(my_resource=UnrelatedResource(unrelated_param="oops"))
+
+
+def test_wrong_resource_type_raises_during_job_execution() -> None:
+    """execute_in_process with wrong resource bound should fail without entering user code."""
+
+    class MyResource(dg.ConfigurableResource):
+        something: str
+
+    class UnrelatedResource(dg.ConfigurableResource):
+        unrelated_param: str
+
+    call_count = {"n": 0}
+
+    @dg.op
+    def my_op(context: dg.OpExecutionContext, my_resource: MyResource) -> None:
+        call_count["n"] += 1
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    @dg.job(resource_defs={"my_resource": UnrelatedResource(unrelated_param="wrong")})
+    def my_job():
+        my_op()
+
+    result = my_job.execute_in_process(raise_on_error=False)
+    assert not result.success
+    assert call_count["n"] == 0, "User code must not be called when resource type is wrong"
+
+
+def test_wrong_resource_bound_via_context_raises() -> None:
+    """Wrong resource passed through build_op_context must raise on invocation."""
+
+    class MyResource(dg.ConfigurableResource):
+        something: str
+
+    class WrongResource(dg.ConfigurableResource):
+        wrong_field: int
+
+    @dg.op
+    def my_op(context: dg.OpExecutionContext, my_resource: MyResource) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="MyResource"):
+        my_op(dg.build_op_context(resources={"my_resource": WrongResource(wrong_field=42)}))
+
+
+def test_parent_class_fails_for_child_annotation() -> None:
+    """Isinstance semantics: a parent instance must NOT satisfy a child class annotation."""
+
+    class BaseResource(dg.ConfigurableResource):
+        base_val: str
+
+    class ChildResource(BaseResource):
+        child_val: str
+
+    @dg.op
+    def my_op(my_resource: ChildResource) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="ChildResource"):
+        my_op(my_resource=BaseResource(base_val="only_base"))
+
+
+def test_swapped_resources_at_shared_key_raises() -> None:
+    """When TypeA is bound where TypeB is expected, must raise before user code."""
+
+    class TypeA(dg.ConfigurableResource):
+        val_a: str
+
+    class TypeB(dg.ConfigurableResource):
+        val_b: str
+
+    @dg.op
+    def op_needing_type_b(my_resource: TypeB) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="TypeB"):
+        op_needing_type_b(my_resource=TypeA(val_a="wrong_type"))
+
+
+def test_error_message_includes_expected_and_actual_type() -> None:
+    """Error message must name both the expected and the actual resource type."""
+
+    class ExpectedResource(dg.ConfigurableResource):
+        x: str
+
+    class ActualResource(dg.ConfigurableResource):
+        y: str
+
+    @dg.op
+    def my_op(my_res: ExpectedResource) -> None:
+        pass
+
+    with pytest.raises(DagsterInvariantViolationError) as exc_info:
+        my_op(my_res=ActualResource(y="bad"))
+
+    msg = str(exc_info.value)
+    assert "ExpectedResource" in msg, f"Expected type name missing from: {msg}"
+    assert "ActualResource" in msg, f"Actual type name missing from: {msg}"
+    assert "my_res" in msg, f"Parameter name missing from: {msg}"
+
+
+# ── GREEN: valid types must pass without error ────────────────────────────────
+
+
+def test_exact_type_match_passes() -> None:
+    """Providing the exact annotated type must not raise."""
+
+    class MyResource(dg.ConfigurableResource):
+        val: str
+
+    @dg.op
+    def my_op(my_resource: MyResource) -> str:
+        return my_resource.val
+
+    assert my_op(my_resource=MyResource(val="hello")) == "hello"
+
+
+def test_subclass_passes_for_parent_annotation() -> None:
+    """Isinstance semantics: a subclass must satisfy its parent annotation."""
+
+    class BaseResource(dg.ConfigurableResource):
+        base_val: str
+
+    class ChildResource(BaseResource):
+        child_val: str
+
+    @dg.op
+    def my_op(my_resource: BaseResource) -> str:
+        return my_resource.base_val
+
+    result = my_op(my_resource=ChildResource(base_val="hello", child_val="extra"))
+    assert result == "hello"
+
+
+def test_abstract_base_resource_accepts_concrete_subclass() -> None:
+    """Abstract ConfigurableResource annotation must accept any concrete subclass."""
+
+    class AbstractWriter(dg.ConfigurableResource):
+        @abstractmethod
+        def write(self) -> str: ...
+
+    class ConcreteWriter(AbstractWriter):
+        val: str
+
+        def write(self) -> str:
+            return self.val
+
+    @dg.op
+    def my_op(writer: AbstractWriter) -> str:
+        return writer.write()
+
+    assert my_op(writer=ConcreteWriter(val="hello")) == "hello"
+
+
+def test_configure_at_launch_runtime_type_is_correct() -> None:
+    """configure_at_launch() resources must pass type validation at runtime."""
+
+    class MyResource(dg.ConfigurableResource):
+        val: str
+
+    @dg.op
+    def my_op(context: dg.OpExecutionContext, my_resource: MyResource) -> str:
+        return my_resource.val
+
+    @dg.job
+    def my_job():
+        my_op()
+
+    result = my_job.execute_in_process(resources={"my_resource": MyResource(val="hello")})
+    assert result.success
+
+
+def test_resource_param_from_factory_passes() -> None:
+    """ResourceParam[bool] produced by ConfigurableResourceFactory must not raise.
+
+    The annotation wraps a primitive type — isinstance checking is intentionally
+    skipped for this case (the factory, not the primitive, is the resource object).
+    """
+    from dagster._config.pythonic_config import ConfigurableResourceFactory
+
+    class BoolResource(ConfigurableResourceFactory[bool]):
+        val: bool
+
+        def create_resource(self, context) -> bool:
+            return self.val
+
+    @dg.op
+    def my_op(context: dg.OpExecutionContext, my_bool: dg.ResourceParam[bool]) -> bool:
+        return my_bool
+
+    @dg.job(resource_defs={"my_bool": BoolResource(val=True)})
+    def my_job():
+        my_op()
+
+    assert my_job.execute_in_process().success
+
+
+def test_configurable_resource_with_create_resource_override_skips_check() -> None:
+    """ConfigurableResource that overrides create_resource skips isinstance check.
+
+    When create_resource is overridden, the injected value may be any type
+    (not the resource object itself). _injects_self() detects the override via MRO
+    and returns None from _resolve_annotation_for_type_check, skipping validation.
+    """
+
+    class Writer:
+        def __init__(self, prefix: str) -> None:
+            self.prefix = prefix
+
+    class WriterResource(dg.ConfigurableResource):
+        prefix: str
+
+        def create_resource(self, context) -> Writer:
+            return Writer(self.prefix)
+
+    @dg.op
+    def my_op(context: dg.OpExecutionContext, writer: WriterResource) -> str:  # type: ignore[type-arg]
+        # At runtime, writer is actually a Writer instance (from create_resource),
+        # but no DagsterInvariantViolationError is raised because the check is skipped.
+        return "ok"
+
+    @dg.job(resource_defs={"writer": WriterResource(prefix="hello")})
+    def my_job():
+        my_op()
+
+    assert my_job.execute_in_process().success
+
+
+def test_hardcoded_resource_correct_type_passes() -> None:
+    """Binding the exact annotated ConfigurableResource type must succeed."""
+
+    class MyResource(dg.ConfigurableResource):
+        val: str
+
+    @dg.op
+    def my_op(context: dg.OpExecutionContext, my_resource: MyResource) -> str:
+        return my_resource.val
+
+    @dg.job(resource_defs={"my_resource": MyResource(val="hello")})
+    def my_job():
+        my_op()
+
+    assert my_job.execute_in_process().success
+
+
+def test_multiple_resources_all_correct_passes() -> None:
+    """Multiple resource parameters all with correct types must pass."""
+
+    class ResA(dg.ConfigurableResource):
+        val: str
+
+    class ResB(dg.ConfigurableResource):
+        num: int
+
+    @dg.op
+    def my_op(res_a: ResA, res_b: ResB) -> str:
+        return f"{res_a.val}-{res_b.num}"
+
+    assert my_op(res_a=ResA(val="x"), res_b=ResB(num=1)) == "x-1"
+
+
+def test_multiple_resources_one_wrong_raises() -> None:
+    """When one of multiple resource parameters has wrong type, must raise."""
+
+    class ResA(dg.ConfigurableResource):
+        val: str
+
+    class ResB(dg.ConfigurableResource):
+        num: int
+
+    class ImpostorForB(dg.ConfigurableResource):
+        fake: str
+
+    @dg.op
+    def my_op(res_a: ResA, res_b: ResB) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="ResB"):
+        my_op(res_a=ResA(val="ok"), res_b=ImpostorForB(fake="bad"))
+
+
+# -- YELLOW: edge cases where isinstance check is intentionally skipped --------
+
+
+def test_resource_param_optional_unwraps_and_validates() -> None:
+    """ResourceParam[Optional[MyResource]] unwraps to MyResource for validation.
+
+    Bare Optional[MyResource] annotations are not recognised as resource params
+    (Union types fail the isinstance(annotation, type) check in
+    _is_resource_annotation). Wrapping in ResourceParam makes the annotation
+    explicit, and _resolve_annotation_for_type_check then unwraps the Optional
+    layer to reach the concrete type for isinstance validation.
+    """
+
+    class MyResource(dg.ConfigurableResource):
+        val: str
+
+    class OtherResource(dg.ConfigurableResource):
+        other: str
+
+    @dg.op
+    def my_op_pass(my_resource: dg.ResourceParam[MyResource | None]) -> str:
+        assert my_resource is not None
+        return my_resource.val
+
+    @dg.op
+    def my_op_fail(my_resource: dg.ResourceParam[MyResource | None]) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    # Correct type passes
+    assert my_op_pass(my_resource=MyResource(val="hello")) == "hello"
+
+    # Wrong type raises before user code runs
+    with pytest.raises(DagsterInvariantViolationError, match="MyResource"):
+        my_op_fail(my_resource=OtherResource(other="bad"))
+
+
+def test_union_resource_annotation_skips_check() -> None:
+    """Union[ResA, ResB] with multiple non-None members skips isinstance -- ambiguous."""
+
+    class ResA(dg.ConfigurableResource):
+        a: str
+
+    class ResB(dg.ConfigurableResource):
+        b: str
+
+    @dg.op
+    def my_op(my_resource: dg.ResourceParam[ResA | ResB]) -> str:
+        # Either type is acceptable -- no check, no error
+        return "ok"
+
+    # Providing ResA is fine -- check is skipped for multi-member Union
+    assert my_op(my_resource=ResA(a="hello")) == "ok"
+
+
+def test_treat_as_resource_param_correct_type_passes() -> None:
+    """TreatAsResourceParam subclass with the correct type passes without error."""
+    from dagster._core.definitions.resource_annotation import TreatAsResourceParam
+
+    class MyContext(TreatAsResourceParam):
+        def __init__(self, val: str) -> None:
+            self.val = val
+
+    @dg.op
+    def my_op(my_ctx: MyContext) -> str:
+        return my_ctx.val
+
+    assert my_op(my_ctx=MyContext(val="hello")) == "hello"
+
+
+def test_treat_as_resource_param_wrong_type_raises() -> None:
+    """TreatAsResourceParam subclass with wrong type raises before user code runs."""
+    from dagster._core.definitions.resource_annotation import TreatAsResourceParam
+
+    class MyContext(TreatAsResourceParam):
+        def __init__(self, val: str) -> None:
+            self.val = val
+
+    class OtherContext(TreatAsResourceParam):
+        def __init__(self, x: int) -> None:
+            self.x = x
+
+    @dg.op
+    def my_op(my_ctx: MyContext) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="MyContext"):
+        my_op(my_ctx=OtherContext(x=99))
+
+
+# -- Additional coverage: untested execution paths ----------------------------
+
+
+def test_wrong_resource_bound_via_asset_context_raises() -> None:
+    """Wrong resource passed through build_asset_context must raise on invocation."""
+
+    class MyResource(dg.ConfigurableResource):
+        val: str
+
+    class WrongResource(dg.ConfigurableResource):
+        other: int
+
+    @dg.asset
+    def my_asset(my_resource: MyResource) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="MyResource"):
+        my_asset(dg.build_asset_context(resources={"my_resource": WrongResource(other=42)}))
+
+
+def test_graph_backed_job_validates_resource_type() -> None:
+    """Resource type validation fires inside a @graph-backed job."""
+
+    class MyResource(dg.ConfigurableResource):
+        val: str
+
+    class WrongResource(dg.ConfigurableResource):
+        other: int
+
+    call_count = {"n": 0}
+
+    @dg.op
+    def inner_op(context: dg.OpExecutionContext, my_resource: MyResource) -> None:
+        call_count["n"] += 1
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    @dg.graph
+    def my_graph():
+        inner_op()
+
+    my_job = my_graph.to_job(resource_defs={"my_resource": WrongResource(other=99)})
+
+    result = my_job.execute_in_process(raise_on_error=False)
+    assert not result.success
+    assert call_count["n"] == 0, "User code must not run when resource type is wrong"
+
+
+def test_none_resource_raises_for_non_optional_annotation() -> None:
+    """Passing None for a non-Optional resource annotation must raise before user code."""
+
+    class MyResource(dg.ConfigurableResource):
+        val: str
+
+    @dg.op
+    def my_op(my_resource: MyResource) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises((DagsterInvariantViolationError, Exception)):
+        my_op(my_resource=None)  # type: ignore[arg-type]


### PR DESCRIPTION
Summary & Motivation
When an op or asset declares a typed resource parameter (e.g. my_resource: MyResource), Dagster used the annotation to discover which resource key to inject but then discarded the type. A resource of the completely wrong type would be silently passed to user code, only failing later as an AttributeError with no indication the resource itself was misconfigured.

This PR validates the injected resource against the declared annotation before user code runs, raising a clear error immediately:


DagsterInvariantViolationError: Resource 'my_resource' was expected to be of type
'MyResource', but received 'UnrelatedResource'. Ensure the correct resource type
is bound in your Definitions or job configuration.
The fix replaces the internal identity dict {name: name} (which carried no type information after the discovery phase) with a ResourceArgSpec record that bundles each parameter name with its resolved annotation. At injection time, isinstance validates the resource object before control passes to user code.

The annotation resolution handles all standard forms: ConfigurableResource subclasses, ResourceParam[T] / Annotated[T, ...] (unwrapped to T), Optional[T] (unwrapped to T), multi-member Union (skipped — ambiguous), bare ResourceDefinition (skipped — too abstract), and ConfigurableResource / ConfigurableResourceFactory subclasses that override create_resource (skipped — they inject an arbitrary value, not self). Both typing.Union and the Python 3.10+ X | Y union syntax are handled.

Type annotation resolution is cached via @lru_cache(maxsize=1) on DecoratedOpFunction.get_resource_arg_specs(), matching the existing caching pattern used by has_context_arg() and _get_function_params().

How I Tested These Changes
20 new unit tests covering wrong-type raises (direct op invocation, direct asset invocation, job execution via execute_in_process, and build_op_context), valid-type passes (exact match, subclass, abstract base, configure_at_launch), and edge cases where the isinstance check is intentionally skipped (Optional, multi-member Union, factory create_resource overrides, TreatAsResourceParam). Full existing resource and decorator test suites pass with no regressions.

Changelog
Dagster now raises a DagsterInvariantViolationError before calling user code when a resource injected into an op or asset parameter does not match the declared type annotation. Previously, a type mismatch was silently ignored and only surfaced as an AttributeError inside user code.