### PR TITLE
fix(resources): ResourceDependency with default value no longer causes RecursionError in sensor context

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -774,10 +774,18 @@ class ResourceDependency(Generic[V]):
         self._name = name
 
     def __get__(self, obj: "ConfigurableResourceFactory", owner: Any) -> V:
-        return getattr(obj, self._name)
+        if obj is None:
+            return self  # type: ignore  # class-level access returns descriptor
+        # Access obj.__dict__ directly to avoid re-invoking this descriptor
+        # (since this is a data descriptor, getattr would recurse infinitely)
+        try:
+            return obj.__dict__[self._name]  # type: ignore[return-value]
+        except KeyError:
+            raise AttributeError(self._name) from None
 
     def __set__(self, obj: object | None, value: ResourceOrPartialOrValue[V]) -> None:
-        setattr(obj, self._name, value)
+        # Write directly to obj.__dict__ to avoid re-invoking this descriptor
+        obj.__dict__[self._name] = value  # type: ignore[union-attr]
 
 
 class ConfigurableLegacyResourceAdapter(ConfigurableResource, ABC):

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -204,8 +204,14 @@ class TypecheckAllowPartialResourceInitParams:
         self._assigned_name = name
 
     def __get__(self: Self, obj: Any, owner: Any) -> Self:
-        # no-op implementation (only used to affect type signature)
-        return cast("Self", getattr(obj, self._assigned_name))
+        if obj is None:
+            return self  # type: ignore  # class-level access returns descriptor
+        # Access obj.__dict__ directly to avoid re-invoking this descriptor
+        # (since this is a data descriptor, getattr would recurse infinitely)
+        try:
+            return cast("Self", obj.__dict__[self._assigned_name])
+        except KeyError:
+            raise AttributeError(self._assigned_name) from None
 
     # The annotation her has been temporarily changed from:
     #     value: Union[Self, "PartialResource[Self]"]
@@ -219,5 +225,5 @@ class TypecheckAllowPartialResourceInitParams:
     # reverted when the bug is fixed or another solution that surface as type
     # errors for mypy users is found.
     def __set__(self, obj: object | None, value: Union[Any, "PartialResource[Any]"]) -> None:
-        # no-op implementation (only used to affect type signature)
-        setattr(obj, self._assigned_name, value)
+        # Write directly to obj.__dict__ to avoid re-invoking this descriptor
+        obj.__dict__[self._assigned_name] = value  # type: ignore[union-attr]

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -1151,3 +1151,51 @@ def test_nested_resources_with_default_set_in_configure_at_launch() -> None:
         }
     ).success
     assert completed["yes"]
+
+
+def test_resource_dependency_with_default_direct_access() -> None:
+    """Regression test for GitHub issue #33650.
+
+    ResourceDependency with a default value caused RecursionError when accessed directly.
+    """
+
+    class Inner(dg.ConfigurableResource):
+        val: str = "hello"
+
+    class Outer(dg.ConfigurableResource):
+        inner: dg.ResourceDependency[Inner] = Inner()
+
+        def greet(self) -> str:
+            return self.inner.val
+
+    outer = Outer()
+    # This should not raise RecursionError
+    assert outer.inner.val == "hello"  # type: ignore[union-attr]
+
+
+def test_resource_dependency_with_default_in_sensor() -> None:
+    """Regression test for GitHub issue #33650.
+
+    ResourceDependency with a default value caused RecursionError in sensor context.
+    """
+
+    class Inner(dg.ConfigurableResource):
+        val: str = "hello"
+
+    class Outer(dg.ConfigurableResource):
+        inner: dg.ResourceDependency[Inner] = Inner()
+
+        def greet(self) -> str:
+            return self.inner.val  # type: ignore[union-attr]
+
+    @dg.sensor(job_name="__ASSET_JOB")
+    def my_sensor(context: dg.SensorEvaluationContext, outer: Outer):
+        result = outer.greet()
+        yield dg.SkipReason(f"got: {result}")
+
+    with dg.build_sensor_context(resources={"outer": Outer()}) as ctx:
+        # This should not raise RecursionError
+        result = list(my_sensor(ctx))
+    assert len(result) == 1
+    assert isinstance(result[0], dg.SkipReason)
+    assert result[0].skip_message == "got: hello"


### PR DESCRIPTION
## Summary & Motivation

Fixes #33650.

When a `ConfigurableResource` has a `ResourceDependency` field with a default value (e.g. `inner: ResourceDependency[Inner] = Inner()`), accessing that field in a sensor context caused infinite recursion in `typing_utils.py`.

**Root cause**: Both `TypecheckAllowPartialResourceInitParams` and `ResourceDependency` are *data descriptors* (they define `__set__`). Python's attribute lookup always prefers a data descriptor over `obj.__dict__`, so their `__get__` implementations calling `getattr(obj, name)` unconditionally re-invoke the descriptor — infinite recursion.

The trigger in sensor context: during resource initialization, `_get_non_default_public_field_values_cls` drops any resolved field value that equals the class default. If `Inner()` equals `Inner()` (both empty-initialized), the nested resource is not passed to the outer resource's constructor, so `inner` is never written to `__dict__`. The first access via `getattr` then enters the recursive loop.

The same code works in asset materialization because the full execution pipeline processes nested resource config differently, ensuring `__dict__` is always populated.

**Fix**: Change both descriptors to read/write `obj.__dict__` directly, bypassing the descriptor protocol entirely. This matches their documented intent ("no-op implementation — only used to affect type signature"). Pydantic 2 `BaseModel` always stores initialized field values in `__dict__`, so this is safe.

```python
# Before (both descriptors):
def __get__(self, obj, owner):
    return getattr(obj, self._name)  # re-invokes descriptor → RecursionError

def __set__(self, obj, value):
    setattr(obj, self._name, value)  # same problem

# After:
def __get__(self, obj, owner):
    if obj is None:
        return self
    try:
        return obj.__dict__[self._name]
    except KeyError:
        raise AttributeError(self._name) from None

def __set__(self, obj, value):
    obj.__dict__[self._name] = value
```

## Test Plan

Added two regression tests in `test_nesting.py`:

- `test_resource_dependency_with_default_direct_access` — directly accesses `outer.inner.val` where `inner` has a default; previously raised `RecursionError`
- `test_resource_dependency_with_default_in_sensor` — uses `build_sensor_context(resources={"outer": Outer()})` and invokes a sensor that calls `self.inner.val`; matches the exact scenario from issue #33650

```
# New regression tests
pytest python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py::test_resource_dependency_with_default_direct_access
pytest python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py::test_resource_dependency_with_default_in_sensor

# Full nesting suite (22 tests) — no regressions
pytest python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py

# Full pythonic resources suite (125 tests) — no regressions
pytest python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/

# Sensor invocation tests (51 tests) — no regressions
pytest python_modules/dagster/dagster_tests/definitions_tests/test_sensor_invocation.py
```

All pass.

## Changelog

`ResourceDependency` fields with default values on a `ConfigurableResource` no longer cause a `RecursionError` when accessed in sensor context (or any context where the default value equals the resolved value). Previously, the workaround was to avoid default values on `ResourceDependency` fields.