### PR TITLE
Fix will_be_requested() across partition definition boundaries

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets/graph/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets/graph/asset_graph.py
@@ -362,13 +362,13 @@ def executable_in_same_run(
         if child_handle != parent_handle:
             return False
 
-    # partitions definitions must match
+    # assets where either side is unpartitioned can always execute together
+    if child_node.partitions_def is None or parent_node.partitions_def is None:
+        return True
+
+    # both are partitioned — definitions must match
     if child_node.partitions_def != parent_node.partitions_def:
         return False
-
-    # unpartitioned assets can always execute together
-    if child_node.partitions_def is None:
-        return True
 
     return isinstance(
         asset_graph.get_partition_mapping(child_node.key, parent_node.key),

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_will_be_requested_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_will_be_requested_condition.py
@@ -57,7 +57,8 @@ async def test_will_be_requested_static_partitioned() -> None:
 
 
 @pytest.mark.asyncio
-async def test_will_be_requested_different_partitions() -> None:
+async def test_will_be_requested_partitioned_parent_unpartitioned_child() -> None:
+    """A partitioned parent and unpartitioned child can execute in the same run."""
     condition = AutomationCondition.any_deps_match(AutomationCondition.will_be_requested())
     state = AutomationConditionScenarioState(
         two_assets_in_sequence, automation_condition=condition
@@ -67,17 +68,38 @@ async def test_will_be_requested_different_partitions() -> None:
     state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
-    # one requested parent, but can't execute in same run
+    # one requested parent — can execute in same run since child is unpartitioned
     state = state.with_requested_asset_partitions([AssetKeyPartitionKey(dg.AssetKey("A"), "1")])
     state, result = await state.evaluate("B")
-    assert result.true_subset.size == 0
+    assert result.true_subset.size == 1
 
-    # two requested parents, but can't execute in same run
+    # two requested parents — still can execute together
     state = state.with_requested_asset_partitions(
         [AssetKeyPartitionKey(dg.AssetKey("A"), "1"), AssetKeyPartitionKey(dg.AssetKey("A"), "2")]
     )
     state, result = await state.evaluate("B")
+    assert result.true_subset.size == 1
+
+
+@pytest.mark.asyncio
+async def test_will_be_requested_unpartitioned_parent_partitioned_child() -> None:
+    """An unpartitioned parent and partitioned child can execute in the same run.
+
+    Non-regression test for https://github.com/dagster-io/dagster/issues/32935
+    """
+    condition = AutomationCondition.any_deps_match(AutomationCondition.will_be_requested())
+    state = AutomationConditionScenarioState(
+        two_assets_in_sequence, automation_condition=condition
+    ).with_asset_properties("B", partitions_def=two_partitions_def)
+
+    # no requested parents
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
+
+    # unpartitioned parent is requested — partitioned child should detect it
+    state = state.with_requested_asset_partitions([AssetKeyPartitionKey(dg.AssetKey("A"))])
+    state, result = await state.evaluate("B")
+    assert result.true_subset.size == 2
 
 
 def test_with_observable_source() -> None:


### PR DESCRIPTION
## Summary

Fixes #32935

`AutomationCondition.will_be_requested()` always returns `False` when evaluating
an unpartitioned asset that depends on a partitioned one (or vice versa), because
`executable_in_same_run()` checks `child_node.partitions_def != parent_node.partitions_def`
before checking if either side is `None`.

Since `None != DynamicPartitionsDefinition()` is always `True`, the function
short-circuits to `False` without ever reaching the unpartitioned check.

## Fix

Reordered the conditions in `executable_in_same_run()`:

1. First check if either side is unpartitioned → return `True`
2. Then compare partition definitions for equality

## Changes

- **`dagster/_core/definitions/assets/graph/asset_graph.py`**: Reordered conditions
- **`dagster_tests/.../test_will_be_requested_condition.py`**: Updated existing test
  expectations and added `test_will_be_requested_unpartitioned_parent_partitioned_child`
  as a non-regression test for the exact topology from the issue