### PR TITLE
[docs] Improve miscellaneous docs

### DIFF
--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -39,7 +39,7 @@ You can develop for Dagster using macOS, Linux, or Windows. If using Windows, yo
    source .venv/bin/activate
    ```
 
-   Dagster supports Python 3.10 through 3.14.
+   Dagster supports Python 3.10 or higher.
 
 4. Install Node.js (20.X and above). We recommend using [nvm](https://github.com/nvm-sh/nvm) (Node Version Manager) to manage Node.js versions. It allows you to switch between different Node versions:
 

--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -35,11 +35,11 @@ You can develop for Dagster using macOS, Linux, or Windows. If using Windows, yo
 3. Create and activate a virtual environment using uv with a Python version that Dagster supports:
 
    ```bash
-   uv venv --python 3.12
+   uv venv --python 3.13
    source .venv/bin/activate
    ```
 
-   Dagster supports Python 3.10 through 3.12.
+   Dagster supports Python 3.10 through 3.14.
 
 4. Install Node.js (20.X and above). We recommend using [nvm](https://github.com/nvm-sh/nvm) (Node Version Manager) to manage Node.js versions. It allows you to switch between different Node versions:
 

--- a/docs/docs/guides/operate/configuration/run-configuration.md
+++ b/docs/docs/guides/operate/configuration/run-configuration.md
@@ -45,6 +45,8 @@ Here, we define a basic op in `ops.py` and its configurable parameters in `resou
 <CodeExample
   path="docs_snippets/docs_snippets/guides/operate/configuration/run_config/op_example/ops.py"
   title="src/<project_name>/defs/ops.py"
+  startAfter="start"
+  endBefore="end"
 />
 
 <CodeExample

--- a/docs/docs/integrations/libraries/clickhouse/clickhouse-sql-component.md
+++ b/docs/docs/integrations/libraries/clickhouse/clickhouse-sql-component.md
@@ -10,15 +10,11 @@ sidebar_custom_props:
 partnerlink: https://clickhouse.com/
 ---
 
-Dagster’s <PyObject section="components" module="dagster" object="TemplatedSqlComponent" /> runs SQL through a connection object.
-The <PyObject section="libraries" integration="clickhouse" module="dagster_clickhouse" object="ClickhouseQueryComponent" />
-(in **`dagster-clickhouse`**) supplies a ClickHouse connection compatible with that workflow so you can
-scaffold a reusable connection and reference it from templated SQL definitions.
+Dagster’s <PyObject section="components" module="dagster" object="TemplatedSqlComponent" /> runs SQL through a connection object. The <PyObject section="libraries" integration="clickhouse" module="dagster_clickhouse" object="ClickhouseQueryComponent" /> (in **`dagster-clickhouse`**) supplies a ClickHouse connection compatible with that workflow so you can scaffold a reusable connection and reference it from templated SQL definitions.
 
 :::info
 
-<PyObject section="libraries" integration="clickhouse" module="dagster_clickhouse" object="ClickhouseQueryComponent" />
-is currently **preview**. Behavior and configuration may change in minor releases.
+<PyObject section="libraries" integration="clickhouse" module="dagster_clickhouse" object="ClickhouseQueryComponent" /> is currently **preview**. Behavior and configuration may change in minor releases.
 
 :::
 

--- a/docs/docs/partials/_InstallUv.md
+++ b/docs/docs/partials/_InstallUv.md
@@ -1,6 +1,6 @@
 <Tabs groupId="os">
   <TabItem value="mac" label="Mac">
-    <CliInvocationExample contents="brew install uv" />
+    <CliInvocationExample contents="curl -LsSf https://astral.sh/uv/install.sh | sh" />
   </TabItem>
   <TabItem value="windows" label="Windows">
     <CliInvocationExample contents="powershell -ExecutionPolicy ByPass -c 'irm https://astral.sh/uv/install.ps1 | iex'" />


### PR DESCRIPTION
## Summary & Motivation
- Correct python version supported in contributing docs
  - Avoids the implication that 3.13 and 3.14 are not supported
  - Consistent with [Installation](https://docs.dagster.io/getting-started/installation) docs and [pyproject.toml](https://github.com/dagster-io/dagster/blob/4b5a9b8cfa3a2060a3e44aa163ecd24c38e881fc/pyproject.toml#L52), simplifying maintenance
- Remove expendable comments in ops run config snippet
  - Keeps the snippet clean and focused by omitting non-relevant comments i.e. `# pyright: reportMissingImports=false`, `# start`, and `# end`
- Use uv standalone installer over brew in Mac uv install partial
  - Does not rely on a third-party package manager, reducing setup prerequisites
  - Aligns with [Astral’s first documented install method](https://docs.astral.sh/uv/getting-started/installation/#installation-methods)
- Fix formatting in ClickHouse SQL component docs
  - Improves readability and consistency by removing unnecessary line breaks

## Test Plan
Launch the documentation website locally and verify the updated docs render as expected.

## Changelog
- [docs] Improve miscellaneous docs