### PR TITLE
[docs] add debugpy attach-mode debugging guide

### DIFF
--- a/docs/docs/guides/log-debug/debugging/debugging-debugpy.md
+++ b/docs/docs/guides/log-debug/debugging/debugging-debugpy.md
@@ -20,13 +20,8 @@ from pathlib import Path
 
 from dagster import Definitions, definitions, load_from_defs_folder
 
-# Enable remote debugging — see README for usage
+# Enable remote debugging when DAGSTER_DEBUG is set.
 if os.environ.get("DAGSTER_DEBUG"):
-    # Suppress debugpy's "frozen modules" warning on Python 3.12+.
-    # Without this, debugpy emits noisy warnings about sys.stdlib_module_names
-    # that don't affect debugging but clutter the console output.
-    os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
-
     try:
         import debugpy
     except ImportError:

--- a/docs/docs/guides/log-debug/debugging/debugging-debugpy.md
+++ b/docs/docs/guides/log-debug/debugging/debugging-debugpy.md
@@ -12,39 +12,11 @@ The most reliable way to wire `debugpy` into Dagster is **attach mode**: run Dag
 
 In your project's definitions module (the one referenced by `tool.dg.project.code_location_target_module` or its `Definitions(...)` equivalent), gate a `debugpy.listen()` call behind an environment variable so it only runs when you ask for it:
 
-```python title="src/<my_project>/definitions.py"
-"""Dagster definitions entry point for this project."""
-
-import os
-from pathlib import Path
-
-from dagster import Definitions, definitions, load_from_defs_folder
-
-# Enable remote debugging when DAGSTER_DEBUG is set.
-if os.environ.get("DAGSTER_DEBUG"):
-    try:
-        import debugpy
-    except ImportError:
-        print("debugpy not installed — install it with your dev tooling.")
-        debugpy = None  # type: ignore[assignment]
-
-    if debugpy is not None:
-        try:
-            debugpy.listen(("localhost", 5678))
-            print("debugpy listening on port 5678 — attach your IDE debugger")
-        except RuntimeError:
-            # Subprocess: pause briefly so debugpy can sync breakpoints from VS Code
-            debugpy.trace_this_thread(True)
-            import time
-
-            time.sleep(0.5)
-
-
-@definitions
-def defs() -> Definitions:
-    """Load all Dagster definitions from the defs/ folder."""
-    return load_from_defs_folder(path_within_project=Path(__file__).parent)
-```
+<CodeExample
+  path="docs_snippets/docs_snippets/guides/log_debug/debugging/debugpy.py"
+  language="python"
+  title="src/<project_name>/definitions.py"
+/>
 
 The `RuntimeError` branch handles Dagster's multiprocess executor. When Dagster spawns a code-server or step subprocess it re-imports your definitions module; the second `listen()` call raises because the port is already in use, so we fall through to `trace_this_thread(True)` and a small sleep that lets VS Code sync breakpoints into the child process before it starts executing user code.
 

