### PR TITLE
fix(components): canonicalize absolute paths in resolve_source_relative_path (#33808)

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/context.py
+++ b/python_modules/dagster/dagster/components/resolved/context.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import traceback
 from collections.abc import Mapping, Sequence
@@ -210,8 +211,13 @@ class ResolutionContext:
 
     def resolve_source_relative_path(self, value: str) -> Path:
         path = Path(value)
-        if not self.source_position_tree or path.is_absolute():
-            # no source, can't transform
+        if path.is_absolute():
+            # collapse `..` segments without resolving symlinks or touching the filesystem,
+            # so a path like `{{ project_root }}/../sibling` becomes canonical even when
+            # the target does not yet exist on disk.
+            return Path(os.path.normpath(str(path)))
+        if not self.source_position_tree:
+            # no source, can't transform a relative path
             return path
 
         source_dir = Path(self.source_position_tree.position.filename).parent

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_source_relative_path.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_source_relative_path.py
@@ -1,0 +1,122 @@
+import os
+from pathlib import Path
+
+from dagster.components.resolved.context import ResolutionContext
+from dagster_shared.yaml_utils.source_position import LineCol, SourcePosition, SourcePositionTree
+
+
+def _context_for(yaml_file: Path) -> ResolutionContext:
+    tree = SourcePositionTree(
+        position=SourcePosition(
+            filename=str(yaml_file),
+            start=LineCol(1, 0),
+            end=LineCol(1, 0),
+        ),
+        children={},
+    )
+    return ResolutionContext.default().with_source_position_tree(tree)
+
+
+def test_absolute_path_with_parent_segments_is_normalized(tmp_path: Path) -> None:
+    # Regression for https://github.com/dagster-io/dagster/issues/33808 — a path like
+    # `{{ context.project_root }}/../sibling` renders to an absolute path containing `..`
+    # and must be canonicalized so downstream consumers (e.g. DbtProject) see a clean path.
+    parent = tmp_path / "parent"
+    dagster_project = parent / "dagster_project"
+    sibling = parent / "sibling"
+    sibling.mkdir(parents=True)
+    dagster_project.mkdir()
+    yaml_file = dagster_project / "defs.yaml"
+    yaml_file.touch()
+
+    ctx = _context_for(yaml_file)
+    raw = str(dagster_project / ".." / "sibling")
+
+    resolved = ctx.resolve_source_relative_path(raw)
+
+    assert ".." not in resolved.parts
+    assert resolved == Path(os.path.normpath(raw))
+
+
+def test_absolute_path_with_parent_segments_normalized_when_target_does_not_exist(
+    tmp_path: Path,
+) -> None:
+    # Mirrors the production scenario from #33808: dbt-prepare has not yet created the
+    # target directory at config-resolution time, so the helper must normalize without
+    # touching the filesystem.
+    parent = tmp_path / "parent"
+    dagster_project = parent / "dagster_project"
+    dagster_project.mkdir(parents=True)
+    yaml_file = dagster_project / "defs.yaml"
+    yaml_file.touch()
+
+    ctx = _context_for(yaml_file)
+    nonexistent = parent / "not_yet_created"
+    raw = str(dagster_project / ".." / "not_yet_created")
+    assert not nonexistent.exists()
+
+    resolved = ctx.resolve_source_relative_path(raw)
+
+    assert ".." not in resolved.parts
+    assert resolved == Path(os.path.normpath(raw))
+
+
+def test_canonical_absolute_path_is_unchanged(tmp_path: Path) -> None:
+    target = tmp_path / "abc"
+    target.mkdir()
+    yaml_file = tmp_path / "defs.yaml"
+    yaml_file.touch()
+
+    ctx = _context_for(yaml_file)
+
+    # normpath of an already-canonical path returns it unchanged on every platform,
+    # without resolving symlinks (e.g. macOS /var -> /private/var).
+    assert ctx.resolve_source_relative_path(str(target)) == Path(os.path.normpath(str(target)))
+
+
+def test_absolute_path_branch_does_not_resolve_symlinks(tmp_path: Path) -> None:
+    # Sean Mackesey's review concern: `Path.resolve()` follows symlinks, which would silently
+    # change paths in symlinked Buildkite/Docker layouts and on macOS where /var -> /private/var.
+    # The helper must use normpath semantics, not resolve semantics.
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    link_dir = tmp_path / "link"
+    try:
+        link_dir.symlink_to(real_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        # Windows without developer mode can't create symlinks; skip the assertion in that case.
+        return
+
+    yaml_file = tmp_path / "defs.yaml"
+    yaml_file.touch()
+    ctx = _context_for(yaml_file)
+
+    resolved = ctx.resolve_source_relative_path(str(link_dir))
+
+    # The symlink path is preserved — we did not silently rewrite to the target.
+    assert resolved == link_dir
+
+
+def test_relative_path_resolved_against_source_dir(tmp_path: Path) -> None:
+    source_dir = tmp_path / "src"
+    target = tmp_path / "target"
+    source_dir.mkdir()
+    target.mkdir()
+    yaml_file = source_dir / "defs.yaml"
+    yaml_file.touch()
+
+    ctx = _context_for(yaml_file)
+
+    # The relative branch still calls .resolve() (preserving prior behavior); compare
+    # against the same operation so the test is robust on platforms where tmp_path
+    # itself contains symlinks.
+    assert ctx.resolve_source_relative_path("../target") == target.resolve()
+
+
+def test_relative_path_without_source_position_tree_is_unchanged() -> None:
+    ctx = ResolutionContext.default()
+
+    resolved = ctx.resolve_source_relative_path("relative/path")
+
+    assert resolved == Path("relative/path")
+    assert not resolved.is_absolute()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -115,6 +115,7 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
             description="The path to the dbt project or a mapping defining a DbtProject",
             examples=[
                 "{{ project_root }}/path/to/dbt_project",
+                "{{ project_root }}/../sibling_dbt_project",
                 {
                     "project_dir": "path/to/dbt_project",
                     "profile": "your_profile",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py
@@ -35,7 +35,9 @@ from dagster_dbt.cli.app import project_app_typer_click_object
 from dagster_dbt.components.dbt_project.component import (
     _set_resolution_context,
     get_projects_from_dbt_component,
+    resolve_dbt_project,
 )
+from dagster_dbt.dbt_project_manager import DbtProjectArgsManager
 from dagster_dbt_tests.dbt_projects import test_metadata_path
 from dagster_dg_cli.cli import cli as dg_cli
 from dagster_shared import check
@@ -280,6 +282,55 @@ def test_exclude(dbt_path: Path) -> None:
 DEPENDENCY_ON_DBT_PROJECT_LOCATION_PATH = (
     Path(__file__).parent / "code_locations" / "dependency_on_dbt_project_location"
 )
+
+
+def test_resolve_dbt_project_normalizes_parent_traversal_path(tmp_path: Path) -> None:
+    """Regression for https://github.com/dagster-io/dagster/issues/33808.
+
+    A project layout where the dbt project is a sibling of the Dagster code location
+    must support `project: "{{ project_root }}/../dbt_project"` in defs.yaml. After
+    Jinja renders this to an absolute path containing `..` segments,
+    `ResolutionContext.resolve_source_relative_path` must collapse the `..` so
+    downstream `DbtProject` construction sees a canonical path. The fix lives in
+    that helper rather than in `resolve_dbt_project` so every component using
+    `resolve_source_relative_path` benefits.
+    """
+    from dagster_shared.yaml_utils.source_position import (
+        LineCol,
+        SourcePosition,
+        SourcePositionTree,
+    )
+
+    parent = tmp_path / "parent"
+    dagster_project = parent / "dagster_project"
+    dbt_project = parent / "dbt_project"
+    dagster_project.mkdir(parents=True)
+    dbt_project.mkdir()
+    yaml_file = dagster_project / "defs.yaml"
+    yaml_file.touch()
+
+    tree = SourcePositionTree(
+        position=SourcePosition(
+            filename=str(yaml_file),
+            start=LineCol(1, 0),
+            end=LineCol(1, 0),
+        ),
+        children={},
+    )
+    ctx = ResolutionContext.default().with_source_position_tree(tree)
+
+    # Mimic the Jinja-rendered output of `{{ project_root }}/../dbt_project`: an
+    # absolute string containing a `..` segment.
+    rendered = str(dagster_project / ".." / "dbt_project")
+    assert ".." in Path(rendered).parts
+
+    manager = resolve_dbt_project(ctx, rendered)
+
+    assert isinstance(manager, DbtProjectArgsManager)
+    project_dir = Path(manager.args.project_dir)
+    assert ".." not in project_dir.parts
+    assert project_dir.name == "dbt_project"
+    assert project_dir.parent.name == "parent"
 
 
 def test_dependency_on_dbt_project():


### PR DESCRIPTION
## Summary & Motivation

Resolves #33808.

A user with a project layout where the dbt project is a sibling of the Dagster code location:

```
parent_folder/
├── dagster_project/   (defs.yaml lives in src/.../defs/)
└── dbt_project/
```

cannot reference the dbt project via `project: "{{ context.project_root }}/../dbt_project"` in `defs.yaml` for `DbtProjectComponent`. After Jinja renders the template, the result is an absolute path containing `..` segments. The early `path.is_absolute()` branch in `ResolutionContext.resolve_source_relative_path` returned the path **unmodified**, so `..` segments were never collapsed. The relative branch already calls `.resolve()`, so the two branches were asymmetric. Downstream `DbtProject` then operated on a non-canonical path and failed.

This same pattern is used in `dagster-open-platform`, so it's a real-world ergonomic gap when migrating a Pythonic project to the components-based model.

### Approach

Centralize the canonicalization invariant in `ResolutionContext.resolve_source_relative_path`:

```python
if path.is_absolute():
    return Path(os.path.normpath(str(path)))
```

`os.path.normpath` is used in preference to `Path.resolve()` so that:

1. `..` segments are collapsed deterministically without filesystem I/O — required for the production scenario where `dbt-prepare` has not yet created the target directory at config-resolution time.
2. **Symlinks are not silently followed.** `Path.resolve()` would rewrite paths on symlinked Buildkite/Docker layouts and on macOS (where `/var` is a symlink to `/private/var`), silently changing downstream dbt manifest paths and asset metadata keys between versions. The issue does not require symlink resolution; `..` collapse is sufficient.

The fix lives at the helper layer rather than in `resolve_dbt_project` so any component using `resolve_source_relative_path` (today: `dagster-dbt`, `dagster-databricks`; tomorrow: anything with a path field) inherits the canonicalization invariant transparently.

## Test Plan

Run from repo root:

```bash
# Unit tests for the helper (new file)
pytest python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_source_relative_path.py -xvs

# Full resolution_tests suite — confirms no regression in adjacent helpers
pytest python_modules/dagster/dagster_tests/components_tests/resolution_tests/

# Caller-boundary regression in dagster-dbt
pytest python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component.py::test_resolve_dbt_project_normalizes_parent_traversal_path -xvs
```

New unit test cases in `test_source_relative_path.py`:
- Absolute path with `..` is normalized (proves the fix; verified to fail on un-fixed code)
- Absolute path with `..` is normalized **even when the target does not exist on disk** — matches the #33808 production scenario before `dbt-prepare` runs
- Already-canonical absolute path passes through unchanged
- Absolute path branch does **not** resolve symlinks (guards the macOS / Buildkite / Docker symlink concern above)
- Relative path still resolved against the source position tree's parent (regression)
- Relative path with no source position tree is unchanged (regression)

Caller-boundary regression test in `test_dbt_project_component.py::test_resolve_dbt_project_normalizes_parent_traversal_path` reconstructs the reporter's parent-folder layout end-to-end and verifies `resolve_dbt_project` returns a `DbtProjectArgsManager` with a normalized `project_dir`.

Locally on Windows, `make ruff` is clean; the resolution_tests suite (62 prior + 6 new = 68 total) passes. The new dagster-dbt test was AST-validated locally but not executed due to a local protobuf gencode/runtime mismatch in the dev env (unrelated to this change); CI will exercise it.

## Changelog

[dagster-dbt] `DbtProjectComponent` now correctly resolves dbt project paths containing `..` segments (e.g. `{{ context.project_root }}/../sibling_dbt_project`), enabling layouts where the dbt project is a sibling or parent of the Dagster code location.