### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -167,6 +167,15 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      },
+      {
         "matcher": "ExitPlanMode",
         "hooks": [
           {


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json`, alongside the existing `permissions.allow`, `permissions.deny`, and `hooks.UserPromptSubmit` configurations.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin, detects the hook-bypass flag across all git subcommands, and exits 2 to block. All existing configuration is preserved unchanged.

Closes #33639

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
