### PR TITLE
chore: include `yarn lint` in docs buildkite step

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
@@ -33,6 +33,7 @@ def build_build_docs_step(ctx: BuildkiteContext) -> GroupLeafStepConfiguration:
             f'pip install -U "{UV_PIN}"',
             "yarn install",
             "yarn test",
+            "yarn lint",
             "yarn build-api-docs",
             "yarn build",
         )

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/docs.py
@@ -33,7 +33,7 @@ def build_build_docs_step(ctx: BuildkiteContext) -> GroupLeafStepConfiguration:
             f'pip install -U "{UV_PIN}"',
             "yarn install",
             "yarn test",
-            "yarn lint",
+            "yarn lint-check",
             "yarn build-api-docs",
             "yarn build",
         )

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "ts": "tsc -p . --noEmit",
     "vale": "vale ./docs --ext=.md,.mdx",
     "lint": "eslint . --ext=.tsx,.ts,.js,.md,.mdx --ignore-pattern 'node_modules/*' --ignore-pattern 'versioned_docs/*' --ignore-pattern 'versioned_sidebars/*' --fix",
+    "lint-check": "eslint . --ext=.tsx,.ts,.js,.md,.mdx --ignore-pattern 'node_modules/*' --ignore-pattern 'versioned_docs/*' --ignore-pattern 'versioned_sidebars/*'",
     "lint-and-vale": "yarn run lint && yarn run vale",
     "generate-code-imports": "node scripts/generate-code-imports.js",
     "build-kinds-tags": "./scripts/build-kinds-tags.sh",


### PR DESCRIPTION
## Summary & Motivation

Was requested to include this as there is a discrepancy in deployment GHA and what is validated in buildkite.

https://github.com/dagster-io/internal/blob/master/.github/workflows/build-docs.yml#L86-L90

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
