### PR TITLE
feat(dg): add agent_queue support to build.yaml for dg plus deploy

### DIFF
--- a/docs/docs/deployment/dagster-plus/management/build-yaml.md
+++ b/docs/docs/deployment/dagster-plus/management/build-yaml.md
@@ -102,6 +102,7 @@ The `build.yaml` file contains a single top-level key, `locations`. This key acc
 - [Build](#build)
 - [Python executable](#python-executable)
 - [Container context](#container-context)
+- [Agent queue](#agent-queue)
 
 ### Location name
 
@@ -257,3 +258,21 @@ Refer to the configuration reference for your agent for more info:
 - [Docker agent configuration reference](/deployment/dagster-plus/hybrid/docker/configuration)
 - [Amazon ECS agent configuration reference](/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference)
 - [Kubernetes agent configuration reference](/deployment/dagster-plus/hybrid/kubernetes/configuration)
+
+### Agent queue
+
+Use the `agent_queue` setting to route a code location to a specific [Hybrid agent queue](/deployment/dagster-plus/hybrid/managing-multiple-agent-deployments). If omitted, the code location is served by the default agent queue.
+
+```yaml
+# build.yaml
+
+locations:
+  - location_name: data-eng-pipeline
+    code_source:
+      package_name: example_etl
+    agent_queue: my-queue
+```
+
+| Property      | Description                                                        | Format   |
+| ------------- | ------------------------------------------------------------------ | -------- |
+| `agent_queue` | The name of the agent queue that should serve this code location   | `string` |

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/utils.py
@@ -349,17 +349,27 @@ def _dagster_cloud_entry_for_project(
         dg_context.container_context_config,
     )
 
+    # agent_queue is a top-level location field in dagster_cloud.yaml; extract it from
+    # the merged build config so users can set it in build.yaml.
+    agent_queue = merged_build_config.get("agent_queue") if merged_build_config else None
+    build_config = (
+        {k: v for k, v in merged_build_config.items() if k != "agent_queue"}
+        if merged_build_config
+        else {}
+    )
+
     return {
         "location_name": dg_context.code_location_name,
         "code_source": {
             **dg_context.target_args,
         },
-        **({"build": merged_build_config} if merged_build_config else {}),
+        **({"build": build_config} if build_config else {}),
         **(
             {"container_context": merged_container_context_config}
             if merged_container_context_config
             else {}
         ),
+        **({"agent_queue": agent_queue} if agent_queue else {}),
     }
 
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/plus_tests/test_plus_deploy_command.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/plus_tests/test_plus_deploy_command.py
@@ -808,6 +808,145 @@ def test_plus_deploy_hybrid_with_merged_yaml_files(
                 }
 
 
+def test_plus_deploy_hybrid_with_agent_queue_in_project_build_yaml(
+    logged_in_dg_cli_config,
+    project,
+    runner,
+    mocker,
+):
+    """agent_queue specified in a single-project build.yaml is surfaced as a top-level
+    location field in the generated dagster_cloud.yaml (not nested inside build:).
+    """
+    mocker.patch(
+        "dagster_dg_cli.cli.plus.deploy.deploy_session.get_local_branch_name",
+        return_value="main",
+    )
+
+    build_yaml_path = project / "build.yaml"
+    build_yaml_path.write_text("registry: my-repo\ndirectory: .\nagent_queue: my-queue\n")
+    try:
+        with mock_external_dagster_cloud_cli_command():
+            with patch("dagster_dg_cli.cli.plus.deploy.deploy_session._build_hybrid_image"):
+                result = runner.invoke("plus", "deploy", "--agent-type", "hybrid", "--yes")
+                assert not result.exit_code, result.output
+
+                dagster_cloud_yaml_path = DEFAULT_STATEDIR_PATH / Path("dagster_cloud.yaml")
+                with open(dagster_cloud_yaml_path) as f:
+                    file = yaml.safe_load(f)
+                    location = file["locations"][0]
+                    assert location["agent_queue"] == "my-queue"
+                    # agent_queue must not be nested under build:
+                    assert "agent_queue" not in location.get("build", {})
+    finally:
+        build_yaml_path.unlink(missing_ok=True)
+
+
+def test_plus_deploy_hybrid_with_agent_queue_in_workspace_build_yaml(
+    logged_in_dg_cli_config,
+    workspace,
+    runner,
+    mocker,
+    workspace_build_yaml_file,
+):
+    """agent_queue set in the workspace-level build.yaml is inherited by all projects."""
+    mocker.patch(
+        "dagster_dg_cli.cli.plus.deploy.deploy_session.get_local_branch_name",
+        return_value="main",
+    )
+
+    # Overwrite the fixture's build.yaml with one that includes agent_queue
+    workspace_build_yaml_file.write_text(
+        "registry: my-workspace-repo\ndirectory: .\nagent_queue: workspace-queue\n"
+    )
+
+    with mock_external_dagster_cloud_cli_command():
+        with patch("dagster_dg_cli.cli.plus.deploy.deploy_session._build_hybrid_image"):
+            result = runner.invoke("plus", "deploy", "--agent-type", "hybrid", "--yes")
+            assert not result.exit_code, result.output
+
+            dagster_cloud_yaml_path = DEFAULT_STATEDIR_PATH / Path("dagster_cloud.yaml")
+            with open(dagster_cloud_yaml_path) as f:
+                file = yaml.safe_load(f)
+                for location in file["locations"]:
+                    assert location["agent_queue"] == "workspace-queue"
+                    assert "agent_queue" not in location.get("build", {})
+
+
+def test_plus_deploy_hybrid_project_agent_queue_overrides_workspace(
+    logged_in_dg_cli_config,
+    workspace,
+    runner,
+    mocker,
+    workspace_build_yaml_file,
+):
+    """Project-level agent_queue overrides workspace-level agent_queue."""
+    mocker.patch(
+        "dagster_dg_cli.cli.plus.deploy.deploy_session.get_local_branch_name",
+        return_value="main",
+    )
+
+    # Workspace has agent_queue: ws-queue
+    workspace_build_yaml_file.write_text(
+        "registry: my-workspace-repo\ndirectory: .\nagent_queue: ws-queue\n"
+    )
+
+    # foo-bar project has agent_queue: proj-queue
+    project_build_yaml_path = workspace / "foo-bar" / "build.yaml"
+    project_build_yaml_path.write_text(
+        "registry: my-project-repo\ndirectory: .\nagent_queue: proj-queue\n"
+    )
+    try:
+        with mock_external_dagster_cloud_cli_command():
+            with patch("dagster_dg_cli.cli.plus.deploy.deploy_session._build_hybrid_image"):
+                result = runner.invoke("plus", "deploy", "--agent-type", "hybrid", "--yes")
+                assert not result.exit_code, result.output
+
+                dagster_cloud_yaml_path = DEFAULT_STATEDIR_PATH / Path("dagster_cloud.yaml")
+                with open(dagster_cloud_yaml_path) as f:
+                    file = yaml.safe_load(f)
+                    locations = {loc["location_name"]: loc for loc in file["locations"]}
+                    # foo-bar project overrides workspace queue
+                    assert locations["foo-bar"]["agent_queue"] == "proj-queue"
+                    # foo-bar-2 has no project-level build.yaml, inherits workspace queue
+                    assert locations["foo-bar-2"]["agent_queue"] == "ws-queue"
+                    # agent_queue must not appear under build: for any location
+                    for loc in file["locations"]:
+                        assert "agent_queue" not in loc.get("build", {})
+    finally:
+        project_build_yaml_path.unlink(missing_ok=True)
+
+
+def test_plus_deploy_hybrid_agent_queue_only_build_yaml(
+    logged_in_dg_cli_config,
+    project,
+    runner,
+    mocker,
+):
+    """build.yaml with only agent_queue (no registry/directory) omits build: key in output."""
+    mocker.patch(
+        "dagster_dg_cli.cli.plus.deploy.deploy_session.get_local_branch_name",
+        return_value="main",
+    )
+
+    build_yaml_path = project / "build.yaml"
+    build_yaml_path.write_text("agent_queue: only-queue\n")
+    try:
+        with mock_external_dagster_cloud_cli_command():
+            with patch("dagster_dg_cli.cli.plus.deploy.deploy_session._build_hybrid_image"):
+                result = runner.invoke("plus", "deploy", "--agent-type", "hybrid", "--yes")
+                assert not result.exit_code, result.output
+
+                dagster_cloud_yaml_path = DEFAULT_STATEDIR_PATH / Path("dagster_cloud.yaml")
+                with open(dagster_cloud_yaml_path) as f:
+                    file = yaml.safe_load(f)
+                    location = file["locations"][0]
+                    assert location["agent_queue"] == "only-queue"
+                    # No build: key since there's no registry or directory
+                    assert "build" not in location
+    finally:
+        build_yaml_path.unlink(missing_ok=True)
+
+
 def test_plus_deploy_subcommands(
     logged_in_dg_cli_config, project, runner, mocker, build_yaml_file
 ) -> None:

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/config.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/config.py
@@ -323,6 +323,7 @@ class DgRawCliConfig(TypedDict, total=False):
 class DgRawBuildConfig(TypedDict):
     registry: str | None
     directory: str | None
+    agent_queue: str | None
 
 
 def merge_build_configs(


### PR DESCRIPTION
## Summary & Motivation

Adds `agent_queue` field to `DgRawBuildConfig` so users can specify which hybrid agent queue handles deployments via `build.yaml`. This is a top-level location field in `dagster_cloud.yaml` (not nested under `build:`), so it is emitted accordingly by `_dagster_cloud_entry_for_project`.

Before this change, users had to manually set `agent_queue` in `dagster_cloud.yaml`; now they can manage it through `build.yaml` alongside `registry` and `directory`.

## Test Plan

Four new tests in `test_plus_deploy_command.py`:

- Project-level `agent_queue` with `registry`/`directory` — emitted as top-level location field, `build:` key preserved
- Workspace-level `agent_queue` inherited by all projects
- Project-level `agent_queue` overrides workspace-level value
- `agent_queue`-only `build.yaml` (no `registry`/`directory`) — `build:` key omitted entirely

```
pytest python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/plus_tests/test_plus_deploy_command.py
```

## Changelog

`dg plus deploy` now supports `agent_queue` in `build.yaml`, allowing users to route deployments to a specific hybrid agent queue without manually editing `dagster_cloud.yaml`.