### PR TITLE
[core] fix: asset check targets current asset materialization

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_checks/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_checks/asset_check_result.py
@@ -155,25 +155,31 @@ class AssetCheckResult(
             all_check_names_by_asset_key.setdefault(check_key.asset_key, set()).add(check_key.name)
         check_key = self.resolve_target_check_key(all_check_names_by_asset_key)
 
-        input_asset_info = step_context.maybe_fetch_and_get_input_asset_version_info(
-            check_key.asset_key
-        )
-        from dagster._core.events import DagsterEventType
+        from dagster._core.storage.event_log.base import AssetRecordsFilter
 
-        if (
-            input_asset_info is not None
-            and input_asset_info.event_type == DagsterEventType.ASSET_MATERIALIZATION
-        ):
+        asset_materializations = step_context.instance.fetch_materializations(
+            AssetRecordsFilter(
+                asset_key=check_key.asset_key,
+                # Target latest materialization of given asset partition
+                asset_partitions=[step_context.partition_key]
+                if step_context.has_partition_key
+                else None,
+            ),
+            limit=1,
+        )
+        if asset_materializations.records:
+            mat = asset_materializations.records[0]
             target_materialization_data = AssetCheckEvaluationTargetMaterializationData(
-                run_id=input_asset_info.run_id,
-                storage_id=input_asset_info.storage_id,
-                timestamp=input_asset_info.timestamp,
+                run_id=mat.event_log_entry.run_id,
+                storage_id=mat.storage_id,
+                timestamp=mat.timestamp,
             )
         else:
             target_materialization_data = None
 
+        # Unpartitioned asset check can exist for partitioned asset
+        check_spec = assets_def_for_check.get_spec_for_check_key(check_key)
         if step_context.has_partition_key:
-            check_spec = assets_def_for_check.get_spec_for_check_key(check_key)
             if check_spec.partitions_def is not None:
                 partition = step_context.partition_key
             else:
@@ -189,7 +195,7 @@ class AssetCheckResult(
             target_materialization_data=target_materialization_data,
             severity=self.severity,
             description=self.description,
-            blocking=assets_def_for_check.get_spec_for_check_key(check_key).blocking,
+            blocking=check_spec.blocking,
             partition=partition,
         )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_decorator_with_check_specs.py
@@ -12,6 +12,7 @@ from dagster import (
 from dagster._core.definitions.asset_selection import AssetCheckKeysSelection, AssetSelection
 from dagster._core.execution.context.compute import AssetExecutionContext
 from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecordStatus
+from dagster._core.storage.event_log.base import AssetRecordsFilter
 
 
 def test_asset_check_same_op() -> None:
@@ -972,3 +973,89 @@ def test_arbitary_asset_check_specs() -> None:
     check_eval = check_evals[0]
     assert check_eval.asset_key == dg.AssetKey("asset1")
     assert check_eval.check_name == "check1"
+
+
+def test_unpartitioned_asset_with_unpartitioned_asset_check() -> None:
+    """For unpartitioned asset, inline check yielded after Output must target this run's materialization."""
+
+    @dg.asset(check_specs=[dg.AssetCheckSpec("check1", asset="asset1")])
+    def asset1() -> Iterable:
+        yield dg.Output(None)
+        yield dg.AssetCheckResult(check_name="check1", passed=True)
+
+    with dg.instance_for_test() as instance:
+        result = dg.materialize(assets=[asset1], instance=instance)
+        assert result.success
+
+        (check_eval,) = result.get_asset_check_evaluations()
+        assert check_eval.partition is None
+        assert check_eval.target_materialization_data is not None
+        assert check_eval.target_materialization_data.run_id == result.run_id
+
+
+def test_partitioned_asset_with_unpartitioned_asset_check() -> None:
+    """Regression: unpartitioned inline check on partitioned asset must target the current partition.
+
+    Injects a concurrent partition B materialization between Output and AssetCheckResult.
+    The check has no partitions_def but runs inside a partitioned step, so it must still
+    use a partition-scoped lookup rather than the global last_materialization_record.
+    """
+    partitions_def = dg.StaticPartitionsDefinition(["A", "B"])
+
+    @dg.asset(
+        partitions_def=partitions_def,
+        check_specs=[dg.AssetCheckSpec("check1", asset="asset1")],
+    )
+    def asset1(context: dg.AssetExecutionContext) -> Iterable:
+        yield dg.Output(None)
+        context.instance.report_runless_asset_event(
+            dg.AssetMaterialization(asset_key=asset1.key, partition="B")
+        )
+        yield dg.AssetCheckResult(check_name="check1", passed=True)
+
+    with dg.instance_for_test() as instance:
+        result = dg.materialize(assets=[asset1], instance=instance, partition_key="A")
+        assert result.success
+
+        (check_eval,) = result.get_asset_check_evaluations()
+        assert check_eval.partition is None  # check itself is unpartitioned
+        assert check_eval.target_materialization_data is not None
+        assert check_eval.target_materialization_data.run_id == result.run_id
+        mat = instance.fetch_materializations(
+            AssetRecordsFilter(asset_key=asset1.key, asset_partitions=["A"]), limit=1
+        ).records[0]
+        assert check_eval.target_materialization_data.storage_id == mat.storage_id
+
+
+def test_partitioned_asset_with_partitioned_asset_check() -> None:
+    """Regression: partitioned check after Output must target the current partition's mat.
+
+    Injects a concurrent partition B materialization between Output and AssetCheckResult to
+    simulate a backfill race; the global last_materialization_record would point to B without
+    the partition-scoped fix.
+    """
+    partitions_def = dg.StaticPartitionsDefinition(["A", "B"])
+
+    @dg.asset(
+        partitions_def=partitions_def,
+        check_specs=[dg.AssetCheckSpec("check1", asset="asset1", partitions_def=partitions_def)],
+    )
+    def asset1(context: dg.AssetExecutionContext) -> Iterable:
+        yield dg.Output(None)
+        context.instance.report_runless_asset_event(
+            dg.AssetMaterialization(asset_key=asset1.key, partition="B")
+        )
+        yield dg.AssetCheckResult(check_name="check1", passed=True)
+
+    with dg.instance_for_test() as instance:
+        result = dg.materialize(assets=[asset1], instance=instance, partition_key="A")
+        assert result.success
+
+        (check_eval,) = result.get_asset_check_evaluations()
+        assert check_eval.partition == "A"
+        assert check_eval.target_materialization_data is not None
+        assert check_eval.target_materialization_data.run_id == result.run_id
+        mat = instance.fetch_materializations(
+            AssetRecordsFilter(asset_key=asset1.key, asset_partitions=["A"]), limit=1
+        ).records[0]
+        assert check_eval.target_materialization_data.storage_id == mat.storage_id


### PR DESCRIPTION
## Summary & Motivation
Fixes bug described in https://github.com/dagster-io/dagster/discussions/33786#:~:text=3.%20Bug%3A%20wrong%20target_materialization_data%20for%20partitioned%20assets%20(backfill%20race)


When multiple partitions run concurrently in a backfill, target_materialization_data is resolved via the global
last_materialization_record on AssetRecord. This record is updated on every materialization across all
partitions, so it can point to a different partition's record by the time the check for partition A is evaluated —
even if partition B Output was already emitted. This is most probably regression from times when asset checks were not partitioned.


How to reproduce the issue:
- Run asset materialization with inline asset check (high concurrency backfill).
```python
"""
Minimal reproducible example

Run with:
    dagster dev -f repro.py
"""

from collections.abc import Iterator

import dagster as dg

partitions_def = dg.DailyPartitionsDefinition(start_date="2024-01-01", end_date="2025-01-01")


@dg.asset(
    partitions_def=partitions_def,
    check_specs=[
        dg.AssetCheckSpec("check", asset="orders", partitions_def=partitions_def)
    ],
)
def orders(context: dg.AssetExecutionContext) -> Iterator:
    yield dg.Output({"partition": context.partition_key})
    yield dg.AssetCheckResult(check_name="check", passed=True)


defs = dg.Definitions(assets=[orders])
```
- Asset check fetches asset metadata from last global materialization, but should use last "current partition" materialization instead.
- In event logs this weird warning appears:
<img width="1562" height="133" alt="Screenshot 2026-05-07 at 15 28 30" src="https://github.com/user-attachments/assets/fcd50a54-a1ad-431d-b360-df5c79287b9a" />
- In asset check timeline, it shows as Missing (due to not matching correct asset materialization), but when I select given partition, it shows as success.
<img width="1243" height="566" alt="Screenshot 2026-05-07 at 15 27 55" src="https://github.com/user-attachments/assets/9d001ee0-7433-442a-a641-43ac2ea4bc85" />


## Test Plan
I included tests to cover expected behavior for all valid asset X asset_check combinations.
Then I implemented fix to make them pass.

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
