### PR TITLE
[dagster] Guard dynamic partition label schema access and narrow launch label fetching

### DIFF
--- a/js_modules/ui-components/src/components/TagSelector.tsx
+++ b/js_modules/ui-components/src/components/TagSelector.tsx
@@ -290,6 +290,7 @@ export const TagSelectorTagsContainer = ({
 export const TagSelectorWithSearch = (
   props: Props & {
     searchPlaceholder?: string;
+    filterTag?: (tag: string, search: string) => boolean;
   },
 ) => {
   const [search, setSearch] = React.useState('');
@@ -300,14 +301,17 @@ export const TagSelectorWithSearch = (
     rowHeight: _rowHeight,
     renderDropdown,
     searchPlaceholder,
+    filterTag,
     ...rest
   } = props;
   const filteredTags = React.useMemo(() => {
     if (search.trim() === '') {
       return allTags;
     }
-    return allTags.filter((tag) => tag.toLowerCase().includes(search.toLowerCase()));
-  }, [allTags, search]);
+    return allTags.filter((tag) =>
+      filterTag ? filterTag(tag, search) : tag.toLowerCase().includes(search.toLowerCase()),
+    );
+  }, [allTags, filterTag, search]);
   return (
     <TagSelector
       {...rest}

--- a/js_modules/ui-core/client.json
+++ b/js_modules/ui-core/client.json
@@ -31,6 +31,7 @@
   "BackfillPreviewQuery": "21a636242bab27144e5627361658207b708cc3e60c149f8901e476c3d9d0b021",
   "AssetStaleStatusQuery": "2c0792a380368dfd0b6c892bd7c18f86bb34e599a2f8b020852b4a6285defa37",
   "DeleteDynamicPartitionsMutation": "dc34ce729a12d80db6cabbb4ed9093ee29b9c4e2c6843074b13b67b454b61471",
+  "DisplayedPartitionLabelsQuery": "0f6be528236c2c0092149cd26185968f7d0ffdb5a94ed8a9ddf1c4695dfbfdaf",
   "LaunchAssetWarningsQuery": "1924efd011a8fa46372d16674bca736ef10e46d3aff77430b0bd24461359813e",
   "LaunchAssetLoaderQuery": "ae6a5d5eaf00ec9eeefaf3e7dc85a7710eb3647608aa00e3ded59877a289d645",
   "LaunchAssetLoaderJobQuery": "112371f3f0c11b7467940b71e83cba8abf678aed019820af94fdee4f99531841",

--- a/js_modules/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -34,6 +34,8 @@ import {
 import {RunningBackfillsNotice} from './RunningBackfillsNotice';
 import {asAssetKeyInput} from './asInput';
 import {
+  DisplayedPartitionLabelsQuery,
+  DisplayedPartitionLabelsQueryVariables,
   LaunchAssetWarningsQuery,
   LaunchAssetWarningsQueryVariables,
 } from './types/LaunchAssetChoosePartitionsDialog.types';
@@ -83,6 +85,20 @@ import {useFeatureFlagForCodeLocation} from '../workspace/WorkspaceContext/util'
 import {RepoAddress} from '../workspace/types';
 
 const MISSING_FAILED_STATUSES = [AssetPartitionStatus.MISSING, AssetPartitionStatus.FAILED];
+
+export const DISPLAYED_PARTITION_LABELS_QUERY = gql`
+  query DisplayedPartitionLabelsQuery($assetKey: AssetKeyInput!) {
+    assetNodeOrError(assetKey: $assetKey) {
+      ... on AssetNode {
+        id
+        partitionKeyLabels {
+          key
+          label
+        }
+      }
+    }
+  }
+`;
 
 export interface LaunchAssetChoosePartitionsDialogProps {
   open: boolean;
@@ -193,6 +209,32 @@ const LaunchAssetChoosePartitionsDialogBody = ({
         : null;
 
   const displayedPartitionDefinition = displayedBaseAsset?.partitionDefinition;
+  const displayedBaseAssetInput = displayedBaseAsset
+    ? asAssetKeyInput(displayedBaseAsset.assetKey)
+    : null;
+  const displayedPartitionLabelsResult = useQuery<
+    DisplayedPartitionLabelsQuery,
+    DisplayedPartitionLabelsQueryVariables
+  >(DISPLAYED_PARTITION_LABELS_QUERY, {
+    variables: {assetKey: displayedBaseAssetInput ?? {path: []}},
+    skip: !displayedBaseAssetInput,
+    blocking: false,
+  });
+  const displayedPartitionLabels = useMemo(
+    () =>
+      displayedPartitionLabelsResult.data?.assetNodeOrError.__typename === 'AssetNode'
+        ? displayedPartitionLabelsResult.data.assetNodeOrError.partitionKeyLabels
+        : [],
+    [displayedPartitionLabelsResult.data],
+  );
+  const partitionLabelMap = useMemo(
+    () => new Map<string, string>(displayedPartitionLabels.map(({key, label}) => [key, label])),
+    [displayedPartitionLabels],
+  );
+  const labelForPartition = useMemo(
+    () => (partitionKey: string) => partitionLabelMap.get(partitionKey),
+    [partitionLabelMap],
+  );
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const knownDimensions = partitionedAssets[0]!.partitionDefinition?.dimensionTypes || [];
@@ -497,6 +539,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
               setSelections={setSelections}
               displayedHealth={displayedHealth}
               displayedPartitionDefinition={displayedPartitionDefinition}
+              labelForPartition={labelForPartition}
             />
           </ToggleableSection>
         )}

--- a/js_modules/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -209,9 +209,10 @@ const LaunchAssetChoosePartitionsDialogBody = ({
         : null;
 
   const displayedPartitionDefinition = displayedBaseAsset?.partitionDefinition;
-  const displayedBaseAssetInput = displayedBaseAsset
-    ? asAssetKeyInput(displayedBaseAsset.assetKey)
-    : null;
+  const displayedBaseAssetInput = useMemo(
+    () => (displayedBaseAsset ? asAssetKeyInput(displayedBaseAsset.assetKey) : null),
+    [displayedBaseAsset?.assetKey.path.join('\0')],
+  );
   const displayedPartitionLabelsResult = useQuery<
     DisplayedPartitionLabelsQuery,
     DisplayedPartitionLabelsQueryVariables

--- a/js_modules/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -219,17 +219,41 @@ const LaunchAssetChoosePartitionsDialogBody = ({
     variables: {assetKey: displayedBaseAssetInput ?? {path: []}},
     skip: !displayedBaseAssetInput,
     blocking: false,
+    notifyOnNetworkStatusChange: true,
   });
-  const displayedPartitionLabels = useMemo(
-    () =>
-      displayedPartitionLabelsResult.data?.assetNodeOrError.__typename === 'AssetNode'
-        ? displayedPartitionLabelsResult.data.assetNodeOrError.partitionKeyLabels
-        : [],
-    [displayedPartitionLabelsResult.data],
-  );
+  const displayedPartitionLabelsState = useMemo(() => {
+    if (!displayedBaseAssetInput) {
+      return {labels: [], status: 'idle' as const};
+    }
+
+    if (displayedPartitionLabelsResult.loading) {
+      return {labels: [], status: 'loading' as const};
+    }
+
+    if (displayedPartitionLabelsResult.error) {
+      return {labels: [], status: 'error' as const};
+    }
+
+    if (displayedPartitionLabelsResult.data?.assetNodeOrError.__typename === 'AssetNode') {
+      return {
+        labels: displayedPartitionLabelsResult.data.assetNodeOrError.partitionKeyLabels ?? [],
+        status: 'ready' as const,
+      };
+    }
+
+    return {labels: [], status: 'ready' as const};
+  }, [
+    displayedBaseAssetInput,
+    displayedPartitionLabelsResult.data,
+    displayedPartitionLabelsResult.error,
+    displayedPartitionLabelsResult.loading,
+  ]);
   const partitionLabelMap = useMemo(
-    () => new Map<string, string>(displayedPartitionLabels.map(({key, label}) => [key, label])),
-    [displayedPartitionLabels],
+    () =>
+      new Map<string, string>(
+        displayedPartitionLabelsState.labels.map(({key, label}) => [key, label]),
+      ),
+    [displayedPartitionLabelsState.labels],
   );
   const labelForPartition = useMemo(
     () => (partitionKey: string) => partitionLabelMap.get(partitionKey),

--- a/js_modules/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -17,7 +17,7 @@ import {
 import {StyledRawCodeMirror} from '@dagster-io/ui-components/editor';
 import {useLaunchWithTelemetry} from '@shared/launchpad/useLaunchWithTelemetry';
 import reject from 'lodash/reject';
-import {useEffect, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {partitionCountString} from './AssetNodePartitionCounts';
 import {AssetPartitionStatus} from './AssetPartitionStatus';
@@ -211,7 +211,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
   const displayedPartitionDefinition = displayedBaseAsset?.partitionDefinition;
   const displayedBaseAssetInput = useMemo(
     () => (displayedBaseAsset ? asAssetKeyInput(displayedBaseAsset.assetKey) : null),
-    [displayedBaseAsset?.assetKey.path.join('\0')],
+    [displayedBaseAsset],
   );
   const displayedPartitionLabelsResult = useQuery<
     DisplayedPartitionLabelsQuery,
@@ -256,8 +256,8 @@ const LaunchAssetChoosePartitionsDialogBody = ({
       ),
     [displayedPartitionLabelsState.labels],
   );
-  const labelForPartition = useMemo(
-    () => (partitionKey: string) => partitionLabelMap.get(partitionKey),
+  const labelForPartition = useCallback(
+    (partitionKey: string) => partitionLabelMap.get(partitionKey),
     [partitionLabelMap],
   );
 

--- a/js_modules/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
+++ b/js_modules/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
@@ -1,5 +1,5 @@
 import {MockedProvider} from '@apollo/client/testing';
-import {render, screen, waitFor} from '@testing-library/react';
+import {render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {MemoryRouter} from 'react-router';
 
@@ -538,12 +538,132 @@ describe('launchAssetChoosePartitionsDialog', () => {
       expect(screen.getByTestId('menu-item-test').textContent).not.toContain('Alpha label');
     });
   });
+
+  it('does not apply dynamic labels to non-dynamic dimensions with overlapping keys', async () => {
+    const asset = buildAsset('asset_a', ['shared'], [], {
+      type: PartitionDefinitionType.STATIC,
+      keys: ['shared', 'plain'],
+    });
+
+    const assetQueryMock = buildQueryMock<PartitionHealthQuery, PartitionHealthQueryVariables>({
+      query: PARTITION_HEALTH_QUERY,
+      variables: {assetKey: {path: ['asset_a']}},
+      data: {assetNodeOrError: asset},
+    });
+    const displayedPartitionLabelsMock = buildQueryMock({
+      query: DISPLAYED_PARTITION_LABELS_QUERY,
+      variables: {assetKey: {path: ['asset_a']}},
+      data: {
+        assetNodeOrError: {
+          __typename: 'AssetNode',
+          id: asset.id,
+          partitionKeyLabels: [
+            {__typename: 'PartitionKeyLabel', key: 'shared', label: 'Friendly label'},
+          ],
+        },
+      },
+    });
+    const assetPermissionsMock = buildQueryMock<
+      AssetsPermissionsQuery,
+      AssetsPermissionsQueryVariables
+    >({
+      query: ASSETS_PERMISSIONS_QUERY,
+      variables: {
+        assetKeys: [{path: ['asset_a']}],
+      },
+      data: {
+        assetNodes: [
+          buildAssetNode({
+            id: 'asset-a-permissions',
+            hasMaterializePermission: true,
+            hasWipePermission: true,
+            hasReportRunlessAssetEventPermission: true,
+          }),
+        ],
+      },
+    });
+    const launchpadRootMock = buildQueryMock<LaunchpadRootQuery, LaunchpadRootQueryVariables>({
+      query: PIPELINE_EXECUTION_ROOT_QUERY,
+      variables: {
+        repositoryName: 'test',
+        repositoryLocationName: 'test',
+        pipelineName: '__ASSET_JOB',
+        assetSelection: [{path: ['asset_a']}],
+      },
+      data: buildQuery({
+        pipelineOrError: buildPipeline(),
+        partitionSetsOrError: buildPartitionSets(),
+        runConfigSchemaOrError: buildRunConfigSchema(),
+      }),
+    });
+
+    render(
+      <MemoryRouter>
+        <MockedProvider
+          mocks={[
+            assetQueryMock,
+            displayedPartitionLabelsMock,
+            assetPermissionsMock,
+            buildLaunchAssetWarningsMock([]),
+            NoRunningBackfills,
+            launchpadRootMock,
+            ...workspaceMocks,
+          ]}
+        >
+          <WorkspaceProvider>
+            <LaunchAssetChoosePartitionsDialog
+              open={true}
+              setOpen={(_open: boolean) => {}}
+              repoAddress={buildRepoAddress('test', 'test')}
+              target={{
+                jobName: '__ASSET_JOB',
+                assetKeys: [asset.assetKey],
+                type: 'job',
+              }}
+              assets={[asset]}
+              upstreamAssetKeys={[]}
+            />
+          </WorkspaceProvider>
+        </MockedProvider>
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    const selectors = await screen.findAllByText('Select a partition or create one');
+    expect(selectors).toHaveLength(2);
+
+    const dynamicSelector = selectors[0];
+    const staticSelector = selectors[1];
+
+    if (!dynamicSelector || !staticSelector) {
+      throw new Error('Expected both dynamic and static partition selectors to be rendered');
+    }
+
+    await user.click(dynamicSelector);
+    await waitFor(() => {
+      expect(screen.getByTestId('menu-item-shared').textContent).toContain('Friendly label');
+    });
+
+    await user.click(staticSelector);
+    const searchInput = await screen.findByPlaceholderText('Filter partitions');
+    await user.type(searchInput, 'Friendly');
+
+    const staticMenu = searchInput.closest('[role="menu"]');
+    expect(staticMenu).not.toBeNull();
+    expect(
+      within(staticMenu as HTMLElement).getByText('No matching partitions found'),
+    ).toBeVisible();
+  });
 });
 
 function buildAsset(
   name: string,
   dynamicPartitionKeys: string[],
   partitionKeyLabels: Array<{__typename: 'PartitionKeyLabel'; key: string; label: string}> = [],
+  secondDimension: {
+    type: PartitionDefinitionType;
+    keys: string[];
+  } = {type: PartitionDefinitionType.TIME_WINDOW, keys: ['2024-01-01']},
 ) {
   return buildAssetNode({
     assetKey: buildAssetKey({path: [name]}),
@@ -557,8 +677,8 @@ function buildAsset(
       }),
       buildDimensionPartitionKeys({
         name: 'b',
-        type: PartitionDefinitionType.TIME_WINDOW,
-        partitionKeys: ['2024-01-01'],
+        type: secondDimension.type,
+        partitionKeys: secondDimension.keys,
       }),
     ],
     partitionDefinition: buildPartitionDefinition({
@@ -571,7 +691,7 @@ function buildAsset(
         }),
         buildDimensionDefinitionType({
           name: 'b',
-          type: PartitionDefinitionType.TIME_WINDOW,
+          type: secondDimension.type,
         }),
       ],
     }),

--- a/js_modules/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
+++ b/js_modules/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
@@ -11,7 +11,6 @@ import {
   buildDimensionPartitionKeys,
   buildMultiPartitionStatuses,
   buildPartitionDefinition,
-  buildPartitionKeyLabel,
   buildPartitionSets,
   buildPipeline,
   buildQuery,
@@ -96,6 +95,17 @@ describe('launchAssetChoosePartitionsDialog', () => {
       data: {assetNodeOrError: buildAsset('asset_b', ['test', 'test2'])},
       delay: 5000,
     });
+    const displayedPartitionLabelsMock = buildQueryMock({
+      query: DISPLAYED_PARTITION_LABELS_QUERY,
+      variables: {assetKey: {path: ['asset_a']}},
+      data: {
+        assetNodeOrError: {
+          __typename: 'AssetNode',
+          id: assetA.id,
+          partitionKeyLabels: [],
+        },
+      },
+    });
 
     const addPartitionMock = buildMutationMock<
       AddDynamicPartitionMutation,
@@ -116,6 +126,45 @@ describe('launchAssetChoosePartitionsDialog', () => {
     const assetBQueryMockResult = getMockResultFn(assetBQueryMock);
     const assetASecondQueryMockResult = getMockResultFn(assetASecondQueryMock);
     const assetBSecondQueryMockResult = getMockResultFn(assetBSecondQueryMock);
+    const assetPermissionsMock = buildQueryMock<
+      AssetsPermissionsQuery,
+      AssetsPermissionsQueryVariables
+    >({
+      query: ASSETS_PERMISSIONS_QUERY,
+      variables: {
+        assetKeys: [{path: ['asset_a']}, {path: ['asset_b']}],
+      },
+      data: {
+        assetNodes: [
+          buildAssetNode({
+            id: 'asset-a-permissions',
+            hasMaterializePermission: true,
+            hasWipePermission: true,
+            hasReportRunlessAssetEventPermission: true,
+          }),
+          buildAssetNode({
+            id: 'asset-b-permissions',
+            hasMaterializePermission: true,
+            hasWipePermission: true,
+            hasReportRunlessAssetEventPermission: true,
+          }),
+        ],
+      },
+    });
+    const launchpadRootMock = buildQueryMock<LaunchpadRootQuery, LaunchpadRootQueryVariables>({
+      query: PIPELINE_EXECUTION_ROOT_QUERY,
+      variables: {
+        repositoryName: 'test',
+        repositoryLocationName: 'test',
+        pipelineName: '__ASSET_JOB',
+        assetSelection: [{path: ['asset_a']}, {path: ['asset_b']}],
+      },
+      data: buildQuery({
+        pipelineOrError: buildPipeline(),
+        partitionSetsOrError: buildPartitionSets(),
+        runConfigSchemaOrError: buildRunConfigSchema(),
+      }),
+    });
     render(
       <MemoryRouter>
         <MockedProvider
@@ -124,7 +173,12 @@ describe('launchAssetChoosePartitionsDialog', () => {
             assetBQueryMock,
             assetASecondQueryMock,
             assetBSecondQueryMock,
+            displayedPartitionLabelsMock,
             addPartitionMock,
+            assetPermissionsMock,
+            buildLaunchAssetWarningsMock([]),
+            NoRunningBackfills,
+            launchpadRootMock,
             ...workspaceMocks,
           ]}
         >
@@ -146,19 +200,20 @@ describe('launchAssetChoosePartitionsDialog', () => {
       </MemoryRouter>,
     );
 
+    const user = userEvent.setup();
     await waitFor(() => {
       expect(assetAQueryMockResult).toHaveBeenCalled();
       expect(assetBQueryMockResult).toHaveBeenCalled();
     });
 
     const link = await screen.findByTestId('add-partition-link');
-    await userEvent.click(link);
+    await user.click(link);
     const partitionInput = await screen.findByTestId('partition-input');
-    await userEvent.type(partitionInput, 'test2');
+    await user.type(partitionInput, 'test2');
     expect(assetASecondQueryMockResult).not.toHaveBeenCalled();
     expect(assetBSecondQueryMockResult).not.toHaveBeenCalled();
     const savePartitionButton = screen.getByTestId('save-partition-button');
-    await userEvent.click(savePartitionButton);
+    await user.click(savePartitionButton);
 
     // Verify that it refreshes asset health after partition is added
     await waitFor(() => {
@@ -184,10 +239,13 @@ describe('launchAssetChoosePartitionsDialog', () => {
       query: DISPLAYED_PARTITION_LABELS_QUERY,
       variables: {assetKey: {path: ['asset_a']}},
       data: {
-        assetNodeOrError: buildAssetNode({
+        assetNodeOrError: {
+          __typename: 'AssetNode',
           id: assetA.id,
-          partitionKeyLabels: [buildPartitionKeyLabel({key: 'test', label: 'Friendly label'})],
-        }),
+          partitionKeyLabels: [
+            {__typename: 'PartitionKeyLabel', key: 'test', label: 'Friendly label'},
+          ],
+        },
       },
     });
     const assetAQueryMockResult = getMockResultFn(assetAQueryMock);
@@ -231,7 +289,6 @@ describe('launchAssetChoosePartitionsDialog', () => {
         runConfigSchemaOrError: buildRunConfigSchema(),
       }),
     });
-
     render(
       <MemoryRouter>
         <MockedProvider
@@ -278,6 +335,208 @@ describe('launchAssetChoosePartitionsDialog', () => {
     await user.type(searchInput, 'Friendly');
 
     expect((await screen.findByTestId('menu-item-test')).textContent).toContain('Friendly label');
+  });
+
+  it('clears stale labels when the displayed asset changes while labels are still loading', async () => {
+    const assetA = buildAsset('asset_a', ['test']);
+    const assetB = buildAsset('asset_b', ['test']);
+
+    const assetAQueryMock = buildQueryMock<PartitionHealthQuery, PartitionHealthQueryVariables>({
+      query: PARTITION_HEALTH_QUERY,
+      variables: {assetKey: {path: ['asset_a']}},
+      data: {assetNodeOrError: assetA},
+    });
+    const assetBQueryMock = buildQueryMock<PartitionHealthQuery, PartitionHealthQueryVariables>({
+      query: PARTITION_HEALTH_QUERY,
+      variables: {assetKey: {path: ['asset_b']}},
+      data: {assetNodeOrError: assetB},
+    });
+    const displayedPartitionLabelsMockA = buildQueryMock({
+      query: DISPLAYED_PARTITION_LABELS_QUERY,
+      variables: {assetKey: {path: ['asset_a']}},
+      data: {
+        assetNodeOrError: {
+          __typename: 'AssetNode',
+          id: assetA.id,
+          partitionKeyLabels: [
+            {__typename: 'PartitionKeyLabel', key: 'test', label: 'Alpha label'},
+          ],
+        },
+      },
+    });
+    const displayedPartitionLabelsMockB = buildQueryMock({
+      query: DISPLAYED_PARTITION_LABELS_QUERY,
+      variables: {assetKey: {path: ['asset_b']}},
+      data: {
+        assetNodeOrError: {
+          __typename: 'AssetNode',
+          id: assetB.id,
+          partitionKeyLabels: [{__typename: 'PartitionKeyLabel', key: 'test', label: 'Beta label'}],
+        },
+      },
+      delay: 5000,
+    });
+    const assetPermissionsMock = buildQueryMock<
+      AssetsPermissionsQuery,
+      AssetsPermissionsQueryVariables
+    >({
+      query: ASSETS_PERMISSIONS_QUERY,
+      variables: {
+        assetKeys: [{path: ['asset_a']}, {path: ['asset_b']}],
+      },
+      data: {
+        assetNodes: [
+          buildAssetNode({
+            id: 'asset-a-permissions',
+            hasMaterializePermission: true,
+            hasWipePermission: true,
+            hasReportRunlessAssetEventPermission: true,
+          }),
+          buildAssetNode({
+            id: 'asset-b-permissions',
+            hasMaterializePermission: true,
+            hasWipePermission: true,
+            hasReportRunlessAssetEventPermission: true,
+          }),
+        ],
+      },
+    });
+    const reversedAssetPermissionsMock = buildQueryMock<
+      AssetsPermissionsQuery,
+      AssetsPermissionsQueryVariables
+    >({
+      query: ASSETS_PERMISSIONS_QUERY,
+      variables: {
+        assetKeys: [{path: ['asset_b']}, {path: ['asset_a']}],
+      },
+      data: {
+        assetNodes: [
+          buildAssetNode({
+            id: 'asset-b-permissions-reordered',
+            hasMaterializePermission: true,
+            hasWipePermission: true,
+            hasReportRunlessAssetEventPermission: true,
+          }),
+          buildAssetNode({
+            id: 'asset-a-permissions-reordered',
+            hasMaterializePermission: true,
+            hasWipePermission: true,
+            hasReportRunlessAssetEventPermission: true,
+          }),
+        ],
+      },
+    });
+    const launchpadRootMock = buildQueryMock<LaunchpadRootQuery, LaunchpadRootQueryVariables>({
+      query: PIPELINE_EXECUTION_ROOT_QUERY,
+      variables: {
+        repositoryName: 'test',
+        repositoryLocationName: 'test',
+        pipelineName: '__ASSET_JOB',
+        assetSelection: [{path: ['asset_a']}, {path: ['asset_b']}],
+      },
+      data: buildQuery({
+        pipelineOrError: buildPipeline(),
+        partitionSetsOrError: buildPartitionSets(),
+        runConfigSchemaOrError: buildRunConfigSchema(),
+      }),
+    });
+    const reversedLaunchpadRootMock = buildQueryMock<
+      LaunchpadRootQuery,
+      LaunchpadRootQueryVariables
+    >({
+      query: PIPELINE_EXECUTION_ROOT_QUERY,
+      variables: {
+        repositoryName: 'test',
+        repositoryLocationName: 'test',
+        pipelineName: '__ASSET_JOB',
+        assetSelection: [{path: ['asset_b']}, {path: ['asset_a']}],
+      },
+      data: buildQuery({
+        pipelineOrError: buildPipeline(),
+        partitionSetsOrError: buildPartitionSets(),
+        runConfigSchemaOrError: buildRunConfigSchema(),
+      }),
+    });
+
+    const {rerender} = render(
+      <MemoryRouter>
+        <MockedProvider
+          mocks={[
+            assetAQueryMock,
+            assetBQueryMock,
+            displayedPartitionLabelsMockA,
+            displayedPartitionLabelsMockB,
+            assetPermissionsMock,
+            reversedAssetPermissionsMock,
+            buildLaunchAssetWarningsMock([]),
+            NoRunningBackfills,
+            launchpadRootMock,
+            reversedLaunchpadRootMock,
+            ...workspaceMocks,
+          ]}
+        >
+          <WorkspaceProvider>
+            <LaunchAssetChoosePartitionsDialog
+              open={true}
+              setOpen={(_open: boolean) => {}}
+              repoAddress={buildRepoAddress('test', 'test')}
+              target={{
+                jobName: '__ASSET_JOB',
+                assetKeys: [assetA.assetKey, assetB.assetKey],
+                type: 'job',
+              }}
+              assets={[assetA, assetB]}
+              upstreamAssetKeys={[]}
+            />
+          </WorkspaceProvider>
+        </MockedProvider>
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByText('Select a partition or create one'));
+    await waitFor(() => {
+      expect(screen.getByTestId('menu-item-test').textContent).toContain('Alpha label');
+    });
+
+    rerender(
+      <MemoryRouter>
+        <MockedProvider
+          mocks={[
+            assetAQueryMock,
+            assetBQueryMock,
+            displayedPartitionLabelsMockA,
+            displayedPartitionLabelsMockB,
+            assetPermissionsMock,
+            reversedAssetPermissionsMock,
+            buildLaunchAssetWarningsMock([]),
+            NoRunningBackfills,
+            launchpadRootMock,
+            reversedLaunchpadRootMock,
+            ...workspaceMocks,
+          ]}
+        >
+          <WorkspaceProvider>
+            <LaunchAssetChoosePartitionsDialog
+              open={true}
+              setOpen={(_open: boolean) => {}}
+              repoAddress={buildRepoAddress('test', 'test')}
+              target={{
+                jobName: '__ASSET_JOB',
+                assetKeys: [assetA.assetKey, assetB.assetKey],
+                type: 'job',
+              }}
+              assets={[assetB, assetA]}
+              upstreamAssetKeys={[]}
+            />
+          </WorkspaceProvider>
+        </MockedProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('menu-item-test').textContent).not.toContain('Alpha label');
+    });
   });
 });
 

--- a/js_modules/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
+++ b/js_modules/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
@@ -11,27 +11,60 @@ import {
   buildDimensionPartitionKeys,
   buildMultiPartitionStatuses,
   buildPartitionDefinition,
+  buildPartitionKeyLabel,
+  buildPartitionSets,
+  buildPipeline,
+  buildQuery,
+  buildRunConfigSchema,
 } from '../../graphql/builders';
 import {PartitionDefinitionType} from '../../graphql/types';
+import {PIPELINE_EXECUTION_ROOT_QUERY} from '../../launchpad/LaunchpadAllowedRoot';
+import {
+  LaunchpadRootQuery,
+  LaunchpadRootQueryVariables,
+} from '../../launchpad/types/LaunchpadAllowedRoot.types';
 import {CREATE_PARTITION_MUTATION} from '../../partitions/CreatePartitionDialog';
 import {
   AddDynamicPartitionMutation,
   AddDynamicPartitionMutationVariables,
 } from '../../partitions/types/CreatePartitionDialog.types';
-import {buildMutationMock, buildQueryMock, getMockResultFn} from '../../testing/mocking';
+import {
+  buildMutationMock,
+  buildQueryMock,
+  getMockResultFn,
+  mockViewportClientRect,
+  restoreViewportClientRect,
+} from '../../testing/mocking';
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext/WorkspaceContext';
 import {buildWorkspaceMocks} from '../../workspace/WorkspaceContext/__fixtures__/Workspace.fixtures';
 import {buildRepoAddress} from '../../workspace/buildRepoAddress';
-import {LaunchAssetChoosePartitionsDialog} from '../LaunchAssetChoosePartitionsDialog';
+import {
+  DISPLAYED_PARTITION_LABELS_QUERY,
+  LaunchAssetChoosePartitionsDialog,
+} from '../LaunchAssetChoosePartitionsDialog';
+import {buildLaunchAssetWarningsMock} from '../__fixtures__/LaunchAssetExecutionButton.fixtures';
+import {NoRunningBackfills} from '../__fixtures__/RunningBackfillsNoticeQuery.fixture';
+import {
+  AssetsPermissionsQuery,
+  AssetsPermissionsQueryVariables,
+} from '../types/useAssetPermissions.types';
 import {
   PartitionHealthQuery,
   PartitionHealthQueryVariables,
 } from '../types/usePartitionHealthData.types';
+import {ASSETS_PERMISSIONS_QUERY} from '../useAssetPermissions';
 import {PARTITION_HEALTH_QUERY} from '../usePartitionHealthData';
 
 const workspaceMocks = buildWorkspaceMocks([]);
-
 describe('launchAssetChoosePartitionsDialog', () => {
+  beforeAll(() => {
+    mockViewportClientRect();
+  });
+
+  afterAll(() => {
+    restoreViewportClientRect();
+  });
+
   it('Adding a dynamic partition when multiple assets selected', async () => {
     const assetA = buildAsset('asset_a', ['test']);
     const assetB = buildAsset('asset_b', ['test']);
@@ -132,12 +165,131 @@ describe('launchAssetChoosePartitionsDialog', () => {
       expect(assetASecondQueryMockResult).toHaveBeenCalled();
     });
   });
+
+  it('renders and searches dynamic partition labels in the selector', async () => {
+    const assetA = buildAsset('asset_a', ['test']);
+    const assetB = buildAsset('asset_b', ['test']);
+
+    const assetAQueryMock = buildQueryMock<PartitionHealthQuery, PartitionHealthQueryVariables>({
+      query: PARTITION_HEALTH_QUERY,
+      variables: {assetKey: {path: ['asset_a']}},
+      data: {assetNodeOrError: assetA},
+    });
+    const assetBQueryMock = buildQueryMock<PartitionHealthQuery, PartitionHealthQueryVariables>({
+      query: PARTITION_HEALTH_QUERY,
+      variables: {assetKey: {path: ['asset_b']}},
+      data: {assetNodeOrError: assetB},
+    });
+    const displayedPartitionLabelsMock = buildQueryMock({
+      query: DISPLAYED_PARTITION_LABELS_QUERY,
+      variables: {assetKey: {path: ['asset_a']}},
+      data: {
+        assetNodeOrError: buildAssetNode({
+          id: assetA.id,
+          partitionKeyLabels: [buildPartitionKeyLabel({key: 'test', label: 'Friendly label'})],
+        }),
+      },
+    });
+    const assetAQueryMockResult = getMockResultFn(assetAQueryMock);
+    const assetBQueryMockResult = getMockResultFn(assetBQueryMock);
+    const assetPermissionsMock = buildQueryMock<
+      AssetsPermissionsQuery,
+      AssetsPermissionsQueryVariables
+    >({
+      query: ASSETS_PERMISSIONS_QUERY,
+      variables: {
+        assetKeys: [{path: ['asset_a']}, {path: ['asset_b']}],
+      },
+      data: {
+        assetNodes: [
+          buildAssetNode({
+            id: 'asset-a-permissions',
+            hasMaterializePermission: true,
+            hasWipePermission: true,
+            hasReportRunlessAssetEventPermission: true,
+          }),
+          buildAssetNode({
+            id: 'asset-b-permissions',
+            hasMaterializePermission: true,
+            hasWipePermission: true,
+            hasReportRunlessAssetEventPermission: true,
+          }),
+        ],
+      },
+    });
+    const launchpadRootMock = buildQueryMock<LaunchpadRootQuery, LaunchpadRootQueryVariables>({
+      query: PIPELINE_EXECUTION_ROOT_QUERY,
+      variables: {
+        repositoryName: 'test',
+        repositoryLocationName: 'test',
+        pipelineName: '__ASSET_JOB',
+        assetSelection: [{path: ['asset_a']}, {path: ['asset_b']}],
+      },
+      data: buildQuery({
+        pipelineOrError: buildPipeline(),
+        partitionSetsOrError: buildPartitionSets(),
+        runConfigSchemaOrError: buildRunConfigSchema(),
+      }),
+    });
+
+    render(
+      <MemoryRouter>
+        <MockedProvider
+          mocks={[
+            assetAQueryMock,
+            assetBQueryMock,
+            displayedPartitionLabelsMock,
+            assetPermissionsMock,
+            buildLaunchAssetWarningsMock([]),
+            NoRunningBackfills,
+            launchpadRootMock,
+            ...workspaceMocks,
+          ]}
+        >
+          <WorkspaceProvider>
+            <LaunchAssetChoosePartitionsDialog
+              open={true}
+              setOpen={(_open: boolean) => {}}
+              repoAddress={buildRepoAddress('test', 'test')}
+              target={{
+                jobName: '__ASSET_JOB',
+                assetKeys: [assetA.assetKey, assetB.assetKey],
+                type: 'job',
+              }}
+              assets={[assetA, assetB]}
+              upstreamAssetKeys={[]}
+            />
+          </WorkspaceProvider>
+        </MockedProvider>
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(assetAQueryMockResult).toHaveBeenCalled();
+      expect(assetBQueryMockResult).toHaveBeenCalled();
+    });
+
+    await user.click(await screen.findByText('Select a partition or create one'));
+
+    expect((await screen.findByTestId('menu-item-test')).textContent).toContain('Friendly label');
+
+    const searchInput = await screen.findByPlaceholderText('Filter partitions');
+    await user.type(searchInput, 'Friendly');
+
+    expect((await screen.findByTestId('menu-item-test')).textContent).toContain('Friendly label');
+  });
 });
 
-function buildAsset(name: string, dynamicPartitionKeys: string[]) {
+function buildAsset(
+  name: string,
+  dynamicPartitionKeys: string[],
+  partitionKeyLabels: Array<{__typename: 'PartitionKeyLabel'; key: string; label: string}> = [],
+) {
   return buildAssetNode({
     assetKey: buildAssetKey({path: [name]}),
     id: `repro_dynamic_in_multipartitions_bug.py.__repository__.["${name}"]`,
+    partitionKeyLabels,
     partitionKeysByDimension: [
       buildDimensionPartitionKeys({
         name: 'a',

--- a/js_modules/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
+++ b/js_modules/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
@@ -540,7 +540,7 @@ describe('launchAssetChoosePartitionsDialog', () => {
   });
 
   it('does not apply dynamic labels to non-dynamic dimensions with overlapping keys', async () => {
-    const asset = buildAsset('asset_a', ['shared'], [], {
+    const asset = buildAsset('asset_a', ['shared'], {
       type: PartitionDefinitionType.STATIC,
       keys: ['shared', 'plain'],
     });
@@ -654,12 +654,195 @@ describe('launchAssetChoosePartitionsDialog', () => {
       within(staticMenu as HTMLElement).getByText('No matching partitions found'),
     ).toBeVisible();
   });
+
+  it('does not rerun displayed partition label queries on rerender for the same asset key', async () => {
+    const assetA = buildAsset('asset_a', ['test']);
+    const assetB = buildAsset('asset_b', ['test']);
+    const rerenderedAssetA = buildAsset('asset_a', ['test']);
+    const rerenderedAssetB = buildAsset('asset_b', ['test']);
+
+    const assetAQueryMock = buildQueryMock<PartitionHealthQuery, PartitionHealthQueryVariables>({
+      query: PARTITION_HEALTH_QUERY,
+      variables: {assetKey: {path: ['asset_a']}},
+      data: {assetNodeOrError: assetA},
+    });
+    const assetBQueryMock = buildQueryMock<PartitionHealthQuery, PartitionHealthQueryVariables>({
+      query: PARTITION_HEALTH_QUERY,
+      variables: {assetKey: {path: ['asset_b']}},
+      data: {assetNodeOrError: assetB},
+    });
+    const rerenderedAssetAQueryMock = buildQueryMock<
+      PartitionHealthQuery,
+      PartitionHealthQueryVariables
+    >({
+      query: PARTITION_HEALTH_QUERY,
+      variables: {assetKey: {path: ['asset_a']}},
+      data: {assetNodeOrError: rerenderedAssetA},
+    });
+    const rerenderedAssetBQueryMock = buildQueryMock<
+      PartitionHealthQuery,
+      PartitionHealthQueryVariables
+    >({
+      query: PARTITION_HEALTH_QUERY,
+      variables: {assetKey: {path: ['asset_b']}},
+      data: {assetNodeOrError: rerenderedAssetB},
+    });
+    const displayedPartitionLabelsMock = buildQueryMock({
+      query: DISPLAYED_PARTITION_LABELS_QUERY,
+      variables: {assetKey: {path: ['asset_a']}},
+      data: {
+        assetNodeOrError: {
+          __typename: 'AssetNode',
+          id: assetA.id,
+          partitionKeyLabels: [
+            {__typename: 'PartitionKeyLabel', key: 'test', label: 'Friendly label'},
+          ],
+        },
+      },
+    });
+    const displayedPartitionLabelsMockResult = getMockResultFn(displayedPartitionLabelsMock);
+    const assetPermissionsMock = buildQueryMock<
+      AssetsPermissionsQuery,
+      AssetsPermissionsQueryVariables
+    >({
+      query: ASSETS_PERMISSIONS_QUERY,
+      variables: {
+        assetKeys: [{path: ['asset_a']}, {path: ['asset_b']}],
+      },
+      data: {
+        assetNodes: [
+          buildAssetNode({
+            id: 'asset-a-permissions',
+            hasMaterializePermission: true,
+            hasWipePermission: true,
+            hasReportRunlessAssetEventPermission: true,
+          }),
+          buildAssetNode({
+            id: 'asset-b-permissions',
+            hasMaterializePermission: true,
+            hasWipePermission: true,
+            hasReportRunlessAssetEventPermission: true,
+          }),
+        ],
+      },
+    });
+    const launchpadRootMock = buildQueryMock<LaunchpadRootQuery, LaunchpadRootQueryVariables>({
+      query: PIPELINE_EXECUTION_ROOT_QUERY,
+      variables: {
+        repositoryName: 'test',
+        repositoryLocationName: 'test',
+        pipelineName: '__ASSET_JOB',
+        assetSelection: [{path: ['asset_a']}, {path: ['asset_b']}],
+      },
+      data: buildQuery({
+        pipelineOrError: buildPipeline(),
+        partitionSetsOrError: buildPartitionSets(),
+        runConfigSchemaOrError: buildRunConfigSchema(),
+      }),
+    });
+    const rerenderedLaunchpadRootMock = buildQueryMock<
+      LaunchpadRootQuery,
+      LaunchpadRootQueryVariables
+    >({
+      query: PIPELINE_EXECUTION_ROOT_QUERY,
+      variables: {
+        repositoryName: 'test',
+        repositoryLocationName: 'test',
+        pipelineName: '__ASSET_JOB',
+        assetSelection: [{path: ['asset_a']}, {path: ['asset_b']}],
+      },
+      data: buildQuery({
+        pipelineOrError: buildPipeline(),
+        partitionSetsOrError: buildPartitionSets(),
+        runConfigSchemaOrError: buildRunConfigSchema(),
+      }),
+    });
+
+    const {rerender} = render(
+      <MemoryRouter>
+        <MockedProvider
+          mocks={[
+            assetAQueryMock,
+            assetBQueryMock,
+            rerenderedAssetAQueryMock,
+            rerenderedAssetBQueryMock,
+            displayedPartitionLabelsMock,
+            assetPermissionsMock,
+            buildLaunchAssetWarningsMock([]),
+            NoRunningBackfills,
+            launchpadRootMock,
+            rerenderedLaunchpadRootMock,
+            ...workspaceMocks,
+          ]}
+        >
+          <WorkspaceProvider>
+            <LaunchAssetChoosePartitionsDialog
+              open={true}
+              setOpen={(_open: boolean) => {}}
+              repoAddress={buildRepoAddress('test', 'test')}
+              target={{
+                jobName: '__ASSET_JOB',
+                assetKeys: [assetA.assetKey, assetB.assetKey],
+                type: 'job',
+              }}
+              assets={[assetA, assetB]}
+              upstreamAssetKeys={[]}
+            />
+          </WorkspaceProvider>
+        </MockedProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(displayedPartitionLabelsMockResult).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <MemoryRouter>
+        <MockedProvider
+          mocks={[
+            assetAQueryMock,
+            assetBQueryMock,
+            rerenderedAssetAQueryMock,
+            rerenderedAssetBQueryMock,
+            displayedPartitionLabelsMock,
+            assetPermissionsMock,
+            buildLaunchAssetWarningsMock([]),
+            NoRunningBackfills,
+            launchpadRootMock,
+            rerenderedLaunchpadRootMock,
+            ...workspaceMocks,
+          ]}
+        >
+          <WorkspaceProvider>
+            <LaunchAssetChoosePartitionsDialog
+              open={true}
+              setOpen={(_open: boolean) => {}}
+              repoAddress={buildRepoAddress('test', 'test')}
+              target={{
+                jobName: '__ASSET_JOB',
+                assetKeys: [rerenderedAssetA.assetKey, rerenderedAssetB.assetKey],
+                type: 'job',
+              }}
+              assets={[rerenderedAssetA, rerenderedAssetB]}
+              upstreamAssetKeys={[]}
+            />
+          </WorkspaceProvider>
+        </MockedProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Select a partition or create one')).toBeVisible();
+    });
+
+    expect(displayedPartitionLabelsMockResult).toHaveBeenCalledTimes(1);
+  });
 });
 
 function buildAsset(
   name: string,
   dynamicPartitionKeys: string[],
-  partitionKeyLabels: Array<{__typename: 'PartitionKeyLabel'; key: string; label: string}> = [],
   secondDimension: {
     type: PartitionDefinitionType;
     keys: string[];
@@ -668,7 +851,6 @@ function buildAsset(
   return buildAssetNode({
     assetKey: buildAssetKey({path: [name]}),
     id: `repro_dynamic_in_multipartitions_bug.py.__repository__.["${name}"]`,
-    partitionKeyLabels,
     partitionKeysByDimension: [
       buildDimensionPartitionKeys({
         name: 'a',

--- a/js_modules/ui-core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
+++ b/js_modules/ui-core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
@@ -2,38 +2,20 @@
 
 import * as Types from '../../graphql/types';
 
+export type DisplayedPartitionLabelsQueryVariables = Types.Exact<{
+  assetKey: Types.AssetKeyInput;
+}>;
+
+
+export type DisplayedPartitionLabelsQuery = { __typename: 'Query', assetNodeOrError: { __typename: 'AssetNode', id: string, partitionKeyLabels: Array<{ __typename: 'PartitionKeyLabel', key: string, label: string }> } | { __typename: 'AssetNotFoundError' } };
+
 export type LaunchAssetWarningsQueryVariables = Types.Exact<{
   upstreamAssetKeys: Array<Types.AssetKeyInput> | Types.AssetKeyInput;
 }>;
 
-export type LaunchAssetWarningsQuery = {
-  __typename: 'Query';
-  assetNodes: Array<{
-    __typename: 'AssetNode';
-    id: string;
-    isMaterializable: boolean;
-    assetKey: {__typename: 'AssetKey'; path: Array<string>};
-    partitionDefinition: {
-      __typename: 'PartitionDefinition';
-      description: string;
-      dimensionTypes: Array<{
-        __typename: 'DimensionDefinitionType';
-        name: string;
-        dynamicPartitionsDefinitionName: string | null;
-      }>;
-    } | null;
-  }>;
-  instance: {
-    __typename: 'Instance';
-    id: string;
-    runQueuingSupported: boolean;
-    daemonHealth: {
-      __typename: 'DaemonHealth';
-      id: string;
-      daemonStatus: {__typename: 'DaemonStatus'; id: string; healthy: boolean | null};
-    };
-    runLauncher: {__typename: 'RunLauncher'; name: string} | null;
-  };
-};
+
+export type LaunchAssetWarningsQuery = { __typename: 'Query', assetNodes: Array<{ __typename: 'AssetNode', id: string, isMaterializable: boolean, assetKey: { __typename: 'AssetKey', path: Array<string> }, partitionDefinition: { __typename: 'PartitionDefinition', description: string, dimensionTypes: Array<{ __typename: 'DimensionDefinitionType', name: string, dynamicPartitionsDefinitionName: string | null }> } | null }>, instance: { __typename: 'Instance', id: string, runQueuingSupported: boolean, daemonHealth: { __typename: 'DaemonHealth', id: string, daemonStatus: { __typename: 'DaemonStatus', id: string, healthy: boolean | null } }, runLauncher: { __typename: 'RunLauncher', name: string } | null } };
+
+export const DisplayedPartitionLabelsQueryVersion = '0f6be528236c2c0092149cd26185968f7d0ffdb5a94ed8a9ddf1c4695dfbfdaf';
 
 export const LaunchAssetWarningsQueryVersion = '1924efd011a8fa46372d16674bca736ef10e46d3aff77430b0bd24461359813e';

--- a/js_modules/ui-core/src/graphql/schema.graphql
+++ b/js_modules/ui-core/src/graphql/schema.graphql
@@ -741,6 +741,7 @@ type AssetNode {
   opVersion: String
   partitionDefinition: PartitionDefinition
   partitionKeys: [String!]!
+  partitionKeyLabels: [PartitionKeyLabel!]!
   partitionKeyConnection(limit: Int!, ascending: Boolean!, cursor: String): PartitionKeyConnection
   partitionKeysByDimension(startIdx: Int, endIdx: Int): [DimensionPartitionKeys!]!
   pools: [String!]!
@@ -803,6 +804,11 @@ type AutoMaterializeRuleEvaluation {
 }
 
 union PartitionKeysOrError = PartitionKeys | PartitionSubsetDeserializationError
+
+type PartitionKeyLabel {
+  key: String!
+  label: String!
+}
 
 type PartitionKeys {
   partitionKeys: [String!]!

--- a/js_modules/ui-core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/ui-core/src/partitions/DimensionRangeWizard.tsx
@@ -27,6 +27,7 @@ export const DimensionRangeWizard = ({
   repoAddress,
   refetch,
   showQuickSelectOptionsForStatuses,
+  labelForPartition,
 }: {
   selected: string[];
   setSelected: (selected: string[]) => void;
@@ -37,6 +38,7 @@ export const DimensionRangeWizard = ({
   repoAddress?: RepoAddress;
   refetch?: () => Promise<void>;
   showQuickSelectOptionsForStatuses: boolean;
+  labelForPartition?: (key: string) => string | undefined;
 }) => {
   const isTimeseries = dimensionType === PartitionDefinitionType.TIME_WINDOW;
   const isDynamic = dimensionType === PartitionDefinitionType.DYNAMIC;
@@ -280,6 +282,7 @@ export const DimensionRangeWizard = ({
               health={health}
               setShowCreatePartition={setShowCreatePartition}
               isDynamic={isDynamic}
+              labelForPartition={labelForPartition}
             />
           )}
         </Box>

--- a/js_modules/ui-core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/ui-core/src/partitions/DimensionRangeWizard.tsx
@@ -42,6 +42,7 @@ export const DimensionRangeWizard = ({
 }) => {
   const isTimeseries = dimensionType === PartitionDefinitionType.TIME_WINDOW;
   const isDynamic = dimensionType === PartitionDefinitionType.DYNAMIC;
+  const scopedLabelForPartition = isDynamic ? labelForPartition : undefined;
 
   const [showCreatePartition, setShowCreatePartition] = React.useState(false);
 
@@ -282,7 +283,7 @@ export const DimensionRangeWizard = ({
               health={health}
               setShowCreatePartition={setShowCreatePartition}
               isDynamic={isDynamic}
-              labelForPartition={labelForPartition}
+              labelForPartition={scopedLabelForPartition}
             />
           )}
         </Box>

--- a/js_modules/ui-core/src/partitions/DimensionRangeWizards.tsx
+++ b/js_modules/ui-core/src/partitions/DimensionRangeWizards.tsx
@@ -15,6 +15,7 @@ export const DimensionRangeWizards = ({
   displayedPartitionDefinition,
   repoAddress,
   refetch,
+  labelForPartition,
 }: {
   selections: PartitionDimensionSelection[];
   setSelections: Dispatch<SetStateAction<PartitionDimensionSelection[]>>;
@@ -28,6 +29,7 @@ export const DimensionRangeWizards = ({
   } | null;
   repoAddress?: RepoAddress;
   refetch?: () => Promise<void>;
+  labelForPartition?: (key: string) => string | undefined;
 }) => {
   return (
     <>
@@ -67,6 +69,7 @@ export const DimensionRangeWizards = ({
               )?.dynamicPartitionsDefinitionName
             }
             showQuickSelectOptionsForStatuses={selections.length === 1}
+            labelForPartition={labelForPartition}
           />
         </Box>
       ))}

--- a/js_modules/ui-core/src/partitions/OrdinalPartitionSelector.tsx
+++ b/js_modules/ui-core/src/partitions/OrdinalPartitionSelector.tsx
@@ -32,6 +32,7 @@ export const OrdinalPartitionSelector = ({
   placeholder,
   mode = 'multiple',
   disabled,
+  labelForPartition,
 }: {
   allPartitions: string[];
   selectedPartitions: string[];
@@ -42,6 +43,7 @@ export const OrdinalPartitionSelector = ({
   placeholder?: string;
   mode?: 'single' | 'multiple';
   disabled?: boolean;
+  labelForPartition?: (key: string) => string | undefined;
 }) => {
   const dotForPartitionKey = React.useCallback(
     (partitionKey: string) => {
@@ -74,13 +76,26 @@ export const OrdinalPartitionSelector = ({
         placeholder ||
         (setShowCreatePartition ? 'Select a partition or create one' : 'Select a partition')
       }
+      filterTag={React.useCallback(
+        (tag: string, search: string) => {
+          const lower = search.toLowerCase();
+          if (tag.toLowerCase().includes(lower)) {
+            return true;
+          }
+          const lbl = labelForPartition?.(tag);
+          return lbl ? lbl.toLowerCase().includes(lower) : false;
+        },
+        [labelForPartition],
+      )}
       renderDropdownItem={React.useCallback(
         (tag: string, dropdownItemProps: TagSelectorDropdownItemProps) => {
+          const label = labelForPartition?.(tag);
+          const displayText = label ? `${tag} (${label})` : tag;
           const sharedContent = (
             <>
               {dotForPartitionKey(tag)}
-              <div data-tooltip={tag} data-tooltip-style={DropdownItemTooltipStyle}>
-                <MiddleTruncate text={tag} />
+              <div data-tooltip={displayText} data-tooltip-style={DropdownItemTooltipStyle}>
+                <MiddleTruncate text={displayText} />
               </div>
             </>
           );
@@ -131,7 +146,7 @@ export const OrdinalPartitionSelector = ({
             </label>
           );
         },
-        [dotForPartitionKey, mode],
+        [dotForPartitionKey, labelForPartition, mode],
       )}
       renderDropdown={React.useCallback(
         (dropdown: React.ReactNode, {width, allTags}: TagSelectorDropdownProps) => {

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1307,6 +1307,9 @@ class GrapheneAssetNode(graphene.ObjectType):
                 if isinstance(dim.partitions_def, DynamicPartitionsDefinition)
                 and dim.partitions_def.name is not None
             ]
+            # Only support labels when exactly one dynamic dimension is present.
+            # Multi-dynamic-dimension assets are not yet supported; return [] rather
+            # than raising, since callers treat an empty list as "no labels available".
             dynamic_partitions_def_name = (
                 dynamic_partitions_def_names[0] if len(dynamic_partitions_def_names) == 1 else None
             )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -113,7 +113,10 @@ from dagster_graphql.schema.owners import (
     GrapheneTeamAssetOwner,
     GrapheneUserAssetOwner,
 )
-from dagster_graphql.schema.partition_keys import GraphenePartitionKeyConnection
+from dagster_graphql.schema.partition_keys import (
+    GraphenePartitionKeyConnection,
+    GraphenePartitionKeyLabel,
+)
 from dagster_graphql.schema.partition_mappings import GraphenePartitionMapping
 from dagster_graphql.schema.partition_sets import (
     GrapheneDimensionPartitionKeys,
@@ -297,6 +300,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     opVersion = graphene.String()
     partitionDefinition = graphene.Field(GraphenePartitionDefinition)
     partitionKeys = non_null_list(graphene.String)
+    partitionKeyLabels = non_null_list(GraphenePartitionKeyLabel)
     partitionKeyConnection = graphene.Field(
         GraphenePartitionKeyConnection,
         limit=graphene.Argument(graphene.NonNull(graphene.Int)),
@@ -1284,6 +1288,38 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def resolve_partitionKeys(self, graphene_info: ResolveInfo) -> Sequence[str]:
         return self._get_partition_keys(graphene_info)
+
+    def resolve_partitionKeyLabels(
+        self, graphene_info: ResolveInfo
+    ) -> Sequence[GraphenePartitionKeyLabel]:
+        from dagster._core.definitions.partitions.definition import DynamicPartitionsDefinition
+        from dagster._core.definitions.partitions.definition.multi import MultiPartitionsDefinition
+
+        partitions_def = self._get_partitions_def()
+        dynamic_partitions_def_name: str | None
+
+        if isinstance(partitions_def, DynamicPartitionsDefinition):
+            dynamic_partitions_def_name = partitions_def.name
+        elif isinstance(partitions_def, MultiPartitionsDefinition):
+            dynamic_partitions_def_names = [
+                dim.partitions_def.name
+                for dim in partitions_def.partitions_defs
+                if isinstance(dim.partitions_def, DynamicPartitionsDefinition)
+                and dim.partitions_def.name is not None
+            ]
+            dynamic_partitions_def_name = (
+                dynamic_partitions_def_names[0] if len(dynamic_partitions_def_names) == 1 else None
+            )
+        else:
+            dynamic_partitions_def_name = None
+
+        if dynamic_partitions_def_name is None:
+            return []
+
+        labels = graphene_info.context.instance.get_dynamic_partition_labels(
+            dynamic_partitions_def_name
+        )
+        return [GraphenePartitionKeyLabel(key=k, label=v) for k, v in labels.items()]
 
     def resolve_partitionKeyConnection(
         self,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_keys.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_keys.py
@@ -4,6 +4,14 @@ from dagster_graphql.schema.errors import GrapheneError
 from dagster_graphql.schema.util import non_null_list
 
 
+class GraphenePartitionKeyLabel(graphene.ObjectType):
+    key = graphene.NonNull(graphene.String)
+    label = graphene.NonNull(graphene.String)
+
+    class Meta:
+        name = "PartitionKeyLabel"
+
+
 class GraphenePartitionKeyConnection(graphene.ObjectType):
     results = non_null_list(graphene.String)
     cursor = graphene.NonNull(graphene.String)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -422,6 +422,18 @@ GET_ASSET_PARTITIONS = """
     }
 """
 
+GET_ASSET_PARTITION_LABELS = """
+    query AssetNodeQuery($assetKeys: [AssetKeyInput!]) {
+        assetNodes(assetKeys: $assetKeys) {
+            id
+            partitionKeyLabels {
+                key
+                label
+            }
+        }
+    }
+"""
+
 GET_ASSET_PARTITIONS_CONNECTION = """
     query AssetNodeQuery($assetKeys: [AssetKeyInput!], $limit: Int!, $ascending: Boolean!, $cursor: String) {
         assetNodes(assetKeys: $assetKeys) {
@@ -1857,6 +1869,32 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         assert asset_node["partitionKeys"] and len(asset_node["partitionKeys"]) > 100
         assert asset_node["partitionKeys"][0] == "2021-05-05-01:00"
         assert asset_node["partitionKeys"][1] == "2021-05-05-02:00"
+
+    def test_dynamic_asset_partition_key_labels(self, graphql_context: WorkspaceRequestContext):
+        graphql_context.instance.add_dynamic_partitions(
+            "foo",
+            ["apple", "banana"],
+            labels={"apple": "Apple label", "banana": "Banana label"},
+        )
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_ASSET_PARTITION_LABELS,
+            variables={
+                "assetKeys": [
+                    {"path": ["upstream_dynamic_partitioned_asset"]},
+                    {"path": ["upstream_static_partitioned_asset"]},
+                ]
+            },
+        )
+
+        assert result.data
+        assert len(result.data["assetNodes"]) == 2
+        assert result.data["assetNodes"][0]["partitionKeyLabels"] == [
+            {"key": "apple", "label": "Apple label"},
+            {"key": "banana", "label": "Banana label"},
+        ]
+        assert result.data["assetNodes"][1]["partitionKeyLabels"] == []
 
     def test_asset_partition_key_connection(self, graphql_context: WorkspaceRequestContext):
         result = execute_dagster_graphql(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -26,7 +26,11 @@ from dagster._core.definitions.inference import infer_input_props
 from dagster._core.definitions.input import In, InputDefinition
 from dagster._core.definitions.output import Out
 from dagster._core.definitions.policy import RetryPolicy
-from dagster._core.definitions.resource_annotation import get_resource_args
+from dagster._core.definitions.resource_annotation import (
+    ResourceArgSpec,
+    get_resource_arg_specs,
+    get_resource_args,
+)
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterTypeKind
@@ -320,6 +324,9 @@ class DecoratedOpFunction(NamedTuple):
 
     def get_resource_args(self) -> Sequence[Parameter]:
         return get_resource_args(self.decorated_fn)
+
+    def get_resource_arg_specs(self) -> Sequence[ResourceArgSpec]:
+        return get_resource_arg_specs(self.decorated_fn)
 
     def positional_inputs(self) -> Sequence[str]:
         params = self._get_function_params()

--- a/python_modules/dagster/dagster/_core/definitions/dynamic_partitions_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/dynamic_partitions_request.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import NamedTuple
 
 from dagster_shared.serdes import whitelist_for_serdes
@@ -15,6 +15,7 @@ class AddDynamicPartitionsRequest(
         [
             ("partitions_def_name", str),
             ("partition_keys", Sequence[str]),
+            ("partition_key_labels", Mapping[str, str] | None),
         ],
     )
 ):
@@ -24,11 +25,18 @@ class AddDynamicPartitionsRequest(
         cls,
         partitions_def_name: str,
         partition_keys: Sequence[str],
+        partition_key_labels: Mapping[str, str] | None = None,
     ):
         return super().__new__(
             cls,
             partitions_def_name=check.str_param(partitions_def_name, "partitions_def_name"),
             partition_keys=check.list_param(partition_keys, "partition_keys", of_type=str),
+            partition_key_labels=check.opt_nullable_mapping_param(
+                partition_key_labels,
+                "partition_key_labels",
+                key_type=str,
+                value_type=str,
+            ),
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -14,6 +14,7 @@ from dagster._core.definitions.events import (
     Output,
 )
 from dagster._core.definitions.output import DynamicOutputDefinition, OutputDefinition
+from dagster._core.definitions.resource_annotation import get_resource_arg_specs
 from dagster._core.definitions.result import AssetResult
 from dagster._core.errors import (
     DagsterInvalidInvocationError,
@@ -43,11 +44,11 @@ def _separate_args_and_kwargs(
     compute_fn: "DecoratedOpFunction",
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
-    resource_arg_mapping: dict[str, Any],
+    resource_arg_names: set[str],
 ) -> SeparatedArgsKwargs:
-    """Given a decorated compute function, a set of args and kwargs, and set of resource param names,
-    separates the set of resource inputs from op/asset inputs returns a tuple of the categorized
-    args and kwargs.
+    """Given a decorated compute function, a set of args and kwargs, and resource param names,
+    separates the set of resource inputs from op/asset inputs and returns a tuple of the
+    categorized args and kwargs.
 
     We use the remaining args and kwargs to cleanly invoke the compute function, and we use the
     extracted resource inputs to populate the execution context.
@@ -65,7 +66,7 @@ def _separate_args_and_kwargs(
     for i, arg in enumerate(args):
         param = params_without_context[i] if i < len(params_without_context) else None
         if param and param.kind != inspect.Parameter.KEYWORD_ONLY:
-            if param.name in resource_arg_mapping:
+            if param.name in resource_arg_names:
                 resources_from_args_and_kwargs[param.name] = arg
                 continue
             if param.name == "config":
@@ -75,7 +76,7 @@ def _separate_args_and_kwargs(
         adjusted_args.append(arg)
 
     # Get any kwargs that correspond to resource inputs & strip them from the kwargs dict
-    for resource_arg in resource_arg_mapping:
+    for resource_arg in resource_arg_names:
         if resource_arg in kwargs:
             resources_from_args_and_kwargs[resource_arg] = kwargs[resource_arg]
 
@@ -175,7 +176,8 @@ def direct_invocation_result(
         context = args[0]
         args = args[1:]
 
-    resource_arg_mapping = {arg.name: arg.name for arg in compute_fn.get_resource_args()}
+    resource_arg_specs = get_resource_arg_specs(compute_fn.decorated_fn)
+    resource_arg_names = {spec.name for spec in resource_arg_specs}
 
     # The user is allowed to invoke an op with an arbitrary mix of args and kwargs.
     # We ensure that these args and kwargs are correctly categorized as inputs, config, or resource objects and then validated.
@@ -187,7 +189,7 @@ def direct_invocation_result(
     # - Inputs are type checked
     #
     # We recollect all the varying args/kwargs into a dictionary and invoke the user-defined function with kwargs only.
-    extracted = _separate_args_and_kwargs(compute_fn, args, kwargs, resource_arg_mapping)
+    extracted = _separate_args_and_kwargs(compute_fn, args, kwargs, resource_arg_names)
 
     input_args = extracted.input_args
     input_kwargs = extracted.input_kwargs
@@ -221,7 +223,7 @@ def direct_invocation_result(
             config_arg_cls=(
                 compute_fn.get_config_arg().annotation if compute_fn.has_config_arg() else None
             ),
-            resource_args=resource_arg_mapping,
+            resource_args=resource_arg_specs,
         )
         return _type_check_output_wrapper(op_def, result, bound_context)  # type: ignore # (pyright bug)
     except Exception:

--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/dynamic.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/dynamic.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, NamedTuple, Optional
 
@@ -208,10 +208,18 @@ class DynamicPartitionsDefinition(
                     partitions_def_name=self._validated_name(), partition_key=partition_key
                 )
 
-    def build_add_request(self, partition_keys: Sequence[str]) -> AddDynamicPartitionsRequest:
+    def build_add_request(
+        self,
+        partition_keys: Sequence[str],
+        partition_key_labels: Mapping[str, str] | None = None,
+    ) -> AddDynamicPartitionsRequest:
         check.sequence_param(partition_keys, "partition_keys", of_type=str)
         validated_name = self._validated_name()
-        return AddDynamicPartitionsRequest(validated_name, partition_keys)
+        return AddDynamicPartitionsRequest(
+            validated_name,
+            partition_keys,
+            partition_key_labels=partition_key_labels,
+        )
 
     def build_delete_request(self, partition_keys: Sequence[str]) -> DeleteDynamicPartitionsRequest:
         check.sequence_param(partition_keys, "partition_keys", of_type=str)

--- a/python_modules/dagster/dagster/_core/definitions/resource_annotation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_annotation.py
@@ -1,8 +1,9 @@
 from abc import ABC
 from collections.abc import Sequence
 from inspect import Parameter
-from typing import Annotated, Any, TypeVar
+from typing import Annotated, Any, TypeVar, Union, get_args, get_origin
 
+from dagster_shared.record import record
 from dagster_shared.seven import is_subclass
 
 from dagster._core.decorator_utils import get_function_params, get_type_hints
@@ -49,6 +50,112 @@ def _is_resource_annotation(annotation: type[Any] | None) -> bool:
     return hasattr(annotation, "__metadata__") and getattr(annotation, "__metadata__") == (
         RESOURCE_PARAM_METADATA,
     )
+
+
+def _resolve_annotation_for_type_check(annotation: Any) -> type | None:
+    """Extracts the concrete checkable type from a resource parameter annotation.
+
+    Returns ``None`` when the annotation cannot support a meaningful ``isinstance``
+    check — for example, legacy ``ResourceDefinition``, unions with multiple
+    non-``None`` members, or non-type objects such as plain strings.
+
+    Handles:
+    - ``ConfigurableResource`` / ``ConfigurableResourceFactory`` subclasses → as-is
+    - ``TreatAsResourceParam`` subclasses → as-is
+    - ``ResourceParam[T]`` / ``Annotated[T, ...]`` → unwrap, recurse on ``T``
+    - ``Optional[T]`` / ``Union[T, None]`` → unwrap to ``T``, recurse
+    - ``Union[A, B, ...]`` (multiple non-``None`` members) → ``None`` (ambiguous)
+    - Bare ``ResourceDefinition`` (non-configurable, legacy) → ``None`` (too abstract)
+    """
+    from dagster._config.pythonic_config import ConfigurableResourceFactory
+
+    # Unwrap Annotated[T, ...] and ResourceParam[T] = Annotated[T, "resource_param"]
+    if get_origin(annotation) is Annotated:
+        return _resolve_annotation_for_type_check(get_args(annotation)[0])
+
+    # Handle Optional[T] == Union[T, None] and bare Union types
+    if get_origin(annotation) is Union:
+        non_none = [a for a in get_args(annotation) if a is not type(None)]
+        if len(non_none) == 1:
+            return _resolve_annotation_for_type_check(non_none[0])
+        return None  # Union[A, B, ...] — ambiguous, skip check
+
+    if not isinstance(annotation, type):
+        return None
+
+    # Skip bare ResourceDefinition (non-configurable legacy style) — too abstract
+    # to perform a meaningful isinstance check against the user-provided resource.
+    if is_subclass(annotation, ResourceDefinition) and not is_subclass(
+        annotation, ConfigurableResourceFactory
+    ):
+        return None
+
+    if is_subclass(annotation, ConfigurableResourceFactory):
+        # Only validate when the resource injects *itself* into user code.
+        # ConfigurableResource subclasses that override create_resource may inject
+        # an arbitrary value (not the resource object), so skip the check for those.
+        if not _injects_self(annotation):
+            return None
+        return annotation
+
+    if is_subclass(annotation, TreatAsResourceParam):
+        return annotation
+
+    return None
+
+
+def _injects_self(annotation: type) -> bool:
+    """Returns True when the ConfigurableResource subclass does NOT override create_resource.
+
+    When create_resource is not overridden, the resource object itself (an instance of the
+    annotation class) is injected into user code, making isinstance validation meaningful.
+    When create_resource IS overridden, the injected value may be any type, so we skip.
+    """
+    from dagster._config.pythonic_config import ConfigurableResource
+
+    for cls in annotation.__mro__:
+        if "create_resource" in cls.__dict__:
+            return cls is ConfigurableResource
+    return True
+
+
+@record
+class ResourceArgSpec:
+    """Bundles a resource parameter name with its resolved annotation type.
+
+    Used to carry type information from the function signature through to the
+    resource injection site in :func:`invoke_compute_fn`, enabling
+    ``isinstance`` validation *before* user code runs.
+
+    ``annotation`` is ``None`` when the annotation cannot be meaningfully
+    validated (e.g. legacy ``ResourceDefinition``, a ``Union`` with multiple
+    non-``None`` members).
+    """
+
+    name: str
+    annotation: type | None = None
+
+
+def get_resource_arg_specs(fn) -> Sequence[ResourceArgSpec]:
+    """Returns a :class:`ResourceArgSpec` for each resource-annotated parameter on ``fn``.
+
+    Replaces the ``{name: name}`` identity-dict pattern with a typed record
+    that also carries the resolved annotation, enabling ``isinstance``
+    validation at injection time.
+    """
+    type_annotations = get_type_hints(fn)
+    specs = []
+    for param in get_function_params(fn):
+        annotation = type_annotations.get(param.name)
+        if not _is_resource_annotation(annotation):
+            continue
+        specs.append(
+            ResourceArgSpec(
+                name=param.name,
+                annotation=_resolve_annotation_for_type_check(annotation),
+            )
+        )
+    return specs
 
 
 T = TypeVar("T")

--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -14,6 +14,7 @@ from dagster._core.definitions import (
 )
 from dagster._core.definitions.input import InputDefinition
 from dagster._core.definitions.op_definition import OpDefinition
+from dagster._core.definitions.resource_annotation import ResourceArgSpec, get_resource_arg_specs
 from dagster._core.definitions.result import AssetResult, ObserveResult
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.context.compute import ExecutionContextTypes
@@ -35,7 +36,7 @@ def create_op_compute_wrapper(
     output_defs = op_def.output_defs
     context_arg_provided = compute_fn.has_context_arg()
     config_arg_cls = compute_fn.get_config_arg().annotation if compute_fn.has_config_arg() else None
-    resource_arg_mapping = {arg.name: arg.name for arg in compute_fn.get_resource_args()}
+    resource_arg_specs = get_resource_arg_specs(fn)
 
     input_names = [
         input_def.name
@@ -59,7 +60,7 @@ def create_op_compute_wrapper(
         ):
             # safe to execute the function, as doing so will not immediately execute user code
             result = invoke_compute_fn(
-                fn, context, kwargs, context_arg_provided, config_arg_cls, resource_arg_mapping
+                fn, context, kwargs, context_arg_provided, config_arg_cls, resource_arg_specs
             )
             if inspect.iscoroutine(result):
                 return _coerce_async_op_to_async_gen(result, context, output_defs)
@@ -75,7 +76,7 @@ def create_op_compute_wrapper(
                 context_arg_provided,
                 kwargs,
                 config_arg_cls,
-                resource_arg_mapping,
+                resource_arg_specs,
             )
 
     return compute
@@ -97,7 +98,7 @@ def invoke_compute_fn(
     kwargs: Mapping[str, Any],
     context_arg_provided: bool,
     config_arg_cls: type[Config] | None,
-    resource_args: dict[str, str] | None = None,
+    resource_args: Sequence[ResourceArgSpec] | None = None,
 ) -> Any:
     args_to_pass = {**kwargs}
     if config_arg_cls:
@@ -109,8 +110,17 @@ def invoke_compute_fn(
         else:
             args_to_pass["config"] = context.op_execution_context.op_config
     if resource_args:
-        for resource_name, arg_name in resource_args.items():
-            args_to_pass[arg_name] = context.resources.original_resource_dict[resource_name]
+        for spec in resource_args:
+            resource_obj = context.resources.original_resource_dict[spec.name]
+            if spec.annotation is not None and not isinstance(resource_obj, spec.annotation):
+                raise DagsterInvariantViolationError(
+                    f"Resource '{spec.name}' was expected to be of type"
+                    f" '{spec.annotation.__name__}' (as annotated on parameter '{spec.name}'),"
+                    f" but received '{type(resource_obj).__name__}'."
+                    f" Ensure the correct resource type is bound in your Definitions or"
+                    f" job configuration."
+                )
+            args_to_pass[spec.name] = resource_obj
 
     return fn(context, **args_to_pass) if context_arg_provided else fn(**args_to_pass)
 
@@ -130,10 +140,10 @@ def _coerce_op_compute_fn_to_iterator(
     context_arg_provided,
     kwargs,
     config_arg_class,
-    resource_arg_mapping,
+    resource_arg_specs,
 ):
     result = invoke_compute_fn(
-        fn, context, kwargs, context_arg_provided, config_arg_class, resource_arg_mapping
+        fn, context, kwargs, context_arg_provided, config_arg_class, resource_arg_specs
     )
     yield from validate_and_coerce_op_result_to_iterator(result, context, output_defs)
 

--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -16,6 +16,7 @@ from typing_extensions import Self
 
 import dagster._check as check
 from dagster._annotations import public
+from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.instance.config import DAGSTER_CONFIG_YAML_FILENAME
 from dagster._core.instance.methods.asset_methods import AssetMethods
 from dagster._core.instance.methods.daemon_methods import DaemonMethods
@@ -598,7 +599,11 @@ class DagsterInstance(
     @public
     @traced
     def add_dynamic_partitions(
-        self, partitions_def_name: str, partition_keys: Sequence[str]
+        self,
+        partitions_def_name: str,
+        partition_keys: Sequence[str],
+        *,
+        labels: Mapping[str, str] | None = None,
     ) -> None:
         """Add partitions to the specified :py:class:`DynamicPartitionsDefinition` idempotently.
         Does not add any partitions that already exist.
@@ -606,8 +611,48 @@ class DagsterInstance(
         Args:
             partitions_def_name (str): The name of the `DynamicPartitionsDefinition`.
             partition_keys (Sequence[str]): Partition keys to add.
+            labels (Optional[Mapping[str, str]]): Optional mapping of partition key to a
+                human-readable display label shown in the Dagster UI. Keys not present in the
+                mapping are left without a label.
         """
-        return self._event_storage.add_dynamic_partitions(partitions_def_name, partition_keys)
+        if labels:
+            for label in labels.values():
+                if len(label) > 255:
+                    raise DagsterInvalidInvocationError(
+                        f"Partition label must be 255 characters or fewer, got {len(label)}."
+                    )
+
+        return self._event_storage.add_dynamic_partitions(
+            partitions_def_name, partition_keys, labels=labels
+        )
+
+    @traced
+    def get_dynamic_partition_labels(self, partitions_def_name: str) -> Mapping[str, str]:
+        """Get a mapping of partition key to display label for partitions that have a label set.
+
+        Args:
+            partitions_def_name (str): The name of the `DynamicPartitionsDefinition`.
+        """
+        return self._event_storage.get_dynamic_partition_labels(partitions_def_name)
+
+    @traced
+    def set_dynamic_partition_label(
+        self, partitions_def_name: str, partition_key: str, label: str
+    ) -> None:
+        """Set a human-readable display label for an existing dynamic partition key.
+
+        Args:
+            partitions_def_name (str): The name of the `DynamicPartitionsDefinition`.
+            partition_key (str): The partition key to label.
+            label (str): The human-readable display label (max 255 characters).
+        """
+        if len(label) > 255:
+            raise DagsterInvalidInvocationError(
+                f"Partition label must be 255 characters or fewer, got {len(label)}."
+            )
+        return self._event_storage.set_dynamic_partition_label(
+            partitions_def_name, partition_key, label
+        )
 
     @public
     @traced

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/049_add_dynamic_partitions_display_label.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/049_add_dynamic_partitions_display_label.py
@@ -1,0 +1,32 @@
+"""add display_label column to dynamic_partitions table
+
+Revision ID: a16d5b32c4e1
+Revises: 29b539ebc72a
+Create Date: 2026-04-07 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from dagster._core.storage.migration.utils import has_column, has_table
+
+# revision identifiers, used by Alembic.
+revision = "a16d5b32c4e1"
+down_revision = "29b539ebc72a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if has_table("dynamic_partitions"):
+        if not has_column("dynamic_partitions", "display_label"):
+            op.add_column(
+                "dynamic_partitions",
+                sa.Column("display_label", sa.Text(), nullable=True),
+            )
+
+
+def downgrade():
+    if has_table("dynamic_partitions"):
+        if has_column("dynamic_partitions", "display_label"):
+            op.drop_column("dynamic_partitions", "display_label")

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -527,9 +527,24 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     @abstractmethod
     def add_dynamic_partitions(
-        self, partitions_def_name: str, partition_keys: Sequence[str]
+        self,
+        partitions_def_name: str,
+        partition_keys: Sequence[str],
+        *,
+        labels: Mapping[str, str] | None = None,
     ) -> None:
         """Add a partition for the specified dynamic partitions definition."""
+        raise NotImplementedError()
+
+    def get_dynamic_partition_labels(self, partitions_def_name: str) -> dict[str, str]:
+        """Get a mapping of partition key -> display label for partitions that have a label set."""
+        return {}
+
+    @abstractmethod
+    def set_dynamic_partition_label(
+        self, partitions_def_name: str, partition_key: str, label: str
+    ) -> None:
+        """Set the display label for an existing dynamic partition key."""
         raise NotImplementedError()
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -540,12 +540,16 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """Get a mapping of partition key -> display label for partitions that have a label set."""
         return {}
 
-    @abstractmethod
     def set_dynamic_partition_label(
         self, partitions_def_name: str, partition_key: str, label: str
     ) -> None:
         """Set the display label for an existing dynamic partition key."""
-        raise NotImplementedError()
+        from dagster._core.errors import DagsterInvalidInvocationError
+
+        raise DagsterInvalidInvocationError(
+            "Dynamic partition labels require a database schema migration. Run"
+            " `dagster instance migrate`."
+        )
 
     @abstractmethod
     def delete_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> None:

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -101,6 +101,7 @@ DynamicPartitionsTable = db.Table(
     db.Column("partitions_def_name", db.Text, nullable=False),
     db.Column("partition", db.Text, nullable=False),
     db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
+    db.Column("display_label", db.Text, nullable=True),
 )
 
 ConcurrencyLimitsTable = db.Table(

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2138,9 +2138,17 @@ class SqlEventLogStorage(EventLogStorage):
         return len(results) > 0
 
     def add_dynamic_partitions(
-        self, partitions_def_name: str, partition_keys: Sequence[str]
+        self,
+        partitions_def_name: str,
+        partition_keys: Sequence[str],
+        *,
+        labels: Mapping[str, str] | None = None,
     ) -> None:
         self._check_partitions_table()
+        supports_display_labels = self.has_dynamic_partition_display_label_col
+        if labels and not supports_display_labels:
+            self._check_dynamic_partition_label_column()
+
         with self.index_connection() as conn:
             existing_rows = conn.execute(
                 db_select([DynamicPartitionsTable.c.partition]).where(
@@ -2160,11 +2168,99 @@ class SqlEventLogStorage(EventLogStorage):
             if new_keys:
                 conn.execute(
                     DynamicPartitionsTable.insert(),
-                    [
-                        dict(partitions_def_name=partitions_def_name, partition=partition_key)
-                        for partition_key in new_keys
-                    ],
+                    (
+                        [
+                            dict(
+                                partitions_def_name=partitions_def_name,
+                                partition=partition_key,
+                                display_label=labels.get(partition_key) if labels else None,
+                            )
+                            for partition_key in new_keys
+                        ]
+                        if supports_display_labels
+                        else [
+                            dict(
+                                partitions_def_name=partitions_def_name,
+                                partition=partition_key,
+                            )
+                            for partition_key in new_keys
+                        ]
+                    ),
                 )
+
+            # Update labels for existing keys that now have a label provided
+            if labels:
+                for partition_key in existing_keys:
+                    if partition_key in labels:
+                        conn.execute(
+                            DynamicPartitionsTable.update()
+                            .where(
+                                db.and_(
+                                    DynamicPartitionsTable.c.partitions_def_name
+                                    == partitions_def_name,
+                                    DynamicPartitionsTable.c.partition == partition_key,
+                                )
+                            )
+                            .values(display_label=labels[partition_key])
+                        )
+
+    def get_dynamic_partition_labels(self, partitions_def_name: str) -> dict[str, str]:
+        self._check_partitions_table()
+        if not self.has_dynamic_partition_display_label_col:
+            return {}
+
+        query = db_select(
+            [DynamicPartitionsTable.c.partition, DynamicPartitionsTable.c.display_label]
+        ).where(
+            db.and_(
+                DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
+                DynamicPartitionsTable.c.display_label.isnot(None),
+            )
+        )
+        with self.index_connection() as conn, db_result(conn, query) as result:
+            rows = result.fetchall()
+        return {row[0]: row[1] for row in rows}
+
+    def set_dynamic_partition_label(
+        self, partitions_def_name: str, partition_key: str, label: str
+    ) -> None:
+        self._check_partitions_table()
+        self._check_dynamic_partition_label_column()
+        with self.index_connection() as conn:
+            result = conn.execute(
+                DynamicPartitionsTable.update()
+                .where(
+                    db.and_(
+                        DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
+                        DynamicPartitionsTable.c.partition == partition_key,
+                    )
+                )
+                .values(display_label=label)
+            )
+            if result.rowcount == 0:
+                raise DagsterInvalidInvocationError(
+                    f"Partition key {partition_key} does not exist for dynamic partitions definition {partitions_def_name}."
+                )
+
+    # This check is intentionally cached for process lifetime. If an instance starts before
+    # migrations run, it will continue treating the column as unavailable until process restart.
+    @cached_property
+    def has_dynamic_partition_display_label_col(self) -> bool:
+        if not self.has_table(DynamicPartitionsTable.name):
+            return False
+
+        with self.index_connection() as conn:
+            column_names = [
+                x.get("name") for x in db.inspect(conn).get_columns(DynamicPartitionsTable.name)
+            ]
+            return DynamicPartitionsTable.c.display_label.name in column_names
+
+    def _check_dynamic_partition_label_column(self) -> None:
+        if not self.has_dynamic_partition_display_label_col:
+            raise DagsterInvalidInvocationError(
+                "Dynamic partition labels require a database schema migration. Run"
+                " `dagster instance migrate`."
+            )
 
     def delete_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> None:
         self._check_partitions_table()

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2148,6 +2148,7 @@ class SqlEventLogStorage(EventLogStorage):
         supports_display_labels = self.has_dynamic_partition_display_label_col()
         if labels and not supports_display_labels:
             self._check_dynamic_partition_label_column()
+            supports_display_labels = True
 
         with self.index_connection() as conn:
             existing_rows = conn.execute(
@@ -2189,7 +2190,7 @@ class SqlEventLogStorage(EventLogStorage):
                 )
 
             # Update labels for existing keys that now have a label provided
-            if labels:
+            if labels and supports_display_labels:
                 for partition_key in existing_keys:
                     if partition_key in labels:
                         conn.execute(
@@ -2242,7 +2243,7 @@ class SqlEventLogStorage(EventLogStorage):
                     f"Partition key {partition_key} does not exist for dynamic partitions definition {partitions_def_name}."
                 )
 
-    def has_dynamic_partition_display_label_col(self) -> bool:
+    def _get_dynamic_partition_display_label_col_support(self) -> bool:
         if not self.has_table(DynamicPartitionsTable.name):
             return False
 
@@ -2252,8 +2253,27 @@ class SqlEventLogStorage(EventLogStorage):
             ]
             return DynamicPartitionsTable.c.display_label.name in column_names
 
+    def has_dynamic_partition_display_label_col(self) -> bool:
+        cached_support = getattr(self, "_dynamic_partition_display_label_col_support", None)
+        if cached_support is True:
+            return True
+
+        cached_support = self._get_dynamic_partition_display_label_col_support()
+        if cached_support:
+            self._dynamic_partition_display_label_col_support = True
+
+        return cached_support
+
+    def _refresh_dynamic_partition_display_label_col_support(self) -> bool:
+        supports_display_labels = self._get_dynamic_partition_display_label_col_support()
+        if supports_display_labels:
+            self._dynamic_partition_display_label_col_support = True
+        else:
+            self.__dict__.pop("_dynamic_partition_display_label_col_support", None)
+        return supports_display_labels
+
     def _check_dynamic_partition_label_column(self) -> None:
-        if not self.has_dynamic_partition_display_label_col():
+        if not self._refresh_dynamic_partition_display_label_col_support():
             raise DagsterInvalidInvocationError(
                 "Dynamic partition labels require a database schema migration. Run"
                 " `dagster instance migrate`."

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2145,7 +2145,7 @@ class SqlEventLogStorage(EventLogStorage):
         labels: Mapping[str, str] | None = None,
     ) -> None:
         self._check_partitions_table()
-        supports_display_labels = self.has_dynamic_partition_display_label_col
+        supports_display_labels = self.has_dynamic_partition_display_label_col()
         if labels and not supports_display_labels:
             self._check_dynamic_partition_label_column()
 
@@ -2206,7 +2206,7 @@ class SqlEventLogStorage(EventLogStorage):
 
     def get_dynamic_partition_labels(self, partitions_def_name: str) -> dict[str, str]:
         self._check_partitions_table()
-        if not self.has_dynamic_partition_display_label_col:
+        if not self.has_dynamic_partition_display_label_col():
             return {}
 
         query = db_select(
@@ -2242,9 +2242,6 @@ class SqlEventLogStorage(EventLogStorage):
                     f"Partition key {partition_key} does not exist for dynamic partitions definition {partitions_def_name}."
                 )
 
-    # This check is intentionally cached for process lifetime. If an instance starts before
-    # migrations run, it will continue treating the column as unavailable until process restart.
-    @cached_property
     def has_dynamic_partition_display_label_col(self) -> bool:
         if not self.has_table(DynamicPartitionsTable.name):
             return False
@@ -2256,7 +2253,7 @@ class SqlEventLogStorage(EventLogStorage):
             return DynamicPartitionsTable.c.display_label.name in column_names
 
     def _check_dynamic_partition_label_column(self) -> None:
-        if not self.has_dynamic_partition_display_label_col:
+        if not self.has_dynamic_partition_display_label_col():
             raise DagsterInvalidInvocationError(
                 "Dynamic partition labels require a database schema migration. Run"
                 " `dagster instance migrate`."

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -650,10 +650,24 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         )
 
     def add_dynamic_partitions(
-        self, partitions_def_name: str, partition_keys: Sequence[str]
+        self,
+        partitions_def_name: str,
+        partition_keys: Sequence[str],
+        *,
+        labels: Mapping[str, str] | None = None,
     ) -> None:
         return self._storage.event_log_storage.add_dynamic_partitions(
-            partitions_def_name, partition_keys
+            partitions_def_name, partition_keys, labels=labels
+        )
+
+    def get_dynamic_partition_labels(self, partitions_def_name: str) -> dict[str, str]:
+        return self._storage.event_log_storage.get_dynamic_partition_labels(partitions_def_name)
+
+    def set_dynamic_partition_label(
+        self, partitions_def_name: str, partition_key: str, label: str
+    ) -> None:
+        return self._storage.event_log_storage.set_dynamic_partition_label(
+            partitions_def_name, partition_key, label
         )
 
     def delete_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> None:

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -935,11 +935,22 @@ def _handle_dynamic_partitions_requests(
                 instance.add_dynamic_partitions(
                     request.partitions_def_name,
                     nonexistent_partitions,
+                    labels=request.partition_key_labels,
                 )
                 context.logger.info(
                     "Added partition keys to dynamic partitions definition"
                     f" '{request.partitions_def_name}': {nonexistent_partitions}"
                 )
+
+            # Update labels for partitions that already exist but have a new label
+            if existent_partitions and request.partition_key_labels:
+                for partition_key in existent_partitions:
+                    if partition_key in request.partition_key_labels:
+                        instance.set_dynamic_partition_label(
+                            request.partitions_def_name,
+                            partition_key,
+                            request.partition_key_labels[partition_key],
+                        )
 
             if existent_partitions:
                 context.logger.info(

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_resource_type_validation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_resource_type_validation.py
@@ -1,0 +1,300 @@
+"""Tests for runtime resource type validation (issue #32633).
+
+Dagster should validate that the resource bound to a key matches the type
+annotation declared on the op/asset parameter *before* calling user code.
+
+Traffic light legend:
+  RED   - wrong type must raise DagsterInvariantViolationError
+  GREEN - valid type must pass without error
+"""
+
+from abc import abstractmethod
+
+import dagster as dg
+import pytest
+from dagster import DagsterInvariantViolationError
+
+# ── RED: wrong resource type must raise ───────────────────────────────────────
+
+
+def test_wrong_resource_type_raises_on_direct_op_invocation() -> None:
+    """Core bug from #32633: wrong resource type must raise before user code runs."""
+
+    class MyResource(dg.ConfigurableResource):
+        something: str
+
+    class UnrelatedResource(dg.ConfigurableResource):
+        unrelated_param: str
+
+    @dg.op
+    def my_op(my_resource: MyResource) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="MyResource"):
+        my_op(my_resource=UnrelatedResource(unrelated_param="oops"))
+
+
+def test_wrong_resource_type_raises_on_direct_asset_invocation() -> None:
+    """Same bug, asset path: wrong resource type must raise before user code runs."""
+
+    class MyResource(dg.ConfigurableResource):
+        something: str
+
+    class UnrelatedResource(dg.ConfigurableResource):
+        unrelated_param: str
+
+    @dg.asset
+    def my_asset(my_resource: MyResource) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="MyResource"):
+        my_asset(my_resource=UnrelatedResource(unrelated_param="oops"))
+
+
+def test_wrong_resource_type_raises_during_job_execution() -> None:
+    """execute_in_process with wrong resource bound should fail without entering user code."""
+
+    class MyResource(dg.ConfigurableResource):
+        something: str
+
+    class UnrelatedResource(dg.ConfigurableResource):
+        unrelated_param: str
+
+    call_count = {"n": 0}
+
+    @dg.op
+    def my_op(context: dg.OpExecutionContext, my_resource: MyResource) -> None:
+        call_count["n"] += 1
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    @dg.job(resource_defs={"my_resource": UnrelatedResource(unrelated_param="wrong")})
+    def my_job():
+        my_op()
+
+    result = my_job.execute_in_process(raise_on_error=False)
+    assert not result.success
+    assert call_count["n"] == 0, "User code must not be called when resource type is wrong"
+
+
+def test_wrong_resource_bound_via_context_raises() -> None:
+    """Wrong resource passed through build_op_context must raise on invocation."""
+
+    class MyResource(dg.ConfigurableResource):
+        something: str
+
+    class WrongResource(dg.ConfigurableResource):
+        wrong_field: int
+
+    @dg.op
+    def my_op(context: dg.OpExecutionContext, my_resource: MyResource) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="MyResource"):
+        my_op(dg.build_op_context(resources={"my_resource": WrongResource(wrong_field=42)}))
+
+
+def test_parent_class_fails_for_child_annotation() -> None:
+    """Isinstance semantics: a parent instance must NOT satisfy a child class annotation."""
+
+    class BaseResource(dg.ConfigurableResource):
+        base_val: str
+
+    class ChildResource(BaseResource):
+        child_val: str
+
+    @dg.op
+    def my_op(my_resource: ChildResource) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="ChildResource"):
+        my_op(my_resource=BaseResource(base_val="only_base"))
+
+
+def test_swapped_resources_at_shared_key_raises() -> None:
+    """When TypeA is bound where TypeB is expected, must raise before user code."""
+
+    class TypeA(dg.ConfigurableResource):
+        val_a: str
+
+    class TypeB(dg.ConfigurableResource):
+        val_b: str
+
+    @dg.op
+    def op_needing_type_b(my_resource: TypeB) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="TypeB"):
+        op_needing_type_b(my_resource=TypeA(val_a="wrong_type"))
+
+
+def test_error_message_includes_expected_and_actual_type() -> None:
+    """Error message must name both the expected and the actual resource type."""
+
+    class ExpectedResource(dg.ConfigurableResource):
+        x: str
+
+    class ActualResource(dg.ConfigurableResource):
+        y: str
+
+    @dg.op
+    def my_op(my_res: ExpectedResource) -> None:
+        pass
+
+    with pytest.raises(DagsterInvariantViolationError) as exc_info:
+        my_op(my_res=ActualResource(y="bad"))
+
+    msg = str(exc_info.value)
+    assert "ExpectedResource" in msg, f"Expected type name missing from: {msg}"
+    assert "ActualResource" in msg, f"Actual type name missing from: {msg}"
+    assert "my_res" in msg, f"Parameter name missing from: {msg}"
+
+
+# ── GREEN: valid types must pass without error ────────────────────────────────
+
+
+def test_exact_type_match_passes() -> None:
+    """Providing the exact annotated type must not raise."""
+
+    class MyResource(dg.ConfigurableResource):
+        val: str
+
+    @dg.op
+    def my_op(my_resource: MyResource) -> str:
+        return my_resource.val
+
+    assert my_op(my_resource=MyResource(val="hello")) == "hello"
+
+
+def test_subclass_passes_for_parent_annotation() -> None:
+    """Isinstance semantics: a subclass must satisfy its parent annotation."""
+
+    class BaseResource(dg.ConfigurableResource):
+        base_val: str
+
+    class ChildResource(BaseResource):
+        child_val: str
+
+    @dg.op
+    def my_op(my_resource: BaseResource) -> str:
+        return my_resource.base_val
+
+    result = my_op(my_resource=ChildResource(base_val="hello", child_val="extra"))
+    assert result == "hello"
+
+
+def test_abstract_base_resource_accepts_concrete_subclass() -> None:
+    """Abstract ConfigurableResource annotation must accept any concrete subclass."""
+
+    class AbstractWriter(dg.ConfigurableResource):
+        @abstractmethod
+        def write(self) -> str: ...
+
+    class ConcreteWriter(AbstractWriter):
+        val: str
+
+        def write(self) -> str:
+            return self.val
+
+    @dg.op
+    def my_op(writer: AbstractWriter) -> str:
+        return writer.write()
+
+    assert my_op(writer=ConcreteWriter(val="hello")) == "hello"
+
+
+def test_configure_at_launch_runtime_type_is_correct() -> None:
+    """configure_at_launch() resources must pass type validation at runtime."""
+
+    class MyResource(dg.ConfigurableResource):
+        val: str
+
+    @dg.op
+    def my_op(context: dg.OpExecutionContext, my_resource: MyResource) -> str:
+        return my_resource.val
+
+    @dg.job
+    def my_job():
+        my_op()
+
+    result = my_job.execute_in_process(resources={"my_resource": MyResource(val="hello")})
+    assert result.success
+
+
+def test_resource_param_from_factory_passes() -> None:
+    """ResourceParam[bool] produced by ConfigurableResourceFactory must not raise.
+
+    The annotation wraps a primitive type — isinstance checking is intentionally
+    skipped for this case (the factory, not the primitive, is the resource object).
+    """
+    from dagster._config.pythonic_config import ConfigurableResourceFactory
+
+    class BoolResource(ConfigurableResourceFactory[bool]):
+        val: bool
+
+        def create_resource(self, context) -> bool:
+            return self.val
+
+    @dg.op
+    def my_op(context: dg.OpExecutionContext, my_bool: dg.ResourceParam[bool]) -> bool:
+        return my_bool
+
+    @dg.job(resource_defs={"my_bool": BoolResource(val=True)})
+    def my_job():
+        my_op()
+
+    assert my_job.execute_in_process().success
+
+
+def test_hardcoded_resource_correct_type_passes() -> None:
+    """A hardcoded (non-configurable) resource bound to a ConfigurableResource annotation
+    should raise - it's the wrong type, not a special legacy bypass.
+    """
+
+    class MyResource(dg.ConfigurableResource):
+        val: str
+
+    @dg.op
+    def my_op(context: dg.OpExecutionContext, my_resource: MyResource) -> str:
+        return my_resource.val
+
+    @dg.job(resource_defs={"my_resource": MyResource(val="hello")})
+    def my_job():
+        my_op()
+
+    assert my_job.execute_in_process().success
+
+
+def test_multiple_resources_all_correct_passes() -> None:
+    """Multiple resource parameters all with correct types must pass."""
+
+    class ResA(dg.ConfigurableResource):
+        val: str
+
+    class ResB(dg.ConfigurableResource):
+        num: int
+
+    @dg.op
+    def my_op(res_a: ResA, res_b: ResB) -> str:
+        return f"{res_a.val}-{res_b.num}"
+
+    assert my_op(res_a=ResA(val="x"), res_b=ResB(num=1)) == "x-1"
+
+
+def test_multiple_resources_one_wrong_raises() -> None:
+    """When one of multiple resource parameters has wrong type, must raise."""
+
+    class ResA(dg.ConfigurableResource):
+        val: str
+
+    class ResB(dg.ConfigurableResource):
+        num: int
+
+    class ImpostorForB(dg.ConfigurableResource):
+        fake: str
+
+    @dg.op
+    def my_op(res_a: ResA, res_b: ResB) -> None:
+        raise AssertionError("BUG: user code executed with wrong resource type")
+
+    with pytest.raises(DagsterInvariantViolationError, match="ResB"):
+        my_op(res_a=ResA(val="ok"), res_b=ImpostorForB(fake="bad"))

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -690,6 +690,18 @@ def add_dynamic_partitions_sensor(context):
     )
 
 
+@sensor()
+def add_dynamic_partitions_with_labels_sensor(context):
+    return dg.SensorResult(
+        dynamic_partitions_requests=[
+            quux.build_add_request(
+                ["baz", "foo"],
+                partition_key_labels={"baz": "Baz label", "foo": "Updated foo label"},
+            ),
+        ],
+    )
+
+
 @sensor(job=quux_asset_job)
 def add_delete_dynamic_partitions_and_yield_run_requests_sensor(context):
     return dg.SensorResult(
@@ -892,6 +904,7 @@ def the_repo():
         logging_fail_tick_sensor,
         logging_status_sensor,
         add_delete_dynamic_partitions_and_yield_run_requests_sensor,
+        add_dynamic_partitions_with_labels_sensor,
         add_dynamic_partitions_sensor,
         quux_asset_job,
         error_on_deleted_dynamic_partitions_run_requests_sensor,
@@ -3230,6 +3243,32 @@ def test_add_dynamic_partitions_sensor(caplog, executor, instance, workspace_con
             "quux", added_partitions=["baz"], deleted_partitions=None, skipped_partitions=["foo"]
         ),
     ]
+
+
+def test_add_dynamic_partitions_with_labels_sensor(
+    caplog, executor, instance, workspace_context, remote_repo
+):
+    foo_job.execute_in_process(instance=instance)  # creates event log storage tables
+    instance.add_dynamic_partitions("quux", ["foo"], labels={"foo": "Original foo label"})
+    assert instance.get_dynamic_partition_labels("quux") == {"foo": "Original foo label"}
+
+    sensor = remote_repo.get_sensor("add_dynamic_partitions_with_labels_sensor")
+    instance.add_instigator_state(
+        InstigatorState(
+            sensor.get_remote_origin(),
+            InstigatorType.SENSOR,
+            InstigatorStatus.RUNNING,
+        )
+    )
+
+    evaluate_sensors(workspace_context, executor)
+
+    assert set(instance.get_dynamic_partitions("quux")) == {"baz", "foo"}
+    assert instance.get_dynamic_partition_labels("quux") == {
+        "baz": "Baz label",
+        "foo": "Updated foo label",
+    }
+    assert "Added partition keys to dynamic partitions definition 'quux': ['baz']" in caplog.text
 
 
 def test_add_delete_skip_dynamic_partitions(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
@@ -61,6 +61,19 @@ def test_dynamic_partitions_def_methods():
         assert instance.has_dynamic_partition("foo", "a") is False
 
 
+def test_dynamic_partitions_build_add_request_with_labels():
+    partitions = dg.DynamicPartitionsDefinition(name="fruits")
+
+    request = partitions.build_add_request(
+        ["apple", "banana"],
+        partition_key_labels={"apple": "Apple", "banana": "Banana"},
+    )
+
+    assert request.partitions_def_name == "fruits"
+    assert request.partition_keys == ["apple", "banana"]
+    assert request.partition_key_labels == {"apple": "Apple", "banana": "Banana"}
+
+
 def test_dynamic_partitioned_run():
     with dg.instance_for_test() as instance:
         partitions_def = dg.DynamicPartitionsDefinition(name="foo")

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import sqlite3
+import tempfile
 import time
 from collections import namedtuple
 from enum import Enum
@@ -1097,6 +1098,55 @@ def test_add_dynamic_partitions_table():
             instance.upgrade()
             assert "dynamic_partitions" in get_sqlite3_tables(db_path)
             assert instance.get_dynamic_partitions("foo") == []
+
+
+def test_dynamic_partition_labels_require_display_label_column():
+    with tempfile.TemporaryDirectory() as test_dir:
+        with dg.instance_for_test(temp_dir=test_dir) as instance:
+            instance.add_dynamic_partitions("foo", ["foo"], labels={"foo": "Foo label"})
+            storage = check.inst(instance.event_log_storage, SqlEventLogStorage)
+            db_path = os.path.join(storage._base_dir, "index.db")
+
+        con = sqlite3.connect(db_path)
+        cursor = con.cursor()
+        cursor.execute("ALTER TABLE dynamic_partitions RENAME TO dynamic_partitions_old")
+        cursor.execute(
+            """
+            CREATE TABLE dynamic_partitions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                partitions_def_name TEXT NOT NULL,
+                partition TEXT NOT NULL,
+                create_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            INSERT INTO dynamic_partitions (id, partitions_def_name, partition, create_timestamp)
+            SELECT id, partitions_def_name, partition, create_timestamp
+            FROM dynamic_partitions_old
+            """
+        )
+        cursor.execute("DROP TABLE dynamic_partitions_old")
+        cursor.execute(
+            """
+            CREATE UNIQUE INDEX idx_dynamic_partitions
+            ON dynamic_partitions (partitions_def_name, partition)
+            """
+        )
+        con.commit()
+        con.close()
+
+        assert "display_label" not in set(get_sqlite3_columns(db_path, "dynamic_partitions"))
+
+        with DagsterInstance.from_config(test_dir) as instance:
+            assert instance.get_dynamic_partition_labels("foo") == {}
+
+            with pytest.raises(dg.DagsterInvalidInvocationError, match="dagster instance migrate"):
+                instance.add_dynamic_partitions("foo", ["bar"], labels={"bar": "Bar label"})
+
+            with pytest.raises(dg.DagsterInvalidInvocationError, match="dagster instance migrate"):
+                instance.set_dynamic_partition_label("foo", "foo", "Updated foo label")
 
 
 def _get_table_row_count(run_storage, table, with_non_null_id=False):

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1149,6 +1149,56 @@ def test_dynamic_partition_labels_require_display_label_column():
                 instance.set_dynamic_partition_label("foo", "foo", "Updated foo label")
 
 
+def test_dynamic_partition_labels_detect_new_column_without_restart():
+    with tempfile.TemporaryDirectory() as test_dir:
+        with dg.instance_for_test(temp_dir=test_dir) as instance:
+            instance.add_dynamic_partitions("foo", ["foo"])
+            storage = check.inst(instance.event_log_storage, SqlEventLogStorage)
+            db_path = os.path.join(storage._base_dir, "index.db")
+
+        con = sqlite3.connect(db_path)
+        cursor = con.cursor()
+        cursor.execute("ALTER TABLE dynamic_partitions RENAME TO dynamic_partitions_old")
+        cursor.execute(
+            """
+            CREATE TABLE dynamic_partitions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                partitions_def_name TEXT NOT NULL,
+                partition TEXT NOT NULL,
+                create_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            INSERT INTO dynamic_partitions (id, partitions_def_name, partition, create_timestamp)
+            SELECT id, partitions_def_name, partition, create_timestamp
+            FROM dynamic_partitions_old
+            """
+        )
+        cursor.execute("DROP TABLE dynamic_partitions_old")
+        cursor.execute(
+            """
+            CREATE UNIQUE INDEX idx_dynamic_partitions
+            ON dynamic_partitions (partitions_def_name, partition)
+            """
+        )
+        con.commit()
+        con.close()
+
+        with DagsterInstance.from_config(test_dir) as instance:
+            assert instance.get_dynamic_partition_labels("foo") == {}
+
+            con = sqlite3.connect(db_path)
+            cursor = con.cursor()
+            cursor.execute("ALTER TABLE dynamic_partitions ADD COLUMN display_label TEXT")
+            con.commit()
+            con.close()
+
+            instance.set_dynamic_partition_label("foo", "foo", "Foo label")
+            assert instance.get_dynamic_partition_labels("foo") == {"foo": "Foo label"}
+
+
 def _get_table_row_count(run_storage, table, with_non_null_id=False):
     query = db_select([db.func.count()]).select_from(table)
     if with_non_null_id:

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1199,6 +1199,62 @@ def test_dynamic_partition_labels_detect_new_column_without_restart():
             assert instance.get_dynamic_partition_labels("foo") == {"foo": "Foo label"}
 
 
+def test_dynamic_partition_labels_detect_new_column_on_read_without_restart():
+    with tempfile.TemporaryDirectory() as test_dir:
+        with dg.instance_for_test(temp_dir=test_dir) as instance:
+            instance.add_dynamic_partitions("foo", ["foo"])
+            storage = check.inst(instance.event_log_storage, SqlEventLogStorage)
+            db_path = os.path.join(storage._base_dir, "index.db")
+
+        con = sqlite3.connect(db_path)
+        cursor = con.cursor()
+        cursor.execute("ALTER TABLE dynamic_partitions RENAME TO dynamic_partitions_old")
+        cursor.execute(
+            """
+            CREATE TABLE dynamic_partitions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                partitions_def_name TEXT NOT NULL,
+                partition TEXT NOT NULL,
+                create_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            INSERT INTO dynamic_partitions (id, partitions_def_name, partition, create_timestamp)
+            SELECT id, partitions_def_name, partition, create_timestamp
+            FROM dynamic_partitions_old
+            """
+        )
+        cursor.execute("DROP TABLE dynamic_partitions_old")
+        cursor.execute(
+            """
+            CREATE UNIQUE INDEX idx_dynamic_partitions
+            ON dynamic_partitions (partitions_def_name, partition)
+            """
+        )
+        con.commit()
+        con.close()
+
+        with DagsterInstance.from_config(test_dir) as instance:
+            assert instance.get_dynamic_partition_labels("foo") == {}
+
+            con = sqlite3.connect(db_path)
+            cursor = con.cursor()
+            cursor.execute("ALTER TABLE dynamic_partitions ADD COLUMN display_label TEXT")
+            cursor.execute(
+                """
+                UPDATE dynamic_partitions
+                SET display_label = 'Foo label'
+                WHERE partitions_def_name = 'foo' AND partition = 'foo'
+                """
+            )
+            con.commit()
+            con.close()
+
+            assert instance.get_dynamic_partition_labels("foo") == {"foo": "Foo label"}
+
+
 def _get_table_row_count(run_storage, table, with_non_null_id=False):
     query = db_select([db.func.count()]).select_from(table)
     if with_non_null_id:

--- a/python_modules/dagster/dagster_tests/storage_tests/test_dynamic_partition_labels.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_dynamic_partition_labels.py
@@ -1,0 +1,70 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from dagster._core.storage.event_log.sql_event_log import SqlEventLogStorage
+from sqlalchemy.engine import Connection
+
+
+class _CacheTestSqlEventLogStorage(SqlEventLogStorage):
+    def __init__(self, support_getter) -> None:  # type: ignore[no-untyped-def]
+        self._support_getter = support_getter
+
+    @contextmanager
+    def run_connection(self, run_id: str | None = None) -> Iterator[Connection]:
+        raise NotImplementedError()
+        yield
+
+    @contextmanager
+    def index_connection(self) -> Iterator[Connection]:
+        raise NotImplementedError()
+        yield
+
+    def upgrade(self) -> None:
+        raise NotImplementedError()
+
+    def has_table(self, table_name: str) -> bool:
+        raise NotImplementedError()
+
+    def watch(self, run_id, cursor, callback):  # type: ignore[no-untyped-def]
+        raise NotImplementedError()
+
+    def end_watch(self, run_id, handler):  # type: ignore[no-untyped-def]
+        raise NotImplementedError()
+
+    def _get_dynamic_partition_display_label_col_support(self) -> bool:
+        return self._support_getter()
+
+
+def test_sql_event_log_storage_caches_positive_display_label_column_support():
+    get_support_call_count = 0
+
+    def _get_support():
+        nonlocal get_support_call_count
+        get_support_call_count += 1
+        return True
+
+    storage = _CacheTestSqlEventLogStorage(_get_support)
+
+    assert storage.has_dynamic_partition_display_label_col() is True
+    assert storage.has_dynamic_partition_display_label_col() is True
+    assert storage.has_dynamic_partition_display_label_col() is True
+    assert get_support_call_count == 1
+
+
+def test_sql_event_log_storage_does_not_cache_missing_display_label_column_support():
+    supports_display_labels = False
+    get_support_call_count = 0
+
+    def _get_support():
+        nonlocal get_support_call_count
+        get_support_call_count += 1
+        return supports_display_labels
+
+    storage = _CacheTestSqlEventLogStorage(_get_support)
+
+    assert storage.has_dynamic_partition_display_label_col() is False
+
+    supports_display_labels = True
+
+    assert storage.has_dynamic_partition_display_label_col() is True
+    assert get_support_call_count == 2

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -5383,6 +5383,26 @@ class TestEventLogStorage:
         # Adding no partitions is a no-op
         storage.add_dynamic_partitions(partitions_def_name="foo", partition_keys=[])
 
+    def test_dynamic_partition_labels(self, storage: EventLogStorage):
+        storage.add_dynamic_partitions(
+            partitions_def_name="foo",
+            partition_keys=["foo", "bar"],
+            labels={"foo": "Foo label"},
+        )
+
+        assert storage.get_dynamic_partition_labels("foo") == {"foo": "Foo label"}
+
+        storage.add_dynamic_partitions(
+            partitions_def_name="foo",
+            partition_keys=["foo", "baz"],
+            labels={"foo": "Updated foo label", "baz": "Baz label"},
+        )
+
+        assert storage.get_dynamic_partition_labels("foo") == {
+            "foo": "Updated foo label",
+            "baz": "Baz label",
+        }
+
     def test_delete_dynamic_partitions(self, storage: EventLogStorage):
         assert storage
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -315,6 +315,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         supports_display_labels = self.has_dynamic_partition_display_label_col()
         if labels and not supports_display_labels:
             self._check_dynamic_partition_label_column()
+            supports_display_labels = True
 
         if not partition_keys:
             return

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -312,7 +312,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     ) -> None:
         # Overload base implementation to push upsert logic down into the db layer
         self._check_partitions_table()
-        supports_display_labels = self.has_dynamic_partition_display_label_col
+        supports_display_labels = self.has_dynamic_partition_display_label_col()
         if labels and not supports_display_labels:
             self._check_dynamic_partition_label_column()
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -304,24 +304,58 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             conn.execute(query)
 
     def add_dynamic_partitions(
-        self, partitions_def_name: str, partition_keys: Sequence[str]
+        self,
+        partitions_def_name: str,
+        partition_keys: Sequence[str],
+        *,
+        labels: Mapping[str, str] | None = None,
     ) -> None:
+        # Overload base implementation to push upsert logic down into the db layer
+        self._check_partitions_table()
+        supports_display_labels = self.has_dynamic_partition_display_label_col
+        if labels and not supports_display_labels:
+            self._check_dynamic_partition_label_column()
+
         if not partition_keys:
             return
 
-        # Overload base implementation to push upsert logic down into the db layer
-        self._check_partitions_table()
+        partition_key_set = set(partition_keys)
         with self.index_connection() as conn:
             conn.execute(
                 db_dialects.postgresql.insert(DynamicPartitionsTable)
                 .values(
                     [
+                        dict(
+                            partitions_def_name=partitions_def_name,
+                            partition=partition_key,
+                            display_label=labels.get(partition_key) if labels else None,
+                        )
+                        for partition_key in partition_keys
+                    ]
+                    if supports_display_labels
+                    else [
                         dict(partitions_def_name=partitions_def_name, partition=partition_key)
                         for partition_key in partition_keys
                     ]
                 )
                 .on_conflict_do_nothing(),
             )
+
+            if labels and supports_display_labels:
+                for partition_key, label in labels.items():
+                    if partition_key not in partition_key_set:
+                        continue
+
+                    conn.execute(
+                        DynamicPartitionsTable.update()
+                        .where(
+                            db.and_(
+                                DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
+                                DynamicPartitionsTable.c.partition == partition_key,
+                            )
+                        )
+                        .values(display_label=label)
+                    )
 
     def _connect(self) -> ContextManager[Connection]:
         return create_pg_connection(self._engine)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -762,6 +762,11 @@ def test_dynamic_partition_labels_require_display_label_column(hostname, conn_st
             with pytest.raises(DagsterInvalidInvocationError, match="dagster instance migrate"):
                 instance.add_dynamic_partitions("foo", [], labels={"baz": "Baz label"})
 
+            with pytest.raises(DagsterInvalidInvocationError, match="dagster instance migrate"):
+                instance.event_log_storage.set_dynamic_partition_label(
+                    "foo", "foo", "Updated foo label"
+                )
+
 
 def _get_table_row_count(run_storage, table, with_non_null_id=False):
     query = db_select([db.func.count()]).select_from(table)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -734,6 +734,35 @@ def test_add_dynamic_partitions_table(hostname, conn_string):
             assert instance.get_dynamic_partitions("foo") == []
 
 
+def test_dynamic_partition_labels_require_display_label_column(hostname, conn_string):
+    with tempfile.TemporaryDirectory() as tempdir:
+        with open(file_relative_path(__file__, "dagster.yaml"), encoding="utf8") as template_fd:
+            with open(os.path.join(tempdir, "dagster.yaml"), "w", encoding="utf8") as target_fd:
+                template = template_fd.read().format(hostname=hostname)
+                target_fd.write(template)
+
+        with DagsterInstance.from_config(tempdir) as instance:
+            instance.add_dynamic_partitions("foo", ["foo"], labels={"foo": "Foo label"})
+            assert {"display_label"} <= get_columns(instance, "dynamic_partitions")
+
+            with instance.event_log_storage.index_connection() as conn:
+                conn.execute(db.text("ALTER TABLE dynamic_partitions DROP COLUMN display_label"))
+
+        with DagsterInstance.from_config(tempdir) as instance:
+            assert "display_label" not in get_columns(instance, "dynamic_partitions")
+            assert instance.get_dynamic_partition_labels("foo") == {}
+
+            instance.add_dynamic_partitions("foo", [])
+            instance.add_dynamic_partitions("foo", ["bar"])
+            assert set(instance.get_dynamic_partitions("foo")) == {"foo", "bar"}
+
+            with pytest.raises(DagsterInvalidInvocationError, match="dagster instance migrate"):
+                instance.add_dynamic_partitions("foo", ["baz"], labels={"baz": "Baz label"})
+
+            with pytest.raises(DagsterInvalidInvocationError, match="dagster instance migrate"):
+                instance.add_dynamic_partitions("foo", [], labels={"baz": "Baz label"})
+
+
 def _get_table_row_count(run_storage, table, with_non_null_id=False):
     query = db_select([db.func.count()]).select_from(table)
     if with_non_null_id:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_dynamic_partition_labels.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_dynamic_partition_labels.py
@@ -1,0 +1,77 @@
+from contextlib import contextmanager
+
+import pytest
+from dagster._core.errors import DagsterInvalidInvocationError
+from dagster_postgres.event_log import PostgresEventLogStorage
+
+
+class _RecordingConnection:
+    def __init__(self) -> None:
+        self.statements = []
+
+    def execute(self, statement):
+        self.statements.append(statement)
+
+
+def _build_storage(
+    connection: _RecordingConnection, supports_display_labels: bool
+) -> PostgresEventLogStorage:
+    storage = PostgresEventLogStorage.__new__(PostgresEventLogStorage)
+    storage.__dict__["has_dynamic_partition_display_label_col"] = supports_display_labels
+    storage._check_partitions_table = lambda: None  # noqa: SLF001
+
+    @contextmanager
+    def _index_connection():
+        yield connection
+
+    storage.index_connection = _index_connection  # type: ignore[method-assign]
+    return storage
+
+
+def test_add_dynamic_partitions_accepts_labels_and_updates_labels():
+    connection = _RecordingConnection()
+    storage = _build_storage(connection, supports_display_labels=True)
+
+    storage.add_dynamic_partitions("foo", ["foo", "bar"], labels={"foo": "Foo label"})
+
+    assert [statement.__visit_name__ for statement in connection.statements] == [
+        "insert",
+        "update",
+    ]
+
+
+def test_add_dynamic_partitions_checks_label_column_migration():
+    storage = _build_storage(_RecordingConnection(), supports_display_labels=False)
+
+    def _check_dynamic_partition_label_column():
+        raise DagsterInvalidInvocationError(
+            "Dynamic partition labels require a database schema migration."
+        )
+
+    storage._check_dynamic_partition_label_column = _check_dynamic_partition_label_column  # noqa: SLF001
+
+    with pytest.raises(DagsterInvalidInvocationError, match="database schema migration"):
+        storage.add_dynamic_partitions("foo", ["bar"], labels={"bar": "Bar label"})
+
+
+def test_add_dynamic_partitions_checks_label_column_migration_for_empty_partition_keys():
+    storage = _build_storage(_RecordingConnection(), supports_display_labels=False)
+
+    def _check_dynamic_partition_label_column():
+        raise DagsterInvalidInvocationError(
+            "Dynamic partition labels require a database schema migration."
+        )
+
+    storage._check_dynamic_partition_label_column = _check_dynamic_partition_label_column  # noqa: SLF001
+
+    with pytest.raises(DagsterInvalidInvocationError, match="database schema migration"):
+        storage.add_dynamic_partitions("foo", [], labels={"bar": "Bar label"})
+
+
+def test_add_dynamic_partitions_noops_for_empty_partition_keys_without_labels():
+    connection = _RecordingConnection()
+    storage = _build_storage(connection, supports_display_labels=False)
+
+    storage.add_dynamic_partitions("foo", [])
+
+    assert connection.statements == []

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_dynamic_partition_labels.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_dynamic_partition_labels.py
@@ -17,7 +17,7 @@ def _build_storage(
     connection: _RecordingConnection, supports_display_labels: bool
 ) -> PostgresEventLogStorage:
     storage = PostgresEventLogStorage.__new__(PostgresEventLogStorage)
-    storage.__dict__["has_dynamic_partition_display_label_col"] = supports_display_labels
+    storage.has_dynamic_partition_display_label_col = lambda: supports_display_labels  # type: ignore[method-assign]
     storage._check_partitions_table = lambda: None  # noqa: SLF001
 
     @contextmanager

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -48,6 +48,22 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
     def can_wipe_asset_partitions(self) -> bool:
         return False
 
+    def test_instance_add_dynamic_partitions_with_labels(self, instance):
+        instance.add_dynamic_partitions("foo", ["foo", "bar"], labels={"foo": "Foo label"})
+
+        assert instance.get_dynamic_partition_labels("foo") == {"foo": "Foo label"}
+
+        instance.add_dynamic_partitions(
+            "foo",
+            ["foo", "baz"],
+            labels={"foo": "Updated foo label", "baz": "Baz label"},
+        )
+
+        assert instance.get_dynamic_partition_labels("foo") == {
+            "foo": "Updated foo label",
+            "baz": "Baz label",
+        }
+
     def test_event_log_storage_two_watchers(self, conn_string):
         with _clean_storage(conn_string) as storage:
             run_id = make_new_run_id()


### PR DESCRIPTION
## Summary & Motivation

This PR addresses two issues in the dynamic partition display-label feature.

- Guard `display_label` reads and writes in SQL event log storage so partially migrated instances fail safely.
- Return empty label mappings on old schemas for read paths, and raise migration guidance for explicit label writes.
- Stop loading `partitionKeyLabels` for every asset in the launch loader query.
- Fetch partition labels only for the displayed base asset in the launch dialog.
- Add regression coverage for the partial-migration storage state and the launch dialog label lookup path.

Root cause:
The feature added a new `dynamic_partitions.display_label` column but runtime checks still only validated table existence, so partially migrated instances could hit raw SQL missing-column errors. In the UI, the launch query requested `partitionKeyLabels` for every selected asset even though the dialog only consumes labels for one asset.

## Test Plan

- `uv run ruff check python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py`
- `pytest python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py -k dynamic_partition_labels_require_display_label_column -q`
- `pytest python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py::test_add_dynamic_partitions_with_labels_sensor -q`
- `yarn tsgo`
- `yarn eslint src/assets/LaunchAssetExecutionButton.tsx src/assets/LaunchAssetChoosePartitionsDialog.tsx src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx`
- `yarn jest src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx --runInBand`

Notes:
- The targeted UI verification ran against identical file content in the original checkout because the clean publish worktree did not have a usable Yarn install state.
- Attempting to run the dagster-graphql asset-label test directly via plain `pytest` was blocked by that package's marker-based GraphQL test harness outside its tox environment.

## Changelog

- Fix dynamic partition display-label compatibility on partially migrated instances and avoid redundant label fetches in the asset launch dialog.
