### PR TITLE
feat: Add opt-in field-based Omni document dependencies

### DIFF
--- a/python_modules/libraries/dagster-omni/dagster_omni/component.py
+++ b/python_modules/libraries/dagster-omni/dagster_omni/component.py
@@ -50,6 +50,8 @@ def _collect_query_table_names_from_fields(query: OmniQuery) -> list[str]:
     seen: set[str] = set()
     for field in query.query_config.fields:
         table_name = _extract_table_name_from_field(field)
+        if table_name is None:
+            table_name = query.query_config.table
         if table_name and table_name not in seen:
             seen.add(table_name)
             table_names.append(table_name)

--- a/python_modules/libraries/dagster-omni/dagster_omni_tests/test_defs.py
+++ b/python_modules/libraries/dagster-omni/dagster_omni_tests/test_defs.py
@@ -133,6 +133,62 @@ def test_get_asset_spec_document_field_based_deps(omni_workspace: OmniWorkspace)
     }
 
 
+def test_get_asset_spec_document_field_based_deps_all_unqualified_falls_back_to_base_table(
+    omni_workspace: OmniWorkspace,
+):
+    component = OmniComponent(
+        workspace=omni_workspace,
+        derive_document_dependencies_from_query_fields=True,
+    )
+    query = OmniQuery(
+        id="query-2",
+        name="Unqualified Fields Query",
+        query_config=OmniQueryConfig(
+            table="omni_dbt_marts__fct_events",
+            fields=["event_id", "created_at"],
+        ),
+    )
+    doc = create_sample_document(queries=[query])
+    workspace_data = create_sample_workspace_data([doc])
+    data = OmniTranslatorData(obj=doc, workspace_data=workspace_data)
+
+    spec = component.get_asset_spec(context, data)
+    assert spec
+
+    assert {dep.asset_key for dep in spec.deps} == {AssetKey(["omni_dbt_marts__fct_events"])}
+
+
+def test_get_asset_spec_document_field_based_deps_mixed_unqualified_includes_base_table(
+    omni_workspace: OmniWorkspace,
+):
+    component = OmniComponent(
+        workspace=omni_workspace,
+        derive_document_dependencies_from_query_fields=True,
+    )
+    query = OmniQuery(
+        id="query-3",
+        name="Mixed Fields Query",
+        query_config=OmniQueryConfig(
+            table="omni_dbt_marts__fct_events",
+            fields=[
+                "omni_dbt_marts__dim_users.user_id",
+                "event_id",
+            ],
+        ),
+    )
+    doc = create_sample_document(queries=[query])
+    workspace_data = create_sample_workspace_data([doc])
+    data = OmniTranslatorData(obj=doc, workspace_data=workspace_data)
+
+    spec = component.get_asset_spec(context, data)
+    assert spec
+
+    assert {dep.asset_key for dep in spec.deps} == {
+        AssetKey(["omni_dbt_marts__fct_events"]),
+        AssetKey(["omni_dbt_marts__dim_users"]),
+    }
+
+
 def test_get_asset_spec_with_translation(component: OmniComponent):
     """Test get_asset_spec with custom translation function."""
 


### PR DESCRIPTION
### Summary

Resolved issue https://github.com/dagster-io/dagster/issues/33588.

- Added an opt-in flag to derive document dependencies from Omni query field references, falling back to base table when fields don’t include a table prefix. See component.py .
- Added coverage for joined table dependencies when the new flag is enabled. See test_defs.py .

### How To Enable

- Set derive_document_dependencies_from_query_fields=True on OmniComponent to use field-based table derivation; default remains False to preserve existing semantics. See component.py .
### Tests To Run

- python -m pytest python_modules/libraries/dagster-omni/dagster_omni_tests/test_defs.py

### Assumptions

- Field references include a table.field prefix when table lineage is available; fields without a dot fall back to the query’s base table.

If you want the Topics API approach instead, I can add a second opt-in flag and wire the async API calls in OmniWorkspace .