### PR TITLE
Improve displaying of TableMetadataValue

### DIFF
--- a/js_modules/ui-core/src/assets/AssetEventMetadataEntriesTable.tsx
+++ b/js_modules/ui-core/src/assets/AssetEventMetadataEntriesTable.tsx
@@ -307,34 +307,7 @@ const AssetEventMetadataScrollContainer = styled.div`
   overflow-x: auto;
 `;
 
-export const StyledTableWithHeader = styled.table`
-  /** -2 accounts for the left and right border, which are not taken into account
-  * and cause a tiny amount of horizontal scrolling at all times. */
-  width: calc(100% - 2px);
-  border-spacing: 0;
-  border-collapse: collapse;
-
-  & > thead > tr > td {
-    color: ${Colors.textLighter()};
-    font-size: 12px;
-    line-height: 16px;
-  }
-
-  & > tbody > tr > td,
-  & > thead > tr > td {
-    border: 1px solid ${Colors.keylineDefault()};
-    padding: 8px 12px;
-    font-size: 14px;
-    line-height: 20px;
-    vertical-align: top;
-
-    &:first-child {
-      max-width: 300px;
-      word-wrap: break-word;
-      width: 25%;
-    }
-  }
-`;
+import {StyledTableWithHeader} from '../metadata/SharedTableStyles';
 
 // table-layout: fixed prevents the value column from growing based on content.
 // overflow: clip on the value cell caps its height so the outer table row doesn't
@@ -345,7 +318,6 @@ const StyledMetadataEntriesTable = styled(StyledTableWithHeader)`
   & > tbody > tr > td[data-value-cell] {
     width: 40%;
     max-width: 500px;
-    max-height: 280px;
     overflow: clip;
   }
 `;

