### PR TITLE
Cache schema-introspection DB calls

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/cached_has_table_method.py
+++ b/python_modules/dagster/dagster/_core/storage/cached_has_table_method.py
@@ -1,0 +1,68 @@
+from collections.abc import Callable
+from functools import wraps
+from typing import TypeVar
+
+T_Storage = TypeVar("T_Storage")
+
+
+CACHED_HAS_TABLE_METHOD_CACHE_FIELD = "_cached_has_table_method_cache__internal__"
+
+
+def cached_has_table_method(
+    has_table_method: Callable[[T_Storage, str], bool],
+) -> Callable[[T_Storage, str], bool]:
+    """Cache True results of the Storage class ``has_table(self, table_name: str) -> bool`` method.
+
+    Can only be used once per class. The internal cache is keyed only by table name, not by method
+    name, so two decorated methods on the same class would share a cache.
+
+    Usage:
+
+        .. code-block:: python
+
+            class Storage:
+                @cached_has_table_method
+                def has_table(self, table_name: str) -> bool:
+                    ...
+
+            storage = Storage()
+            assert storage.has_table("existing_table")  # compute value and cache the True result
+            assert storage.has_table("existing_table")  # return cached True
+            if not storage.has_table("new_table"):
+                do_upgrade_migration()
+            assert storage.has_table("new_table") is True   # re-compute value, cache the new True
+            assert storage.has_table("new_table") is True   # return cached True
+
+    Intended for use when:
+        - There is any chance that the method might be called frequently; AND
+        - There is an assumption that table names passed to the method will not be DROPed.
+
+    This prevents frequent and useless schema-introspection calls to
+    ``db.inspect(conn).get_table_names()``, which in turn prevents frequent and useless database
+    queries on hot paths. On postgres, ``get_table_names()`` expands to
+
+        .. code-block:: sql
+
+            SELECT pg_catalog.pg_class.relname FROM pg_catalog.pg_class JOIN pg_catalog.pg_namespace
+            ON pg_catalog.pg_namespace.oid = pg_catalog.pg_class.relnamespace WHERE
+            pg_catalog.pg_class.relkind = ANY (ARRAY['r', 'p']) AND
+            pg_catalog.pg_class.relpersistence != 't' AND
+            pg_catalog.pg_table_is_visible(pg_catalog.pg_class.oid) AND
+            pg_catalog.pg_namespace.nspname != 'pg_catalog'
+    """
+
+    @wraps(has_table_method)
+    def _cached_has_table_method_wrapper(self: T_Storage, table_name: str) -> bool:
+        if not hasattr(self, CACHED_HAS_TABLE_METHOD_CACHE_FIELD):
+            setattr(self, CACHED_HAS_TABLE_METHOD_CACHE_FIELD, {})
+
+        cache: dict[str, bool] = getattr(self, CACHED_HAS_TABLE_METHOD_CACHE_FIELD)
+
+        if table_name in cache:
+            return cache[table_name]
+        result = has_table_method(self, table_name)
+        if result:
+            cache[table_name] = result
+        return result
+
+    return _cached_has_table_method_wrapper

--- a/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
@@ -9,6 +9,7 @@ from typing import Any
 import sqlalchemy as db
 from sqlalchemy.pool import NullPool
 
+from dagster._core.storage.cached_has_table_method import cached_has_table_method
 from dagster._core.storage.event_log.base import EventLogCursor
 from dagster._core.storage.event_log.schema import SqlEventLogStorageMetadata
 from dagster._core.storage.event_log.sql_event_log import SqlEventLogStorage
@@ -64,6 +65,7 @@ class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def index_connection(self):
         return self._connect()
 
+    @cached_has_table_method
     def has_table(self, table_name: str) -> bool:
         with self._engine.connect() as conn:
             return bool(self._engine.dialect.has_table(conn, table_name))

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -101,6 +101,7 @@ from dagster._core.types.pagination import PaginatedResults, StorageIdCursor
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._time import datetime_from_timestamp, get_current_timestamp, utc_datetime_from_naive
 from dagster._utils import PrintFn
