### PR TITLE
[pipes] make PipesLaunchedData public

### DIFF
--- a/docs/sphinx/sections/api/dagster/pipes.rst
+++ b/docs/sphinx/sections/api/dagster/pipes.rst
@@ -16,6 +16,8 @@ Sessions
 
 .. autoclass:: PipesSession
 
+.. autoclass:: PipesLaunchedData
+
 .. autofunction:: open_pipes_session
 
 .. currentmodule:: dagster._core.pipes.subprocess

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -563,6 +563,7 @@ from dagster._core.pipes.client import (
     PipesMessageReader as PipesMessageReader,
 )
 from dagster._core.pipes.context import (
+    PipesLaunchedData as PipesLaunchedData,
     PipesMessageHandler as PipesMessageHandler,
     PipesSession as PipesSession,
 )

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
 PipesExecutionResult: TypeAlias = MaterializeResult | AssetCheckResult
 
 
+@public
 class PipesLaunchedData(TypedDict):
     """Payload generated in the orchestration process after external process startup
     containing arbitrary information about the external process.


### PR DESCRIPTION
## Summary & Motivation
It should be public because it's used by another public API: `PipesMessageReader.on_launch`.

