### PR TITLE
[dagster-postgres]: add workload identity federation auth for PostgreSQL

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -63,11 +63,14 @@ spec:
           env:
             - name: DAGSTER_CURRENT_IMAGE
               value: {{ include "dagster.dagsterImage.name" (list $ $deployment.image) | quote }}
+            {{- $global := $.Values.global | default dict }}
+            {{- if not ($global.postgresqlAuthWifEnabled | default false) }}
             - name: DAGSTER_PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagsterUserDeployments.postgresql.secretName" $ }}
                   key: postgresql-password
+            {{- end }}
             {{- $includeConfigInLaunchedRuns := $deployment.includeConfigInLaunchedRuns | default (dict "enabled" true) }}
             {{- if $includeConfigInLaunchedRuns.enabled }}
             {{- if $deployment.dagsterApiGrpcArgs }}

--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -65,7 +65,7 @@ spec:
           command: ["dagster-celery"]
           args: ["worker", "start", "-A", "dagster_celery_k8s.app", "-y", "{{ $.Values.global.dagsterHome }}/celery-config.yaml", "-q", "{{- $queue.name -}}", {{- if $queue.additionalCeleryArgs -}}"--", "{{- join "\",\"" $queue.additionalCeleryArgs -}}" {{- end -}}]
           env:
-            {{- if not $.Values.postgresql.authProvider.enabled }}
+            {{- if not $.Values.global.postgresqlAuthWifEnabled }}
             - name: DAGSTER_PG_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -65,11 +65,13 @@ spec:
           command: ["dagster-celery"]
           args: ["worker", "start", "-A", "dagster_celery_k8s.app", "-y", "{{ $.Values.global.dagsterHome }}/celery-config.yaml", "-q", "{{- $queue.name -}}", {{- if $queue.additionalCeleryArgs -}}"--", "{{- join "\",\"" $queue.additionalCeleryArgs -}}" {{- end -}}]
           env:
+            {{- if not $.Values.postgresql.authProvider.enabled }}
             - name: DAGSTER_PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" $ | quote }}
                   key: postgresql-password
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "dagster.fullname" $ }}-celery-worker-env

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -89,7 +89,7 @@ spec:
             "{{- template "dagster.dagsterDaemon.daemonCommand" . }}"
           ]
           env:
-            {{- if not .Values.postgresql.authProvider.enabled }}
+            {{- if not .Values.global.postgresqlAuthWifEnabled }}
             - name: DAGSTER_PG_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -89,11 +89,13 @@ spec:
             "{{- template "dagster.dagsterDaemon.daemonCommand" . }}"
           ]
           env:
+            {{- if not .Values.postgresql.authProvider.enabled }}
             - name: DAGSTER_PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" $ | quote }}
                   key: postgresql-password
+            {{- end }}
             - name: DAGSTER_DAEMON_HEARTBEAT_TOLERANCE
               value: "{{ .Values.dagsterDaemon.heartbeatTolerance }}"
             # This is a list by default, but for backcompat it can be a map. As a map it's written to the daemon-env

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -89,11 +89,13 @@ spec:
             "{{ template "dagster.webserver.dagsterWebserverCommand" . }}"
           ]
           env:
+            {{- if not .Values.postgresql.authProvider.enabled }}
             - name: DAGSTER_PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" . | quote }}
                   key: postgresql-password
+            {{- end }}
             # This is a list by default, but for backcompat it can be a map. As
             # a map it's written to the webserver-env configmap.
             {{- if and ($_.Values.dagsterWebserver.env) (kindIs "slice" $_.Values.dagsterWebserver.env) }}

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -89,7 +89,7 @@ spec:
             "{{ template "dagster.webserver.dagsterWebserverCommand" . }}"
           ]
           env:
-            {{- if not .Values.postgresql.authProvider.enabled }}
+            {{- if not .Values.global.postgresqlAuthWifEnabled }}
             - name: DAGSTER_PG_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/dagster/templates/helpers/instance/_postgresql.tpl
+++ b/helm/dagster/templates/helpers/instance/_postgresql.tpl
@@ -1,8 +1,10 @@
 {{- define "dagsterYaml.postgresql.config" }}
 postgres_db:
   username: {{ .Values.postgresql.postgresqlUsername }}
+  {{- if not .Values.postgresql.authProvider.enabled }}
   password:
     env: DAGSTER_PG_PASSWORD
+  {{- end }}
   hostname: {{ include "dagster.postgresql.host" . }}
   db_name: {{ .Values.postgresql.postgresqlDatabase	}}
   port: {{ .Values.postgresql.service.port }}
@@ -10,4 +12,16 @@ postgres_db:
   {{- if .Values.postgresql.postgresqlScheme }}
   scheme: {{ .Values.postgresql.postgresqlScheme }}
   {{- end }}
