### PR TITLE
Fix UPathIOManager.storage_options on universal-pathlib >= 0.3

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -117,7 +117,16 @@ class UPathIOManager(IOManager):
         from upath import UPath
 
         if isinstance(self._base_path, UPath):
-            return self._base_path._kwargs.copy()  # noqa  # pyright: ignore[reportAttributeAccessIssue]
+            # `UPath.storage_options` is the public accessor (universal-pathlib >= 0.1);
+            # the prior `_kwargs` private attribute was deprecated in 0.2 and removed
+            # in 0.3. Prefer the public API and fall back to `_kwargs` only on the
+            # ancient 0.0.x line that predates `storage_options`. Wrap in `dict()` so
+            # callers retain the previous mutable-copy contract — `storage_options`
+            # returns a `MappingProxyType` on 0.3+.
+            options = getattr(self._base_path, "storage_options", None)
+            if options is None:
+                options = getattr(self._base_path, "_kwargs", {})
+            return dict(options)
         elif isinstance(self._base_path, Path):
             return {}
         else:

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -653,7 +653,7 @@ def test_upath_can_transition_from_non_partitioned_to_partitioned(
     ).success
 
 
-def test_storage_options_returns_upath_kwargs(tmp_path: Path):
+def test_storage_options_returns_upath_kwargs():
     """Cloud-backed UPaths expose configuration via the public `storage_options`
     accessor. The IOManager's `storage_options` property must surface that
     mapping as a mutable dict so downstream callers (e.g. dagster-polars,

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -651,3 +651,27 @@ def test_upath_can_transition_from_non_partitioned_to_partitioned(
     assert dg.materialize(
         [my_asset], resources={"io_manager": my_io_manager}, partition_key=start.strftime(daily.fmt)
     ).success
+
+
+def test_storage_options_returns_upath_kwargs(tmp_path: Path):
+    """Cloud-backed UPaths expose configuration via the public `storage_options`
+    accessor. The IOManager's `storage_options` property must surface that
+    mapping as a mutable dict so downstream callers (e.g. dagster-polars,
+    dagster-deltalake) can pass it to readers/writers without aliasing the
+    UPath internals.
+
+    Regression test for the `_kwargs` private-attribute usage that broke on
+    universal-pathlib >= 0.3 (see dagster-io/dagster#32637).
+    """
+    options = {"anon": True, "endpoint_url": "http://localhost:9000"}
+    manager = DummyIOManager(base_path=UPath("s3://bucket/prefix", **options))
+    so = manager.storage_options
+    assert so == options
+    # Must be a real, mutable dict — not the underlying mapping proxy.
+    so["mutated"] = True
+    assert "mutated" not in manager.storage_options
+
+
+def test_storage_options_local_path_returns_empty(tmp_path: Path):
+    manager = DummyIOManager(base_path=tmp_path)
+    assert manager.storage_options == {}


### PR DESCRIPTION
## Summary

`UPathIOManager.storage_options` reaches for the private `UPath._kwargs` attribute. universal-pathlib deprecated `_kwargs` in 0.2 (use `storage_options`) and removed it in 0.3, so any cloud-backed IO manager that reads `self.storage_options` crashes with:

```
AttributeError: 'S3Path' object has no attribute '_kwargs'
```

Easiest place to hit it: `PolarsDeltaIOManager` on `universal-pathlib >= 0.3`, but it also breaks `PolarsParquetIOManager` once [community-integrations#264](https://github.com/dagster-io/community-integrations/pull/264) merges (which adds a `self.storage_options` lookup on the cloud-write path).

This PR switches to the public `UPath.storage_options` accessor and wraps it in `dict()` to preserve the previous mutable-copy contract — `storage_options` is a `MappingProxyType` on 0.3+. A `_kwargs` fallback is retained for pre-0.1 universal-pathlib versions that predate the public attribute, since the Python <3.12 install requirement is unpinned.

Fixes #32637.

## Test plan

- [x] Added `test_storage_options_returns_upath_kwargs` covering the cloud branch (mutable-dict contract included).
- [x] Added `test_storage_options_local_path_returns_empty` covering the `pathlib.Path` branch.
- [x] `pytest python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py` — 31 passed (verified on universal-pathlib 0.2.6 and 0.3.10).
- [x] `pytest python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py` — 12 passed, 1 pre-existing skip.
- [x] Smoke-tested the exact failure path from #32637 against universal-pathlib 0.3.10 — no longer raises.
- [x] `ruff check` clean on both touched files.