### PR TITLE
[buildkite] Rebalance k8s job-pod CPU defaults (cpu 1500→1000, docker_cpu 500→2000)

### DIFF
--- a/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
+++ b/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
@@ -22,7 +22,7 @@ ECR_LOGIN_FAILURE_EXIT_CODE = 200
 
 
 class ResourceRequests:
-    def __init__(self, cpu: str, memory: str | None, docker_cpu: str = "500m") -> None:
+    def __init__(self, cpu: str, memory: str | None, docker_cpu: str = "2000m") -> None:
         self._cpu = cpu
         self._memory = memory
         self._docker_cpu = docker_cpu
@@ -390,7 +390,7 @@ class CommandStepBuilder:
                     "command": ["dockerd-entrypoint.sh"],
                     "resources": {
                         "requests": {
-                            "cpu": self._resources.docker_cpu if self._resources else "500m"
+                            "cpu": self._resources.docker_cpu if self._resources else "2000m"
                         }
                     },
                     "env": [

--- a/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
+++ b/.buildkite/buildkite-shared/buildkite_shared/step_builders/command_step_builder.py
@@ -304,7 +304,7 @@ class CommandStepBuilder:
         cpu = (
             self._resources.cpu
             if self._resources
-            else ("1500m" if self._requires_docker else "500m")
+            else ("1000m" if self._requires_docker else "500m")
         )
         memory = self._resources.memory if self._resources else None
         return {


### PR DESCRIPTION
## Summary

Rebalance the two CPU-request defaults for k8s job pods produced by `CommandStepBuilder`:

- **`docker_cpu`** (DinD sidecar): **500m → 2000m**
- **`cpu`** (main test-runner container, when `_requires_docker=True`): **1500m → 1000m**

Net default pod request goes from `1500 + 500 = 2000m` to `1000 + 2000 = 3000m` — closer to what these pods actually consume, and a better signal for Karpenter to pack against.

## Scope: k8s only

`_get_resources()` is only referenced inside `_base_k8s_settings()`, which is only emitted when the step's queue is `KUBERNETES_GKE` or `KUBERNETES_EKS` (see `build()`). The EC2 queues (`MEDIUM`, `DOCKER`, `WINDOWS`) emit the `docker` plugin instead and ignore `ResourceRequests` entirely — those instances run `AgentsPerInstance=1`, so the agent already has the whole host. **No EC2 pipelines are affected by this change.**

## Why each part

**docker_cpu**: `docker-compose up` runs against the DinD sidecar, so every container compose brings up (postgres, redis, pgbouncer, dagster-webserver, user code) shares the sidecar's request. 500m for that whole stack is severely under-provisioned for integration tests. Almost no callers override `docker_cpu` (only image-build pipelines in `internal`), so lifting the default fixes every compose-based step at once.

**cpu (main container)**: For test steps the main container is just the pytest harness — Python interpreter, dagster client, asserts. The actual work happens in the sidecar. 1500m is over-provisioned for the dominant case; 1000m leaves comfortable headroom for pytest workers and result handling without burning bin-packing density. The shift of capacity from main → sidecar is the central rebalance here.

## Evidence

Snapshot of ~2,300 active buildkite-agent pods on EKS (us-west-2):

| pods/node | failure rate | exit 1 (test) | exit 255 (abort) | OOMKilled |
|-----------|--------------|---------------|------------------|-----------|
| 0–19      | ~1%          | 0%            | 0.9%             | 0         |
| 20–39     | ~3%          | 1.0%          | 1.2%             | 0         |
| 40–59     | ~4%          | 1.8%          | 1.6%             | 0         |
| 60+       | ~5%          | **3.2%**      | 0.9%             | 0         |

Failure rate scales monotonically with node density. Decomposing by exit code, it's specifically **exit 1 (test-logic failure)** that climbs with density — not crashes, not OOMs, not agent disconnects. That's the classic noisy-neighbor *timing-sensitive fixture wait* signature: under host contention the throttled DinD takes 8s instead of 2s to bring up postgres, \`pg_isready\` retries time out, and the test reports failure.

## Test plan

- [ ] Watch flake rate for integration pipelines (dagster-docker, k8s, celery-k8s, backcompat) over the next 24–48h.
- [ ] Spot-check \`kubectl describe pod\` on a fresh compose test to confirm sidecar \`requests.cpu\` is 2000m and main container is 1000m.
- [ ] Confirm EKS scheduling latency hasn't regressed (Karpenter should comfortably provision for the higher total request).
- [ ] Watch for any pipelines where 1000m main-container is too low (would surface as new test timeouts on previously-fine pipelines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)