### PR TITLE
Fix dbt path selectors in manifest asset selection

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -1,5 +1,8 @@
 from argparse import Namespace
 from collections.abc import Mapping
+from fnmatch import fnmatchcase
+from functools import lru_cache
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, AbstractSet, Any, Optional, cast  # noqa: UP035
 
 import dagster_shared.check as check
@@ -17,6 +20,69 @@ if TYPE_CHECKING:
 ASSET_RESOURCE_TYPES = ["model", "seed", "snapshot"]
 
 clean_name = clean_name_lower
+
+
+def _get_patch_path_relative_to_manifest(node: Any) -> str | None:
+    patch_path = getattr(node, "patch_path", None)
+    if not patch_path or "://" not in patch_path:
+        return None
+
+    _, relative_path = patch_path.split("://", 1)
+    return relative_path or None
+
+
+def _normalize_manifest_relative_path(path_str: str) -> str:
+    return str(PurePosixPath(path_str.replace("\\", "/")))
+
+
+@lru_cache(maxsize=None)
+def _split_manifest_relative_path(path_str: str) -> tuple[str, ...]:
+    normalized_path = _normalize_manifest_relative_path(path_str)
+    if normalized_path in {"", "."}:
+        return ()
+    return tuple(part for part in normalized_path.split("/") if part)
+
+
+@lru_cache(maxsize=None)
+def _compile_manifest_relative_glob(selector: str) -> tuple[tuple[str, ...], bool]:
+    normalized_selector = selector.replace("\\", "/")
+    directory_only = normalized_selector.endswith("/")
+    stripped_selector = normalized_selector.strip("/")
+    if stripped_selector in {"", "."}:
+        return (), directory_only
+    return tuple(part for part in stripped_selector.split("/") if part), directory_only
+
+
+def _matches_manifest_relative_glob(path_str: str, selector: str, *, is_dir: bool) -> bool:
+    pattern_parts, directory_only = _compile_manifest_relative_glob(selector)
+    if directory_only and not is_dir:
+        return False
+
+    path_parts = _split_manifest_relative_path(path_str)
+
+    @lru_cache(maxsize=None)
+    def _matches(pattern_index: int, path_index: int) -> bool:
+        if pattern_index == len(pattern_parts):
+            return path_index == len(path_parts)
+
+        pattern_part = pattern_parts[pattern_index]
+        if pattern_part == "**":
+            if pattern_index == len(pattern_parts) - 1:
+                return True
+            return any(
+                _matches(pattern_index + 1, candidate_path_index)
+                for candidate_path_index in range(path_index, len(path_parts) + 1)
+            )
+
+        if path_index == len(path_parts):
+            return False
+
+        if not fnmatchcase(path_parts[path_index], pattern_part):
+            return False
+
+        return _matches(pattern_index + 1, path_index + 1)
+
+    return _matches(0, 0)
 
 
 def default_node_info_to_asset_key(node_info: Mapping[str, Any]) -> AssetKey:
