### PR TITLE
[dagster-cloud-cli] Fix uv deployment bug in PEX builder

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/package_manager.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/package_manager.py
@@ -1,0 +1,107 @@
+"""Detect and wrap pip/uv for local package installation in the PEX builder.
+
+This module provides a unified interface for installing local packages into a
+target directory, abstracting over whether the environment provides pip (the
+preferred default) or uv (the fallback for uv-managed environments where pip
+may be absent).
+"""
+
+import shutil
+import subprocess
+from typing import Literal
+
+from dagster_shared.record import record
+
+
+class PackageManagerError(Exception):
+    """Raised when no suitable package manager is found."""
+
+
+@record(kw_only=False)
+class PackageManager:
+    name: Literal["pip", "uv"]
+    executable: str
+    # Resolved absolute path of the target Python interpreter (via shutil.which at detection time).
+    # Used as the --python argument for uv so that the path is stable regardless of caller cwd.
+    python_interpreter: str
+
+    def build_install_command(self, target_dir: str, no_deps: bool = True) -> list[str]:
+        """Construct full install command for local package.
+
+        The returned command appends ``"."`` as the package source, which means
+        the caller MUST set ``cwd`` to the package directory when invoking
+        ``subprocess.run`` with this command.
+        """
+        if self.name == "pip":
+            cmd = [self.executable, "-m", "pip", "install", "--target", target_dir]
+        elif self.name == "uv":
+            cmd = [
+                self.executable,
+                "pip",
+                "install",
+                "--target",
+                target_dir,
+                "--python",
+                self.python_interpreter,  # always the shutil.which-resolved absolute path
+            ]
+        else:
+            raise AssertionError(f"Unexpected package manager: {self.name!r}")
+
+        if no_deps:
+            cmd.append("--no-deps")
+        cmd.append(".")  # Current directory (local package)
+        return cmd
+
+
+def detect_package_manager(python_interpreter: str) -> PackageManager:
+    """Detect available package manager for the given interpreter.
+
+    Strategy:
+    1. Check if pip is importable in the interpreter (preferred for compatibility)
+    2. If no pip, check for uv availability
+    3. Raise clear error if neither available
+    """
+    # Resolve to absolute path so uv's --python flag works regardless of caller cwd.
+    python_interpreter = shutil.which(python_interpreter) or python_interpreter
+
+    # Test 1: Can we import pip in this interpreter?
+    pip_test = subprocess.run(
+        [python_interpreter, "-c", "import pip; print(pip.__version__)"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    if pip_test.returncode == 0:
+        return PackageManager(
+            name="pip",
+            executable=python_interpreter,
+            python_interpreter=python_interpreter,
+        )
+
+    # Test 2: Is uv available in PATH?
+    uv_path = shutil.which("uv")
+    if uv_path:
+        # Verify uv supports pip subcommand
+        uv_test = subprocess.run(
+            [uv_path, "pip", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        if uv_test.returncode == 0:
+            return PackageManager(
+                name="uv",
+                executable=uv_path,
+                python_interpreter=python_interpreter,  # resolved absolute path for --python flag
+            )
+
+    # Failure: Neither available
+    raise PackageManagerError(
+        f"No package manager available for interpreter: {python_interpreter}\n"
+        f"Pip check failed: {pip_test.stderr.strip()}\n"
+        f"Uv availability: {'found but pip subcommand failed' if uv_path else 'not found'}\n"
+        "Please ensure either pip is installed in your environment or uv is available."
+    )

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/source.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/source.py
@@ -120,8 +120,14 @@ def build_pex_using_setup_py(
         for d in all_package_dirs
     )
     pm: PackageManager | None = None
+    pm: PackageManager | None = None
     if has_pyproject:
-        pm = detect_package_manager(python_interpreter)
+        try:
+            pm = detect_package_manager(python_interpreter)
+        except PackageManagerError as e:
+            raise ui.error(
+                f"No package manager available for building local packages: {e}"
+            ) from e
         if pm.name == "uv":
             ui.warn(
                 f"pip not available in {python_interpreter}, falling back to uv for local package builds"

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/source.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/core/pex_builder/source.py
@@ -11,6 +11,11 @@ import click
 
 from dagster_cloud_cli import ui
 from dagster_cloud_cli.core.pex_builder import deps, util
+from dagster_cloud_cli.core.pex_builder.package_manager import (
+    PackageManager,
+    PackageManagerError,
+    detect_package_manager,
+)
 
 # inspired by https://github.com/github/gitignore/blob/main/Python.gitignore
 # would be nice to just read the gitignore and use that
@@ -46,34 +51,54 @@ def build_source_pex(
     return final_pex_path
 
 
-def _build_local_package(local_dir: str, build_dir: str, python_interpreter: str):
-    if os.path.exists(os.path.join(local_dir, "setup.py")):
-        ui.print(f"Building package at {local_dir!r} using {python_interpreter} setup.py build")
-        command = [
-            python_interpreter,
-            "setup.py",
-            "build",
-            "--build-lib",
-            build_dir,
-        ]
-        subprocess.run(command, check=True, cwd=local_dir)
-    elif os.path.exists(os.path.join(local_dir, "pyproject.toml")):
-        ui.print(f"Building package at {local_dir!r} using {python_interpreter} -m pip install")
-        # Use pip install with --target to build and install the package to the build directory
-        # This handles pyproject.toml files properly using modern Python build standards
-        command = [
-            python_interpreter,
-            "-m",
-            "pip",
-            "install",
-            "--target",
-            build_dir,
-            "--no-deps",  # Don't install dependencies, just the package itself
-            ".",
-        ]
-        subprocess.run(command, check=True, cwd=local_dir)
-    else:
-        ui.warn(f"No setup.py or pyproject.toml found in {local_dir!r} - will not build.")
+def _build_local_package(
+    local_dir: str,
+    build_dir: str,
+    python_interpreter: str,
+    # When ``pm`` is None, detection is deferred to the first pyproject.toml package
+    # encountered. Callers should prefer passing ``pm`` explicitly to avoid repeated
+    # detection overhead.
+    pm: PackageManager | None = None,
+):
+    pm_name = "unknown"
+    try:
+        if os.path.exists(os.path.join(local_dir, "setup.py")):
+            ui.print(f"Building package at {local_dir!r} using {python_interpreter} setup.py build")
+            command = [
+                python_interpreter,
+                "setup.py",
+                "build",
+                "--build-lib",
+                build_dir,
+            ]
+            pm_name = "setup.py"
+            subprocess.run(command, check=True, cwd=local_dir, capture_output=True, text=True)
+        elif os.path.exists(os.path.join(local_dir, "pyproject.toml")):
+            if pm is None:
+                pm = detect_package_manager(python_interpreter)
+            command = pm.build_install_command(
+                target_dir=build_dir,
+                no_deps=True,
+            )
+            ui.print(
+                f"Building package at {local_dir!r} using {pm.name} install "
+                f"(interpreter: {python_interpreter})"
+            )
+            pm_name = pm.name
+            subprocess.run(command, check=True, cwd=local_dir, capture_output=True, text=True)
+        else:
+            ui.warn(f"No setup.py or pyproject.toml found in {local_dir!r} - will not build.")
+            return
+    except PackageManagerError as e:
+        raise ui.error(f"Failed to build local package at {local_dir!r}: {e}") from e
+    except subprocess.CalledProcessError as e:
+        raise ui.error(
+            f"Package installation failed using {pm_name} for {local_dir!r}:\n"
+            f"Command: {' '.join(e.cmd)}\n"
+            f"Exit code: {e.returncode}\n"
+            f"Stdout: {e.stdout if e.stdout else ''}\n"
+            f"Stderr: {e.stderr if e.stderr else ''}"
+        ) from e
 
 
 def build_pex_using_setup_py(
@@ -84,6 +109,23 @@ def build_pex_using_setup_py(
 ):
     """Builds package using setup.py and copies built output into PEX."""
     python_interpreter = util.python_interpreter_for(python_version)
+    # Only probe for a package manager if at least one package uses pyproject.toml *without*
+    # a co-located setup.py.  setup.py always wins in _build_local_package, so a directory
+    # that has both files will never reach the pyproject.toml branch and does not need a pm.
+    # Detection runs two subprocess probes with 15s timeouts each, so avoid it whenever possible.
+    all_package_dirs = [*local_package_paths, code_directory]
+    has_pyproject = any(
+        os.path.exists(os.path.join(d, "pyproject.toml"))
+        and not os.path.exists(os.path.join(d, "setup.py"))
+        for d in all_package_dirs
+    )
+    pm: PackageManager | None = None
+    if has_pyproject:
+        pm = detect_package_manager(python_interpreter)
+        if pm.name == "uv":
+            ui.warn(
+                f"pip not available in {python_interpreter}, falling back to uv for local package builds"
+            )
     with tempfile.TemporaryDirectory() as build_dir, tempfile.TemporaryDirectory() as sources_dir:
         included_dirs = [build_dir]
 
@@ -92,12 +134,14 @@ def build_pex_using_setup_py(
                 local_dir=local_dir,
                 build_dir=build_dir,
                 python_interpreter=python_interpreter,
+                pm=pm,
             )
 
         _build_local_package(
             local_dir=code_directory,
             build_dir=build_dir,
             python_interpreter=python_interpreter,
+            pm=pm,
         )
 
         # We always include the code_directory source in a special package called working_directory

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/pex_builder_tests/test_build_local_package_integration.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/pex_builder_tests/test_build_local_package_integration.py
@@ -1,0 +1,135 @@
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+from dagster_cloud_cli.core.pex_builder.package_manager import detect_package_manager
+from dagster_cloud_cli.core.pex_builder.source import _build_local_package
+from dagster_cloud_cli.ui import ExitWithMessage
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not shutil.which("uv"), reason="uv not installed")
+class TestBuildLocalPackageUV:
+    """Integration tests with real uv environments."""
+
+    def test_build_with_uv_environment(self):
+        """Create a uv venv without pip, verify local package builds successfully."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Setup: Create uv virtualenv (no pip)
+            venv_path = Path(tmpdir) / "venv"
+            # Use current python if 3.12 is not available
+            subprocess.run(["uv", "venv", "--no-pip", str(venv_path)], check=True)
+
+            if os.name == "nt":
+                python_interp = str(venv_path / "Scripts" / "python.exe")
+            else:
+                python_interp = str(venv_path / "bin" / "python")
+
+            # Create minimal local package
+            pkg_dir = Path(tmpdir) / "local_pkg"
+            pkg_dir.mkdir()
+            (pkg_dir / "pyproject.toml").write_text(
+                """
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "test-pkg"
+version = "0.1.0"
+"""
+            )
+            (pkg_dir / "test_pkg.py").write_text("__version__ = '0.1.0'")
+
+            # Verify detection selects uv (no pip in this venv)
+            pm = detect_package_manager(python_interp)
+            assert pm.name == "uv"
+
+            # Test: _build_local_package should use uv and install successfully
+            target_dir = Path(tmpdir) / "target"
+            _build_local_package(str(pkg_dir), str(target_dir), python_interp, pm=pm)
+
+            # Verify installation
+            assert (target_dir / "test_pkg.py").exists()
+
+
+@pytest.mark.integration
+class TestBuildLocalPackagePip:
+    """Integration tests with standard pip environments."""
+
+    def test_build_with_pip_environment(self):
+        """Verify pip environments continue to work."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Setup: Create standard virtualenv (has pip)
+            venv_path = Path(tmpdir) / "venv"
+            subprocess.run(["python", "-m", "venv", str(venv_path)], check=True)
+
+            if os.name == "nt":
+                python_interp = str(venv_path / "Scripts" / "python.exe")
+                # Windows venv sometimes needs pip upgraded or installed
+                subprocess.run(
+                    [python_interp, "-m", "pip", "install", "--upgrade", "pip"], check=False
+                )
+            else:
+                python_interp = str(venv_path / "bin" / "python")
+
+            # Create minimal local package
+            pkg_dir = Path(tmpdir) / "local_pkg"
+            pkg_dir.mkdir()
+            (pkg_dir / "pyproject.toml").write_text(
+                """
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "test-pkg"
+version = "0.1.0"
+"""
+            )
+            (pkg_dir / "test_pkg.py").write_text("__version__ = '0.1.0'")
+
+            # Verify detection selects pip
+            pm = detect_package_manager(python_interp)
+            assert pm.name == "pip"
+
+            # Test: _build_local_package should use pip and install successfully
+            target_dir = Path(tmpdir) / "target"
+            _build_local_package(str(pkg_dir), str(target_dir), python_interp, pm=pm)
+
+            # Verify installation
+            assert (target_dir / "test_pkg.py").exists()
+
+    def test_failed_build_captures_output(self):
+        """Verify that failed builds capture and report stdout/stderr."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Setup: Create standard virtualenv (has pip)
+            venv_path = Path(tmpdir) / "venv"
+            subprocess.run(["python", "-m", "venv", str(venv_path)], check=True)
+
+            if os.name == "nt":
+                python_interp = str(venv_path / "Scripts" / "python.exe")
+            else:
+                python_interp = str(venv_path / "bin" / "python")
+
+            # Ensure setuptools is available for setup.py build
+            subprocess.run([python_interp, "-m", "pip", "install", "setuptools"], check=True)
+
+            # Create a broken local package (invalid syntax in setup.py)
+            pkg_dir = Path(tmpdir) / "broken_pkg"
+            pkg_dir.mkdir()
+            (pkg_dir / "setup.py").write_text(
+                "import setuptools; raise Exception('Build failed manually!')"
+            )
+
+            with pytest.raises(ExitWithMessage) as exc_info:
+                _build_local_package(str(pkg_dir), str(Path(tmpdir) / "build"), python_interp)
+
+            error_msg = exc_info.value.message
+            assert "Package installation failed" in error_msg
+            assert "Build failed manually!" in error_msg
+            assert "Stdout: " in error_msg
+            assert "Stderr: " in error_msg

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/pex_builder_tests/test_package_manager.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/pex_builder_tests/test_package_manager.py
@@ -1,0 +1,254 @@
+import os
+import subprocess
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dagster_cloud_cli.core.pex_builder.package_manager import (
+    PackageManager,
+    PackageManagerError,
+    detect_package_manager,
+)
+from dagster_cloud_cli.core.pex_builder.source import _build_local_package, build_pex_using_setup_py
+from dagster_cloud_cli.ui import ExitWithMessage
+
+
+class TestDetectPackageManager:
+    """Test package manager detection logic."""
+
+    def test_prefers_pip_when_available(self):
+        """Should return pip manager when pip is importable."""
+        with patch("subprocess.run") as mock_run:
+            # Mock successful pip check
+            mock_run.return_value = MagicMock(returncode=0, stdout="24.0", stderr="")
+
+            pm = detect_package_manager("/usr/bin/python3")
+            assert pm.name == "pip"
+            assert pm.executable == "/usr/bin/python3"
+
+    def test_falls_back_to_uv_when_pip_missing(self):
+        """Should return uv manager when pip fails but uv available."""
+        with patch("subprocess.run") as mock_run, patch("shutil.which") as mock_which:
+            # First call (pip check) fails, second (uv check) succeeds
+            mock_run.side_effect = [
+                MagicMock(returncode=1, stderr="No module named pip"),  # pip check
+                MagicMock(returncode=0),  # uv pip --help check
+            ]
+
+            def which_side_effect(name):
+                if name == "uv":
+                    return "/usr/bin/uv"
+                return name  # passthrough for interpreter normalization
+
+            mock_which.side_effect = which_side_effect
+
+            pm = detect_package_manager("/path/to/python")
+            assert pm.name == "uv"
+            assert pm.executable == "/usr/bin/uv"
+
+    def test_raises_error_when_neither_available(self):
+        """Should raise PackageManagerError when no manager found."""
+        with patch("subprocess.run") as mock_run, patch("shutil.which") as mock_which:
+            mock_run.return_value = MagicMock(returncode=1, stderr="No module named pip")
+            mock_which.return_value = None
+
+            with pytest.raises(PackageManagerError) as exc_info:
+                detect_package_manager("/path/to/python")
+
+            assert "No package manager available" in str(exc_info.value)
+
+    def test_uv_pip_subcommand_validation(self):
+        """Should verify uv supports pip subcommand."""
+        with patch("subprocess.run") as mock_run, patch("shutil.which") as mock_which:
+            mock_run.side_effect = [
+                MagicMock(returncode=1),  # pip fails
+                MagicMock(returncode=1, stderr="unknown command"),  # uv pip fails
+            ]
+
+            def which_side_effect(name):
+                if name == "uv":
+                    return "/usr/bin/uv"
+                return name  # passthrough for interpreter normalization
+
+            mock_which.side_effect = which_side_effect
+
+            with pytest.raises(PackageManagerError):
+                detect_package_manager("/path/to/python")
+
+
+class TestPackageManagerCommands:
+    """Test command construction."""
+
+    def test_pip_command_structure(self):
+        pm = PackageManager("pip", "/usr/bin/python3", "/usr/bin/python3")
+        cmd = pm.build_install_command("/tmp/target")
+        assert cmd[0] == "/usr/bin/python3"
+        assert "-m" in cmd
+        assert "pip" in cmd
+        assert "--target" in cmd
+        assert "/tmp/target" in cmd
+        assert "--no-deps" in cmd
+        assert "." in cmd
+
+    def test_uv_command_structure(self):
+        pm = PackageManager("uv", "/usr/bin/uv", "/usr/bin/python3")
+        cmd = pm.build_install_command("/tmp/target")
+        assert cmd[0] == "/usr/bin/uv"
+        assert "pip" in cmd
+        assert "--python" in cmd
+        assert "/usr/bin/python3" in cmd  # uses pm.python_interpreter, not caller-supplied path
+        assert "--target" in cmd
+
+    def test_error_handler_attribute_error_regression(self):
+        """P1: Verify the error handler is safe when stderr is None but stdout has content."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a dummy pyproject.toml to hit the relevant code path
+            with open(os.path.join(temp_dir, "pyproject.toml"), "w") as f:
+                f.write("[project]\nname='test'")
+
+            with (
+                patch(
+                    "dagster_cloud_cli.core.pex_builder.source.detect_package_manager"
+                ) as mock_detect,
+                patch("subprocess.run") as mock_run,
+            ):
+                mock_detect.return_value = PackageManager("pip", "python", "python")
+
+                # Simulate CalledProcessError where stdout exists but stderr is None
+                # This could happen if capture_output=False (legacy) or if mocked incorrectly
+                error = subprocess.CalledProcessError(returncode=1, cmd=["pip", "install"])
+                error.stdout = "some stdout content"
+                error.stderr = None
+
+                mock_run.side_effect = error
+
+                with pytest.raises(ExitWithMessage) as exc_info:
+                    _build_local_package(temp_dir, "/tmp/build", "python")
+
+                # The fix ensures we don't raise AttributeError: 'NoneType' object has no attribute 'decode'
+                # and instead include the stdout content correctly.
+                assert "Package installation failed" in exc_info.value.message
+                assert "Stdout: some stdout content" in exc_info.value.message
+                assert "Stderr: " in exc_info.value.message
+
+
+class TestBuildPexUsingSetupPy:
+    """Test lazy package manager detection in build_pex_using_setup_py."""
+
+    def test_detect_called_once_for_multiple_pyproject_packages(self):
+        """detect_package_manager should be called exactly once even for multiple pyproject packages."""
+        with (
+            tempfile.TemporaryDirectory() as code_dir,
+            tempfile.TemporaryDirectory() as dep1_dir,
+            tempfile.TemporaryDirectory() as dep2_dir,
+        ):
+            # All three dirs have pyproject.toml
+            for d in (code_dir, dep1_dir, dep2_dir):
+                with open(os.path.join(d, "pyproject.toml"), "w") as f:
+                    f.write("[project]\nname='test'")
+
+            fake_pm = PackageManager("pip", "python", "python")
+
+            with (
+                patch(
+                    "dagster_cloud_cli.core.pex_builder.source.detect_package_manager"
+                ) as mock_detect,
+                patch(
+                    "dagster_cloud_cli.core.pex_builder.source._build_local_package"
+                ) as mock_build,
+                patch(
+                    "dagster_cloud_cli.core.pex_builder.util.python_interpreter_for"
+                ) as mock_interp,
+                patch("dagster_cloud_cli.core.pex_builder.source._prepare_working_directory"),
+                patch("dagster_cloud_cli.core.pex_builder.util.get_pex_flags") as mock_pex_flags,
+                patch("dagster_cloud_cli.core.pex_builder.util.build_pex") as mock_build_pex,
+            ):
+                mock_detect.return_value = fake_pm
+                mock_interp.return_value = "/usr/bin/python3"
+                mock_pex_flags.return_value = []
+                mock_build_pex.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+                build_pex_using_setup_py(code_dir, [dep1_dir, dep2_dir], "/tmp/out.pex", (3, 10))
+
+                # Detection should happen exactly once, not once per package
+                assert mock_detect.call_count == 1
+
+                # Verify the detected pm was forwarded to all _build_local_package calls
+                for call in mock_build.call_args_list:
+                    assert call.kwargs.get("pm") is mock_detect.return_value
+
+    def test_detect_not_called_for_setup_py_only_projects(self):
+        """detect_package_manager should never be called when all packages use setup.py."""
+        with (
+            tempfile.TemporaryDirectory() as code_dir,
+            tempfile.TemporaryDirectory() as dep1_dir,
+        ):
+            # Both dirs have only setup.py, no pyproject.toml
+            for d in (code_dir, dep1_dir):
+                with open(os.path.join(d, "setup.py"), "w") as f:
+                    f.write("from setuptools import setup\nsetup(name='test')")
+
+            with (
+                patch(
+                    "dagster_cloud_cli.core.pex_builder.source.detect_package_manager"
+                ) as mock_detect,
+                patch(
+                    "dagster_cloud_cli.core.pex_builder.source._build_local_package"
+                ) as mock_build,
+                patch(
+                    "dagster_cloud_cli.core.pex_builder.util.python_interpreter_for"
+                ) as mock_interp,
+                patch("dagster_cloud_cli.core.pex_builder.source._prepare_working_directory"),
+                patch("dagster_cloud_cli.core.pex_builder.util.get_pex_flags") as mock_pex_flags,
+                patch("dagster_cloud_cli.core.pex_builder.util.build_pex") as mock_build_pex,
+            ):
+                mock_interp.return_value = "/usr/bin/python3"
+                mock_pex_flags.return_value = []
+                mock_build_pex.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+                build_pex_using_setup_py(code_dir, [dep1_dir], "/tmp/out.pex", (3, 10))
+
+                # Detection should never be called for setup.py-only projects
+                assert mock_detect.call_count == 0
+                assert mock_build.call_count == 2  # called once for dep1_dir, once for code_dir
+
+    def test_detect_not_called_for_dual_manifest_packages(self):
+        """detect_package_manager should not be called when all pyproject.toml dirs also have setup.py.
+
+        setup.py always wins in _build_local_package, so a co-located pyproject.toml never
+        triggers the pm code path and does not need a manager to be detected upfront.
+        """
+        with (
+            tempfile.TemporaryDirectory() as code_dir,
+            tempfile.TemporaryDirectory() as dep1_dir,
+        ):
+            # Both dirs have BOTH setup.py and pyproject.toml — setup.py should win
+            for d in (code_dir, dep1_dir):
+                with open(os.path.join(d, "setup.py"), "w") as f:
+                    f.write("from setuptools import setup\nsetup(name='test')")
+                with open(os.path.join(d, "pyproject.toml"), "w") as f:
+                    f.write("[project]\nname='test'")
+
+            with (
+                patch(
+                    "dagster_cloud_cli.core.pex_builder.source.detect_package_manager"
+                ) as mock_detect,
+                patch(
+                    "dagster_cloud_cli.core.pex_builder.source._build_local_package"
+                ) as mock_build,
+                patch(
+                    "dagster_cloud_cli.core.pex_builder.util.python_interpreter_for"
+                ) as mock_interp,
+                patch("dagster_cloud_cli.core.pex_builder.source._prepare_working_directory"),
+                patch("dagster_cloud_cli.core.pex_builder.util.get_pex_flags") as mock_pex_flags,
+                patch("dagster_cloud_cli.core.pex_builder.util.build_pex") as mock_build_pex,
+            ):
+                mock_interp.return_value = "/usr/bin/python3"
+                mock_pex_flags.return_value = []
+                mock_build_pex.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+                build_pex_using_setup_py(code_dir, [dep1_dir], "/tmp/out.pex", (3, 10))
+
+                # Detection should NOT be called: pyproject.toml dirs all have co-located setup.py
+                assert mock_detect.call_count == 0
+                assert mock_build.call_count == 2

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/test_pyproject_toml_support.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli_tests/test_pyproject_toml_support.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from dagster_cloud_cli.commands.serverless import _check_source_directory
 from dagster_cloud_cli.core.pex_builder import deps, source
+from dagster_cloud_cli.core.pex_builder.package_manager import PackageManager
 from dagster_cloud_cli.ui import ExitWithMessage
 from packaging import version
 
@@ -163,9 +164,11 @@ dependencies = ["requests>=2.25.0"]
 
 
 @patch("subprocess.run")
-def test_build_local_package_with_pyproject_toml(mock_run, temp_dir):
+@patch("dagster_cloud_cli.core.pex_builder.source.detect_package_manager")
+def test_build_local_package_with_pyproject_toml(mock_detect_package_manager, mock_run, temp_dir):
     """Test building a package with pyproject.toml."""
     mock_run.return_value = None
+    mock_detect_package_manager.return_value = PackageManager("pip", "python", "python")
 
     pyproject_path = Path(temp_dir) / "pyproject.toml"
     pyproject_path.write_text("""
@@ -179,8 +182,9 @@ version = "0.1.0"
 
     source._build_local_package(temp_dir, str(build_dir), "python")  # noqa: SLF001
 
+    mock_detect_package_manager.assert_called_once_with("python")
     mock_run.assert_called_once()
-    args, _kwargs = mock_run.call_args
+    args, kwargs = mock_run.call_args
     command = args[0]
 
     expected_command = [
@@ -194,6 +198,10 @@ version = "0.1.0"
         ".",
     ]
     assert command == expected_command
+    assert kwargs["check"] is True
+    assert kwargs["cwd"] == temp_dir
+    assert kwargs["capture_output"] is True
+    assert kwargs["text"] is True
 
 
 @patch("subprocess.run")
@@ -218,11 +226,15 @@ name = "test-package"
 
     # Should use setup.py, not pyproject.toml
     mock_run.assert_called_once()
-    args, _ = mock_run.call_args
+    args, kwargs = mock_run.call_args
     command = args[0]
 
     expected_command = ["python", "setup.py", "build", "--build-lib", str(build_dir)]
     assert command == expected_command
+    assert kwargs["check"] is True
+    assert kwargs["cwd"] == temp_dir
+    assert kwargs["capture_output"] is True
+    assert kwargs["text"] is True
 
 
 @patch("dagster_cloud_cli.ui.warn")


### PR DESCRIPTION
## Summary & Motivation

This PR resolves an issue in `dg plus deploy --build-strategy python-executable` where deployments fail in environments managed by `uv`. The current implementation of the PEX builder assumes that `pip` is always available in the target Python interpreter's virtual environment. However, `uv`-managed environments often omit `pip` by default.

To fix this, I've introduced a deterministic package manager detection utility (`PackageManager`). The builder now:
1.  Attempts to use `pip` in the target interpreter for best compatibility.
2.  Falls back to `uv pip` if `pip` is missing but `uv` is available on the system.
3.  Provides clear, actionable error messages if neither is available.

This ensures a seamless experience for `uv` users while maintaining strict backward compatibility for standard `pip` environments.

## Test Plan

- **Unit Tests**: Added `dagster_cloud_cli_tests/pex_builder_tests/test_package_manager.py` to verify the detection logic and command construction across various environment states (pip available, pip missing, uv fallback).
- **Integration Tests**: Added `dagster_cloud_cli_tests/pex_builder_tests/test_build_local_package_integration.py` which performs end-to-end building of local packages in real `venv` and `uv` environments.

## Changelog

[dagster-cloud-cli] Fix deployment failures in uv-managed environments by adding automatic uv fallback for local package building.