--- a/docs/docs/guides/log-debug/debugging/debugging-debugpy.md
+++ b/docs/docs/guides/log-debug/debugging/debugging-debugpy.md
@@ -1,0 +1,95 @@
+---
+title: 'Debugging Dagster with VS Code (debugpy)'
+description: Attach the VS Code debugger to a running Dagster process via debugpy.
+sidebar_position: 20
+---
+
+`pdb` (covered in the [previous guide](/guides/log-debug/debugging/debugging-pdb)) is great when you want to drop into a single asset on demand. When you want a full IDE debugging experience — breakpoints, watch expressions, and step-through debugging across the entire Dagster process — VS Code's [`debugpy`](https://github.com/microsoft/debugpy) is the way to go.
+
+The most reliable way to wire `debugpy` into Dagster is **attach mode**: run Dagster normally and connect the debugger to the already-running process. Trying to launch Dagster *through* `debugpy` (`request: "launch"` with `module: "dagster"`) ends up re-execing the CLI through `debugpy`'s launcher, which can break the gRPC code-server subprocess Dagster spawns — you'll see errors like `No module named dagster` from the child process.
+
+## Step 1: Add a `debugpy` listener to your project
+
+In your project's definitions module (the one referenced by `tool.dg.project.code_location_target_module` or its `Definitions(...)` equivalent), gate a `debugpy.listen()` call behind an environment variable so it only runs when you ask for it:
+
+```python title="src/<my_project>/definitions.py"
+"""Dagster definitions entry point for this project."""
+
+import os
+from pathlib import Path
+
+from dagster import Definitions, definitions, load_from_defs_folder
+
+# Enable remote debugging — see README for usage
+if os.environ.get("DAGSTER_DEBUG"):
+    # Suppress debugpy's "frozen modules" warning on Python 3.12+.
+    # Without this, debugpy emits noisy warnings about sys.stdlib_module_names
+    # that don't affect debugging but clutter the console output.
+    os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
+
+    try:
+        import debugpy
+    except ImportError:
+        print("debugpy not installed — install it with your dev tooling.")
+        debugpy = None  # type: ignore[assignment]
+
+    if debugpy is not None:
+        try:
+            debugpy.listen(("localhost", 5678))
+            print("debugpy listening on port 5678 — attach your IDE debugger")
+        except RuntimeError:
+            # Subprocess: pause briefly so debugpy can sync breakpoints from VS Code
+            debugpy.trace_this_thread(True)
+            import time
+
+            time.sleep(0.5)
+
+
+@definitions
+def defs() -> Definitions:
+    """Load all Dagster definitions from the defs/ folder."""
+    return load_from_defs_folder(path_within_project=Path(__file__).parent)
+```
+
+The `RuntimeError` branch handles Dagster's multiprocess executor. When Dagster spawns a code-server or step subprocess it re-imports your definitions module; the second `listen()` call raises because the port is already in use, so we fall through to `trace_this_thread(True)` and a small sleep that lets VS Code sync breakpoints into the child process before it starts executing user code.
+
+## Step 2: Add a VS Code launch configuration
+
+```json title=".vscode/launch.json"
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Dagster: Attach",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {"host": "localhost", "port": 5678},
+      "justMyCode": false
+    }
+  ]
+}
+```
+
+`justMyCode: false` is optional — set it if you want to step into Dagster's own code or third-party libraries.
+
+## Step 3: Run Dagster with debugging enabled
+
+```sh
+DAGSTER_DEBUG=1 dg dev
+```
+
+When you see `debugpy listening on port 5678` in the terminal, switch to VS Code and run the **Dagster: Attach** configuration. Set breakpoints in your asset, sensor, or schedule code and trigger a materialisation as normal — execution will pause at your breakpoints.
+
+The same pattern works with `dagster dev`, `dagster job execute`, and any custom scripts that import your project's definitions module.
+
+## Why not `request: "launch"`?
+
+`request: "launch"` with `module: "dagster"` makes VS Code re-execute the Dagster CLI through `debugpy`'s launcher. Dagster then spawns a gRPC code-server subprocess to load your code, and that child process inherits an environment from the launcher that doesn't always have `dagster` resolvable on `sys.path`. Symptoms include:
+
+```
+DagsterUserCodeProcessError: gRPC server exited with return code 0 while starting up
+…
+ModuleNotFoundError: No module named 'dagster'
+```
+
+Attach mode sidesteps this entirely — Dagster bootstraps with a normal venv, the code-server subprocess works as usual, and `debugpy` only ever runs as a listener inside an already-bootstrapped process.

--- a/examples/docs_snippets/docs_snippets/guides/log_debug/debugging/debugpy.py
+++ b/examples/docs_snippets/docs_snippets/guides/log_debug/debugging/debugpy.py
@@ -1,0 +1,30 @@
+"""Dagster definitions entry point for this project."""
+
+import os
+import time
+from pathlib import Path
+
+from dagster import Definitions, definitions, load_from_defs_folder
+
+# Enable remote debugging when DAGSTER_DEBUG is set.
+if os.environ.get("DAGSTER_DEBUG"):
+    try:
+        import debugpy
+    except ImportError:
+        print("debugpy not installed — install it with your dev tooling.")
+        debugpy = None  # type: ignore[assignment]
+
+    if debugpy is not None:
+        try:
+            debugpy.listen(("localhost", 5678))
+            print("debugpy listening on port 5678 — attach your IDE debugger")
+        except RuntimeError:
+            # Subprocess: pause briefly so debugpy can sync breakpoints from VS Code
+            debugpy.trace_this_thread(True)
+            time.sleep(0.5)
+
+
+@definitions
+def defs() -> Definitions:
+    """Load all Dagster definitions from the defs/ folder."""
+    return load_from_defs_folder(path_within_project=Path(__file__).parent)


### PR DESCRIPTION
## Summary & Motivation

Adds `debugging-debugpy.md` next to the existing `debugging-pdb.md` under `guides/log-debug/debugging/`. Documents a working pattern for full IDE debugging of Dagster with VS Code via `debugpy`.

The current docs only cover `pdb` (asset-level breakpoint), which doesn't help when you want to step through sensors, schedules, definitions loading, or anything outside an asset's execution. Users on the obvious path — `request: "launch"` with `module: "dagster"` — hit subprocess errors like `No module named dagster` because Dagster's gRPC code-server spawn doesn't survive being re-exec'd through `debugpy`'s launcher (see [#33761](https://github.com/dagster-io/dagster/issues/33761) for one such report).

The PR documents the **attach-mode** pattern that does work:

1. Gate a `debugpy.listen(("localhost", 5678))` call in `definitions.py` behind `DAGSTER_DEBUG=1`.
2. Add a VS Code attach configuration.
3. Run `DAGSTER_DEBUG=1 dg dev`.
4. Attach when you see the listener log line.

The page also handles the multiprocess executor case (subprocess re-imports the definitions module → second `listen()` call raises → fall through to `trace_this_thread()` + small sleep so VS Code can sync breakpoints into the child).

## How I Tested These Changes

- This pattern is in production use across multiple projects; it has been the reliable path through the multiprocess executor and across `dagster dev` / `dg dev` / `dagster job execute` / scripts.
- Markdown content checked locally; no code changes, no tests touched.
