### PR TITLE
[bugfix] Cache asset check support per GraphQL request

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -54,7 +54,7 @@ def check_asset_checks_support(
     | GrapheneAssetCheckNeedsAgentUpgradeError
     | None
 ):
-    asset_check_support = graphene_info.context.instance.get_asset_check_support()
+    asset_check_support = graphene_info.context.get_asset_check_support()
     if asset_check_support == AssetCheckInstanceSupport.NEEDS_MIGRATION:
         return GrapheneAssetCheckNeedsMigrationError(
             message="Asset checks require an instance migration. Run `dagster instance migrate`."

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -44,7 +44,6 @@ from dagster._core.events import DagsterEventType
 from dagster._core.remote_representation.external import RemoteJob, RemoteRepository, RemoteSensor
 from dagster._core.remote_representation.external_data import AssetNodeSnap
 from dagster._core.snap.node import GraphDefSnap, OpDefSnap
-from dagster._core.storage.asset_check_execution_record import AssetCheckInstanceSupport
 from dagster._core.storage.event_log.base import AssetRecord
 from dagster._core.storage.tags import KIND_PREFIX
 from dagster._core.utils import is_valid_email
@@ -69,8 +68,6 @@ from dagster_graphql.schema import external
 from dagster_graphql.schema.asset_checks import (
     AssetChecksOrErrorUnion,
     GrapheneAssetCheck,
-    GrapheneAssetCheckNeedsAgentUpgradeError,
-    GrapheneAssetCheckNeedsMigrationError,
     GrapheneAssetCheckNeedsUserCodeUpgrade,
     GrapheneAssetCheckNotFoundError,
     GrapheneAssetCheckOrError,
@@ -1427,21 +1424,6 @@ class GrapheneAssetNode(graphene.ObjectType):
         validation_error = check_asset_checks_support(graphene_info, self._repository_handle)
         if validation_error:
             return validation_error
-
-        asset_check_support = graphene_info.context.instance.get_asset_check_support()
-        if asset_check_support == AssetCheckInstanceSupport.NEEDS_MIGRATION:
-            return GrapheneAssetCheckNeedsMigrationError(
-                message="Asset checks require an instance migration. Run `dagster instance migrate`."
-            )
-        elif asset_check_support == AssetCheckInstanceSupport.NEEDS_AGENT_UPGRADE:
-            return GrapheneAssetCheckNeedsAgentUpgradeError(
-                "Asset checks require an agent upgrade to 1.5.0 or greater."
-            )
-        else:
-            check.invariant(
-                asset_check_support == AssetCheckInstanceSupport.SUPPORTED,
-                f"Unexpected asset check support status {asset_check_support}",
-            )
 
         library_versions = graphene_info.context.get_dagster_library_versions(
             self._repository_handle.location_name

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -1,4 +1,5 @@
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 from dagster import AssetKey, DagsterEvent, DagsterEventType
 from dagster._core.definitions.asset_checks.asset_check_evaluation import (
@@ -13,6 +14,7 @@ from dagster._core.definitions.partitions.subset.default import DefaultPartition
 from dagster._core.event_api import EventLogRecord
 from dagster._core.events import StepMaterializationData
 from dagster._core.events.log import EventLogEntry
+from dagster._core.storage.asset_check_execution_record import AssetCheckInstanceSupport
 from dagster._core.test_utils import create_run_for_test, poll_for_finished_run
 from dagster._core.utils import make_new_run_id
 from dagster._core.workspace.context import WorkspaceRequestContext
@@ -412,6 +414,48 @@ class TestAssetChecks(ExecutingGraphQLContextTestMatrix):
                 "assetChecksOrError": {"checks": [{"name": "unowned_asset_check"}]},
             },
         ]
+
+    def test_asset_check_support_checked_once_per_asset_nodes_query(
+        self, graphql_context: WorkspaceRequestContext, monkeypatch
+    ):
+        support_call_count = 0
+
+        def get_asset_check_support():
+            nonlocal support_call_count
+            support_call_count += 1
+            return AssetCheckInstanceSupport.SUPPORTED
+
+        monkeypatch.setattr(
+            graphql_context.instance, "get_asset_check_support", get_asset_check_support
+        )
+
+        res = execute_dagster_graphql(graphql_context, GET_ASSET_CHECK_NAMES_QUERY)
+
+        assert not res.errors
+        assert support_call_count == 1
+
+    def test_asset_check_support_request_cache_is_thread_safe(
+        self, graphql_context: WorkspaceRequestContext, monkeypatch
+    ):
+        support_call_count = 0
+
+        def get_asset_check_support():
+            nonlocal support_call_count
+            support_call_count += 1
+            time.sleep(0.05)
+            return AssetCheckInstanceSupport.SUPPORTED
+
+        monkeypatch.setattr(
+            graphql_context.instance, "get_asset_check_support", get_asset_check_support
+        )
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(
+                executor.map(lambda _: graphql_context.get_asset_check_support(), range(8))
+            )
+
+        assert results == [AssetCheckInstanceSupport.SUPPORTED] * 8
+        assert support_call_count == 1
 
     def test_asset_check_asset_node_job_selection(self, graphql_context: WorkspaceRequestContext):
         res = execute_dagster_graphql(

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -83,6 +83,7 @@ from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.mode import ResourceDefSnap
 from dagster._core.snap.node import GraphDefSnap, OpDefSnap
+from dagster._core.storage.asset_check_execution_record import AssetCheckInstanceSupport
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
 from dagster._core.workspace.permissions import (
     PermissionResult,
@@ -177,6 +178,9 @@ class BaseWorkspaceRequestContext(LoadingContext):
     @cached_property
     def dynamic_partitions_loader(self) -> CachingDynamicPartitionsLoader:
         return CachingDynamicPartitionsLoader(self.instance)
+
+    def get_asset_check_support(self) -> AssetCheckInstanceSupport:
+        return self.instance.get_asset_check_support()
 
     @cached_property
     def stale_status_loader(self) -> CachingStaleStatusResolver:
@@ -769,6 +773,8 @@ class WorkspaceRequestContext(BaseWorkspaceRequestContext):
         )
         self._checked_permissions: set[str] = set()
         self._loaders = {}
+        self._asset_check_support: AssetCheckInstanceSupport | None = None
+        self._asset_check_support_lock = threading.Lock()
 
     def reset_for_test(self) -> "WorkspaceRequestContext":
         return WorkspaceRequestContext(
@@ -784,6 +790,14 @@ class WorkspaceRequestContext(BaseWorkspaceRequestContext):
     @property
     def instance(self) -> DagsterInstance:
         return self._instance
+
+    def get_asset_check_support(self) -> AssetCheckInstanceSupport:
+        if self._asset_check_support is None:
+            with self._asset_check_support_lock:
+                if self._asset_check_support is None:
+                    self._asset_check_support = self.instance.get_asset_check_support()
+
+        return self._asset_check_support
 
     def get_current_workspace(self) -> CurrentWorkspace:
         return self._current_workspace

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -797,7 +797,7 @@ class WorkspaceRequestContext(BaseWorkspaceRequestContext):
                 if self._asset_check_support is None:
                     self._asset_check_support = self.instance.get_asset_check_support()
 
-        return self._asset_check_support
+        return check.not_none(self._asset_check_support)
 
     def get_current_workspace(self) -> CurrentWorkspace:
         return self._current_workspace


### PR DESCRIPTION
## Summary & Motivation

Fixes #33749.

`assetChecksOrError` currently checks asset-check instance support for each asset node that has checks. On SQL-backed instances, that support check can hit storage to verify the `asset_check_executions` table exists, which can exhaust DB connections for large asset groups under concurrent GraphQL field resolution.

This change adds request-scoped caching for asset-check support on `WorkspaceRequestContext`, routes GraphQL asset-check support validation through that cache, and removes the duplicate support check in the `assetChecksOrError` resolver.

## Changes

- Add a thread-safe request-local `WorkspaceRequestContext.get_asset_check_support()` cache.
- Reuse that cached support lookup in `check_asset_checks_support(...)`.
- Remove duplicate support validation from `resolve_assetChecksOrError`.
- Add regression coverage that verifies multi-asset `assetChecksOrError` queries and concurrent cache access only call the underlying instance lookup once per request.

## Test Plan

- Confirmed red phase before the fix: the new regression saw 14 support lookups instead of 1.
- `make ruff`
- `PYTHONPATH=<worktree dagster packages> pytest -o addopts='' "python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py::TestAssetChecks::test_asset_check_support_checked_once_per_asset_nodes_query[sqlite_with_default_run_launcher_managed_grpc_env]" "python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py::TestAssetChecks::test_asset_check_support_request_cache_is_thread_safe[sqlite_with_default_run_launcher_managed_grpc_env]" "python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py::TestAssetChecks::test_asset_check_asset_node_limit[sqlite_with_default_run_launcher_managed_grpc_env]" -q`