### PR TITLE
fix(storage): scope dynamic partitions to code location to prevent cross-location key leakage

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/dynamic_partitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/dynamic_partitions.py
@@ -86,12 +86,18 @@ def add_dynamic_partition(
             )
         )
 
-    if graphene_info.context.instance.has_dynamic_partition(partitions_def_name, partition_key):
+    location_name = unpacked_repository_selector.location_name
+
+    if graphene_info.context.instance.has_dynamic_partition(
+        partitions_def_name, partition_key, code_location_name=location_name
+    ):
         raise UserFacingGraphQLError(
             GrapheneDuplicateDynamicPartitionError(partitions_def_name, partition_key)
         )
 
-    graphene_info.context.instance.add_dynamic_partitions(partitions_def_name, [partition_key])
+    graphene_info.context.instance.add_dynamic_partitions(
+        partitions_def_name, [partition_key], code_location_name=location_name
+    )
     return GrapheneAddDynamicPartitionSuccess(
         partitionsDefName=partitions_def_name, partitionKey=partition_key
     )
@@ -126,7 +132,10 @@ def delete_dynamic_partitions(
             )
         )
 
+    location_name = unpacked_repository_selector.location_name
     for partition_key in partition_keys:
-        graphene_info.context.instance.delete_dynamic_partition(partitions_def_name, partition_key)
+        graphene_info.context.instance.delete_dynamic_partition(
+            partitions_def_name, partition_key, code_location_name=location_name
+        )
 
     return GrapheneDeleteDynamicPartitionsSuccess(partitionsDefName=partitions_def_name)

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -229,8 +229,15 @@ class SensorEvaluationContext:
         return check.not_none(self._sensor_name, "Only valid when sensor name provided")
 
     @functools.cached_property
-    def caching_dynamic_partitions_loader(self):
-        return CachingDynamicPartitionsLoader(self.instance) if self.instance_ref else None
+    def caching_dynamic_partitions_loader(self) -> Optional["CachingDynamicPartitionsLoader"]:
+        if not self.instance_ref:
+            return None
+        location_name = (
+            self._code_location_origin.location_name
+            if self._code_location_origin is not None
+            else None
+        )
+        return CachingDynamicPartitionsLoader(self.instance, code_location_name=location_name)
 
     def merge_resources(self, resources_dict: Mapping[str, Any]) -> "SensorEvaluationContext":
         """Merge the specified resources into this context.

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -250,8 +250,16 @@ def run_step_from_ref(
             isinstance(partitions_def, DynamicPartitionsDefinition)
             and partitions_def.name is not None
         ):
+            origin = step_context.dagster_run.remote_job_origin
+            code_location_name = (
+                origin.repository_origin.code_location_origin.location_name
+                if origin is not None
+                else None
+            )
             step_context.instance.add_dynamic_partitions(
-                partitions_def_name=partitions_def.name, partition_keys=[step_context.partition_key]
+                partitions_def_name=partitions_def.name,
+                partition_keys=[step_context.partition_key],
+                code_location_name=code_location_name,
             )
 
     # The step should be forced to run locally with respect to the remote process that this step

--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -598,7 +598,10 @@ class DagsterInstance(
     @public
     @traced
     def add_dynamic_partitions(
-        self, partitions_def_name: str, partition_keys: Sequence[str]
+        self,
+        partitions_def_name: str,
+        partition_keys: Sequence[str],
+        code_location_name: str | None = None,
     ) -> None:
         """Add partitions to the specified :py:class:`DynamicPartitionsDefinition` idempotently.
         Does not add any partitions that already exist.
