### PR TITLE
[ui] Fix tag filter parsing for values containing = signs

### DIFF
--- a/js_modules/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/ui-core/src/runs/RunsFilterInput.tsx
@@ -34,6 +34,18 @@ import {TimeRangeState, useTimeRangeFilter} from '../ui/BaseFilters/useTimeRange
 import {TruncatedTextWithFullTextOnHover} from '../ui/TruncatedTextWithFullTextOnHover';
 import {useRepositoryOptions} from '../workspace/WorkspaceContext/util';
 
+/**
+ * Split a tag string on the first `=` only, so tag values containing `=` are preserved.
+ * Returns [key, value] where value defaults to '' if no `=` is present.
+ */
+export function splitTagString(tagStr: string): [string, string] {
+  const eqIndex = tagStr.indexOf('=');
+  if (eqIndex === -1) {
+    return [tagStr, ''];
+  }
+  return [tagStr.slice(0, eqIndex), tagStr.slice(eqIndex + 1)];
+}
+
 export interface RunsFilterInputProps {
   loading?: boolean;
   tokens: RunFilterToken[];
@@ -157,15 +169,11 @@ export function runsFilterForSearchTokens(search: TokenizingFieldValue[]) {
     } else if (item.token === 'snapshotId') {
       obj.snapshotId = item.value;
     } else if (item.token === 'tag') {
-      const eqIndex = item.value.indexOf('=');
-      const key = eqIndex === -1 ? item.value : item.value.slice(0, eqIndex);
-      const value = eqIndex === -1 ? '' : item.value.slice(eqIndex + 1);
+      const [key, value] = splitTagString(item.value);
       if (obj.tags) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        obj.tags.push({key: key!, value});
+        obj.tags.push({key, value});
       } else {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        obj.tags = [{key: key!, value}];
+        obj.tags = [{key, value}];
       }
     }
   }
@@ -644,9 +652,8 @@ export const useRunsFilterInput = ({tokens, onChange, enabledFilters}: RunsFilte
           return !tagsToExclude.includes(value.split('=')[0] as DagsterTag);
         })
         .map((token) => {
-          const [key, value] = token.value.split('=');
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return tagSuggestionValueObject(key!, value!).value;
+          const [key, value] = splitTagString(token.value);
+          return tagSuggestionValueObject(key, value).value;
         });
     }, [tokens]),
 
@@ -780,11 +787,11 @@ function tagToFilterValue(key: string, value: string) {
 
 // Memoize this object because the static set filter component checks for object equality (set.has)
 export const tagValueToFilterObject = memoize((value: string) => {
-  const eqIndex = value.indexOf('=');
+  const [type, tagValue] = splitTagString(value);
   return {
     key: value,
-    type: (eqIndex === -1 ? value : value.slice(0, eqIndex)) as DagsterTag,
-    value: eqIndex === -1 ? '' : value.slice(eqIndex + 1),
+    type: type as DagsterTag,
+    value: tagValue,
   };
 });
 

--- a/js_modules/ui-core/src/runs/__tests__/RunFilterInput.test.tsx
+++ b/js_modules/ui-core/src/runs/__tests__/RunFilterInput.test.tsx
@@ -21,6 +21,7 @@ import {
   RunFilterToken,
   RunsFilterInputProps,
   runsFilterForSearchTokens,
+  splitTagString,
   tagSuggestionValueObject,
   tagValueToFilterObject,
   useRunsFilterInput,
@@ -113,6 +114,31 @@ describe('useTagDataFilterValues', () => {
         },
       ]);
     });
+  });
+});
+
+describe('splitTagString', () => {
+  it('should split on the first = only', () => {
+    expect(splitTagString('foo=bar')).toEqual(['foo', 'bar']);
+  });
+
+  it('should preserve = signs in the value', () => {
+    expect(splitTagString('dagster/partition=foo=bar/baz=qux')).toEqual([
+      'dagster/partition',
+      'foo=bar/baz=qux',
+    ]);
+  });
+
+  it('should return empty value when no = is present', () => {
+    expect(splitTagString('just-a-key')).toEqual(['just-a-key', '']);
+  });
+
+  it('should handle = as the last character', () => {
+    expect(splitTagString('key=')).toEqual(['key', '']);
+  });
+
+  it('should handle = as the first character', () => {
+    expect(splitTagString('=value')).toEqual(['', 'value']);
   });
 });
 


### PR DESCRIPTION
## Summary & Motivation

Tag values containing `=` characters (e.g. hive-style partition keys like `program=foo/project=bar`) are truncated at the first `=` when parsed into filter objects. This causes "Add tag to filter" on the Runs page to produce incorrect filters that match no runs.

The root cause is `split('=')` without limiting to the first occurrence in both `tagValueToFilterObject` and `runsFilterForSearchTokens`. Replaced with `indexOf`/`slice` to split only on the first `=`, preserving the full tag value.

## How I Tested These Changes

- Added unit tests for `tagValueToFilterObject` and `runsFilterForSearchTokens` covering tag values with multiple `=` signs
- Verified all existing tests continue to pass (`yarn jest` — 150 suites, 1244 tests passed)
- `yarn tsgo` and `yarn lint` pass with no errors
- Manually tested in the Dagster UI with a run tagged `dagster/partition=foo=bar/baz=qux`