### PR TITLE
fix(config): reject unknown kwargs to Config subclasses

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -33,6 +33,7 @@ from dagster._config.pythonic_config.typing_utils import BaseConfigMeta
 from dagster._core.definitions.definition_config_schema import DefinitionConfigSchema
 from dagster._core.errors import (
     DagsterInvalidConfigDefinitionError,
+    DagsterInvalidConfigError,
     DagsterInvalidDefinitionError,
     DagsterInvalidInvocationError,
     DagsterInvalidPythonicConfigDefinitionError,
@@ -197,6 +198,27 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
             field.alias if field.alias else field_key: (field_key, field)
             for field_key, field in model_fields(self.__class__).items()
         }
+
+        # Reject kwargs that don't correspond to any declared field. Pydantic's
+        # default extra="ignore" would silently drop them, hiding typos until
+        # the missing attribute surfaced at runtime. PermissiveConfig opts in to
+        # the open-ended behavior via extra="allow".
+        if model_config(self.__class__).get("extra") != "allow":
+            undeclared = [
+                config_key
+                for config_key in config_dict
+                if config_key not in field_info_by_config_key
+            ]
+            if undeclared:
+                declared = sorted(field_info_by_config_key)
+                raise DagsterInvalidConfigError(
+                    f"Received unexpected config entries {sorted(undeclared)!r} for "
+                    f"'{self.__class__.__name__}'. Expected: {declared!r}. "
+                    "Use 'PermissiveConfig' if open-ended inputs are intentional.",
+                    [],
+                    config_dict,
+                )
+
         for config_key, value in config_dict.items():
             field_info = field_info_by_config_key.get(config_key)
             field = None