@@ -95,6 +161,7 @@ def _select_unique_ids_from_manifest(
     from dbt.contracts.graph.manifest import Manifest
     from dbt.contracts.graph.nodes import SavedQuery, SemanticModel
     from dbt.contracts.selection import SelectorFile
+    from dbt.graph.selector_methods import MethodName, PathSelectorMethod
     from dbt.graph.selector_spec import IndirectSelection, SelectionSpec
     from networkx import DiGraph
 
@@ -227,8 +294,42 @@ def _select_unique_ids_from_manifest(
         parsed_exclude_spec = graph_cli.parse_union([exclude], False)
         parsed_spec = graph_cli.SelectionDifference(components=[parsed_spec, parsed_exclude_spec])
 
+    class _ManifestRelativePathSelectorMethod(PathSelectorMethod):
+        def search(self, included_nodes, selector):
+            """Apply dbt path selectors against manifest-relative paths instead of the process cwd."""
+            candidate_nodes = list(self.all_nodes(included_nodes))
+
+            for unique_id, node in candidate_nodes:
+                original_file_path = _normalize_manifest_relative_path(node.original_file_path)
+                if _matches_manifest_relative_glob(original_file_path, selector, is_dir=False):
+                    yield unique_id
+                    continue
+
+                patch_path = _get_patch_path_relative_to_manifest(node)
+                if (
+                    patch_path
+                    and _matches_manifest_relative_glob(
+                        _normalize_manifest_relative_path(patch_path), selector, is_dir=False
+                    )
+                ):
+                    yield unique_id
+                    continue
+
+                if any(
+                    _matches_manifest_relative_glob(str(parent), selector, is_dir=True)
+                    for parent in PurePosixPath(original_file_path).parents
+                    if str(parent) != "."
+                ):
+                    yield unique_id
+
+    class _ManifestRelativePathNodeSelector(graph_selector.NodeSelector):
+        SELECTOR_METHODS = {
+            **graph_selector.NodeSelector.SELECTOR_METHODS,
+            MethodName.Path: _ManifestRelativePathSelectorMethod,
+        }
+
     # execute this selection against the graph
-    node_selector = graph_selector.NodeSelector(graph, manifest)
+    node_selector = _ManifestRelativePathNodeSelector(graph, manifest)
     selected, _ = node_selector.select_nodes(parsed_spec)
     return selected
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -53,36 +53,43 @@ def _compile_manifest_relative_glob(selector: str) -> tuple[tuple[str, ...], boo
     return tuple(part for part in stripped_selector.split("/") if part), directory_only
 
 
+@lru_cache(maxsize=None)
+def _match_manifest_relative_glob_parts(
+    pattern_parts: tuple[str, ...], path_parts: tuple[str, ...], pattern_index: int, path_index: int
+) -> bool:
+    if pattern_index == len(pattern_parts):
+        return path_index == len(path_parts)
+
+    pattern_part = pattern_parts[pattern_index]
+    if pattern_part == "**":
+        if pattern_index == len(pattern_parts) - 1:
+            return True
+        return any(
+            _match_manifest_relative_glob_parts(
+                pattern_parts, path_parts, pattern_index + 1, candidate_path_index
+            )
+            for candidate_path_index in range(path_index, len(path_parts) + 1)
+        )
+
+    if path_index == len(path_parts):
+        return False
+
+    if not fnmatchcase(path_parts[path_index], pattern_part):
+        return False
+
+    return _match_manifest_relative_glob_parts(
+        pattern_parts, path_parts, pattern_index + 1, path_index + 1
+    )
+
+
+@lru_cache(maxsize=None)
 def _matches_manifest_relative_glob(path_str: str, selector: str, *, is_dir: bool) -> bool:
     pattern_parts, directory_only = _compile_manifest_relative_glob(selector)
     if directory_only and not is_dir:
         return False
 
     path_parts = _split_manifest_relative_path(path_str)
-
-    @lru_cache(maxsize=None)
-    def _matches(pattern_index: int, path_index: int) -> bool:
-        if pattern_index == len(pattern_parts):
-            return path_index == len(path_parts)
-
-        pattern_part = pattern_parts[pattern_index]
-        if pattern_part == "**":
-            if pattern_index == len(pattern_parts) - 1:
-                return True
-            return any(
-                _matches(pattern_index + 1, candidate_path_index)
-                for candidate_path_index in range(path_index, len(path_parts) + 1)
-            )
-
-        if path_index == len(path_parts):
-            return False
-
-        if not fnmatchcase(path_parts[path_index], pattern_part):
-            return False
-
-        return _matches(pattern_index + 1, path_index + 1)
-
-    return _matches(0, 0)
+    return _match_manifest_relative_glob_parts(pattern_parts, path_parts, 0, 0)
 
 
 def default_node_info_to_asset_key(node_info: Mapping[str, Any]) -> AssetKey:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -216,12 +216,23 @@ def test_dependencies_manifest_fixture() -> dict[str, Any]:
 def test_dependencies_manifest_windows_fixture(
     test_dependencies_manifest: dict[str, Any],
 ) -> dict[str, Any]:
+    def _to_windows_path(path_str: str | None) -> str | None:
+        return path_str.replace("/", "\\") if path_str else path_str
+
+    def _to_windows_patch_path(patch_path: str | None) -> str | None:
+        if not patch_path or "://" not in patch_path:
+            return patch_path
+
+        scheme, relative_path = patch_path.split("://", 1)
+        return f"{scheme}://{_to_windows_path(relative_path)}"
+
     return {
         **test_dependencies_manifest,
         "nodes": {
             node: {
                 **node_details,
-                "original_file_path": node_details.get("original_file_path").replace("/", "\\"),
+                "original_file_path": _to_windows_path(node_details.get("original_file_path")),
+                "patch_path": _to_windows_patch_path(node_details.get("patch_path")),
             }
             for node, node_details in test_dependencies_manifest["nodes"].items()
         },

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -8,11 +8,13 @@ import pytest
 from dagster._core.definitions.assets.graph.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster._record import replace
-from dagster_dbt import DagsterDbtTranslator, build_dbt_asset_selection
+from dagster_dbt import DagsterDbtTranslator, DbtProject, build_dbt_asset_selection
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.asset_utils import DBT_DEFAULT_EXCLUDE, DBT_DEFAULT_SELECT
 from dagster_dbt.dbt_manifest_asset_selection import DbtManifestAssetSelection
+from dagster_dbt.utils import _select_unique_ids_from_cli, _select_unique_ids_from_manifest
 from dagster_shared.check.functions import ParameterCheckError
+from dagster_dbt_tests.dbt_projects import test_dependencies_path, test_jaffle_shop_path, test_metadata_path
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_selection import AndAssetSelection
@@ -331,6 +333,199 @@ def test_dbt_asset_selection_selector(
     asset_selection = build_dbt_asset_selection([selected_dbt_assets])
     selected_asset_keys = asset_selection.resolve([selected_dbt_assets])
     assert selected_asset_keys == expected_asset_keys
+
+
+@pytest.mark.parametrize(
+    ["dbt_selector", "expected_dbt_resource_names"],
+    [
+        (
+            "select-with-fqn",
+            {
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+        (
+            "select-with-path",
+            {
+                "raw_customers",
+                "raw_orders",
+                "raw_payments",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+        (
+            "select-staging-with-path",
+            {
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+            },
+        ),
+        (
+            "select-model-sql-files",
+            {
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+        ("select-root-sql-files", set()),
+        (
+            "select-staging-schema-patch",
+            {
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+            },
+        ),
+        (
+            "select-model-directories",
+            {
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+                "customers",
+                "orders",
+            },
+        ),
+        (
+            "select-staging-directory",
+            {
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+            },
+        ),
+        ("select-missing-path", set()),
+    ],
+)
+def test_dbt_asset_selection_selector_path_method(
+    test_jaffle_shop_manifest: dict[str, Any],
+    dbt_selector: str,
+    expected_dbt_resource_names: set[str],
+) -> None:
+    expected_asset_keys = {AssetKey(key) for key in expected_dbt_resource_names}
+
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
+    def all_dbt_assets(): ...
+
+    asset_selection = build_dbt_asset_selection([all_dbt_assets], dbt_selector=dbt_selector)
+    selected_asset_keys = asset_selection.resolve([all_dbt_assets])
+
+    assert selected_asset_keys == expected_asset_keys
+
+
+@pytest.mark.parametrize(
+    "dbt_selector",
+    [
+        "select-with-path",
+        "select-staging-with-path",
+        "select-model-sql-files",
+        "select-root-sql-files",
+        "select-staging-schema-patch",
+        "select-model-directories",
+        "select-staging-directory",
+        "select-missing-path",
+    ],
+)
+def test_manifest_path_selector_matches_dbt_cli(
+    test_jaffle_shop_manifest: dict[str, Any],
+    dbt_selector: str,
+) -> None:
+    project = DbtProject(project_dir=os.fspath(test_jaffle_shop_path))
+
+    manifest_selected_unique_ids = _select_unique_ids_from_manifest(
+        select=DBT_DEFAULT_SELECT,
+        exclude=DBT_DEFAULT_EXCLUDE,
+        selector=dbt_selector,
+        manifest_json=test_jaffle_shop_manifest,
+    )
+    cli_selected_unique_ids = _select_unique_ids_from_cli(
+        select=DBT_DEFAULT_SELECT,
+        exclude=DBT_DEFAULT_EXCLUDE,
+        selector=dbt_selector,
+        project=project,
+    )
+
+    assert manifest_selected_unique_ids == cli_selected_unique_ids
+
+
+@pytest.mark.parametrize(
+    "dbt_select",
+    [
+        "path:*",
+        "path:models/**/*.sql",
+        "path:models/staging/",
+        "path:models/schema.yml",
+        "path:seeds/*.csv",
+        "path:packages.yml",
+        "path:models/does_not_exist.sql",
+        "path:snapshots/**/*.sql",
+    ],
+)
+def test_manifest_path_select_matches_dbt_cli_metadata_project(
+    test_metadata_manifest: dict[str, Any],
+    dbt_select: str,
+) -> None:
+    project = DbtProject(project_dir=os.fspath(test_metadata_path))
+
+    manifest_selected_unique_ids = _select_unique_ids_from_manifest(
+        select=dbt_select,
+        exclude=DBT_DEFAULT_EXCLUDE,
+        selector="",
+        manifest_json=test_metadata_manifest,
+    )
+    cli_selected_unique_ids = _select_unique_ids_from_cli(
+        select=dbt_select,
+        exclude=DBT_DEFAULT_EXCLUDE,
+        selector="",
+        project=project,
+    )
+
+    assert manifest_selected_unique_ids == cli_selected_unique_ids
+
+
+@pytest.mark.parametrize(
+    "dbt_select",
+    [
+        "path:models/",
+        "path:models/schema.yml",
+        "path:models/does_not_exist.sql",
+    ],
+)
+def test_manifest_path_select_matches_dbt_cli_for_windows_style_paths(
+    test_dependencies_manifest_windows: dict[str, Any],
+    dbt_select: str,
+) -> None:
+    project = DbtProject(project_dir=os.fspath(test_dependencies_path))
+
+    manifest_selected_unique_ids = _select_unique_ids_from_manifest(
+        select=dbt_select,
+        exclude=DBT_DEFAULT_EXCLUDE,
+        selector="",
+        manifest_json=test_dependencies_manifest_windows,
+    )
+    cli_selected_unique_ids = _select_unique_ids_from_cli(
+        select=dbt_select,
+        exclude=DBT_DEFAULT_EXCLUDE,
+        selector="",
+        project=project,
+    )
+
+    assert manifest_selected_unique_ids == cli_selected_unique_ids
 
 
 def test_dbt_asset_selection_selector_invalid(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/selectors.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/selectors.yml
@@ -1,4 +1,49 @@
 selectors:
+  - name: select-with-fqn
+    description: "Equivalent to fqn:*"
+    definition:
+      method: fqn
+      value: "*"
+  - name: select-with-path
+    description: "Equivalent to path:*"
+    definition:
+      method: path
+      value: "*"
+  - name: select-staging-with-path
+    description: "Select staging models via path"
+    definition:
+      method: path
+      value: "models/staging"
+  - name: select-model-sql-files
+    description: "Select model SQL files recursively via path"
+    definition:
+      method: path
+      value: "models/**/*.sql"
+  - name: select-root-sql-files
+    description: "Select SQL files at the dbt project root"
+    definition:
+      method: path
+      value: "*.sql"
+  - name: select-staging-schema-patch
+    description: "Select nodes patched by the staging schema file"
+    definition:
+      method: path
+      value: "models/staging/schema.yml"
+  - name: select-model-directories
+    description: "Select model directories recursively via trailing-slash path glob"
+    definition:
+      method: path
+      value: "models/**/"
+  - name: select-staging-directory
+    description: "Select the staging directory via trailing-slash path"
+    definition:
+      method: path
+      value: "models/staging/"
+  - name: select-missing-path
+    description: "Select no nodes when the path does not exist"
+    definition:
+      method: path
+      value: "models/does_not_exist.sql"
   - name: raw_customer_child_models
     description: "Equivalent to raw_customers+,resource_type:model"
     definition:


### PR DESCRIPTION
## Summary & Motivation

Fix `dagster-dbt` manifest-based `path` selector resolution so it matches dbt CLI behavior instead of resolving relative to the Dagster process cwd.

This updates the manifest selection path to evaluate `path` selectors against manifest-relative file paths, including:
- model SQL files
- schema patch files
- directory selectors, including trailing-slash forms
- Windows-style manifest paths
- empty-match cases

The change stays internal to `dagster-dbt` and does not require user config or setup changes.

## Test Plan

- Added end-to-end selector regression coverage in `dagster_dbt_tests/core/test_asset_selection.py`
- Added manifest-vs-CLI parity tests for:
  - jaffle shop selector-based path selection
  - direct `path:` selects on the metadata project
  - Windows-style manifest paths
  - nonexistent path selectors
- Ran:
  - `python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py` (`46 passed`)
  - `python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py` (`3 passed`)
- Verified the changed module source-compiles on Python 3.12

## Changelog

[dagster-dbt] Fix manifest-based dbt `path` selectors to resolve using manifest-relative paths
