### PR TITLE
Fix high IO waits on asset check queries (#33494)

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -114,6 +114,30 @@ query GetLatestExecution($assetKey: AssetKeyInput!) {
 }
 """
 
+GET_PARTITION_STATUSES = """
+query GetPartitionStatuses($assetKey: AssetKeyInput!) {
+    assetNodes(assetKeys: [$assetKey]) {
+        assetChecksOrError {
+            ... on AssetChecks {
+                checks {
+                    name
+                    partitionStatuses {
+                        __typename
+                        ... on AssetCheckDefaultPartitionStatuses {
+                            succeededPartitions
+                            failedPartitions
+                            inProgressPartitions
+                            skippedPartitions
+                            executionFailedPartitions
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
 GET_ASSET_CHECK_HISTORY_WITH_STEP_KEY = """
 query GetAssetChecksQuery($assetKey: AssetKeyInput!, $checkName: String!) {
     assetCheckExecutions(assetKey: $assetKey, checkName: $checkName, limit: 10) {
@@ -1688,3 +1712,87 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
 
         executions = res.data["assetCheckExecutions"]
         assert len(executions) == 2
+
+    def test_partitioned_asset_check_partition_statuses(
+        self, graphql_context: WorkspaceRequestContext
+    ):
+        run_id_one, run_id_two, run_id_three = [make_new_run_id() for _ in range(3)]
+        create_run_for_test(graphql_context.instance, run_id=run_id_one)
+        create_run_for_test(graphql_context.instance, run_id=run_id_two)
+        create_run_for_test(graphql_context.instance, run_id=run_id_three)
+
+        graphql_context.instance.event_log_storage.store_event(
+            _planned_event(
+                run_id_one,
+                AssetCheckEvaluationPlanned(
+                    asset_key=AssetKey(["partitioned_asset_for_checks"]),
+                    check_name="partitioned_asset_check",
+                    partitions_subset=DefaultPartitionsSubset({"a"}),
+                ),
+            )
+        )
+        graphql_context.instance.event_log_storage.store_event(
+            _evaluation_event(
+                run_id_one,
+                AssetCheckEvaluation(
+                    asset_key=AssetKey(["partitioned_asset_for_checks"]),
+                    check_name="partitioned_asset_check",
+                    passed=True,
+                    severity=AssetCheckSeverity.WARN,
+                    partition="a",
+                ),
+            )
+        )
+
+        graphql_context.instance.event_log_storage.store_event(
+            _planned_event(
+                run_id_two,
+                AssetCheckEvaluationPlanned(
+                    asset_key=AssetKey(["partitioned_asset_for_checks"]),
+                    check_name="partitioned_asset_check",
+                    partitions_subset=DefaultPartitionsSubset({"b"}),
+                ),
+            )
+        )
+        graphql_context.instance.event_log_storage.store_event(
+            _evaluation_event(
+                run_id_two,
+                AssetCheckEvaluation(
+                    asset_key=AssetKey(["partitioned_asset_for_checks"]),
+                    check_name="partitioned_asset_check",
+                    passed=False,
+                    severity=AssetCheckSeverity.ERROR,
+                    partition="b",
+                ),
+            )
+        )
+
+        graphql_context.instance.event_log_storage.store_event(
+            _planned_event(
+                run_id_three,
+                AssetCheckEvaluationPlanned(
+                    asset_key=AssetKey(["partitioned_asset_for_checks"]),
+                    check_name="partitioned_asset_check",
+                    partitions_subset=DefaultPartitionsSubset({"c"}),
+                ),
+            )
+        )
+
+        res = execute_dagster_graphql(
+            graphql_context,
+            GET_PARTITION_STATUSES,
+            variables={"assetKey": {"path": ["partitioned_asset_for_checks"]}},
+        )
+
+        assert res.data is not None
+        checks = res.data["assetNodes"][0]["assetChecksOrError"]["checks"]
+        partitioned_check = next(check for check in checks if check["name"] == "partitioned_asset_check")
+
+        assert partitioned_check["partitionStatuses"] == {
+            "__typename": "AssetCheckDefaultPartitionStatuses",
+            "succeededPartitions": ["a"],
+            "failedPartitions": ["b"],
+            "inProgressPartitions": ["c"],
+            "skippedPartitions": [],
+            "executionFailedPartitions": [],
+        }

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/5d7426c3e7f2_add_asset_check_partition_latest_idx.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/5d7426c3e7f2_add_asset_check_partition_latest_idx.py
@@ -1,0 +1,34 @@
+"""add asset check partition latest index
+
+Revision ID: 5d7426c3e7f2
+Revises: 29b539ebc72a
+Create Date: 2026-03-18 11:45:00.000000
+
+"""
+
+from alembic import op
+from dagster._core.storage.migration.utils import has_index, has_table
+
+# revision identifiers, used by Alembic.
+revision = "5d7426c3e7f2"
+down_revision = "29b539ebc72a"
+branch_labels = None
+depends_on = None
+
+TABLE_NAME = "asset_check_executions"
+INDEX_NAME = "idx_asset_check_executions_partition_latest"
+
+
+def upgrade():
+    if has_table(TABLE_NAME) and not has_index(TABLE_NAME, INDEX_NAME):
+        op.create_index(
+            INDEX_NAME,
+            TABLE_NAME,
+            ["asset_key", "check_name", "partition", "id"],
+            mysql_length={"asset_key": 64, "partition": 64, "check_name": 64},
+        )
+
+
+def downgrade():
+    if has_table(TABLE_NAME) and has_index(TABLE_NAME, INDEX_NAME):
+        op.drop_index(INDEX_NAME, TABLE_NAME)

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -196,6 +196,19 @@ db.Index(
     },
 )
 
+db.Index(
+    "idx_asset_check_executions_partition_latest",
+    AssetCheckExecutionsTable.c.asset_key,
+    AssetCheckExecutionsTable.c.check_name,
+    AssetCheckExecutionsTable.c.partition,
+    AssetCheckExecutionsTable.c.id,
+    mysql_length={
+        "asset_key": 64,
+        "partition": 64,
+        "check_name": 64,
+    },
+)
+
 # This index doesn't enforce the uniqueness how we want it to because partition and run_id can be
 # null. Postgres and other dbms's consider each null value distinct.
 db.Index(

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -119,6 +119,8 @@ if TYPE_CHECKING:
     from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
 MIN_ASSET_ROWS = 25
+ASSET_CHECK_PARTITION_INFO_BATCH_SIZE = 400
+ASSET_CHECK_PARTITION_INFO_MAX_BIND_PARAMS = 900
 DEFAULT_MAX_LIMIT_EVENT_RECORDS = 10000
 
 
@@ -3250,51 +3252,92 @@ class SqlEventLogStorage(EventLogStorage):
             results[check_key] = AssetCheckExecutionRecord.from_db_row(row, key=check_key)
         return results
 
-    def _get_asset_check_partition_info_for_key(
+    def _latest_materialization_ids_by_asset_partition_subquery(
         self,
-        check_key: AssetCheckKey,
-        after_storage_id: int | None,
-        partition_keys: Sequence[str] | None,
-        latest_unpartitioned_materialization_storage_ids: Mapping[AssetKey, int],
-    ) -> Sequence[AssetCheckPartitionInfo]:
-        # Build the base filter conditions
-        filter_conditions = [
-            AssetCheckExecutionsTable.c.asset_key == check_key.asset_key.to_string(),
-            AssetCheckExecutionsTable.c.check_name == check_key.name,
-            # Historical records may have NULL in the evaluation_event_storage_id column for
-            # PLANNED events
-            AssetCheckExecutionsTable.c.evaluation_event_storage_id.isnot(None),
-        ]
-        if partition_keys is not None:
-            filter_conditions.append(AssetCheckExecutionsTable.c.partition.in_(partition_keys))
+        asset_keys: Sequence[AssetKey],
+        asset_partitions: Sequence[str] | None = None,
+    ):
+        query = db_select(
+            [
+                SqlEventLogStorageTable.c.asset_key,
+                SqlEventLogStorageTable.c.partition,
+                db.func.max(SqlEventLogStorageTable.c.id).label("id"),
+            ]
+        ).where(
+            db.and_(
+                SqlEventLogStorageTable.c.asset_key.in_(
+                    [asset_key.to_string() for asset_key in asset_keys]
+                ),
+                SqlEventLogStorageTable.c.partition != None,  # noqa: E711
+                SqlEventLogStorageTable.c.dagster_event_type
+                == DagsterEventType.ASSET_MATERIALIZATION.value,
+            )
+        )
+        if asset_partitions is not None:
+            query = query.where(SqlEventLogStorageTable.c.partition.in_(asset_partitions))
 
-        # Subquery to find the max id for each partition
+        latest_event_ids_subquery = query.group_by(
+            SqlEventLogStorageTable.c.asset_key, SqlEventLogStorageTable.c.partition
+        )
+        assets_details = self._get_assets_details(asset_keys)
+        return db_subquery(
+            self._add_assets_wipe_filter_to_query(
+                latest_event_ids_subquery, assets_details, asset_keys
+            ),
+            "latest_event_ids_by_asset_partition_subquery",
+        )
+
+    def _get_asset_check_partition_info_rows_for_keys(
+        self,
+        keys: Sequence[AssetCheckKey],
+        after_storage_id: int | None = None,
+        partition_keys: Sequence[str] | None = None,
+    ) -> Sequence[Mapping[str, Any]]:
+        unique_asset_keys = list(dict.fromkeys(key.asset_key for key in keys))
         latest_check_ids_subquery = db_subquery(
             db_select(
                 [
                     db.func.max(AssetCheckExecutionsTable.c.id).label("id"),
+                    AssetCheckExecutionsTable.c.asset_key.label("asset_key"),
+                    AssetCheckExecutionsTable.c.check_name.label("check_name"),
                     AssetCheckExecutionsTable.c.partition.label("partition"),
                 ]
             )
-            .where(db.and_(*filter_conditions))
-            .group_by(AssetCheckExecutionsTable.c.partition),
+            .where(
+                db.and_(
+                    db.tuple_(
+                        AssetCheckExecutionsTable.c.asset_key,
+                        AssetCheckExecutionsTable.c.check_name,
+                    ).in_([(key.asset_key.to_string(), key.name) for key in keys]),
+                    # Historical records may have NULL in the evaluation_event_storage_id column for
+                    # PLANNED events.
+                    AssetCheckExecutionsTable.c.evaluation_event_storage_id.isnot(None),
+                    *(
+                        [AssetCheckExecutionsTable.c.partition.in_(partition_keys)]
+                        if partition_keys is not None
+                        else []
+                    ),
+                )
+            )
+            .group_by(
+                AssetCheckExecutionsTable.c.asset_key,
+                AssetCheckExecutionsTable.c.check_name,
+                AssetCheckExecutionsTable.c.partition,
+            ),
             "latest_check_ids_subquery",
         )
 
-        # Subquery to find the latest materialization storage id for each partition of the
-        # target asset. Note: we don't filter by after_storage_id here because we always want
-        # to return the latest materialization storage id, even if it's older than after_storage_id.
-        latest_materialization_ids_subquery = self._latest_event_ids_by_partition_subquery(
-            check_key.asset_key,
-            [DagsterEventType.ASSET_MATERIALIZATION],
-            asset_partitions=partition_keys,
+        latest_materialization_ids_subquery = (
+            self._latest_materialization_ids_by_asset_partition_subquery(
+                unique_asset_keys,
+                asset_partitions=partition_keys,
+            )
         )
 
-        # Main query to get all columns for the latest records, joined with latest
-        # materialization storage ids
         query = db_select(
             [
-                AssetCheckExecutionsTable.c.id,
+                AssetCheckExecutionsTable.c.asset_key,
+                AssetCheckExecutionsTable.c.check_name,
                 AssetCheckExecutionsTable.c.partition,
                 AssetCheckExecutionsTable.c.execution_status,
                 AssetCheckExecutionsTable.c.evaluation_event_storage_id,
@@ -3308,14 +3351,18 @@ class SqlEventLogStorage(EventLogStorage):
                 AssetCheckExecutionsTable.c.id == latest_check_ids_subquery.c.id,
             ).join(
                 latest_materialization_ids_subquery,
-                AssetCheckExecutionsTable.c.partition
-                == latest_materialization_ids_subquery.c.partition,
+                db.and_(
+                    AssetCheckExecutionsTable.c.asset_key
+                    == latest_materialization_ids_subquery.c.asset_key,
+                    AssetCheckExecutionsTable.c.partition
+                    == latest_materialization_ids_subquery.c.partition,
+                ),
                 isouter=True,
             )
         )
 
-        # these filters are applied to the main query rather than the individual subqueries to ensure
-        # we don't miss records that only have a new materialization or a new check execution but not both
+        # Apply the cursor filter once after selecting the latest row for each partition so we keep
+        # rows that changed via either a new check execution or a new materialization.
         if after_storage_id is not None:
             query = query.where(
                 db.or_(
@@ -3325,31 +3372,33 @@ class SqlEventLogStorage(EventLogStorage):
             )
 
         with self.index_connection() as conn:
-            rows = db_fetch_mappings(conn, query)
+            return db_fetch_mappings(conn, query)
 
+    def _get_asset_check_partition_info_partition_key_chunks(
+        self, partition_keys: Sequence[str] | None
+    ) -> Sequence[Sequence[str] | None]:
+        if partition_keys is None:
+            return [None]
+
+        max_partition_keys_per_query = max(1, ASSET_CHECK_PARTITION_INFO_MAX_BIND_PARAMS - 2)
+        unique_partition_keys = list(dict.fromkeys(partition_keys))
         return [
-            AssetCheckPartitionInfo(
-                check_key=check_key,
-                partition_key=row["partition"],
-                latest_execution_status=AssetCheckExecutionRecordStatus(row["execution_status"]),
-                latest_target_materialization_storage_id=row["materialization_event_storage_id"],
-                latest_planned_run_id=row["run_id"],
-                latest_check_event_storage_id=row["evaluation_event_storage_id"],
-                latest_materialization_storage_id=max(
-                    filter(
-                        None,
-                        [
-                            row["latest_materialization_storage_id"],
-                            latest_unpartitioned_materialization_storage_ids.get(
-                                check_key.asset_key
-                            ),
-                        ],
-                    ),
-                    default=None,
-                ),
-            )
-            for row in rows
+            unique_partition_keys[i : i + max_partition_keys_per_query]
+            for i in range(0, len(unique_partition_keys), max_partition_keys_per_query)
         ]
+
+    def _get_asset_check_partition_info_key_batch_size(
+        self, partition_keys: Sequence[str] | None
+    ) -> int:
+        partition_key_count = len(partition_keys) if partition_keys is not None else 0
+        remaining_bind_budget = ASSET_CHECK_PARTITION_INFO_MAX_BIND_PARAMS - partition_key_count
+        return max(
+            1,
+            min(
+                ASSET_CHECK_PARTITION_INFO_BATCH_SIZE,
+                remaining_bind_budget // 2,
+            ),
+        )
 
     def get_asset_check_partition_info(
         self,
@@ -3360,24 +3409,67 @@ class SqlEventLogStorage(EventLogStorage):
         check.list_param(keys, "keys", of_type=AssetCheckKey)
         check.opt_int_param(after_storage_id, "after_storage_id")
 
-        infos = []
+        if not keys:
+            return []
+        if partition_keys is not None and len(partition_keys) == 0:
+            return []
+
+        unique_keys = list(dict.fromkeys(keys))
+        unique_asset_keys = list(dict.fromkeys(key.asset_key for key in unique_keys))
         latest_unpartitioned_materialization_storage_ids = (
             self._get_latest_unpartitioned_materialization_storage_ids(
-                list(set(key.asset_key for key in keys))
+                unique_asset_keys
             )
         )
-        # the inner query is not feasible to join in a single query because the latest materialization ids subquery,
-        # so for now we fetch the info for each key separately
-        for key in keys:
-            infos.extend(
-                self._get_asset_check_partition_info_for_key(
-                    key,
-                    after_storage_id,
-                    partition_keys,
-                    latest_unpartitioned_materialization_storage_ids,
-                )
+        infos_by_key = defaultdict(list)
+        key_by_tuple = {
+            (key.asset_key.to_string(), key.name): key for key in unique_keys
+        }
+
+        # Fetch rows in bounded chunks so large bulk state reads do not exceed backend bind limits,
+        # while still avoiding the old O(number_of_checks) per-key query fan-out.
+        for partition_key_chunk in self._get_asset_check_partition_info_partition_key_chunks(
+            partition_keys
+        ):
+            key_batch_size = self._get_asset_check_partition_info_key_batch_size(
+                partition_key_chunk
             )
-        return infos
+            for chunk_start in range(0, len(unique_keys), key_batch_size):
+                chunk = unique_keys[chunk_start : chunk_start + key_batch_size]
+                for row in self._get_asset_check_partition_info_rows_for_keys(
+                    chunk,
+                    after_storage_id=after_storage_id,
+                    partition_keys=partition_key_chunk,
+                ):
+                    check_key = key_by_tuple[(row["asset_key"], row["check_name"])]
+                    infos_by_key[check_key].append(
+                        AssetCheckPartitionInfo(
+                            check_key=check_key,
+                            partition_key=row["partition"],
+                            latest_execution_status=AssetCheckExecutionRecordStatus(
+                                row["execution_status"]
+                            ),
+                            latest_target_materialization_storage_id=row[
+                                "materialization_event_storage_id"
+                            ],
+                            latest_planned_run_id=row["run_id"],
+                            latest_check_event_storage_id=row["evaluation_event_storage_id"],
+                            latest_materialization_storage_id=max(
+                                filter(
+                                    None,
+                                    [
+                                        row["latest_materialization_storage_id"],
+                                        latest_unpartitioned_materialization_storage_ids.get(
+                                            check_key.asset_key
+                                        ),
+                                    ],
+                                ),
+                                default=None,
+                            ),
+                        )
+                    )
+
+        return [info for key in keys for info in infos_by_key.get(key, [])]
 
     @property
     def supports_asset_checks(self):  # pyright: ignore[reportIncompatibleMethodOverride]

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -7414,6 +7414,183 @@ class TestEventLogStorage:
         assert len(partition_records) == 1
         assert not partition_records[0].is_current
 
+    def test_asset_check_partition_info_batched_across_keys(
+        self,
+        storage: EventLogStorage,
+    ):
+        run_ids = [make_new_run_id() for _ in range(4)]
+        asset_key_one = dg.AssetKey(["asset_one"])
+        asset_key_two = dg.AssetKey(["asset_two"])
+        check_key_one = dg.AssetCheckKey(asset_key_one, "check_one")
+        check_key_two = dg.AssetCheckKey(asset_key_two, "check_two")
+        partitions_def = dg.StaticPartitionsDefinition(["a", "b"])
+
+        storage.store_event(
+            _create_check_planned_event(
+                run_ids[0],
+                check_key_one,
+                partitions_subset=partitions_def.subset_with_partition_keys(["a"]),
+            )
+        )
+        storage.store_event(
+            _create_check_evaluation_event(run_ids[0], check_key_one, passed=True, partition="a")
+        )
+        storage.store_event(
+            _create_check_planned_event(
+                run_ids[1],
+                check_key_one,
+                partitions_subset=partitions_def.subset_with_partition_keys(["b"]),
+            )
+        )
+
+        storage.store_event(
+            _create_check_planned_event(
+                run_ids[2],
+                check_key_two,
+                partitions_subset=partitions_def.subset_with_partition_keys(["a"]),
+            )
+        )
+        storage.store_event(
+            _create_check_evaluation_event(run_ids[2], check_key_two, passed=False, partition="a")
+        )
+        storage.store_event(
+            _create_check_planned_event(
+                run_ids[3],
+                check_key_two,
+                partitions_subset=partitions_def.subset_with_partition_keys(["b"]),
+            )
+        )
+        storage.store_event(
+            _create_check_evaluation_event(run_ids[3], check_key_two, passed=True, partition="b")
+        )
+
+        partition_records = storage.get_asset_check_partition_info([check_key_one, check_key_two])
+        assert len(partition_records) == 4
+        records_by_key_and_partition = {
+            (record.check_key, record.partition_key): record for record in partition_records
+        }
+
+        assert (
+            records_by_key_and_partition[(check_key_one, "a")].latest_execution_status
+            == AssetCheckExecutionRecordStatus.SUCCEEDED
+        )
+        assert (
+            records_by_key_and_partition[(check_key_one, "b")].latest_execution_status
+            == AssetCheckExecutionRecordStatus.PLANNED
+        )
+        assert (
+            records_by_key_and_partition[(check_key_two, "a")].latest_execution_status
+            == AssetCheckExecutionRecordStatus.FAILED
+        )
+        assert (
+            records_by_key_and_partition[(check_key_two, "b")].latest_execution_status
+            == AssetCheckExecutionRecordStatus.SUCCEEDED
+        )
+
+        filtered_records = storage.get_asset_check_partition_info(
+            [check_key_one, check_key_two], partition_keys=["a"]
+        )
+        assert {(record.check_key, record.partition_key) for record in filtered_records} == {
+            (check_key_one, "a"),
+            (check_key_two, "a"),
+        }
+
+        latest_storage_id = max(
+            record.latest_check_event_storage_id for record in partition_records
+        )
+
+        storage.store_event(
+            _create_materialization_event(make_new_run_id(), asset_key_one, partition="a")
+        )
+        storage.store_event(
+            _create_materialization_event(make_new_run_id(), asset_key_two, partition="b")
+        )
+
+        updated_records = storage.get_asset_check_partition_info(
+            [check_key_one, check_key_two], after_storage_id=latest_storage_id
+        )
+        assert {(record.check_key, record.partition_key) for record in updated_records} == {
+            (check_key_one, "a"),
+            (check_key_two, "b"),
+        }
+
+        partition_records = storage.get_asset_check_partition_info([check_key_one, check_key_two])
+        records_by_key_and_partition = {
+            (record.check_key, record.partition_key): record for record in partition_records
+        }
+        assert not records_by_key_and_partition[(check_key_one, "a")].is_current
+        assert not records_by_key_and_partition[(check_key_two, "b")].is_current
+
+    def test_asset_check_partition_info_large_batch_safe(
+        self,
+        storage: EventLogStorage,
+    ):
+        partitions_subset = dg.StaticPartitionsDefinition(["a"]).subset_with_partition_keys(["a"])
+        check_keys = [
+            dg.AssetCheckKey(dg.AssetKey([f"asset_{index}"]), f"check_{index}")
+            for index in range(600)
+        ]
+
+        for check_key in check_keys:
+            run_id = make_new_run_id()
+            storage.store_event(
+                _create_check_planned_event(
+                    run_id,
+                    check_key,
+                    partitions_subset=partitions_subset,
+                )
+            )
+            storage.store_event(
+                _create_check_evaluation_event(run_id, check_key, passed=True, partition="a")
+            )
+
+        partition_records = storage.get_asset_check_partition_info(check_keys)
+
+        assert len(partition_records) == len(check_keys)
+        assert {record.check_key for record in partition_records} == set(check_keys)
+        assert {record.partition_key for record in partition_records} == {"a"}
+        assert all(
+            record.latest_execution_status == AssetCheckExecutionRecordStatus.SUCCEEDED
+            for record in partition_records
+        )
+
+    def test_asset_check_partition_info_large_filtered_batch_safe(
+        self,
+        storage: EventLogStorage,
+    ):
+        partitions_subset = dg.StaticPartitionsDefinition(["a"]).subset_with_partition_keys(["a"])
+        check_keys = [
+            dg.AssetCheckKey(dg.AssetKey([f"asset_{index}"]), f"check_{index}")
+            for index in range(600)
+        ]
+        partition_keys = ["a", *[f"unused_{index}" for index in range(250)]]
+
+        for check_key in check_keys:
+            run_id = make_new_run_id()
+            storage.store_event(
+                _create_check_planned_event(
+                    run_id,
+                    check_key,
+                    partitions_subset=partitions_subset,
+                )
+            )
+            storage.store_event(
+                _create_check_evaluation_event(run_id, check_key, passed=True, partition="a")
+            )
+
+        partition_records = storage.get_asset_check_partition_info(
+            check_keys,
+            partition_keys=partition_keys,
+        )
+
+        assert len(partition_records) == len(check_keys)
+        assert {record.check_key for record in partition_records} == set(check_keys)
+        assert {record.partition_key for record in partition_records} == {"a"}
+        assert all(
+            record.latest_execution_status == AssetCheckExecutionRecordStatus.SUCCEEDED
+            for record in partition_records
+        )
+
 
 def _create_check_planned_event(
     run_id: str,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -1,18 +1,30 @@
 import gc
+import math
 import time
 from contextlib import contextmanager
 
+import dagster_postgres.event_log.event_log as dagster_postgres_event_log
 import objgraph
 import pytest
 import yaml
+from dagster import AssetCheckKey, AssetKey, StaticPartitionsDefinition
+from dagster._core.storage.event_log.sql_event_log import (
+    ASSET_CHECK_PARTITION_INFO_BATCH_SIZE,
+    ASSET_CHECK_PARTITION_INFO_MAX_BIND_PARAMS,
+)
 from dagster._core.storage.event_log.base import EventLogCursor
+from dagster._core.storage.sql import stamp_alembic_rev
 from dagster._core.test_utils import ensure_dagster_tests_import, instance_for_test
 from dagster._core.utils import make_new_run_id
+from sqlalchemy import event, inspect
+from dagster_postgres.utils import pg_alembic_config
 from dagster_postgres.event_log import PostgresEventLogStorage
 
 ensure_dagster_tests_import()
 from dagster_tests.storage_tests.utils.event_log_storage import (
     TestEventLogStorage,
+    _create_check_evaluation_event,
+    _create_check_planned_event,
     create_test_event_log_record,
 )
 
@@ -47,6 +59,156 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
 
     def can_wipe_asset_partitions(self) -> bool:
         return False
+
+    def test_asset_check_partition_info_uses_single_batched_query(self, storage):
+        check_keys = [
+            AssetCheckKey(AssetKey(["asset_one"]), "check_one"),
+            AssetCheckKey(AssetKey(["asset_two"]), "check_two"),
+            AssetCheckKey(AssetKey(["asset_three"]), "check_three"),
+        ]
+        partitions_subset = StaticPartitionsDefinition(["a"]).subset_with_partition_keys(["a"])
+
+        for check_key in check_keys:
+            run_id = make_new_run_id()
+            storage.store_event(
+                _create_check_planned_event(run_id, check_key, partitions_subset=partitions_subset)
+            )
+            storage.store_event(
+                _create_check_evaluation_event(run_id, check_key, passed=True, partition="a")
+            )
+
+        statements = []
+
+        def _capture_statement(
+            conn, cursor, statement, parameters, context, executemany
+        ):  # noqa: ARG001
+            statements.append(statement)
+
+        event.listen(storage._engine, "before_cursor_execute", _capture_statement)
+        try:
+            storage.get_asset_check_partition_info(check_keys)
+        finally:
+            event.remove(storage._engine, "before_cursor_execute", _capture_statement)
+
+        asset_check_selects = [
+            statement
+            for statement in statements
+            if statement.lstrip().upper().startswith("SELECT")
+            and "asset_check_executions" in statement
+        ]
+        assert len(asset_check_selects) == 1
+
+    def test_asset_check_partition_info_uses_bounded_queries_for_large_batches(self, storage):
+        check_keys = [
+            AssetCheckKey(AssetKey([f"asset_{index}"]), f"check_{index}")
+            for index in range(ASSET_CHECK_PARTITION_INFO_BATCH_SIZE + 200)
+        ]
+        partitions_subset = StaticPartitionsDefinition(["a"]).subset_with_partition_keys(["a"])
+
+        for check_key in check_keys:
+            run_id = make_new_run_id()
+            storage.store_event(
+                _create_check_planned_event(run_id, check_key, partitions_subset=partitions_subset)
+            )
+            storage.store_event(
+                _create_check_evaluation_event(run_id, check_key, passed=True, partition="a")
+            )
+
+        statements = []
+
+        def _capture_statement(
+            conn, cursor, statement, parameters, context, executemany
+        ):  # noqa: ARG001
+            statements.append(statement)
+
+        event.listen(storage._engine, "before_cursor_execute", _capture_statement)
+        try:
+            records = storage.get_asset_check_partition_info(check_keys)
+        finally:
+            event.remove(storage._engine, "before_cursor_execute", _capture_statement)
+
+        assert len(records) == len(check_keys)
+
+        asset_check_selects = [
+            statement
+            for statement in statements
+            if statement.lstrip().upper().startswith("SELECT")
+            and "asset_check_executions" in statement
+        ]
+        assert len(asset_check_selects) == math.ceil(
+            len(check_keys) / ASSET_CHECK_PARTITION_INFO_BATCH_SIZE
+        )
+
+    def test_asset_check_partition_info_uses_bounded_queries_for_large_filtered_batches(
+        self, storage
+    ):
+        check_keys = [
+            AssetCheckKey(AssetKey([f"asset_{index}"]), f"check_{index}")
+            for index in range(600)
+        ]
+        partition_keys = ["a", *[f"unused_{index}" for index in range(250)]]
+        partitions_subset = StaticPartitionsDefinition(["a"]).subset_with_partition_keys(["a"])
+
+        for check_key in check_keys:
+            run_id = make_new_run_id()
+            storage.store_event(
+                _create_check_planned_event(run_id, check_key, partitions_subset=partitions_subset)
+            )
+            storage.store_event(
+                _create_check_evaluation_event(run_id, check_key, passed=True, partition="a")
+            )
+
+        statements = []
+
+        def _capture_statement(
+            conn, cursor, statement, parameters, context, executemany
+        ):  # noqa: ARG001
+            statements.append(statement)
+
+        event.listen(storage._engine, "before_cursor_execute", _capture_statement)
+        try:
+            records = storage.get_asset_check_partition_info(
+                check_keys,
+                partition_keys=partition_keys,
+            )
+        finally:
+            event.remove(storage._engine, "before_cursor_execute", _capture_statement)
+
+        assert len(records) == len(check_keys)
+
+        asset_check_selects = [
+            statement
+            for statement in statements
+            if statement.lstrip().upper().startswith("SELECT")
+            and "asset_check_executions" in statement
+        ]
+        expected_batch_size = min(
+            ASSET_CHECK_PARTITION_INFO_BATCH_SIZE,
+            (ASSET_CHECK_PARTITION_INFO_MAX_BIND_PARAMS - len(partition_keys)) // 2,
+        )
+        assert len(asset_check_selects) == math.ceil(len(check_keys) / expected_batch_size)
+
+    def test_asset_check_partition_latest_index_migration(self, instance):
+        event_log_storage = instance.event_log_storage
+        assert isinstance(event_log_storage, PostgresEventLogStorage)
+
+        with event_log_storage.index_connection() as conn:
+            conn.exec_driver_sql("DROP INDEX IF EXISTS idx_asset_check_executions_partition_latest")
+            stamp_alembic_rev(
+                pg_alembic_config(dagster_postgres_event_log.__file__),
+                conn,
+                "29b539ebc72a",
+            )
+
+        instance.upgrade()
+
+        indexes = {
+            index["name"]
+            for index in inspect(event_log_storage._engine).get_indexes(
+                "asset_check_executions"
+            )
+        }
+        assert "idx_asset_check_executions_partition_latest" in indexes
 
     def test_event_log_storage_two_watchers(self, conn_string):
         with _clean_storage(conn_string) as storage:


### PR DESCRIPTION
## Summary & Motivation
Resolves performance issue #33494.
This PR adds the compound index `idx_asset_check_executions_partition_latest` and optimizes `get_asset_check_partition_info` query chunking to resolve high Postgres IO waits on asset check queries.

## Test Plan
- Added `test_asset_check_partition_info_uses_bounded_queries_for_large_batches` and other tests using SQLAlchemy listeners to confirm `asset_check_executions` statements are correctly bounded and chunked.
- Added `test_asset_check_partition_latest_index_migration` to verify alembic downgrades/upgrades.
- Added `test_partitioned_asset_check_partition_statuses` to confirm GraphQL resolvers correctly fetch partitioned check states.

## Changelog
- Fix high IO waits on asset check partition queries by chunking evaluations and adding a new db index.
