### PR TITLE
[dagster-dbt] Fix dbt-fusion v2+ silently capping materialized rows to 10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,7 @@
 
 ### Bugfixes
 
+- [dagster-dbt] Fixed an issue where using dbt-fusion's `dbtf` executable (v2+) would silently cap materialized rows to 10. `DbtCliResource` now automatically injects `--limit 0` for materialization commands (`build`, `run`, `seed`, `snapshot`, `test`), including when the command is preceded by leading global flags, unless the caller has already supplied `--limit`.
 - Fixed an issue where a sensor targeting a job with `run_tags` and specifying an `asset_selection` in the `RunRequest` would not apply the job's `run_tags` to the resulting run.
 - Fixed a potential error in YAML config snapshot conversion when encountering `None` fields.
 - [dg] Fixed `dg plus deploy configure` generating a GitHub Action that used Docker instead of the PEX build strategy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,12 @@ filterwarnings = [
 markers = [
   "integration: Tests requiring real git operations or other I/O",
   "slow: Tests that take more than 1 second",
+  "core: dagster-dbt core tests (not cloud, snowflake, bigquery, or fusion)",
+  "cloud: dagster-dbt cloud integration tests",
+  "fusion: dagster-dbt tests requiring dbt-fusion (dbtf) binary",
+  "snowflake: dagster-dbt tests requiring Snowflake credentials",
+  "bigquery: dagster-dbt tests requiring BigQuery credentials",
+  "derived_metadata: dagster-dbt tests for derived metadata features",
 ]
 
 ### pytest-asyncio configuration

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -56,6 +56,7 @@ _DBT_FLAGS_WITH_VALUES = frozenset(
     {
         "--deprecated-favor-state",
         "--defer-state",
+        "--exclude-resource-type",
         "--indirect-selection",
         "--log-format",
         "--log-format-file",
@@ -68,6 +69,7 @@ _DBT_FLAGS_WITH_VALUES = frozenset(
         "--profiles-dir",
         "--project-dir",
         "--record-timing-info",
+        "--resource-type",
         "--state",
         "--target",
         "--vars",
@@ -736,21 +738,27 @@ class DbtCliResource(ConfigurableResource):
         if self.target:
             profile_args += ["--target", self.target]
 
+        is_fusion_executable = _is_dbt_fusion_executable(self.dbt_executable)
+        try:
+            cli_version = self._cli_version
+            should_inject_row_limit = is_fusion_executable and cli_version.major >= 2
+        except Exception:
+            if not is_fusion_executable:
+                raise
+
+            logger.warning(
+                "Could not determine dbt CLI version; skipping dbt-fusion row-limit injection.",
+                exc_info=True,
+            )
+            # Preserve fusion execution behavior even when version probing fails later in `cli()`.
+            cli_version = version.parse("2.0.0")
+            should_inject_row_limit = False
+
         # dbt-fusion's `dbtf` executable (v2+) silently caps row output to 10 rows by default.
         # Inject --limit 0 to disable this unless the user already supplied --limit in `args`.
         # `DbtCliResource.cli()` accepts leading global flags, so find the first dbt subcommand
         # rather than assuming it is always the first token.
-        try:
-            is_fusion = (
-                _is_dbt_fusion_executable(self.dbt_executable) and self._cli_version.major >= 2
-            )
-        except Exception:
-            logger.debug(
-                "Could not determine dbt CLI version; skipping dbt-fusion row-limit injection.",
-                exc_info=True,
-            )
-            is_fusion = False
-        if is_fusion:
+        if should_inject_row_limit:
             dbt_command = _get_dbt_command(args)
             user_supplied_limit = any(
                 arg == "--limit" or arg.startswith("--limit=") for arg in args
@@ -773,7 +781,7 @@ class DbtCliResource(ConfigurableResource):
         adapter: BaseAdapter | None = None
         with pushd(str(project_dir)):
             # we do not need to initialize the adapter if we are using the fusion engine
-            if self._cli_version.major < 2:
+            if cli_version.major < 2:
                 try:
                     adapter = self._initialize_dbt_core_adapter(args)
                 except:
@@ -792,7 +800,7 @@ class DbtCliResource(ConfigurableResource):
                 raise_on_error=raise_on_error,
                 context=context,
                 adapter=adapter,
-                cli_version=self._cli_version,
+                cli_version=cli_version,
                 dbt_project=updated_params.dbt_project,
             )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -52,6 +52,11 @@ DBT_PROFILES_YML_NAME = "profiles.yml"
 # Materialization and test commands query full datasets, so the cap causes silent data loss or
 # incorrect test results.
 _FUSION_ROW_LIMITED_CMDS = frozenset({"build", "run", "seed", "snapshot", "test"})
+# All dbt / dbt-fusion global flags that accept a space-separated value token.
+# MAINTENANCE: if dbt-fusion adds a new value-taking global flag (e.g. `--new-flag <val>`),
+# add it here.  A missing entry causes `_get_dbt_command` to treat its value as the
+# subcommand, silently skipping --limit 0 injection and leaving the 10-row cap in place.
+# Flags that use `--flag=value` syntax do NOT need to be listed (handled by the `=` check).
 _DBT_FLAGS_WITH_VALUES = frozenset(
     {
         "--deprecated-favor-state",
@@ -88,6 +93,16 @@ def _is_dbt_fusion_executable(dbt_executable: str) -> bool:
 
 
 def _get_dbt_command(args: Sequence[str]) -> str | None:
+    """Return the first dbt subcommand token from *args*, skipping leading global flags.
+
+    Flags in ``_DBT_FLAGS_WITH_VALUES`` are treated as taking one value token (skipped over).
+    Flags with an inline ``=`` value (``--flag=val``) are handled automatically.
+    Boolean flags not in ``_DBT_FLAGS_WITH_VALUES`` are skipped individually.
+
+    If ``_DBT_FLAGS_WITH_VALUES`` is missing a value-taking flag, its value token is
+    returned instead of the real subcommand; the caller's ``in _FUSION_ROW_LIMITED_CMDS``
+    check then fails silently, skipping --limit 0 injection.  Keep the allowlist current.
+    """
     idx = 0
     while idx < len(args):
         arg = args[idx]
@@ -755,13 +770,14 @@ class DbtCliResource(ConfigurableResource):
             should_inject_row_limit = False
 
         # dbt-fusion's `dbtf` executable (v2+) silently caps row output to 10 rows by default.
-        # Inject --limit 0 to disable this unless the user already supplied --limit in `args`.
-        # `DbtCliResource.cli()` accepts leading global flags, so find the first dbt subcommand
-        # rather than assuming it is always the first token.
+        # Inject --limit 0 to disable this unless the user already supplied --limit in `args` or
+        # `global_config_flags`. `DbtCliResource.cli()` accepts leading global flags, so find the
+        # first dbt subcommand rather than assuming it is always the first token.
         if should_inject_row_limit:
             dbt_command = _get_dbt_command(args)
+            all_supplied_args = [*self.global_config_flags, *args]
             user_supplied_limit = any(
-                arg == "--limit" or arg.startswith("--limit=") for arg in args
+                arg == "--limit" or arg.startswith("--limit=") for arg in all_supplied_args
             )
             if dbt_command in _FUSION_ROW_LIMITED_CMDS and not user_supplied_limit:
                 args = [*args, "--limit", "0"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -760,8 +760,9 @@ class DbtCliResource(ConfigurableResource):
         # rather than assuming it is always the first token.
         if should_inject_row_limit:
             dbt_command = _get_dbt_command(args)
+            supplied_args = [*self.global_config_flags, *args]
             user_supplied_limit = any(
-                arg == "--limit" or arg.startswith("--limit=") for arg in args
+                arg == "--limit" or arg.startswith("--limit=") for arg in supplied_args
             )
             if dbt_command in _FUSION_ROW_LIMITED_CMDS and not user_supplied_limit:
                 args = [*args, "--limit", "0"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -760,9 +760,8 @@ class DbtCliResource(ConfigurableResource):
         # rather than assuming it is always the first token.
         if should_inject_row_limit:
             dbt_command = _get_dbt_command(args)
-            supplied_args = [*self.global_config_flags, *args]
             user_supplied_limit = any(
-                arg == "--limit" or arg.startswith("--limit=") for arg in supplied_args
+                arg == "--limit" or arg.startswith("--limit=") for arg in args
             )
             if dbt_command in _FUSION_ROW_LIMITED_CMDS and not user_supplied_limit:
                 args = [*args, "--limit", "0"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -47,8 +47,58 @@ DBT_EXECUTABLE = _get_dbt_executable()
 DBT_PROJECT_YML_NAME = "dbt_project.yml"
 DBT_PROFILES_YML_NAME = "profiles.yml"
 
+# dbt-fusion's `dbtf` executable (v2+) silently caps row output to 10 rows by default for these
+# commands.
+# Materialization and test commands query full datasets, so the cap causes silent data loss or
+# incorrect test results.
+_FUSION_ROW_LIMITED_CMDS = frozenset({"build", "run", "seed", "snapshot", "test"})
+_DBT_FLAGS_WITH_VALUES = frozenset(
+    {
+        "--deprecated-favor-state",
+        "--defer-state",
+        "--indirect-selection",
+        "--log-format",
+        "--log-format-file",
+        "--log-level",
+        "--log-level-file",
+        "--log-path",
+        "--partial-parse-file-diff",
+        "--printer-width",
+        "--profile",
+        "--profiles-dir",
+        "--project-dir",
+        "--record-timing-info",
+        "--state",
+        "--target",
+        "--vars",
+        "--warn-error-options",
+        "-r",
+        "-t",
+    }
+)
+
 
 DAGSTER_GITHUB_REPO_DBT_PACKAGE = "https://github.com/dagster-io/dagster.git"
+
+
+def _is_dbt_fusion_executable(dbt_executable: str) -> bool:
+    return Path(os.fspath(dbt_executable)).stem.lower() == "dbtf"
+
+
+def _get_dbt_command(args: Sequence[str]) -> str | None:
+    idx = 0
+    while idx < len(args):
+        arg = args[idx]
+        if not arg.startswith("-"):
+            return arg
+        if arg.startswith("--") and "=" in arg:
+            idx += 1
+        elif arg in _DBT_FLAGS_WITH_VALUES:
+            idx += 2
+        else:
+            idx += 1
+
+    return None
 
 
 def _dbt_packages_has_dagster_dbt(packages_file: Path) -> bool:
@@ -685,6 +735,28 @@ class DbtCliResource(ConfigurableResource):
 
         if self.target:
             profile_args += ["--target", self.target]
+
+        # dbt-fusion's `dbtf` executable (v2+) silently caps row output to 10 rows by default.
+        # Inject --limit 0 to disable this unless the user already supplied --limit in `args`.
+        # `DbtCliResource.cli()` accepts leading global flags, so find the first dbt subcommand
+        # rather than assuming it is always the first token.
+        try:
+            is_fusion = (
+                _is_dbt_fusion_executable(self.dbt_executable) and self._cli_version.major >= 2
+            )
+        except Exception:
+            logger.debug(
+                "Could not determine dbt CLI version; skipping dbt-fusion row-limit injection.",
+                exc_info=True,
+            )
+            is_fusion = False
+        if is_fusion:
+            dbt_command = _get_dbt_command(args)
+            user_supplied_limit = any(
+                arg == "--limit" or arg.startswith("--limit=") for arg in args
+            )
+            if dbt_command in _FUSION_ROW_LIMITED_CMDS and not user_supplied_limit:
+                args = [*args, "--limit", "0"]
 
         full_dbt_args = [
             self.dbt_executable,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_fusion_support.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_fusion_support.py
@@ -1,4 +1,6 @@
 import json
+import shutil
+from pathlib import Path
 
 import dagster as dg
 import pytest
@@ -48,3 +50,38 @@ def test_basic(project: DbtProject, fail: bool) -> None:
     else:
         assert n_materializations == n_assets
         assert n_check_evaluations == n_checks
+
+
+@pytest.mark.fusion
+@pytest.mark.skipif(
+    shutil.which("dbtf") is None,
+    reason="dbtf executable is required for fusion tests",
+)
+def test_fusion_no_row_limit_injected(project: DbtProject) -> None:
+    """Verify that dbt-fusion's `dbtf` executable receives --limit 0 for materialization commands.
+
+    dbt-fusion silently caps row output to 10 rows by default. This test confirms that Dagster
+    injects --limit 0 so the cap is disabled in real runs against a fusion binary.
+    """
+    dbt = DbtCliResource(project_dir=project.project_dir)
+
+    # Confirm we're actually running against dbt-fusion v2+ via the dbtf executable.
+    assert Path(dbt.dbt_executable).stem == "dbtf", (
+        f"Expected dbtf executable, got {dbt.dbt_executable}"
+    )
+    assert dbt._cli_version.major >= 2, (  # noqa: SLF001
+        f"Expected fusion v2+, got {dbt._cli_version}. Is dbtf on PATH?"  # noqa: SLF001
+    )
+
+    # Run seed with a leading global flag; args should still contain --limit 0 injected by Dagster.
+    invocation = dbt.cli(["--debug", "seed"])
+    assert "--limit" in invocation.process.args, (
+        "Dagster must inject --limit into fusion materialization commands"
+    )
+    limit_idx = list(invocation.process.args).index("--limit")
+    assert invocation.process.args[limit_idx + 1] == "0", (
+        f"Expected --limit 0, got --limit {invocation.process.args[limit_idx + 1]}"
+    )
+
+    # The seed must succeed with the injected flag (proves fusion accepts --limit 0).
+    assert invocation.is_successful(), "dbt seed with --limit 0 must succeed on fusion"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -353,26 +353,6 @@ def test_dbt_fusion_no_row_limit_on_materialization(mocker: MockerFixture, tmp_p
     limit_idx = list(invocation.process.args).index("--limit")
     assert invocation.process.args[limit_idx + 1] == "0"
 
-    dbt_with_global_limit = DbtCliResource(
-        project_dir=os.fspath(test_jaffle_shop_path),
-        dbt_executable=fusion_executable,
-        global_config_flags=["--limit", "5"],
-    )
-    dbt_with_global_limit.__dict__["_cli_version"] = version.parse("2.0.0")
-    invocation = dbt_with_global_limit.cli(["seed"])
-    assert list(invocation.process.args).count("--limit") == 1
-    assert invocation.process.args[list(invocation.process.args).index("--limit") + 1] == "5"
-
-    dbt_with_global_limit = DbtCliResource(
-        project_dir=os.fspath(test_jaffle_shop_path),
-        dbt_executable=fusion_executable,
-        global_config_flags=["--limit=5"],
-    )
-    dbt_with_global_limit.__dict__["_cli_version"] = version.parse("2.0.0")
-    invocation = dbt_with_global_limit.cli(["seed"])
-    assert "--limit" not in invocation.process.args
-    assert any(arg == "--limit=5" for arg in invocation.process.args)
-
 
 @pytest.mark.core
 def test_dbt_fusion_v1_no_row_limit_injection(mocker: MockerFixture, tmp_path: Path) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -343,6 +343,16 @@ def test_dbt_fusion_no_row_limit_on_materialization(mocker: MockerFixture, tmp_p
     limit_idx = list(invocation.process.args).index("--limit")
     assert invocation.process.args[limit_idx + 1] == "0"
 
+    invocation = dbt.cli(["--resource-type", "model", "build"])
+    assert "--limit" in invocation.process.args
+    limit_idx = list(invocation.process.args).index("--limit")
+    assert invocation.process.args[limit_idx + 1] == "0"
+
+    invocation = dbt.cli(["--exclude-resource-type", "test", "build"])
+    assert "--limit" in invocation.process.args
+    limit_idx = list(invocation.process.args).index("--limit")
+    assert invocation.process.args[limit_idx + 1] == "0"
+
 
 @pytest.mark.core
 def test_dbt_fusion_v1_no_row_limit_injection(mocker: MockerFixture, tmp_path: Path) -> None:
@@ -380,6 +390,29 @@ def test_dbt_core_v2_no_row_limit_injection(mocker: MockerFixture, tmp_path: Pat
         assert "--limit" not in invocation.process.args, (
             f"dbt-core v2 must not receive --limit injection for '{cmd}'"
         )
+
+
+@pytest.mark.core
+def test_dbt_fusion_row_limit_injection_warns_on_version_probe_failure(
+    caplog: pytest.LogCaptureFixture, mocker: MockerFixture, tmp_path: Path
+) -> None:
+    fusion_executable = _make_fake_executable(tmp_path, "dbtf")
+    _patch_fake_which(mocker, fusion_executable)
+    dbt = DbtCliResource(
+        project_dir=os.fspath(test_jaffle_shop_path),
+        dbt_executable=fusion_executable,
+    )
+    mocker.patch("dagster_dbt.core.resource.check_output", side_effect=ValueError("boom"))
+    _make_fake_popen(mocker)
+
+    with caplog.at_level("WARNING"):
+        invocation = dbt.cli(["build"])
+
+    assert "--limit" not in invocation.process.args
+    assert (
+        "Could not determine dbt CLI version; skipping dbt-fusion row-limit injection."
+        in caplog.text
+    )
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -353,6 +353,26 @@ def test_dbt_fusion_no_row_limit_on_materialization(mocker: MockerFixture, tmp_p
     limit_idx = list(invocation.process.args).index("--limit")
     assert invocation.process.args[limit_idx + 1] == "0"
 
+    dbt_with_global_limit = DbtCliResource(
+        project_dir=os.fspath(test_jaffle_shop_path),
+        dbt_executable=fusion_executable,
+        global_config_flags=["--limit", "5"],
+    )
+    dbt_with_global_limit.__dict__["_cli_version"] = version.parse("2.0.0")
+    invocation = dbt_with_global_limit.cli(["seed"])
+    assert list(invocation.process.args).count("--limit") == 1
+    assert invocation.process.args[list(invocation.process.args).index("--limit") + 1] == "5"
+
+    dbt_with_global_limit = DbtCliResource(
+        project_dir=os.fspath(test_jaffle_shop_path),
+        dbt_executable=fusion_executable,
+        global_config_flags=["--limit=5"],
+    )
+    dbt_with_global_limit.__dict__["_cli_version"] = version.parse("2.0.0")
+    invocation = dbt_with_global_limit.cli(["seed"])
+    assert "--limit" not in invocation.process.args
+    assert any(arg == "--limit=5" for arg in invocation.process.args)
+
 
 @pytest.mark.core
 def test_dbt_fusion_v1_no_row_limit_injection(mocker: MockerFixture, tmp_path: Path) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -353,6 +353,28 @@ def test_dbt_fusion_no_row_limit_on_materialization(mocker: MockerFixture, tmp_p
     limit_idx = list(invocation.process.args).index("--limit")
     assert invocation.process.args[limit_idx + 1] == "0"
 
+    # --limit in global_config_flags (space form) must suppress injection.
+    dbt_with_global_limit = DbtCliResource(
+        project_dir=os.fspath(test_jaffle_shop_path),
+        dbt_executable=fusion_executable,
+        global_config_flags=["--limit", "5"],
+    )
+    dbt_with_global_limit.__dict__["_cli_version"] = version.parse("2.0.0")
+    invocation = dbt_with_global_limit.cli(["seed"])
+    assert list(invocation.process.args).count("--limit") == 1
+    assert invocation.process.args[list(invocation.process.args).index("--limit") + 1] == "5"
+
+    # --limit in global_config_flags (equals form) must also suppress injection.
+    dbt_with_global_limit = DbtCliResource(
+        project_dir=os.fspath(test_jaffle_shop_path),
+        dbt_executable=fusion_executable,
+        global_config_flags=["--limit=5"],
+    )
+    dbt_with_global_limit.__dict__["_cli_version"] = version.parse("2.0.0")
+    invocation = dbt_with_global_limit.cli(["seed"])
+    assert "--limit" not in invocation.process.args
+    assert any(arg == "--limit=5" for arg in invocation.process.args)
+
 
 @pytest.mark.core
 def test_dbt_fusion_v1_no_row_limit_injection(mocker: MockerFixture, tmp_path: Path) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -254,6 +254,134 @@ def test_dbt_profile_configuration() -> None:
     assert dbt_cli_invocation.is_successful()
 
 
+def _make_fake_popen(mocker: MockerFixture) -> None:
+    """Patch subprocess.Popen to capture args without executing dbt."""
+
+    class _FakePopen:
+        def __init__(self, args: list[str], **kwargs: object) -> None:
+            self.args = args
+            self.stdout = iter([])
+            self.returncode = 0
+
+        def wait(self) -> int:
+            return 0
+
+    mocker.patch("dagster_dbt.core.dbt_cli_invocation.subprocess.Popen", _FakePopen)
+
+
+def _make_fake_executable(tmp_path: Path, name: str) -> str:
+    executable_path = tmp_path / name
+    executable_path.write_text("", encoding="utf-8")
+    return os.fspath(executable_path)
+
+
+def _patch_fake_which(mocker: MockerFixture, *fake_executables: str) -> None:
+    real_which = shutil.which
+    fake_executable_set = set(fake_executables)
+
+    def _which(executable: str) -> str | None:
+        if executable in fake_executable_set:
+            return executable
+        return real_which(executable)
+
+    mocker.patch("dagster_dbt.core.resource.shutil.which", side_effect=_which)
+
+
+@pytest.mark.core
+def test_dbt_fusion_no_row_limit_on_materialization(mocker: MockerFixture, tmp_path: Path) -> None:
+    """dbt-fusion (v2+) injects --limit 0 for materialization commands to suppress the 10-row default."""
+    # cached_property stores its value in instance.__dict__, which Python's descriptor protocol
+    # checks before the class descriptor for non-data descriptors. Setting it here is the
+    # canonical way to bypass a cached_property without a subprocess call.
+    fusion_executable = _make_fake_executable(tmp_path, "dbtf")
+    _patch_fake_which(mocker, fusion_executable)
+    dbt = DbtCliResource(
+        project_dir=os.fspath(test_jaffle_shop_path),
+        dbt_executable=fusion_executable,
+    )
+    dbt.__dict__["_cli_version"] = version.parse("2.0.0")
+    _make_fake_popen(mocker)
+
+    # Row-limited commands must receive --limit 0.
+    for cmd in ["build", "run", "seed", "snapshot", "test"]:
+        invocation = dbt.cli([cmd])
+        assert "--limit" in invocation.process.args, f"Expected --limit in args for '{cmd}'"
+        limit_idx = list(invocation.process.args).index("--limit")
+        assert invocation.process.args[limit_idx + 1] == "0", f"Expected --limit 0 for '{cmd}'"
+
+    # User-supplied --limit (space form) must be preserved and not duplicated.
+    invocation = dbt.cli(["seed", "--limit", "5"])
+    assert list(invocation.process.args).count("--limit") == 1
+    assert invocation.process.args[list(invocation.process.args).index("--limit") + 1] == "5"
+
+    # User-supplied --limit (equals form) must also suppress injection.
+    invocation = dbt.cli(["seed", "--limit=5"])
+    assert "--limit" not in invocation.process.args, (
+        "Equals-form --limit must not be injected when user passed --limit=N"
+    )
+    assert any(arg == "--limit=5" for arg in invocation.process.args)
+
+    # Non-materialization commands must NOT receive --limit.
+    for cmd in ["parse", "compile", "debug", "deps"]:
+        invocation = dbt.cli([cmd])
+        assert "--limit" not in invocation.process.args, f"Unexpected --limit in args for '{cmd}'"
+
+    # Leading global flags are a supported call shape and must not skip injection.
+    invocation = dbt.cli(["--debug", "build"])
+    assert "--limit" in invocation.process.args
+    limit_idx = list(invocation.process.args).index("--limit")
+    assert invocation.process.args[limit_idx + 1] == "0"
+
+    # Flags with values before the subcommand must also preserve injection.
+    invocation = dbt.cli(["--profiles-dir", "/tmp", "run"])
+    assert "--limit" in invocation.process.args
+    limit_idx = list(invocation.process.args).index("--limit")
+    assert invocation.process.args[limit_idx + 1] == "0"
+
+    invocation = dbt.cli(["-t", "dev", "seed"])
+    assert "--limit" in invocation.process.args
+    limit_idx = list(invocation.process.args).index("--limit")
+    assert invocation.process.args[limit_idx + 1] == "0"
+
+
+@pytest.mark.core
+def test_dbt_fusion_v1_no_row_limit_injection(mocker: MockerFixture, tmp_path: Path) -> None:
+    """dbt-fusion v1 must NOT have --limit injected before the v2 behavior change."""
+    fusion_executable = _make_fake_executable(tmp_path, "dbtf")
+    _patch_fake_which(mocker, fusion_executable)
+    dbt = DbtCliResource(
+        project_dir=os.fspath(test_jaffle_shop_path),
+        dbt_executable=fusion_executable,
+    )
+    dbt.__dict__["_cli_version"] = version.parse("1.9.0")
+    _make_fake_popen(mocker)
+
+    for cmd in ["build", "run", "seed", "snapshot", "test"]:
+        invocation = dbt.cli([cmd])
+        assert "--limit" not in invocation.process.args, (
+            f"dbt-fusion v1 must not receive --limit injection for '{cmd}'"
+        )
+
+
+@pytest.mark.core
+def test_dbt_core_v2_no_row_limit_injection(mocker: MockerFixture, tmp_path: Path) -> None:
+    """dbt-core v2 must NOT receive the fusion-specific row-limit injection."""
+    core_executable = _make_fake_executable(tmp_path, "dbt")
+    _patch_fake_which(mocker, core_executable)
+    dbt = DbtCliResource(
+        project_dir=os.fspath(test_jaffle_shop_path),
+        dbt_executable=core_executable,
+    )
+    dbt.__dict__["_cli_version"] = version.parse("2.0.0")
+    _make_fake_popen(mocker)
+
+    for cmd in ["build", "run", "seed", "snapshot", "test"]:
+        invocation = dbt.cli([cmd])
+        assert "--limit" not in invocation.process.args, (
+            f"dbt-core v2 must not receive --limit injection for '{cmd}'"
+        )
+
+
 @pytest.mark.parametrize(
     "profiles_dir", [None, test_jaffle_shop_path, os.fspath(test_jaffle_shop_path)]
 )
@@ -381,6 +509,10 @@ def test_dbt_partial_parse(dbt: DbtCliResource) -> None:
     )
 
 
+@pytest.mark.skipif(
+    DBT_PYTHON_VERSION is None,
+    reason="dbt-core Python modules are required for manifest-based asset selection in this test",
+)
 def test_dbt_cli_debug_execution(
     test_jaffle_shop_manifest: dict[str, Any], dbt: DbtCliResource
 ) -> None:


### PR DESCRIPTION
## Summary & Motivation

dbt-fusion's `dbtf` executable (v2+) defaults to a **10-row output limit** for materialization commands (`build`, `run`, `seed`, `snapshot`, `test`). This causes silent data loss and incorrect test results — models silently materialize only the first 10 rows, and tests only validate 10-row samples, with no warning from dbt.

`DbtCliResource` now detects dbt-fusion v2+ via `_cli_version.major >= 2` and automatically injects `--limit 0` to disable the cap for affected commands, unless the caller has already supplied `--limit`.

**Edge cases handled:**
- User-supplied `--limit N` (space form) is preserved and prevents injection
- User-supplied `--limit=N` (equals form) is also detected and prevents injection
- Leading global flags before the subcommand (e.g. `dbt.cli(["--debug", "build"])`) are parsed correctly via `_get_dbt_command()`
- Non-materialization commands (`parse`, `compile`, `debug`, `deps`) are never affected
- dbt-core v2 (non-fusion) is unaffected — detection is based on the `dbtf` executable name
- dbt-fusion v1 is unaffected — injection only applies to `major >= 2`
- Version detection failures log a debug message and skip injection gracefully

Fixes #33753

## Test Plan

**Unit tests** (no `dbtf` binary required, mocked subprocess):
- `test_dbt_fusion_no_row_limit_on_materialization` — verifies `--limit 0` injection for all 5 affected commands, user limit preservation (both forms), non-materialization command exclusion, and leading global flag handling
- `test_dbt_fusion_v1_no_row_limit_injection` — verifies fusion v1 is unaffected
- `test_dbt_core_v2_no_row_limit_injection` — verifies dbt-core v2 (non-fusion executable) is unaffected

**Integration test** (requires `dbtf` on PATH, skipped otherwise):
- `test_fusion_no_row_limit_injected` in `test_fusion_support.py` — runs a real `dbt seed` with a leading global flag and asserts `--limit 0` appears in the subprocess args and the command succeeds

```
pytest python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py -k "row_limit" -v
# 3 passed
```

## Changelog

Fixed a bug where using dbt-fusion's `dbtf` executable (v2+) would silently cap materialized rows to 10. `DbtCliResource` now automatically injects `--limit 0` for materialization commands (`build`, `run`, `seed`, `snapshot`, `test`) when dbt-fusion v2+ is detected, unless the caller has already supplied `--limit`.