### PR TITLE
[dagster-dlt] Add partitions_def and backfill_policy support to DltLoadCollectionComponent

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
@@ -81,14 +81,8 @@ class DltLoadSpecModel(Resolvable):
     translation: (
         Annotated[
             TranslationFn[DltResourceTranslatorData],
-            TranslationFnResolver[DltResourceTranslatorData](
-                lambda data: {"resource": data.resource, "pipeline": data.pipeline}
-            ),
-        ]
-        | None
-    ) = None
     partitions_def: Annotated[
-        PartitionsDefinition | None,
+        Optional[PartitionsDefinition],
         Resolver(
             resolve_partitions_def,
             model_field_type=HourlyPartitionsDefinitionModel
@@ -99,7 +93,7 @@ class DltLoadSpecModel(Resolvable):
         ),
     ] = None
     backfill_policy: Annotated[
-        BackfillPolicy | None,
+        Optional[BackfillPolicy],
         Resolver(
             resolve_backfill_policy,
             model_field_type=SingleRunBackfillPolicyModel | MultiRunBackfillPolicyModel,

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
@@ -2,7 +2,7 @@ import importlib
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from functools import cached_property
-from typing import TYPE_CHECKING, Annotated, Optional, Union
+from typing import TYPE_CHECKING, Annotated
 
 import dagster as dg
 from dagster import (
@@ -88,27 +88,21 @@ class DltLoadSpecModel(Resolvable):
         | None
     ) = None
     partitions_def: Annotated[
-        Optional[PartitionsDefinition],
+        PartitionsDefinition | None,
         Resolver(
             resolve_partitions_def,
-            model_field_type=Optional[
-                Union[
-                    HourlyPartitionsDefinitionModel,
-                    DailyPartitionsDefinitionModel,
-                    WeeklyPartitionsDefinitionModel,
-                    TimeWindowPartitionsDefinitionModel,
-                    StaticPartitionsDefinitionModel,
-                ]
-            ],
+            model_field_type=HourlyPartitionsDefinitionModel
+            | DailyPartitionsDefinitionModel
+            | WeeklyPartitionsDefinitionModel
+            | TimeWindowPartitionsDefinitionModel
+            | StaticPartitionsDefinitionModel,
         ),
     ] = None
     backfill_policy: Annotated[
-        Optional[BackfillPolicy],
+        BackfillPolicy | None,
         Resolver(
             resolve_backfill_policy,
-            model_field_type=Optional[
-                Union[SingleRunBackfillPolicyModel, MultiRunBackfillPolicyModel]
-            ],
+            model_field_type=SingleRunBackfillPolicyModel | MultiRunBackfillPolicyModel,
         ),
     ] = None
 

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
@@ -2,13 +2,33 @@ import importlib
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from functools import cached_property
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Optional, Union
 
 import dagster as dg
-from dagster import AssetKey, AssetSpec, Component, ComponentLoadContext, Resolvable, Resolver
+from dagster import (
+    AssetKey,
+    AssetSpec,
+    BackfillPolicy,
+    Component,
+    ComponentLoadContext,
+    PartitionsDefinition,
+    Resolvable,
+    Resolver,
+)
 from dagster._annotations import public
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster.components.resolved.context import ResolutionContext
+from dagster.components.resolved.core_models import (
+    DailyPartitionsDefinitionModel,
+    HourlyPartitionsDefinitionModel,
+    MultiRunBackfillPolicyModel,
+    SingleRunBackfillPolicyModel,
+    StaticPartitionsDefinitionModel,
+    TimeWindowPartitionsDefinitionModel,
+    WeeklyPartitionsDefinitionModel,
+    resolve_backfill_policy,
+    resolve_partitions_def,
+)
 from dagster.components.scaffold.scaffold import scaffold_with
 from dagster.components.utils.translation import (
     ComponentTranslator,
@@ -67,6 +87,30 @@ class DltLoadSpecModel(Resolvable):
         ]
         | None
     ) = None
+    partitions_def: Annotated[
+        Optional[PartitionsDefinition],
+        Resolver(
+            resolve_partitions_def,
+            model_field_type=Optional[
+                Union[
+                    HourlyPartitionsDefinitionModel,
+                    DailyPartitionsDefinitionModel,
+                    WeeklyPartitionsDefinitionModel,
+                    TimeWindowPartitionsDefinitionModel,
+                    StaticPartitionsDefinitionModel,
+                ]
+            ],
+        ),
+    ] = None
+    backfill_policy: Annotated[
+        Optional[BackfillPolicy],
+        Resolver(
+            resolve_backfill_policy,
+            model_field_type=Optional[
+                Union[SingleRunBackfillPolicyModel, MultiRunBackfillPolicyModel]
+            ],
+        ),
+    ] = None
 
 
 @public
@@ -133,6 +177,8 @@ class DltLoadCollectionComponent(Component, Resolvable):
                 dlt_pipeline=load.pipeline,
                 name=f"dlt_assets_{load.source.name}_{load.pipeline.dataset_name}",
                 dagster_dlt_translator=translator,
+                partitions_def=load.partitions_def,
+                backfill_policy=load.backfill_policy,
             )
             def dlt_assets_def(context: AssetExecutionContext):
                 yield from self.execute(context, self.dlt_pipeline_resource)

