### PR TITLE
[fix] Handle transition from partitioned to non-partitioned assets in UPathIOManager

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -420,11 +420,25 @@ class UPathIOManager(IOManager):
         # TODO: this might not be the case if the serialization format is already operating with directories
         # e.g. DeltaLake, zarr
         if path.exists() and path.is_file():
-            context.log.warn(
+            context.log.warning(
                 f"Found file at {path} believed to correspond with previously non-partitioned version"
                 f" of {context.asset_key}. Removing {path} and replacing with directory for partitioned data files."
             )
             path.unlink(missing_ok=True)
+
+    def _handle_transition_from_partitioned_asset(self, context: OutputContext, path: "UPath"):
+        # if the asset was previously partitioned, path will be a directory, when it should
+        # be a file for the non-partitioned asset. Delete the directory so that it can be
+        # replaced with a file.
+
+        # TODO: this might not be the case if the serialization format is already operating with directories
+        # e.g. DeltaLake, zarr
+        if path.exists() and path.is_dir():
+            context.log.warning(
+                f"Found directory at {path} believed to correspond with previously partitioned version"
+                f" of {context.asset_key}. Removing {path} and replacing with file for non-partitioned data."
+            )
+            path.fs.rm(str(path), recursive=True)
 
     def handle_output(self, context: OutputContext, obj: Any):
         if context.has_asset_partitions:
@@ -443,6 +457,7 @@ class UPathIOManager(IOManager):
             self._handle_transition_to_partitioned_asset(context, path.parent)
         else:
             path = self._get_path(context)
+            self._handle_transition_from_partitioned_asset(context, path)
         self.make_directory(path.parent)
         context.log.debug(self.get_writing_output_log_message(path))
         self.dump_to_path(context=context, obj=obj, path=path)

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -651,3 +651,30 @@ def test_upath_can_transition_from_non_partitioned_to_partitioned(
     assert dg.materialize(
         [my_asset], resources={"io_manager": my_io_manager}, partition_key=start.strftime(daily.fmt)
     ).success
+
+
+def test_upath_can_transition_from_partitioned_to_non_partitioned(
+    tmp_path: Path, daily: DailyPartitionsDefinition, start: datetime
+):
+    my_io_manager = PickleIOManager(UPath(tmp_path))
+    asset_path = UPath(tmp_path) / "my_asset"
+
+    @dg.asset(partitions_def=daily)
+    def my_asset():
+        return 1
+
+    assert dg.materialize(
+        [my_asset], resources={"io_manager": my_io_manager}, partition_key=start.strftime(daily.fmt)
+    ).success
+    assert asset_path.is_dir(), (
+        "Pre-condition: asset should be stored as a directory when partitioned"
+    )
+
+    @dg.asset
+    def my_asset():  # type: ignore
+        return 1
+
+    # Previously failed with PermissionError because asset_name existed as a directory
+    result = dg.materialize([my_asset], resources={"io_manager": my_io_manager})
+    assert result.success
+    assert asset_path.is_file(), "Asset should be a file after transitioning to non-partitioned"


### PR DESCRIPTION
## Summary & Motivation

Resolves: https://github.com/dagster-io/dagster/issues/33614

When a partitioned asset is materialized via `FilesystemIOManager`, Dagster stores each partition under a directory at `<base>/asset_name/<partition_key>`. If the asset is later made non-partitioned, `handle_output` attempts to write a file at `<base>/asset_name` — which already exists as a directory — causing:

```
PermissionError: [Errno 13] Permission denied: 'dagster_home\io\asset_name'
```

`UPathIOManager` already handles the reverse case (non-partitioned → partitioned) via `_handle_transition_to_partitioned_asset`. This PR adds the symmetric `_handle_transition_from_partitioned_asset`, which detects a directory at the target path and removes it using `path.fs.rm` (fsspec-backed, cloud-safe for S3/GCS/Azure).

## Test Plan

Added `test_upath_can_transition_from_partitioned_to_non_partitioned` to `test_upath_io_manager.py`, verifying:
- Pre-condition: asset directory exists after partitioned materialization
- Post-condition: directory is replaced by a file after non-partitioned materialization

## Changelog

Fix `PermissionError` when materializing a previously-partitioned asset as non-partitioned using `FilesystemIOManager`.