### PR TITLE
[dagster-postgres] Add default connect timeout

### DIFF
--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -68,15 +68,25 @@ def helm_template() -> HelmTemplate:
 
 @pytest.mark.parametrize("postgresql_scheme", ["", "postgresql", "postgresql+psycopg2"])
 @pytest.mark.parametrize("storage", ["schedule_storage", "run_storage", "event_log_storage"])
-def test_storage_postgres_db_config(template: HelmTemplate, postgresql_scheme: str, storage: str):
+@pytest.mark.parametrize("connect_timeout", [0, 10, 15])
+def test_storage_postgres_db_config(
+    template: HelmTemplate, postgresql_scheme: str, storage: str, connect_timeout: int
+):
     postgresql_username = "username"
     postgresql_host = "1.1.1.1"
     postgresql_database = "database"
-    postgresql_params = {
-        "connect_timeout": 10,
+    postgresql_params: dict[str, object] = {
         "application_name": "myapp",
         "options": "-c synchronous_commit=off",
     }
+    if connect_timeout:
+        postgresql_params["connect_timeout"] = connect_timeout
+    expected_postgresql_params = {
+        **postgresql_params,
+        "fallback_application_name": "dagster",
+    }
+    expected_postgresql_params.setdefault("connect_timeout", 15)
+
     postgresql_port = 8080
     helm_values = DagsterHelmValues.construct(
         postgresql=PostgreSQL.construct(
@@ -104,7 +114,7 @@ def test_storage_postgres_db_config(template: HelmTemplate, postgresql_scheme: s
     assert postgres_db["hostname"] == postgresql_host
     assert postgres_db["db_name"] == postgresql_database
     assert postgres_db["port"] == postgresql_port
-    assert postgres_db["params"] == postgresql_params
+    assert postgres_db["params"] == expected_postgresql_params
     if not postgresql_scheme:
         assert "scheme" not in postgres_db
     else:

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -68,9 +68,9 @@ def helm_template() -> HelmTemplate:
 
 @pytest.mark.parametrize("postgresql_scheme", ["", "postgresql", "postgresql+psycopg2"])
 @pytest.mark.parametrize("storage", ["schedule_storage", "run_storage", "event_log_storage"])
-@pytest.mark.parametrize("connect_timeout", [0, 10, 15])
+@pytest.mark.parametrize("connect_timeout", [None, 0, 10, 15])
 def test_storage_postgres_db_config(
-    template: HelmTemplate, postgresql_scheme: str, storage: str, connect_timeout: int
+    template: HelmTemplate, postgresql_scheme: str, storage: str, connect_timeout: int | None
 ):
     postgresql_username = "username"
     postgresql_host = "1.1.1.1"
@@ -79,7 +79,7 @@ def test_storage_postgres_db_config(
         "application_name": "myapp",
         "options": "-c synchronous_commit=off",
     }
-    if connect_timeout:
+    if connect_timeout is not None:
         postgresql_params["connect_timeout"] = connect_timeout
     expected_postgresql_params = {
         **postgresql_params,

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -831,7 +831,9 @@ postgresql:
 
   # set postgresql parameter keywords for the connection string.
   # see: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
-  postgresqlParams: {}
+  postgresqlParams:
+    fallback_application_name: dagster
+    connect_timeout: 15
 
   # When set, overrides the default `postgresql` scheme for the connection string.
   # (e.g., set to `postgresql+pg8000` to use the `pg8000` library).

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
@@ -50,9 +50,11 @@ def get_conn_string(
 ) -> str:
     uri = f"{scheme}://{quote(username)}:{quote(password)}@{hostname}:{port}/{db_name}"
 
-    if params:
-        query_string = f"{urlencode(params, quote_via=quote)}"
-        uri = f"{uri}?{query_string}"
+    params = dict(params) if isinstance(params, Mapping) else {}
+    params.setdefault("fallback_application_name", "dagster")
+    params.setdefault("connect_timeout", 15)
+    query_string = f"{urlencode(params, quote_via=quote)}"
+    uri = f"{uri}?{query_string}"
 
     return uri
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -118,7 +118,7 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
             module: dagster_postgres.event_log
             class: PostgresEventLogStorage
             config:
-                postgres_url: postgresql://test:test@{hostname}:5432/test
+                postgres_url: postgresql://test:test@{hostname}:5432/test?fallback_application_name=dagster&connect_timeout=15
         """
 
         explicit_cfg = f"""

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
@@ -248,7 +248,7 @@ def test_specify_pg_params(hostname):
     with instance_for_test(
         overrides=yaml.safe_load(params_specified_pg_config(hostname))
     ) as instance:
-        postgres_url = f"postgresql://test:test@{hostname}:5432/test?application_name=myapp&connect_timeout=10&options=-c%20synchronous_commit%3Doff"
+        postgres_url = f"postgresql://test:test@{hostname}:5432/test?application_name=myapp&connect_timeout=10&options=-c%20synchronous_commit%3Doff&fallback_application_name=dagster"
 
         assert instance._event_storage.postgres_url == postgres_url  # noqa: SLF001  # pyright: ignore[reportAttributeAccessIssue]
         assert instance._run_storage.postgres_url == postgres_url  # noqa: SLF001  # pyright: ignore[reportAttributeAccessIssue]
@@ -269,7 +269,10 @@ def test_conn_str():
         db_name=db_name,
         hostname=hostname,
     )
-    assert conn_str == f"postgresql://{url_wo_scheme}"
+    assert (
+        conn_str
+        == f"postgresql://{url_wo_scheme}?fallback_application_name=dagster&connect_timeout=15"
+    )
     parsed = urlparse(conn_str)
     assert unquote(parsed.username) == username  # pyright: ignore[reportArgumentType]
     assert unquote(parsed.password) == password  # pyright: ignore[reportArgumentType]
@@ -285,7 +288,10 @@ def test_conn_str():
         scheme=custom_scheme,
     )
 
-    assert conn_str == f"postgresql+dialect://{url_wo_scheme}"
+    assert (
+        conn_str
+        == f"postgresql+dialect://{url_wo_scheme}?fallback_application_name=dagster&connect_timeout=15"
+    )
     parsed = urlparse(conn_str)
     assert unquote(parsed.username) == username  # pyright: ignore[reportArgumentType]
     assert unquote(parsed.password) == password  # pyright: ignore[reportArgumentType]

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_run_storage.py
@@ -43,7 +43,7 @@ class TestPostgresRunStorage(TestRunStorage):
             module: dagster_postgres.run_storage
             class: PostgresRunStorage
             config:
-              postgres_url: postgresql://test:test@{hostname}:5432/test
+              postgres_url: postgresql://test:test@{hostname}:5432/test?fallback_application_name=dagster&connect_timeout=15
         """
 
         explicit_cfg = f"""


### PR DESCRIPTION
A lack of connect timeout may be a cause of #28910.

## Summary & Motivation

When diagnosing an instance of #28910 that happened to our Dagster installation, our observation was that the node that hosted the Dagster daemon experienced a full network partition for a few minutes, leading to an understandable pause in the ability of the `QueuedRunCoordinator` daemon being able to discover and start new jobs. When the network healed, the `QueuedRunCoordinator` daemon remained in a degraded state for over 80 minutes, until a manual restart of the daemon pod. The `QueuedRunCoordinator` background threads were all frozen and not emitting any logs, and it wasn't sending heartbeats to the daemon.

Our leading hypothesis was this: during the full network partition, all of the `QueuedRunCoordinator` background threads tried to initiate TCP connections to the database. Somehow, due to the nature of the particular network issue and the TCP packets that did / did not get exchanged, the `connect()` call neither succeeded nor failed, and instead, without a connect timeout, was waiting for an indefinite amount of time for an eventual packet (that was never going to arrive) or an eventual failure from the OS that did not arrive in the 80 minutes before we decided to restart the daemon pod.

With all `QueuedRunCoordinator` background threads stuck in these blocking `connect()` calls, `as_completed()` on the `QueuedRunCoordinator` thread blocks indefinitely, preventing heartbeats and run processing. `retry_pg_connection_fn` never gets a chance to retry because the call hangs rather than raising an exception.

With `connect_timeout` configured by default, any `connect()` attempt to an unreachable endpoint would fail with an exception within a short amount of time instead of hanging. This would unblock the thread and allow retries and heartbeats to occur.

Even if this change doesn't (completely) fix #28910, it is still beneficial in that it follows distributed systems best-practices of having timeouts around unreliable network calls, especially blocking ones.

The value of 15 seconds for the default `connect_timeout` was chosen arbitrarily. Also added a connection parameter `fallback_application_name=dagster` so that the client will identify itself as a dagster client, unless an
`application_name` connection parameter is set in the user's instance config or somewhere else in this codebase.

Relates to #28910.

## Test Plan

Unit tests confirm that the defaults are used, but can also be overridden by `postgres_db.params` in the `dagster.yaml` instance configs.

## Changelog

`dagster-postgres`: PostgreSQL connections now default to a 15-second connect timeout and identify themselves with `fallback_application_name=dagster`. This prevents daemon threads from hanging indefinitely when the database is unreachable due to a network partition. Both defaults can be overridden via `postgres_db.params` in `dagster.yaml`.