### PR TITLE
Handle missing cgroup v2 files in container metrics on ECS managed instances

### DIFF
--- a/python_modules/dagster/dagster/_utils/container.py
+++ b/python_modules/dagster/dagster/_utils/container.py
@@ -117,6 +117,58 @@ class ContainerUtilizationMetrics(TypedDict):
     cgroup_version: str | None
 
 
+def _read_cgroup_file(path: str, logger: logging.Logger | None, debug_message: str) -> str | None:
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        if logger:
+            logger.debug(debug_message)
+        return None
+    except Exception:
+        if logger:
+            logger.debug(debug_message, exc_info=True)
+        return None
+
+
+def _parse_cgroup_numeric_value(
+    raw_value: str | None,
+    logger: logging.Logger | None,
+    debug_message: str,
+    *,
+    unlimited_sentinel: str | None = None,
+) -> int | None:
+    if raw_value is None or raw_value == "" or raw_value == unlimited_sentinel:
+        return None
+
+    try:
+        return int(raw_value)
+    except ValueError:
+        if logger:
+            logger.debug(debug_message, exc_info=True)
+        return None
+
+
+def _retrieve_cpu_max_fields_v2(logger: logging.Logger | None) -> tuple[str, str] | None:
+    raw_value = _read_cgroup_file(
+        cpu_max_path_cgroup_v2(),
+        logger,
+        "Unable to read cpu.max from cgroup v2. CPU limits may be unavailable in this environment.",
+    )
+    if raw_value is None:
+        return None
+
+    parts = raw_value.split()
+    if len(parts) != 2:
+        if logger:
+            logger.debug(
+                "Unable to parse cpu.max from cgroup v2. Expected '$MAX $PERIOD'.",
+            )
+        return None
+
+    return parts[0], parts[1]
+
+
 def retrieve_containerized_utilization_metrics(
     logger: logging.Logger | None,
     previous_measurement_timestamp: float | None = None,
@@ -178,12 +230,18 @@ def _retrieve_containerized_cpu_usage_v1(logger: logging.Logger | None) -> float
 
 def _retrieve_containerized_cpu_usage_v2(logger: logging.Logger | None) -> float | None:
     try:
-        with open(cpu_stat_path_cgroup_v2()) as f:
-            lines = f.readlines()
-            for line in lines:
-                if line.startswith("usage_usec"):
-                    return float(line.split()[1]) / 1e6  # Cpu.stat usage_usec is in microseconds
+        raw_value = _read_cgroup_file(
+            cpu_stat_path_cgroup_v2(),
+            logger,
+            "Unable to read cpu.stat from cgroup v2. CPU usage metrics may be unavailable in this environment.",
+        )
+        if raw_value is None:
             return None
+
+        for line in raw_value.splitlines():
+            if line.startswith("usage_usec"):
+                return float(line.split()[1]) / 1e6  # Cpu.stat usage_usec is in microseconds
+        return None
     except Exception as e:
         if logger:
             logger.error(f"Failed to retrieve CPU time from cgroup: {e}")
@@ -224,13 +282,15 @@ def _retrieve_containerized_memory_usage_v1(logger: logging.Logger | None) -> in
 
 
 def _retrieve_containerized_memory_usage_v2(logger: logging.Logger | None) -> int | None:
-    try:
-        with open(memory_usage_path_cgroup_v2()) as f:
-            return int(f.read())
-    except Exception as e:
-        if logger:
-            logger.error(f"Failed to retrieve memory usage from cgroup: {e}")
-        return None
+    return _parse_cgroup_numeric_value(
+        _read_cgroup_file(
+            memory_usage_path_cgroup_v2(),
+            logger,
+            "Unable to read memory.current from cgroup v2. Memory usage metrics may be unavailable in this environment.",
+        ),
+        logger,
+        "Unable to parse memory.current from cgroup v2. Memory usage metrics may be unavailable in this environment.",
+    )
 
 
 def _retrieve_containerized_memory_limit(
@@ -256,15 +316,16 @@ def _retrieve_containerized_memory_limit_v1(logger: logging.Logger | None) -> in
 
 
 def _retrieve_containerized_memory_limit_v2(logger: logging.Logger | None) -> int | None:
-    try:
-        with open(memory_limit_path_cgroup_v2()) as f:
-            return int(f.read())
-    except:
-        if logger:
-            logger.exception(
-                "Failed to retrieve memory limit from cgroup. There may be no limit set on the container."
-            )
-        return None
+    return _parse_cgroup_numeric_value(
+        _read_cgroup_file(
+            memory_limit_path_cgroup_v2(),
+            logger,
+            "Unable to read memory.max from cgroup v2. There may be no memory limit in this environment.",
+        ),
+        logger,
+        "Unable to parse memory.max from cgroup v2. There may be no memory limit in this environment.",
+        unlimited_sentinel="max",
+    )
 
 
 def _retrieve_containerized_cpu_cfs_period_us(
@@ -295,13 +356,15 @@ def _retrieve_containerized_cpu_cfs_period_us_v2(
     logger: logging.Logger | None,
 ) -> float | None:
     # We can retrieve period information from the cpu.max file. The file is in the format $MAX $PERIOD and is only one line.
+    cpu_max_fields = _retrieve_cpu_max_fields_v2(logger)
+    if cpu_max_fields is None:
+        return None
+
     try:
-        with open(cpu_max_path_cgroup_v2()) as f:
-            line = f.readline()
-            return float(line.split()[1])
-    except:
+        return float(cpu_max_fields[1])
+    except ValueError:
         if logger:
-            logger.exception("Failed to retrieve CPU period from cgroup")
+            logger.debug("Unable to parse CPU period from cgroup v2.", exc_info=True)
         return None
 
 
@@ -333,14 +396,16 @@ def _retrieve_containerized_cpu_cfs_quota_us_v2(
     logger: logging.Logger | None,
 ) -> float | None:
     # We can retrieve quota information from the cpu.max file. The file is in the format $MAX $PERIOD .
+    cpu_max_fields = _retrieve_cpu_max_fields_v2(logger)
+    if cpu_max_fields is None or cpu_max_fields[0] == "max":
+        return None
+
     try:
-        with open(cpu_max_path_cgroup_v2()) as f:
-            line = f.readline()
-            return float(line.split()[0])
-    except:
+        return float(cpu_max_fields[0])
+    except ValueError:
         if logger:
             logger.debug(
-                "Failed to retrieve CPU quota from cgroup. There might not be a limit set on the container.",
+                "Unable to parse CPU quota from cgroup v2. There might not be a CPU limit set on the container.",
                 exc_info=True,
             )
         return None

--- a/python_modules/dagster/dagster_tests/utils_tests/test_container_utils.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_container_utils.py
@@ -2,7 +2,14 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from dagster._utils.container import CGroupVersion, retrieve_containerized_utilization_metrics
+from dagster._utils.container import (
+    CGroupVersion,
+    _retrieve_containerized_cpu_cfs_period_us_v2,
+    _retrieve_containerized_cpu_cfs_quota_us_v2,
+    _retrieve_containerized_memory_limit_v2,
+    _retrieve_containerized_memory_usage_v2,
+    retrieve_containerized_utilization_metrics,
+)
 from dagster._utils.env import environ
 
 
@@ -189,3 +196,86 @@ def test_containerized_utilization_metrics_cgroup_v2(
     assert utilization_metrics["previous_measurement_timestamp"] == (
         1.0 if was_previous_timestamp_previously_set else None
     )
+
+
+def test_cgroup_v2_missing_files_return_partial_metrics(temp_dir: str, cgroup_version_mock: mock.Mock):
+    with open(f"{temp_dir}/cpu.stat", "w") as f:
+        f.write("usage_usec 1000000")
+
+    with open(f"{temp_dir}/cpuinfo", "w") as f:
+        f.write("processor : 0")
+
+    cgroup_version_mock.return_value = CGroupVersion.V2
+
+    utilization_metrics = retrieve_containerized_utilization_metrics(logger=None)
+
+    assert utilization_metrics["cpu_usage"] == 1.0
+    assert utilization_metrics["num_allocated_cores"] == 1
+    assert utilization_metrics["cpu_cfs_quota_us"] is None
+    assert utilization_metrics["cpu_cfs_period_us"] is None
+    assert utilization_metrics["memory_usage"] is None
+    assert utilization_metrics["memory_limit"] is None
+
+
+def test_cgroup_v2_missing_files_do_not_log_exceptions(cgroup_version_mock: mock.Mock):
+    logger = mock.Mock()
+    with mock.patch("dagster._utils.container._retrieve_containerized_num_allocated_cores", return_value=1):
+        with mock.patch("dagster._utils.container._retrieve_containerized_cpu_usage_v2", return_value=1.0):
+            cgroup_version_mock.return_value = CGroupVersion.V2
+
+            retrieve_containerized_utilization_metrics(logger=logger)
+
+    logger.error.assert_not_called()
+    logger.exception.assert_not_called()
+
+
+def test_cgroup_v2_empty_override_files_return_none(temp_dir: str):
+    Path(f"{temp_dir}/cpu.max").write_text("")
+    Path(f"{temp_dir}/memory.current").write_text("")
+    Path(f"{temp_dir}/memory.max").write_text("")
+
+    assert _retrieve_containerized_cpu_cfs_quota_us_v2(logger=None) is None
+    assert _retrieve_containerized_cpu_cfs_period_us_v2(logger=None) is None
+    assert _retrieve_containerized_memory_usage_v2(logger=None) is None
+    assert _retrieve_containerized_memory_limit_v2(logger=None) is None
+
+
+def test_cgroup_v2_empty_override_files_do_not_log_exceptions(temp_dir: str):
+    logger = mock.Mock()
+    Path(f"{temp_dir}/cpu.max").write_text("")
+    Path(f"{temp_dir}/memory.current").write_text("")
+    Path(f"{temp_dir}/memory.max").write_text("")
+
+    assert _retrieve_containerized_cpu_cfs_quota_us_v2(logger=logger) is None
+    assert _retrieve_containerized_cpu_cfs_period_us_v2(logger=logger) is None
+    assert _retrieve_containerized_memory_usage_v2(logger=logger) is None
+    assert _retrieve_containerized_memory_limit_v2(logger=logger) is None
+
+    logger.error.assert_not_called()
+    logger.exception.assert_not_called()
+
+
+def test_cgroup_v2_cpu_max_with_unlimited_quota_returns_none_for_quota(temp_dir: str):
+    Path(f"{temp_dir}/cpu.max").write_text("max 100000")
+
+    assert _retrieve_containerized_cpu_cfs_quota_us_v2(logger=None) is None
+    assert _retrieve_containerized_cpu_cfs_period_us_v2(logger=None) == 100000.0
+
+
+def test_cgroup_v2_memory_max_with_unlimited_limit_returns_none(temp_dir: str):
+    Path(f"{temp_dir}/memory.max").write_text("max")
+
+    assert _retrieve_containerized_memory_limit_v2(logger=None) is None
+
+
+def test_cgroup_v2_unlimited_values_do_not_log_exceptions(temp_dir: str):
+    logger = mock.Mock()
+    Path(f"{temp_dir}/cpu.max").write_text("max 100000")
+    Path(f"{temp_dir}/memory.max").write_text("max")
+
+    assert _retrieve_containerized_cpu_cfs_quota_us_v2(logger=logger) is None
+    assert _retrieve_containerized_cpu_cfs_period_us_v2(logger=logger) == 100000.0
+    assert _retrieve_containerized_memory_limit_v2(logger=logger) is None
+
+    logger.error.assert_not_called()
+    logger.exception.assert_not_called()


### PR DESCRIPTION
## Summary
Fixes #33360.

This hardens Dagster's cgroup v2 container metrics readers so environments like AWS ECS Managed Instances on Bottlerocket can degrade cleanly when `cpu.max`, `memory.current`, or `memory.max` are missing or inaccessible from inside the container namespace.

## Problem
The previous implementation assumed that once cgroup v2 was detected, the relevant files were available and parseable. In ECS Managed Instances that assumption can be false, which caused repeated error and exception log noise during optional metrics collection. Override paths pointing to empty files could also trigger malformed-input parsing errors.

## What changed
- Added shared helpers to safely read optional cgroup files and parse numeric cgroup values.
- Updated cgroup v2 memory usage and memory limit readers to return `None` for missing, empty, malformed, or unlimited values instead of logging exception-level noise.
- Updated `cpu.max` parsing so missing or malformed content degrades cleanly, and `max <period>` is treated as an unlimited quota while still preserving the period.
- Preserved partial metrics collection when some probes succeed and others are unavailable.

## Tests
Added regression coverage for:
- missing cgroup v2 files returning partial metrics without exception logging
- empty override files returning `None` without exception logging
- `cpu.max` values of `max <period>`
- `memory.max` values of `max`

## Validation
Ran locally with:

```powershell
$env:PYTHONPATH='python_modules/dagster;python_modules/libraries/dagster-shared'
python -m pytest python_modules/dagster/dagster_tests/utils_tests/test_container_utils.py python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_run_metrics_thread.py -q
```

Result: `412 passed`

## Scope
This is a bug fix with a small internal refactor for parser reuse. It does not introduce a broader design or architecture change.