### PR TITLE
Move toast to top-center to prevent UI blocking

### DIFF
--- a/js_modules/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/ui-core/src/app/AppProvider.tsx
@@ -183,7 +183,7 @@ export const AppProvider = (props: AppProviderProps) => {
           <PermissionsProvider>
             <BrowserRouter basename={basePath || ''}>
               <GlobalStyleProvider />
-              <Toaster richColors />
+              <Toaster richColors position="top-center"/>
               <CompatRouter>
                 <TimeProvider>
                   <CodeLinkProtocolProvider>

--- a/js_modules/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/ui-core/src/app/AppProvider.tsx
@@ -183,7 +183,7 @@ export const AppProvider = (props: AppProviderProps) => {
           <PermissionsProvider>
             <BrowserRouter basename={basePath || ''}>
               <GlobalStyleProvider />
-              <Toaster richColors position="top-center"/>
+              <Toaster richColors position="top-center" />
               <CompatRouter>
                 <TimeProvider>
                   <CodeLinkProtocolProvider>


### PR DESCRIPTION
Fixes #33746

## Summary & Motivation

Fixes an issue where toast notifications block UI interactions by moving the Toaster position to the top-center of the screen.

## Test Plan

Verified that the Toaster component in AppProvider.tsx uses `position="top-center"`. This ensures toast notifications no longer overlap UI elements like the "Launch job" button.

## Changelog

- UI: Move toast notifications to top-center to prevent blocking UI elements