### PR TITLE
fix(pydantic wrapper): don't access __fields__ if model_fields exists

### DIFF
--- a/python_modules/libraries/dagster-shared/dagster_shared/dagster_model/pydantic_compat_layer.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/dagster_model/pydantic_compat_layer.py
@@ -69,8 +69,9 @@ def model_fields(model: type[BaseModel]) -> dict[str, ModelFieldCompat]:
     """Returns a dictionary of fields for a given pydantic model, wrapped
     in a compat class to provide a consistent interface between Pydantic 1 and 2.
     """
-    fields = getattr(model, "model_fields", None)
-    if not fields:
+    try:
+        fields = getattr(model, "model_fields")
+    except AttributeError:
         fields = getattr(model, "__fields__")
 
     return {k: ModelFieldCompat(v) for k, v in fields.items()}


### PR DESCRIPTION
## Summary & Motivation

Fixes #33880

This MR changes the getattr logic so that the legacy attribute access is only attempted if the first one fails, whereas today it would attempt the legacy access also for an empty `model_fields` dictionary, which was likely not the intention. The overall result is less warnings noise to the user.

## Test Plan

None, this is a very minor change

