### PR TITLE
fix: io_manager = None error

### DIFF
--- a/docs/docs/guides/build/io-managers/index.md
+++ b/docs/docs/guides/build/io-managers/index.md
@@ -24,7 +24,7 @@ This article assumes familiarity with: [assets](/guides/build/assets) and [resou
 
 ## Before you begin
 
-**I/O managers aren't required to use Dagster, nor are they the best option in all scenarios.** If you find yourself writing the same code at the start and end of each asset to load and store data, an I/O manager may be useful. For example:
+**I/O managers aren't required in your asset code, nor are they the best option in all scenarios.** Dagster still requires an I/O manager resource to be configured for asset outputs; if you don't provide one, the default filesystem I/O manager is used. If you find yourself writing the same code at the start and end of each asset to load and store data, an I/O manager may be useful. For example:
 
 - You have assets that are stored in the same location and follow a consistent set of rules to determine the storage path
 - You have assets that are stored differently in local, staging, and production environments

--- a/python_modules/dagster/dagster/_core/definitions/resource_requirement.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_requirement.py
@@ -168,7 +168,7 @@ class OutputManagerRequirement(ResourceKeyRequirement):
     def describe_requirement(self) -> str:
         return (
             f"io manager with key '{self.key}' required by output '{self.output_name}' of"
-            f" {self.node_description}'"
+            f" {self.node_description}"
         )
 
 

--- a/python_modules/dagster/dagster/_core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/build_resources.py
@@ -11,8 +11,9 @@ from dagster._core.definitions.resource_definition import (
     Resources,
     ScopedResourcesBuilder,
 )
+from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY
 from dagster._core.definitions.run_config import define_resource_dictionary_cls
-from dagster._core.errors import DagsterInvalidConfigError
+from dagster._core.errors import DagsterInvalidConfigError, DagsterInvalidDefinitionError
 from dagster._core.execution.api import ephemeral_instance_if_missing
 from dagster._core.execution.context_creation_job import initialize_console_manager
 from dagster._core.execution.resources_init import resource_initialization_manager
@@ -122,14 +123,18 @@ def build_resources(
 def wrap_resources_for_execution(
     resources: Mapping[str, Any] | None = None,
 ) -> dict[str, ResourceDefinition]:
-    return (
-        {
-            resource_key: wrap_resource_for_execution(resource)
-            for resource_key, resource in resources.items()
-        }
-        if resources
-        else {}
-    )
+    if not resources:
+        return {}
+
+    resource_defs: dict[str, ResourceDefinition] = {}
+    for resource_key, resource in resources.items():
+        if resource_key == DEFAULT_IO_MANAGER_KEY and resource is None:
+            raise DagsterInvalidDefinitionError(
+                "Resource 'io_manager' was set to None. Remove this key to use the default IO"
+                " manager, or provide an IOManager/IOManagerDefinition."
+            )
+        resource_defs[resource_key] = wrap_resource_for_execution(resource)
+    return resource_defs
 
 
 def wrap_resource_for_execution(resource: Any) -> ResourceDefinition:

--- a/python_modules/dagster/dagster/_core/execution/build_resources.py
+++ b/python_modules/dagster/dagster/_core/execution/build_resources.py
@@ -128,10 +128,15 @@ def wrap_resources_for_execution(
 
     resource_defs: dict[str, ResourceDefinition] = {}
     for resource_key, resource in resources.items():
-        if resource_key == DEFAULT_IO_MANAGER_KEY and resource is None:
+        if resource is None:
+            if resource_key == DEFAULT_IO_MANAGER_KEY:
+                raise DagsterInvalidDefinitionError(
+                    "Resource 'io_manager' was set to None. Remove this key to use the default IO"
+                    " manager, or provide an IOManager/IOManagerDefinition."
+                )
             raise DagsterInvalidDefinitionError(
-                "Resource 'io_manager' was set to None. Remove this key to use the default IO"
-                " manager, or provide an IOManager/IOManagerDefinition."
+                f"Resource '{resource_key}' was set to None. Provide a resource definition or"
+                " instance, or remove this key if it is unused."
             )
         resource_defs[resource_key] = wrap_resource_for_execution(resource)
     return resource_defs

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py
@@ -568,7 +568,7 @@ def test_io_manager_missing_fails():
         dg.DagsterInvalidDefinitionError,
         match=(
             "io manager with key 'missing_io_manager' required by output 'result' of op"
-            " 'requires_missing_io_manager'' was not provided"
+            " 'requires_missing_io_manager' was not provided"
         ),
     ):
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -649,11 +649,26 @@ def test_asset_missing_io_manager():
     with pytest.raises(
         dg.DagsterInvalidDefinitionError,
         match=(
-            r"io manager with key 'blah' required by output 'result' of op 'asset_foo'' was not"
+            r"io manager with key 'blah' required by output 'result' of op 'asset_foo' was not"
             " provided."
         ),
     ):
         Definitions.validate_loadable(dg.Definitions(assets=[asset_foo]))
+
+
+def test_io_manager_none_resource():
+    @dg.asset
+    def an_asset():
+        pass
+
+    with pytest.raises(
+        dg.DagsterInvalidDefinitionError,
+        match=re.escape(
+            "Resource 'io_manager' was set to None. Remove this key to use the default IO manager,"
+            " or provide an IOManager/IOManagerDefinition."
+        ),
+    ):
+        Definitions.validate_loadable(dg.Definitions(assets=[an_asset], resources={"io_manager": None}))
 
 
 def test_resource_defs_on_asset():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -668,7 +668,26 @@ def test_io_manager_none_resource():
             " or provide an IOManager/IOManagerDefinition."
         ),
     ):
-        Definitions.validate_loadable(dg.Definitions(assets=[an_asset], resources={"io_manager": None}))
+        Definitions.validate_loadable(
+            dg.Definitions(assets=[an_asset], resources={"io_manager": None})
+        )
+
+
+def test_resource_none_value():
+    @dg.asset
+    def an_asset():
+        pass
+
+    with pytest.raises(
+        dg.DagsterInvalidDefinitionError,
+        match=re.escape(
+            "Resource 'my_db' was set to None. Provide a resource definition or instance, or"
+            " remove this key if it is unused."
+        ),
+    ):
+        Definitions.validate_loadable(
+            dg.Definitions(assets=[an_asset], resources={"my_db": None})
+        )
 
 
 def test_resource_defs_on_asset():


### PR DESCRIPTION
## Summary & Motivation

Resolved issue https://github.com/dagster-io/dagster/issues/32065.

Clarify that an IO manager is still required as a configured resource even when not used directly, and make the `io_manager=None` case fail with a clear, actionable error. Also fix a formatting typo in IO manager requirement messages and update tests accordingly.

## Test Plan
- `python -m pytest python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py -q`
- `python -m pytest python_modules/dagster/dagster_tests/core_tests/resource_tests/test_required_resources.py::test_io_manager_missing_fails -q`

## Changelog
Clarify IO manager configuration requirements and improve error messaging for `io_manager=None`.