### PR TITLE
[dagster-pandera] enhance validation logic (update #33479)

### DIFF
--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -178,6 +178,17 @@ def _pandera_schema_to_type_check_fn(
 ) -> Callable[[TypeCheckContext, object], TypeCheck]:
     def type_check_fn(_context, value: object) -> TypeCheck:
         if isinstance(value, VALID_DATAFRAME_CLASSES):
+            # Skip re-validation if the DataFrame already carries a matching schema.
+            # Pandera attaches the schema to the DataFrame via the `.pandera` accessor
+            # after a successful `validate()` call. This is an internal Pandera mechanism
+            # (not part of its public API) and may change across versions.
+            if (
+                hasattr(value, "pandera")
+                and value.pandera.schema is not None  # type: ignore[union-attr]
+                and value.pandera.schema == schema  # type: ignore[union-attr]
+            ):
+                return TypeCheck(success=True)
+
             try:
                 # `lazy` instructs pandera to capture every (not just the first) validation error
                 # TODO: pending alternative dataframe support

--- a/python_modules/libraries/dagster-pandera/dagster_pandera_tests/test_dagster_pandera.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera_tests/test_dagster_pandera.py
@@ -188,3 +188,21 @@ def test_validate_inv_missing_column(dagster_type, dataframe):
     dataframe.drop("a", axis=1, inplace=True)
     result = check_dagster_type(dagster_type, dataframe)
     assert not result.success
+
+
+def test_skip_revalidation_when_schema_attached(dataframe):
+    # Use sample_dataframe_schema so we can call schema.validate() directly with the
+    # same schema instance that the dagster type was built from.
+    schema = sample_dataframe_schema()
+    dagster_type = pandera_schema_to_dagster_type(schema)
+
+    # schema.validate() returns a new DataFrame with the schema attached via
+    # the .pandera accessor — that's the internal mechanism the guard relies on.
+    validated_df = schema.validate(dataframe)
+
+    # Mutate the already-validated DataFrame to make it invalid. If re-validation
+    # were run this would fail; the guard should skip it and return success.
+    validated_df.loc[0, "a"] = 999  # violates le(10)
+
+    result = check_dagster_type(dagster_type, validated_df)
+    assert result.success, "Should skip re-validation for DataFrame with matching schema attached"


### PR DESCRIPTION
## Summary & Motivation

Supersedes https://github.com/dagster-io/dagster/pull/33479

When a Pandera schema validates a DataFrame, it attaches itself to the result via the `.pandera.schema` accessor. If that same DataFrame is passed back through a Dagster type check, there is no reason to run validation again — the schema has already accepted it.

This PR adds a guard clause to `_pandera_schema_to_type_check_fn` that checks for the attached schema and returns `TypeCheck(success=True)` early, skipping redundant validation:

```python
if (
    hasattr(value, "pandera")
    and value.pandera.schema is not None
    and value.pandera.schema == schema
):
    return TypeCheck(success=True)
```

The guard relies on .pandera.schema, a Pandera internal accessor (not public API), so a comment is included noting it may change across Pandera versions.

## How I Tested These Changes

New unit test (test_skip_revalidation_when_schema_attached) validates a DataFrame with the schema directly, mutates it to be invalid, then asserts the Dagster type check still succeeds — confirming re-validation was skipped.

## Changelog

- dagster-pandera now skips re-validation when a DataFrame already carries a matching Pandera schema from a prior validate() call, avoiding redundant work in pipelines where DataFrames pass through multiple type-checked ops.
