### PR TITLE
[ui] Allow materializing asset group selections that include external assets

### DIFF
--- a/js_modules/ui-core/src/asset-graph/CollapsedGroupNode.tsx
+++ b/js_modules/ui-core/src/asset-graph/CollapsedGroupNode.tsx
@@ -309,16 +309,19 @@ export const useGroupNodeContextMenu = ({
     featureContext: {canSeeMaterializeAction},
   } = useContext(CloudOSSContext);
 
+  const executableAssets = assets.filter((asset) => asset.definition.isExecutable);
+
   const menu = (
     <Menu>
       {canSeeMaterializeAction ? (
         <>
           <MenuItem
             icon="materialization"
-            text={`Materialize assets (${numberFormatter.format(assets.length)})`}
+            text={`Materialize assets (${numberFormatter.format(executableAssets.length)}${executableAssets.length !== assets.length ? ` of ${numberFormatter.format(assets.length)}` : ''})`}
+            disabled={executableAssets.length === 0}
             onClick={(e) => {
               onClick(
-                assets.map((asset) => asset.assetKey),
+                executableAssets.map((asset) => asset.assetKey),
                 e,
               );
             }}

--- a/js_modules/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -578,7 +578,7 @@ async function stateForLaunchingAssets(
     };
   }
   // Filter out external assets so mixed selections launch only materializable assets.
-  const launchAssets = executableAssets.length < assets.length ? executableAssets : assets;
+  // Filter out external assets so mixed selections launch only materializable assets.
 
   const repoAddress = buildRepoAddress(
     launchAssets[0]?.repository.name || '',

--- a/js_modules/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -578,22 +578,21 @@ async function stateForLaunchingAssets(
     };
   }
   // Filter out external assets so mixed selections launch only materializable assets.
-  // Filter out external assets so mixed selections launch only materializable assets.
 
   const repoAddress = buildRepoAddress(
-    launchAssets[0]?.repository.name || '',
-    launchAssets[0]?.repository.location.name || '',
+    executableAssets[0]?.repository.name || '',
+    executableAssets[0]?.repository.location.name || '',
   );
-  const jobName = getCommonJob(launchAssets, preferredJobName);
-  const partitionDefinition = launchAssets.find(
+  const jobName = getCommonJob(executableAssets, preferredJobName);
+  const partitionDefinition = executableAssets.find(
     (a) => !!a.partitionDefinition,
   )?.partitionDefinition;
 
-  const inSameRepo = launchAssets.every(
+  const inSameRepo = executableAssets.every(
     (a) =>
       a.repository.name === repoAddress.name && a.repository.location.name === repoAddress.location,
   );
-  const inSameOrNoPartitionSpace = launchAssets.every(
+  const inSameOrNoPartitionSpace = executableAssets.every(
     (a) =>
       !a.partitionDefinition ||
       !partitionDefinition ||
@@ -604,11 +603,11 @@ async function stateForLaunchingAssets(
     if (!partitionDefinition) {
       return {type: 'error', error: ERROR_INVALID_ASSET_SELECTION};
     }
-    const anchorAsset = getAnchorAssetForPartitionMappedBackfill(launchAssets);
+    const anchorAsset = getAnchorAssetForPartitionMappedBackfill(executableAssets);
     if (!anchorAsset) {
       return {
         type: 'partitions',
-        assets: launchAssets,
+        assets: executableAssets,
         target: {type: 'pureAll'},
         upstreamAssetKeys: [],
         repoAddress,
@@ -616,9 +615,9 @@ async function stateForLaunchingAssets(
     }
     return {
       type: 'partitions',
-      assets: launchAssets,
+      assets: executableAssets,
       target: {type: 'pureWithAnchorAsset', anchorAssetKey: anchorAsset.assetKey},
-      upstreamAssetKeys: getUpstreamAssetKeys(launchAssets),
+      upstreamAssetKeys: getUpstreamAssetKeys(executableAssets),
       repoAddress,
     };
   }
@@ -627,7 +626,7 @@ async function stateForLaunchingAssets(
   // we assume that any required config will be provided by a PartitionedConfig function
   // attached to the job. Otherwise backfills won't work and you'll know to add one!
   const configAssumedPresent = partitionDefinition && !isHiddenAssetGroupJob(jobName);
-  const configRequired = launchAssets.some((a) => a.configField?.isRequired);
+  const configRequired = executableAssets.some((a) => a.configField?.isRequired);
   let needLaunchpad = false;
 
   if (configAssumedPresent) {
@@ -635,7 +634,7 @@ async function stateForLaunchingAssets(
   } else if (configRequired) {
     needLaunchpad = true;
   } else {
-    const requiredResourceKeys = launchAssets.flatMap((a) =>
+    const requiredResourceKeys = executableAssets.flatMap((a) =>
       a.requiredResources.map((r) => r.resourceKey),
     );
     if (requiredResourceKeys.length) {
@@ -655,15 +654,15 @@ async function stateForLaunchingAssets(
   }
 
   if (needLaunchpad || forceLaunchpad) {
-    const assetOpNames = launchAssets.flatMap((a) => a.opNames || []);
+    const assetOpNames = executableAssets.flatMap((a) => a.opNames || []);
     return {
       type: 'launchpad',
       jobName,
       repoAddress,
       sessionPresets: {
         flattenGraphs: true,
-        assetSelection: launchAssets.map((a) => ({assetKey: a.assetKey, opNames: a.opNames})),
-        assetChecksAvailable: launchAssets.flatMap((a) =>
+        assetSelection: executableAssets.map((a) => ({assetKey: a.assetKey, opNames: a.opNames})),
+        assetChecksAvailable: executableAssets.flatMap((a) =>
           a.assetChecksOrError.__typename === 'AssetChecks'
             ? a.assetChecksOrError.checks
                 // For user code prior to 1.5.10 jobNames isn't populated, so don't filter on it
@@ -682,15 +681,15 @@ async function stateForLaunchingAssets(
   if (partitionDefinition) {
     return {
       type: 'partitions',
-      assets: launchAssets,
-      target: {type: 'job', jobName, assetKeys: launchAssets.map(asAssetKeyInput)},
-      upstreamAssetKeys: getUpstreamAssetKeys(launchAssets),
+      assets: executableAssets,
+      target: {type: 'job', jobName, assetKeys: executableAssets.map(asAssetKeyInput)},
+      upstreamAssetKeys: getUpstreamAssetKeys(executableAssets),
       repoAddress,
     };
   }
   return {
     type: 'single-run',
-    executionParams: executionParamsForAssetJob(repoAddress, jobName, launchAssets, []),
+    executionParams: executionParamsForAssetJob(repoAddress, jobName, executableAssets, []),
   };
 }
 

--- a/js_modules/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -570,25 +570,30 @@ async function stateForLaunchingAssets(
       error: 'One or more observable assets are selected and cannot be materialized.',
     };
   }
-  if (assets.some((x) => !x.isExecutable)) {
+  const executableAssets = assets.filter((x) => x.isExecutable);
+  if (executableAssets.length === 0) {
     return {
       type: 'error',
       error: 'One or more external assets are selected.',
     };
   }
+  // Filter out external assets so mixed selections launch only materializable assets.
+  const launchAssets = executableAssets.length < assets.length ? executableAssets : assets;
 
   const repoAddress = buildRepoAddress(
-    assets[0]?.repository.name || '',
-    assets[0]?.repository.location.name || '',
+    launchAssets[0]?.repository.name || '',
+    launchAssets[0]?.repository.location.name || '',
   );
-  const jobName = getCommonJob(assets, preferredJobName);
-  const partitionDefinition = assets.find((a) => !!a.partitionDefinition)?.partitionDefinition;
+  const jobName = getCommonJob(launchAssets, preferredJobName);
+  const partitionDefinition = launchAssets.find(
+    (a) => !!a.partitionDefinition,
+  )?.partitionDefinition;
 
-  const inSameRepo = assets.every(
+  const inSameRepo = launchAssets.every(
     (a) =>
       a.repository.name === repoAddress.name && a.repository.location.name === repoAddress.location,
   );
-  const inSameOrNoPartitionSpace = assets.every(
+  const inSameOrNoPartitionSpace = launchAssets.every(
     (a) =>
       !a.partitionDefinition ||
       !partitionDefinition ||
@@ -599,11 +604,11 @@ async function stateForLaunchingAssets(
     if (!partitionDefinition) {
       return {type: 'error', error: ERROR_INVALID_ASSET_SELECTION};
     }
-    const anchorAsset = getAnchorAssetForPartitionMappedBackfill(assets);
+    const anchorAsset = getAnchorAssetForPartitionMappedBackfill(launchAssets);
     if (!anchorAsset) {
       return {
         type: 'partitions',
-        assets,
+        assets: launchAssets,
         target: {type: 'pureAll'},
         upstreamAssetKeys: [],
         repoAddress,
@@ -611,9 +616,9 @@ async function stateForLaunchingAssets(
     }
     return {
       type: 'partitions',
-      assets,
+      assets: launchAssets,
       target: {type: 'pureWithAnchorAsset', anchorAssetKey: anchorAsset.assetKey},
-      upstreamAssetKeys: getUpstreamAssetKeys(assets),
+      upstreamAssetKeys: getUpstreamAssetKeys(launchAssets),
       repoAddress,
     };
   }
@@ -622,7 +627,7 @@ async function stateForLaunchingAssets(
   // we assume that any required config will be provided by a PartitionedConfig function
   // attached to the job. Otherwise backfills won't work and you'll know to add one!
   const configAssumedPresent = partitionDefinition && !isHiddenAssetGroupJob(jobName);
-  const configRequired = assets.some((a) => a.configField?.isRequired);
+  const configRequired = launchAssets.some((a) => a.configField?.isRequired);
   let needLaunchpad = false;
 
   if (configAssumedPresent) {
@@ -630,7 +635,7 @@ async function stateForLaunchingAssets(
   } else if (configRequired) {
     needLaunchpad = true;
   } else {
-    const requiredResourceKeys = assets.flatMap((a) =>
+    const requiredResourceKeys = launchAssets.flatMap((a) =>
       a.requiredResources.map((r) => r.resourceKey),
     );
     if (requiredResourceKeys.length) {
@@ -650,15 +655,15 @@ async function stateForLaunchingAssets(
   }
 
   if (needLaunchpad || forceLaunchpad) {
-    const assetOpNames = assets.flatMap((a) => a.opNames || []);
+    const assetOpNames = launchAssets.flatMap((a) => a.opNames || []);
     return {
       type: 'launchpad',
       jobName,
       repoAddress,
       sessionPresets: {
         flattenGraphs: true,
-        assetSelection: assets.map((a) => ({assetKey: a.assetKey, opNames: a.opNames})),
-        assetChecksAvailable: assets.flatMap((a) =>
+        assetSelection: launchAssets.map((a) => ({assetKey: a.assetKey, opNames: a.opNames})),
+        assetChecksAvailable: launchAssets.flatMap((a) =>
           a.assetChecksOrError.__typename === 'AssetChecks'
             ? a.assetChecksOrError.checks
                 // For user code prior to 1.5.10 jobNames isn't populated, so don't filter on it
@@ -677,15 +682,15 @@ async function stateForLaunchingAssets(
   if (partitionDefinition) {
     return {
       type: 'partitions',
-      assets,
-      target: {type: 'job', jobName, assetKeys: assets.map(asAssetKeyInput)},
-      upstreamAssetKeys: getUpstreamAssetKeys(assets),
+      assets: launchAssets,
+      target: {type: 'job', jobName, assetKeys: launchAssets.map(asAssetKeyInput)},
+      upstreamAssetKeys: getUpstreamAssetKeys(launchAssets),
       repoAddress,
     };
   }
   return {
     type: 'single-run',
-    executionParams: executionParamsForAssetJob(repoAddress, jobName, assets, []),
+    executionParams: executionParamsForAssetJob(repoAddress, jobName, launchAssets, []),
   };
 }
 

--- a/js_modules/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -236,6 +236,31 @@ describe('LaunchAssetExecutionButton', () => {
       await waitFor(() => expect(launchMock.result).toHaveBeenCalled());
     });
 
+    it('should launch only executable assets from a mixed selection', async () => {
+      const launchMock = buildExpectedLaunchSingleRunMutation({
+        mode: 'default',
+        executionMetadata: {
+          tags: [...UI_EXECUTION_TAGS],
+        },
+        runConfigData: '{}',
+        selector: {
+          repositoryLocationName: 'test.py',
+          repositoryName: 'repo',
+          pipelineName: 'my_asset_job',
+          assetSelection: [{path: ['unpartitioned_asset']}],
+          assetCheckSelection: [],
+        },
+      });
+      renderButton({
+        scope: {all: [UNPARTITIONED_ASSET, UNPARTITIONED_NON_EXECUTABLE_ASSET]},
+        preferredJobName: 'my_asset_job',
+        extraMocks: [buildLaunchAssetLoaderMock([UNPARTITIONED_ASSET.assetKey])],
+        launchMock,
+      });
+      await clickMaterializeButton();
+      await waitFor(() => expect(launchMock.result).toHaveBeenCalled());
+    });
+
     describe('assets with checks', () => {
       it('should not include checks if the job in context is marked without_checks', async () => {
         const launchMock = buildExpectedLaunchSingleRunMutation({
@@ -730,10 +755,12 @@ describe('LaunchAssetExecutionButton', () => {
 function renderButton({
   scope,
   launchMock,
+  extraMocks = [],
   preferredJobName,
 }: {
   scope: AssetsInScope;
   launchMock?: MockedResponse<Record<string, any>>;
+  extraMocks?: MockedResponse<Record<string, any>>[];
   preferredJobName?: string;
 }) {
   const assetKeys = (
@@ -758,6 +785,7 @@ function renderButton({
     buildConfigPartitionSelectionLatestPartitionMock('2020-01-02', 'my_asset_job'),
     buildConfigPartitionSelectionLatestPartitionMock('2023-02-22', 'my_asset_job'),
     buildConfigPartitionSelectionLatestPartitionMock('2023-02-22', '__ASSET_JOB'),
+    ...extraMocks,
     buildLaunchAssetLoaderMock([MULTI_ASSET_OUT_1.assetKey], {
       assetNodeAdditionalRequiredKeys: [MULTI_ASSET_OUT_2.assetKey],
     }),


### PR DESCRIPTION
## Summary & Motivation

Fixes #33199.

When a user right-clicks an asset group in the global lineage view, the launch flow currently treats any external asset in the group as a blocker for the entire materialization action. That makes mixed groups behave like fully non-materializable groups even when some assets in the selection are executable.

This PR updates the group action and launch path so mixed selections behave correctly:

- the context menu shows `Materialize assets (N of M)` when some assets in the group are external
- the menu item is disabled only when all assets in the group are external
- the launch flow filters out external assets and continues with the executable subset instead of erroring

## Test Plan

- `cd js_modules && yarn tsgo`
- `cd js_modules && yarn jest ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx`

## Changelog

- [ui] Fixed asset group materialization so mixed selections with external assets launch the executable assets instead of failing.
