### PR TITLE
Add `internal_asset_deps` to `graph_multi_asset`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -1045,6 +1045,7 @@ def graph_multi_asset(
     outs: Mapping[str, AssetOut],
     name: str | None = None,
     ins: Mapping[str, AssetIn] | None = None,
+    internal_asset_deps: Mapping[str, set[AssetKey]] | None = None,
     partitions_def: PartitionsDefinition | None = None,
     hooks: AbstractSet[HookDefinition] | None = None,
     backfill_policy: BackfillPolicy | None = None,
@@ -1065,6 +1066,11 @@ def graph_multi_asset(
         outs: (Optional[Dict[str, AssetOut]]): The AssetOuts representing the produced assets.
         ins (Optional[Mapping[str, AssetIn]]): A dictionary that maps input names to information
             about the input.
+        internal_asset_deps (Optional[Mapping[str, Set[AssetKey]]]): By default, it is assumed
+            that all assets produced by the graph depend on all assets that are consumed by that
+            graph. If this default is not correct, you pass in a map of output names to a
+            corrected set of AssetKeys that they depend on. Any AssetKeys in this list must be
+            either used as input to the asset or produced within the graph.
         partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
             compose the assets.
         hooks (Optional[AbstractSet[HookDefinition]]): A list of hooks to attach to the asset.
@@ -1167,6 +1173,7 @@ def graph_multi_asset(
             keys_by_output_name={
                 output_name: asset_key for asset_key, (output_name, _) in named_outs.items()
             },
+            internal_asset_deps=internal_asset_deps,
             partitions_def=partitions_def,
             partition_mappings=partition_mappings if partition_mappings else None,
             group_name=group_name,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -9,6 +9,7 @@ from dagster import (
     DagsterInstance,
     Definitions,
     IOManagerDefinition,
+    Nothing,
     PartitionsDefinition,
 )
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
@@ -880,6 +881,102 @@ def test_self_dependent_partition_mapping_with_asset_deps():
         assert current_partition_key - asset_1_key == timedelta(days=1)
 
     dg.materialize([the_multi_asset], partition_key="2023-08-20")
+
+
+def test_graph_backed_self_dependent_partition_mapping():
+    partitions_def = dg.DailyPartitionsDefinition(start_date="2023-08-15")
+
+    @dg.op(ins={"self_dependent": dg.In(Nothing)})
+    def build_graph_asset_self_dependent(context: AssetExecutionContext):
+        if context.partition_key == "2023-08-15":
+            assert context.asset_partition_keys_for_input("self_dependent") == []
+        else:
+            self_dependent_key = datetime.strptime(
+                context.asset_partition_key_for_input("self_dependent"), "%Y-%m-%d"
+            )
+            current_partition_key = datetime.strptime(context.partition_key, "%Y-%m-%d")
+
+            assert current_partition_key - self_dependent_key == timedelta(days=1)
+
+        return 1
+
+    @dg.graph_asset(
+        partitions_def=partitions_def,
+        ins={
+            "self_dependent": dg.AssetIn(
+                dagster_type=Nothing,
+                partition_mapping=dg.TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            )
+        },
+    )
+    def self_dependent(self_dependent):
+        return build_graph_asset_self_dependent(self_dependent)
+
+    assert self_dependent.get_partition_mapping(dg.AssetKey("self_dependent")) == (
+        dg.TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
+    )
+
+    assert dg.materialize([self_dependent], partition_key="2023-08-15").success
+    assert dg.materialize([self_dependent], partition_key="2023-08-16").success
+
+    @dg.asset(partitions_def=partitions_def)
+    def upstream():
+        return 1
+
+    @dg.op
+    def build_regular(upstream_value: int) -> int:
+        return upstream_value + 1
+
+    @dg.op(ins={"self_dependent": dg.In(Nothing), "upstream_value": dg.In(int)})
+    def build_self_dependent(context: AssetExecutionContext, upstream_value: int) -> int:
+        if context.partition_key == "2023-08-15":
+            assert context.asset_partition_keys_for_input("self_dependent") == []
+        else:
+            self_dependent_key = datetime.strptime(
+                context.asset_partition_key_for_input("self_dependent"), "%Y-%m-%d"
+            )
+            current_partition_key = datetime.strptime(context.partition_key, "%Y-%m-%d")
+
+            assert current_partition_key - self_dependent_key == timedelta(days=1)
+
+        return upstream_value + 1
+
+    @dg.graph_multi_asset(
+        outs={
+            "regular": dg.AssetOut(),
+            "self_dependent": dg.AssetOut(),
+        },
+        ins={
+            "self_dependent": dg.AssetIn(
+                dagster_type=Nothing,
+                partition_mapping=dg.TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            ),
+        },
+        internal_asset_deps={
+            "regular": {dg.AssetKey("upstream")},
+            "self_dependent": {dg.AssetKey("upstream"), dg.AssetKey("self_dependent")},
+        },
+        partitions_def=partitions_def,
+    )
+    def graph_backed_asset(upstream, self_dependent):
+        return {
+            "regular": build_regular(upstream),
+            "self_dependent": build_self_dependent(
+                upstream_value=upstream,
+                self_dependent=self_dependent,
+            ),
+        }
+
+    assert graph_backed_asset.asset_deps == {
+        dg.AssetKey("regular"): {dg.AssetKey("upstream")},
+        dg.AssetKey("self_dependent"): {dg.AssetKey("upstream"), dg.AssetKey("self_dependent")},
+    }
+    assert graph_backed_asset.get_partition_mapping(dg.AssetKey("self_dependent")) == (
+        dg.TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
+    )
+
+    assert dg.materialize([upstream, graph_backed_asset], partition_key="2023-08-15").success
+    assert dg.materialize([upstream, graph_backed_asset], partition_key="2023-08-16").success
 
 
 def test_dynamic_partition_mapping_with_asset_deps():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -248,6 +248,35 @@ def test_multi_asset_internal_asset_deps_metadata():
     }
 
 
+def test_graph_multi_asset_internal_asset_deps_metadata():
+    @dg.op(out={"my_out_name": dg.Out(), "my_other_out_name": dg.Out()})
+    def emit_outputs(my_in_name):
+        yield dg.Output(my_in_name + 1, "my_out_name")
+        yield dg.Output(my_in_name + 2, "my_other_out_name")
+
+    @dg.graph_multi_asset(
+        outs={
+            "my_out_name": dg.AssetOut(metadata={"foo": "bar"}),
+            "my_other_out_name": dg.AssetOut(metadata={"bar": "foo"}),
+        },
+        internal_asset_deps={
+            "my_out_name": {dg.AssetKey("my_other_out_name"), dg.AssetKey("my_in_name")},
+            "my_other_out_name": {dg.AssetKey("my_in_name")},
+        },
+    )
+    def my_asset(my_in_name):
+        my_out_name, my_other_out_name = emit_outputs(my_in_name)
+        return {"my_out_name": my_out_name, "my_other_out_name": my_other_out_name}
+
+    assert my_asset.keys == {dg.AssetKey("my_out_name"), dg.AssetKey("my_other_out_name")}
+    assert my_asset.metadata_by_key[dg.AssetKey("my_out_name")] == {"foo": "bar"}
+    assert my_asset.metadata_by_key[dg.AssetKey("my_other_out_name")] == {"bar": "foo"}
+    assert my_asset.asset_deps == {
+        dg.AssetKey("my_out_name"): {dg.AssetKey("my_other_out_name"), dg.AssetKey("my_in_name")},
+        dg.AssetKey("my_other_out_name"): {dg.AssetKey("my_in_name")},
+    }
+
+
 def test_multi_asset_internal_asset_deps_invalid():
     with pytest.raises(check.CheckError, match="Invalid out key"):
 


### PR DESCRIPTION
## Summary & Motivation

As outlined in #33773 this PR adds `internal_asset_deps` to `graph_multi_asset` so that self-dependent `graph_multi_asset` can be defined.

I thought I would take a stab as the original issue #23504 said that PRs are welcome for it. If this view has changed, then no harm done but it would be great if we can add this.

Since `AssetsDefinition.from_graph` already exposes `internal_asset_deps` as an argument and tests already exist for the required validation of invalid dependencies & configuration this PR is small. I have added said arg and then added some tests.

## Test Plan

I have tried to follow existing tests structure and added:
1) Test checking the metadata and dependencies are correctly set when `internal_asset_deps` is used.
2) Added a self-dependency test when using `dg.TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)` alongside `internal_asset_deps`.
    - I added a test for a self-dependent `graph_asset` as well as I noticed this was missing. Happy to remove or add separately if you wish. 


## Changelog

Add `internal_asset_deps` to `graph_multi_asset`.