### PR TITLE
dagstermill: add html output option for notebook assets

### DIFF
--- a/docs/docs/integrations/libraries/jupyter/reference.md
+++ b/docs/docs/integrations/libraries/jupyter/reference.md
@@ -14,7 +14,20 @@ To load a Jupyter notebook as a Dagster [asset](/guides/build/assets/defining-as
 
 <CodeExample path="docs_snippets/docs_snippets/integrations/dagstermill/iris_notebook_asset.py" />
 
-In this code block, we use `define_dagstermill_asset` to create a Dagster asset. We provide the name for the asset with the `name` parameter and the path to our `.ipynb` file with the `notebook_path` parameter. The resulting asset will execute our notebook and store the resulting `.ipynb` file in a persistent location.
+In this code block, we use `define_dagstermill_asset` to create a Dagster asset. We provide the name for the asset with the `name` parameter and the path to our `.ipynb` file with the `notebook_path` parameter. By default, the resulting asset will execute our notebook and store the resulting `.ipynb` file in a persistent location.
+
+If you want to persist a rendered HTML report instead of the executed notebook, set `output_notebook_format="html"`. You can also set `output_notebook_html_no_input=True` to omit code cell inputs from the rendered HTML:
+
+```python
+report_asset = define_dagstermill_asset(
+    name="daily_report",
+    notebook_path=file_relative_path(__file__, "notebooks/daily_report.ipynb"),
+    output_notebook_format="html",
+    output_notebook_html_no_input=True,
+)
+```
+
+When HTML output is enabled, Dagster stores the rendered `.html` artifact through the configured `output_notebook_io_manager`. In the built-in local IO manager, the materialization metadata points to the rendered HTML file instead of using the notebook preview flow in the Dagster UI.
 
 ## Notebooks as ops
 

--- a/docs/docs/integrations/libraries/jupyter/using-notebooks-with-dagster.md
+++ b/docs/docs/integrations/libraries/jupyter/using-notebooks-with-dagster.md
@@ -124,6 +124,8 @@ Using `define_dagstermill_asset`, we've created and returned a Dagster asset. Le
 
 When materialized, the `iris_kmeans_jupyter` asset will execute the notebook (`/notebooks/iris-kmeans.ipynb`) and store the resulting `.ipynb` file in a persistent location.
 
+If you want a notebook asset to persist a rendered HTML report instead, set `output_notebook_format="html"` on `define_dagstermill_asset`. You can optionally combine it with `output_notebook_html_no_input=True` to hide code cell inputs in the rendered report. This is useful when you want a browser-friendly artifact for sharing or remote storage rather than the executed notebook preview in Dagster.
+
 ## Step 3: Add a Dagster Definitions object and supply an I/O manager
 
 We want to execute our Dagster asset and save the resulting notebook to a persistent location. This is called materializing the asset and to do this, we need to add the asset to a Dagster <PyObject section="definitions" module="dagster" object="Definitions" /> object.

--- a/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
@@ -60,16 +60,18 @@ def _make_dagstermill_asset_compute_fn(
                 output_notebook_dir=output_notebook_dir,
             )
 
+            output_nb_node = nbformat.read(executed_notebook_path, as_version=4)
+
             yield Output(
                 serialize_notebook_artifact(
                     executed_notebook_path,
                     output_notebook_format,
                     html_no_input=output_notebook_html_no_input,
+                    notebook_node=output_nb_node,
                 ),
                 metadata={SERIALIZED_ARTIFACT_TYPE_METADATA_KEY: output_notebook_format},
             )
 
-            output_nb_node = nbformat.read(executed_notebook_path, as_version=4)
             if "scrapbook" not in output_nb_node.metadata:
                 return
 

--- a/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Iterable, Mapping
 from typing import Any, cast
 
 import dagster._check as check
+import nbformat
 from dagster import (
     AssetIn,
     AssetKey,
@@ -25,13 +26,22 @@ from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.storage.tags import COMPUTE_KIND_TAG
 from dagster._utils.tags import normalize_tags
 
-from dagstermill.factory import _clean_path_for_windows, execute_notebook
+from dagstermill.factory import (
+    SERIALIZED_ARTIFACT_HTML,
+    SERIALIZED_ARTIFACT_NOTEBOOK,
+    SERIALIZED_ARTIFACT_TYPE_METADATA_KEY,
+    _clean_path_for_windows,
+    execute_notebook,
+    serialize_notebook_artifact,
+)
 
 
 def _make_dagstermill_asset_compute_fn(
     name: str,
     notebook_path: str,
     save_notebook_on_failure: bool,
+    output_notebook_format: str,
+    output_notebook_html_no_input: bool,
 ) -> Callable:
     def _t_fn(context: OpExecutionContext, **inputs) -> Iterable:
         check.param_invariant(
@@ -50,8 +60,18 @@ def _make_dagstermill_asset_compute_fn(
                 output_notebook_dir=output_notebook_dir,
             )
 
-            with open(executed_notebook_path, "rb") as fd:
-                yield Output(fd.read())
+            yield Output(
+                serialize_notebook_artifact(
+                    executed_notebook_path,
+                    output_notebook_format,
+                    html_no_input=output_notebook_html_no_input,
+                ),
+                metadata={SERIALIZED_ARTIFACT_TYPE_METADATA_KEY: output_notebook_format},
+            )
+
+            output_nb_node = nbformat.read(executed_notebook_path, as_version=4)
+            if "scrapbook" not in output_nb_node.metadata:
+                return
 
             # deferred import for perf
             import scrapbook
@@ -89,6 +109,8 @@ def define_dagstermill_asset(
     io_manager_key: str | None = None,
     retry_policy: RetryPolicy | None = None,
     save_notebook_on_failure: bool = False,
+    output_notebook_format: str = SERIALIZED_ARTIFACT_NOTEBOOK,
+    output_notebook_html_no_input: bool = False,
     non_argument_deps: set[AssetKey] | set[str] | None = None,
     asset_tags: Mapping[str, Any] | None = None,
 ) -> AssetsDefinition:
@@ -129,6 +151,10 @@ def define_dagstermill_asset(
         save_notebook_on_failure (bool): If True and the notebook fails during execution, the failed notebook will be
             written to the Dagster storage directory. The location of the file will be printed in the Dagster logs.
             Defaults to False.
+        output_notebook_format (str): Format to persist for the executed notebook artifact. Supported
+            values are "ipynb" and "html". Defaults to "ipynb".
+        output_notebook_html_no_input (bool): If True and output_notebook_format is "html", the
+            rendered HTML will exclude code cell inputs. Defaults to False.
         asset_tags (Optional[Dict[str, Any]]): A dictionary of tags to apply to the asset.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead. Set of asset keys that are
             upstream dependencies, but do not pass an input to the asset.
@@ -161,6 +187,16 @@ def define_dagstermill_asset(
     check.str_param(name, "name")
     check.str_param(notebook_path, "notebook_path")
     check.bool_param(save_notebook_on_failure, "save_notebook_on_failure")
+    output_notebook_format = check.str_param(output_notebook_format, "output_notebook_format")
+    check.bool_param(output_notebook_html_no_input, "output_notebook_html_no_input")
+    check.invariant(
+        output_notebook_format in {SERIALIZED_ARTIFACT_NOTEBOOK, SERIALIZED_ARTIFACT_HTML},
+        "output_notebook_format must be either 'ipynb' or 'html'.",
+    )
+    check.invariant(
+        not output_notebook_html_no_input or output_notebook_format == SERIALIZED_ARTIFACT_HTML,
+        "output_notebook_html_no_input can only be set when output_notebook_format is 'html'.",
+    )
 
     required_resource_keys = set(
         check.opt_set_param(required_resource_keys, "required_resource_keys", of_type=str)
@@ -223,5 +259,7 @@ def define_dagstermill_asset(
             name=name,
             notebook_path=notebook_path,
             save_notebook_on_failure=save_notebook_on_failure,
+            output_notebook_format=output_notebook_format,
+            output_notebook_html_no_input=output_notebook_html_no_input,
         )
     )

--- a/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
@@ -512,6 +512,13 @@ hello_world_asset = dagstermill.define_dagstermill_asset(
     name="hello_world_asset", notebook_path=nb_test_path("hello_world")
 )
 
+hello_world_html_asset = dagstermill.define_dagstermill_asset(
+    name="hello_world_html_asset",
+    notebook_path=nb_test_path("hello_world"),
+    output_notebook_format="html",
+    output_notebook_html_no_input=True,
+)
+
 
 hello_world_with_custom_tags_and_description_asset = dagstermill.define_dagstermill_asset(
     name="hello_world_custom_asset",
@@ -541,6 +548,13 @@ error_notebook_asset = dagstermill.define_dagstermill_asset(
     name="error_notebook_asset",
     notebook_path=nb_test_path("error_notebook"),
     save_notebook_on_failure=True,
+)
+
+error_notebook_html_asset = dagstermill.define_dagstermill_asset(
+    name="error_notebook_html_asset",
+    notebook_path=nb_test_path("error_notebook"),
+    save_notebook_on_failure=True,
+    output_notebook_format="html",
 )
 
 
@@ -584,6 +598,7 @@ yield_event_asset = dagstermill.define_dagstermill_asset(
 assets = with_resources(
     [
         hello_world_asset,
+        hello_world_html_asset,
         hello_world_with_custom_tags_and_description_asset,
         hello_world_config_asset,
         goodbye_config_asset,
@@ -593,6 +608,7 @@ assets = with_resources(
         add_two_number_asset,
         hello_world_resource_asset,
         error_notebook_asset,
+        error_notebook_html_asset,
         yield_event_asset,
     ],
     resource_defs={
@@ -609,6 +625,7 @@ def make_resolved_job(asset):
 
 
 hello_world_asset_job = make_resolved_job(hello_world_asset)
+hello_world_html_asset_job = make_resolved_job(hello_world_html_asset)
 hello_world_with_custom_tags_and_description_asset_job = make_resolved_job(
     hello_world_with_custom_tags_and_description_asset
 )
@@ -618,6 +635,7 @@ hello_logging_asset_job = make_resolved_job(hello_logging_asset)
 add_two_number_asset_job = make_resolved_job(add_two_number_asset)
 hello_world_resource_asset_job = make_resolved_job(hello_world_resource_asset)
 error_notebook_asset_job = make_resolved_job(error_notebook_asset)
+error_notebook_html_asset_job = make_resolved_job(error_notebook_html_asset)
 yield_event_asset_job = make_resolved_job(yield_event_asset)
 
 

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -41,6 +41,10 @@ from dagstermill.engine import DagstermillEngine
 from dagstermill.errors import DagstermillError
 from dagstermill.translator import DagsterTranslator
 
+SERIALIZED_ARTIFACT_TYPE_METADATA_KEY = "dagstermill/serialized_artifact_type"
+SERIALIZED_ARTIFACT_NOTEBOOK = "ipynb"
+SERIALIZED_ARTIFACT_HTML = "html"
+
 
 def _clean_path_for_windows(notebook_path: str) -> str:
     """In windows, the notebook can't render in the Dagster UI unless the C: prefix is removed.
@@ -162,6 +166,35 @@ def get_papermill_parameters(
     parameters["__dm_input_names"] = list(inputs.keys())
 
     return parameters
+
+
+@beta
+def serialize_notebook_artifact(
+    executed_notebook_path: str,
+    serialized_artifact_type: str,
+    html_no_input: bool = False,
+) -> bytes:
+    serialized_artifact_type = check.str_param(serialized_artifact_type, "serialized_artifact_type")
+    check.bool_param(html_no_input, "html_no_input")
+    check.invariant(
+        serialized_artifact_type in {SERIALIZED_ARTIFACT_NOTEBOOK, SERIALIZED_ARTIFACT_HTML},
+        f"Unexpected serialized artifact type '{serialized_artifact_type}'.",
+    )
+
+    if serialized_artifact_type == SERIALIZED_ARTIFACT_NOTEBOOK:
+        with open(executed_notebook_path, "rb") as notebook_file:
+            return notebook_file.read()
+
+    from nbconvert import HTMLExporter
+
+    notebook = nbformat.read(executed_notebook_path, as_version=4)
+    html_exporter = HTMLExporter()
+    if html_no_input:
+        html_exporter.exclude_input = True
+        html_exporter.exclude_input_prompt = True
+
+    html, _resources = html_exporter.from_notebook_node(notebook)
+    return html.encode("utf8")
 
 
 @beta

--- a/python_modules/libraries/dagstermill/dagstermill/factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/factory.py
@@ -173,6 +173,7 @@ def serialize_notebook_artifact(
     executed_notebook_path: str,
     serialized_artifact_type: str,
     html_no_input: bool = False,
+    notebook_node: "nbformat.NotebookNode | None" = None,
 ) -> bytes:
     serialized_artifact_type = check.str_param(serialized_artifact_type, "serialized_artifact_type")
     check.bool_param(html_no_input, "html_no_input")
@@ -187,13 +188,14 @@ def serialize_notebook_artifact(
 
     from nbconvert import HTMLExporter
 
-    notebook = nbformat.read(executed_notebook_path, as_version=4)
+    if notebook_node is None:
+        notebook_node = nbformat.read(executed_notebook_path, as_version=4)
     html_exporter = HTMLExporter()
     if html_no_input:
         html_exporter.exclude_input = True
         html_exporter.exclude_input_prompt = True
 
-    html, _resources = html_exporter.from_notebook_node(notebook)
+    html, _resources = html_exporter.from_notebook_node(notebook_node)
     return html.encode("utf8")
 
 

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -114,16 +114,10 @@ class LocalOutputNotebookIOManager(OutputNotebookIOManager):
         check.inst_param(context, "context", InputContext)
         # pass output notebook to downstream ops as File Object
         output_context = check.not_none(context.upstream_output)
-        for extension in _SERIALIZED_ARTIFACT_EXTENSION_BY_TYPE.values():
-            candidate_path = self._get_path(output_context, extension)
-            if os.path.exists(candidate_path):
-                with open(candidate_path, self.read_mode) as file_obj:
-                    return file_obj.read()
-
-        raise FileNotFoundError(
-            f"No output notebook artifact found for context {output_context}. "
-            f"Checked extensions: {list(_SERIALIZED_ARTIFACT_EXTENSION_BY_TYPE.values())}"
-        )
+        serialized_artifact_type = self._get_serialized_artifact_type(output_context)
+        extension = _SERIALIZED_ARTIFACT_EXTENSION_BY_TYPE[serialized_artifact_type]
+        with open(self._get_path(output_context, extension), self.read_mode) as file_obj:
+            return file_obj.read()
 
 
 @beta

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -120,8 +120,10 @@ class LocalOutputNotebookIOManager(OutputNotebookIOManager):
                 with open(candidate_path, self.read_mode) as file_obj:
                     return file_obj.read()
 
-        with open(self._get_path(output_context), self.read_mode) as file_obj:
-            return file_obj.read()
+        raise FileNotFoundError(
+            f"No output notebook artifact found for context {output_context}. "
+            f"Checked extensions: {list(_SERIALIZED_ARTIFACT_EXTENSION_BY_TYPE.values())}"
+        )
 
 
 @beta

--- a/python_modules/libraries/dagstermill/dagstermill/io_managers.py
+++ b/python_modules/libraries/dagstermill/dagstermill/io_managers.py
@@ -19,7 +19,21 @@ from dagster._core.storage.io_manager import dagster_maintained_io_manager, io_m
 from dagster._utils import mkdir_p
 from pydantic import Field
 
-from dagstermill.factory import _clean_path_for_windows
+from dagstermill.factory import (
+    SERIALIZED_ARTIFACT_HTML,
+    SERIALIZED_ARTIFACT_NOTEBOOK,
+    SERIALIZED_ARTIFACT_TYPE_METADATA_KEY,
+    _clean_path_for_windows,
+)
+
+_SERIALIZED_ARTIFACT_EXTENSION_BY_TYPE = {
+    SERIALIZED_ARTIFACT_NOTEBOOK: ".ipynb",
+    SERIALIZED_ARTIFACT_HTML: ".html",
+}
+_SERIALIZED_ARTIFACT_METADATA_LABEL_BY_TYPE = {
+    SERIALIZED_ARTIFACT_NOTEBOOK: "Executed notebook",
+    SERIALIZED_ARTIFACT_HTML: "Rendered notebook",
+}
 
 
 class OutputNotebookIOManager(IOManager):
@@ -40,29 +54,49 @@ class LocalOutputNotebookIOManager(OutputNotebookIOManager):
         self.write_mode = "wb"
         self.read_mode = "rb"
 
-    def _get_path(self, context: OutputContext) -> str:
+    def _get_path(self, context: OutputContext, extension: str = ".ipynb") -> str:
         """Automatically construct filepath."""
         if context.has_asset_key:
             keys = context.get_asset_identifier()
         else:
             keys = context.get_run_scoped_output_identifier()
-        return str(Path(self.base_dir, *keys).with_suffix(".ipynb"))
+        return str(Path(self.base_dir, *keys).with_suffix(extension))
+
+    def _get_serialized_artifact_type(self, context: OutputContext) -> str:
+        serialized_artifact_type = context.output_metadata.get(
+            SERIALIZED_ARTIFACT_TYPE_METADATA_KEY, SERIALIZED_ARTIFACT_NOTEBOOK
+        )
+        if isinstance(serialized_artifact_type, MetadataValue):
+            serialized_artifact_type = serialized_artifact_type.value
+        check.invariant(
+            isinstance(serialized_artifact_type, str)
+            and serialized_artifact_type in _SERIALIZED_ARTIFACT_EXTENSION_BY_TYPE,
+            f"Unexpected dagstermill artifact type '{serialized_artifact_type}'.",
+        )
+        return serialized_artifact_type
+
+    def _get_metadata(self, path: str, serialized_artifact_type: str) -> dict[str, MetadataValue]:
+        normalized_path = _clean_path_for_windows(path)
+        label = _SERIALIZED_ARTIFACT_METADATA_LABEL_BY_TYPE[serialized_artifact_type]
+        if serialized_artifact_type == SERIALIZED_ARTIFACT_NOTEBOOK:
+            return {label: MetadataValue.notebook(normalized_path)}
+
+        return {label: MetadataValue.path(normalized_path)}
 
     def handle_output(self, context: OutputContext, obj: bytes):
         """obj: bytes."""
         check.inst_param(context, "context", OutputContext)
 
         # the output notebook itself is stored at output_file_path
-        output_notebook_path = self._get_path(context)
+        serialized_artifact_type = self._get_serialized_artifact_type(context)
+        output_notebook_path = self._get_path(
+            context, _SERIALIZED_ARTIFACT_EXTENSION_BY_TYPE[serialized_artifact_type]
+        )
         mkdir_p(os.path.dirname(output_notebook_path))
         with open(output_notebook_path, self.write_mode) as dest_file_obj:
             dest_file_obj.write(obj)
 
-        metadata = {
-            "Executed notebook": MetadataValue.notebook(
-                _clean_path_for_windows(output_notebook_path)
-            )
-        }
+        metadata = self._get_metadata(output_notebook_path, serialized_artifact_type)
 
         if context.has_asset_key:
             context.add_output_metadata(metadata)
@@ -80,6 +114,12 @@ class LocalOutputNotebookIOManager(OutputNotebookIOManager):
         check.inst_param(context, "context", InputContext)
         # pass output notebook to downstream ops as File Object
         output_context = check.not_none(context.upstream_output)
+        for extension in _SERIALIZED_ARTIFACT_EXTENSION_BY_TYPE.values():
+            candidate_path = self._get_path(output_context, extension)
+            if os.path.exists(candidate_path):
+                with open(candidate_path, self.read_mode) as file_obj:
+                    return file_obj.read()
+
         with open(self._get_path(output_context), self.read_mode) as file_obj:
             return file_obj.read()
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py
@@ -2,13 +2,16 @@ import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, cast
 
+import dagstermill
 import pytest
 from dagster import AssetKey, DagsterEventType
+from dagster._check import CheckError
 from dagster._core.definitions.metadata import NotebookMetadataValue, PathMetadataValue
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.execution.api import execute_job
 from dagster._core.execution.execution_result import ExecutionResult
 from dagster._core.test_utils import instance_for_test
+from dagster._utils import file_relative_path
 from dagstermill.compat import ExecutionError
 from dagstermill.examples.repository import custom_io_mgr_key_asset
 
@@ -114,6 +117,39 @@ def test_hello_world_resource_asset():
 
 
 @pytest.mark.notebook_test
+def test_html_output_asset():
+    with exec_for_test("hello_world_html_asset_job") as result:
+        assert result.success
+
+        materializations = [
+            x for x in result.all_events if x.event_type == DagsterEventType.ASSET_MATERIALIZATION
+        ]
+        assert len(materializations) == 1
+
+        output_path = get_path(materializations[0])
+        assert output_path
+        assert output_path.endswith(".html")
+        assert os.path.exists(output_path)
+
+        with open(output_path, encoding="utf8") as html_file:
+            html = html_file.read()
+
+        assert "hello" in html
+        assert 'print("hello")' not in html
+
+
+def test_html_no_input_requires_html_output():
+    with pytest.raises(CheckError, match="output_notebook_html_no_input"):
+        dagstermill.define_dagstermill_asset(
+            name="invalid_html_asset",
+            notebook_path=file_relative_path(
+                __file__, "../dagstermill/examples/notebooks/hello_world.ipynb"
+            ),
+            output_notebook_html_no_input=True,
+        )
+
+
+@pytest.mark.notebook_test
 def test_asset_tags() -> None:
     key = cast("AssetsDefinition", custom_io_mgr_key_asset).key
     assert cast("AssetsDefinition", custom_io_mgr_key_asset).tags_by_key[key] == {"foo": "bar"}
@@ -144,6 +180,37 @@ def test_error_notebook_saved_asset():
                 storage_dir = instance.storage_directory()
                 files = os.listdir(storage_dir)
                 notebook_found = (False,)
+                for f in files:
+                    if "-out.ipynb" in f:
+                        notebook_found = True
+                outer_result = result
+
+                assert notebook_found
+
+        finally:
+            if outer_result:
+                cleanup_result_notebook(outer_result)
+
+
+@pytest.mark.notebook_test
+def test_error_notebook_saved_html_asset():
+    result = None
+    recon_job = ReconstructableJob.for_module(
+        "dagstermill.examples.repository", "error_notebook_html_asset_job"
+    )
+
+    with instance_for_test() as instance:
+        outer_result = None
+        try:
+            with execute_job(
+                recon_job,
+                run_config={},
+                instance=instance,
+                raise_on_error=False,
+            ) as result:
+                storage_dir = instance.storage_directory()
+                files = os.listdir(storage_dir)
+                notebook_found = False
                 for f in files:
                     if "-out.ipynb" in f:
                         notebook_found = True

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_io.py
@@ -1,9 +1,10 @@
 import os
 
 import pytest
-from dagster import job, repository
+from dagster import build_input_context, build_output_context, job, repository
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagstermill.examples.repository import hello_world
+from dagstermill.io_managers import LocalOutputNotebookIOManager
 from dagstermill.test_utils import exec_for_test
 
 
@@ -73,3 +74,24 @@ def test_yes_output_notebook_yes_io_manager():
 
         with open(output_path, "rb") as f:  # pyright: ignore[reportCallIssue,reportArgumentType]
             assert f.read() == result.output_for_node("load_notebook")
+
+
+def test_local_output_notebook_io_manager_supports_html_artifacts(tmp_path):
+    manager = LocalOutputNotebookIOManager(base_dir=str(tmp_path))
+    html_bytes = b"<html><body><h1>hello</h1></body></html>"
+
+    with build_output_context(
+        asset_key=["hello_world_html_asset"],
+        output_metadata={"dagstermill/serialized_artifact_type": "html"},
+    ) as context:
+        manager.handle_output(context, html_bytes)
+        output_path = context.get_logged_metadata()["Rendered notebook"].path
+
+    assert output_path.endswith(".html")
+    assert os.path.exists(output_path)
+
+    with open(output_path, "rb") as f:
+        assert f.read() == html_bytes
+
+    input_context = build_input_context(upstream_output=context)
+    assert manager.load_input(input_context) == html_bytes


### PR DESCRIPTION
## Summary & Motivation

Adds HTML export support for dagstermill notebook assets for issue #33190.

- adds `output_notebook_format="ipynb" | "html"` to `define_dagstermill_asset`
- adds `output_notebook_html_no_input`
- renders executed notebooks to HTML via `nbconvert`
- updates the local output notebook IO manager to persist `.html` artifacts and emit rendered-notebook metadata
- adds docs, examples, and targeted tests for the new HTML output flow

## Test Plan

- `ruff check --fix .`
- `ruff format .`
- `pytest -o markers="notebook_test: notebook tests" python_modules/libraries/dagstermill/dagstermill_tests/test_io.py python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py -k "local_output_notebook_io_manager_supports_html_artifacts or html_output_asset or html_no_input_requires_html_output or error_notebook_saved_html_asset" -q`
- attempted `python scripts/run-pyright.py --diff`, but the repo script failed in this PowerShell environment while bootstrapping `uv venv` with interpreter path `/c/Users/aakas/anaconda3/python`

## Changelog

- Adds HTML output support for dagstermill notebook assets and rendered notebook metadata.
