### PR TITLE
[utils] add gate to prevent unnecessary timezone conversion

### DIFF
--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -35,6 +35,12 @@ class CroniterShim(_croniter):
         return super().expand(*args, **kwargs)
 
 
+@functools.cache
+def has_nonzero_minute_offset(tz_str: str) -> bool:
+    offset = datetime.datetime.now(get_timezone(tz_str)).utcoffset()
+    return offset is not None and (offset.total_seconds() % 3600) != 0
+
+
 def _is_simple_cron(
     cron_expression: str,
     dt: datetime.datetime,
@@ -148,6 +154,7 @@ def _find_hourly_schedule_time(
     date: datetime.datetime,
     ascending: bool,
     already_on_boundary: bool,
+    use_timezone_minute_resolution: bool,
 ) -> datetime.datetime:
     if ascending:
         # short-circuit if minutes and seconds are already correct
@@ -168,7 +175,11 @@ def _find_hourly_schedule_time(
             + (SECONDS_PER_MINUTE - new_timestamp % SECONDS_PER_MINUTE) % SECONDS_PER_MINUTE
         )
 
-        current_minute = datetime.datetime.fromtimestamp(new_timestamp, tz=date.tzinfo).minute
+        current_minute = (
+            datetime.datetime.fromtimestamp(new_timestamp, tz=date.tzinfo).minute
+            if use_timezone_minute_resolution
+            else (new_timestamp // SECONDS_PER_MINUTE) % MINUTES_PER_HOUR
+        )
 
         final_timestamp = None
 
@@ -202,7 +213,11 @@ def _find_hourly_schedule_time(
         new_timestamp = new_timestamp - new_timestamp % SECONDS_PER_MINUTE
 
         # move minutes back to correct place
-        current_minute = datetime.datetime.fromtimestamp(new_timestamp, tz=date.tzinfo).minute
+        current_minute = (
+            datetime.datetime.fromtimestamp(new_timestamp, tz=date.tzinfo).minute
+            if use_timezone_minute_resolution
+            else (new_timestamp // SECONDS_PER_MINUTE) % MINUTES_PER_HOUR
+        )
 
         final_timestamp = None
 
@@ -382,12 +397,17 @@ def _find_schedule_time(
     # lets us skip slow work to find the starting point if we know that
     # we are already on the boundary of the cron interval
     already_on_boundary: bool,
+    use_timezone_minute_resolution: bool = False,
 ) -> datetime.datetime:
     from dagster._core.definitions.partitions.schedule_type import ScheduleType
 
     if schedule_type == ScheduleType.HOURLY:
         return _find_hourly_schedule_time(
-            check.not_none(minutes), date, ascending, already_on_boundary
+            check.not_none(minutes),
+            date,
+            ascending,
+            already_on_boundary,
+            use_timezone_minute_resolution,
         )
     elif schedule_type == ScheduleType.DAILY:
         minutes = check.not_none(minutes)
@@ -723,6 +743,11 @@ def cron_string_iterator(
         expected_days_of_week = cron_parts[4]
 
     if known_schedule_type:
+        use_timezone_minute_resolution = (
+            known_schedule_type == ScheduleType.HOURLY
+            and execution_timezone is not None
+            and has_nonzero_minute_offset(execution_timezone)
+        )
         start_datetime = datetime.datetime.fromtimestamp(
             start_timestamp, tz=get_timezone(execution_timezone)
         )
@@ -743,6 +768,7 @@ def cron_string_iterator(
                 start_datetime,
                 ascending=not ascending,  # Going in the reverse direction
                 already_on_boundary=False,
+                use_timezone_minute_resolution=use_timezone_minute_resolution,
             )
             check.invariant(start_offset <= 0)
             for _ in range(-start_offset):
@@ -755,6 +781,7 @@ def cron_string_iterator(
                     next_date,
                     ascending=not ascending,  # Going in the reverse direction
                     already_on_boundary=True,
+                    use_timezone_minute_resolution=use_timezone_minute_resolution,
                 )
 
         while True:
@@ -767,6 +794,7 @@ def cron_string_iterator(
                 next_date,
                 ascending=ascending,
                 already_on_boundary=True,
+                use_timezone_minute_resolution=use_timezone_minute_resolution,
             )
 
             if start_offset == 0:


### PR DESCRIPTION
## Summary & Motivation

Adds a gate to prevent `datetime` conversion for common timezones.

```
Benchmarking with 250,000 iterations/timezone over 7 rounds

timezone               case            old ns/op    new ns/op   gated ns/op    new/old   gated/old
--------------------------------------------------------------------------------------------------
UTC                    minute              106.3        178.2         108.8       1.68x        1.02x
UTC                    hourly_path         360.3        505.4         358.8       1.40x        1.00x
Asia/Kolkata           minute              108.6        178.4         179.0       1.64x        1.65x
Asia/Kolkata           hourly_path         360.1        499.1         496.3       1.39x        1.38x
Asia/Kathmandu         minute              109.7        179.6         179.9       1.64x        1.64x
Asia/Kathmandu         hourly_path         358.5        516.2         510.9       1.44x        1.43x
Australia/Adelaide     minute              110.7        196.0         198.5       1.77x        1.79x
Australia/Adelaide     hourly_path         348.3        517.2         514.2       1.48x        1.48x
America/St_Johns       minute              110.6        196.7         196.4       1.78x        1.78x
America/St_Johns       hourly_path         354.6        529.1         527.7       1.49x        1.49x
Pacific/Chatham        minute              110.1        193.7         194.7       1.76x        1.77x
Pacific/Chatham        hourly_path         353.8        524.9         527.9       1.48x        1.49x
Europe/Berlin          minute              111.3        197.3         111.5       1.77x        1.00x
Europe/Berlin          hourly_path         354.7        524.1         360.6       1.48x        1.02x
America/New_York       minute              111.1        200.7         110.9       1.81x        1.00x
America/New_York       hourly_path         358.9        520.4         350.7       1.45x        0.98x
```

Amendment to https://github.com/dagster-io/dagster/pull/33474/changes

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
