### PR TITLE
fix(ui): restore CommonMark newline behavior in Markdown renderer

### DIFF
--- a/js_modules/ui-core/package.json
+++ b/js_modules/ui-core/package.json
@@ -81,6 +81,7 @@
     "rehype-sanitize": "^5.0.1",
     "rehype-slug": "^6.0.0",
     "remark": "^14.0.2",
+    "remark-breaks": "^4.0.0",
     "remark-directive": "^4.0.0",
     "remark-gfm": "3.0.1",
     "spark-md5": "^3.0.2",

--- a/js_modules/ui-core/package.json
+++ b/js_modules/ui-core/package.json
@@ -81,7 +81,6 @@
     "rehype-sanitize": "^5.0.1",
     "rehype-slug": "^6.0.0",
     "remark": "^14.0.2",
-    "remark-breaks": "^4.0.0",
     "remark-directive": "^4.0.0",
     "remark-gfm": "3.0.1",
     "spark-md5": "^3.0.2",

--- a/js_modules/ui-core/src/ui/Markdown.tsx
+++ b/js_modules/ui-core/src/ui/Markdown.tsx
@@ -5,6 +5,7 @@ const MarkdownWithPlugins = lazy(() => import('./MarkdownWithPlugins'));
 
 interface Props {
   children: string;
+  softBreaks?: boolean;
 }
 
 export const Markdown = (props: Props) => {

--- a/js_modules/ui-core/src/ui/MarkdownWithPlugins.tsx
+++ b/js_modules/ui-core/src/ui/MarkdownWithPlugins.tsx
@@ -2,6 +2,7 @@ import {Colors} from '@dagster-io/ui-components';
 import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeSanitize, {defaultSchema} from 'rehype-sanitize';
+import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import {createGlobalStyle} from 'styled-components';
 import 'highlight.js/styles/github.css';
@@ -123,16 +124,17 @@ const GlobalStyle = createGlobalStyle`
 
 interface Props {
   children: string;
+  softBreaks?: boolean;
 }
 
-export const MarkdownWithPlugins = (props: Props) => {
+export const MarkdownWithPlugins = ({softBreaks, ...props}: Props) => {
   return (
     <>
       <GlobalStyle />
       <ReactMarkdown
         {...props}
         className="dagster-markdown"
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={softBreaks ? [remarkBreaks, remarkGfm] : [remarkGfm]}
         rehypePlugins={[
           [rehypeHighlight, {ignoreMissing: true}],
           [rehypeSanitize, sanitizeConfig],

--- a/js_modules/ui-core/src/ui/MarkdownWithPlugins.tsx
+++ b/js_modules/ui-core/src/ui/MarkdownWithPlugins.tsx
@@ -2,7 +2,6 @@ import {Colors} from '@dagster-io/ui-components';
 import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeSanitize, {defaultSchema} from 'rehype-sanitize';
-import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import {createGlobalStyle} from 'styled-components';
 import 'highlight.js/styles/github.css';
@@ -133,7 +132,7 @@ export const MarkdownWithPlugins = (props: Props) => {
       <ReactMarkdown
         {...props}
         className="dagster-markdown"
-        remarkPlugins={[remarkBreaks, remarkGfm]}
+        remarkPlugins={[remarkGfm]}
         rehypePlugins={[
           [rehypeHighlight, {ignoreMissing: true}],
           [rehypeSanitize, sanitizeConfig],

--- a/js_modules/ui-core/src/ui/__stories__/Markdown.stories.tsx
+++ b/js_modules/ui-core/src/ui/__stories__/Markdown.stories.tsx
@@ -76,6 +76,28 @@ export const foo = (): number => {
   );
 };
 
+export const SingleNewlineCollapse = () => {
+  return (
+    <Markdown>
+      {`## Overview
+New line expected here as it follows a heading
+No new line expected here as there is only a single line break
+
+New line is expected here as there are two in a row`}
+    </Markdown>
+  );
+};
+
+export const BlockquoteNewlines = () => {
+  return (
+    <Markdown>
+      {`> ✅ Step one
+> ✅ Step two
+> ✅ Step three`}
+    </Markdown>
+  );
+};
+
 export const MarkdownBase64Image = () => {
   return (
     <Markdown>

--- a/js_modules/ui-core/src/ui/__stories__/Markdown.stories.tsx
+++ b/js_modules/ui-core/src/ui/__stories__/Markdown.stories.tsx
@@ -90,7 +90,7 @@ New line is expected here as there are two in a row`}
 
 export const BlockquoteNewlines = () => {
   return (
-    <Markdown>
+    <Markdown softBreaks>
       {`> ✅ Step one
 > ✅ Step two
 > ✅ Step three`}

--- a/js_modules/ui-core/src/ui/__stories__/Markdown.stories.tsx
+++ b/js_modules/ui-core/src/ui/__stories__/Markdown.stories.tsx
@@ -98,6 +98,16 @@ export const BlockquoteNewlines = () => {
   );
 };
 
+export const BlockquoteHardBreaks = () => {
+  return (
+    <Markdown>
+      {`> ✅ Step one\\
+> ✅ Step two\\
+> ✅ Step three`}
+    </Markdown>
+  );
+};
+
 export const MarkdownBase64Image = () => {
   return (
     <Markdown>


### PR DESCRIPTION
## Summary & Motivation

Fixes #33776.

The shared UI Markdown renderer was using `remark-breaks` as a default plugin, which turns every single newline into a `<br />`. This does not match CommonMark behavior, where a single newline should collapse to a space and only explicit hard breaks (trailing `\`) or blank-line paragraph separators should affect layout.

**Changes:**
- Removes `remark-breaks` from the default plugin list in `MarkdownWithPlugins` — single newlines now collapse to spaces (correct CommonMark behavior)
- Adds a `softBreaks` opt-in prop to `Markdown` / `MarkdownWithPlugins` so callers that need single-newline → `<br>` behavior (e.g. blockquote step lists) can request it explicitly
- Adds Storybook stories covering the main newline cases

## Test Plan

- Added Storybook coverage:
  - `SingleNewlineCollapse` — single newlines collapse within a paragraph (default)
  - `BlockquoteNewlines` — blockquote checklist using `softBreaks` for per-line breaks
  - `BlockquoteHardBreaks` — blockquote using explicit Markdown hard breaks (`\`)

## Changelog

Restore CommonMark-compliant Markdown line break rendering in Dagster UI Markdown descriptions and docs blocks. Adds a `softBreaks` opt-in prop for callers that need single-newline → `<br>` behavior.