### PR TITLE
Add service_spec_config to UserDefinedDagsterK8sConfig

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
@@ -109,6 +109,7 @@ class K8sContainerContext(
             top_level_k8s_config._replace(  # remove k8s service/deployment fields
                 deployment_metadata={},
                 service_metadata={},
+                service_spec_config={},
             ),
             run_k8s_config or UserDefinedDagsterK8sConfig.from_dict({}),
         )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/job.py
@@ -111,6 +111,7 @@ class UserDefinedDagsterK8sConfig(
             ("job_spec_config", Mapping[str, Any]),
             ("deployment_metadata", Mapping[str, Any]),
             ("service_metadata", Mapping[str, Any]),
+            ("service_spec_config", Mapping[str, Any]),
             ("merge_behavior", K8sConfigMergeBehavior),
         ],
     )
@@ -126,6 +127,7 @@ class UserDefinedDagsterK8sConfig(
         job_spec_config: Mapping[str, Any] | None = None,
         deployment_metadata: Mapping[str, Any] | None = None,
         service_metadata: Mapping[str, Any] | None = None,
+        service_spec_config: Mapping[str, Any] | None = None,
         merge_behavior: K8sConfigMergeBehavior = K8sConfigMergeBehavior.DEEP,
     ):
         container_config = check.opt_mapping_param(
@@ -144,6 +146,9 @@ class UserDefinedDagsterK8sConfig(
         )
         service_metadata = check.opt_mapping_param(
             service_metadata, "service_metadata", key_type=str
+        )
+        service_spec_config = check.opt_mapping_param(
+            service_spec_config, "service_spec_config", key_type=str
         )
 
         if container_config:
@@ -174,6 +179,11 @@ class UserDefinedDagsterK8sConfig(
         if service_metadata:
             service_metadata = k8s_snake_case_dict(kubernetes.client.V1ObjectMeta, service_metadata)
 
+        if service_spec_config:
+            service_spec_config = k8s_snake_case_dict(
+                kubernetes.client.V1ServiceSpec, service_spec_config
+            )
+
         return super().__new__(
             cls,
             container_config=container_config,
@@ -184,6 +194,7 @@ class UserDefinedDagsterK8sConfig(
             job_spec_config=job_spec_config,
             deployment_metadata=deployment_metadata,
             service_metadata=service_metadata,
+            service_spec_config=service_spec_config,
             merge_behavior=check.inst_param(
                 merge_behavior, "merge_behavior", K8sConfigMergeBehavior
             ),
@@ -199,6 +210,7 @@ class UserDefinedDagsterK8sConfig(
             "job_spec_config": self.job_spec_config,
             "deployment_metadata": self.deployment_metadata,
             "service_metadata": self.service_metadata,
+            "service_spec_config": self.service_spec_config,
             "merge_behavior": self.merge_behavior.value,
         }
 
@@ -213,6 +225,7 @@ class UserDefinedDagsterK8sConfig(
             job_spec_config=config_dict.get("job_spec_config"),
             deployment_metadata=config_dict.get("deployment_metadata"),
             service_metadata=config_dict.get("service_metadata"),
+            service_spec_config=config_dict.get("service_spec_config"),
             merge_behavior=K8sConfigMergeBehavior(
                 config_dict.get("merge_behavior", K8sConfigMergeBehavior.DEEP.value)
             ),
@@ -275,6 +288,7 @@ def get_user_defined_k8s_config(tags: Mapping[str, str]):
         job_spec_config=user_defined_k8s_config.get("job_spec_config"),
         deployment_metadata=user_defined_k8s_config.get("deployment_metadata"),
         service_metadata=user_defined_k8s_config.get("service_metadata"),
+        service_spec_config=user_defined_k8s_config.get("service_spec_config"),
         merge_behavior=K8sConfigMergeBehavior(
             user_defined_k8s_config.get("merge_behavior", K8sConfigMergeBehavior.DEEP.value)
         ),


### PR DESCRIPTION
## Summary

Adds a `service_spec_config` field to `UserDefinedDagsterK8sConfig`, following the existing pattern of `pod_spec_config` and `job_spec_config`. This allows customizing the Kubernetes Service spec for code location servers.

Related: dagster-io/dagster-cloud#39

## Motivation

In Dagster Cloud hybrid deployments, each code location creates a ClusterIP service. With many code locations across multiple deployments, this can exhaust the cluster's service CIDR range. Adding `service_spec_config` allows setting `clusterIP: None` to create headless services, which work fine since the agent communicates with code servers via DNS.

## What's included

- `UserDefinedDagsterK8sConfig` NamedTuple: new `service_spec_config` field with `V1ServiceSpec` snake_case conversion
- `from_dict` / `to_dict`: round-trip support
- `get_user_defined_k8s_config`: reads from tags
- `K8sContainerContext`: strips `service_spec_config` from run config (same as `service_metadata` and `deployment_metadata`)

## Usage

```python
UserDefinedDagsterK8sConfig(
    service_spec_config={"cluster_ip": "None"},
)
```

## Test plan

- Existing tests should pass — the new field defaults to `{}` and is fully backwards-compatible
- A companion PR (dagster-io/dagster-cloud#40) consumes this field in `construct_code_location_service`