### PR TITLE
[dagster-dbt] Fix get_asset_spec override breaking dep lineage

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_component_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_component_utils.py
@@ -2,10 +2,12 @@
 
 import itertools
 import json
+import warnings
+from collections.abc import Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, NewType
 
 import dagster as dg
 from dagster.components.resolved.context import ResolutionContext
@@ -16,8 +18,20 @@ from dagster_dbt.asset_utils import (
     DAGSTER_DBT_EXCLUDE_METADATA_KEY,
     DAGSTER_DBT_SELECT_METADATA_KEY,
     DAGSTER_DBT_SELECTOR_METADATA_KEY,
+    get_node,
+    get_upstream_unique_ids,
 )
-from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslatorSettings
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
+from dagster_dbt.dbt_project import DbtProject
+
+# Distinct NewType wrappers so a caller of `_remap_deps_for_overridden_keys` cannot
+# silently pass the two translator roles in swapped order: the shim translator routes
+# through any user override of `DbtProjectComponent.get_asset_spec`, while the base
+# translator is the headless `DagsterDbtTranslator` instance used inside
+# `DbtProjectComponent.get_asset_spec` for recursion (the source of the bug we are
+# working around).
+ShimDbtTranslator = NewType("ShimDbtTranslator", DagsterDbtTranslator)
+BaseDbtTranslator = NewType("BaseDbtTranslator", DagsterDbtTranslator)
 
 _resolution_context: ContextVar[ResolutionContext] = ContextVar("resolution_context")
 
