### PR TITLE
[core] improves error messages when required config is missing in Dagster jobs

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_environment_schema.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_environment_schema.ambr
@@ -20,7 +20,7 @@
             'field': dict({
               'name': 'ops',
             }),
-            'message': 'Missing required config entry "ops" at the root. Sample config for missing entry: {\'ops\': {\'sum_op\': {\'inputs\': {\'num\': \'...\'}}}}',
+            'message': 'Missing required config entry "ops" at the root. You must provide this value in your run config. Example config for the missing entry: {\'ops\': {\'sum_op\': {\'inputs\': {\'num\': \'...\'}}}}',
             'reason': 'MISSING_REQUIRED_FIELD',
             'stack': dict({
               'entries': list([

--- a/python_modules/dagster/dagster/_config/errors.py
+++ b/python_modules/dagster/dagster/_config/errors.py
@@ -275,8 +275,8 @@ def create_missing_required_field_error(
         stack=context.stack,
         reason=DagsterEvaluationErrorReason.MISSING_REQUIRED_FIELD,
         message=(
-            'Missing required config entry "{expected}" {path_msg}. Sample config for missing'
-            " entry: {minimal_config}"
+            'Missing required config entry "{expected}" {path_msg}. You must provide this value in your'
+            " run config. Example config for the missing entry: {minimal_config}"
         ).format(
             expected=expected_field,
             path_msg=get_friendly_path_msg(context.stack),
@@ -305,8 +305,8 @@ def create_missing_required_fields_error(
         stack=context.stack,
         reason=DagsterEvaluationErrorReason.MISSING_REQUIRED_FIELDS,
         message=(
-            "Missing required config entries {missing_fields} {path_msg}. Sample config for missing"
-            " entries: {minimal_config}".format(
+            "Missing required config entries {missing_fields} {path_msg}. You must provide these values in your"
+            " run config. Example config for the missing entries: {minimal_config}".format(
                 missing_fields=missing_fields,
                 path_msg=get_friendly_path_msg(context.stack),
                 minimal_config={

--- a/python_modules/dagster/dagster/_config/field.py
+++ b/python_modules/dagster/dagster/_config/field.py
@@ -315,7 +315,7 @@ class Field:
             evr = validate_config(self.config_type, default_value)
             if not evr.success:
                 raise DagsterInvalidConfigError(
-                    "Invalid default_value for Field.",
+                    "Invalid default_value for Field. Ensure all required config entries are provided and all values match the expected types.",
                     evr.errors,
                     default_value,
                 )

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -1359,7 +1359,7 @@ def _config_mapping_with_default_value(
     config_evr = validate_config(config_schema, default_config)
     if not config_evr.success:
         raise DagsterInvalidConfigError(
-            f"Error in config when building job '{job_name}' ",
+            f"Error in config when building job '{job_name}': the provided config is missing required fields or contains invalid entries",
             config_evr.errors,
             default_config,
         )

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_config_mappings.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/evaluator_tests/test_config_mappings.py
@@ -73,7 +73,7 @@ def test_missing_config():
 
     assert len(exc_info.value.errors) == 1
     assert exc_info.value.errors[0].message.startswith(
-        'Missing required config entry "ops" at the root.'
+        'Missing required config entry "ops" at the root. You must provide this value in your run config.'
     )
     assert str(expected_suggested_config) in exc_info.value.errors[0].message
 
@@ -82,7 +82,7 @@ def test_missing_config():
 
     assert len(exc_info.value.errors) == 1
     assert exc_info.value.errors[0].message.startswith(
-        'Missing required config entry "ops" at the root.'
+        'Missing required config entry "ops" at the root. You must provide this value in your run config.'
     )
     assert str(expected_suggested_config) in exc_info.value.errors[0].message
 
@@ -92,7 +92,7 @@ def test_missing_config():
 
     assert len(exc_info.value.errors) == 1
     assert exc_info.value.errors[0].message.startswith(
-        'Missing required config entry "do_stuff" at path root:ops.'
+        'Missing required config entry "do_stuff" at path root:ops. You must provide this value in your run config.'
     )
     assert str(expected_suggested_config) in exc_info.value.errors[0].message
 
@@ -102,7 +102,7 @@ def test_missing_config():
 
     assert len(exc_info.value.errors) == 1
     assert exc_info.value.errors[0].message.startswith(
-        'Missing required config entry "config" at path root:ops:do_stuff.'
+        'Missing required config entry "config" at path root:ops:do_stuff. You must provide this value in your run config.'
     )
     assert str(expected_suggested_config) in exc_info.value.errors[0].message
 
@@ -112,7 +112,7 @@ def test_missing_config():
 
     assert len(exc_info.value.errors) == 1
     assert exc_info.value.errors[0].message.startswith(
-        'Missing required config entry "override_str" at path root:ops:do_stuff:config.'
+        'Missing required config entry "override_str" at path root:ops:do_stuff:config. You must provide this value in your run config.'
     )
     assert str(expected_suggested_config) in exc_info.value.errors[0].message
 

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_enums.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_config_enums.py
@@ -182,7 +182,10 @@ def test_list_enum_with_bad_default_value():
 
     # This error message is bad
     # https://github.com/dagster-io/dagster/issues/2339
-    assert "Invalid default_value for Field." in str(exc_info.value)
+    assert (
+        "Invalid default_value for Field. Ensure all required config entries are provided and all values match the expected types."
+        in str(exc_info.value)
+    )
     assert "Error 1: Value at path root[0] for enum type NativeEnum must be a string" in str(
         exc_info.value
     )

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -506,8 +506,10 @@ def test_to_job_incomplete_default_config():
     def my_graph():
         my_op()
 
-    default_config_error = "Error in config when building job 'my_job' "
-    invalid_default_error = "Invalid default_value for Field."
+    default_config_error = "Error in config when building job 'my_job': the provided config is missing required fields or contains invalid entries"
+    invalid_default_error = (
+        "Invalid default_value for Field. Ensure all required config entries are provided"
+    )
     invalid_configs = [
         (
             {},


### PR DESCRIPTION
## Summary & Motivation

- Improves error messages when required config is missing in Dagster jobs
- `to_job(config={...})` errors now explain the config is missing required fields instead of referencing `default_value`
- Missing field errors now say "You must provide this value in your run config" with "Example config" instead of "Sample config"
- Fixes dagster-io/dagster#4689

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