+from dagster._utils.cached_method import cached_if_true_no_arg_method
 from dagster._utils.concurrency import (
     ClaimedSlotInfo,
     ConcurrencyClaimStatus,
@@ -183,8 +184,14 @@ class SqlEventLogStorage(EventLogStorage):
         """
 
     @abstractmethod
+    # @dagster._core.storage.cached_has_table_method.cached_has_table_method
     def has_table(self, table_name: str) -> bool:
-        """This method checks if a table exists in the database."""
+        """This method checks if a table exists in the database.
+
+        Concrete subclasses should apply ``@cached_has_table_method`` to this method so that
+        ``True`` results are cached for the lifetime of the instance, avoiding frequent and useless
+        schema-introspection ``db.inspect(conn).get_table_names()`` queries on hot paths.
+        """
 
     def prepare_insert_event(self, event: EventLogEntry) -> Any:
         """Helper method for preparing the event log SQL insertion statement.  Abstracted away to
@@ -232,6 +239,7 @@ class SqlEventLogStorage(EventLogStorage):
             column_names = [x.get("name") for x in db.inspect(conn).get_columns(AssetKeyTable.name)]
             return column_name in column_names
 
+    @cached_if_true_no_arg_method
     def has_asset_key_index_cols(self) -> bool:
         return self.has_asset_key_col("last_materialization_timestamp")
 
@@ -1226,9 +1234,11 @@ class SqlEventLogStorage(EventLogStorage):
                 )
         return results
 
+    @cached_if_true_no_arg_method
     def can_read_asset_status_cache(self) -> bool:
         return self.has_asset_key_col("cached_status_data")
 
+    @cached_if_true_no_arg_method
     def can_write_asset_status_cache(self) -> bool:
         return self.has_asset_key_col("cached_status_data")
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
@@ -15,6 +15,7 @@ from watchdog.observers import Observer
 import dagster._check as check
 from dagster._annotations import public
 from dagster._config import StringSource
+from dagster._core.storage.cached_has_table_method import cached_has_table_method
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.event_log.base import EventLogCursor
 from dagster._core.storage.event_log.schema import SqlEventLogStorageMetadata
@@ -122,6 +123,7 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def index_connection(self):
         return self._connect()
 
