### PR TITLE
[dagster-dg-cli] fix: bound requests.* calls so the CLI fails fast (#33747)

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/organization.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/organization.py
@@ -11,6 +11,13 @@ from dagster_dg_cli.cli.api.formatters import format_organization_settings, form
 from dagster_dg_cli.cli.api.shared import handle_api_errors
 from dagster_dg_cli.cli.response_schema import dg_response_schema
 
+# Default timeout (seconds) for plain `requests.*` calls in this module.
+# `requests` defaults to *no* timeout, which causes the CLI to hang
+# indefinitely on a misconfigured organization_url or an unavailable Plus
+# instance. 30s is comfortably long enough for an idp-metadata XML upload
+# while still surfacing a hard failure to the user. See #33747.
+DG_API_REQUEST_TIMEOUT_SECONDS = 30
+
 
 @click.command(name="get", cls=DgClickCommand)
 @click.option(
@@ -134,6 +141,9 @@ def upload_saml_metadata_command(
 
     with handle_api_errors(ctx, output_json):
         with open(metadata_file_path, "rb") as f:
+            # Bound the POST so a misconfigured organization_url or an
+            # unavailable Plus instance fails fast instead of hanging forever
+            # (requests' default is no timeout). See dagster-io/dagster#33747.
             response = requests.post(
                 url=f"{config.organization_url}/upload_idp_metadata",
                 headers={
@@ -141,6 +151,7 @@ def upload_saml_metadata_command(
                     "Dagster-Cloud-Organization": organization,
                 },
                 files={"metadata.xml": f},
+                timeout=DG_API_REQUEST_TIMEOUT_SECONDS,
             )
 
         response.raise_for_status()
@@ -194,12 +205,16 @@ def remove_saml_metadata_command(
     )
 
     with handle_api_errors(ctx, output_json):
+        # Bound the POST so a misconfigured organization_url or an
+        # unavailable Plus instance fails fast instead of hanging forever
+        # (requests' default is no timeout). See dagster-io/dagster#33747.
         response = requests.post(
             url=f"{config.organization_url}/remove_idp_metadata",
             headers={
                 "Dagster-Cloud-Api-Token": api_token,
                 "Dagster-Cloud-Organization": organization,
             },
+            timeout=DG_API_REQUEST_TIMEOUT_SECONDS,
         )
 
         response.raise_for_status()

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_integrity.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_integrity.py
@@ -1,9 +1,14 @@
+import ast
+import pathlib
 import shutil
 import subprocess
 
+import dagster_dg_cli
 from dagster_dg_cli.cli import cli
 from dagster_dg_core.utils import DgClickCommand, DgClickGroup
 from dagster_test.dg_utils.utils import ProxyRunner, isolated_dg_venv
+
+_REQUESTS_HTTP_VERBS = {"get", "post", "put", "delete", "patch", "head", "request"}
 
 
 # Important that all nodes of the command tree inherit from one of our customized click
@@ -44,3 +49,52 @@ def test_isolated_dg_executes():
         assert dg_path is not None, "dg executable not found in PATH"
         assert dg_path.startswith(str(venv_path)), "dg executable not resolving to local venv"
         assert subprocess.check_output(["dg", "--help"])
+
+
+def _iter_requests_calls_without_timeout(tree: ast.AST):
+    """Yield ast.Call nodes that look like ``requests.<verb>(...)`` and have
+    no ``timeout=`` keyword argument. Picks up both bare ``requests.get(...)``
+    and aliased ``r.get(...)`` where the receiver is named ``requests`` (the
+    common pattern in this package).
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        if func.attr not in _REQUESTS_HTTP_VERBS:
+            continue
+        # `requests.<verb>(...)` — receiver must be a Name whose id is "requests"
+        if not isinstance(func.value, ast.Name) or func.value.id != "requests":
+            continue
+        if any(kw.arg == "timeout" for kw in node.keywords):
+            continue
+        yield node
+
+
+def test_all_requests_calls_have_timeout():
+    """Regression guard for #33747.
+
+    The default for ``requests.<verb>(...)`` is no timeout, which means a
+    misconfigured URL or unreachable Plus instance hangs the CLI forever.
+    Every direct ``requests`` call inside ``dagster_dg_cli`` must pass
+    ``timeout=...`` explicitly.
+    """
+    pkg_root = pathlib.Path(dagster_dg_cli.__file__).parent
+    offenders: list[str] = []
+    for path in pkg_root.rglob("*.py"):
+        # Skip vendored / test data; we only want the shipped CLI sources.
+        if any(part.endswith("_tests") or part == "tests" for part in path.parts):
+            continue
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - shouldn't happen
+            continue
+        for call in _iter_requests_calls_without_timeout(tree):
+            offenders.append(f"{path.relative_to(pkg_root.parent)}:{call.lineno}")
+
+    assert offenders == [], (
+        "requests.* calls without an explicit `timeout=` kwarg "
+        "(see #33747 — the CLI hangs forever otherwise):\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Summary & Motivation

Fixes #33747.

`requests.<verb>(...)` defaults to **no timeout** ([requests docs](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) — "without a timeout, your code may hang for minutes or more"). Two `dg plus saml ...` commands ship `requests.post(...)` calls without `timeout=`, so a misconfigured `organization_url` or an unavailable Dagster Plus instance hangs the CLI indefinitely instead of failing fast.

This PR:

1. Adds a module-level `DG_API_REQUEST_TIMEOUT_SECONDS = 30` constant in `dagster_dg_cli/cli/api/organization.py` (long enough for an idp-metadata XML upload, short enough to surface a hard failure to the user).
2. Passes `timeout=DG_API_REQUEST_TIMEOUT_SECONDS` on both `requests.post(...)` call sites:
   - L137 — `dg plus saml upload-identity-provider-metadata`
   - L197 — `dg plus saml remove-identity-provider-metadata`
3. Adds a load-bearing **AST-based regression test** to `dagster_dg_cli_tests/cli_tests/test_integrity.py` (`test_all_requests_calls_have_timeout`) that walks every shipped `dagster_dg_cli` module and asserts every `requests.<verb>(...)` call passes an explicit `timeout=` kwarg. The test fails on `origin/master` (2 offenders) and passes on this branch.

The third call site mentioned in the original report (`utils.py:582` for `dg integrations docs` against `dagster-marketplace.vercel.app`) was already removed by an unrelated refactor since the issue was filed; the AST regression test would catch any reintroduction.

## Test Plan

Local checks:

- `ruff check python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/organization.py python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_integrity.py` → clean.
- `ruff format --check` on the same files → clean.
- The new AST regression test runs without importing dagster (it only uses `ast`, `pathlib`, and the package's `__file__`), so it executes correctly even in a slim test env. I exercised the AST-walking logic standalone against both refs to confirm it fails on master and passes on the branch:
  ```
  $ git checkout origin/master && python3 .../regression_logic.py
  offenders on master: ['python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/organization.py:197',
                       'python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/api/organization.py:137']
  $ git checkout feat/33747-add-timeouts-dg-cli-requests && python3 .../regression_logic.py
  offenders on AFTER branch: []
  ```

I did **not** run the full `dagster-dg-cli` pytest suite locally because it requires `make dev_install` of the umbrella dagster package, which is an hour-long bootstrap. Buildkite will exercise the full suite. The change is purely additive (one new kwarg per call site, one new constant, one new test) — so the risk of breakage in the existing test suite is limited to the test-import cost added by the new test.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/dagster-io/dagster.git /tmp/repro && cd /tmp/repro

# --- BEFORE (origin/master) — the AST scan finds two unbounded calls ---
git checkout origin/master
python3 - <<'PY'
import ast, pathlib
VERBS = {"get","post","put","delete","patch","head","request"}
root = pathlib.Path("python_modules/libraries/dagster-dg-cli/dagster_dg_cli")
offenders = []
for p in root.rglob("*.py"):
    if any(part.endswith("_tests") or part == "tests" for part in p.parts): continue
    for n in ast.walk(ast.parse(p.read_text())):
        if (isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
                and n.func.attr in VERBS and isinstance(n.func.value, ast.Name)
                and n.func.value.id == "requests"
                and not any(kw.arg == "timeout" for kw in n.keywords)):
            offenders.append(f"{p}:{n.lineno}")
print(offenders)
PY
# Expected: ['.../organization.py:197', '.../organization.py:137'] — both bare requests.post() calls.

# --- AFTER (this PR) — same scan returns empty ---
git fetch https://github.com/jbbqqf/dagster.git feat/33747-add-timeouts-dg-cli-requests
git checkout FETCH_HEAD
python3 - <<'PY'
import ast, pathlib
VERBS = {"get","post","put","delete","patch","head","request"}
root = pathlib.Path("python_modules/libraries/dagster-dg-cli/dagster_dg_cli")
offenders = []
for p in root.rglob("*.py"):
    if any(part.endswith("_tests") or part == "tests" for part in p.parts): continue
    for n in ast.walk(ast.parse(p.read_text())):
        if (isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
                and n.func.attr in VERBS and isinstance(n.func.value, ast.Name)
                and n.func.value.id == "requests"
                and not any(kw.arg == "timeout" for kw in n.keywords)):
            offenders.append(f"{p}:{n.lineno}")
print(offenders)
PY
# Expected: [] — every requests.* call now passes timeout=DG_API_REQUEST_TIMEOUT_SECONDS.
```

The exact same logic is what the new pytest regression `test_all_requests_calls_have_timeout` runs — so once installed, `pytest python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_integrity.py -k requests_calls_have_timeout` shows the same divergence.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Existing call without `timeout=` reaches a slow/unreachable endpoint | misconfigured `organization_url` | now raises `requests.exceptions.Timeout` after 30 s instead of hanging forever | manual reasoning + AST regression test |
| 2 | A future contributor adds a new `requests.post(...)` without `timeout=` | new call site in `dagster_dg_cli/**/*.py` | `test_all_requests_calls_have_timeout` fails CI with the offending `path:line` | new pytest regression |
| 3 | A `requests.post(..., timeout=...)` call is added correctly | any future call site with explicit timeout | regression test passes | new pytest regression |

## Risk / blast radius

Additive only — adds one keyword argument to two call sites and one new test function. The 30 s default is slack-side: the existing `requests.post` had no timeout at all, so anything that completed before now will continue to complete. Worst case for a slow but functioning Plus instance: a 30 s ceiling on a single SAML metadata round-trip, well above the typical p99.

## Changelog

```release-note
fix(dagster-dg-cli): `dg plus saml upload-identity-provider-metadata` and `dg plus saml remove-identity-provider-metadata` no longer hang forever on a slow or unreachable Plus instance — they now time out after 30 s.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against `dagster-io/dagster` master; the reproducer block above was used during development and is the same one a reviewer can paste verbatim.*