--- a/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/components/dlt_load_collection/component.py
@@ -81,8 +81,14 @@ class DltLoadSpecModel(Resolvable):
     translation: (
         Annotated[
             TranslationFn[DltResourceTranslatorData],
+            TranslationFnResolver[DltResourceTranslatorData](
+                lambda data: {"resource": data.resource, "pipeline": data.pipeline}
+            ),
+        ]
+        | None
+    ) = None
     partitions_def: Annotated[
-        Optional[PartitionsDefinition],
+        PartitionsDefinition | None,
         Resolver(
             resolve_partitions_def,
             model_field_type=HourlyPartitionsDefinitionModel
@@ -93,7 +99,7 @@ class DltLoadSpecModel(Resolvable):
         ),
     ] = None
     backfill_policy: Annotated[
-        Optional[BackfillPolicy],
+        BackfillPolicy | None,
         Resolver(
             resolve_backfill_policy,
             model_field_type=SingleRunBackfillPolicyModel | MultiRunBackfillPolicyModel,

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -367,26 +367,41 @@ def test_subclass_override_get_asset_spec(dlt_pipeline: Pipeline):
     }
 
 
-def test_daily_partitioned_component(dlt_pipeline: Pipeline):
-    """Test that partitions_def and backfill_policy are correctly applied to assets."""
-    partitions_def = DailyPartitionsDefinition(start_date="2024-01-01")
-    backfill_policy = BackfillPolicy.single_run()
+def partitioned_load():
+    import dlt
 
-    context = ComponentTree.for_test().load_context
-    defs = DltLoadCollectionComponent(
-        loads=[
-            DltLoadSpecModel(
-                pipeline=dlt_pipeline,
-                source=dlt_source(),
-                partitions_def=partitions_def,
-                backfill_policy=backfill_policy,
-            )
-        ]
-    ).build_defs(context)
+    from dagster_dlt_tests.dlt_test_sources.duckdb_with_transformer import pipeline as dlt_source
 
-    assets_def = defs.resolve_assets_def(AssetKey(["example", "repos"]))
-    assert assets_def.partitions_def == partitions_def
-    assert assets_def.backfill_policy == backfill_policy
+    source = dlt_source()
+    pipeline = dlt.pipeline(
+        pipeline_name="pipeline",
+        destination="duckdb",
+        dataset_name="example",
+    )
+
+
+def test_daily_partitioned_component() -> None:
+    """Test that partitions_def and backfill_policy from YAML are applied to assets."""
+    with setup_dlt_component(
+        load_py_contents=partitioned_load,
+        defs_yaml_contents={
+            "type": "dagster_dlt.DltLoadCollectionComponent",
+            "attributes": {
+                "loads": [
+                    {
+                        "pipeline": ".load.pipeline",
+                        "source": ".load.source",
+                        "partitions_def": {"type": "daily", "start_date": "2024-01-01"},
+                        "backfill_policy": {"type": "single_run"},
+                    }
+                ]
+            },
+        },
+        setup_dlt_sources=lambda: None,
+    ) as (_component, defs):
+        assets_def = defs.resolve_assets_def(AssetKey(["example", "repos"]))
+        assert assets_def.partitions_def == DailyPartitionsDefinition(start_date="2024-01-01")
+        assert assets_def.backfill_policy == BackfillPolicy.single_run()
 
 
 def test_no_partitions_backwards_compatible(dlt_pipeline: Pipeline):

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_dlt_load_collection_component.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
-from dagster import AssetKey
+from dagster import AssetKey, BackfillPolicy, DailyPartitionsDefinition
 from dagster._core.definitions import materialize
 from dagster._core.definitions.assets.definition.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
@@ -365,3 +365,42 @@ def test_subclass_override_get_asset_spec(dlt_pipeline: Pipeline):
         AssetKey(["example", "repo_issues"]),
         AssetKey(["pipeline_repos"]),
     }
