### PR TITLE
[dagster-databricks] Fix run_multi_task() file collision and premature stream closure

### DIFF
--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -1,4 +1,5 @@
 import sys
+import threading
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -85,6 +86,7 @@ class PipesMessageHandler:
         self,
         context: OpExecutionContext | AssetExecutionContext,
         message_reader: "PipesMessageReader",
+        expected_closed_messages: int = 1,
     ) -> None:
         self._context = context
         self._message_reader = message_reader
@@ -96,6 +98,11 @@ class PipesMessageHandler:
         self._messages_include_stdio_logs = False
         self._received_closed_msg = False
         self._opened_payload: PipesOpenedData | None = None
+        # Multi-task support: track how many "closed" messages are expected (one per task).
+        # Protected by _closed_lock because _handle_closed may be called from N reader threads.
+        self._expected_closed_message_count: int = expected_closed_messages
+        self._received_closed_count: int = 0
+        self._closed_lock: threading.Lock = threading.Lock()
 
     @contextmanager
     def handle_messages(self) -> Iterator[PipesParams]:
@@ -152,7 +159,10 @@ class PipesMessageHandler:
         self._message_reader.on_opened(opened_payload)
 
     def _handle_closed(self, params: Mapping[str, Any] | None) -> None:
-        self._received_closed_msg = True
+        with self._closed_lock:
+            self._received_closed_count += 1
+            if self._received_closed_count >= self._expected_closed_message_count:
+                self._received_closed_msg = True
         if params and "exception" in params:
             err_info = _ser_err_from_pipes_exc(params["exception"])
             # report as an engine event to provide structured exception data

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -727,6 +727,7 @@ def open_pipes_session(
     context_injector: PipesContextInjector,
     message_reader: PipesMessageReader,
     extras: PipesExtras | None = None,
+    expected_closed_messages: int = 1,
 ) -> Iterator[PipesSession]:
     """Context manager that opens and closes a pipes session.
 
@@ -780,7 +781,9 @@ def open_pipes_session(
         context.set_requires_typed_event_stream(error_message=_FAIL_TO_YIELD_ERROR_MESSAGE)
 
     context_data = build_external_execution_context_data(context, extras)
-    message_handler = PipesMessageHandler(context, message_reader)
+    message_handler = PipesMessageHandler(
+        context, message_reader, expected_closed_messages=expected_closed_messages
+    )
     try:
         with (
             context_injector.inject_context(context_data) as ci_params,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -8,6 +8,7 @@ import sys
 import time
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import ExitStack, contextmanager
+from threading import Event, Thread
 from typing import Any, Literal, TextIO
 
 import dagster._check as check
@@ -23,14 +24,24 @@ from dagster._core.pipes.client import (
     PipesContextInjector,
     PipesMessageReader,
 )
-from dagster._core.pipes.context import PipesSession
+from dagster._core.pipes.context import PipesMessageHandler, PipesSession
 from dagster._core.pipes.utils import (
     PipesBlobStoreMessageReader,
     PipesChunkedLogReader,
     PipesLogReader,
+    _join_thread,
     open_pipes_session,
 )
-from dagster_pipes import PipesBlobStoreMessageWriter, PipesContextData, PipesExtras, PipesParams
+from dagster_pipes import (
+    DAGSTER_PIPES_CONTEXT_ENV_VAR,
+    DAGSTER_PIPES_MESSAGES_ENV_VAR,
+    PipesBlobStoreMessageWriter,
+    PipesContextData,
+    PipesExtras,
+    PipesParams,
+    _env_var_to_cli_argument,
+    encode_param,
+)
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import files, jobs
 from pydantic import Field
@@ -159,10 +170,13 @@ class BasePipesDatabricksClient(PipesClient):
             message_reader=message_reader,
         ) as pipes_session:
             enriched_tasks = []
-            for task in tasks:
+            for i, task in enumerate(tasks):
                 submit_task_dict = task.as_dict()
                 submit_task_dict = self._enrich_submit_task_dict(
-                    context=context, session=pipes_session, submit_task_dict=submit_task_dict
+                    context=context,
+                    session=pipes_session,
+                    submit_task_dict=submit_task_dict,
+                    task_index=i,
                 )
                 enriched_tasks.append(jobs.SubmitTask.from_dict(submit_task_dict))
 
@@ -189,6 +203,7 @@ class BasePipesDatabricksClient(PipesClient):
         context: OpExecutionContext | AssetExecutionContext,
         session: PipesSession,
         submit_task_dict: dict[str, Any],
+        task_index: int | None = None,
     ) -> dict[str, Any]:
         raise NotImplementedError()
 
@@ -398,6 +413,7 @@ class PipesDatabricksClient(BasePipesDatabricksClient, TreatAsResourceParam):
         context: OpExecutionContext | AssetExecutionContext,
         session: PipesSession,
         submit_task_dict: dict[str, Any],
+        task_index: int | None = None,
     ) -> dict[str, Any]:
         if "existing_cluster_id" in submit_task_dict:
             # we can't set env vars on an existing cluster
@@ -788,14 +804,42 @@ class PipesDatabricksServerlessClient(BasePipesDatabricksClient, TreatAsResource
         message_reader = self.message_reader or PipesUnityCatalogVolumesMessageReader(
             client=self.client,
             volume_path=self.volume_path,
+            num_tasks=len(tasks),
         )
-        return self._submit_multi_task_and_poll(
+        with open_pipes_session(
             context=context,
             extras=extras,
-            tasks=tasks,
-            submit_args=submit_args,
             context_injector=context_injector,
             message_reader=message_reader,
+            expected_closed_messages=len(tasks),
+        ) as pipes_session:
+            enriched_tasks = []
+            for i, task in enumerate(tasks):
+                submit_task_dict = task.as_dict()
+                submit_task_dict = self._enrich_submit_task_dict(
+                    context=context,
+                    session=pipes_session,
+                    submit_task_dict=submit_task_dict,
+                    task_index=i,
+                )
+                enriched_tasks.append(jobs.SubmitTask.from_dict(submit_task_dict))
+
+            run_id = self.client.jobs.submit(
+                tasks=enriched_tasks,
+                **(submit_args or {}),
+            ).bind()["run_id"]
+
+            try:
+                self._poll_til_success(context, run_id)
+            except DagsterExecutionInterruptedError as e:
+                if self.forward_termination:
+                    context.log.info("[pipes] execution interrupted, canceling Databricks job.")
+                    self.client.jobs.cancel_run(run_id)
+                    self._poll_til_terminating(run_id)
+                raise e
+
+        return PipesClientCompletedInvocation(
+            pipes_session, metadata=self._extract_dagster_metadata(run_id)
         )
 
     def _enrich_submit_task_dict(
@@ -803,16 +847,38 @@ class PipesDatabricksServerlessClient(BasePipesDatabricksClient, TreatAsResource
         context: OpExecutionContext | AssetExecutionContext,
         session: PipesSession,
         submit_task_dict: dict[str, Any],
+        task_index: int | None = None,
     ) -> dict[str, Any]:
+        # When running multi-task, assign each task its own subdirectory so that their
+        # {counter}.json files don't collide (each writer starts its counter at 1).
+        bootstrap_env_vars = dict(session.get_bootstrap_env_vars())
+        if task_index is not None:
+            task_msg_params = {
+                **session.message_reader_params,
+                "path": f"{session.message_reader_params['path']}/task_{task_index}",
+            }
+            bootstrap_env_vars[DAGSTER_PIPES_MESSAGES_ENV_VAR] = encode_param(task_msg_params)
+
         if "notebook_task" in submit_task_dict:
             existing_params = submit_task_dict["notebook_task"].get("base_parameters", {})
 
-            # merge the existing parameters with the CLI arguments
-            existing_params = {**existing_params, **session.get_bootstrap_env_vars()}
+            # merge the existing parameters with the bootstrap arguments
+            existing_params = {**existing_params, **bootstrap_env_vars}
 
             submit_task_dict["notebook_task"]["base_parameters"] = existing_params
         else:
-            cli_args = session.get_bootstrap_cli_arguments()  # this is a mapping
+            # Rebuild CLI args using the (possibly overridden) per-task message path.
+            if task_index is not None:
+                cli_args = {
+                    _env_var_to_cli_argument(DAGSTER_PIPES_CONTEXT_ENV_VAR): encode_param(
+                        session.context_injector_params
+                    ),
+                    _env_var_to_cli_argument(DAGSTER_PIPES_MESSAGES_ENV_VAR): encode_param(
+                        task_msg_params  # pyright: ignore[reportPossiblyUnboundVariable]
+                    ),
+                }
+            else:
+                cli_args = session.get_bootstrap_cli_arguments()
 
             for task_type in self.get_task_fields_which_support_cli_parameters():
                 if task_type in submit_task_dict:
@@ -931,10 +997,12 @@ class PipesUnityCatalogVolumesMessageReader(PipesBlobStoreMessageReader):
         client: WorkspaceClient,
         volume_path: str,
         include_stdio_in_messages: bool = True,
+        num_tasks: int = 1,
     ):
         self.include_stdio_in_messages = check.bool_param(
             include_stdio_in_messages, "include_stdio_in_messages"
         )
+        self.num_tasks = check.int_param(num_tasks, "num_tasks")
 
         super().__init__(
             interval=interval,
@@ -946,13 +1014,62 @@ class PipesUnityCatalogVolumesMessageReader(PipesBlobStoreMessageReader):
     def get_params(self) -> Iterator[PipesParams]:
         with ExitStack() as stack:
             params: PipesParams = {}
-            params["path"] = stack.enter_context(
-                volumes_tempdir(self.files_client, self.volume_path)
-            )
+            base_path = stack.enter_context(volumes_tempdir(self.files_client, self.volume_path))
+            params["path"] = base_path
+            if self.num_tasks > 1:
+                # Pre-create per-task subdirectories so writers can start immediately.
+                # Each task writes {index}.json starting from 1; without isolation the counters
+                # from different tasks collide in the same directory.
+                task_paths = []
+                for i in range(self.num_tasks):
+                    task_dir = f"{base_path}/task_{i}"
+                    self.files_client.create_directory(task_dir)
+                    task_paths.append(task_dir)
+                params["task_paths"] = task_paths
             params[PipesBlobStoreMessageWriter.INCLUDE_STDIO_IN_MESSAGES_KEY] = (
                 self.include_stdio_in_messages
             )
             yield params
+
+    @contextmanager
+    def read_messages(
+        self,
+        handler: "PipesMessageHandler",
+    ) -> Iterator[PipesParams]:
+        if self.num_tasks <= 1:
+            with super().read_messages(handler) as params:
+                yield params
+            return
+
+        # Multi-task: spawn one message thread + one log thread per task directory so each
+        # task's numbered chunks are read independently without counter collisions.
+        with self.get_params() as params:
+            is_session_closed = Event()
+            threads: list[tuple[str, Thread]] = []
+            try:
+                for task_path in params["task_paths"]:
+                    task_params = {**params, "path": task_path}
+                    msg_thread = Thread(
+                        target=self._messages_thread,
+                        args=(handler, task_params, is_session_closed),
+                        daemon=True,
+                    )
+                    msg_thread.start()
+                    threads.append(("messages", msg_thread))
+
+                    log_thread = Thread(
+                        target=self._logs_thread,
+                        args=(handler, task_params, is_session_closed, msg_thread),
+                        daemon=True,
+                    )
+                    log_thread.start()
+                    threads.append(("logs", log_thread))
+
+                yield params
+            finally:
+                is_session_closed.set()
+                for thread_name, t in threads:
+                    _join_thread(t, thread_name)
 
     def messages_are_readable(self, params: PipesParams) -> bool:
         """Check if the messages directory exists and is readable."""

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes_multi_task.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes_multi_task.py
@@ -1,0 +1,299 @@
+"""Unit tests for the multi-task Pipes fix (dagster-io/dagster#33700).
+
+Tests are split into two groups:
+  Group A — PipesMessageHandler (dagster core, no Databricks dependency)
+  Group B — Databricks-specific classes (pipes.py loaded directly to bypass
+             the full dagster_databricks package init chain)
+"""
+
+import importlib.util
+import sys
+import threading
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+# ---------------------------------------------------------------------------
+# Load dagster_databricks.pipes module directly, bypassing __init__.py.
+# This avoids the pyspark / dagster_pyspark chain that is not installed in
+# pure unit-test environments.
+# ---------------------------------------------------------------------------
+_PIPES_PY = Path(__file__).parent.parent / "dagster_databricks" / "pipes.py"
+
+
+# Pre-populate sys.modules with stubs for the databricks SDK which is not
+# installed in pure unit-test environments.
+def _stub(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    # Return a MagicMock for any undefined attribute so that type annotations
+    # like `jobs.RunState` and `files.FilesAPI` resolve without error.
+    mod.__getattr__ = lambda attr: MagicMock()  # type: ignore[method-assign]
+    sys.modules[name] = mod
+    return mod
+
+
+for _n in (
+    "databricks",
+    "databricks.sdk",
+    "databricks.sdk.service",
+    "databricks.sdk.service.files",
+    "databricks.sdk.service.jobs",
+):
+    if _n not in sys.modules:
+        _stub(_n)
+
+# Attach sub-namespaces so attribute access works
+sys.modules["databricks"].sdk = sys.modules["databricks.sdk"]  # type: ignore[attr-defined]
+sys.modules["databricks.sdk"].service = sys.modules["databricks.sdk.service"]  # type: ignore[attr-defined]
+sys.modules["databricks.sdk.service"].files = sys.modules["databricks.sdk.service.files"]  # type: ignore[attr-defined]
+sys.modules["databricks.sdk.service"].jobs = sys.modules["databricks.sdk.service.jobs"]  # type: ignore[attr-defined]
+sys.modules["databricks.sdk"].WorkspaceClient = MagicMock  # type: ignore[attr-defined]
+
+_PIPES_MODULE_NAME = "dagster_databricks_pipes_module"
+_spec = importlib.util.spec_from_file_location(_PIPES_MODULE_NAME, _PIPES_PY)
+assert _spec is not None
+_db_pipes = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+# Register in sys.modules so patch() can find it by name
+sys.modules[_PIPES_MODULE_NAME] = _db_pipes
+_spec.loader.exec_module(_db_pipes)  # type: ignore[union-attr]
+
+PipesDatabricksServerlessClient = _db_pipes.PipesDatabricksServerlessClient
+PipesUnityCatalogVolumesMessageReader = _db_pipes.PipesUnityCatalogVolumesMessageReader
+
+# ---------------------------------------------------------------------------
+# Standard imports (no Databricks dependency)
+# ---------------------------------------------------------------------------
+from dagster._core.pipes.context import PipesMessageHandler, PipesSession
+from dagster_pipes import (
+    DAGSTER_PIPES_MESSAGES_ENV_VAR,
+    PIPES_PROTOCOL_VERSION,
+    PIPES_PROTOCOL_VERSION_FIELD,
+    decode_param,
+    encode_param,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _closed_message() -> dict[str, Any]:
+    return {
+        PIPES_PROTOCOL_VERSION_FIELD: PIPES_PROTOCOL_VERSION,
+        "method": "closed",
+        "params": None,
+    }
+
+
+def _make_handler(expected_closed_messages: int = 1) -> PipesMessageHandler:
+    return PipesMessageHandler(
+        MagicMock(), MagicMock(), expected_closed_messages=expected_closed_messages
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group A — PipesMessageHandler: N-closed-message counting
+# ---------------------------------------------------------------------------
+
+
+def test_handler_single_task_closed_on_first_message():
+    """Default (1 task): backward compat — session closes after first 'closed'."""
+    handler = _make_handler(expected_closed_messages=1)
+    assert not handler.received_closed_message
+    handler.handle_message(_closed_message())
+    assert handler.received_closed_message
+
+
+def test_handler_multi_task_not_closed_until_all_tasks_close():
+    """3 tasks: closed only after receiving 3 'closed' messages."""
+    handler = _make_handler(expected_closed_messages=3)
+    handler.handle_message(_closed_message())
+    assert not handler.received_closed_message
+    handler.handle_message(_closed_message())
+    assert not handler.received_closed_message
+    handler.handle_message(_closed_message())
+    assert handler.received_closed_message
+
+
+def test_handler_closed_count_is_thread_safe():
+    """Concurrent 'closed' messages from N threads are counted without data races."""
+    n_tasks = 10
+    handler = _make_handler(expected_closed_messages=n_tasks)
+    barrier = threading.Barrier(n_tasks)
+
+    def send_closed():
+        barrier.wait()  # maximise contention
+        handler.handle_message(_closed_message())
+
+    threads = [threading.Thread(target=send_closed) for _ in range(n_tasks)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert handler.received_closed_message
+    assert handler._received_closed_count == n_tasks  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Group B — Databricks: per-task path injection
+# ---------------------------------------------------------------------------
+
+
+def _make_session(base_path: str) -> MagicMock:
+    session = MagicMock(spec=PipesSession)
+    session.message_reader_params = {"path": base_path}
+    session.context_injector_params = {"path": f"{base_path}/context.json"}
+    session.get_bootstrap_env_vars.return_value = {
+        DAGSTER_PIPES_MESSAGES_ENV_VAR: encode_param({"path": base_path}),
+    }
+    session.get_bootstrap_cli_arguments.return_value = {}
+    session.default_remote_invocation_info = {}
+    return session
+
+
+def _make_serverless_client() -> Any:
+    return PipesDatabricksServerlessClient.__new__(PipesDatabricksServerlessClient)
+
+
+def test_enrich_task_dict_injects_per_task_path_notebook():
+    """Each task's notebook_task params must point to its own task_{i} subdirectory."""
+    client = _make_serverless_client()
+    session = _make_session("/Volumes/base/tmp/ABC")
+
+    for i in range(3):
+        task_dict: dict[str, Any] = {"notebook_task": {"base_parameters": {}}}
+        result = client._enrich_submit_task_dict(  # noqa: SLF001
+            context=MagicMock(), session=session, submit_task_dict=task_dict, task_index=i
+        )
+        injected = decode_param(
+            result["notebook_task"]["base_parameters"][DAGSTER_PIPES_MESSAGES_ENV_VAR]
+        )
+        assert injected["path"] == f"/Volumes/base/tmp/ABC/task_{i}"
+
+
+def test_enrich_task_dict_without_task_index_uses_shared_path():
+    """task_index=None (single-task) leaves the shared base path unchanged."""
+    client = _make_serverless_client()
+    session = _make_session("/Volumes/base/tmp/ABC")
+
+    task_dict: dict[str, Any] = {"notebook_task": {"base_parameters": {}}}
+    result = client._enrich_submit_task_dict(  # noqa: SLF001
+        context=MagicMock(), session=session, submit_task_dict=task_dict, task_index=None
+    )
+    injected = decode_param(
+        result["notebook_task"]["base_parameters"][DAGSTER_PIPES_MESSAGES_ENV_VAR]
+    )
+    assert injected["path"] == "/Volumes/base/tmp/ABC"
+
+
+def test_enrich_task_dict_all_paths_unique():
+    """No two tasks must receive the same message directory path."""
+    client = _make_serverless_client()
+    session = _make_session("/Volumes/base")
+    paths: set[str] = set()
+
+    for i in range(5):
+        task_dict: dict[str, Any] = {"notebook_task": {"base_parameters": {}}}
+        result = client._enrich_submit_task_dict(  # noqa: SLF001
+            context=MagicMock(), session=session, submit_task_dict=task_dict, task_index=i
+        )
+        path = decode_param(
+            result["notebook_task"]["base_parameters"][DAGSTER_PIPES_MESSAGES_ENV_VAR]
+        )["path"]
+        assert path not in paths, f"Duplicate path: {path}"
+        paths.add(path)
+
+
+# ---------------------------------------------------------------------------
+# Group B — Databricks: PipesUnityCatalogVolumesMessageReader
+# ---------------------------------------------------------------------------
+
+
+def _make_reader(num_tasks: int) -> Any:
+    reader = PipesUnityCatalogVolumesMessageReader.__new__(PipesUnityCatalogVolumesMessageReader)
+    reader.num_tasks = num_tasks
+    reader.include_stdio_in_messages = True
+    reader.volume_path = "/Volumes/test"
+    reader.files_client = MagicMock()
+    reader.interval = 10
+    reader.log_readers = {}
+    reader.opened_payload = None
+    reader.launched_payload = None
+    reader.counter = 1
+    return reader
+
+
+def test_reader_get_params_creates_task_subdirs():
+    """get_params() creates task_{i} subdirectories and returns their paths when num_tasks > 1."""
+    reader = _make_reader(num_tasks=3)
+    base_path = "/Volumes/test/tmp/XYZ"
+
+    @contextmanager
+    def fake_volumes_tempdir(files_client, volume_path):
+        yield base_path
+
+    with patch(f"{_db_pipes.__name__}.volumes_tempdir", fake_volumes_tempdir):
+        with reader.get_params() as params:
+            assert params["path"] == base_path
+            assert params["task_paths"] == [
+                f"{base_path}/task_0",
+                f"{base_path}/task_1",
+                f"{base_path}/task_2",
+            ]
+            reader.files_client.create_directory.assert_has_calls(
+                [
+                    call(f"{base_path}/task_0"),
+                    call(f"{base_path}/task_1"),
+                    call(f"{base_path}/task_2"),
+                ],
+                any_order=False,
+            )
+
+
+def test_reader_get_params_no_task_paths_for_single_task():
+    """Single-task path: task_paths key must NOT be added (backward compat)."""
+    reader = _make_reader(num_tasks=1)
+
+    @contextmanager
+    def fake_volumes_tempdir(files_client, volume_path):
+        yield "/Volumes/test/tmp/SINGLE"
+
+    with patch(f"{_db_pipes.__name__}.volumes_tempdir", fake_volumes_tempdir):
+        with reader.get_params() as params:
+            assert "task_paths" not in params
+
+
+def test_reader_read_messages_spawns_n_thread_pairs():
+    """read_messages() starts 2*N daemon threads (1 message + 1 log per task) for num_tasks > 1."""
+    reader = _make_reader(num_tasks=3)
+    base_path = "/Volumes/test/tmp/MT"
+    task_paths = [f"{base_path}/task_{i}" for i in range(3)]
+
+    handler = MagicMock()
+    handler.received_closed_message = True  # threads exit immediately
+
+    @contextmanager
+    def fake_volumes_tempdir(files_client, volume_path):
+        yield base_path
+
+    with (
+        patch(f"{_db_pipes.__name__}.volumes_tempdir", fake_volumes_tempdir),
+        patch.object(reader, "_messages_thread", side_effect=lambda *a, **kw: None) as mock_msg,
+        patch.object(reader, "_logs_thread", side_effect=lambda *a, **kw: None) as mock_log,
+        patch(f"{_db_pipes.__name__}._join_thread"),
+    ):
+        with reader.read_messages(handler):
+            pass
+
+    assert mock_msg.call_count == 3
+    assert mock_log.call_count == 3
+
+    # Each call used a distinct task path
+    msg_paths = {
+        c.args[1]["path"] if c.args else c.kwargs["params"]["path"] for c in mock_msg.call_args_list
+    }
+    assert msg_paths == set(task_paths)


### PR DESCRIPTION
## Summary

Fixes #33700

Two independent bugs caused metadata/logs from tasks 2+ to be silently dropped when using `PipesDatabricksServerlessClient.run_multi_task()` with `implicit_materialization=False`:

**Root Cause 1 — File counter collision**

All tasks shared the same Unity Catalog Volumes directory and each independently started their `{index}.json` counter at 1. Task N's `1.json`, `2.json`, etc. collided with files already consumed (or overwritten) by task 0. Fixed by injecting a per-task subdirectory (`task_{i}/`) into each task's `DAGSTER_PIPES_MESSAGES_ENV_VAR` bootstrap params so each writer has an isolated namespace.

**Root Cause 2 — Premature reader thread exit**

`PipesThreadedMessageReader._messages_thread()` exits as soon as `handler.received_closed_message` is `True`. With N tasks, task 0's `"closed"` message triggered this immediately, dropping all of task 1..N's messages. Fixed by counting N expected `"closed"` messages (one per task) in `PipesMessageHandler` before marking the session closed. The counter increment is protected by `threading.Lock` to prevent data races under concurrent task completion.

**Changes**

- `PipesMessageHandler` (`context.py`): new `expected_closed_messages` param (default `1`, backward-compatible); thread-safe count-based closed tracking via `threading.Lock`
- `open_pipes_session` (`utils.py`): forwards `expected_closed_messages` to `PipesMessageHandler`
- `PipesDatabricksServerlessClient.run_multi_task()` (`dagster_databricks/pipes.py`): passes `num_tasks=len(tasks)` to the reader and `expected_closed_messages=len(tasks)` to `open_pipes_session`; injects per-task subdirectory path via `_enrich_submit_task_dict(..., task_index=i)`
- `PipesUnityCatalogVolumesMessageReader`: new `num_tasks` param; `get_params()` pre-creates `task_{i}/` subdirs; `read_messages()` spawns N message+log thread pairs for multi-task

All changes are scoped to the serverless client. The DBFS client and every single-task code path are unchanged (all new parameters default to `1`).

## Test Plan

- [x] 9 new unit tests in `test_pipes_multi_task.py` covering:
  - `PipesMessageHandler` counts N closed messages correctly (thread-safety verified with 10 concurrent threads)
  - Per-task path injection produces unique, non-colliding paths
  - `PipesUnityCatalogVolumesMessageReader.get_params()` creates correct task subdirs
  - `read_messages()` spawns exactly N message+log thread pairs
  - All single-task defaults unchanged (backward compat)
- [ ] Manual integration test: 3-task serverless job with `implicit_materialization=False` — all 3 `MaterializeResult` objects present in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)