### PR TITLE
feat(ui): support explicit dagster/ui_color tags for asset backgrounds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - [dagster-spark] Added Spark Declarative Pipeline support in feature preview.
 - [ui] Added a date range picker to the backfill modal for date-formatted partitions.
 - [ui] The "Report evaluation" action for asset checks has been moved to a consolidated dropdown menu.
+- [ui] Asset nodes in the lineage graph now support custom background colors via the `dagster/ui_color` metadata tag. Supported values are `red`, `yellow`, `green`, `blue`, `olive`, `cyan`, `lime`, and `gray`. Colors are applied to both the node header and body, and adapt automatically to dark and light mode.
 
 ### Bugfixes
 

--- a/js_modules/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/ui-core/src/asset-graph/AssetNode.tsx
@@ -42,12 +42,8 @@ interface Props2025 {
   onChangeAssetSelection?: (selection: string) => void;
 }
 
-const getCustomBackgroundForAsset = (
-  tags?: {key: string; value: string}[],
-): string | undefined => {
-  const uiColorTag = tags?.find(
-    (t) => t.key === 'dagster/ui_color',
-  );
+const getCustomBackgroundForAsset = (tags?: {key: string; value: string}[]): string | undefined => {
+  const uiColorTag = tags?.find((t) => t.key === 'dagster/ui_color');
   if (!uiColorTag) {
     return undefined;
   }
@@ -483,7 +479,10 @@ export const AssetNameRow = ({
   const displayName = definition.assetKey.path[definition.assetKey.path.length - 1]!;
 
   return (
-    <AssetName $isMaterializable={definition.isMaterializable} $customBackground={$customBackground}>
+    <AssetName
+      $isMaterializable={definition.isMaterializable}
+      $customBackground={$customBackground}
+    >
       <span style={{marginTop: 1}}>
         <Icon name={definition.isMaterializable ? 'asset' : 'source_asset'} />
       </span>
@@ -572,6 +571,8 @@ export const AssetNodeMinimalWithHealth = ({
     return statusToIconAndColor[health?.assetHealth ?? 'undefined'];
   }, [health, isMaterializing]);
 
+  const customBackground = getCustomBackgroundForAsset(definition.tags);
+
   // old design
   let paddingTop = height / 2 - 52;
   let nodeHeight = 86;
@@ -598,7 +599,7 @@ export const AssetNodeMinimalWithHealth = ({
         <MinimalAssetNodeBox
           $selected={selected}
           $isMaterializable={isMaterializable}
-          $background={backgroundColor}
+          $background={customBackground ?? backgroundColor}
           $border={borderColor}
           $inProgress={!!inProgressRuns}
           $isQueued={!!queuedRuns}
@@ -627,6 +628,7 @@ export const AssetNodeMinimalWithoutHealth = ({
   const {liveData} = useAssetLiveData(assetKey);
 
   const {border, background} = buildAssetNodeStatusContent({assetKey, definition, liveData});
+  const customBackground = getCustomBackgroundForAsset(definition.tags);
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const displayName = assetKey.path[assetKey.path.length - 1]!;
 
@@ -662,7 +664,7 @@ export const AssetNodeMinimalWithoutHealth = ({
         <MinimalAssetNodeBox
           $selected={selected}
           $isMaterializable={isMaterializable}
-          $background={background}
+          $background={customBackground ?? background}
           $border={border}
           $inProgress={!!inProgressRuns}
           $isQueued={!!queuedRuns}
@@ -800,7 +802,8 @@ const AssetName = styled.div<{$isMaterializable: boolean; $customBackground?: st
   display: flex;
   gap: 4px;
   background: ${(p) =>
-    p.$customBackground || (p.$isMaterializable ? Colors.lineageNodeBackground() : Colors.backgroundLight())};
+    p.$customBackground ||
+    (p.$isMaterializable ? Colors.lineageNodeBackground() : Colors.backgroundLight())};
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
 `;

--- a/js_modules/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/ui-core/src/asset-graph/AssetNode.tsx
@@ -46,7 +46,7 @@ const getCustomBackgroundForAsset = (
   tags?: {key: string; value: string}[],
 ): string | undefined => {
   const uiColorTag = tags?.find(
-    (t) => t.key === 'dagster/ui_color' || t.key === 'dagster/ui/color',
+    (t) => t.key === 'dagster/ui_color',
   );
   if (!uiColorTag) {
     return undefined;
@@ -121,7 +121,10 @@ export const AssetNodeWithLiveData = ({
         $isMaterializable={definition.isMaterializable}
         $customBackground={getCustomBackgroundForAsset(definition.tags)}
       >
-        <AssetNameRow definition={definition} />
+        <AssetNameRow
+          definition={definition}
+          $customBackground={getCustomBackgroundForAsset(definition.tags)}
+        />
         {facets.has(AssetNodeFacet.Description) && (
           <AssetNodeRow label={null}>
             {definition.description ? (
@@ -469,12 +472,18 @@ export const AutomationConditionEvaluationLink = ({
   );
 };
 
-export const AssetNameRow = ({definition}: {definition: AssetNodeFragment}) => {
+export const AssetNameRow = ({
+  definition,
+  $customBackground,
+}: {
+  definition: AssetNodeFragment;
+  $customBackground?: string;
+}) => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const displayName = definition.assetKey.path[definition.assetKey.path.length - 1]!;
 
   return (
-    <AssetName $isMaterializable={definition.isMaterializable}>
+    <AssetName $isMaterializable={definition.isMaterializable} $customBackground={$customBackground}>
       <span style={{marginTop: 1}}>
         <Icon name={definition.isMaterializable ? 'asset' : 'source_asset'} />
       </span>
@@ -786,12 +795,12 @@ const NameTooltipStyleSource = JSON.stringify({
   border: `none`,
 });
 
-const AssetName = styled.div<{$isMaterializable: boolean}>`
+const AssetName = styled.div<{$isMaterializable: boolean; $customBackground?: string}>`
   ${NameCSS};
   display: flex;
   gap: 4px;
   background: ${(p) =>
-    p.$isMaterializable ? Colors.lineageNodeBackground() : Colors.backgroundLight()};
+    p.$customBackground || (p.$isMaterializable ? Colors.lineageNodeBackground() : Colors.backgroundLight())};
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
 `;

--- a/js_modules/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/ui-core/src/asset-graph/AssetNode.tsx
@@ -42,29 +42,40 @@ interface Props2025 {
   onChangeAssetSelection?: (selection: string) => void;
 }
 
-const getCustomBackgroundForAsset = (tags?: {key: string; value: string}[]): string | undefined => {
+type CustomBackgrounds = {body: string; header: string};
+
+const getCustomBackgroundsForAsset = (
+  tags?: {key: string; value: string}[],
+): CustomBackgrounds | undefined => {
   const uiColorTag = tags?.find((t) => t.key === 'dagster/ui_color');
   if (!uiColorTag) {
     return undefined;
   }
   switch (uiColorTag.value.toLowerCase()) {
     case 'red':
-      return Colors.backgroundRed();
+      return {body: Colors.backgroundRed(), header: Colors.backgroundRedHover()};
     case 'yellow':
-      return Colors.backgroundYellow();
+      return {body: Colors.backgroundYellow(), header: Colors.backgroundYellowHover()};
     case 'green':
-      return Colors.backgroundGreen();
+      return {body: Colors.backgroundGreen(), header: Colors.backgroundGreenHover()};
     case 'blue':
-      return Colors.backgroundBlue();
+      return {body: Colors.backgroundBlue(), header: Colors.backgroundBlueHover()};
     case 'olive':
-      return Colors.backgroundOlive();
+      return {body: Colors.backgroundOlive(), header: Colors.backgroundOliverHover()};
     case 'cyan':
-      return Colors.backgroundCyan();
+      return {body: Colors.backgroundCyan(), header: Colors.backgroundCyanHover()};
     case 'lime':
-      return Colors.backgroundLime();
+      return {body: Colors.backgroundLime(), header: Colors.backgroundLimeHover()};
     case 'gray':
-      return Colors.backgroundGray();
+      return {body: Colors.backgroundGray(), header: Colors.backgroundGrayHover()};
     default:
+      if (process.env['NODE_ENV'] === 'development') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[dagster/ui_color] Unrecognized color value "${uiColorTag.value}". ` +
+            `Supported values: red, yellow, green, blue, olive, cyan, lime, gray.`,
+        );
+      }
       return undefined;
   }
 };
@@ -94,6 +105,8 @@ export const AssetNodeWithLiveData = ({
   automationData?: AssetAutomationFragment | undefined;
   assetHealthEnabled: boolean;
 }) => {
+  const customBackgrounds = getCustomBackgroundsForAsset(definition.tags);
+
   return (
     <AssetNodeContainer $selected={selected}>
       {facets.has(AssetNodeFacet.UnsyncedTag) ? (
@@ -115,12 +128,9 @@ export const AssetNodeWithLiveData = ({
       <AssetNodeBox
         $selected={selected}
         $isMaterializable={definition.isMaterializable}
-        $customBackground={getCustomBackgroundForAsset(definition.tags)}
+        $customBackground={customBackgrounds?.body}
       >
-        <AssetNameRow
-          definition={definition}
-          $customBackground={getCustomBackgroundForAsset(definition.tags)}
-        />
+        <AssetNameRow definition={definition} $customBackground={customBackgrounds?.header} />
         {facets.has(AssetNodeFacet.Description) && (
           <AssetNodeRow label={null}>
             {definition.description ? (
@@ -571,7 +581,7 @@ export const AssetNodeMinimalWithHealth = ({
     return statusToIconAndColor[health?.assetHealth ?? 'undefined'];
   }, [health, isMaterializing]);
 
-  const customBackground = getCustomBackgroundForAsset(definition.tags);
+  const customBackground = getCustomBackgroundsForAsset(definition.tags)?.body;
 
   // old design
   let paddingTop = height / 2 - 52;
@@ -628,7 +638,7 @@ export const AssetNodeMinimalWithoutHealth = ({
   const {liveData} = useAssetLiveData(assetKey);
 
   const {border, background} = buildAssetNodeStatusContent({assetKey, definition, liveData});
-  const customBackground = getCustomBackgroundForAsset(definition.tags);
+  const customBackground = getCustomBackgroundsForAsset(definition.tags)?.body;
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const displayName = assetKey.path[assetKey.path.length - 1]!;
 

--- a/js_modules/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/ui-core/src/asset-graph/AssetNode.tsx
@@ -42,6 +42,37 @@ interface Props2025 {
   onChangeAssetSelection?: (selection: string) => void;
 }
 
+const getCustomBackgroundForAsset = (
+  tags?: {key: string; value: string}[],
+): string | undefined => {
+  const uiColorTag = tags?.find(
+    (t) => t.key === 'dagster/ui_color' || t.key === 'dagster/ui/color',
+  );
+  if (!uiColorTag) {
+    return undefined;
+  }
+  switch (uiColorTag.value.toLowerCase()) {
+    case 'red':
+      return Colors.backgroundRed();
+    case 'yellow':
+      return Colors.backgroundYellow();
+    case 'green':
+      return Colors.backgroundGreen();
+    case 'blue':
+      return Colors.backgroundBlue();
+    case 'olive':
+      return Colors.backgroundOlive();
+    case 'cyan':
+      return Colors.backgroundCyan();
+    case 'lime':
+      return Colors.backgroundLime();
+    case 'gray':
+      return Colors.backgroundGray();
+    default:
+      return undefined;
+  }
+};
+
 export const ASSET_NODE_HOVER_EXPAND_HEIGHT = 3;
 
 export const AssetNode = React.memo((props: Props2025) => {
@@ -85,7 +116,11 @@ export const AssetNodeWithLiveData = ({
       ) : (
         <div style={{minHeight: ASSET_NODE_HOVER_EXPAND_HEIGHT}} />
       )}
-      <AssetNodeBox $selected={selected} $isMaterializable={definition.isMaterializable}>
+      <AssetNodeBox
+        $selected={selected}
+        $isMaterializable={definition.isMaterializable}
+        $customBackground={getCustomBackgroundForAsset(definition.tags)}
+      >
         <AssetNameRow definition={definition} />
         {facets.has(AssetNodeFacet.Description) && (
           <AssetNodeRow label={null}>
@@ -698,6 +733,7 @@ export const AssetNodeBox = styled.div<{
   $isMaterializable: boolean;
   $selected: boolean;
   $noScale?: boolean;
+  $customBackground?: string;
 }>`
   ${(p) =>
     !p.$isMaterializable
@@ -707,7 +743,7 @@ export const AssetNodeBox = styled.div<{
         }`};
   ${(p) => p.$selected && `outline: 2px solid ${Colors.lineageNodeBorderSelected()}`};
 
-  background: ${Colors.backgroundDefault()};
+  background: ${(p) => p.$customBackground || Colors.backgroundDefault()};
   border-radius: 10px;
   position: relative;
   margin: ${ASSET_NODE_VERTICAL_MARGIN}px 0;

--- a/js_modules/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/ui-core/src/asset-graph/AssetNode.tsx
@@ -498,7 +498,10 @@ export const AssetNameRow = ({
       </span>
       <div
         data-tooltip={displayName}
-        data-tooltip-style={definition.isMaterializable ? NameTooltipStyle : NameTooltipStyleSource}
+        data-tooltip-style={getNameTooltipStyle({
+          customBackground: $customBackground,
+          isMaterializable: definition.isMaterializable,
+        })}
         style={{overflow: 'hidden', textOverflow: 'ellipsis'}}
       >
         {withMiddleTruncation(displayName, {
@@ -795,17 +798,20 @@ export const NameTooltipCSS: CSSObject = {
   fontSize: 14,
 };
 
-export const NameTooltipStyle = JSON.stringify({
-  ...NameTooltipCSS,
-  background: Colors.lineageNodeBackground(),
-  border: `none`,
-});
-
-const NameTooltipStyleSource = JSON.stringify({
-  ...NameTooltipCSS,
-  background: Colors.backgroundLight(),
-  border: `none`,
-});
+const getNameTooltipStyle = ({
+  customBackground,
+  isMaterializable,
+}: {
+  customBackground?: string;
+  isMaterializable: boolean;
+}) =>
+  JSON.stringify({
+    ...NameTooltipCSS,
+    background:
+      customBackground ||
+      (isMaterializable ? Colors.lineageNodeBackground() : Colors.backgroundLight()),
+    border: `none`,
+  });
 
 const AssetName = styled.div<{$isMaterializable: boolean; $customBackground?: string}>`
   ${NameCSS};

--- a/js_modules/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
+++ b/js_modules/ui-core/src/asset-graph/__tests__/AssetNode.test.tsx
@@ -1,4 +1,5 @@
 import {MockedProvider} from '@apollo/client/testing';
+import {Colors} from '@dagster-io/ui-components';
 import {render, screen, waitFor} from '@testing-library/react';
 import {MemoryRouter} from 'react-router-dom';
 
@@ -9,8 +10,13 @@ import {AssetHealthData} from '../../asset-data/AssetHealthDataProvider';
 import {AssetLiveDataProvider} from '../../asset-data/AssetLiveDataProvider';
 import {AssetStaleStatusData} from '../../asset-data/AssetStaleStatusDataProvider';
 import {AssetHealthFragment} from '../../asset-data/types/AssetHealthDataProvider.types';
-import {buildAssetKey, buildAssetNode, buildStaleCause} from '../../graphql/builders';
-import {AssetNode} from '../AssetNode';
+import {
+  buildAssetKey,
+  buildAssetNode,
+  buildDefinitionTag,
+  buildStaleCause,
+} from '../../graphql/builders';
+import {AssetNameRow, AssetNode} from '../AssetNode';
 import {AllAssetNodeFacets} from '../AssetNodeFacets';
 import {tokenForAssetKey} from '../Utils';
 import {
@@ -123,6 +129,31 @@ describe('AssetNode', function () {
       });
     }),
   );
+});
+
+describe('AssetNameRow', () => {
+  it('uses the custom header background for the truncated-name tooltip style', () => {
+    const displayName = 'very_long_asset_name_that_should_truncate_in_the_asset_graph';
+    const definition = buildAssetNode({
+      assetKey: buildAssetKey({path: [displayName]}),
+      isMaterializable: true,
+      tags: [buildDefinitionTag({key: 'dagster/ui_color', value: 'blue'})],
+    });
+
+    render(
+      <AssetNameRow definition={definition} $customBackground={Colors.backgroundBlueHover()} />,
+    );
+
+    const tooltipTarget = screen.getByText(
+      withMiddleTruncation(displayName, {
+        maxLength: ASSET_NODE_NAME_MAX_LENGTH,
+      }),
+    );
+
+    expect(JSON.parse(tooltipTarget.getAttribute('data-tooltip-style') || '{}')).toMatchObject({
+      background: Colors.backgroundBlueHover(),
+    });
+  });
 });
 
 function scenarioAssetKey(scenario: AssetNodeScenario) {


### PR DESCRIPTION
## Summary
- Introduces manual color designation using the dagster/ui_color tag.
- Converts UI string literals into predefined structurally accessible Dagster UI color tokens to ensure safety and dark/light contrast support.
- Resolves upstream feature request #33663.

## Test Plan
- [x] Verified yarn run ts locally.
- [x] Hardened component rendering with Typescript strict null-safety checks.