### PR TITLE
[dg] Bump actions/setup-python

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/hybrid-github-action.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/hybrid-github-action.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Python ${{ env.PYTHON_VERSION }} for target
         id: setup-python-version
         if: steps.prerun.outputs.result != 'skip'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-github-action.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-github-action.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python ${{ env.PYTHON_VERSION }} for target
         id: setup-python-version
         if: steps.prerun.outputs.result != 'skip'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 


### PR DESCRIPTION
## Summary & Motivation
Bump actions/setup-python in dagster_dg_cli to address Node20 deprecation on GHA https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