--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -183,6 +183,8 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
 
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     def __init__(self, **config_dict) -> None:
         """This constructor is overridden to handle any remapping of raw config dicts to
         the appropriate config classes. For example, discriminated unions are represented
@@ -197,6 +199,15 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
             field.alias if field.alias else field_key: (field_key, field)
             for field_key, field in model_fields(self.__class__).items()
         }
+        populate_by_name = model_config(self.__class__).get("populate_by_name")
+        if populate_by_name:
+            field_info_by_config_key.update(
+                {
+                    field_key: (field_key, field)
+                    for field_key, field in model_fields(self.__class__).items()
+                }
+            )
+
         for config_key, value in config_dict.items():
             field_info = field_info_by_config_key.get(config_key)
             field = None
@@ -245,7 +256,11 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
 
         for field_key, field in model_fields(self.__class__).items():
             config_key = field.alias if field.alias else field_key
-            if field.is_required() and config_key not in modified_data_by_config_key:
+            if (
+                field.is_required()
+                and config_key not in modified_data_by_config_key
+                and (not populate_by_name or field_key not in modified_data_by_config_key)
+            ):
                 modified_data_by_config_key[config_key] = (
                     field.default if field.default != PydanticUndefined else None
                 )

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -228,10 +228,14 @@ class ConfigurableResourceFactory(  # ty: ignore[conflicting-metaclass]
 
         # We pull the values from the Pydantic config object, which may cast values
         # to the correct type under the hood - useful in particular for enums
+        fields = model_fields(self.__class__)
+        data_without_resources_config_keys = {
+            fields[key].alias or key if key in fields else key for key in data_without_resources
+        }
         casted_data_without_resources = {
             k: v
             for k, v in self._convert_to_config_dictionary().items()
-            if k in data_without_resources
+            if k in data_without_resources_config_keys
         }
         resolved_config_dict = config_dictionary_from_values(casted_data_without_resources, schema)
 

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -1006,3 +1006,62 @@ def test_permissive_extra_field_via_dot():
     # confirm it's in dict and convert_to_config_dictionary
     expected = {"foo": 10, "bar": "hello", "baz": [1, 2, 3]}
     assert conf.model_dump() == expected
+
+
+def test_config_rejects_unknown_kwargs() -> None:
+    """`Config` subclasses should raise when instantiated with kwargs that don't
+    match any declared field. Previously these were silently dropped, so a typo
+    like `MyConfig(my_strr=...)` would survive validation and surface as a
+    missing-attribute error far from its source.
+
+    `PermissiveConfig` is the escape hatch for open-ended inputs.
+    """
+
+    class MyOpConfig(dg.Config):
+        person_name: str
+
+    # Sanity: declared field works.
+    MyOpConfig(person_name="Alice")
+
+    # Unknown kwarg should raise a clear error pointing at the bad name.
+    with pytest.raises(dg.DagsterInvalidConfigError, match="nonexistent_config_value"):
+        MyOpConfig(person_name="Alice", nonexistent_config_value=1)
+
+    # And again when passing via the RunConfig+materialize path the user hit.
+    class MyAssetConfig(dg.Config):
+        person_name: str
+
+    @dg.asset
+    def greeting(config: MyAssetConfig) -> str:
+        return f"hello {config.person_name}"
+
+    with pytest.raises(dg.DagsterInvalidConfigError, match="nonexistent_config_value"):
+        dg.materialize(
+            [greeting],
+            run_config=dg.RunConfig(
+                {"greeting": MyAssetConfig(person_name="Alice", nonexistent_config_value=1)}
+            ),
+        )
+
+
+def test_permissive_config_keeps_unknown_kwargs() -> None:
+    """`PermissiveConfig` continues to accept unknown kwargs."""
+
+    class OpenConfig(dg.PermissiveConfig):
+        person_name: str
+
+    conf = OpenConfig(person_name="Alice", whatever=1)
+    assert conf.person_name == "Alice"
+    assert conf.whatever == 1  # ty: ignore[unresolved-attribute]
+
+
+def test_configurable_resource_rejects_unknown_kwargs() -> None:
+    """Resources inherit from `Config`, so the same rule should apply."""
+
+    class MyResource(dg.ConfigurableResource):
+        url: str
+
+    MyResource(url="https://example.com")
+
+    with pytest.raises(dg.DagsterInvalidConfigError, match="not_a_field"):
+        MyResource(url="https://example.com", not_a_field=1)

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -1071,3 +1071,41 @@ def test_permissive_extra_field_via_dot():
     # confirm it's in dict and convert_to_config_dictionary
     expected = {"foo": 10, "bar": "hello", "baz": [1, 2, 3]}
     assert conf.model_dump() == expected
+
+
+def test_config_rejects_unknown_kwargs() -> None:
+    class MyConfig(dg.Config):
+        person_name: str
+
+    with pytest.raises(pydantic.ValidationError) as exc_info:
+        MyConfig(person_name="Alice", nonexistent_config_value=1)
+
+    assert exc_info.value.errors()[0]["type"] == "extra_forbidden"
+
+
+def test_config_alias_with_populate_by_name() -> None:
+    class MyConfig(dg.Config):
+        model_config = pydantic.ConfigDict(populate_by_name=True)
+        python_name: str = pydantic.Field(alias="configName")
+
+    assert MyConfig(configName="alias").python_name == "alias"
+    assert MyConfig(python_name="name").python_name == "name"
+
+
+def test_config_alias_without_populate_by_name() -> None:
+    class MyConfig(dg.Config):
+        python_name: str = pydantic.Field(alias="configName")
+
+    assert MyConfig(configName="alias").python_name == "alias"
+    with pytest.raises(pydantic.ValidationError):
+        MyConfig(python_name="name")
+
+
+def test_configurable_resource_rejects_unknown_kwargs() -> None:
+    class MyResource(dg.ConfigurableResource):
+        url: str
+
+    with pytest.raises(pydantic.ValidationError) as exc_info:
+        MyResource(url="https://example.com", not_a_field=1)
+
+    assert exc_info.value.errors()[0]["type"] == "extra_forbidden"

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -1092,6 +1092,24 @@ def test_config_alias_with_populate_by_name() -> None:
     assert MyConfig(python_name="name").python_name == "name"
 
 
+def test_configurable_resource_alias_with_populate_by_name() -> None:
+    class MyResource(dg.ConfigurableResource):
+        model_config = pydantic.ConfigDict(populate_by_name=True)
+        python_name: str | None = pydantic.Field(default=None, alias="configName")
+
+    @dg.op
+    def read_resource(resource: MyResource) -> str | None:
+        return resource.python_name
+
+    @dg.job
+    def resource_job() -> None:
+        read_resource()
+
+    result = resource_job.execute_in_process(resources={"resource": MyResource(python_name="name")})
+
+    assert result.output_for_node("read_resource") == "name"
+
+
 def test_config_alias_without_populate_by_name() -> None:
     class MyConfig(dg.Config):
         python_name: str = pydantic.Field(alias="configName")


### PR DESCRIPTION
## Summary & motivation

`Config` subclasses silently discard unknown constructor arguments. A typo such as `MyConfig(person_name="Alice", nonexistent_config_value=1)` succeeds, then fails later when code expects the missing value.

`Config` now uses Pydantic's `extra="forbid"` policy, while `PermissiveConfig` keeps `extra="allow"`. Alias-aware initialization accepts either an alias or the Python field name when `populate_by_name=True`, including through `ConfigurableResource` runtime conversion.

Before: unknown arguments disappear, Python field names can be rejected, and an accepted resource value can become `None` at runtime. After: unknown arguments raise `extra_forbidden`, and both accepted names reach runtime intact.

Closes https://github.com/dagster-io/dagster/issues/30669.

## Test plan

<details>
<summary>Raw before/after output</summary>

Against `upstream/master`:

```console
$ git worktree add /tmp/dagster-config-base upstream/master
$ git show HEAD:python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py \
    > /tmp/dagster-config-base/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
$ (cd /tmp/dagster-config-base && uv run --python python3.12 --frozen \
    --project python_modules/dagster --extra test --group test pytest \
    python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py \
    -k 'config_rejects_unknown_kwargs or config_alias or permissive_extra_field_via_dot or configurable_resource' -q)
5 failed, 1 passed
python field name: string_type ('externalName',)
unknown_present False {'known': 'ok'}
resource runtime value: None
```

This branch:

```console
$ uv run --python python3.12 --frozen --project python_modules/dagster \
    --extra test --group test pytest \
    python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py \
    -k 'config_rejects_unknown_kwargs or config_alias or permissive_extra_field_via_dot or configurable_resource' -q
6 passed, 32 deselected
resource runtime value: supplied-by-name
```

</details>

## Hygiene

Ruff and `ty` pass.

## Changelog

[dagster] `Config` subclasses now reject unknown constructor arguments instead of silently dropping them. `PermissiveConfig` is unchanged.