@@ -606,30 +609,46 @@ class DagsterInstance(
         Args:
             partitions_def_name (str): The name of the `DynamicPartitionsDefinition`.
             partition_keys (Sequence[str]): Partition keys to add.
+            code_location_name (str | None): The code location the partitions belong to.
         """
-        return self._event_storage.add_dynamic_partitions(partitions_def_name, partition_keys)
+        return self._event_storage.add_dynamic_partitions(
+            partitions_def_name, partition_keys, code_location_name=code_location_name
+        )
 
     @public
     @traced
-    def delete_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> None:
+    def delete_dynamic_partition(
+        self,
+        partitions_def_name: str,
+        partition_key: str,
+        code_location_name: str | None = None,
+    ) -> None:
         """Delete a partition for the specified :py:class:`DynamicPartitionsDefinition`.
         If the partition does not exist, exits silently.
 
         Args:
             partitions_def_name (str): The name of the `DynamicPartitionsDefinition`.
             partition_key (str): Partition key to delete.
+            code_location_name (str | None): The code location the partition belongs to.
         """
-        return self._event_storage.delete_dynamic_partition(partitions_def_name, partition_key)
+        return self._event_storage.delete_dynamic_partition(
+            partitions_def_name, partition_key, code_location_name=code_location_name
+        )
 
     @public
     @traced
-    def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
+    def get_dynamic_partitions(
+        self, partitions_def_name: str, code_location_name: str | None = None
+    ) -> Sequence[str]:
         """Get the set of partition keys for the specified :py:class:`DynamicPartitionsDefinition`.
 
         Args:
             partitions_def_name (str): The name of the `DynamicPartitionsDefinition`.
+            code_location_name (str | None): The code location to scope the query to.
         """
-        return self._event_storage.get_dynamic_partitions(partitions_def_name)
+        return self._event_storage.get_dynamic_partitions(
+            partitions_def_name, code_location_name=code_location_name
+        )
 
     def get_dynamic_partitions_definition_id(self, partitions_def_name: str) -> str:
         from dagster._core.definitions.partitions.context import partition_loading_context
@@ -645,14 +664,19 @@ class DagsterInstance(
 
     @public
     @traced
-    def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
+    def has_dynamic_partition(
+        self, partitions_def_name: str, partition_key: str, code_location_name: str | None = None
+    ) -> bool:
         """Check if a partition key exists for the :py:class:`DynamicPartitionsDefinition`.
 
         Args:
             partitions_def_name (str): The name of the `DynamicPartitionsDefinition`.
             partition_key (str): Partition key to check.
+            code_location_name (str | None): The code location to scope the query to.
         """
-        return self._event_storage.has_dynamic_partition(partitions_def_name, partition_key)
+        return self._event_storage.has_dynamic_partition(
+            partitions_def_name, partition_key, code_location_name=code_location_name
+        )
 
     # =====================================================================================
     # INTERNAL METHODS

--- a/python_modules/dagster/dagster/_core/instance/methods/storage_methods.py
+++ b/python_modules/dagster/dagster/_core/instance/methods/storage_methods.py
@@ -54,6 +54,7 @@ class StorageMethods:
         limit: int,
         ascending: bool,
         cursor: str | None = None,
+        code_location_name: str | None = None,
     ) -> PaginatedResults[str]:
         """Get a paginatable subset of partition keys for the specified :py:class:`DynamicPartitionsDefinition`.
 
@@ -62,12 +63,14 @@ class StorageMethods:
             limit (int): Maximum number of partition keys to return.
             ascending (bool): The order of dynamic partitions to return.
             cursor (Optional[str]): Cursor to use for pagination. Defaults to None.
+            code_location_name (str | None): The code location to scope the query to.
         """
         return self._event_storage.get_paginated_dynamic_partitions(
             partitions_def_name=partitions_def_name,
             limit=limit,
             ascending=ascending,
             cursor=cursor,
+            code_location_name=code_location_name,
         )
 
     def optimize_for_webserver(

--- a/python_modules/dagster/dagster/_core/instance/types.py
+++ b/python_modules/dagster/dagster/_core/instance/types.py
@@ -144,24 +144,37 @@ class CachingDynamicPartitionsLoader(DynamicPartitionsStore):
     to avoid repeated calls to the database for the same partitions definition.
     """
 
-    def __init__(self, instance: "DagsterInstance"):
+    def __init__(self, instance: "DagsterInstance", code_location_name: str | None = None):
         self._instance = instance
+        self._code_location_name = code_location_name
 
     @cached_method
     def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
-        return self._instance.get_dynamic_partitions(partitions_def_name)
+        return self._instance.get_dynamic_partitions(
+            partitions_def_name, code_location_name=self._code_location_name
+        )
 
     @cached_method
     def get_paginated_dynamic_partitions(
-        self, partitions_def_name: str, limit: int, ascending: bool, cursor: str | None = None
+        self,
+        partitions_def_name: str,
+        limit: int,
+        ascending: bool,
+        cursor: str | None = None,
     ) -> PaginatedResults[str]:
         return self._instance.get_paginated_dynamic_partitions(
-            partitions_def_name=partitions_def_name, limit=limit, ascending=ascending, cursor=cursor
+            partitions_def_name=partitions_def_name,
+            limit=limit,
+            ascending=ascending,
+            cursor=cursor,
+            code_location_name=self._code_location_name,
         )
 
     @cached_method
     def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
-        return self._instance.has_dynamic_partition(partitions_def_name, partition_key)
+        return self._instance.has_dynamic_partition(
+            partitions_def_name, partition_key, code_location_name=self._code_location_name
+        )
 
     @cached_method
     def get_dynamic_partitions_definition_id(self, partitions_def_name: str) -> str:
@@ -223,7 +236,11 @@ class DynamicPartitionsStoreAfterRequests(DynamicPartitionsStore):
 
     @cached_method
     def get_paginated_dynamic_partitions(
-        self, partitions_def_name: str, limit: int, ascending: bool, cursor: str | None = None
+        self,
+        partitions_def_name: str,
+        limit: int,
+        ascending: bool,
+        cursor: str | None = None,
     ) -> PaginatedResults[str]:
         partition_keys = self.get_dynamic_partitions(partitions_def_name)
         return PaginatedResults.create_from_sequence(

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/049_119af5a61af8_add_code_location_to_dynamic_partitions.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/049_119af5a61af8_add_code_location_to_dynamic_partitions.py
@@ -1,0 +1,71 @@
+"""add code_location_name to dynamic_partitions table
+
+Revision ID: 119af5a61af8
+Revises: 29b539ebc72a
+Create Date: 2026-04-30
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from dagster._core.storage.migration.utils import has_column, has_index, has_table
+
+revision = "119af5a61af8"
+down_revision = "29b539ebc72a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not has_table("dynamic_partitions"):
+        return
+
+    if not has_column("dynamic_partitions", "code_location_name"):
+        op.add_column(
+            "dynamic_partitions",
+            sa.Column("code_location_name", sa.Text(), nullable=True),
+        )
+
+    # Replace the unique index (which cannot scope NULLs correctly) with a
+    # non-unique composite index. App-level dedup in add_dynamic_partitions
+    # ensures idempotency without relying on a DB-level unique constraint.
+    if has_index("dynamic_partitions", "idx_dynamic_partitions"):
+        op.drop_index("idx_dynamic_partitions", table_name="dynamic_partitions")
+
+    op.create_index(
+        "idx_dynamic_partitions",
+        "dynamic_partitions",
+        ["code_location_name", "partitions_def_name", "partition"],
+        mysql_length={"code_location_name": 64, "partitions_def_name": 64, "partition": 64},
+    )
+
+
+def downgrade():
+    if not has_table("dynamic_partitions"):
+        return
+
+    if has_index("dynamic_partitions", "idx_dynamic_partitions"):
+        op.drop_index("idx_dynamic_partitions", table_name="dynamic_partitions")
+
+    # Scoped rows (code_location_name IS NOT NULL) cannot survive the column drop.
+    # Unscoped rows may have duplicates if concurrent inserts raced after the unique
+    # index was removed in upgrade(). Delete both to ensure the UNIQUE index below
+    # can be recreated without a constraint violation.
+    op.execute("DELETE FROM dynamic_partitions WHERE code_location_name IS NOT NULL")
+    op.execute(
+        "DELETE FROM dynamic_partitions WHERE id NOT IN ("
+        "  SELECT MIN(id) FROM dynamic_partitions"
+        "  GROUP BY partitions_def_name, partition"
+        ")"
+    )
+
+    op.create_index(
+        "idx_dynamic_partitions",
+        "dynamic_partitions",
+        ["partitions_def_name", "partition"],
+        mysql_length={"partitions_def_name": 64, "partition": 64},
+        unique=True,
+    )
+
+    if has_column("dynamic_partitions", "code_location_name"):
+        op.drop_column("dynamic_partitions", "code_location_name")

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -510,30 +510,44 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         pass
 
     @abstractmethod
-    def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
+    def get_dynamic_partitions(
+        self, partitions_def_name: str, code_location_name: str | None = None
+    ) -> Sequence[str]:
         """Get the list of partition keys for a dynamic partitions definition."""
         raise NotImplementedError()
 
     @abstractmethod
     def get_paginated_dynamic_partitions(
-        self, partitions_def_name: str, limit: int, ascending: bool, cursor: str | None = None
+        self,
+        partitions_def_name: str,
+        limit: int,
+        ascending: bool,
+        cursor: str | None = None,
+        code_location_name: str | None = None,
     ) -> PaginatedResults[str]:
         raise NotImplementedError()
 
     @abstractmethod
-    def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
+    def has_dynamic_partition(
+        self, partitions_def_name: str, partition_key: str, code_location_name: str | None = None
+    ) -> bool:
         """Check if a dynamic partition exists."""
         raise NotImplementedError()
 
     @abstractmethod
     def add_dynamic_partitions(
-        self, partitions_def_name: str, partition_keys: Sequence[str]
+        self,
+        partitions_def_name: str,
+        partition_keys: Sequence[str],
+        code_location_name: str | None = None,
     ) -> None:
         """Add a partition for the specified dynamic partitions definition."""
         raise NotImplementedError()
 
     @abstractmethod
-    def delete_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> None:
+    def delete_dynamic_partition(
+        self, partitions_def_name: str, partition_key: str, code_location_name: str | None = None
+    ) -> None:
         """Delete a partition for the specified dynamic partitions definition."""
         raise NotImplementedError()
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -101,6 +101,7 @@ DynamicPartitionsTable = db.Table(
     db.Column("partitions_def_name", db.Text, nullable=False),
     db.Column("partition", db.Text, nullable=False),
     db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
+    db.Column("code_location_name", db.Text, nullable=True),
 )
 
 ConcurrencyLimitsTable = db.Table(
@@ -260,10 +261,10 @@ db.Index(
 )
 db.Index(
     "idx_dynamic_partitions",
+    DynamicPartitionsTable.c.code_location_name,
     DynamicPartitionsTable.c.partitions_def_name,
     DynamicPartitionsTable.c.partition,
-    mysql_length={"partitions_def_name": 64, "partition": 64},
-    unique=True,
+    mysql_length={"code_location_name": 64, "partitions_def_name": 64, "partition": 64},
 )
 db.Index(
     "idx_pending_steps",

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2102,13 +2102,12 @@ class SqlEventLogStorage(EventLogStorage):
         code_location_name: str | None = None,
     ) -> PaginatedResults[str]:
         self._check_partitions_table()
-        order_by = (
-            DynamicPartitionsTable.c.id.asc() if ascending else DynamicPartitionsTable.c.id.desc()
-        )
+        storage_id = db.func.min(DynamicPartitionsTable.c.id)
+        order_by = storage_id.asc() if ascending else storage_id.desc()
         query = (
             db_select(
                 [
-                    DynamicPartitionsTable.c.id,
+                    storage_id.label("storage_id"),
                     DynamicPartitionsTable.c.partition,
                 ]
             )
@@ -2118,15 +2117,16 @@ class SqlEventLogStorage(EventLogStorage):
                     self._code_location_filter(code_location_name),
                 )
             )
+            .group_by(DynamicPartitionsTable.c.partition)
             .order_by(order_by)
             .limit(limit)
         )
         if cursor:
             last_storage_id = StorageIdCursor.from_cursor(cursor).storage_id
             if ascending:
-                query = query.where(DynamicPartitionsTable.c.id > last_storage_id)
+                query = query.having(storage_id > last_storage_id)
             else:
-                query = query.where(DynamicPartitionsTable.c.id < last_storage_id)
+                query = query.having(storage_id < last_storage_id)
 
         with self.index_connection() as conn, db_result(conn, query) as result:
             rows = result.fetchall()

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2052,17 +2052,47 @@ class SqlEventLogStorage(EventLogStorage):
 
         return materialization_planned_rows_by_partition
 
+    @cached_property
+    def _has_code_location_name_col(self) -> bool:
+        if not self.has_table(DynamicPartitionsTable.name):
+            return False
+        with self.index_connection() as conn:
+            col_names = [
+                c["name"] for c in db.inspect(conn).get_columns(DynamicPartitionsTable.name)
+            ]
+        return DynamicPartitionsTable.c.code_location_name.name in col_names
+
     def _check_partitions_table(self) -> None:
         # Guards against cases where the user is not running the latest migration for
         # partitions storage. Should be updated when the partitions storage schema changes.
         if not self.has_table("dynamic_partitions"):
             raise DagsterInvalidInvocationError(
                 "Using dynamic partitions definitions requires the dynamic partitions table, which"
-                " currently does not exist. Add this table by running `dagster"
-                " instance migrate`."
+                " currently does not exist. Add this table by running `dagster instance migrate`."
+            )
+        if not self._has_code_location_name_col:
+            raise DagsterInvalidInvocationError(
+                "The dynamic_partitions table is missing the code_location_name column required"
+                " for code-location-scoped dynamic partitions. Add this column by running"
+                " `dagster instance migrate`."
             )
 
-    def _code_location_filter(self, code_location_name: str | None):
+    def _code_location_read_filter(self, code_location_name: str | None):
+        """Filter for read operations. When code_location_name is provided, returns rows
+        scoped to that location AND legacy NULL-scoped rows so pre-migration data remains
+        visible after upgrade.
+        """
+        if code_location_name is None:
+            return DynamicPartitionsTable.c.code_location_name.is_(None)
+        return db.or_(
+            DynamicPartitionsTable.c.code_location_name == code_location_name,
+            DynamicPartitionsTable.c.code_location_name.is_(None),
+        )
+
+    def _code_location_exact_filter(self, code_location_name: str | None):
+        """Exact filter for write/delete operations. Only matches rows for the given
+        scope; never touches rows belonging to a different code location.
+        """
         if code_location_name is None:
             return DynamicPartitionsTable.c.code_location_name.is_(None)
         return DynamicPartitionsTable.c.code_location_name == code_location_name
@@ -2082,7 +2112,7 @@ class SqlEventLogStorage(EventLogStorage):
             .where(
                 db.and_(
                     DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
-                    self._code_location_filter(code_location_name),
+                    self._code_location_read_filter(code_location_name),
                 )
             )
             .group_by(DynamicPartitionsTable.c.partition)
@@ -2114,7 +2144,7 @@ class SqlEventLogStorage(EventLogStorage):
             .where(
                 db.and_(
                     DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
-                    self._code_location_filter(code_location_name),
+                    self._code_location_read_filter(code_location_name),
                 )
             )
             .group_by(DynamicPartitionsTable.c.partition)
@@ -2154,7 +2184,7 @@ class SqlEventLogStorage(EventLogStorage):
                 db.and_(
                     DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
                     DynamicPartitionsTable.c.partition == partition_key,
-                    self._code_location_filter(code_location_name),
+                    self._code_location_read_filter(code_location_name),
                 )
             )
             .limit(1)
@@ -2177,7 +2207,7 @@ class SqlEventLogStorage(EventLogStorage):
                     db.and_(
                         DynamicPartitionsTable.c.partition.in_(partition_keys),
                         DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
-                        self._code_location_filter(code_location_name),
+                        self._code_location_exact_filter(code_location_name),
                     )
                 )
             ).fetchall()
@@ -2207,7 +2237,7 @@ class SqlEventLogStorage(EventLogStorage):
                     db.and_(
                         DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
                         DynamicPartitionsTable.c.partition == partition_key,
-                        self._code_location_filter(code_location_name),
+                        self._code_location_exact_filter(code_location_name),
                     )
                 )
             )

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2062,25 +2062,44 @@ class SqlEventLogStorage(EventLogStorage):
                 " instance migrate`."
             )
 
-    def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
+    def _code_location_filter(self, code_location_name: str | None):
+        if code_location_name is None:
+            return DynamicPartitionsTable.c.code_location_name.is_(None)
+        return DynamicPartitionsTable.c.code_location_name == code_location_name
+
+    def get_dynamic_partitions(
+        self, partitions_def_name: str, code_location_name: str | None = None
+    ) -> Sequence[str]:
         """Get the list of partition keys for a partition definition."""
         self._check_partitions_table()
-        columns = [
-            DynamicPartitionsTable.c.partitions_def_name,
-            DynamicPartitionsTable.c.partition,
-        ]
         query = (
-            db_select(columns)
-            .where(DynamicPartitionsTable.c.partitions_def_name == partitions_def_name)
-            .order_by(DynamicPartitionsTable.c.id)
+            db_select(
+                [
+                    DynamicPartitionsTable.c.partition,
+                    db.func.min(DynamicPartitionsTable.c.id).label("min_id"),
+                ]
+            )
+            .where(
+                db.and_(
+                    DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
+                    self._code_location_filter(code_location_name),
+                )
+            )
+            .group_by(DynamicPartitionsTable.c.partition)
+            .order_by(db.func.min(DynamicPartitionsTable.c.id))
         )
         with self.index_connection() as conn, db_result(conn, query) as result:
             rows = result.fetchall()
 
-        return [cast("str", row[1]) for row in rows]
+        return [cast("str", row[0]) for row in rows]
 
     def get_paginated_dynamic_partitions(
-        self, partitions_def_name: str, limit: int, ascending: bool, cursor: str | None = None
+        self,
+        partitions_def_name: str,
+        limit: int,
+        ascending: bool,
+        cursor: str | None = None,
+        code_location_name: str | None = None,
     ) -> PaginatedResults[str]:
         self._check_partitions_table()
         order_by = (
@@ -2093,7 +2112,12 @@ class SqlEventLogStorage(EventLogStorage):
                     DynamicPartitionsTable.c.partition,
                 ]
             )
-            .where(DynamicPartitionsTable.c.partitions_def_name == partitions_def_name)
+            .where(
+                db.and_(
+                    DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
+                    self._code_location_filter(code_location_name),
+                )
+            )
             .order_by(order_by)
             .limit(limit)
         )
@@ -2120,7 +2144,9 @@ class SqlEventLogStorage(EventLogStorage):
             has_more=len(rows) == limit,
         )
 
-    def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
+    def has_dynamic_partition(
+        self, partitions_def_name: str, partition_key: str, code_location_name: str | None = None
+    ) -> bool:
         self._check_partitions_table()
         query = (
             db_select([DynamicPartitionsTable.c.partition])
@@ -2128,6 +2154,7 @@ class SqlEventLogStorage(EventLogStorage):
                 db.and_(
                     DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
                     DynamicPartitionsTable.c.partition == partition_key,
+                    self._code_location_filter(code_location_name),
                 )
             )
             .limit(1)
@@ -2138,7 +2165,10 @@ class SqlEventLogStorage(EventLogStorage):
         return len(results) > 0
 
     def add_dynamic_partitions(
-        self, partitions_def_name: str, partition_keys: Sequence[str]
+        self,
+        partitions_def_name: str,
+        partition_keys: Sequence[str],
+        code_location_name: str | None = None,
     ) -> None:
         self._check_partitions_table()
         with self.index_connection() as conn:
@@ -2147,26 +2177,29 @@ class SqlEventLogStorage(EventLogStorage):
                     db.and_(
                         DynamicPartitionsTable.c.partition.in_(partition_keys),
                         DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
+                        self._code_location_filter(code_location_name),
                     )
                 )
             ).fetchall()
-            existing_keys = set([row[0] for row in existing_rows])
-            new_keys = [
-                partition_key
-                for partition_key in partition_keys
-                if partition_key not in existing_keys
-            ]
+            existing_keys = {row[0] for row in existing_rows}
+            new_keys = [k for k in partition_keys if k not in existing_keys]
 
             if new_keys:
                 conn.execute(
                     DynamicPartitionsTable.insert(),
                     [
-                        dict(partitions_def_name=partitions_def_name, partition=partition_key)
+                        dict(
+                            partitions_def_name=partitions_def_name,
+                            partition=partition_key,
+                            code_location_name=code_location_name,
+                        )
                         for partition_key in new_keys
                     ],
                 )
 
-    def delete_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> None:
+    def delete_dynamic_partition(
+        self, partitions_def_name: str, partition_key: str, code_location_name: str | None = None
+    ) -> None:
         self._check_partitions_table()
         with self.index_connection() as conn:
             conn.execute(
@@ -2174,6 +2207,7 @@ class SqlEventLogStorage(EventLogStorage):
                     db.and_(
                         DynamicPartitionsTable.c.partitions_def_name == partitions_def_name,
                         DynamicPartitionsTable.c.partition == partition_key,
+                        self._code_location_filter(code_location_name),
                     )
                 )
             )

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -634,31 +634,51 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
             asset_key, after_storage_id
         )
 
-    def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
-        return self._storage.event_log_storage.get_dynamic_partitions(partitions_def_name)
-
-    def get_paginated_dynamic_partitions(
-        self, partitions_def_name: str, limit: int, ascending: bool, cursor: str | None = None
-    ) -> PaginatedResults[str]:
-        return self._storage.event_log_storage.get_paginated_dynamic_partitions(
-            partitions_def_name=partitions_def_name, limit=limit, ascending=ascending, cursor=cursor
+    def get_dynamic_partitions(
+        self, partitions_def_name: str, code_location_name: str | None = None
+    ) -> Sequence[str]:
+        return self._storage.event_log_storage.get_dynamic_partitions(
+            partitions_def_name, code_location_name=code_location_name
         )
 
-    def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
+    def get_paginated_dynamic_partitions(
+        self,
+        partitions_def_name: str,
+        limit: int,
+        ascending: bool,
+        cursor: str | None = None,
+        code_location_name: str | None = None,
+    ) -> PaginatedResults[str]:
+        return self._storage.event_log_storage.get_paginated_dynamic_partitions(
+            partitions_def_name=partitions_def_name,
+            limit=limit,
+            ascending=ascending,
+            cursor=cursor,
+            code_location_name=code_location_name,
+        )
+
+    def has_dynamic_partition(
+        self, partitions_def_name: str, partition_key: str, code_location_name: str | None = None
+    ) -> bool:
         return self._storage.event_log_storage.has_dynamic_partition(
-            partitions_def_name, partition_key
+            partitions_def_name, partition_key, code_location_name=code_location_name
         )
 
     def add_dynamic_partitions(
-        self, partitions_def_name: str, partition_keys: Sequence[str]
+        self,
+        partitions_def_name: str,
+        partition_keys: Sequence[str],
+        code_location_name: str | None = None,
     ) -> None:
         return self._storage.event_log_storage.add_dynamic_partitions(
-            partitions_def_name, partition_keys
+            partitions_def_name, partition_keys, code_location_name=code_location_name
         )
 
-    def delete_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> None:
+    def delete_dynamic_partition(
+        self, partitions_def_name: str, partition_key: str, code_location_name: str | None = None
+    ) -> None:
         return self._storage.event_log_storage.delete_dynamic_partition(
-            partitions_def_name, partition_key
+            partitions_def_name, partition_key, code_location_name=code_location_name
         )
 
     def get_event_tags_for_asset(

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -862,7 +862,10 @@ def _evaluate_sensor(
 
     if sensor_runtime_data.dynamic_partitions_requests:
         _handle_dynamic_partitions_requests(
-            sensor_runtime_data.dynamic_partitions_requests, instance, context
+            sensor_runtime_data.dynamic_partitions_requests,
+            instance,
+            context,
+            code_location_name=code_location.name,
         )
     if not (
         sensor_runtime_data.run_requests or sensor_runtime_data.automation_condition_evaluations
@@ -920,12 +923,15 @@ def _handle_dynamic_partitions_requests(
     ],
     instance: DagsterInstance,
     context: SensorLaunchContext,
+    code_location_name: str | None = None,
 ) -> None:
     for request in dynamic_partitions_requests:
         existent_partitions = []
         nonexistent_partitions = []
         for partition_key in request.partition_keys:
-            if instance.has_dynamic_partition(request.partitions_def_name, partition_key):
+            if instance.has_dynamic_partition(
+                request.partitions_def_name, partition_key, code_location_name=code_location_name
+            ):
                 existent_partitions.append(partition_key)
             else:
                 nonexistent_partitions.append(partition_key)
@@ -935,6 +941,7 @@ def _handle_dynamic_partitions_requests(
                 instance.add_dynamic_partitions(
                     request.partitions_def_name,
                     nonexistent_partitions,
+                    code_location_name=code_location_name,
                 )
                 context.logger.info(
                     "Added partition keys to dynamic partitions definition"
@@ -960,7 +967,11 @@ def _handle_dynamic_partitions_requests(
             if existent_partitions:
                 # TODO add a bulk delete method to the instance
                 for partition in existent_partitions:
-                    instance.delete_dynamic_partition(request.partitions_def_name, partition)
+                    instance.delete_dynamic_partition(
+                        request.partitions_def_name,
+                        partition,
+                        code_location_name=code_location_name,
+                    )
 
                 context.logger.info(
                     "Deleted partition keys from dynamic partitions definition"

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -645,6 +645,30 @@ def test_create_run_with_dynamic_partitioned_asset_stores_partitions_snapshot():
         )
 
 
+def test_caching_dynamic_partitions_loader_scoped_to_code_location():
+    from dagster._core.instance.types import CachingDynamicPartitionsLoader
+
+    with dg.instance_for_test() as instance:
+        instance.add_dynamic_partitions("fruits", ["apple", "banana"], code_location_name="loc_a")
+        instance.add_dynamic_partitions("fruits", ["cherry", "date"], code_location_name="loc_b")
+
+        loader_a = CachingDynamicPartitionsLoader(instance, code_location_name="loc_a")
+        loader_b = CachingDynamicPartitionsLoader(instance, code_location_name="loc_b")
+        loader_global = CachingDynamicPartitionsLoader(instance)
+
+        assert list(loader_a.get_dynamic_partitions("fruits")) == ["apple", "banana"]
+        assert list(loader_b.get_dynamic_partitions("fruits")) == ["cherry", "date"]
+        assert list(loader_global.get_dynamic_partitions("fruits")) == []
+
+        assert loader_a.has_dynamic_partition("fruits", "apple") is True
+        assert loader_a.has_dynamic_partition("fruits", "cherry") is False
+        assert loader_b.has_dynamic_partition("fruits", "cherry") is True
+        assert loader_b.has_dynamic_partition("fruits", "apple") is False
+
+        # results are cached — second call must not hit the db again
+        assert list(loader_a.get_dynamic_partitions("fruits")) == ["apple", "banana"]
+
+
 def test_get_required_daemon_types():
     from dagster._daemon.daemon import (
         BackfillDaemon,

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -5417,6 +5417,30 @@ class TestEventLogStorage:
         assert not storage.has_dynamic_partition(partitions_def_name="foo", partition_key="qux")
         assert not storage.has_dynamic_partition(partitions_def_name="bar", partition_key="foo")
 
+    def test_dynamic_partitions_isolated_across_code_locations(self, storage: EventLogStorage):
+        """Two code locations with the same partitions_def_name must not share partition keys."""
+        storage.add_dynamic_partitions("fruits", ["apple", "banana"], code_location_name="loc_a")
+        storage.add_dynamic_partitions("fruits", ["cherry", "date"], code_location_name="loc_b")
+
+        assert list(storage.get_dynamic_partitions("fruits", code_location_name="loc_a")) == [
+            "apple",
+            "banana",
+        ]
+        assert list(storage.get_dynamic_partitions("fruits", code_location_name="loc_b")) == [
+            "cherry",
+            "date",
+        ]
+        # Null namespace is still empty — didn't bleed into global scope
+        assert storage.get_dynamic_partitions("fruits", code_location_name=None) == []
+
+        assert storage.has_dynamic_partition("fruits", "apple", code_location_name="loc_a") is True
+        assert storage.has_dynamic_partition("fruits", "apple", code_location_name="loc_b") is False
+
+        storage.delete_dynamic_partition("fruits", "apple", code_location_name="loc_a")
+        assert storage.has_dynamic_partition("fruits", "apple", code_location_name="loc_a") is False
+        # loc_b still unaffected
+        assert storage.has_dynamic_partition("fruits", "cherry", code_location_name="loc_b") is True
+
     def test_concurrency(self, storage: EventLogStorage):
         if not storage.supports_global_concurrency_limits:
             pytest.skip("storage does not support global op concurrency")

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -14,7 +14,6 @@ from dagster._core.events.log import EventLogEntry
 from dagster._core.storage.config import pg_config
 from dagster._core.storage.event_log import (
     AssetKeyTable,
-    DynamicPartitionsTable,
     SqlEventLogStorage,
     SqlEventLogStorageMetadata,
     SqlEventLogStorageTable,
@@ -313,26 +312,6 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             else:
                 query = query.on_conflict_do_nothing()
             conn.execute(query)
-
-    def add_dynamic_partitions(
-        self, partitions_def_name: str, partition_keys: Sequence[str]
-    ) -> None:
-        if not partition_keys:
-            return
-
-        # Overload base implementation to push upsert logic down into the db layer
-        self._check_partitions_table()
-        with self.index_connection() as conn:
-            conn.execute(
-                db_dialects.postgresql.insert(DynamicPartitionsTable)
-                .values(
-                    [
-                        dict(partitions_def_name=partitions_def_name, partition=partition_key)
-                        for partition_key in partition_keys
-                    ]
-                )
-                .on_conflict_do_nothing(),
-            )
 
     def _connect(self) -> ContextManager[Connection]:
         return create_pg_connection(self._engine)


### PR DESCRIPTION
## Summary & Motivation

Two code locations that define a `DynamicPartitionsDefinition` with the same name silently share
partition keys, because the `dynamic_partitions` table has no concept of ownership. This means a
sensor in `loc_a` adding `"apple"` and a sensor in `loc_b` adding `"cherry"` results in both
locations seeing `["apple", "cherry"]` when they should each see only their own.

This PR fixes the bug by adding a nullable `code_location_name` column to the `dynamic_partitions`
table and threading it through every layer of the stack.

The storage layer gains a `_code_location_filter` helper that scopes all queries with
`WHERE code_location_name = ?` (or `IS NULL` for the legacy global namespace). The four public
`DagsterInstance` methods gain an optional `code_location_name` parameter:

```python
instance.add_dynamic_partitions("fruits", ["apple"], code_location_name="loc_a")
instance.get_dynamic_partitions("fruits", code_location_name="loc_a")  # -> ["apple"]
instance.get_dynamic_partitions("fruits", code_location_name="loc_b")  # -> []
```

The sensor daemon and GraphQL mutation layer now pass the code location name on all writes.
`CachingDynamicPartitionsLoader` gains an optional `code_location_name` constructor argument and
uses it implicitly on all reads, so sensor user code that calls
`context.caching_dynamic_partitions_loader.get_dynamic_partitions(name)` automatically queries
the correct namespace. `SensorEvaluationContext` passes `code_location_origin.location_name` when
constructing the loader.

All existing callers that omit `code_location_name` default to `None`, which maps to
`WHERE code_location_name IS NULL` -- the same global namespace as before. Existing data and
callers are fully unaffected.

Note: the auto-materialization daemon uses a workspace-level unscoped loader shared across all
code locations. Scoping that path requires per-asset location context and is left as follow-up work.

## How I Tested These Changes

New unit tests: a storage-layer isolation test verifying that two code locations with the same
partition definition name cannot read, check, or delete each other's keys, and a
`CachingDynamicPartitionsLoader` test verifying that a scoped loader returns only its own
location's partitions and that the cache key is stable.

Validation run locally:

```bash
pytest -q python_modules/dagster/dagster_tests/storage_tests/test_event_log.py -k dynamic_partitions_isolated_across_code_locations
pytest -q python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py -k caching_dynamic_partitions_loader_scoped_to_code_location
```

## Changelog

Added optional `code_location_name` parameter to `DagsterInstance.add_dynamic_partitions`,
`delete_dynamic_partition`, `get_dynamic_partitions`, and `has_dynamic_partition`. When supplied,
partition operations are scoped to the given code location, preventing two code locations that use
the same `DynamicPartitionsDefinition` name from sharing partition keys. Existing calls that omit
the parameter continue to use the global namespace with no behavior change.