+{{- if .Values.postgresql.authProvider.enabled }}
+auth_provider:
+  {{- if eq .Values.postgresql.authProvider.type "azure_wif" }}
+  azure_wif:
+    scope: {{ .Values.postgresql.authProvider.azureScope }}
+  {{- else if eq .Values.postgresql.authProvider.type "gcp_wif" }}
+  gcp_wif: {}
+  {{- else if eq .Values.postgresql.authProvider.type "aws_wif" }}
+  aws_wif:
+    region: {{ .Values.postgresql.authProvider.awsRegion }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/dagster/templates/helpers/instance/_postgresql.tpl
+++ b/helm/dagster/templates/helpers/instance/_postgresql.tpl
@@ -23,8 +23,11 @@ auth_provider:
   {{- else if eq .Values.postgresql.authProvider.type "gcp_wif" }}
   gcp_wif: {}
   {{- else if eq .Values.postgresql.authProvider.type "aws_wif" }}
+  {{- if not .Values.postgresql.authProvider.awsRegion }}
+  {{- fail "postgresql.authProvider.awsRegion is required when type is aws_wif" }}
+  {{- end }}
   aws_wif:
-    region: {{ .Values.postgresql.authProvider.awsRegion }}
+    region: {{ .Values.postgresql.authProvider.awsRegion | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/dagster/templates/helpers/instance/_postgresql.tpl
+++ b/helm/dagster/templates/helpers/instance/_postgresql.tpl
@@ -19,7 +19,7 @@ postgres_db:
 auth_provider:
   {{- if eq .Values.postgresql.authProvider.type "azure_wif" }}
   azure_wif:
-    scope: {{ .Values.postgresql.authProvider.azureScope }}
+    scope: {{ .Values.postgresql.authProvider.azureScope | quote }}
   {{- else if eq .Values.postgresql.authProvider.type "gcp_wif" }}
   gcp_wif: {}
   {{- else if eq .Values.postgresql.authProvider.type "aws_wif" }}

--- a/helm/dagster/templates/helpers/instance/_postgresql.tpl
+++ b/helm/dagster/templates/helpers/instance/_postgresql.tpl
@@ -13,6 +13,9 @@ postgres_db:
   scheme: {{ .Values.postgresql.postgresqlScheme }}
   {{- end }}
 {{- if .Values.global.postgresqlAuthWifEnabled }}
+{{- if not (or (eq .Values.postgresql.authProvider.type "azure_wif") (eq .Values.postgresql.authProvider.type "gcp_wif") (eq .Values.postgresql.authProvider.type "aws_wif")) }}
+{{- fail (printf "postgresql.authProvider.type must be one of azure_wif, gcp_wif, aws_wif when postgresqlAuthWifEnabled is true; got %q" .Values.postgresql.authProvider.type) }}
+{{- end }}
 auth_provider:
   {{- if eq .Values.postgresql.authProvider.type "azure_wif" }}
   azure_wif:

--- a/helm/dagster/templates/helpers/instance/_postgresql.tpl
+++ b/helm/dagster/templates/helpers/instance/_postgresql.tpl
@@ -1,7 +1,7 @@
 {{- define "dagsterYaml.postgresql.config" }}
 postgres_db:
   username: {{ .Values.postgresql.postgresqlUsername }}
-  {{- if not .Values.postgresql.authProvider.enabled }}
+  {{- if not .Values.global.postgresqlAuthWifEnabled }}
   password:
     env: DAGSTER_PG_PASSWORD
   {{- end }}
@@ -12,7 +12,7 @@ postgres_db:
   {{- if .Values.postgresql.postgresqlScheme }}
   scheme: {{ .Values.postgresql.postgresqlScheme }}
   {{- end }}
-{{- if .Values.postgresql.authProvider.enabled }}
+{{- if .Values.global.postgresqlAuthWifEnabled }}
 auth_provider:
   {{- if eq .Values.postgresql.authProvider.type "azure_wif" }}
   azure_wif:

--- a/helm/dagster/templates/job-instance-migrate.yaml
+++ b/helm/dagster/templates/job-instance-migrate.yaml
@@ -36,7 +36,7 @@ spec:
           command: ["dagster"]
           args: ["instance", "migrate"]
           env:
-            {{- if not .Values.postgresql.authProvider.enabled }}
+            {{- if not .Values.global.postgresqlAuthWifEnabled }}
             - name: DAGSTER_PG_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/dagster/templates/job-instance-migrate.yaml
+++ b/helm/dagster/templates/job-instance-migrate.yaml
@@ -36,11 +36,13 @@ spec:
           command: ["dagster"]
           args: ["instance", "migrate"]
           env:
+            {{- if not .Values.postgresql.authProvider.enabled }}
             - name: DAGSTER_PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "dagster.postgresql.secretName" . | quote }}
                   key: postgresql-password
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "dagster.fullname" . }}-webserver-env

