### PR TITLE
[dagster-docker] fix: correct registry param name in PipesDockerClient docstring (#33425)

### DIFF
--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -64,7 +64,7 @@ class PipesDockerClient(PipesClient, TreatAsResourceParam):
     Args:
         env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the
             container.
-        register (Optional[Mapping[str, str]]): An optional dict of registry credentials to login to
+        registry (Optional[Mapping[str, str]]): An optional dict of registry credentials to login to
             the docker client.
         context_injector (Optional[PipesContextInjector]): A context injector to use to inject
             context into the docker container process. Defaults to :py:class:`PipesEnvContextInjector`.


### PR DESCRIPTION
## Summary & Motivation

Fixes #33425.

The `Args:` block of `PipesDockerClient` documented its second parameter as `register`, but the actual `__init__` signature uses `registry` (and exposes it as `self.registry`). The rendered API reference therefore listed a parameter name that doesn't exist. This PR renames the docstring entry so the public docs match the public API.

```diff
-        register (Optional[Mapping[str, str]]): An optional dict of registry credentials to login to
+        registry (Optional[Mapping[str, str]]): An optional dict of registry credentials to login to
             the docker client.
```

## Test Plan

Single-character docstring change. No behavioral divergence; existing `dagster-docker` unit tests cover `PipesDockerClient.__init__`. Verified locally with `ruff check` / `ruff format --check` on the modified file (clean).

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/dagster-io/dagster.git /tmp/repro && cd /tmp/repro

# --- BEFORE (origin/master) ---
git checkout origin/master
grep -n "register\|registry" python_modules/libraries/dagster-docker/dagster_docker/pipes.py | head -3
# Expected:
#   67: register (Optional[Mapping[str, str]]): An optional dict of registry credentials to login to
#   78: registry: Mapping[str, str] | None = None,
#   83: self.registry = check.opt_mapping_param(registry, "registry", key_type=str, value_type=str)
# (docstring uses 'register', signature uses 'registry' — public name mismatch.)

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/dagster.git feat/33425-fix-pipes-docstring-typo
git checkout FETCH_HEAD
grep -n "register\|registry" python_modules/libraries/dagster-docker/dagster_docker/pipes.py | head -3
# Expected:
#   67: registry (Optional[Mapping[str, str]]): An optional dict of registry credentials to login to
#   78: registry: Mapping[str, str] | None = None,
#   83: self.registry = check.opt_mapping_param(registry, "registry", key_type=str, value_type=str)
# (docstring matches signature.)
```

## Changelog

```release-note
docs(dagster-docker): fix `PipesDockerClient` docstring — parameter is `registry`, not `register`.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against `dagster-io/dagster` master; the reproducer block above was used during development and is the same one a reviewer can paste verbatim.*