--- a/js_modules/ui-core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/ui-core/src/metadata/MetadataEntry.tsx
@@ -15,6 +15,7 @@ import * as React from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
+import {StyledTableWithHeader} from './SharedTableStyles';
 import {TableSchema} from './TableSchema';
 import {
   MetadataEntryFragment,
@@ -70,34 +71,7 @@ const MetadataEntryValueCell = styled.div`
   overflow-x: auto;
 `;
 
-const StyledTableWithHeader = styled.table`
-  /** -2 accounts for the left and right border, which are not taken into account
-  * and cause a tiny amount of horizontal scrolling at all times. */
-  width: calc(100% - 2px);
-  border-spacing: 0;
-  border-collapse: collapse;
 
-  & > thead > tr > td {
-    color: ${Colors.textLighter()};
-    font-size: 12px;
-    line-height: 16px;
-  }
-
-  & > tbody > tr > td,
-  & > thead > tr > td {
-    border: 1px solid ${Colors.keylineDefault()};
-    padding: 8px 12px;
-    font-size: 14px;
-    line-height: 20px;
-    vertical-align: top;
-
-    &:first-child {
-      max-width: 300px;
-      word-wrap: break-word;
-      width: 25%;
-    }
-  }
-`;
 
 export const LogRowStructuredContentTable = ({
   rows,
@@ -107,7 +81,7 @@ export const LogRowStructuredContentTable = ({
   styles?: React.CSSProperties;
 }) => (
   <div style={{paddingBottom: 10, ...(styles || {})}}>
-    <StructuredContentTable cellPadding="0" cellSpacing="0">
+    <FixedLayoutContentTable cellPadding="0" cellSpacing="0">
       <tbody>
         {rows.map(({label, item}, idx) => (
           <tr key={idx} style={{display: 'flex'}}>
@@ -127,7 +101,7 @@ export const LogRowStructuredContentTable = ({
           </tr>
         ))}
       </tbody>
-    </StructuredContentTable>
+    </FixedLayoutContentTable>
   </div>
 );
 
@@ -510,7 +484,6 @@ export const MetadataEntryLink = styled(Link)`
 
 export const StructuredContentTable = styled.table`
   width: 100%;
-  table-layout: fixed;
   padding: 0;
   margin-top: 4px;
   border-top: 1px solid ${Colors.keylineDefault()};
@@ -528,4 +501,8 @@ export const StructuredContentTable = styled.table`
     vertical-align: top;
     box-shadow: none !important;
   }
+`;
+
+const FixedLayoutContentTable = styled(StructuredContentTable)`
+  table-layout: fixed;
 `;

--- a/js_modules/ui-core/src/metadata/SharedTableStyles.tsx
+++ b/js_modules/ui-core/src/metadata/SharedTableStyles.tsx
@@ -1,0 +1,31 @@
+import {Colors} from '@dagster-io/ui-components';
+import styled from 'styled-components';
+
+export const StyledTableWithHeader = styled.table`
+  /** -2 accounts for the left and right border, which are not taken into account
+   * and cause a tiny amount of horizontal scrolling at all times. */
+  width: calc(100% - 2px);
+  border-spacing: 0;
+  border-collapse: collapse;
+
+  & > thead > tr > td {
+    color: ${Colors.textLighter()};
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  & > tbody > tr > td,
+  & > thead > tr > td {
+    border: 1px solid ${Colors.keylineDefault()};
+    padding: 8px 12px;
+    font-size: 14px;
+    line-height: 20px;
+    vertical-align: top;
+
+    &:first-child {
+      max-width: 300px;
+      word-wrap: break-word;
+      width: 25%;
+    }
+  }
+`;

--- a/js_modules/ui-core/src/metadata/TableSchema.tsx
+++ b/js_modules/ui-core/src/metadata/TableSchema.tsx
@@ -15,7 +15,7 @@ import {createContext, useContext, useState} from 'react';
 import {MetadataEntryLabelOnly} from './MetadataEntry';
 import {TableSchemaFragment} from './types/TableSchemaFragment.types';
 import {Timestamp} from '../app/time/Timestamp';
-import {StyledTableWithHeader} from '../assets/AssetEventMetadataEntriesTable';
+import {StyledTableWithHeader} from './SharedTableStyles';
 import {AssetFeatureContext} from '../assets/AssetFeatureContext';
 import {
   AssetKeyInput,


### PR DESCRIPTION
# Fix TableMetadataValue overflow by wrapping entries in a scrollable container

## Summary & Motivation

Fixes wide or tall `TableMetadataValue` entries overflowing their containers and expanding surrounding table rows (#32718).

Two changes:

1. **`MetadataEntry.tsx`**: Wraps `TableMetadataEntryComponent` and inline `TableSchemaMetadataEntry` in a `MetadataEntryScrollWrapper` (max-height: 240px, overflow: auto). Replaces the generic `Table $compact` with a local `StyledTableWithHeader` and adds `minWidth: max-content` so horizontal scrollbars trigger correctly. Adds per-cell scroll to `LogRowStructuredContentTable` and `table-layout: fixed` to `StructuredContentTable` for stable column widths. Exports `MetadataEntryScrollWrapper` for downstream use.

**Before**: The metadata table row expands unbounded, pushing content off-screen with no scroll.  
<img width="1145" height="828" alt="before_metadata_table" src="https://github.com/user-attachments/assets/55b76a67-77f1-407d-8080-1d67f0127719" />

**After**: The table scrolls independently within a capped container.
<img width="644" height="411" alt="after_metadata_table" src="https://github.com/user-attachments/assets/b255e75a-cc8a-4a98-8f9d-65864f174a9d" />

## Test Plan

- Open an asset with a `TableMetadataValue` entry containing many rows or wide columns
- Verify the table scrolls vertically and horizontally within its cell rather than expanding the row
- Verify `TableSchemaMetadataEntry` inline views are no longer cropped

## Changelog

`TableMetadataValue` entries now scroll independently rather than overflowing their parent containers.