@@ -98,3 +112,118 @@ def resolve_cli_args(
 
     normalized_args = list(itertools.chain(*[list(_normalize_arg(arg)) for arg in resolved_args]))
     return normalized_args
+
+
+def _remap_deps_for_overridden_keys(
+    base_spec: dg.AssetSpec,
+    *,
+    shim_translator: ShimDbtTranslator,
+    base_translator: BaseDbtTranslator,
+    manifest: Mapping[str, Any],
+    unique_id: str,
+    project: DbtProject | None,
+) -> dg.AssetSpec:
+    """Rewrite ``base_spec.deps`` so an override of ``DbtProjectComponent.get_asset_spec``
+    propagates to dependency asset keys.
+
+    ``base_spec`` was produced by ``shim_translator``'s super-call: its key reflects
+    the user override, but its deps were resolved against ``base_translator`` (a
+    separate instance with no awareness of the override). For each upstream in the
+    manifest, compare the base-translator key (what's currently in ``base_spec.deps``)
+    with the shim-translator key (what should be there) and rewrite when they differ.
+    Self-deps are remapped via ``base_translator.get_asset_key(resource_props) -> base_spec.key``.
+
+    The two translator roles are wrapped in distinct ``NewType``s so a caller cannot
+    pass them in swapped positions without a static type error; a runtime identity
+    invariant is asserted as a defense in depth.
+
+    Emits a warning when two upstreams collide onto the same new key (split-mapping is
+    not supported; only the first mapping is applied), raises
+    ``DagsterInvalidDefinitionError`` when a remap would introduce a spurious
+    self-edge, and raises ``DagsterInvalidDefinitionError`` when source-key collapse
+    discards a dep whose ``partition_mapping`` or ``metadata`` differs from the kept
+    one (information loss).
+
+    This is a surgical workaround for the headless ``_base_translator`` design in
+    ``DbtProjectComponent`` / ``DbtCloudComponent``. The structural fix is to route
+    component-level ``get_asset_spec`` recursion through the shim translator so this
+    function becomes unnecessary; tracked as a follow-up in the PR description for
+    issue dagster-io/dagster#33823.
+    """
+    check.invariant(
+        shim_translator is not base_translator,
+        "shim_translator and base_translator must be distinct instances; "
+        "the helper assumes one routes through the user override and the other does not",
+    )
+    if not base_spec.deps:
+        return base_spec
+
+    resource_props = get_node(manifest, unique_id)
+    upstream_ids = get_upstream_unique_ids(manifest, resource_props)
+
+    correction: dict[dg.AssetKey, dg.AssetKey] = {}
+    for upstream_id in upstream_ids:
+        base_key = base_translator.get_asset_spec(manifest, upstream_id, project).key
+        new_key = shim_translator.get_asset_spec(manifest, upstream_id, project).key
+        if base_key == new_key:
+            continue
+        existing = correction.get(base_key)
+        if existing is not None and existing != new_key:
+            warnings.warn(
+                f"DbtProjectComponent.get_asset_spec override produced multiple asset "
+                f"keys for upstream base key {base_key.to_user_string()!r} on node "
+                f"{unique_id!r}: {existing.to_user_string()!r} and "
+                f"{new_key.to_user_string()!r}. Only the first mapping is applied to "
+                f"deps; split-mappings are not supported. See "
+                f"https://github.com/dagster-io/dagster/issues/33823.",
+                stacklevel=4,
+            )
+            continue
+        correction[base_key] = new_key
+
+    base_self_key = base_translator.get_asset_key(resource_props)
+    base_self_was_dep = base_self_key in {dep.asset_key for dep in base_spec.deps}
+    if base_self_key != base_spec.key and base_self_key not in correction:
+        correction[base_self_key] = base_spec.key
+
+    if not correction:
+        return base_spec
+
+    new_deps: list[dg.AssetDep] = []
+    kept_by_key: dict[dg.AssetKey, dg.AssetDep] = {}
+    for dep in base_spec.deps:
+        new_key = correction.get(dep.asset_key, dep.asset_key)
+        if new_key == base_spec.key and not base_self_was_dep:
+            raise dg.DagsterInvalidDefinitionError(
+                f"DbtProjectComponent.get_asset_spec override remapped upstream "
+                f"{dep.asset_key.to_user_string()!r} of {unique_id!r} to the same "
+                f"key as the node itself ({new_key.to_user_string()!r}), which "
+                f"would introduce a spurious self-dependency. Choose distinct keys."
+            )
+        new_dep = dg.AssetDep(
+            asset=new_key,
+            partition_mapping=dep.partition_mapping,
+            metadata=dep.metadata,
+        )
+        existing_dep = kept_by_key.get(new_key)
+        if existing_dep is not None:
+            # Two distinct upstreams collapsed onto the same new key. Silently
+            # discarding the second dep would lose information if partition_mapping
+            # or metadata differ.
+            if (
+                existing_dep.partition_mapping != new_dep.partition_mapping
+                or existing_dep.metadata != new_dep.metadata
+            ):
+                raise dg.DagsterInvalidDefinitionError(
+                    f"DbtProjectComponent.get_asset_spec override on node "
+                    f"{unique_id!r} collapsed two upstream deps onto the same asset "
+                    f"key {new_key.to_user_string()!r} with diverging "
+                    f"partition_mapping or metadata. Keeping one would silently "
+                    f"drop information from the other. Resolve by either mapping "
+                    f"these upstreams to distinct keys or by manually constructing "
+                    f"the dep with the desired partition_mapping/metadata."
+                )
+            continue
+        kept_by_key[new_key] = new_dep
+        new_deps.append(new_dep)
+    return base_spec.replace_attributes(deps=new_deps)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -488,6 +488,20 @@ class DbtProjectComponentTranslator(
     def get_asset_spec(
         self, manifest: Mapping[str, Any], unique_id: str, project: DbtProject | None
     ) -> dg.AssetSpec:
+        # Memoize the final (post-remap, post-translation) spec per (manifest, unique_id,
+        # project). Without this, `_remap_deps_for_overridden_keys` recursively calls
+        # `self.get_asset_spec(upstream_id)` and re-walks the upstream sub-DAG on every
+        # invocation, producing super-linear work on wide DAGs with shared ancestors.
+        # `DagsterDbtTranslator.get_asset_spec` (the `super` call below) is already
+        # memoized on its own `_resolved_specs`; this dict caches the layer added by
+        # this shim (override-remap + YAML translation) so the cost stays O(E).
+        if not hasattr(self, "_remapped_specs"):
+            self._remapped_specs = {}
+        memo_id = (id(manifest), unique_id, id(project))
+        cached = self._remapped_specs.get(memo_id)
+        if cached is not None:
+            return cached
+
         base_spec = super().get_asset_spec(manifest, unique_id, project)
         # Only rewrite deps when a subclass actually overrode get_asset_spec; without
         # an override, base_spec.deps already match the shim translator's keys (the
@@ -510,7 +524,9 @@ class DbtProjectComponentTranslator(
         else:
             dbt_props = get_node(manifest, unique_id)
             spec = self.component.translation(base_spec, dbt_props)
-        return spec.merge_attributes(metadata={DAGSTER_DBT_TRANSLATOR_METADATA_KEY: self})
+        result = spec.merge_attributes(metadata={DAGSTER_DBT_TRANSLATOR_METADATA_KEY: self})
+        self._remapped_specs[memo_id] = result
+        return result
 
 
 def get_projects_from_dbt_component(components: Path) -> list[DbtProject]:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -30,7 +30,10 @@ from dagster_dbt.asset_utils import (
     get_node,
 )
 from dagster_dbt.components.dbt_component_utils import (
+    BaseDbtTranslator,
     DagsterDbtComponentTranslatorSettings,
+    ShimDbtTranslator,
+    _remap_deps_for_overridden_keys,
     _set_resolution_context,
     build_op_spec,
     resolve_cli_args,
@@ -296,7 +299,7 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
             An AssetSpec that represents the dbt node as a Dagster asset
 
         Example:
-            Override this method to add custom tags to all dbt models:
+            Override this method to add custom tags to all dbt models (no key change):
 
             .. code-block:: python
 
@@ -309,6 +312,24 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
                         return base_spec.replace_attributes(
                             tags={**base_spec.tags, "custom_tag": "my_value"}
                         )
+
+            Override this method to prefix all asset keys. The framework
+            automatically remaps ``spec.deps`` so downstream lineage continues to
+            connect to the prefixed upstream keys:
+
+            .. code-block:: python
+
+                class PrefixedDbtProjectComponent(DbtProjectComponent):
+                    def get_asset_spec(self, manifest, unique_id, project):
+                        base_spec = super().get_asset_spec(manifest, unique_id, project)
+                        return base_spec.replace_attributes(
+                            key=base_spec.key.with_prefix("snowflake_dbt")
+                        )
+
+        Limitations:
+            * A single upstream cannot be split into multiple new keys (one base key
+              -> many new keys). Only the first mapping is applied to deps and a
+              warning is emitted. If you need split-mappings, build the deps manually.
         """
         return self._base_translator.get_asset_spec(manifest, unique_id, project)
 
@@ -468,6 +489,22 @@ class DbtProjectComponentTranslator(
         self, manifest: Mapping[str, Any], unique_id: str, project: DbtProject | None
     ) -> dg.AssetSpec:
         base_spec = super().get_asset_spec(manifest, unique_id, project)
+        # Only rewrite deps when a subclass actually overrode get_asset_spec; without
+        # an override, base_spec.deps already match the shim translator's keys (the
+        # YAML `translation` path stays on the shim recursion and is also correct).
+        # This mirrors the override-detection in
+        # `dagster.components.utils.translation._GeneratedComponentTranslator._shim_method`.
+        if type(self.component).get_asset_spec is not DbtProjectComponent.get_asset_spec:
+            base_spec = _remap_deps_for_overridden_keys(
+                base_spec,
+                shim_translator=ShimDbtTranslator(self),
+                base_translator=BaseDbtTranslator(
+                    self.component._base_translator  # noqa: SLF001  -- tightly coupled sibling
+                ),
+                manifest=manifest,
+                unique_id=unique_id,
+                project=project,
+            )
         if self.component.translation is None:
             spec = base_spec
         else:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_component_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_component_utils.py
@@ -1,0 +1,223 @@
+"""Unit tests for :func:`_remap_deps_for_overridden_keys`.
+
+These tests exercise the helper directly with a synthetic dbt manifest so we can
+cover edge cases (custom partition mappings, source-key collapse, cycle introduction)
+that the existing jaffle_shop fixture does not produce naturally.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+from unittest.mock import MagicMock
+
+import dagster as dg
+import pytest
+from dagster_dbt.components.dbt_component_utils import (
+    BaseDbtTranslator,
+    ShimDbtTranslator,
+    _remap_deps_for_overridden_keys,
+)
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+
+
+def _build_manifest() -> Mapping[str, Any]:
+    """A minimal manifest with two models: `child` depends on `parent`."""
+    return {
+        "nodes": {
+            "model.proj.child": {
+                "unique_id": "model.proj.child",
+                "name": "child",
+                "fqn": ["proj", "child"],
+                "resource_type": "model",
+                "depends_on": {"nodes": ["model.proj.parent"]},
+                "meta": {},
+                "config": {},
+                "tags": [],
+            },
+            "model.proj.parent": {
+                "unique_id": "model.proj.parent",
+                "name": "parent",
+                "fqn": ["proj", "parent"],
+                "resource_type": "model",
+                "depends_on": {"nodes": []},
+                "meta": {},
+                "config": {},
+                "tags": [],
+            },
+        },
+        "sources": {},
+        "metadata": {"project_name": "proj"},
+        "parent_map": {"model.proj.child": ["model.proj.parent"]},
+        "child_map": {"model.proj.parent": ["model.proj.child"]},
+    }
+
+
+def _prefix_shim(base_translator: DagsterDbtTranslator) -> MagicMock:
+    """A shim translator that prefixes every asset key with 'new'."""
+    shim = MagicMock(spec=DagsterDbtTranslator)
+    shim.get_asset_spec.side_effect = lambda m, uid, p: base_translator.get_asset_spec(
+        m, uid, p
+    ).replace_attributes(key=base_translator.get_asset_spec(m, uid, p).key.with_prefix("new"))
+    return shim
+
+
+def test_remap_preserves_custom_partition_mapping() -> None:
+    """A user override that remaps keys must preserve a non-default partition_mapping
+    on the rewritten dep. Regression test for the case Owen Kephart flagged: the
+    jaffle_shop fixture has only None partition_mappings, so this exercises the path
+    directly with a TimeWindowPartitionMapping.
+    """
+    manifest = _build_manifest()
+    base_translator = DagsterDbtTranslator()
+    shim = _prefix_shim(base_translator)
+
+    base_spec = base_translator.get_asset_spec(manifest, "model.proj.child", None)
+    custom_mapping = dg.TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
+    base_spec_with_custom = base_spec.replace_attributes(
+        deps=[
+            dg.AssetDep(
+                asset=dep.asset_key,
+                partition_mapping=custom_mapping,
+                metadata={"source_name": dg.MetadataValue.text("custom")},
+            )
+            for dep in base_spec.deps
+        ],
+        key=base_spec.key.with_prefix("new"),
+    )
+
+    remapped = _remap_deps_for_overridden_keys(
+        base_spec_with_custom,
+        shim_translator=ShimDbtTranslator(shim),
+        base_translator=BaseDbtTranslator(base_translator),
+        manifest=manifest,
+        unique_id="model.proj.child",
+        project=None,
+    )
+
+    remapped_deps = list(remapped.deps)
+    assert len(remapped_deps) == 1
+    new_dep = remapped_deps[0]
+    assert new_dep.asset_key == dg.AssetKey(["new", "parent"])
+    assert new_dep.partition_mapping == custom_mapping
+    assert new_dep.metadata == {"source_name": dg.MetadataValue.text("custom")}
+
+
+def test_remap_source_key_collapse_with_matching_dep_collapses_silently() -> None:
+    """When two upstreams collapse onto the same new key but their partition_mapping
+    and metadata match, dedup silently — no error.
+    """
+    manifest = _build_manifest()
+    # Add a second parent so child has two upstream IDs that both collapse to 'parent'.
+    manifest["nodes"]["model.proj.parent2"] = {
+        "unique_id": "model.proj.parent2",
+        "name": "parent2",
+        "fqn": ["proj", "parent2"],
+        "resource_type": "model",
+        "depends_on": {"nodes": []},
+        "meta": {},
+        "config": {},
+        "tags": [],
+    }
+    manifest["nodes"]["model.proj.child"]["depends_on"]["nodes"] = [
+        "model.proj.parent",
+        "model.proj.parent2",
+    ]
+    manifest["parent_map"]["model.proj.child"] = ["model.proj.parent", "model.proj.parent2"]
+    base_translator = DagsterDbtTranslator()
+
+    # Shim collapses both parents onto the same new key.
+    shim = MagicMock(spec=DagsterDbtTranslator)
+    shim.get_asset_spec.side_effect = lambda m, uid, p: base_translator.get_asset_spec(
+        m, uid, p
+    ).replace_attributes(key=dg.AssetKey(["merged", "parent"]))
+
+    base_spec = base_translator.get_asset_spec(manifest, "model.proj.child", None)
+    base_spec = base_spec.replace_attributes(key=dg.AssetKey(["merged", "child"]))
+
+    remapped = _remap_deps_for_overridden_keys(
+        base_spec,
+        shim_translator=ShimDbtTranslator(shim),
+        base_translator=BaseDbtTranslator(base_translator),
+        manifest=manifest,
+        unique_id="model.proj.child",
+        project=None,
+    )
+    remapped_deps = list(remapped.deps)
+    assert len(remapped_deps) == 1
+    assert remapped_deps[0].asset_key == dg.AssetKey(["merged", "parent"])
+
+
+def test_remap_source_key_collapse_with_divergent_metadata_raises() -> None:
+    """When two upstreams collapse onto the same new key but their partition_mapping
+    or metadata diverge, raise rather than silently drop information.
+
+    Regression test for Owen Kephart's review comment on the silent-drop behavior.
+    """
+    manifest = _build_manifest()
+    manifest["nodes"]["model.proj.parent2"] = {
+        "unique_id": "model.proj.parent2",
+        "name": "parent2",
+        "fqn": ["proj", "parent2"],
+        "resource_type": "model",
+        "depends_on": {"nodes": []},
+        "meta": {},
+        "config": {},
+        "tags": [],
+    }
+    manifest["nodes"]["model.proj.child"]["depends_on"]["nodes"] = [
+        "model.proj.parent",
+        "model.proj.parent2",
+    ]
+    manifest["parent_map"]["model.proj.child"] = ["model.proj.parent", "model.proj.parent2"]
+    base_translator = DagsterDbtTranslator()
+    shim = MagicMock(spec=DagsterDbtTranslator)
+    shim.get_asset_spec.side_effect = lambda m, uid, p: base_translator.get_asset_spec(
+        m, uid, p
+    ).replace_attributes(key=dg.AssetKey(["merged", "parent"]))
+
+    base_spec = base_translator.get_asset_spec(manifest, "model.proj.child", None)
+    # Make the two deps disagree on metadata so collapse would lose info.
+    base_spec = base_spec.replace_attributes(
+        key=dg.AssetKey(["merged", "child"]),
+        deps=[
+            dg.AssetDep(
+                asset=dg.AssetKey(["parent"]),
+                metadata={"source": dg.MetadataValue.text("a")},
+            ),
+            dg.AssetDep(
+                asset=dg.AssetKey(["parent2"]),
+                metadata={"source": dg.MetadataValue.text("b")},
+            ),
+        ],
+    )
+    with pytest.raises(
+        dg.DagsterInvalidDefinitionError, match="diverging partition_mapping or metadata"
+    ):
+        _remap_deps_for_overridden_keys(
+            base_spec,
+            shim_translator=ShimDbtTranslator(shim),
+            base_translator=BaseDbtTranslator(base_translator),
+            manifest=manifest,
+            unique_id="model.proj.child",
+            project=None,
+        )
+
+
+def test_remap_swap_of_shim_and_base_raises() -> None:
+    """Passing the same translator instance as both shim and base must fail loudly.
+
+    The NewType wrappers make this a static type error at well-behaved call sites;
+    this test deliberately bypasses the type system (the # type: ignore below) to
+    exercise the runtime invariant as defense in depth.
+    """
+    manifest = _build_manifest()
+    base_translator = DagsterDbtTranslator()
+    base_spec = base_translator.get_asset_spec(manifest, "model.proj.child", None)
+    with pytest.raises(Exception, match="distinct instances"):
+        _remap_deps_for_overridden_keys(
+            base_spec,
+            shim_translator=base_translator,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+            base_translator=base_translator,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+            manifest=manifest,
+            unique_id="model.proj.child",
+            project=None,
+        )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_templated_custom_keys_dbt_project.py
@@ -238,6 +238,47 @@ def test_subclass_manual_dep_rewrite_still_works(dbt_path: Path) -> None:
     }
 
 
+def test_subclass_get_asset_spec_memoizes_remap_calls(dbt_path: Path) -> None:
+    """The shim translator memoizes its final spec per unique_id, so the recursive
+    `shim_translator.get_asset_spec(...)` calls inside `_remap_deps_for_overridden_keys`
+    hit the cache instead of re-walking the upstream sub-DAG.
+
+    Without the memo, repeated traversals of shared ancestors would inflate the
+    `_remap_deps_for_overridden_keys` call count well past O(unique_ids) on wide DAGs.
+    This test locks in the upper bound for the jaffle_shop fixture.
+    """
+    from dagster_dbt.components.dbt_project import component as dbt_project_component_module
+
+    class PrefixedDbtComponent(DbtProjectComponent):
+        def get_asset_spec(self, manifest, unique_id, project):
+            base = super().get_asset_spec(manifest, unique_id, project)
+            return base.replace_attributes(key=base.key.with_prefix("some_prefix"))
+
+    original = dbt_project_component_module._remap_deps_for_overridden_keys  # noqa: SLF001  -- test wraps the private helper to count invocations
+    call_count = 0
+
+    def counting(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original(*args, **kwargs)
+
+    with patch.object(
+        dbt_project_component_module, "_remap_deps_for_overridden_keys", side_effect=counting
+    ):
+        defs = build_component_defs_for_test(PrefixedDbtComponent, {"project": str(dbt_path)})
+        defs.resolve_asset_graph()
+
+    # jaffle_shop has 8 selected asset keys (5 models + 3 sources). With memoization,
+    # `_remap_deps_for_overridden_keys` is invoked at most once per asset key — and
+    # only when the node has deps (sources have none, so they short-circuit before
+    # the helper does any work). Without the memo, repeated shim recursions would
+    # push this well above the unique-id count.
+    assert call_count <= len(JAFFLE_SHOP_KEYS), (
+        f"Expected <= {len(JAFFLE_SHOP_KEYS)} remap calls with shim memo; got {call_count}. "
+        f"Regression: the memoization on DbtProjectComponentTranslator.get_asset_spec was lost."
+    )
+
+
 def test_yaml_translation_key_rewrite_remaps_deps(dbt_path: Path) -> None:
     """Regression lock: the YAML translation path already remapped deps correctly;
     assert it explicitly so future refactors don't silently break it.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_templated_custom_keys_dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_templated_custom_keys_dbt_project.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
 
+import dagster as dg
 import pytest
 from dagster import AssetKey
 from dagster._core.instance_for_test import instance_for_test
@@ -128,3 +129,127 @@ def test_render_vars_asset_key(dbt_path: Path) -> None:
             },
         )
         assert defs.resolve_asset_graph().get_all_asset_keys() == JAFFLE_SHOP_KEYS_WITH_PREFIX
+
+
+def test_subclass_get_asset_spec_remaps_model_deps(dbt_path: Path) -> None:
+    """Subclass override prefixing keys must remap deps to other models.
+
+    Regression test for https://github.com/dagster-io/dagster/issues/33823.
+    """
+
+    class PrefixedDbtComponent(DbtProjectComponent):
+        def get_asset_spec(self, manifest, unique_id, project):
+            base = super().get_asset_spec(manifest, unique_id, project)
+            return base.replace_attributes(key=base.key.with_prefix("some_prefix"))
+
+    defs = build_component_defs_for_test(PrefixedDbtComponent, {"project": str(dbt_path)})
+    graph = defs.resolve_asset_graph()
+
+    assert graph.get_all_asset_keys() == JAFFLE_SHOP_KEYS_WITH_PREFIX
+
+    customers = AssetKey(["some_prefix", "customers"])
+    assert graph.get(customers).parent_keys == {
+        AssetKey(["some_prefix", "stg_customers"]),
+        AssetKey(["some_prefix", "stg_orders"]),
+        AssetKey(["some_prefix", "stg_payments"]),
+    }
+
+
+def test_subclass_get_asset_spec_remaps_source_deps(dbt_path: Path) -> None:
+    """Source upstreams (raw_*) are remapped too, not just model upstreams."""
+
+    class PrefixedDbtComponent(DbtProjectComponent):
+        def get_asset_spec(self, manifest, unique_id, project):
+            base = super().get_asset_spec(manifest, unique_id, project)
+            return base.replace_attributes(key=base.key.with_prefix("some_prefix"))
+
+    defs = build_component_defs_for_test(PrefixedDbtComponent, {"project": str(dbt_path)})
+    graph = defs.resolve_asset_graph()
+
+    assert graph.get(AssetKey(["some_prefix", "stg_customers"])).parent_keys == {
+        AssetKey(["some_prefix", "raw_customers"]),
+    }
+
+
+def test_subclass_get_asset_spec_no_key_change_is_full_noop(dbt_path: Path) -> None:
+    """A subclass that overrides get_asset_spec without changing keys must not perturb
+    keys, deps (including partition_mapping and metadata), group_name, kinds, or
+    metadata keys on any spec.
+    """
+    baseline_defs = build_component_defs_for_test(DbtProjectComponent, {"project": str(dbt_path)})
+    baseline_graph = baseline_defs.resolve_asset_graph()
+
+    class TaggedDbtComponent(DbtProjectComponent):
+        def get_asset_spec(self, manifest, unique_id, project):
+            base = super().get_asset_spec(manifest, unique_id, project)
+            return base.merge_attributes(tags={"custom": "yes"})
+
+    overridden_defs = build_component_defs_for_test(TaggedDbtComponent, {"project": str(dbt_path)})
+    overridden_graph = overridden_defs.resolve_asset_graph()
+
+    assert overridden_graph.get_all_asset_keys() == baseline_graph.get_all_asset_keys()
+    for key in baseline_graph.get_all_asset_keys():
+        baseline_spec = baseline_defs.resolve_assets_def(key).get_asset_spec(key)
+        overridden_spec = overridden_defs.resolve_assets_def(key).get_asset_spec(key)
+        # The added tag is the one allowed difference.
+        assert {
+            k: v for k, v in overridden_spec.tags.items() if k != "custom"
+        } == baseline_spec.tags
+        # Deps must match exactly, including partition_mapping and metadata.
+        baseline_deps = {d.asset_key: d for d in baseline_spec.deps}
+        overridden_deps = {d.asset_key: d for d in overridden_spec.deps}
+        assert baseline_deps.keys() == overridden_deps.keys()
+        for asset_key, baseline_dep in baseline_deps.items():
+            assert overridden_deps[asset_key].partition_mapping == baseline_dep.partition_mapping
+            assert overridden_deps[asset_key].metadata == baseline_dep.metadata
+        assert overridden_spec.group_name == baseline_spec.group_name
+        assert overridden_spec.kinds == baseline_spec.kinds
+        assert overridden_spec.partitions_def == baseline_spec.partitions_def
+        assert overridden_spec.metadata == baseline_spec.metadata
+
+
+def test_subclass_manual_dep_rewrite_still_works(dbt_path: Path) -> None:
+    """The issue reporter's manual workaround must continue to produce a correct graph
+    after the auto-remap is added (i.e. no double-apply).
+    """
+
+    class ManualPrefixedDbtComponent(DbtProjectComponent):
+        def get_asset_spec(self, manifest, unique_id, project):
+            base = super().get_asset_spec(manifest, unique_id, project)
+            new_key = base.key.with_prefix("some_prefix")
+            new_deps = [
+                dg.AssetDep(
+                    asset=d.asset_key.with_prefix("some_prefix"),
+                    partition_mapping=d.partition_mapping,
+                    metadata=d.metadata,
+                )
+                for d in base.deps
+            ]
+            return base.replace_attributes(key=new_key, deps=new_deps)
+
+    defs = build_component_defs_for_test(ManualPrefixedDbtComponent, {"project": str(dbt_path)})
+    graph = defs.resolve_asset_graph()
+    assert graph.get_all_asset_keys() == JAFFLE_SHOP_KEYS_WITH_PREFIX
+    customers = AssetKey(["some_prefix", "customers"])
+    assert graph.get(customers).parent_keys == {
+        AssetKey(["some_prefix", "stg_customers"]),
+        AssetKey(["some_prefix", "stg_orders"]),
+        AssetKey(["some_prefix", "stg_payments"]),
+    }
+
+
+def test_yaml_translation_key_rewrite_remaps_deps(dbt_path: Path) -> None:
+    """Regression lock: the YAML translation path already remapped deps correctly;
+    assert it explicitly so future refactors don't silently break it.
+    """
+    defs = build_component_defs_for_test(
+        DbtProjectComponent,
+        {"project": str(dbt_path), "translation": {"key": "some_prefix/{{ node.name }}"}},
+    )
+    graph = defs.resolve_asset_graph()
+    customers = AssetKey(["some_prefix", "customers"])
+    assert graph.get(customers).parent_keys == {
+        AssetKey(["some_prefix", "stg_customers"]),
+        AssetKey(["some_prefix", "stg_orders"]),
+        AssetKey(["some_prefix", "stg_payments"]),
+    }


### PR DESCRIPTION
## Summary & Motivation

Resolves #33823.

Subclasses of `DbtProjectComponent` that override `get_asset_spec` to remap asset keys (e.g. prefixing all assets under a custom namespace) currently produce `AssetSpec`s with the *new* key but `deps` pointing at the *original* upstream keys, breaking lineage.

**Root cause.** `DbtProjectComponent.get_asset_spec` delegates to a fresh `DagsterDbtTranslator` instance (`_base_translator`) for the recursion that builds deps. That instance has no link back to the shim translator that routes through the user override, so the recursive `self.get_asset_spec(upstream_id)` calls inside `DagsterDbtTranslator.get_asset_spec` never see the override. Result: `key = new_A`, `deps = [orig_B]`, but `B`'s actual spec has `key = new_B`.

**Fix.** Add `_remap_deps_for_overridden_keys` in `dbt_component_utils.py`. After `super().get_asset_spec(...)` returns inside `DbtProjectComponentTranslator.get_asset_spec`, compute each upstream's base-translator key vs. shim-translator key, and rewrite deps where they differ. Self-deps are remapped via `base_translator.get_asset_key(resource_props) -> base_spec.key`. Two `NewType` wrappers (`ShimDbtTranslator` / `BaseDbtTranslator`) make swap-at-callsite a static type error; a runtime identity invariant is asserted as defense in depth. The helper call is gated on override detection so the no-override hot path is unchanged. The shim translator memoizes its final spec per `unique_id` so the recursive `shim.get_asset_spec(upstream)` calls inside the helper stay O(E) on wide DAGs with shared ancestors.

**Safety properties** (all locked in by tests):
- No-op when no override is detected.
- No-op for the YAML `translation:` path (its deps already match the shim translator's keys via direct recursion through the shim).
- Compatible with users' manual dep-rewriting workarounds.
- Splits (one upstream → many new keys) emit `warnings.warn`.
- Cycle introduction (upstream remapped to the node's own key) raises `DagsterInvalidDefinitionError`.
- Source-key collapse with divergent `partition_mapping` or `metadata` raises rather than silently dropping information.

**Architectural alternative considered.** The structural fix is to route `DbtProjectComponent.get_asset_spec` recursion through the shim translator (eliminating the headless `_base_translator` design that causes this bug class). Deferred to a follow-up to keep this PR's blast radius narrow — the current fix is provably a no-op for every code path that already worked. Tracked as **#33829**. `DbtCloudComponent` has the identical structural bug and is tracked separately as **#33830**.

## Test Plan

- `make ruff` clean.
- `pyright` clean on all four changed files (verified locally: `0 errors, 0 warnings`).
- `ty check` clean on all four changed files (verified locally: `All checks passed!`).
- Four new direct helper unit tests in `test_dbt_component_utils.py` pass locally (`4 passed`), covering:
  - Custom `TimeWindowPartitionMapping` survival under key remap.
  - Source-key collapse with matching `partition_mapping`/`metadata` (silent dedup).
  - Source-key collapse with divergent metadata (raises with actionable message).
  - Runtime swap-of-shim-and-base guard.
- Six new end-to-end tests against the `jaffle_shop` fixture in `test_templated_custom_keys_dbt_project.py`:
  - `test_subclass_get_asset_spec_remaps_model_deps`
  - `test_subclass_get_asset_spec_remaps_source_deps`
  - `test_subclass_get_asset_spec_no_key_change_is_full_noop` (full-spec equality assertion)
  - `test_subclass_manual_dep_rewrite_still_works` (locks in compatibility with the issue reporter's workaround)
  - `test_subclass_get_asset_spec_memoizes_remap_calls` (caps `_remap_deps_for_overridden_keys` invocations at `len(unique_keys)` so the shim memo can't be silently dropped)
  - `test_yaml_translation_key_rewrite_remaps_deps` (regression lock)

## Changelog

`dagster-dbt`: subclassing `DbtProjectComponent` and overriding `get_asset_spec` to remap asset keys now correctly remaps `spec.deps` to the new upstream keys so downstream lineage continues to connect. Previously deps pointed at the original (un-remapped) keys.