### PR TITLE
fix(pythonic-resources): ResourceDependency with default causes RecursionError

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -226,6 +226,23 @@ class ConfigurableResourceFactory(
         # Populate config values
         super().__init__(**data_without_resources, **resource_pointers)
 
+        # After Pydantic initialises the model (populating defaults from the class), re-scan
+        # the instance dict for any resource-typed fields that were not explicitly provided
+        # by the caller.  This handles the case where a ConfigurableResource subclass is
+        # used as a default value:
+        #
+        #     class Outer(ConfigurableResource):
+        #         inner: ResourceDependency[Inner] = Inner()
+        #
+        # Because ConfigurableResource instances are Python data descriptors (they inherit
+        # __get__/__set__ from TypecheckAllowPartialResourceInitParams), Pydantic's field
+        # introspection previously could not read the default, leaving ``_nested_resources``
+        # empty and causing a RecursionError when ``self.inner`` was accessed.  The
+        # descriptor __get__/__set__ fix now lets Pydantic store the default in the instance
+        # __dict__, so we can safely pick it up here.
+        all_resource_pointers, _ = separate_resource_params(self.__class__, dict(self.__dict__))
+        resource_pointers = {**all_resource_pointers, **resource_pointers}
+
         # We pull the values from the Pydantic config object, which may cast values
         # to the correct type under the hood - useful in particular for enums
         casted_data_without_resources = {
@@ -902,6 +919,7 @@ def separate_resource_params(cls: type[BaseModel], data: dict[str, Any]) -> Sepa
         non_resources=non_resources,
     )
     return out
+
 
 
 def _call_resource_fn_with_default(

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -921,7 +921,6 @@ def separate_resource_params(cls: type[BaseModel], data: dict[str, Any]) -> Sepa
     return out
 
 
-
 def _call_resource_fn_with_default(
     stack: contextlib.ExitStack, obj: ResourceDefinition, context: InitResourceContext
 ) -> Any:
@@ -1093,3 +1092,4 @@ def get_resource_type_name(resource: ResourceDefinition) -> str:
     else:
         resource_type = _get_class_name(type(resource))
     return resource_type
+

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -234,5 +234,4 @@ class TypecheckAllowPartialResourceInitParams:
         # resource class.
         if obj is not None:
             object.__setattr__(obj, self._assigned_name, value)
-        else:
-            setattr(obj, self._assigned_name, value)
+

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -205,7 +205,16 @@ class TypecheckAllowPartialResourceInitParams:
 
     def __get__(self: Self, obj: Any, owner: Any) -> Self:
         # no-op implementation (only used to affect type signature)
-        return cast("Self", getattr(obj, self._assigned_name))
+        # When obj is None this is a class-level access; return the descriptor itself.
+        if obj is None:
+            return self  # type: ignore
+        # Read directly from the instance __dict__ to avoid triggering the descriptor
+        # protocol again (which would cause infinite recursion when a ConfigurableResource
+        # subclass instance is stored as a class-level default on another resource).
+        try:
+            return cast("Self", obj.__dict__[self._assigned_name])
+        except KeyError:
+            raise AttributeError(self._assigned_name)
 
     # The annotation her has been temporarily changed from:
     #     value: Union[Self, "PartialResource[Self]"]
@@ -220,4 +229,10 @@ class TypecheckAllowPartialResourceInitParams:
     # errors for mypy users is found.
     def __set__(self, obj: object | None, value: Union[Any, "PartialResource[Any]"]) -> None:
         # no-op implementation (only used to affect type signature)
-        setattr(obj, self._assigned_name, value)
+        # Use object.__setattr__ to bypass the descriptor protocol and avoid recursion
+        # when this class (or a subclass) is stored as a class-level default on another
+        # resource class.
+        if obj is not None:
+            object.__setattr__(obj, self._assigned_name, value)
+        else:
+            setattr(obj, self._assigned_name, value)

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -1151,3 +1151,94 @@ def test_nested_resources_with_default_set_in_configure_at_launch() -> None:
         }
     ).success
     assert completed["yes"]
