### PR TITLE
fix: can_subset=True multi-asset no longer raises DagsterStepOutputNotFoundError for unselected outputs

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -298,12 +298,13 @@ def _step_output_error_checked_user_event_sequence(
                     )
                     yield Output(output_name=step_output_def.name, value=None)
             elif not step_output_def.is_dynamic:
-                raise DagsterStepOutputNotFoundError(
-                    f"Core compute for {op_label} did not return an output for non-optional "
-                    f'output "{step_output_def.name}"',
-                    step_key=step.key,
-                    output_name=step_output_def.name,
-                )
+                if step_output.name in selected_output_names:
+                    raise DagsterStepOutputNotFoundError(
+                        f"Core compute for {op_label} did not return an output for non-optional "
+                        f'output "{step_output_def.name}"',
+                        step_key=step.key,
+                        output_name=step_output_def.name,
+                    )
 
 
 def do_type_check(context: TypeCheckContext, dagster_type: DagsterType, value: Any) -> TypeCheck:

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_require_typed_event_stream.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_require_typed_event_stream.py
@@ -228,3 +228,45 @@ def test_requires_typed_event_stream_subsettable_multi_asset():
 
     with raises_missing_output_error():
         dg.materialize([asset_subsettable_none], selection=["bar"])
+
+
+def test_can_subset_multi_asset_subset_execution_no_output_not_found_error():
+    """Regression test for GitHub issue #33648.
+
+    Non-selected outputs on a can_subset=True multi-asset must not raise
+    DagsterStepOutputNotFoundError when the op correctly skips them.
+    """
+
+    @dg.multi_asset(
+        outs={"a": dg.AssetOut(), "b": dg.AssetOut()},
+        can_subset=True,
+    )
+    def multi_with_required_outs(context: dg.AssetExecutionContext):
+        if "a" in context.op_execution_context.selected_output_names:
+            yield dg.Output(1, output_name="a")
+        if "b" in context.op_execution_context.selected_output_names:
+            yield dg.Output(2, output_name="b")
+
+    # Select only "a" — "b" not selected, not yielded, must NOT raise
+    result = dg.materialize([multi_with_required_outs], selection=["a"])
+    assert result.success
+
+    # Select only "b" — same symmetry
+    result = dg.materialize([multi_with_required_outs], selection=["b"])
+    assert result.success
+
+    # Select all — both must be yielded
+    result = dg.materialize([multi_with_required_outs])
+    assert result.success
+
+    # Negative case: selected required output NOT yielded → must still raise
+    @dg.multi_asset(
+        outs={"a": dg.AssetOut(), "b": dg.AssetOut()},
+        can_subset=True,
+    )
+    def incomplete_multi_asset(context: dg.AssetExecutionContext):
+        yield dg.Output(1, output_name="a")
+        # "b" is selected but intentionally not yielded
+
+    with pytest.raises(dg.DagsterStepOutputNotFoundError):
+        dg.materialize([incomplete_multi_asset])  # both selected by default


### PR DESCRIPTION
## Summary & Motivation

Fixes #33648.

When a `@multi_asset` with `can_subset=True` executes with only a subset of its outputs selected, Dagster was raising `DagsterStepOutputNotFoundError` for the non-selected outputs — even when the op correctly skipped them by checking `context.selected_output_names`.

**Root cause**: `_step_output_error_checked_user_event_sequence()` in `execute_step.py` had an asymmetry. The `Nothing`-type branch already guarded with `selected_output_names`, but the non-dynamic branch raised unconditionally:

```python
# Nothing-type branch — correctly guarded ✓
if step_output_def.dagster_type.is_nothing and not is_observable_asset:
    if step_output.name in selected_output_names:
        yield Output(...)

# Non-dynamic branch — raised unconditionally, ignoring selection ✗
elif not step_output_def.is_dynamic:
    raise DagsterStepOutputNotFoundError(...)
```

**Fix**: apply the same `selected_output_names` guard to the non-dynamic branch. `selected_output_names` is already in scope and already excludes unselected outputs for `can_subset=True` assets (via `system.py`), so no new logic is needed.

The previous workaround was marking every `AssetOut` with `is_required=False` (`skippable=True`), which is semantically incorrect for outputs that *should* be required when selected.

**No regression for existing cases:**
- Non-`can_subset` multi-assets: `selected_output_names` returns all outputs → guard is always true → error still raised if output missing
- Plain `@op` (no asset): same as above
- `can_subset=True` with `is_required=False`: already skipped at the `not step_output_def.optional` guard
- Dynamic outputs: already skipped at the `is_dynamic` guard
- Op forgets to yield a *selected* output: output is in `selected_output_names` → error still raised ✓

## Test Plan

Added `test_can_subset_multi_asset_subset_execution_no_output_not_found_error` in `test_require_typed_event_stream.py`:

- Subset execution selecting only `"a"` (required `"b"` not selected, not yielded) → succeeds
- Subset execution selecting only `"b"` → succeeds
- Full execution (both selected, both yielded) → succeeds
- Negative case: both selected, `"b"` intentionally not yielded → `DagsterStepOutputNotFoundError` still raised

```
pytest python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_require_typed_event_stream.py
# 5 passed
```

## Changelog

`@multi_asset` with `can_subset=True` no longer raises `DagsterStepOutputNotFoundError` for outputs that were not selected during subset execution. Previously, the workaround was to mark all `AssetOut`s with `is_required=False`, which was semantically incorrect.