### PR TITLE
docs: add -p to mkdir command

### DIFF
--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -178,7 +178,8 @@ src
 Next, create a `sample_data.csv` file. This file will act as the data source for your Dagster pipeline:
 
 ```shell
-mkdir src/dagster_quickstart/defs/data && touch src/dagster_quickstart/defs/data/sample_data.csv
+mkdir -p src/dagster_quickstart/defs/data && \
+  touch src/dagster_quickstart/defs/data/sample_data.csv
 ```
 
 In your preferred editor, copy the following data into this file:


### PR DESCRIPTION
## Summary & Motivation

Without `-p`, I experience this on a mac.
```bash
$ mkdir src/dagster_quickstart/defs/data && touch src/dagster_quickstart/defs/data/sample_data.csv

=> mkdir: src/dagster_quickstart/defs: No such file or directory
```

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
