### PR TITLE
Reduce number of postgres connections opened by dagster

### DIFF
--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -94,12 +94,12 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         )
         self._token_provider = token_provider
 
-        # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
         self._engine = create_pg_engine(
             self.postgres_url,
             self._token_provider,
             isolation_level="AUTOCOMMIT",
-            poolclass=db_pool.NullPool,
+            poolclass=db_pool.QueuePool,
+            pool_size=3,
         )
         self._event_watcher: SqlPollingEventWatcher | None = None
 
@@ -171,7 +171,10 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         conn_string: str, should_autocreate_tables: bool = True
     ) -> "PostgresEventLogStorage":
         engine = create_engine(
-            conn_string, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
+            conn_string, 
+            isolation_level="AUTOCOMMIT", 
+            poolclass=db_pool.QueuePool,
+            pool_size=3,
         )
         try:
             SqlEventLogStorageMetadata.drop_all(engine)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -86,12 +86,12 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         )
         self._token_provider = token_provider
 
-        # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
         self._engine = create_pg_engine(
             self.postgres_url,
             self._token_provider,
             isolation_level="AUTOCOMMIT",
-            poolclass=db_pool.NullPool,
+            poolclass=db_pool.QueuePool,
+            pool_size=3,
         )
 
         self._index_migration_cache = {}
@@ -160,7 +160,10 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         postgres_url: str, should_autocreate_tables: bool = True
     ) -> "PostgresRunStorage":
         engine = create_engine(
-            postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
+            postgres_url, 
+            isolation_level="AUTOCOMMIT", 
+            poolclass=db_pool.QueuePool,
+            pool_size=3,
         )
         try:
             RunStorageSqlMetadata.drop_all(engine)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -86,12 +86,12 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         )
         self._token_provider = token_provider
 
-        # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
         self._engine = create_pg_engine(
             self.postgres_url,
             self._token_provider,
             isolation_level="AUTOCOMMIT",
-            poolclass=db_pool.NullPool,
+            poolclass=db_pool.QueuePool,
+            pool_size=3,
         )
 
         # Stamp and create tables if the main table does not exist (we can't check alembic
@@ -158,7 +158,10 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         postgres_url: str, should_autocreate_tables: bool = True
     ) -> "PostgresScheduleStorage":
         engine = create_engine(
-            postgres_url, isolation_level="AUTOCOMMIT", poolclass=db_pool.NullPool
+            postgres_url, 
+            isolation_level="AUTOCOMMIT", 
+            poolclass=db_pool.QueuePool,
+            pool_size=3,
         )
         try:
             ScheduleStorageSqlMetadata.drop_all(engine)


### PR DESCRIPTION
## Summary & Motivation

An attempt to alleviate the large number of transient short-lived connections with low I/O observed in #20325

## Test Plan

This change has been tested on a mostly idle environment; have observed nearly a 50% reduction in CPU usage, and nearly 60% reduction in daily connection count. As the number of connections has reduced from nearly 750k per day to 317k per day, it appears that the connection pooling only applies on a per process / worker thread basis - and not for the whole application.

Marking this as a draft PR to invite further testing and feedback from other affected users.

## Changelog
Introduce QueuePool for `event_log`, `run_storage` and `schedule_storage` with a suggested `pool_size` of 3. This has not been tested under heavy workloads. The pool size can certainly be lowered, or made configurable - however; this doesn't look to fully resolve the issue more than the short-term. 