### PR TITLE
[dg] Bump actions/checkout

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -56,7 +56,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
 

--- a/.github/workflows/build-integration-registry.yml
+++ b/.github/workflows/build-integration-registry.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -12,7 +12,7 @@ jobs:
   check-frontmatter:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5

--- a/.github/workflows/update-dagster-ui-yarn-lock.yml
+++ b/.github/workflows/update-dagster-ui-yarn-lock.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Enable Corepack
         run: corepack enable

--- a/docs/docs/deployment/dagster-plus/serverless/runtime-environment.md
+++ b/docs/docs/deployment/dagster-plus/serverless/runtime-environment.md
@@ -332,7 +332,7 @@ If you use PEX deploys in your workflow (`ENABLE_FAST_DEPLOYS: 'true'`), the fol
 
     ```yaml
     - name: Checkout internal repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         token: ${{ secrets.GH_PAT }}
         repository: my-org/private-repo

--- a/examples/assets_dbt_python/.github/workflows/examples/branch_deployments.yml
+++ b/examples/assets_dbt_python/.github/workflows/examples/branch_deployments.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Checkout for Python Executable Deploy
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           path: project-repo
@@ -70,7 +70,7 @@ jobs:
         location: ${{ fromJSON(needs.dagster_cloud_default_deploy.outputs.build_info) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless

--- a/examples/assets_dbt_python/.github/workflows/examples/deploy.yml
+++ b/examples/assets_dbt_python/.github/workflows/examples/deploy.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Checkout for Python Executable Deploy
         if: steps.prerun.outputs.result == 'pex-deploy'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           path: project-repo
@@ -72,7 +72,7 @@ jobs:
         location: ${{ fromJSON(needs.dagster_cloud_default_deploy.outputs.build_info) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
       - name: Build and deploy to Dagster Cloud serverless

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/hybrid-github-action.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/hybrid-github-action.yaml
@@ -33,7 +33,7 @@ jobs:
 
       # Checkout the project
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         if: steps.prerun.outputs.result != 'skip'
         with:
           ref: ${{ github.head_ref }}

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-github-action.yaml
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/templates/serverless-github-action.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: dagster-io/dagster-cloud-action/actions/utils/prerun@TEMPLATE_DAGSTER_CLOUD_ACTION_VERSION
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 


### PR DESCRIPTION
## Summary & Motivation
Bump actions/checkout in dagster_dg_cli and examples to address Node20 deprecation on GHA https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
