### PR TITLE
Fix translated deps for DbtProjectComponent subclasses

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -310,7 +310,10 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
                             tags={**base_spec.tags, "custom_tag": "my_value"}
                         )
         """
-        return self._base_translator.get_asset_spec(manifest, unique_id, project)
+        # Call through the translation-aware default implementation so subclasses that
+        # call `super().get_asset_spec(...)` get the same spec shape as the default
+        # component path, including YAML-based translation.
+        return self.translator._get_default_asset_spec(manifest, unique_id, project)
 
     def get_asset_check_spec(
         self,
@@ -464,16 +467,29 @@ class DbtProjectComponentTranslator(
         self._component = component
         super().__init__(settings)
 
-    def get_asset_spec(
+    def _get_default_asset_spec(
         self, manifest: Mapping[str, Any], unique_id: str, project: DbtProject | None
     ) -> dg.AssetSpec:
-        base_spec = super().get_asset_spec(manifest, unique_id, project)
+        base_spec = DagsterDbtTranslator.get_asset_spec(self, manifest, unique_id, project)
         if self.component.translation is None:
             spec = base_spec
         else:
             dbt_props = get_node(manifest, unique_id)
             spec = self.component.translation(base_spec, dbt_props)
         return spec.merge_attributes(metadata={DAGSTER_DBT_TRANSLATOR_METADATA_KEY: self})
+
+    def get_asset_spec(
+        self, manifest: Mapping[str, Any], unique_id: str, project: DbtProject | None
+    ) -> dg.AssetSpec:
+        # Intentionally shadows _GeneratedComponentTranslator.get_asset_spec so that
+        # the non-override path routes to _get_default_asset_spec (translation-aware)
+        # rather than super().get_asset_spec (which would skip YAML translation).
+        component_base_method = DbtProjectComponent.get_asset_spec
+        component_instance_method = getattr(self.component.__class__, "get_asset_spec")
+        if component_base_method is component_instance_method:
+            return self._get_default_asset_spec(manifest, unique_id, project)
+
+        return component_instance_method(self.component, manifest, unique_id, project)
 
 
 def get_projects_from_dbt_component(components: Path) -> list[DbtProject]:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -582,6 +582,86 @@ def test_subclass_override_get_asset_spec_translator_metadata(dbt_path: Path) ->
     )
 
 
+def test_subclass_override_get_asset_spec_with_translation(dbt_path: Path) -> None:
+    """Regression test: translation key config must apply to deps when subclass overrides get_asset_spec.
+
+    Verifies fix for https://github.com/dagster-io/dagster/issues/33632.
+    """
+
+    @dataclass
+    class CustomDbtProjectComponent(DbtProjectComponent):
+        def get_asset_spec(
+            self, manifest: Mapping[str, Any], unique_id: str, project: DbtProject | None
+        ) -> dg.AssetSpec:
+            base_spec = super().get_asset_spec(manifest, unique_id, project)
+            return base_spec.replace_attributes(tags={**base_spec.tags, "custom_tag": "true"})
+
+    defs = build_component_defs_for_test(
+        CustomDbtProjectComponent,
+        {
+            "project": str(dbt_path),
+            "translation": {"key": "some_prefix/{{ node.name }}"},
+        },
+    )
+
+    # All asset keys must carry the "some_prefix" prefix
+    all_keys = defs.resolve_asset_graph().get_all_asset_keys()
+    assert AssetKey(["some_prefix", "customers"]) in all_keys
+    assert AssetKey(["some_prefix", "stg_customers"]) in all_keys
+    # Untranslated keys must not appear
+    assert AssetKey("customers") not in all_keys
+    assert AssetKey("stg_customers") not in all_keys
+
+    # Deps of "customers" must reference translated upstream keys
+    customers_spec = defs.resolve_assets_def(AssetKey(["some_prefix", "customers"])).get_asset_spec(
+        AssetKey(["some_prefix", "customers"])
+    )
+
+    dep_keys = {dep.asset_key for dep in customers_spec.deps}
+    assert AssetKey(["some_prefix", "stg_customers"]) in dep_keys
+    assert AssetKey("stg_customers") not in dep_keys  # the bug: untranslated key in deps
+
+    # Custom tag from the subclass override must still be present
+    assert customers_spec.tags.get("custom_tag") == "true"
+
+
+def test_subclass_override_get_asset_spec_with_translation_preserves_source_dep_metadata() -> None:
+    """Regression test: translated subclass overrides must preserve source dep metadata."""
+    project = DbtProject(test_metadata_path)
+    project.preparer.prepare(project)
+
+    @dataclass
+    class CustomDbtProjectComponent(DbtProjectComponent):
+        def get_asset_spec(
+            self, manifest: Mapping[str, Any], unique_id: str, project: DbtProject | None
+        ) -> dg.AssetSpec:
+            base_spec = super().get_asset_spec(manifest, unique_id, project)
+            return base_spec.replace_attributes(tags={**base_spec.tags, "custom_tag": "true"})
+
+    defs = build_component_defs_for_test(
+        CustomDbtProjectComponent,
+        {
+            "project": str(test_metadata_path),
+            "select": "stg_customers",
+            "translation": {"key": "some_prefix/{{ node.name }}"},
+            "translation_settings": {
+                "enable_source_metadata": True,
+            },
+        },
+    )
+
+    stg_customers_spec = defs.resolve_assets_def(
+        AssetKey(["some_prefix", "stg_customers"])
+    ).get_asset_spec(AssetKey(["some_prefix", "stg_customers"]))
+
+    assert stg_customers_spec.tags.get("custom_tag") == "true"
+    deps = list(stg_customers_spec.deps)
+    assert len(deps) == 1
+    assert deps[0].asset_key == AssetKey(["some_prefix", "raw_customers"])
+    assert deps[0].metadata["dagster/table_name"] == "local_jaffle_shop.main.raw_customers"
+
+
+
 def test_basic_component_dev_mode(tmp_dbt_path: Path) -> None:
     with (
         instance_for_test(),


### PR DESCRIPTION
Fixes #33632.

## Summary & Motivation

Fix `dagster-dbt` YAML translation for subclasses of `DbtProjectComponent`.

When a component subclass overrides `get_asset_spec(...)` and calls `super().get_asset_spec(...)`, the base spec should match the default `DbtProjectComponent` path, including YAML-based translation. Previously, translated asset keys were applied, but upstream dependency keys were not consistently translated in that subclass `super()` path.

This change aligns the subclass `super()` behavior with the default component path by making the default component implementation translation-aware while preserving subclass override dispatch.

## Test Plan

- Added regression coverage for a subclass override with YAML translation to verify upstream deps use translated keys
- Added regression coverage to verify translated subclass overrides still preserve source dependency metadata
- Validated the exact regression scenario locally with focused component-level reproductions
- Validated a no-regression subclass override scenario locally

## Changelog

[dagster-dbt] Fix YAML translation for `DbtProjectComponent` subclasses that override `get_asset_spec`