### PR TITLE
[docs] Add ClickHouse Python API docs

### DIFF
--- a/docs/docs/integrations/libraries/clickhouse/clickhouse-sql-component.md
+++ b/docs/docs/integrations/libraries/clickhouse/clickhouse-sql-component.md
@@ -17,8 +17,7 @@ scaffold a reusable connection and reference it from templated SQL definitions.
 
 :::info
 
-<PyObject section="libraries" integration="clickhouse" module="dagster_clickhouse" object="ClickhouseQueryComponent" />
-is currently **preview**. Behavior and configuration may change in minor releases.
+<PyObject section="libraries" integration="clickhouse" module="dagster_clickhouse" object="ClickhouseQueryComponent" /> is currently **preview**. Behavior and configuration may change in minor releases.
 
 :::
 

--- a/docs/docs/integrations/libraries/clickhouse/dagster-clickhouse-pandas.mdx
+++ b/docs/docs/integrations/libraries/clickhouse/dagster-clickhouse-pandas.mdx
@@ -15,9 +15,8 @@ custom_edit_url: null
 This library provides an integration for storing and loading Pandas DataFrames in [ClickHouse](https://clickhouse.com/) using Dagster.
 
 Related Guides:
-
-  - [Using Dagster with ClickHouse tutorial](https://docs.dagster.io/integrations/libraries/clickhouse)
-  - [ClickHouse reference](https://docs.dagster.io/integrations/libraries/clickhouse/reference)
+    - [Using Dagster with ClickHouse tutorial](/integrations/libraries/clickhouse/using-clickhouse-with-dagster)
+    - [ClickHouse reference](/integrations/libraries/clickhouse/reference)
 
 <dl>
     <dt><Link class="anchor" id='dagster_clickhouse_pandas.ClickhousePandasIOManager'>dagster_clickhouse_pandas.ClickhousePandasIOManager IOManagerDefinition <a href='https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-clickhouse-pandas/dagster_clickhouse_pandas/clickhouse_pandas_type_handler.py#L101' className='source-link' target='_blank' rel='noopener noreferrer'>[source]</a><a href="#dagster_clickhouse_pandas.ClickhousePandasIOManager" class="hash-link"></a></Link></dt>

--- a/docs/docs/integrations/libraries/clickhouse/dagster-clickhouse-pandas.mdx
+++ b/docs/docs/integrations/libraries/clickhouse/dagster-clickhouse-pandas.mdx
@@ -1,0 +1,48 @@
+---
+title: 'dagster-clickhouse-pandas library'
+sidebar_position: 1000
+title_meta: 'dagster-clickhouse-pandas library API Documentation - Build Better Data Pipelines | Python Reference Documentation for Dagster'
+description: 'dagster-clickhouse-pandas library Dagster API | Comprehensive Python API documentation for Dagster, the data orchestration platform. Learn how to build, test, and maintain data pipelines with our detailed guides and examples.'
+last_update:
+  date: '2026-04-27'
+custom_edit_url: null
+---
+
+<div class="section" id="dagster-clickhouse-pandas-library">
+
+# dagster-clickhouse-pandas library
+
+This library provides an integration for storing and loading Pandas DataFrames in [ClickHouse](https://clickhouse.com/) using Dagster.
+
+Related Guides:
+
+  - [Using Dagster with ClickHouse tutorial](https://docs.dagster.io/integrations/libraries/clickhouse)
+  - [ClickHouse reference](https://docs.dagster.io/integrations/libraries/clickhouse/reference)
+
+<dl>
+    <dt><Link class="anchor" id='dagster_clickhouse_pandas.ClickhousePandasIOManager'>dagster_clickhouse_pandas.ClickhousePandasIOManager IOManagerDefinition <a href='https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-clickhouse-pandas/dagster_clickhouse_pandas/clickhouse_pandas_type_handler.py#L101' className='source-link' target='_blank' rel='noopener noreferrer'>[source]</a><a href="#dagster_clickhouse_pandas.ClickhousePandasIOManager" class="hash-link"></a></Link></dt>
+    <dd>
+        <div className='lineblock'> </div>
+        I/O manager for Pandas DataFrames stored in ClickHouse.
+
+        Examples:
+        ```python
+        from dagster import Definitions
+        from dagster_clickhouse_pandas import ClickhousePandasIOManager
+
+        defs = Definitions(
+            assets=[example_df],
+            resources={
+                "io_manager": ClickhousePandasIOManager(
+                    host="localhost",
+                    port=9000,
+                    database="default",
+                    schema="example_schema",
+                )
+            },
+        )
+
+        ```
+    </dd>
+</dl>
+</div>

--- a/docs/docs/integrations/libraries/clickhouse/dagster-clickhouse-polars.mdx
+++ b/docs/docs/integrations/libraries/clickhouse/dagster-clickhouse-polars.mdx
@@ -1,0 +1,47 @@
+---
+title: 'dagster-clickhouse-polars library'
+sidebar_position: 1000
+title_meta: 'dagster-clickhouse-polars library API Documentation - Build Better Data Pipelines | Python Reference Documentation for Dagster'
+description: 'dagster-clickhouse-polars library Dagster API | Comprehensive Python API documentation for Dagster, the data orchestration platform. Learn how to build, test, and maintain data pipelines with our detailed guides and examples.'
+last_update:
+  date: '2026-04-27'
+custom_edit_url: null
+---
+
+<div class="section" id="dagster-clickhouse-polars-library">
+
+# dagster-clickhouse-polars library
+
+This library provides an integration for storing and loading Polars DataFrames in [ClickHouse](https://clickhouse.com/) using Dagster.
+
+Related Guides:
+
+  - [Using Dagster with ClickHouse tutorial](https://docs.dagster.io/integrations/libraries/clickhouse)
+  - [ClickHouse reference](https://docs.dagster.io/integrations/libraries/clickhouse/reference)
+
+<dl>
+    <dt><Link class="anchor" id='dagster_clickhouse_polars.ClickhousePolarsIOManager'>dagster_clickhouse_polars.ClickhousePolarsIOManager IOManagerDefinition <a href='https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-clickhouse-polars/dagster_clickhouse_polars/clickhouse_polars_type_handler.py#L115' className='source-link' target='_blank' rel='noopener noreferrer'>[source]</a><a href="#dagster_clickhouse_polars.ClickhousePolarsIOManager" class="hash-link"></a></Link></dt>
+    <dd>
+        <div className='lineblock'> </div>
+        I/O manager for Polars DataFrames stored in ClickHouse.
+
+        Examples:
+        ```python
+        from dagster import Definitions
+        from dagster_clickhouse_polars import ClickhousePolarsIOManager
+
+        defs = Definitions(
+            assets=[example_df],
+            resources={
+                "io_manager": ClickhousePolarsIOManager(
+                    host="localhost",
+                    port=9000,
+                    database="default",
+                    schema="example_schema",
+                )
+            },
+        )
+        ```
+    </dd>
+</dl>
+</div>

--- a/docs/docs/integrations/libraries/clickhouse/dagster-clickhouse-polars.mdx
+++ b/docs/docs/integrations/libraries/clickhouse/dagster-clickhouse-polars.mdx
@@ -16,8 +16,8 @@ This library provides an integration for storing and loading Polars DataFrames i
 
 Related Guides:
 
-  - [Using Dagster with ClickHouse tutorial](https://docs.dagster.io/integrations/libraries/clickhouse)
-  - [ClickHouse reference](https://docs.dagster.io/integrations/libraries/clickhouse/reference)
+    - [Using Dagster with ClickHouse tutorial](/integrations/libraries/clickhouse/using-clickhouse-with-dagster)
+    - [ClickHouse reference](/integrations/libraries/clickhouse/reference)
 
 <dl>
     <dt><Link class="anchor" id='dagster_clickhouse_polars.ClickhousePolarsIOManager'>dagster_clickhouse_polars.ClickhousePolarsIOManager IOManagerDefinition <a href='https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-clickhouse-polars/dagster_clickhouse_polars/clickhouse_polars_type_handler.py#L115' className='source-link' target='_blank' rel='noopener noreferrer'>[source]</a><a href="#dagster_clickhouse_polars.ClickhousePolarsIOManager" class="hash-link"></a></Link></dt>

--- a/docs/docs/integrations/libraries/clickhouse/dagster-clickhouse.mdx
+++ b/docs/docs/integrations/libraries/clickhouse/dagster-clickhouse.mdx
@@ -16,8 +16,8 @@ This library provides an integration with the [ClickHouse](https://clickhouse.co
 
 Related Guides:
 
-  - [Using Dagster with ClickHouse tutorial](https://docs.dagster.io/integrations/libraries/clickhouse)
-  - [ClickHouse reference](https://docs.dagster.io/integrations/libraries/clickhouse/reference)
+    - [Using Dagster with ClickHouse tutorial](/integrations/libraries/clickhouse/using-clickhouse-with-dagster)
+    - [ClickHouse reference](/integrations/libraries/clickhouse/reference)
 
 <dl>
     <dt><Link class="anchor" id='dagster_clickhouse.ClickhouseResource'>dagster_clickhouse.ClickhouseResource ResourceDefinition <a href='https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-clickhouse/dagster_clickhouse/resource.py#L24' className='source-link' target='_blank' rel='noopener noreferrer'>[source]</a><a href="#dagster_clickhouse.ClickhouseResource" class="hash-link"></a></Link></dt>

--- a/docs/docs/integrations/libraries/clickhouse/dagster-clickhouse.mdx
+++ b/docs/docs/integrations/libraries/clickhouse/dagster-clickhouse.mdx
@@ -1,0 +1,134 @@
+---
+title: 'dagster-clickhouse library'
+sidebar_position: 1000
+title_meta: 'dagster-clickhouse library API Documentation - Build Better Data Pipelines | Python Reference Documentation for Dagster'
+description: 'dagster-clickhouse library Dagster API | Comprehensive Python API documentation for Dagster, the data orchestration platform. Learn how to build, test, and maintain data pipelines with our detailed guides and examples.'
+last_update:
+  date: '2026-04-27'
+custom_edit_url: null
+---
+
+<div class="section" id="dagster-clickhouse-library">
+
+# dagster-clickhouse library
+
+This library provides an integration with the [ClickHouse](https://clickhouse.com/) database.
+
+Related Guides:
+
+  - [Using Dagster with ClickHouse tutorial](https://docs.dagster.io/integrations/libraries/clickhouse)
+  - [ClickHouse reference](https://docs.dagster.io/integrations/libraries/clickhouse/reference)
+
+<dl>
+    <dt><Link class="anchor" id='dagster_clickhouse.ClickhouseResource'>dagster_clickhouse.ClickhouseResource ResourceDefinition <a href='https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-clickhouse/dagster_clickhouse/resource.py#L24' className='source-link' target='_blank' rel='noopener noreferrer'>[source]</a><a href="#dagster_clickhouse.ClickhouseResource" class="hash-link"></a></Link></dt>
+    <dd>
+        <div className='lineblock'> </div>
+        Resource for interacting with a ClickHouse database via the native protocol.
+
+        Examples:
+        ```python
+        from dagster import Definitions, asset
+        from dagster_clickhouse import ClickhouseResource
+
+        @asset
+        def my_table(clickhouse: ClickhouseResource):
+            with clickhouse.get_connection() as client:
+                client.execute("SELECT * FROM my_database.my_table LIMIT 1")
+
+        Definitions(
+            assets=[my_table],
+            resources={"clickhouse": ClickhouseResource(host="localhost")},
+        )
+        ```
+    </dd>
+</dl>
+
+<dl>
+    <dt><Link class="anchor" id='dagster_clickhouse.ClickhouseIOManager'>dagster_clickhouse.ClickhouseIOManager IOManagerDefinition <a href='https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-clickhouse/dagster_clickhouse/io_manager.py#L47' className='source-link' target='_blank' rel='noopener noreferrer'>[source]</a><a href="#dagster_clickhouse.ClickhouseIOManager" class="hash-link"></a></Link></dt>
+    <dd>
+        <div className='lineblock'> </div>
+        Base class for an IO manager that reads inputs from and writes outputs to ClickHouse.
+
+        Asset and op metadata `schema` (and the I/O manager `schema` config) refer to the ClickHouse **database** that contains the table.
+
+        The `database` field is the default database **on the ClickHouse connection** (server-side), not the database that qualifies table names in Dagster metadata (that is `schema`).
+
+        Examples:
+        ```python
+        from dagster_clickhouse import ClickhouseIOManager
+        from dagster_clickhouse_pandas import ClickhousePandasTypeHandler
+
+        class MyClickhouseIOManager(ClickhouseIOManager):
+            @staticmethod
+            def type_handlers() -> Sequence[DbTypeHandler]:
+                return [ClickhousePandasTypeHandler()]
+
+        @asset(
+            key_prefix=["my_database"]  # will be used as the database in ClickHouse
+        )
+        def my_table() -> pd.DataFrame:  # the name of the asset will be the table name
+            ...
+
+        Definitions(
+            assets=[my_table],
+            resources={"io_manager": MyClickhouseIOManager()}
+        )
+        ```
+        If you do not provide a database, Dagster will determine a database based on the assets and ops using the I/O Manager. For assets, the database will be determined from the asset key, as in the above example. For ops, the database can be specified by including a "schema" entry in output metadata. If none of these is provided, the database will default to "default".
+
+        ```python
+        @op(
+            out={"my_table": Out(metadata={"schema": "my_database"})}
+        )
+        def make_my_table() -> pd.DataFrame:
+            ...
+        ```
+        To only use specific columns of a table as input to a downstream op or asset, add the metadata "columns" to the In or AssetIn.
+
+        ```python
+        @asset(
+            ins={"my_table": AssetIn("my_table", metadata={"columns": ["a"]})}
+        )
+        def my_table_a(my_table: pd.DataFrame):
+            # my_table will just contain the data from column "a"
+            ...
+        ```
+    </dd>
+</dl>
+
+<dl>
+    <dt><Link class="anchor" id='dagster_clickhouse.ClickhouseQueryComponent'>dagster_clickhouse.ClickhouseQueryComponent Component <a href='https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-clickhouse/dagster_clickhouse/components/sql_component/component.py' className='source-link' target='_blank' rel='noopener noreferrer'>[source]</a><a href="#dagster_clickhouse.ClickhouseQueryComponent" class="hash-link"></a></Link></dt>
+    <dd>
+        <div className='lineblock'> </div>
+        A ClickHouse connection component for ``TemplatedSqlComponent`` and other SQL tooling.
+
+        Examples:
+        ```yaml
+        type: dagster_clickhouse.ClickhouseQueryComponent
+
+        attributes:
+            host: localhost
+            port: 9000
+            user: default
+            password: ""
+        ```
+    </dd>
+</dl>
+
+<dl>
+    <dt><Link class="anchor" id='dagster_clickhouse.ClickhouseDbClient'>dagster_clickhouse.ClickhouseDbClient Utility <a href='https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-clickhouse/dagster_clickhouse/db_client.py#L30' className='source-link' target='_blank' rel='noopener noreferrer'>[source]</a><a href="#dagster_clickhouse.ClickhouseDbClient" class="hash-link"></a></Link></dt>
+    <dd>
+        <div className='lineblock'> </div>
+        Low-level client for interacting with ClickHouse databases, used internally by IO managers and type handlers.
+    </dd>
+</dl>
+
+<dl>
+    <dt><Link class="anchor" id='dagster_clickhouse.build_clickhouse_io_manager'>dagster_clickhouse.build_clickhouse_io_manager Function <a href='https://github.com/dagster-io/dagster/blob/master/python_modules/libraries/dagster-clickhouse/dagster_clickhouse/io_manager.py#L14' className='source-link' target='_blank' rel='noopener noreferrer'>[source]</a><a href="#dagster_clickhouse.build_clickhouse_io_manager" class="hash-link"></a></Link></dt>
+    <dd>
+        <div className='lineblock'> </div>
+        Builds an IO manager definition that reads inputs from and writes outputs to ClickHouse.
+
+    </dd>
+</dl>
+</div>


### PR DESCRIPTION
## Summary & Motivation
Add missing Python API docs for ClickHouse integration introduced in [PR33727](https://github.com/dagster-io/dagster/pull/33727), fixing all broken links:
```zsh
  Exhaustive list of all broken links found:
  - Broken link on source page path = /guides/build/io-managers:
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse-pandas#dagster_clickhouse_pandas.ClickhousePandasIOManager
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse-polars#dagster_clickhouse_polars.ClickhousePolarsIOManager
  - Broken link on source page path = /integrations/libraries/clickhouse:
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse#dagster_clickhouse.ClickhouseResource
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse#dagster_clickhouse.ClickhouseIOManager
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse#dagster_clickhouse.ClickhouseQueryComponent
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse-pandas#dagster_clickhouse_pandas.ClickhousePandasIOManager
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse-polars#dagster_clickhouse_polars.ClickhousePolarsIOManager
  - Broken link on source page path = /integrations/libraries/clickhouse/clickhouse-sql-component:
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse#dagster_clickhouse.ClickhouseQueryComponent
  - Broken link on source page path = /integrations/libraries/clickhouse/reference:
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse#dagster_clickhouse.ClickhouseResource
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse#dagster_clickhouse.ClickhouseDbClient
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse#dagster_clickhouse.build_clickhouse_io_manager
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse
  - Broken link on source page path = /integrations/libraries/clickhouse/using-clickhouse-with-dagster:
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse#dagster_clickhouse.ClickhouseResource
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse-pandas#dagster_clickhouse_pandas.ClickhousePandasIOManager
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse-polars#dagster_clickhouse_polars.ClickhousePolarsIOManager
     -> linking to /integrations/libraries/clickhouse/dagster-clickhouse#dagster_clickhouse.ClickhouseQueryComponent
```

> [!NOTE]
> Followed the style of [Delta Lake integration](https://docs.dagster.io/integrations/libraries/deltalake) which was updated recently (`2026-04-04`) 

## Test Plan
1. Run `yarn build` and ensure there are no broken links
2. Launch the documentation website locally and verify the updated docs render as expected

## Changelog
- [docs] Add ClickHouse Python API docs