### PR TITLE
[pipes] make PipesClientCompletedInvocation public

### DIFF
--- a/docs/sphinx/sections/api/dagster/pipes.rst
+++ b/docs/sphinx/sections/api/dagster/pipes.rst
@@ -29,6 +29,8 @@ Clients
 
 .. autoclass:: PipesClient
 
+.. autoclass:: PipesClientCompletedInvocation
+
 .. autoclass:: PipesSubprocessClient
 
 ----

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -558,6 +558,7 @@ from dagster._core.launcher.default_run_launcher import DefaultRunLauncher as De
 from dagster._core.log_manager import DagsterLogManager as DagsterLogManager
 from dagster._core.pipes.client import (
     PipesClient as PipesClient,
+    PipesClientCompletedInvocation as PipesClientCompletedInvocation,
     PipesContextInjector as PipesContextInjector,
     PipesExecutionResult as PipesExecutionResult,
     PipesMessageReader as PipesMessageReader,

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -54,6 +54,7 @@ class PipesClient(ABC):
         """
 
 
+@public
 class PipesClientCompletedInvocation:
     """A wrapper for the results of a pipes client invocation, typically returned from `PipesClient.run`.
 


### PR DESCRIPTION
## Summary & Motivation
It should be public because it's returned by another public API: `PipesClient.run`.