+
+
+def test_daily_partitioned_component(dlt_pipeline: Pipeline):
+    """Test that partitions_def and backfill_policy are correctly applied to assets."""
+    partitions_def = DailyPartitionsDefinition(start_date="2024-01-01")
+    backfill_policy = BackfillPolicy.single_run()
+
+    context = ComponentTree.for_test().load_context
+    defs = DltLoadCollectionComponent(
+        loads=[
+            DltLoadSpecModel(
+                pipeline=dlt_pipeline,
+                source=dlt_source(),
+                partitions_def=partitions_def,
+                backfill_policy=backfill_policy,
+            )
+        ]
+    ).build_defs(context)
+
+    assets_def = defs.resolve_assets_def(AssetKey(["example", "repos"]))
+    assert assets_def.partitions_def == partitions_def
+    assert assets_def.backfill_policy == backfill_policy
+
+
+def test_no_partitions_backwards_compatible(dlt_pipeline: Pipeline):
+    """Test that omitting partitions_def and backfill_policy still works (backwards compatibility)."""
+    context = ComponentTree.for_test().load_context
+    defs = DltLoadCollectionComponent(
+        loads=[
+            DltLoadSpecModel(
+                pipeline=dlt_pipeline,
+                source=dlt_source(),
+            )
+        ]
+    ).build_defs(context)
+
+    assets_def = defs.resolve_assets_def(AssetKey(["example", "repos"]))
+    assert assets_def.partitions_def is None
+    assert assets_def.backfill_policy is None


### PR DESCRIPTION
## Summary & Motivation

`DltLoadCollectionComponent` (YAML-based declarative dlt asset definition) does not support `partitions_def` or `backfill_policy`. The `@dlt_assets` decorator already supports both (added in #22000 and #28195), but `DltLoadCollectionComponent.build_defs()` does not pass them through.

`DbtProjectComponent` already supports `partitions_def` via YAML configuration, so adding the same capability to `DltLoadCollectionComponent` maintains consistency across Dagster's component ecosystem.

This PR adds `partitions_def` and `backfill_policy` fields to `DltLoadSpecModel`, reusing the existing resolver infrastructure from `dagster.components.resolved.core_models`.

Closes #33730

## Changes

### `dagster_dlt/components/dlt_load_collection/component.py`

- Added `partitions_def` field to `DltLoadSpecModel` with `Resolver(resolve_partitions_def, ...)` supporting `daily`, `hourly`, `weekly`, `time_window`, and `static` partition types
- Added `backfill_policy` field to `DltLoadSpecModel` with `Resolver(resolve_backfill_policy, ...)` supporting `single_run` and `multi_run` policies
- Updated `build_defs()` to pass both fields to `@dlt_assets()`
- All new fields are `Optional` with `None` defaults (fully backwards compatible)

## Example YAML

```yaml
type: dagster_dlt.DltLoadCollectionComponent

attributes:
  loads:
    - pipeline: .loads.pipeline
      source: .loads.source
      partitions_def:
        type: daily
        start_date: "2024-01-01"
      backfill_policy:
        type: single_run
      translation:
        group_name: dlt
```

How I Tested These Changes

- Verified Definitions loads successfully with and without partitions_def / backfill_policy in YAML
- Confirmed DailyPartitionsDefinition and BackfillPolicy.single_run() are correctly applied to the resulting AssetsDefinition
- Confirmed Dagster UI displays the partition selector and backfill button for the configured assets    
- Verified backwards compatibility: existing YAML without these fields continues to work unchanged 