--- a/helm/dagster/templates/secret-postgres.yaml
+++ b/helm/dagster/templates/secret-postgres.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.generatePostgresqlPasswordSecret }}
+{{ if and .Values.generatePostgresqlPasswordSecret (not .Values.postgresql.authProvider.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/dagster/templates/secret-postgres.yaml
+++ b/helm/dagster/templates/secret-postgres.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.generatePostgresqlPasswordSecret (not .Values.postgresql.authProvider.enabled) }}
+{{ if and .Values.generatePostgresqlPasswordSecret (not .Values.global.postgresqlAuthWifEnabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -846,7 +846,6 @@ postgresql:
   # Workload Identity Federation auth. When enabled, no password/secret is needed.
   # The pod's service account token is exchanged for a short-lived DB access token.
   authProvider:
-    enabled: false
     # One of: azure_wif, gcp_wif, aws_wif
     type: ""
     # Azure-specific: override the default token scope

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -6,6 +6,8 @@
 ---
 global:
   postgresqlSecretName: "dagster-postgresql-secret"
+  # When true, PostgreSQL uses workload identity federation instead of a password secret.
+  postgresqlAuthWifEnabled: false
   # The DAGSTER_HOME env var is set by default on all nodes from this value
   dagsterHome: "/opt/dagster/dagster_home"
 
@@ -840,6 +842,17 @@ postgresql:
 
   service:
     port: 5432
+
+  # Workload Identity Federation auth. When enabled, no password/secret is needed.
+  # The pod's service account token is exchanged for a short-lived DB access token.
+  authProvider:
+    enabled: false
+    # One of: azure_wif, gcp_wif, aws_wif
+    type: ""
+    # Azure-specific: override the default token scope
+    azureScope: "https://ossrdbms-aad.database.windows.net/.default"
+    # AWS-specific: the RDS region
+    awsRegion: ""
 
 # Whether to generate a secret resource for the PostgreSQL password. Useful if
 # global.postgresqlSecretName is managed outside of this helm chart.

--- a/python_modules/dagster/dagster/_core/storage/config.py
+++ b/python_modules/dagster/dagster/_core/storage/config.py
@@ -1,6 +1,6 @@
 from typing_extensions import TypedDict
 
-from dagster._config import Field, IntSource, Permissive, Selector, StringSource
+from dagster._config import Field, IntSource, Permissive, Selector, Shape, StringSource
 from dagster._config.config_schema import UserConfigSchema
 
 
@@ -32,12 +32,13 @@ def mysql_config() -> UserConfigSchema:
     )
 
 
-class PostgresStorageConfig(TypedDict):
+class PostgresStorageConfig(TypedDict, total=False):
     postgres_url: str
     postgres_db: "PostgresStorageConfigDb"
+    auth_provider: dict[str, object]
 
 
-class PostgresStorageConfigDb(TypedDict):
+class PostgresStorageConfigDb(TypedDict, total=False):
     username: str
     password: str
     hostname: str
@@ -53,13 +54,35 @@ def pg_config() -> UserConfigSchema:
         "postgres_db": Field(
             {
                 "username": StringSource,
-                "password": StringSource,
+                "password": Field(StringSource, is_required=False, default_value=""),
                 "hostname": StringSource,
                 "db_name": StringSource,
                 "port": Field(IntSource, is_required=False, default_value=5432),
                 "params": Field(Permissive(), is_required=False, default_value={}),
                 "scheme": Field(StringSource, is_required=False, default_value="postgresql"),
             },
+            is_required=False,
+        ),
+        "auth_provider": Field(
+            Selector(
+                {
+                    "azure_wif": Shape(
+                        {
+                            "scope": Field(
+                                StringSource,
+                                is_required=False,
+                                default_value="https://ossrdbms-aad.database.windows.net/.default",
+                            ),
+                        }
+                    ),
+                    "gcp_wif": Shape({}),
+                    "aws_wif": Shape(
+                        {
+                            "region": StringSource,
+                        }
+                    ),
+                }
+            ),
             is_required=False,
         ),
         "should_autocreate_tables": Field(bool, is_required=False, default_value=True),

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/auth.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/auth.py
@@ -1,0 +1,182 @@
+import abc
+import logging
+import threading
+import time
+from typing import Any
+
+import sqlalchemy
+from sqlalchemy import event
+
+logger = logging.getLogger(__name__)
+
+
+class PgTokenProvider(abc.ABC):
+    """Abstract base for providers that supply short-lived database access tokens.
+
+    Subclasses implement ``_fetch_token`` to obtain a fresh token from their
+    respective cloud provider.  Caching and thread-safety are handled by the
+    base class so that callers can simply invoke ``get_token()``.
+    """
+
+    def __init__(self) -> None:
+        self._cached_token: str | None = None
+        self._token_expiry: float = 0.0  # epoch seconds
+        self._lock = threading.Lock()
+
+    @abc.abstractmethod
+    def _fetch_token(self) -> tuple[str, float]:
+        """Return ``(token, expiry_epoch_seconds)``.
+
+        If the exact expiry is unknown, implementations should return
+        ``time.time() + 3600`` as a conservative default (1 hour).
+        """
+        ...
+
+    def get_token(self) -> str:
+        """Return a valid token, refreshing if expired or about to expire."""
+        # Refresh 5 minutes before expiry to avoid races
+        with self._lock:
+            if self._cached_token is None or time.time() >= (self._token_expiry - 300):
+                logger.debug("Refreshing PostgreSQL auth token")
+                self._cached_token, self._token_expiry = self._fetch_token()
+            return self._cached_token
+
+
+class AzureWifTokenProvider(PgTokenProvider):
+    """Azure Workload Identity Federation token provider.
+
+    Uses ``DefaultAzureCredential`` which automatically picks up the
+    ``AZURE_CLIENT_ID``, ``AZURE_TENANT_ID``, and
+    ``AZURE_FEDERATED_TOKEN_FILE`` environment variables set by the Azure
+    Workload Identity webhook on AKS pods.
+    """
+
+    def __init__(
+        self,
+        scope: str = "https://ossrdbms-aad.database.windows.net/.default",
+    ) -> None:
+        super().__init__()
+        self._scope = scope
+
+    def _fetch_token(self) -> tuple[str, float]:
+        # Optional dependency — import lazily so the error is clear.
+        try:
+            from azure.identity import DefaultAzureCredential  # type: ignore[import-untyped]
+        except ImportError:
+            raise ImportError(
+                "azure-identity is required for Azure WIF auth. "
+                "Install with: pip install dagster-postgres[azure]"
+            )
+        credential = DefaultAzureCredential()
+        token = credential.get_token(self._scope)
+        return token.token, token.expires_on
+
+
+class GcpWifTokenProvider(PgTokenProvider):
+    """GCP Workload Identity Federation token provider.
+
+    Uses Application Default Credentials (ADC), which automatically picks up
+    the projected service account token on GKE pods.
+    """
+
+    def _fetch_token(self) -> tuple[str, float]:
+        try:
+            import google.auth  # type: ignore[import-untyped]
+            import google.auth.transport.requests  # type: ignore[import-untyped]
+        except ImportError:
+            raise ImportError(
+                "google-auth is required for GCP WIF auth. "
+                "Install with: pip install dagster-postgres[gcp]"
+            )
+        credentials, _ = google.auth.default(
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+        credentials.refresh(google.auth.transport.requests.Request())
+        expiry = credentials.expiry.timestamp() if credentials.expiry else (time.time() + 3600)
+        return credentials.token, expiry
+
+
+class AwsWifTokenProvider(PgTokenProvider):
+    """AWS IAM / IRSA token provider for RDS.
+
+    Uses ``boto3`` to generate an RDS auth token.  Requires the hostname,
+    port, username, and AWS region from the connection config.
+    """
+
+    def __init__(
+        self,
+        hostname: str,
+        port: int,
+        username: str,
+        region: str,
+    ) -> None:
+        super().__init__()
+        self._hostname = hostname
+        self._port = port
+        self._username = username
+        self._region = region
+
+    def _fetch_token(self) -> tuple[str, float]:
+        try:
+            import boto3  # type: ignore[import-untyped]
+        except ImportError:
+            raise ImportError(
+                "boto3 is required for AWS WIF auth. "
+                "Install with: pip install dagster-postgres[aws]"
+            )
+        client = boto3.client("rds", region_name=self._region)
+        token = client.generate_db_auth_token(
+            DBHostname=self._hostname,
+            Port=self._port,
+            DBUsername=self._username,
+            Region=self._region,
+        )
+        # RDS auth tokens are valid for 15 minutes
+        return token, time.time() + 900
+
+
+def create_token_provider(
+    auth_config: dict[str, Any],
+    db_config: dict[str, Any] | None = None,
+) -> PgTokenProvider:
+    """Create a token provider from the ``auth_provider`` config block."""
+    if "azure_wif" in auth_config:
+        azure_cfg = auth_config["azure_wif"]
+        return AzureWifTokenProvider(
+            scope=azure_cfg.get("scope", "https://ossrdbms-aad.database.windows.net/.default"),
+        )
+    elif "gcp_wif" in auth_config:
+        return GcpWifTokenProvider()
+    elif "aws_wif" in auth_config:
+        aws_cfg = auth_config["aws_wif"]
+        if db_config is None:
+            raise ValueError(
+                "AWS WIF requires postgres_db config (not postgres_url) to"
+                " extract hostname/port/username"
+            )
+        return AwsWifTokenProvider(
+            hostname=db_config["hostname"],
+            port=db_config.get("port", 5432),
+            username=db_config["username"],
+            region=aws_cfg["region"],
+        )
+    else:
+        raise ValueError(f"Unknown auth_provider config: {auth_config}")
+
+
+def register_do_connect_hook(
+    engine: sqlalchemy.engine.Engine,
+    token_provider: PgTokenProvider,
+) -> None:
+    """Register a ``do_connect`` event listener that injects a fresh token as
+    the password before each DBAPI connection.
+    """
+
+    @event.listens_for(engine, "do_connect")
+    def _inject_token(
+        dialect: Any,
+        conn_rec: Any,
+        cargs: list[Any],
+        cparams: dict[str, Any],
+    ) -> None:
+        cparams["password"] = token_provider.get_token()

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/auth.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/auth.py
@@ -143,7 +143,6 @@ class AwsWifTokenProvider(PgTokenProvider):
             DBHostname=self._hostname,
             Port=self._port,
             DBUsername=self._username,
-            Region=self._region,
         )
         # RDS auth tokens are valid for 15 minutes
         return token, time.time() + 900

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/auth.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/auth.py
@@ -57,18 +57,19 @@ class AzureWifTokenProvider(PgTokenProvider):
     ) -> None:
         super().__init__()
         self._scope = scope
+        self._credential: Any = None
 
     def _fetch_token(self) -> tuple[str, float]:
-        # Optional dependency — import lazily so the error is clear.
-        try:
-            from azure.identity import DefaultAzureCredential  # type: ignore[import-untyped]
-        except ImportError:
-            raise ImportError(
-                "azure-identity is required for Azure WIF auth. "
-                "Install with: pip install dagster-postgres[azure]"
-            )
-        credential = DefaultAzureCredential()
-        token = credential.get_token(self._scope)
+        if self._credential is None:
+            try:
+                from azure.identity import DefaultAzureCredential  # type: ignore[import-untyped]
+            except ImportError:
+                raise ImportError(
+                    "azure-identity is required for Azure WIF auth. "
+                    "Install with: pip install dagster-postgres[azure]"
+                )
+            self._credential = DefaultAzureCredential()
+        token = self._credential.get_token(self._scope)
         return token.token, token.expires_on
 
 
@@ -79,21 +80,32 @@ class GcpWifTokenProvider(PgTokenProvider):
     the projected service account token on GKE pods.
     """
 
+    def __init__(self) -> None:
+        super().__init__()
+        self._credentials: Any = None
+        self._request: Any = None
+
     def _fetch_token(self) -> tuple[str, float]:
-        try:
-            import google.auth  # type: ignore[import-untyped]
-            import google.auth.transport.requests  # type: ignore[import-untyped]
-        except ImportError:
-            raise ImportError(
-                "google-auth is required for GCP WIF auth. "
-                "Install with: pip install dagster-postgres[gcp]"
+        if self._credentials is None:
+            try:
+                import google.auth  # type: ignore[import-untyped]
+                import google.auth.transport.requests  # type: ignore[import-untyped]
+            except ImportError:
+                raise ImportError(
+                    "google-auth is required for GCP WIF auth. "
+                    "Install with: pip install dagster-postgres[gcp]"
+                )
+            self._credentials, _ = google.auth.default(
+                scopes=["https://www.googleapis.com/auth/cloud-platform"],
             )
-        credentials, _ = google.auth.default(
-            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            self._request = google.auth.transport.requests.Request()
+        self._credentials.refresh(self._request)
+        expiry = (
+            self._credentials.expiry.timestamp()
+            if self._credentials.expiry
+            else (time.time() + 3600)
         )
-        credentials.refresh(google.auth.transport.requests.Request())
-        expiry = credentials.expiry.timestamp() if credentials.expiry else (time.time() + 3600)
-        return credentials.token, expiry
+        return self._credentials.token, expiry
 
 
 class AwsWifTokenProvider(PgTokenProvider):
@@ -115,17 +127,19 @@ class AwsWifTokenProvider(PgTokenProvider):
         self._port = port
         self._username = username
         self._region = region
+        self._client: Any = None
 
     def _fetch_token(self) -> tuple[str, float]:
-        try:
-            import boto3  # type: ignore[import-untyped]
-        except ImportError:
-            raise ImportError(
-                "boto3 is required for AWS WIF auth. "
-                "Install with: pip install dagster-postgres[aws]"
-            )
-        client = boto3.client("rds", region_name=self._region)
-        token = client.generate_db_auth_token(
+        if self._client is None:
+            try:
+                import boto3  # type: ignore[import-untyped]
+            except ImportError:
+                raise ImportError(
+                    "boto3 is required for AWS WIF auth. "
+                    "Install with: pip install dagster-postgres[aws]"
+                )
+            self._client = boto3.client("rds", region_name=self._region)
+        token = self._client.generate_db_auth_token(
             DBHostname=self._hostname,
             Port=self._port,
             DBUsername=self._username,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from typing import Any, ContextManager, cast  # noqa: UP035
+from typing import TYPE_CHECKING, Any, ContextManager, cast  # noqa: UP035
 
 import dagster._check as check
 import sqlalchemy as db
@@ -36,12 +36,17 @@ from sqlalchemy.engine import Connection
 
 from dagster_postgres.utils import (
     create_pg_connection,
+    create_pg_engine,
+    get_token_provider_from_config,
     pg_alembic_config,
     pg_url_from_config,
     retry_pg_connection_fn,
     retry_pg_creation_fn,
     set_pg_statement_timeout,
 )
+
+if TYPE_CHECKING:
+    from dagster_postgres.auth import PgTokenProvider
 
 CHANNEL_NAME = "run_events"
 
@@ -80,16 +85,21 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         postgres_url: str,
         should_autocreate_tables: bool = True,
         inst_data: ConfigurableClassData | None = None,
+        token_provider: "PgTokenProvider | None" = None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.postgres_url = check.str_param(postgres_url, "postgres_url")
         self.should_autocreate_tables = check.bool_param(
             should_autocreate_tables, "should_autocreate_tables"
         )
+        self._token_provider = token_provider
 
         # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
-        self._engine = create_engine(
-            self.postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
+        self._engine = create_pg_engine(
+            self.postgres_url,
+            self._token_provider,
+            isolation_level="AUTOCOMMIT",
+            poolclass=db_pool.NullPool,
         )
         self._event_watcher: SqlPollingEventWatcher | None = None
 
@@ -125,7 +135,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         existing_options = self._engine.url.query.get("options")
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
-        self._engine = create_engine(self.postgres_url, **kwargs)
+        self._engine = create_pg_engine(self.postgres_url, self._token_provider, **kwargs)
         event.listen(
             self._engine,
             "connect",
@@ -153,6 +163,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             inst_data=inst_data,
             postgres_url=pg_url_from_config(config_value),
             should_autocreate_tables=config_value.get("should_autocreate_tables", True),
+            token_provider=get_token_provider_from_config(config_value),
         )
 
     @staticmethod

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -1,6 +1,6 @@
 import zlib
 from collections.abc import Mapping
-from typing import ContextManager  # noqa: UP035
+from typing import TYPE_CHECKING, ContextManager  # noqa: UP035
 
 import dagster._check as check
 import sqlalchemy as db
@@ -31,12 +31,17 @@ from sqlalchemy.engine import Connection
 
 from dagster_postgres.utils import (
     create_pg_connection,
+    create_pg_engine,
+    get_token_provider_from_config,
     pg_alembic_config,
     pg_url_from_config,
     retry_pg_connection_fn,
     retry_pg_creation_fn,
     set_pg_statement_timeout,
 )
+
+if TYPE_CHECKING:
+    from dagster_postgres.auth import PgTokenProvider
 
 
 class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
@@ -72,16 +77,19 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         postgres_url: str,
         should_autocreate_tables: bool = True,
         inst_data: ConfigurableClassData | None = None,
+        token_provider: "PgTokenProvider | None" = None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.postgres_url = postgres_url
         self.should_autocreate_tables = check.bool_param(
             should_autocreate_tables, "should_autocreate_tables"
         )
+        self._token_provider = token_provider
 
         # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
-        self._engine = create_engine(
+        self._engine = create_pg_engine(
             self.postgres_url,
+            self._token_provider,
             isolation_level="AUTOCOMMIT",
             poolclass=db_pool.NullPool,
         )
@@ -121,7 +129,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         existing_options = self._engine.url.query.get("options")
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
-        self._engine = create_engine(self.postgres_url, **kwargs)
+        self._engine = create_pg_engine(self.postgres_url, self._token_provider, **kwargs)
         event.listen(
             self._engine,
             "connect",
@@ -144,6 +152,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
             inst_data=inst_data,
             postgres_url=pg_url_from_config(config_value),
             should_autocreate_tables=config_value.get("should_autocreate_tables", True),
+            token_provider=get_token_provider_from_config(config_value),
         )
 
     @staticmethod

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import ContextManager  # noqa: UP035
+from typing import TYPE_CHECKING, ContextManager  # noqa: UP035
 
 import dagster._check as check
 import sqlalchemy as db
@@ -31,12 +31,17 @@ from sqlalchemy.engine import Connection
 
 from dagster_postgres.utils import (
     create_pg_connection,
+    create_pg_engine,
+    get_token_provider_from_config,
     pg_alembic_config,
     pg_url_from_config,
     retry_pg_connection_fn,
     retry_pg_creation_fn,
     set_pg_statement_timeout,
 )
+
+if TYPE_CHECKING:
+    from dagster_postgres.auth import PgTokenProvider
 
 
 class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
@@ -72,16 +77,21 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         postgres_url: str,
         should_autocreate_tables: bool = True,
         inst_data: ConfigurableClassData | None = None,
+        token_provider: "PgTokenProvider | None" = None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.postgres_url = postgres_url
         self.should_autocreate_tables = check.bool_param(
             should_autocreate_tables, "should_autocreate_tables"
         )
+        self._token_provider = token_provider
 
         # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
-        self._engine = create_engine(
-            self.postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
+        self._engine = create_pg_engine(
+            self.postgres_url,
+            self._token_provider,
+            isolation_level="AUTOCOMMIT",
+            poolclass=db_pool.NullPool,
         )
 
         # Stamp and create tables if the main table does not exist (we can't check alembic
@@ -117,7 +127,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         existing_options = self._engine.url.query.get("options")
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
-        self._engine = create_engine(self.postgres_url, **kwargs)
+        self._engine = create_pg_engine(self.postgres_url, self._token_provider, **kwargs)
         event.listen(
             self._engine,
             "connect",
@@ -140,6 +150,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             inst_data=inst_data,
             postgres_url=pg_url_from_config(config_value),
             should_autocreate_tables=config_value.get("should_autocreate_tables", True),
+            token_provider=get_token_provider_from_config(config_value),
         )
 
     @staticmethod

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/storage.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from dagster import _check as check
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.storage.base_storage import DagsterStorage
@@ -10,7 +12,10 @@ from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster_postgres.event_log import PostgresEventLogStorage
 from dagster_postgres.run_storage import PostgresRunStorage
 from dagster_postgres.schedule_storage import PostgresScheduleStorage
-from dagster_postgres.utils import pg_url_from_config
+from dagster_postgres.utils import get_token_provider_from_config, pg_url_from_config
+
+if TYPE_CHECKING:
+    from dagster_postgres.auth import PgTokenProvider
 
 
 class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
@@ -34,18 +39,25 @@ class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
 
     def __init__(
         self,
-        postgres_url,
-        should_autocreate_tables=True,
+        postgres_url: str,
+        should_autocreate_tables: bool = True,
         inst_data: ConfigurableClassData | None = None,
+        token_provider: "PgTokenProvider | None" = None,
     ):
         self.postgres_url = postgres_url
         self.should_autocreate_tables = check.bool_param(
             should_autocreate_tables, "should_autocreate_tables"
         )
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
-        self._run_storage = PostgresRunStorage(postgres_url, should_autocreate_tables)
-        self._event_log_storage = PostgresEventLogStorage(postgres_url, should_autocreate_tables)
-        self._schedule_storage = PostgresScheduleStorage(postgres_url, should_autocreate_tables)
+        self._run_storage = PostgresRunStorage(
+            postgres_url, should_autocreate_tables, token_provider=token_provider
+        )
+        self._event_log_storage = PostgresEventLogStorage(
+            postgres_url, should_autocreate_tables, token_provider=token_provider
+        )
+        self._schedule_storage = PostgresScheduleStorage(
+            postgres_url, should_autocreate_tables, token_provider=token_provider
+        )
         super().__init__()
 
     @property
@@ -64,6 +76,7 @@ class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
             inst_data=inst_data,
             postgres_url=pg_url_from_config(config_value),
             should_autocreate_tables=config_value.get("should_autocreate_tables", True),
+            token_provider=get_token_provider_from_config(config_value),
         )
 
     @property

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import quote, urlencode
 
 import alembic.config
@@ -13,8 +13,11 @@ from dagster._core.definitions.policy import Backoff, Jitter, calculate_delay
 
 # re-export
 from dagster._core.storage.config import pg_config as pg_config
-from dagster._core.storage.sql import get_alembic_config
+from dagster._core.storage.sql import create_engine, get_alembic_config
 from sqlalchemy.engine import Connection
+
+if TYPE_CHECKING:
+    from dagster_postgres.auth import PgTokenProvider
 
 T = TypeVar("T")
 
@@ -41,14 +44,18 @@ def pg_url_from_config(config_value: Mapping[str, Any]) -> str:
 
 def get_conn_string(
     username: str,
-    password: str,
-    hostname: str,
-    db_name: str,
+    password: str = "",
+    hostname: str = "",
+    db_name: str = "",
     port: str = "5432",
     params: Mapping[str, object] | None = None,
     scheme: str = "postgresql",
 ) -> str:
-    uri = f"{scheme}://{quote(username)}:{quote(password)}@{hostname}:{port}/{db_name}"
+    if password:
+        userinfo = f"{quote(username)}:{quote(password)}"
+    else:
+        userinfo = quote(username)
+    uri = f"{scheme}://{userinfo}@{hostname}:{port}/{db_name}"
 
     if params:
         query_string = f"{urlencode(params, quote_via=quote)}"
@@ -157,3 +164,41 @@ def set_pg_statement_timeout(conn: Any, millis: int):
     with conn:
         with conn.cursor() as curs:
             curs.execute(f"SET statement_timeout = {millis};")
+
+
+def create_pg_engine(
+    postgres_url: str,
+    token_provider: "PgTokenProvider | None" = None,
+    **engine_kwargs: Any,
+) -> sqlalchemy.engine.Engine:
+    """Create a SQLAlchemy engine, optionally with WIF token injection via
+    the ``do_connect`` event hook.
+    """
+    engine = create_engine(postgres_url, **engine_kwargs)
+    if token_provider is not None:
+        from dagster_postgres.auth import register_do_connect_hook
+
+        register_do_connect_hook(engine, token_provider)
+    return engine
+
+
+def get_token_provider_from_config(
+    config_value: Mapping[str, Any],
+) -> "PgTokenProvider | None":
+    """Extract and build a token provider from config, or return ``None`` for
+    password auth.
+    """
+    auth_config = config_value.get("auth_provider")
+    if auth_config is None:
+        return None
+
+    check.invariant(
+        "postgres_url" not in config_value or not config_value["postgres_url"],
+        "auth_provider cannot be used with postgres_url. Use postgres_db instead"
+        " so that tokens can be injected at the DBAPI connection level.",
+    )
+
+    from dagster_postgres.auth import create_token_provider
+
+    db_config = config_value.get("postgres_db")
+    return create_token_provider(auth_config, db_config)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_auth.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_auth.py
@@ -1,0 +1,227 @@
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+import sqlalchemy
+from dagster_postgres.auth import (
+    AwsWifTokenProvider,
+    AzureWifTokenProvider,
+    GcpWifTokenProvider,
+    PgTokenProvider,
+    create_token_provider,
+    register_do_connect_hook,
+)
+from dagster_postgres.utils import get_token_provider_from_config
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeTokenProvider(PgTokenProvider):
+    """A concrete token provider that returns a fixed token for testing."""
+
+    def __init__(self, token: str = "fake-token", ttl: float = 3600) -> None:
+        super().__init__()
+        self._token = token
+        self._ttl = ttl
+        self.fetch_count = 0
+
+    def _fetch_token(self) -> tuple[str, float]:
+        self.fetch_count += 1
+        return self._token, time.time() + self._ttl
+
+
+# ---------------------------------------------------------------------------
+# Token caching
+# ---------------------------------------------------------------------------
+
+
+class TestTokenCaching:
+    def test_caches_token_within_ttl(self) -> None:
+        provider = FakeTokenProvider(token="tok-1", ttl=3600)
+        assert provider.get_token() == "tok-1"
+        assert provider.get_token() == "tok-1"
+        assert provider.fetch_count == 1
+
+    def test_refreshes_on_expiry(self) -> None:
+        provider = FakeTokenProvider(token="tok-1", ttl=0)
+        # ttl=0 means the token is already expired on creation
+        tok1 = provider.get_token()
+        assert tok1 == "tok-1"
+        assert provider.fetch_count == 1
+
+        # Second call should refresh because token is already past expiry
+        tok2 = provider.get_token()
+        assert tok2 == "tok-1"
+        assert provider.fetch_count == 2
+
+    def test_refreshes_within_margin(self) -> None:
+        # Token expires in 4 minutes — within the 5-minute refresh margin
+        provider = FakeTokenProvider(token="tok-1", ttl=240)
+        provider.get_token()
+        assert provider.fetch_count == 1
+
+        # Should refresh because 240s < 300s margin
+        provider.get_token()
+        assert provider.fetch_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    def test_concurrent_get_token(self) -> None:
+        provider = FakeTokenProvider(token="tok-1", ttl=3600)
+        results: list[str] = []
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                results.append(provider.get_token())
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert all(r == "tok-1" for r in results)
+        # May have fetched more than once due to race at startup, but should be bounded
+        assert provider.fetch_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# do_connect hook
+# ---------------------------------------------------------------------------
+
+
+class TestDoConnectHook:
+    def test_hook_injects_token_on_connect(self) -> None:
+        """Verify that register_do_connect_hook causes the provider's token
+        to be used as the password when psycopg2.connect is called.
+        """
+        provider = FakeTokenProvider(token="injected-password", ttl=3600)
+        engine = sqlalchemy.create_engine(
+            "postgresql://user:dummy@localhost:5432/db",
+            poolclass=sqlalchemy.pool.NullPool,
+        )
+        register_do_connect_hook(engine, provider)
+
+        # Patch psycopg2.connect to capture the password that SQLAlchemy passes
+        captured_kwargs: dict[str, object] = {}
+        with patch("psycopg2.connect") as mock_connect:
+
+            def capture_connect(*args: object, **kwargs: object) -> None:
+                captured_kwargs.update(kwargs)
+                raise sqlalchemy.exc.OperationalError("test", {}, Exception("skip"))
+
+            mock_connect.side_effect = capture_connect
+
+            # Attempting to connect will invoke do_connect, which injects the token,
+            # then psycopg2.connect is called with the modified password.
+            try:
+                with engine.connect():
+                    pass
+            except Exception:
+                pass
+
+        # The do_connect hook should have replaced "dummy" with the token
+        assert captured_kwargs.get("password") == "injected-password"
+        assert provider.fetch_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Factory function
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTokenProvider:
+    def test_azure_wif(self) -> None:
+        provider = create_token_provider({"azure_wif": {"scope": "custom-scope"}})
+        assert isinstance(provider, AzureWifTokenProvider)
+        assert provider._scope == "custom-scope"  # noqa: SLF001
+
+    def test_azure_wif_default_scope(self) -> None:
+        provider = create_token_provider({"azure_wif": {}})
+        assert isinstance(provider, AzureWifTokenProvider)
+        assert "ossrdbms-aad" in provider._scope  # noqa: SLF001
+
+    def test_gcp_wif(self) -> None:
+        provider = create_token_provider({"gcp_wif": {}})
+        assert isinstance(provider, GcpWifTokenProvider)
+
+    def test_aws_wif(self) -> None:
+        db_config = {"hostname": "my-host", "port": 5432, "username": "myuser"}
+        provider = create_token_provider({"aws_wif": {"region": "us-east-1"}}, db_config)
+        assert isinstance(provider, AwsWifTokenProvider)
+        assert provider._region == "us-east-1"  # noqa: SLF001
+        assert provider._hostname == "my-host"  # noqa: SLF001
+
+    def test_aws_wif_requires_db_config(self) -> None:
+        with pytest.raises(ValueError, match="AWS WIF requires postgres_db"):
+            create_token_provider({"aws_wif": {"region": "us-east-1"}})
+
+    def test_unknown_provider(self) -> None:
+        with pytest.raises(ValueError, match="Unknown auth_provider"):
+            create_token_provider({"unknown_wif": {}})
+
+
+# ---------------------------------------------------------------------------
+# Config extraction
+# ---------------------------------------------------------------------------
+
+
+class TestGetTokenProviderFromConfig:
+    def test_returns_none_without_auth_provider(self) -> None:
+        config = {
+            "postgres_db": {"username": "u", "password": "p", "hostname": "h", "db_name": "d"}
+        }
+        assert get_token_provider_from_config(config) is None
+
+    def test_returns_provider_with_auth_provider(self) -> None:
+        config = {
+            "postgres_db": {"username": "u", "hostname": "h", "db_name": "d"},
+            "auth_provider": {"azure_wif": {}},
+        }
+        provider = get_token_provider_from_config(config)
+        assert isinstance(provider, AzureWifTokenProvider)
+
+    def test_rejects_auth_provider_with_postgres_url(self) -> None:
+        config = {
+            "postgres_url": "postgresql://user:pass@host/db",
+            "auth_provider": {"azure_wif": {}},
+        }
+        with pytest.raises(Exception, match="auth_provider cannot be used with postgres_url"):
+            get_token_provider_from_config(config)
+
+
+# ---------------------------------------------------------------------------
+# Cloud provider import errors
+# ---------------------------------------------------------------------------
+
+
+class TestImportErrors:
+    def test_azure_missing_import(self) -> None:
+        provider = AzureWifTokenProvider()
+        with patch.dict("sys.modules", {"azure.identity": None, "azure": None}):
+            with pytest.raises(ImportError, match="azure-identity"):
+                provider._fetch_token()  # noqa: SLF001
+
+    def test_gcp_missing_import(self) -> None:
+        provider = GcpWifTokenProvider()
+        with patch.dict("sys.modules", {"google.auth": None, "google": None}):
+            with pytest.raises(ImportError, match="google-auth"):
+                provider._fetch_token()  # noqa: SLF001
+
+    def test_aws_missing_import(self) -> None:
+        provider = AwsWifTokenProvider(hostname="h", port=5432, username="u", region="us-east-1")
+        with patch.dict("sys.modules", {"boto3": None}):
+            with pytest.raises(ImportError, match="boto3"):
+                provider._fetch_token()  # noqa: SLF001

--- a/python_modules/libraries/dagster-postgres/pyproject.toml
+++ b/python_modules/libraries/dagster-postgres/pyproject.toml
@@ -23,6 +23,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+azure = ["azure-identity>=1.12.0"]
+gcp = ["google-auth>=2.0.0"]
+aws = ["boto3>=1.26.0"]
+wif = [
+    "azure-identity>=1.12.0",
+    "google-auth>=2.0.0",
+    "boto3>=1.26.0",
+]
 test = []
 
 [project.urls]

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -77,7 +77,6 @@ def main(
         "python_modules/libraries/dagster-deltalake-polars",
         "python_modules/libraries/dagster-dg-core",
         "python_modules/libraries/dagster-dg-cli",
-        "python_modules/libraries/dagster-rest-resources",
         "python_modules/libraries/dagster-dlt",
         "python_modules/libraries/dagster-docker",
         "python_modules/libraries/dagster-gcp[test, dataproc]",

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -77,6 +77,7 @@ def main(
         "python_modules/libraries/dagster-deltalake-polars",
         "python_modules/libraries/dagster-dg-core",
         "python_modules/libraries/dagster-dg-cli",
+        "python_modules/libraries/dagster-rest-resources",
         "python_modules/libraries/dagster-dlt",
         "python_modules/libraries/dagster-docker",
         "python_modules/libraries/dagster-gcp[test, dataproc]",


### PR DESCRIPTION
## Summary & Motivation

Adds workload identity federation (WIF) support to `dagster-postgres`, allowing Kubernetes pods on Azure AKS, GCP GKE, and AWS EKS to authenticate to PostgreSQL using cloud-native token exchange instead of static passwords.

Currently, Dagster's PostgreSQL storage only supports static username/password authentication. Users deploying on managed Kubernetes need the ability to use their pod's service account identity to obtain short-lived database access tokens.

**Approach:** Uses SQLAlchemy's `do_connect` event hook to dynamically inject a fresh token as the password before each DBAPI connection is established. Tokens are cached with a 5-minute refresh margin and protected by a threading lock.

**Cloud providers supported:**
- **Azure** — `DefaultAzureCredential` with configurable scope
- **GCP** — `google.auth.default()` with Application Default Credentials
- **AWS** — `boto3` RDS IAM auth token generation

**Helm chart:** A single `global.postgresqlAuthWifEnabled` flag controls secret creation, `DAGSTER_PG_PASSWORD` env var injection, and instance config across both the parent chart and the `dagster-user-deployments` subchart.

  Closes #13917. Closes #19723.

## Test Plan
- 17 unit tests in `dagster_postgres_tests/test_auth.py` covering:
- Token caching and expiry refresh
- Thread safety under concurrent access
- `do_connect` hook password injection (via mocked `psycopg2.connect`)
- Factory function for all three cloud providers
- Config extraction and validation (`auth_provider` + `postgres_url` rejection)
- Graceful `ImportError` when cloud SDKs are missing
- `make ruff` passes with no issues
- `helm template` with WIF values produces correct output (no password secret, no `DAGSTER_PG_PASSWORD` env var, `auth_provider` in dagster.yaml)

## Changelog

Adds workload identity federation (WIF) authentication for `dagster-postgres`. Users can now configure `auth_provider` with `azure_wif`, `gcp_wif`, or `aws_wif` to authenticate to PostgreSQL using cloud-native identity instead of static passwords. 

Optional extras: `dagster-postgres[azure]`, `dagster-postgres[gcp]`, `dagster-postgres[aws]`. Helm chart supports WIF via `global.postgresqlAuthWifEnabled`.