+    @cached_has_table_method
     def has_table(self, table_name: str) -> bool:
         engine = create_engine(
             self._conn_string,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -37,6 +37,7 @@ from dagster._core.events import (
 )
 from dagster._core.events.log import EventLogEntry
 from dagster._core.instance import RUNLESS_RUN_ID
+from dagster._core.storage.cached_has_table_method import cached_has_table_method
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.base import EventLogCursor, EventLogRecord, EventRecordsFilter
 from dagster._core.storage.event_log.schema import (
@@ -161,6 +162,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             if os.path.splitext(os.path.basename(filename))[0] != INDEX_SHARD_NAME
         ]
 
+    @cached_has_table_method
     def has_table(self, table_name: str) -> bool:
         conn_string = self.conn_string_for_shard(INDEX_SHARD_NAME)
         engine = create_engine(

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -79,6 +79,7 @@ from dagster._daemon.types import DaemonHeartbeat
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._time import datetime_from_timestamp, get_current_datetime, utc_datetime_from_naive
 from dagster._utils import PrintFn
+from dagster._utils.cached_method import cached_if_true_no_arg_method
 from dagster._utils.merger import merge_dicts
 
 
@@ -788,11 +789,13 @@ class SqlRunStorage(RunStorage):
 
     # Checking for migrations
 
+    @cached_if_true_no_arg_method
     def has_run_stats_index_cols(self) -> bool:
         with self.connect() as conn:
             column_names = [x.get("name") for x in db.inspect(conn).get_columns(RunsTable.name)]
             return "start_time" in column_names and "end_time" in column_names
 
+    @cached_if_true_no_arg_method
     def has_bulk_actions_selector_cols(self) -> bool:
         with self.connect() as conn:
             column_names = [
@@ -800,11 +803,13 @@ class SqlRunStorage(RunStorage):
             ]
             return "selector_id" in column_names
 
+    @cached_if_true_no_arg_method
     def has_backfill_id_column(self) -> bool:
         with self.connect() as conn:
             column_names = [x.get("name") for x in db.inspect(conn).get_columns(RunsTable.name)]
             return "backfill_id" in column_names
 
+    @cached_if_true_no_arg_method
     def has_bulk_action_job_name_column(self) -> bool:
         with self.connect() as conn:
             column_names = [
@@ -812,6 +817,7 @@ class SqlRunStorage(RunStorage):
             ]
             return "job_name" in column_names
 
+    @cached_if_true_no_arg_method
     def has_backfill_tags_table(self) -> bool:
         with self.connect() as conn:
             return BackfillTagsTable.name in db.inspect(conn).get_table_names()
@@ -1054,9 +1060,10 @@ class SqlRunStorage(RunStorage):
         if self.has_bulk_action_job_name_column():
             values["job_name"] = partition_backfill.job_name
 
+        has_backfill_tags_table = self.has_backfill_tags_table()
         with self.connect() as conn:
             conn.execute(BulkActionsTable.insert().values(**values))
-            if self.has_backfill_tags_table():
+            if has_backfill_tags_table:
                 tags_to_insert = partition_backfill.tags
                 if len(tags_to_insert.items()) > 0:
                     conn.execute(

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -48,6 +48,7 @@ from dagster._core.storage.sqlalchemy_compat import (
 from dagster._serdes import serialize_value
 from dagster._time import datetime_from_timestamp, get_current_datetime
 from dagster._utils import PrintFn
+from dagster._utils.cached_method import cached_if_true_no_arg_method
 
 T_NamedTuple = TypeVar("T_NamedTuple", bound=NamedTuple)
 
@@ -165,6 +166,7 @@ class SqlScheduleStorage(ScheduleStorage):
 
     def add_instigator_state(self, state: InstigatorState) -> InstigatorState:
         check.inst_param(state, "state", InstigatorState)
+        has_instigators_table = self.has_instigators_table()
         with self.connect() as conn:
             try:
                 conn.execute(
@@ -182,7 +184,7 @@ class SqlScheduleStorage(ScheduleStorage):
                 ) from exc
 
             # try writing to the instigators table
-            if self._has_instigators_table(conn):
+            if has_instigators_table:
                 self._add_or_update_instigators_table(conn, state)
 
         return state
@@ -199,7 +201,8 @@ class SqlScheduleStorage(ScheduleStorage):
             "job_body": serialize_value(state),
             "update_timestamp": get_current_datetime(),
         }
-        if self.has_instigators_table():
+        has_instigators_table = self.has_instigators_table()
+        if has_instigators_table:
             values["selector_id"] = state.selector_id
 
         with self.connect() as conn:
@@ -208,7 +211,7 @@ class SqlScheduleStorage(ScheduleStorage):
                 .where(JobTable.c.job_origin_id == state.instigator_origin_id)
                 .values(**values)
             )
-            if self._has_instigators_table(conn):
+            if has_instigators_table:
                 self._add_or_update_instigators_table(conn, state)
 
         return state
@@ -222,10 +225,11 @@ class SqlScheduleStorage(ScheduleStorage):
                 f"InstigatorState {origin_id} is not present in storage"
             )
 
+        has_instigators_table = self.has_instigators_table()
         with self.connect() as conn:
             conn.execute(JobTable.delete().where(JobTable.c.job_origin_id == origin_id))
 
-            if self._has_instigators_table(conn):
+            if has_instigators_table:
                 if not self._jobs_has_selector_state(conn, selector_id):
                     conn.execute(
                         InstigatorsTable.delete().where(
@@ -268,20 +272,21 @@ class SqlScheduleStorage(ScheduleStorage):
         return query
 
     @property
+    @cached_if_true_no_arg_method
     def supports_batch_queries(self) -> bool:
         return self.has_instigators_table() and self.has_built_index(SCHEDULE_TICKS_SELECTOR_ID)
 
+    @cached_if_true_no_arg_method
     def has_instigators_table(self) -> bool:
         with self.connect() as conn:
-            return self._has_instigators_table(conn)
+            table_names = db.inspect(conn).get_table_names()
+            return "instigators" in table_names
 
-    def _has_instigators_table(self, conn: Connection) -> bool:
-        table_names = db.inspect(conn).get_table_names()
-        return "instigators" in table_names
-
-    def _has_asset_daemon_asset_evaluations_table(self, conn: Connection) -> bool:
-        table_names = db.inspect(conn).get_table_names()
-        return "asset_daemon_asset_evaluations" in table_names
+    @cached_if_true_no_arg_method
+    def _has_asset_daemon_asset_evaluations_table(self) -> bool:
+        with self.connect() as conn:
+            table_names = db.inspect(conn).get_table_names()
+            return "asset_daemon_asset_evaluations" in table_names
 
     def get_batch_ticks(
         self,
@@ -472,8 +477,7 @@ class SqlScheduleStorage(ScheduleStorage):
 
     @property
     def supports_auto_materialize_asset_evaluations(self) -> bool:
-        with self.connect() as conn:
-            return self._has_asset_daemon_asset_evaluations_table(conn)
+        return self._has_asset_daemon_asset_evaluations_table()
 
     def add_auto_materialize_asset_evaluations(
         self,
@@ -567,17 +571,20 @@ class SqlScheduleStorage(ScheduleStorage):
 
     def wipe(self) -> None:
         """Clears the schedule storage."""
+        has_instigators_table = self.has_instigators_table()
+        has_asset_daemon_asset_evaluations_table = self._has_asset_daemon_asset_evaluations_table()
         with self.connect() as conn:
             # https://stackoverflow.com/a/54386260/324449
             conn.execute(JobTable.delete())
             conn.execute(JobTickTable.delete())
-            if self._has_instigators_table(conn):
+            if has_instigators_table:
                 conn.execute(InstigatorsTable.delete())
-            if self._has_asset_daemon_asset_evaluations_table(conn):
+            if has_asset_daemon_asset_evaluations_table:
                 conn.execute(AssetDaemonAssetEvaluationsTable.delete())
 
     # MIGRATIONS
 
+    @cached_if_true_no_arg_method
     def has_secondary_index_table(self) -> bool:
         with self.connect() as conn:
             return "secondary_indexes" in db.inspect(conn).get_table_names()

--- a/python_modules/dagster/dagster/_utils/cached_method.py
+++ b/python_modules/dagster/dagster/_utils/cached_method.py
@@ -1,1 +1,56 @@
+from collections.abc import Callable
+from functools import wraps
+from typing import TypeVar
+
 from dagster_shared.utils.cached_method import cached_method as cached_method
+
+S = TypeVar("S")
+
+CACHED_IF_TRUE_NO_ARG_METHOD_CACHE_FIELD = "_cached_if_true_no_arg_method_cache__internal__"
+
+
+def cached_if_true_no_arg_method(method: Callable[[S], bool]) -> Callable[[S], bool]:
+    """Caches the results of a zero-argument method call, only if it returns True.
+
+    Usage:
+
+        .. code-block:: python
+
+            class MyClass:
+                @cached_if_true_no_arg_method
+                def col_c1_is_present_on_table_t1(self) -> bool:
+                    ...
+
+                @property
+                @cached_if_true_no_arg_method
+                def col_c2_is_present_on_table_t2(self) -> bool:
+                    ...
+
+            obj = MyClass()
+            obj.col_c1_is_present_on_table_t1() # compute value, cache if True
+            obj.col_c1_is_present_on_table_t1() # return cached True or re-compute value
+            obj.col_c2_is_present_on_table_t2   # compute value, cache if True
+            obj.col_c2_is_present_on_table_t2   # return cached True or re-compute value
+
+    Intended for use when:
+        - The method will be called frequently; AND
+        - The method calls an external system such as a database; AND
+        - If the result is ever True, there is an assumption that it will never return back to False
+    """
+
+    @wraps(method)
+    def _cached_if_true_no_arg_method_wrapper(self: S) -> bool:
+        if not hasattr(self, CACHED_IF_TRUE_NO_ARG_METHOD_CACHE_FIELD):
+            setattr(self, CACHED_IF_TRUE_NO_ARG_METHOD_CACHE_FIELD, {})
+
+        cache: dict[str, bool] = getattr(self, CACHED_IF_TRUE_NO_ARG_METHOD_CACHE_FIELD)
+        method_name = method.__name__
+
+        if method_name in cache:
+            return cache[method_name]
+        result = method(self)
+        if result:
+            cache[method_name] = result
+        return result
+
+    return _cached_if_true_no_arg_method_wrapper

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_cached_method.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_cached_method.py
@@ -3,9 +3,13 @@
 import asyncio
 import gc
 import random
+from collections import Counter
+from collections.abc import Iterator
+from itertools import cycle, repeat
 from typing import NamedTuple
 
 import objgraph
+from dagster._utils.cached_method import cached_if_true_no_arg_method
 from dagster_shared.utils.cached_method import (
     CACHED_METHOD_CACHE_FIELD,
     cached_method,
@@ -200,3 +204,144 @@ def test_explicit_test() -> None:
     assert inst.boop() == 1
 
     assert next(iter(get_cached_method_cache(inst, "boop").values())) == 1
+
+
+class TestCachedIfTrueNoArgMethod:
+    class MyClass:
+        def __init__(self, return_values: bool | Iterator[bool] | list[bool]) -> None:
+            self._return_values: Iterator[bool] = (
+                return_values
+                if isinstance(return_values, Iterator)
+                else repeat(return_values)
+                if isinstance(return_values, bool)
+                else cycle(return_values)
+            )
+            self.call_counts: Counter[str] = Counter()
+
+        @cached_if_true_no_arg_method
+        def has_table_t1(self) -> bool:
+            self.call_counts["has_table_t1"] += 1
+            return next(self._return_values)
+
+        @cached_if_true_no_arg_method
+        def has_table_missing(self) -> bool:
+            self.call_counts["has_table_missing"] += 1
+            return False
+
+        @cached_if_true_no_arg_method
+        def has_table_exists(self) -> bool:
+            self.call_counts["has_table_exists"] += 1
+            return True
+
+        def assert_call_counts(self, t1: int, missing: int = 0, exists: int = 0) -> None:
+            total = t1 + missing + exists
+            assert self.call_counts["has_table_t1"] == t1
+            assert self.call_counts["has_table_missing"] == missing
+            assert self.call_counts["has_table_exists"] == exists
+            assert self.call_counts.total() == total
+            assert set(self.call_counts.keys()) <= {
+                "has_table_t1",
+                "has_table_missing",
+                "has_table_exists",
+            }
+
+    def test_cached_if_true_no_arg_method_caches_true(self) -> None:
+        obj = self.MyClass(return_values=True)
+        assert obj.has_table_t1() is True
+        obj.assert_call_counts(1)
+
+        assert obj.has_table_t1() is True
+        obj.assert_call_counts(1)
+
+    def test_cached_if_true_no_arg_method_does_not_cache_false(self) -> None:
+        obj = self.MyClass(return_values=False)
+        assert obj.has_table_t1() is False
+        obj.assert_call_counts(1)
+
+        assert obj.has_table_t1() is False
+        obj.assert_call_counts(2)
+
+    def test_cached_if_true_no_arg_method_caches_after_transition(self) -> None:
+        """False results are not cached; once True is returned it is cached."""
+        obj = self.MyClass(return_values=[False, False, True, False])
+
+        assert obj.has_table_t1() is False  # call 1: False, not cached
+        obj.assert_call_counts(1)
+
+        assert obj.has_table_t1() is False  # call 2: False, not cached
+        obj.assert_call_counts(2)
+
+        assert obj.has_table_t1() is True  # call 3: True, cached
+        obj.assert_call_counts(3)
+
+        assert obj.has_table_t1() is True  # call 4: cached, not re-computed
+        obj.assert_call_counts(3)
+
+    def test_cached_if_true_no_arg_method_per_method_isolation(self) -> None:
+        obj = self.MyClass(return_values=[False, True, False])
+        obj.assert_call_counts(0, 0, 0)
+
+        assert obj.has_table_t1() is False
+        obj.assert_call_counts(1, 0, 0)
+
+        assert obj.has_table_missing() is False
+        obj.assert_call_counts(1, 1, 0)
+
+        assert obj.has_table_exists() is True
+        obj.assert_call_counts(1, 1, 1)
+
+        assert obj.has_table_t1() is True
+        obj.assert_call_counts(2, 1, 1)
+
+        assert obj.has_table_missing() is False
+        obj.assert_call_counts(2, 2, 1)
+
+        assert obj.has_table_exists() is True
+        obj.assert_call_counts(2, 2, 1)
+
+        assert obj.has_table_t1() is True
+        obj.assert_call_counts(2, 2, 1)
+
+        assert obj.has_table_missing() is False
+        obj.assert_call_counts(2, 3, 1)
+
+        assert obj.has_table_exists() is True
+        obj.assert_call_counts(2, 3, 1)
+
+    def test_cached_if_true_no_arg_method_per_instance_isolation(self) -> None:
+        obj_true = self.MyClass(return_values=True)
+        obj_false = self.MyClass(return_values=False)
+
+        assert obj_true.has_table_t1() is True
+        obj_true.assert_call_counts(1)
+        obj_false.assert_call_counts(0)
+
+        assert obj_false.has_table_t1() is False
+        obj_true.assert_call_counts(1)
+        obj_false.assert_call_counts(1)
+
+        assert obj_true.has_table_t1() is True
+        obj_true.assert_call_counts(1)
+        obj_false.assert_call_counts(1)
+
+        assert obj_false.has_table_t1() is False
+        obj_true.assert_call_counts(1)
+        obj_false.assert_call_counts(2)
+
+    def test_cached_if_true_no_arg_method_as_property(self) -> None:
+        class MyClass:
+            def __init__(self, return_value: bool) -> None:
+                self._return_value = return_value
+                self.call_count = 0
+
+            @property
+            @cached_if_true_no_arg_method
+            def has_table_t1(self) -> bool:
+                self.call_count += 1
+                return self._return_value
+
+        obj = MyClass(return_value=True)
+        assert obj.has_table_t1 is True
+        assert obj.call_count == 1
+        assert obj.has_table_t1 is True
+        assert obj.call_count == 1  # cached

--- a/python_modules/dagster/dagster_tests/storage_tests/test_cached_has_table_method.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_cached_has_table_method.py
@@ -1,0 +1,90 @@
+from collections import Counter
+
+from dagster._core.storage.cached_has_table_method import cached_has_table_method
+
+
+class MyStorage:
+    def __init__(self, tables: set[str] | None = None) -> None:
+        self._tables: set[str] = tables if tables is not None else {"t1"}
+        self.call_counts: Counter[str] = Counter()
+
+    @cached_has_table_method
+    def has_table(self, table_name: str) -> bool:
+        self.call_counts[table_name] += 1
+        return table_name in self._tables
+
+    def create_table(self, table_name: str) -> None:
+        self._tables.add(table_name)
+
+
+def test_cached_has_table_method_caches_true() -> None:
+    storage = MyStorage()
+    assert storage.has_table("t1") is True
+    assert storage.call_counts.total() == storage.call_counts["t1"] == 1
+
+    assert storage.has_table("t1") is True
+    assert storage.call_counts.total() == storage.call_counts["t1"] == 1
+
+
+def test_cached_has_table_method_does_not_cache_false() -> None:
+    storage = MyStorage()
+    assert storage.has_table("missing") is False
+    assert storage.call_counts.total() == storage.call_counts["missing"] == 1
+
+    assert storage.has_table("missing") is False
+    assert storage.call_counts.total() == storage.call_counts["missing"] == 2
+
+
+def test_cached_has_table_method_caches_after_table_created() -> None:
+    """False is not cached; once a table exists (True) the result is cached."""
+    storage = MyStorage()
+    assert storage.has_table("t2") is False  # call 1
+    assert storage.call_counts.total() == storage.call_counts["t2"] == 1
+
+    storage.create_table("t2")
+    assert storage.has_table("t2") is True  # call 2: now True, cached
+    assert storage.call_counts.total() == storage.call_counts["t2"] == 2
+
+    assert storage.has_table("t2") is True  # cached, not re-computed
+    assert storage.call_counts.total() == storage.call_counts["t2"] == 2
+
+
+def test_cached_has_table_method_per_table_isolation() -> None:
+    storage = MyStorage()
+    assert storage.has_table("t1") is True
+    assert storage.call_counts.total() == storage.call_counts["t1"] == 1
+    assert storage.call_counts["t2"] == 0
+
+    assert storage.has_table("t2") is False
+    assert storage.call_counts.total() == 2
+    assert storage.call_counts["t1"] == storage.call_counts["t2"] == 1
+
+    assert storage.has_table("t1") is True  # cached
+    assert storage.call_counts.total() == 2
+    assert storage.call_counts["t1"] == storage.call_counts["t2"] == 1
+
+    assert storage.has_table("t2") is False  # not cached
+    assert storage.call_counts.total() == 3
+    assert storage.call_counts["t1"] == 1
+    assert storage.call_counts["t2"] == 2
+
+
+def test_cached_has_table_method_per_instance_isolation() -> None:
+    s1 = MyStorage({"t1"})
+    s2 = MyStorage(set())
+
+    assert s1.has_table("t1") is True
+    assert s1.call_counts.total() == s1.call_counts["t1"] == 1
+    assert s2.call_counts.total() == s2.call_counts["t1"] == 0
+
+    assert s2.has_table("t1") is False
+    assert s1.call_counts.total() == s1.call_counts["t1"] == 1
+    assert s2.call_counts.total() == s2.call_counts["t1"] == 1
+
+    assert s1.has_table("t1") is True  # cached on s1
+    assert s1.call_counts.total() == s1.call_counts["t1"] == 1
+    assert s2.call_counts.total() == s2.call_counts["t1"] == 1
+
+    assert s2.has_table("t1") is False  # not cached on s2
+    assert s1.call_counts.total() == s1.call_counts["t1"] == 1
+    assert s2.call_counts.total() == s2.call_counts["t1"] == 2

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -8,6 +8,7 @@ import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.event_api import EventHandlerFn
 from dagster._core.events.log import EventLogEntry
+from dagster._core.storage.cached_has_table_method import cached_has_table_method
 from dagster._core.storage.config import MySqlStorageConfig, mysql_config
 from dagster._core.storage.event_log import (
     AssetKeyTable,
@@ -186,6 +187,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def index_connection(self) -> ContextManager[Connection]:
         return self._connect()
 
+    @cached_has_table_method
     def has_table(self, table_name: str) -> bool:
         with self._connect() as conn:
             return table_name in db.inspect(conn).get_table_names()

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -11,6 +11,7 @@ from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventHandlerFn
 from dagster._core.events import ASSET_CHECK_EVENTS, ASSET_EVENTS, BATCH_WRITABLE_EVENTS
 from dagster._core.events.log import EventLogEntry
+from dagster._core.storage.cached_has_table_method import cached_has_table_method
 from dagster._core.storage.config import pg_config
 from dagster._core.storage.event_log import (
     AssetKeyTable,
@@ -354,6 +355,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 with conn.begin():
                     yield conn
 
+    @cached_has_table_method
     def has_table(self, table_name: str) -> bool:
         return bool(self._engine.dialect.has_table(self._engine.connect(), table_name))
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -357,7 +357,8 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
     @cached_has_table_method
     def has_table(self, table_name: str) -> bool:
-        return bool(self._engine.dialect.has_table(self._engine.connect(), table_name))
+        with self._connect() as conn:
+            return bool(self._engine.dialect.has_table(conn, table_name))
 
     def has_secondary_index(self, name: str) -> bool:
         if name not in self._secondary_index_cache:


### PR DESCRIPTION
This PR adds two caching decorators and applies them across schema-introspection DB calls that were being fired on hot paths.

## Summary & Motivation

Several SQL storage classes make frequent schema-introspection calls (`db.inspect(conn).get_table_names()` or
`db.inspect(conn).get_columns()`) to check whether certain tables or columns exist. These checks happen on hot paths (including asset event writes and schedule ticks), so they can accumulate into unnecessary database load.

Some schema-introspection methods were already being cached. This PR adds two caching decorators and applies them across the remaining introspection methods in all the SQL storage backends:

- **`@cached_has_table_method`** wraps the `has_table(table_name)` method on SQL storage classes. It caches only `True` results (a table that exists will not be dropped, so caching `True` is safe; `False` must be re-checked after migrations).

- **`@cached_if_true_no_arg_method`** wraps zero-argument schema-check methods (e.g. `has_asset_key_index_cols()`, `has_run_stats_index_cols()`). Same semantics: only `True` is cached, `False` is re-computed on every call.

Both decorators model the same invariant: if a table or column were to be DROPed, all code references would be removed first. So if a code reference does exist, the table/column will not disappear after previously being observed during the lifetime of the process. So a `True` result is permanent, but a `False` result could change to `True` after a migration.

## Test Plan

New unit tests for both decorators.

## Changelog

Reduced excessive database queries on hot paths (asset event writes, schedule ticks) by caching schema-introspection calls in SQL storage backends. This should reduce database connection pressure for users running concurrent jobs against a PostgreSQL or MySQL backend.