### PR TITLE
Fix dbt path selectors in manifest asset selection

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -1,6 +1,8 @@
 from argparse import Namespace
 from collections.abc import Mapping
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, AbstractSet, Any, Optional, cast  # noqa: UP035
+from unittest import mock
 
 import dagster_shared.check as check
 import orjson
@@ -17,6 +19,32 @@ if TYPE_CHECKING:
 ASSET_RESOURCE_TYPES = ["model", "seed", "snapshot"]
 
 clean_name = clean_name_lower
+
+
+def _match_path_selector(path_str: str, selector: str, *, include_parents: bool) -> bool:
+    path = PurePosixPath(path_str.replace("\\", "/"))
+    normalized_selector = selector.replace("\\", "/")
+
+    if path.match(normalized_selector):
+        return True
+
+    return include_parents and any(
+        parent.match(normalized_selector) for parent in path.parents if str(parent) != "."
+    )
+
+
+def _search_manifest_relative_paths(self, included_nodes, selector):
+    """Apply dbt path selectors against manifest-relative paths instead of the process cwd."""
+    for unique_id, node in self.all_nodes(included_nodes):
+        if _match_path_selector(node.original_file_path, selector, include_parents=True):
+            yield unique_id
+            continue
+
+        patch_path = getattr(node, "patch_path", None)
+        if patch_path and _match_path_selector(
+            patch_path.split("://", 1)[1], selector, include_parents=False
+        ):
+            yield unique_id
 
 
 def default_node_info_to_asset_key(node_info: Mapping[str, Any]) -> AssetKey:
@@ -228,8 +256,12 @@ def _select_unique_ids_from_manifest(
         parsed_spec = graph_cli.SelectionDifference(components=[parsed_spec, parsed_exclude_spec])
 
     # execute this selection against the graph
-    node_selector = graph_selector.NodeSelector(graph, manifest)
-    selected, _ = node_selector.select_nodes(parsed_spec)
+    with mock.patch(
+        "dbt.graph.selector_methods.PathSelectorMethod.search",
+        _search_manifest_relative_paths,
+    ):
+        node_selector = graph_selector.NodeSelector(graph, manifest)
+        selected, _ = node_selector.select_nodes(parsed_spec)
     return selected
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -333,6 +333,61 @@ def test_dbt_asset_selection_selector(
     assert selected_asset_keys == expected_asset_keys
 
 
+@pytest.mark.parametrize(
+    ["dbt_selector", "expected_dbt_resource_names"],
+    [
+        (
+            "select-with-fqn",
+            {
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+        (
+            "select-with-path",
+            {
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+        (
+            "select-staging-with-path",
+            {
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+            },
+        ),
+    ],
+)
+def test_dbt_asset_selection_selector_path_method(
+    test_jaffle_shop_manifest: dict[str, Any],
+    dbt_selector: str,
+    expected_dbt_resource_names: set[str],
+) -> None:
+    expected_asset_keys = {AssetKey(key) for key in expected_dbt_resource_names}
+
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
+    def all_dbt_assets(): ...
+
+    asset_selection = build_dbt_asset_selection([all_dbt_assets], dbt_selector=dbt_selector)
+    selected_asset_keys = asset_selection.resolve([all_dbt_assets])
+
+    assert selected_asset_keys == expected_asset_keys
+
+
 def test_dbt_asset_selection_selector_invalid(
     test_jaffle_shop_manifest: dict[str, Any],
 ) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/selectors.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/selectors.yml
@@ -1,4 +1,19 @@
 selectors:
+  - name: select-with-fqn
+    description: "Equivalent to fqn:*"
+    definition:
+      method: fqn
+      value: "*"
+  - name: select-with-path
+    description: "Equivalent to path:*"
+    definition:
+      method: path
+      value: "*"
+  - name: select-staging-with-path
+    description: "Select staging models via path"
+    definition:
+      method: path
+      value: "models/staging"
   - name: raw_customer_child_models
     description: "Equivalent to raw_customers+,resource_type:model"
     definition:


### PR DESCRIPTION
## Summary & Motivation

Fixes #32692.

uild_dbt_asset_selection(..., dbt_selector=...) currently fails for selectors that use method: path when dagster-dbt resolves the selector from the manifest instead of via dbt CLI.

The root cause is that dbt's default PathSelectorMethod resolves globs relative to process cwd. That works in dbt CLI, where dbt has already established project context, but not in Dagster's manifest-only selection path.

This change makes manifest-based path selection resolve against manifest-relative paths (original_file_path / patch_path) so path selectors behave consistently with dbt CLI without requiring any user config or API changes.

## Test Plan

- Added selector fixtures in the jaffle shop test project for broad and narrow method: path selectors
- Added regression coverage in dagster_dbt_tests/core/test_asset_selection.py for:
  - select-with-fqn
  - select-with-path
  - select-staging-with-path
- Ran:
  - 	est_env\\Scripts\\python.exe -m pytest python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py -q
  - 	est_env\\Scripts\\python.exe -m pytest python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py -q

## Changelog

- Fixed dagster-dbt manifest-based asset selection so dbt selectors using method: path resolve correctly.
