### PR TITLE
User roles permissions doc fix

### DIFF
--- a/docs/docs/deployment/dagster-plus/authentication-and-access-control/rbac/user-roles-permissions.md
+++ b/docs/docs/deployment/dagster-plus/authentication-and-access-control/rbac/user-roles-permissions.md
@@ -145,7 +145,7 @@ If there are code location-level overrides, a small **N override(s)** link will 
 | View runs of [jobs](/guides/build/jobs)                   | ✅     | ✅       | ✅     | ✅    | ✅                       |
 | Launch, re-execute, terminate, and delete runs of jobs    | ❌     | ✅       | ✅     | ✅    | ✅                       |
 | Start and stop [schedules](/guides/automate/schedules)    | ❌     | ❌       | ✅     | ✅    | ✅                       |
-| Start and stop [schedules](/guides/automate/sensors)      | ❌     | ❌       | ✅     | ✅    | ✅                       |
+| Start and stop [sensors](/guides/automate/sensors)      | ❌     | ❌       | ✅     | ✅    | ✅                       |
 | Wipe assets                                               | ❌     | ❌       | ✅     | ✅    | ✅                       |
 | Launch and cancel [schedules](/guides/automate/schedules) | ❌     | ✅       | ✅     | ✅    | ✅                       |
 | Add dynamic partitions                                    | ❌     | ❌       | ✅     | ✅    | ✅                       |

--- a/docs/docs/deployment/dagster-plus/authentication-and-access-control/rbac/user-roles-permissions.md
+++ b/docs/docs/deployment/dagster-plus/authentication-and-access-control/rbac/user-roles-permissions.md
@@ -145,7 +145,7 @@ If there are code location-level overrides, a small **N override(s)** link will 
 | View runs of [jobs](/guides/build/jobs)                   | ✅     | ✅       | ✅     | ✅    | ✅                       |
 | Launch, re-execute, terminate, and delete runs of jobs    | ❌     | ✅       | ✅     | ✅    | ✅                       |
 | Start and stop [schedules](/guides/automate/schedules)    | ❌     | ❌       | ✅     | ✅    | ✅                       |
-| Start and stop [sensors](/guides/automate/sensors)      | ❌     | ❌       | ✅     | ✅    | ✅                       |
+| Start and stop [sensors](/guides/automate/sensors)        | ❌     | ❌       | ✅     | ✅    | ✅                       |
 | Wipe assets                                               | ❌     | ❌       | ✅     | ✅    | ✅                       |
 | Launch and cancel [schedules](/guides/automate/schedules) | ❌     | ✅       | ✅     | ✅    | ✅                       |
 | Add dynamic partitions                                    | ❌     | ❌       | ✅     | ✅    | ✅                       |


### PR DESCRIPTION
## Summary & Motivation

While perusing the docs, I noticed this very minor issue and figured I'd submit a PR to clean it up. The link to sensors documentation on the user permissions page was misnamed as schedules. This PR renames schedules -> sensors in that link.

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