+
+
+def test_resource_dependency_with_default_no_recursion() -> None:
+    """Regression test for https://github.com/dagster-io/dagster/issues/33650.
+
+    A ResourceDependency field with a default ConfigurableResource instance used to trigger
+    infinite recursion (RecursionError) when the resource was accessed in a sensor context
+    because the default instance acted as a data descriptor (inheriting __get__/__set__ from
+    TypecheckAllowPartialResourceInitParams) and getattr(obj, name) re-invoked the same
+    __get__ endlessly.
+    """
+
+    class InnerResource(dg.ConfigurableResource):
+        val: str = "hello"
+
+    class OuterResource(dg.ConfigurableResource):
+        inner: dg.ResourceDependency[InnerResource] = InnerResource()
+
+        def greet(self) -> str:
+            return self.inner.val
+
+    @dg.asset
+    def my_asset() -> None:
+        pass
+
+    my_job = dg.define_asset_job("my_job", selection=[my_asset])
+
+    # Pattern 1: required_resource_keys (old-style sensor)
+    @dg.sensor(name="test_sensor_33650", required_resource_keys={"outer"}, job=my_job)
+    def my_sensor(context: dg.SensorEvaluationContext):
+        result = context.resources.outer.greet()
+        assert result == "hello"
+        yield dg.SkipReason("done")
+
+    with dg.build_sensor_context(
+        resources={"outer": OuterResource()}, sensor_name="test_sensor_33650"
+    ) as ctx:
+        outer = ctx.resources.outer
+        assert outer.greet() == "hello"
+
+    # Pattern 2: default value is properly tracked in nested_resources
+    outer_default = OuterResource()
+    assert "inner" in outer_default._nested_resources  # type: ignore
+
+    # Pattern 3: explicit override still works
+    outer_explicit = OuterResource(inner=InnerResource(val="world"))
+    assert outer_explicit._nested_resources["inner"].val == "world"  # type: ignore
+
+    # Pattern 4: sensor resolves the nested resource correctly end-to-end
+    # (access via context.resources to verify full resource initialization path)
+    with dg.build_sensor_context(
+        resources={"outer": OuterResource()}, sensor_name="test_sensor_33650"
+    ) as ctx:
+        outer = ctx.resources.outer
+        assert outer.greet() == "hello"
+
+
+def test_resource_dependency_with_default_in_asset() -> None:
+    """Companion to test_resource_dependency_with_default_no_recursion for asset execution.
+
+    The same RecursionError also manifests in asset execution (the issue report was
+    incorrect in stating assets worked).  This verifies that assets with a
+    ResourceDependency-default resource now execute successfully.
+    """
+
+    class InnerResource(dg.ConfigurableResource):
+        val: str = "default"
+
+    class OuterResource(dg.ConfigurableResource):
+        inner: dg.ResourceDependency[InnerResource] = InnerResource()
+
+        def greet(self) -> str:
+            return self.inner.val
+
+    completed: dict[str, str] = {}
+
+    @dg.asset
+    def my_asset(outer: OuterResource) -> None:
+        completed["result"] = outer.greet()
+
+    result = dg.materialize([my_asset], resources={"outer": OuterResource()})
+    assert result.success
+    assert completed["result"] == "default"
+
+    # Override the default
+    completed.clear()
+    result = dg.materialize(
+        [my_asset], resources={"outer": OuterResource(inner=InnerResource(val="overridden"))}
+    )
+    assert result.success
+    assert completed["result"] == "overridden"

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -1199,13 +1199,12 @@ def test_resource_dependency_with_default_no_recursion() -> None:
     outer_explicit = OuterResource(inner=InnerResource(val="world"))
     assert outer_explicit._nested_resources["inner"].val == "world"  # type: ignore
 
-    # Pattern 4: sensor body executes correctly end-to-end
+    # Pattern 4: sensor body executes correctly end-to-end via evaluate_tick
     with dg.build_sensor_context(
         resources={"outer": OuterResource()}, sensor_name="test_sensor_33650"
     ) as ctx:
-        results = list(my_sensor(ctx))
-        assert len(results) == 1
-        assert isinstance(results[0], dg.SkipReason)
+        result = my_sensor.evaluate_tick(ctx)
+        assert result.skip_message == "done"
 
 
 def test_resource_dependency_with_default_in_asset() -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -1199,13 +1199,13 @@ def test_resource_dependency_with_default_no_recursion() -> None:
     outer_explicit = OuterResource(inner=InnerResource(val="world"))
     assert outer_explicit._nested_resources["inner"].val == "world"  # type: ignore
 
-    # Pattern 4: sensor resolves the nested resource correctly end-to-end
-    # (access via context.resources to verify full resource initialization path)
+    # Pattern 4: sensor body executes correctly end-to-end
     with dg.build_sensor_context(
         resources={"outer": OuterResource()}, sensor_name="test_sensor_33650"
     ) as ctx:
-        outer = ctx.resources.outer
-        assert outer.greet() == "hello"
+        results = list(my_sensor(ctx))
+        assert len(results) == 1
+        assert isinstance(results[0], dg.SkipReason)
 
 
 def test_resource_dependency_with_default_in_asset() -> None:
@@ -1242,3 +1242,4 @@ def test_resource_dependency_with_default_in_asset() -> None:
     )
     assert result.success
     assert completed["result"] == "overridden"
+


### PR DESCRIPTION
## Summary

Fixes #33650.

When a `ConfigurableResource` subclass instance is used as a class-level default for a `ResourceDependency` field, accessing that field triggered infinite recursion:

```python
class Outer(ConfigurableResource):
    inner: ResourceDependency[Inner] = Inner()  # Inner() is a data descriptor

    def greet(self):
        return self.inner.val  # RecursionError
```

**Root cause:** `ConfigurableResourceFactory` inherits `__get__`/`__set__` from `TypecheckAllowPartialResourceInitParams`, making every `ConfigurableResource` instance a Python *data descriptor*. When `Inner()` is stored as a class attribute of `Outer`, accessing `outer.inner` called `TypecheckAllowPartialResourceInitParams.__get__` which called `getattr(obj, self._assigned_name)`, which re-triggered `__get__` — infinite recursion.

A secondary effect was that Pydantic could not read the `Inner()` class-level default (because `Inner().__get__(None, Outer)` raised `AttributeError` before the fix), causing `_nested_resources` to be empty and the nested resource's lifecycle to be skipped.

**Fix — two changes:**

1. **`TypecheckAllowPartialResourceInitParams.__get__`/`__set__`** (`typing_utils.py`):
   - `__get__`: return `self` when `obj is None` (class-level access) so Pydantic can read the default. When `obj` is an instance, read from `obj.__dict__` directly to bypass the descriptor protocol.
   - `__set__`: use `object.__setattr__` instead of `setattr` to avoid re-entering the descriptor.

2. **`ConfigurableResourceFactory.__init__`** (`resource.py`):
   After `super().__init__()`, Pydantic has populated `self.__dict__` with all values including defaults. Re-run `separate_resource_params` over `self.__dict__` to pick up resource-typed fields populated from defaults, ensuring they are tracked in `_nested_resources` and resolved at execution time.

## Test plan

- New regression test `test_resource_dependency_with_default_no_recursion` covers sensor context
- New test `test_resource_dependency_with_default_in_asset` covers asset execution  
- All existing resource tests pass (243 passed including 2 new)
- All pythonic config tests pass (140 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)