### PR TITLE
Fix TypeError in truncate_serialized_error when message is None

### DIFF
--- a/python_modules/dagster/dagster/_utils/error.py
+++ b/python_modules/dagster/dagster/_utils/error.py
@@ -261,11 +261,12 @@ def truncate_serialized_error(
 
     error_info = error_info._replace(stack=truncated_stack)
 
-    msg_len = len(error_info.message)
+    msg = error_info.message or ""
+    msg_len = len(msg)
     if msg_len > field_size_limit:
         truncations.append(f"message from {msg_len} to {field_size_limit}")
         error_info = error_info._replace(
-            message=error_info.message[:field_size_limit] + " (TRUNCATED)"
+            message=msg[:field_size_limit] + " (TRUNCATED)"
         )
 
     if error_info.cls_name and len(error_info.cls_name) > ERROR_CLASS_NAME_SIZE_LIMIT:

--- a/python_modules/dagster/dagster_tests/utils_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_errors.py
@@ -117,3 +117,27 @@ def test_truncate_serialized_error():
         truncate_serialized_error(error._replace(cls_name="A" * 1001), 10000, max_depth=0).cls_name
         == "A" * 1000 + " (TRUNCATED)"
     )
+
+
+def test_truncate_serialized_error_none_message():
+    """Test that truncate_serialized_error handles None message without raising TypeError.
+
+    Regression test for https://github.com/dagster-io/dagster/issues/33662.
+    During deserialization of older event log entries, the message field of
+    SerializableErrorInfo can be None, causing `len(None)` to raise
+    `TypeError: object of type 'NoneType' has no len()`.
+    """
+    error_with_none_message = SerializableErrorInfo(
+        message=None,
+        stack=["some stack"],
+        cls_name="Exception",
+        cause=None,
+        context=None,
+    )
+
+    result = truncate_serialized_error(
+        error_with_none_message, field_size_limit=150, max_depth=0
+    )
+    assert result.message is None
+    assert result.stack == ["some stack"]
+    assert result.cls_name == "Exception"


### PR DESCRIPTION
## Summary

Fixes #33662

- **Bug**: `truncate_serialized_error` calls `len(error_info.message)` without guarding against `None`. When deserializing older event log entries, the `message` field of `SerializableErrorInfo` can be `None` (the `@record` decorator has `checked=False`, so runtime type enforcement is disabled). This causes a `TypeError: object of type 'NoneType' has no len()` crash when viewing failed runs in the Dagster UI via the `RunStepStatsQuery` GraphQL query.

- **Fix**: Fall back to an empty string (`error_info.message or ""`) before computing the length and slicing, consistent with the defensive pattern already used for `cls_name` on the same function (line 271: `if error_info.cls_name and len(...)`).

- **Test**: Added a regression test `test_truncate_serialized_error_none_message` that constructs a `SerializableErrorInfo` with `message=None` and verifies `truncate_serialized_error` handles it without raising.

## Test plan

- [x] Added `test_truncate_serialized_error_none_message` regression test
- [ ] Existing `test_truncate_serialized_error` continues to pass
- [ ] Manual verification: the fix matches exactly what the issue reporter validated in their own environment