### PR TITLE
[dagster-postgres] Batch-write planned asset/check events on run launch

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/methods/event_methods.py
+++ b/python_modules/dagster/dagster/_core/instance/methods/event_methods.py
@@ -206,10 +206,6 @@ class EventMethods:
             event (EventLogEntry): The event to handle.
             batch_metadata (Optional[DagsterEventBatchMetadata]): Metadata for batch writing.
         """
-        from dagster._core.events import RunFailureReason
-        from dagster._core.storage.tags import RUN_FAILURE_REASON_TAG, WILL_RETRY_TAG
-        from dagster._time import datetime_from_timestamp
-
         if not self.should_store_event(event):
             return
 
@@ -227,6 +223,22 @@ class EventMethods:
             else:
                 return
 
+        self._store_and_notify(events)
+
+    def handle_new_event_batch(self, events: Sequence["EventLogEntry"]) -> None:
+        """Store a list of events as a single batch and notify subscribers.
+
+        Unlike `handle_new_event` with `batch_metadata`, this path is not gated on
+        `DAGSTER_EVENT_BATCH_SIZE` -- callers that have already collected a batch (for
+        example, planned-event emission at run creation time) can use it to invoke the
+        storage layer's `store_event_batch` directly.
+        """
+        events = [event for event in events if self.should_store_event(event)]
+        if not events:
+            return
+        self._store_and_notify(events)
+
+    def _store_and_notify(self, events: Sequence["EventLogEntry"]) -> None:
         if len(events) == 1:
             self._event_storage_impl.store_event(events[0])
         else:
@@ -244,6 +256,13 @@ class EventMethods:
                 )
                 for event in events:
                     self._event_storage_impl.store_event(event)
+
+        self._notify_after_store(events)
+
+    def _notify_after_store(self, events: Sequence["EventLogEntry"]) -> None:
+        from dagster._core.events import RunFailureReason
+        from dagster._core.storage.tags import RUN_FAILURE_REASON_TAG, WILL_RETRY_TAG
+        from dagster._time import datetime_from_timestamp
 
         for event in events:
             run_id = event.run_id
@@ -370,6 +389,36 @@ class EventMethods:
             dagster_event=dagster_event,
         )
         self.handle_new_event(event_record, batch_metadata=batch_metadata)
+
+    def report_dagster_event_batch(
+        self,
+        dagster_events: Sequence["DagsterEvent"],
+        run_id: str,
+        log_level: str | int = logging.INFO,
+    ) -> None:
+        """Take a list of DagsterEvents and store them in one batch.
+
+        Bypasses the `DAGSTER_EVENT_BATCH_SIZE` gate that governs `report_dagster_event`'s
+        opt-in batching; callers that have already accumulated a batch (e.g. planned-event
+        emission at run creation) get a single storage call regardless of the env var.
+        """
+        from dagster._core.events.log import EventLogEntry
+
+        now = get_current_timestamp()
+        records = [
+            EventLogEntry(
+                user_message="",
+                level=log_level,
+                job_name=dagster_event.job_name,
+                run_id=run_id,
+                error_info=None,
+                timestamp=now,
+                step_key=dagster_event.step_key,
+                dagster_event=dagster_event,
+            )
+            for dagster_event in dagster_events
+        ]
+        self.handle_new_event_batch(records)
 
     def report_run_canceling(self, run: "DagsterRun", message: str | None = None) -> None:
         """Report run canceling event."""

--- a/python_modules/dagster/dagster/_core/instance/runs/run_domain.py
+++ b/python_modules/dagster/dagster/_core/instance/runs/run_domain.py
@@ -73,6 +73,16 @@ if TYPE_CHECKING:
     from dagster._core.workspace.context import BaseWorkspaceRequestContext
 
 
+# Default chunk size for bulk-writing planned events on run creation. Chosen to stay well
+# under PostgreSQL's 65535 bind-parameter ceiling for a single statement while still
+# keeping the typical run-launch path to a small number of round-trips. Operators can
+# override with the `DAGSTER_PLANNED_EVENT_CHUNK_SIZE` env var; this is a separate knob
+# from `DAGSTER_EVENT_BATCH_SIZE` (which gates `handle_new_event`'s opt-in batching for
+# non-planned event callers) because they control different mechanisms.
+_DEFAULT_PLANNED_EVENT_CHUNK_SIZE = 1024
+_PLANNED_EVENT_CHUNK_SIZE_ENV_VAR = "DAGSTER_PLANNED_EVENT_CHUNK_SIZE"
+
+
 class RunDomain:
     """Domain object encapsulating run-related operations.
 
@@ -838,16 +848,11 @@ class RunDomain:
         asset_graph: "BaseAssetGraph",
     ) -> None:
         """Moved from DagsterInstance._log_asset_planned_events."""
-        from dagster._core.events import (
-            DagsterEvent,
-            DagsterEventBatchMetadata,
-            DagsterEventType,
-            generate_event_batch_id,
-        )
+        from dagster._core.events import DagsterEvent, DagsterEventType
 
         job_name = dagster_run.job_name
 
-        events = []
+        events: list[DagsterEvent] = []
 
         for step in execution_plan_snapshot.steps:
             if step.key in execution_plan_snapshot.step_keys_to_execute:
@@ -890,32 +895,38 @@ class RunDomain:
                         )
                         events.append(event)
 
-        batch_id = generate_event_batch_id()
-        last_index = len(events) - 1
+        if not events:
+            return
 
         batch_planned_events = not bool(os.getenv("DAGSTER_EMIT_PLANNED_EVENTS_INDIVIDUALLY"))
 
-        if batch_planned_events:
-            # sort events by asset key to ensure they are inserted in a consistent order
-            # if they are batched
-            events = sorted(
-                events,
-                key=lambda event: (
-                    event.asset_key.to_db_string()
-                    if event.asset_key
-                    else event.asset_check_planned_data.asset_check_key.to_db_string()
-                ),
-            )
+        if not batch_planned_events:
+            for event in events:
+                self._instance.report_dagster_event(event, dagster_run.run_id, logging.DEBUG)
+            return
 
-        for i, event in enumerate(events):
-            batch_metadata = (
-                DagsterEventBatchMetadata(batch_id, i == last_index)
-                if batch_planned_events
-                else None
-            )
-            self._instance.report_dagster_event(
-                event, dagster_run.run_id, logging.DEBUG, batch_metadata=batch_metadata
-            )
+        # sort events by asset key for deterministic insert order
+        events = sorted(
+            events,
+            key=lambda event: (
+                event.asset_key.to_db_string()
+                if event.asset_key
+                else event.asset_check_planned_data.asset_check_key.to_db_string()
+            ),
+        )
+
+        # Bulk-write planned events directly via the batch path so we are not gated on
+        # DAGSTER_EVENT_BATCH_SIZE (which defaults to 0/disabled and governs
+        # `handle_new_event`'s opt-in batching, not this path). Chunk to keep individual
+        # INSERTs bounded; respect DAGSTER_PLANNED_EVENT_CHUNK_SIZE if set.
+        try:
+            env_chunk_size = int(os.getenv(_PLANNED_EVENT_CHUNK_SIZE_ENV_VAR, "0"))
+        except ValueError:
+            env_chunk_size = 0
+        chunk_size = env_chunk_size if env_chunk_size > 0 else _DEFAULT_PLANNED_EVENT_CHUNK_SIZE
+        for start in range(0, len(events), chunk_size):
+            chunk = events[start : start + chunk_size]
+            self._instance.report_dagster_event_batch(chunk, dagster_run.run_id, logging.DEBUG)
 
     def get_materialization_planned_events_for_asset(
         self,

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1686,6 +1686,213 @@ class TestEventLogStorage:
                 dg.AssetCheckKey(dg.AssetKey("my_other_asset"), "my_other_check"),
             }
 
+    def test_create_run_batches_planned_events_without_env_var(self, storage, instance):
+        """Planned events should be written in one bulk path on run creation even when
+        `DAGSTER_EVENT_BATCH_SIZE` is unset (the previous default behavior fell back to
+        per-event writes, blocking run launch on hundreds of round-trips for large jobs).
+        """
+
+        @dg.multi_asset(
+            outs={
+                "my_out_name": dg.AssetOut(key=dg.AssetKey("my_asset_name")),
+                "my_other_out_name": dg.AssetOut(key=dg.AssetKey("my_other_asset")),
+            },
+            check_specs=[
+                dg.AssetCheckSpec(
+                    name="my_check",
+                    asset="my_asset_name",
+                    description="My check",
+                ),
+                dg.AssetCheckSpec(
+                    name="my_other_check",
+                    asset="my_other_asset",
+                    description="My other check",
+                ),
+            ],
+        )
+        def my_asset():
+            yield dg.Output(1, "my_out_name")
+            yield dg.Output(2, "my_other_out_name")
+            yield dg.AssetCheckResult(
+                check_name="my_check",
+                asset_key=dg.AssetKey("my_asset_name"),
+                passed=True,
+            )
+            yield dg.AssetCheckResult(
+                check_name="my_other_check",
+                asset_key=dg.AssetKey("my_other_asset"),
+                passed=True,
+            )
+
+        from dagster._core.test_utils import environ
+
+        with environ(
+            {
+                # explicitly cleared -- planned events should still get the batch path
+                "DAGSTER_EVENT_BATCH_SIZE": "",
+                "DAGSTER_EMIT_PLANNED_EVENTS_INDIVIDUALLY": "",
+            }
+        ):
+            result = materialize([my_asset], instance=instance)
+
+            assert self._get_planned_asset_keys_from_event_log(instance, result.run_id) == {
+                dg.AssetKey("my_asset_name"),
+                dg.AssetKey("my_other_asset"),
+            }
+            assert self._get_planned_check_keys_from_event_log(instance, result.run_id) == {
+                dg.AssetCheckKey(dg.AssetKey("my_asset_name"), "my_check"),
+                dg.AssetCheckKey(dg.AssetKey("my_other_asset"), "my_other_check"),
+            }
+
+    def test_store_event_batch_materialization_planned(self, storage, test_run_id):
+        """store_event_batch with only ASSET_MATERIALIZATION_PLANNED events: assert event-log
+        rows + asset_keys.last_run_id populated for every distinct asset.
+        """
+        keys = [dg.AssetKey(["bulk_planned", str(i)]) for i in range(5)]
+        events = [
+            dg.EventLogEntry(
+                error_info=None,
+                level="debug",
+                user_message="",
+                run_id=test_run_id,
+                timestamp=time.time(),
+                dagster_event=dg.DagsterEvent(
+                    DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value,
+                    "nonce",
+                    event_specific_data=AssetMaterializationPlannedData(key),
+                ),
+            )
+            for key in keys
+        ]
+
+        storage.store_event_batch(events)
+
+        planned_event_keys = {
+            record.event_log_entry.dagster_event.asset_key
+            for record in storage.get_records_for_run(
+                test_run_id, of_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED
+            ).records
+        }
+        assert planned_event_keys == set(keys)
+
+        records_by_key = {
+            record.asset_entry.asset_key: record for record in storage.get_asset_records(keys)
+        }
+        assert set(records_by_key) == set(keys)
+        assert all(
+            record.asset_entry.last_run_id == test_run_id for record in records_by_key.values()
+        )
+
+    def test_store_event_batch_check_evaluation_planned(self, storage, test_run_id):
+        """store_event_batch with only ASSET_CHECK_EVALUATION_PLANNED events: assert event-log
+        rows + one asset_check_executions row per (event, partition_key) at status PLANNED.
+        """
+        if not storage.supports_asset_checks:
+            pytest.skip("storage does not support asset checks")
+
+        unpartitioned_key = dg.AssetCheckKey(dg.AssetKey(["bulk_check_a"]), "c1")
+        partitioned_key = dg.AssetCheckKey(dg.AssetKey(["bulk_check_b"]), "c2")
+        partitions_def = dg.StaticPartitionsDefinition(["p1", "p2", "p3"])
+        partitions_subset = partitions_def.subset_with_partition_keys(["p1", "p2"])
+
+        events = [
+            _create_check_planned_event(test_run_id, unpartitioned_key),
+            _create_check_planned_event(
+                test_run_id, partitioned_key, partitions_subset=partitions_subset
+            ),
+        ]
+
+        storage.store_event_batch(events)
+
+        planned_check_keys = {
+            record.event_log_entry.dagster_event.asset_check_planned_data.asset_check_key
+            for record in storage.get_records_for_run(
+                test_run_id, of_type=DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED
+            ).records
+        }
+        assert planned_check_keys == {unpartitioned_key, partitioned_key}
+
+        unpartitioned_history = storage.get_asset_check_execution_history(
+            unpartitioned_key, limit=10
+        )
+        assert len(unpartitioned_history) == 1
+        assert unpartitioned_history[0].status == AssetCheckExecutionRecordStatus.PLANNED
+        assert unpartitioned_history[0].partition is None
+        assert unpartitioned_history[0].run_id == test_run_id
+
+        partitioned_history = storage.get_asset_check_execution_history(partitioned_key, limit=10)
+        assert len(partitioned_history) == 2
+        assert all(
+            record.status == AssetCheckExecutionRecordStatus.PLANNED
+            for record in partitioned_history
+        )
+        assert {record.partition for record in partitioned_history} == {"p1", "p2"}
+
+    def test_store_event_batch_mixed_planned(self, storage, test_run_id):
+        """A single store_event_batch call mixing ASSET_MATERIALIZATION_PLANNED and
+        ASSET_CHECK_EVALUATION_PLANNED events should populate both side tables.
+        """
+        if not storage.supports_asset_checks:
+            pytest.skip("storage does not support asset checks")
+
+        mat_key_a = dg.AssetKey(["mixed_a"])
+        mat_key_b = dg.AssetKey(["mixed_b"])
+        check_key = dg.AssetCheckKey(mat_key_a, "c")
+
+        events = [
+            dg.EventLogEntry(
+                error_info=None,
+                level="debug",
+                user_message="",
+                run_id=test_run_id,
+                timestamp=time.time(),
+                dagster_event=dg.DagsterEvent(
+                    DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value,
+                    "nonce",
+                    event_specific_data=AssetMaterializationPlannedData(mat_key_a),
+                ),
+            ),
+            dg.EventLogEntry(
+                error_info=None,
+                level="debug",
+                user_message="",
+                run_id=test_run_id,
+                timestamp=time.time(),
+                dagster_event=dg.DagsterEvent(
+                    DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value,
+                    "nonce",
+                    event_specific_data=AssetMaterializationPlannedData(mat_key_b),
+                ),
+            ),
+            _create_check_planned_event(test_run_id, check_key),
+        ]
+
+        storage.store_event_batch(events)
+
+        # event log rows for both types
+        planned_mat_keys = {
+            record.event_log_entry.dagster_event.asset_key
+            for record in storage.get_records_for_run(
+                test_run_id, of_type=DagsterEventType.ASSET_MATERIALIZATION_PLANNED
+            ).records
+        }
+        assert planned_mat_keys == {mat_key_a, mat_key_b}
+        planned_check_records = storage.get_records_for_run(
+            test_run_id, of_type=DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED
+        ).records
+        assert len(planned_check_records) == 1
+
+        # asset_keys side table updated for each asset
+        asset_records = storage.get_asset_records([mat_key_a, mat_key_b])
+        assert {r.asset_entry.asset_key for r in asset_records} == {mat_key_a, mat_key_b}
+        assert all(r.asset_entry.last_run_id == test_run_id for r in asset_records)
+
+        # asset_check_executions side table updated
+        check_history = storage.get_asset_check_execution_history(check_key, limit=10)
+        assert len(check_history) == 1
+        assert check_history[0].status == AssetCheckExecutionRecordStatus.PLANNED
+        assert check_history[0].run_id == test_run_id
+
     def test_asset_materialization_fetch(self, storage, instance):
         asset_key = dg.AssetKey(["path", "to", "asset_one"])
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, ContextManager, cast  # noqa: UP035
@@ -11,6 +12,7 @@ from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventHandlerFn
 from dagster._core.events import ASSET_CHECK_EVENTS, ASSET_EVENTS, BATCH_WRITABLE_EVENTS
 from dagster._core.events.log import EventLogEntry
+from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecordStatus
 from dagster._core.storage.config import pg_config
 from dagster._core.storage.event_log import (
     AssetKeyTable,
@@ -22,6 +24,7 @@ from dagster._core.storage.event_log import (
 from dagster._core.storage.event_log.base import EventLogCursor
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.event_log.polling_event_watcher import SqlPollingEventWatcher
+from dagster._core.storage.event_log.schema import AssetCheckExecutionsTable
 from dagster._core.storage.sql import (
     AlembicVersion,
     check_alembic_revision,
@@ -30,7 +33,12 @@ from dagster._core.storage.sql import (
     stamp_alembic_rev,
 )
 from dagster._core.storage.sqlalchemy_compat import db_result, db_select
-from dagster._serdes import ConfigurableClass, ConfigurableClassData, deserialize_value
+from dagster._serdes import (
+    ConfigurableClass,
+    ConfigurableClassData,
+    deserialize_value,
+    serialize_value,
+)
 from sqlalchemy import event
 from sqlalchemy.engine import Connection
 
@@ -46,6 +54,10 @@ from dagster_postgres.utils import (
 )
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.asset_checks.asset_check_evaluation import (
+        AssetCheckEvaluationPlanned,
+    )
+
     from dagster_postgres.auth import PgTokenProvider
 
 CHANNEL_NAME = "run_events"
@@ -239,6 +251,8 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         ]
         if len(events) == 0:
             return
+        # recompute after filtering (ASSET_FAILED_TO_MATERIALIZE may have been the only type)
+        event_types = {event.get_dagster_event().event_type for event in events}
 
         if event_types == {DagsterEventType.ASSET_MATERIALIZATION} or event_types == {
             DagsterEventType.ASSET_OBSERVATION
@@ -259,8 +273,170 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 )
 
             self.store_asset_event_tags(events, event_ids)
-        else:
-            return super().store_event_batch(events)
+            return
+
+        planned_event_types = {
+            DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+            DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED,
+        }
+        if event_types.issubset(planned_event_types):
+            self._store_planned_events_batch(events)
+            return
+
+        return super().store_event_batch(events)
+
+    def _store_planned_events_batch(self, events: Sequence[EventLogEntry]) -> None:
+        """Bulk-write ASSET_MATERIALIZATION_PLANNED and ASSET_CHECK_EVALUATION_PLANNED events.
+
+        Replaces O(N) per-event inserts (one event-log row, one asset-key upsert, and one
+        asset-check-execution row per event) with at most three statements: one bulk INSERT
+        into the event log, one bulk upsert into the asset_keys table, and one bulk INSERT
+        into the asset_check_executions table.
+
+        Scope: this fast path is Postgres-only. `SqliteEventLogStorage`, the in-memory
+        storage, and `dagster-mysql` (`MySQLEventLogStorage`) still inherit the base
+        `EventLogStorage.store_event_batch` per-event loop. They get correct results but
+        not the speedup. Generalizing to those backends requires per-dialect upsert syntax
+        (`INSERT OR REPLACE` / `INSERT ... ON DUPLICATE KEY UPDATE`) and is intentionally
+        deferred -- see the PR description for the follow-up.
+
+        All three statements run on a single connection inside a single explicit transaction.
+        On Postgres the engine runs in AUTOCOMMIT isolation level, so a partial failure
+        without an enclosing transaction would leave the event_log rows committed while the
+        side-table rows were not. Storage callers (`DagsterInstance._store_and_notify`) then
+        fall back to per-event `store_event`, which would duplicate event_log rows and
+        `asset_check_executions` rows. Wrapping in `conn.begin()` makes the bulk path
+        all-or-nothing so that fallback is correct.
+        """
+        from dagster import DagsterEventType
+
+        insert_event_statement = self.prepare_insert_event_batch(events)
+        # Use `index_connection()` so this path honors any subclass override that points
+        # the side-table writes (asset_keys, asset_check_executions) at a separate
+        # connection/database. For PostgresEventLogStorage in OSS this aliases to
+        # `_connect()`, but the abstraction exists for sharded-index setups and the
+        # existing materialization fast path's side-table writes (via store_asset_event)
+        # go through `index_connection()`. Keeping the convention here means the bulk
+        # path doesn't silently bypass the abstraction.
+        with self.index_connection() as conn:
+            with conn.begin():
+                result = conn.execute(
+                    insert_event_statement.returning(SqlEventLogStorageTable.c.id)
+                )
+                event_ids = [cast("int", row[0]) for row in result.fetchall()]
+
+                if any(event_id is None for event_id in event_ids):
+                    raise DagsterInvariantViolationError(
+                        "Cannot store planned events with null event id."
+                    )
+
+                # Pair each event_id (returned in input order) back with its source event.
+                mat_planned: list[tuple[EventLogEntry, int]] = []
+                check_planned: list[tuple[EventLogEntry, int]] = []
+                for log_entry, event_id in zip(events, event_ids):
+                    dagster_event = log_entry.get_dagster_event()
+                    if dagster_event.is_asset_materialization_planned:
+                        mat_planned.append((log_entry, event_id))
+                    elif (
+                        dagster_event.event_type == DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED
+                    ):
+                        check_planned.append((log_entry, event_id))
+
+                if mat_planned:
+                    self._bulk_upsert_asset_keys_for_planned(conn, mat_planned)
+                if check_planned:
+                    self._bulk_insert_check_planned_evaluations(conn, check_planned)
+
+    def _bulk_upsert_asset_keys_for_planned(
+        self,
+        conn: Connection,
+        mat_planned: Sequence[tuple[EventLogEntry, int]],
+    ) -> None:
+        """Upsert AssetKeyTable rows for ASSET_MATERIALIZATION_PLANNED events in one statement.
+
+        Contract: the *last* event per asset key in input order wins, matching the per-event
+        behavior of `store_asset_event` (which writes each row sequentially so each successive
+        write overwrites the previous). Callers that resort the batch may inadvertently flip
+        which event is materialized into AssetKeyTable -- the caller in
+        `RunDomain._log_asset_planned_events` sorts by `asset_key.to_db_string()`, which is
+        deterministic but independent of this contract.
+
+        Dedup is keyed by `asset_key.to_string()` because that is the value stored in the
+        `asset_key` column. `to_db_string()` (used by the upstream sort) is a separate
+        normalization and is not interchangeable.
+        """
+        has_index_cols = self.has_secondary_index(ASSET_KEY_INDEX_COLS)
+
+        latest_by_key: OrderedDict[str, tuple[EventLogEntry, int]] = OrderedDict()
+        for log_entry, event_id in mat_planned:
+            asset_key = check.not_none(log_entry.get_dagster_event().asset_key)
+            latest_by_key[asset_key.to_string()] = (log_entry, event_id)
+
+        rows: list[dict[str, Any]] = []
+        for asset_key_str, (log_entry, event_id) in latest_by_key.items():
+            values = self._get_asset_entry_values(log_entry, event_id, has_index_cols)
+            if not values:
+                continue
+            rows.append({"asset_key": asset_key_str, **values})
+
+        if not rows:
+            return
+
+        # All rows have the same keys (values shape only depends on event type +
+        # has_index_cols), so any row's keys are representative.
+        update_cols = [key for key in rows[0].keys() if key != "asset_key"]
+
+        stmt = db_dialects.postgresql.insert(AssetKeyTable).values(rows)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[AssetKeyTable.c.asset_key],
+            set_={col: stmt.excluded[col] for col in update_cols},
+        )
+        conn.execute(stmt)
+
+    def _bulk_insert_check_planned_evaluations(
+        self,
+        conn: Connection,
+        check_planned: Sequence[tuple[EventLogEntry, int]],
+    ) -> None:
+        """Insert all AssetCheckExecutionsTable rows for ASSET_CHECK_EVALUATION_PLANNED events
+        in one statement, flattening across each event's partitions_subset.
+        """
+        check.invariant(
+            self.supports_asset_checks,
+            "Asset checks require a database schema migration. Run `dagster instance migrate`.",
+        )
+
+        rows: list[dict[str, Any]] = []
+        for log_entry, event_id in check_planned:
+            planned = cast(
+                "AssetCheckEvaluationPlanned",
+                check.not_none(log_entry.dagster_event).event_specific_data,
+            )
+            partition_keys: Sequence[str | None]
+            if planned.partitions_subset:
+                partition_keys = list(planned.partitions_subset.get_partition_keys())
+            else:
+                partition_keys = [None]
+            event_timestamp = self._event_insert_timestamp(log_entry)
+            serialized_event = serialize_value(log_entry)
+            for partition_key in partition_keys:
+                rows.append(
+                    dict(
+                        asset_key=planned.asset_key.to_string(),
+                        check_name=planned.check_name,
+                        partition=partition_key,
+                        run_id=log_entry.run_id,
+                        execution_status=AssetCheckExecutionRecordStatus.PLANNED.value,
+                        evaluation_event=serialized_event,
+                        evaluation_event_timestamp=event_timestamp,
+                        evaluation_event_storage_id=event_id,
+                    )
+                )
+
+        if not rows:
+            return
+
+        conn.execute(AssetCheckExecutionsTable.insert().values(rows))
 
     def store_asset_event(self, event: EventLogEntry, event_id: int) -> None:
         check.inst_param(event, "event", EventLogEntry)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -62,6 +62,17 @@ if TYPE_CHECKING:
 
 CHANNEL_NAME = "run_events"
 
+# AssetCheckExecutionsTable bulk INSERT row cap. Each row binds 8 parameters
+# (asset_key, check_name, partition, run_id, execution_status, evaluation_event,
+# evaluation_event_timestamp, evaluation_event_storage_id), and PostgreSQL caps
+# bind parameters per statement at 65_535. floor(65_535 / 8) = 8_191; we cap at
+# 8_000 to leave headroom. The planned-event chunking in
+# `RunDomain._log_asset_planned_events` bounds by *event* count
+# (DAGSTER_PLANNED_EVENT_CHUNK_SIZE = 1024 by default), but each event can fan
+# out to many rows when `partitions_subset` is non-empty, so the storage layer
+# bounds again by row count.
+_CHECK_EXECUTION_ROWS_PER_INSERT = 8_000
+
 
 class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     """Postgres-backed event log storage.
@@ -398,8 +409,15 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         conn: Connection,
         check_planned: Sequence[tuple[EventLogEntry, int]],
     ) -> None:
-        """Insert all AssetCheckExecutionsTable rows for ASSET_CHECK_EVALUATION_PLANNED events
-        in one statement, flattening across each event's partitions_subset.
+        """Insert AssetCheckExecutionsTable rows for ASSET_CHECK_EVALUATION_PLANNED events,
+        flattening across each event's partitions_subset.
+
+        Bounded on *row count* (not event count) because each event fans out to one row
+        per partition in its subset. At 8 columns per row Postgres allows
+        floor(65_535 / 8) = 8_191 rows in a single statement; we cap at
+        `_CHECK_EXECUTION_ROWS_PER_INSERT` and emit multiple INSERTs on the same
+        connection inside the enclosing `conn.begin()` transaction so they remain
+        all-or-nothing.
         """
         check.invariant(
             self.supports_asset_checks,
@@ -436,7 +454,9 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         if not rows:
             return
 
-        conn.execute(AssetCheckExecutionsTable.insert().values(rows))
+        for start in range(0, len(rows), _CHECK_EXECUTION_ROWS_PER_INSERT):
+            chunk = rows[start : start + _CHECK_EXECUTION_ROWS_PER_INSERT]
+            conn.execute(AssetCheckExecutionsTable.insert().values(chunk))
 
     def store_asset_event(self, event: EventLogEntry, event_id: int) -> None:
         check.inst_param(event, "event", EventLogEntry)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -102,6 +102,54 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
             assert len(records) == 1
             assert records[0].asset_entry.last_run_id == second_run_id
 
+    def test_store_planned_events_batch_chunks_check_execution_rows(self, conn_string, monkeypatch):
+        """Postgres-specific: the asset_check_executions bulk INSERT fans out to one row
+        per (event x partition), so the row count can exceed PG's 65_535 bind-parameter
+        ceiling even when the *event* count is under DAGSTER_PLANNED_EVENT_CHUNK_SIZE.
+        Verify the storage layer chunks by row count and still produces the full set.
+        """
+        import dagster as dg
+        import dagster_postgres.event_log.event_log as pg_event_log
+        from dagster._core.definitions.asset_checks.asset_check_evaluation import (
+            AssetCheckEvaluationPlanned,
+        )
+        from dagster._core.definitions.partitions.definition import StaticPartitionsDefinition
+        from dagster._core.events import DagsterEvent, DagsterEventType
+        from dagster._core.events.log import EventLogEntry
+
+        # Squeeze the row cap so we don't have to allocate 8k partitions in a test.
+        monkeypatch.setattr(pg_event_log, "_CHECK_EXECUTION_ROWS_PER_INSERT", 3)
+
+        partition_keys = ["p1", "p2", "p3", "p4", "p5", "p6", "p7"]
+        partitions_def = StaticPartitionsDefinition(partition_keys)
+        partitions_subset = partitions_def.subset_with_partition_keys(partition_keys)
+
+        with _clean_storage(conn_string) as storage:
+            run_id = make_new_run_id()
+            check_key = dg.AssetCheckKey(dg.AssetKey(["pg_chunk_check"]), "c")
+            event = EventLogEntry(
+                error_info=None,
+                level="debug",
+                user_message="",
+                run_id=run_id,
+                timestamp=time.time(),
+                dagster_event=DagsterEvent(
+                    DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED.value,
+                    "nonce",
+                    event_specific_data=AssetCheckEvaluationPlanned(
+                        asset_key=check_key.asset_key,
+                        check_name=check_key.name,
+                        partitions_subset=partitions_subset,
+                    ),
+                ),
+            )
+
+            storage.store_event_batch([event])
+
+            history = storage.get_asset_check_execution_history(check_key, limit=20)
+            assert len(history) == 7
+            assert {r.partition for r in history} == set(partition_keys)
+
     def test_store_planned_events_batch_rolls_back_on_partial_failure(self, conn_string):
         """Postgres-specific: if the asset-check-execution insert fails mid-batch, the
         wrapping transaction must roll back so that no event-log rows are committed.

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -48,6 +48,96 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
     def can_wipe_asset_partitions(self) -> bool:
         return False
 
+    def test_store_planned_events_batch_on_conflict_updates_asset_keys(self, conn_string):
+        """Postgres-specific: re-running a batch of ASSET_MATERIALIZATION_PLANNED events for
+        an asset key that already has a row in AssetKeyTable should *update* the existing row
+        via ON CONFLICT DO UPDATE rather than fail or insert a duplicate. This exercises the
+        upsert path that the shared sqlite/in-memory inherited tests do not cover (those
+        storages fall through to the base per-event loop).
+        """
+        import dagster as dg
+        from dagster._core.events import (
+            AssetMaterializationPlannedData,
+            DagsterEvent,
+            DagsterEventType,
+        )
+        from dagster._core.events.log import EventLogEntry
+        from dagster._core.storage.event_log.schema import AssetKeyTable
+
+        with _clean_storage(conn_string) as storage:
+            asset_key = dg.AssetKey(["pg_planned_conflict"])
+            first_run_id = make_new_run_id()
+            second_run_id = make_new_run_id()
+
+            def _planned_event(run_id):
+                return EventLogEntry(
+                    error_info=None,
+                    level="debug",
+                    user_message="",
+                    run_id=run_id,
+                    timestamp=time.time(),
+                    dagster_event=DagsterEvent(
+                        DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value,
+                        "nonce",
+                        event_specific_data=AssetMaterializationPlannedData(asset_key),
+                    ),
+                )
+
+            storage.store_event_batch([_planned_event(first_run_id)])
+
+            records = storage.get_asset_records([asset_key])
+            assert len(records) == 1
+            assert records[0].asset_entry.last_run_id == first_run_id
+
+            # Second batch for the same key must UPDATE (not raise IntegrityError, not duplicate)
+            storage.store_event_batch([_planned_event(second_run_id)])
+
+            with storage.index_connection() as conn:
+                row_count = conn.execute(
+                    AssetKeyTable.select().where(AssetKeyTable.c.asset_key == asset_key.to_string())
+                ).rowcount
+            assert row_count == 1
+
+            records = storage.get_asset_records([asset_key])
+            assert len(records) == 1
+            assert records[0].asset_entry.last_run_id == second_run_id
+
+    def test_store_planned_events_batch_rolls_back_on_partial_failure(self, conn_string):
+        """Postgres-specific: if the asset-check-execution insert fails mid-batch, the
+        wrapping transaction must roll back so that no event-log rows are committed.
+        The outer `_store_and_notify` fallback then re-runs per-event without producing
+        duplicate rows.
+        """
+        from dagster._core.events import DagsterEvent, DagsterEventType
+        from dagster._core.events.log import EventLogEntry
+
+        with _clean_storage(conn_string) as storage:
+            run_id = make_new_run_id()
+
+            # Build a planned check event with malformed event_specific_data (None)
+            # so the bulk check-execution insert raises mid-transaction. The event-log
+            # bulk insert should not be visible after the rollback.
+            bad_event = EventLogEntry(
+                error_info=None,
+                level="debug",
+                user_message="",
+                run_id=run_id,
+                timestamp=time.time(),
+                dagster_event=DagsterEvent(
+                    DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED.value,
+                    "nonce",
+                    event_specific_data=None,  # forces the check insert helper to raise
+                ),
+            )
+
+            with pytest.raises(Exception):
+                storage.store_event_batch([bad_event])
+
+            records = storage.get_records_for_run(
+                run_id, of_type=DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED
+            ).records
+            assert records == []
+
     def test_event_log_storage_two_watchers(self, conn_string):
         with _clean_storage(conn_string) as storage:
             run_id = make_new_run_id()


### PR DESCRIPTION
## Summary & Motivation

Closes #33831.

Launching a run with many planned asset/check events stalls for 5+ minutes because the events are written one row at a time to Postgres, exhausting the webserver pool before the run can enqueue. The reporter's case: 183 dbt models + 816 dbt-test asset checks ⇒ ~1,000 sequential `INSERT`s, and `QueuePool limit ... reached` errors on the webserver.

The root cause sits at two layers and both need to move for the typical user to see relief:

1. **`RunDomain._log_asset_planned_events` only got batching when `DAGSTER_EVENT_BATCH_SIZE > 0`** (defaults to `0` = off). Now it always calls a new `instance.report_dagster_event_batch(...)` in chunks of 1024 (overridable via a new `DAGSTER_PLANNED_EVENT_CHUNK_SIZE` env var). `DAGSTER_EMIT_PLANNED_EVENTS_INDIVIDUALLY` opt-out is preserved.

2. **`PostgresEventLogStorage.store_event_batch` only fast-pathed `ASSET_MATERIALIZATION` / `ASSET_OBSERVATION`.** It now routes pure-or-mixed `{ASSET_MATERIALIZATION_PLANNED, ASSET_CHECK_EVALUATION_PLANNED}` batches through a new `_store_planned_events_batch` that runs three statements on a single connection inside one explicit `conn.begin()` transaction:
   - bulk `INSERT` of event-log rows,
   - bulk upsert of `asset_keys` rows (`ON CONFLICT DO UPDATE`, last-event-per-key wins in input order),
   - bulk `INSERT` of `asset_check_executions` rows (one per partition in each event's `partitions_subset`, with `[None]` fallback for unpartitioned).

   The explicit transaction is required under the AUTOCOMMIT isolation level so a partial failure rolls back cleanly instead of leaving event-log rows committed and tripping the outer per-event fallback into duplicating side-table rows.

`handle_new_event`'s body is extracted into shared `_store_and_notify` + `_notify_after_store` helpers; behavior is unchanged for existing callers.

### Scope (intentional)

This PR specializes the Postgres backend, since that's the reported failure mode. `SqliteEventLogStorage`, the in-memory storage, and `dagster-mysql` still inherit the base per-event loop -- correct results, no speedup. Generalizing requires per-dialect upsert syntax (`INSERT ... ON CONFLICT DO UPDATE` vs `INSERT ... ON DUPLICATE KEY UPDATE` vs `INSERT OR REPLACE`) and is deferred to a follow-up; happy to file that as a follow-up issue.

### Env-var surface

- `DAGSTER_PLANNED_EVENT_CHUNK_SIZE` (new) -- chunk size for the planned-event batch path. Default `1024`.
- `DAGSTER_EVENT_BATCH_SIZE` (existing) -- unchanged. Still gates `handle_new_event`'s opt-in batching for non-planned callers. The two knobs control different mechanisms and are intentionally separate.
- `DAGSTER_EMIT_PLANNED_EVENTS_INDIVIDUALLY` (existing) -- still the escape hatch back to the per-event path.

## Test Plan

- [x] `make ruff` clean.
- [x] 24/24 batch + planned tests pass on `TestInMemoryEventLogStorage`, `TestSqliteEventLogStorage`, `TestConsolidatedSqliteEventLogStorage`.
- [x] New shared tests in `dagster_tests/storage_tests/utils/event_log_storage.py`:
  - `test_store_event_batch_materialization_planned` -- N planned mats for distinct keys, asserts event-log rows + `asset_keys.last_run_id`.
  - `test_store_event_batch_check_evaluation_planned` -- partitioned + unpartitioned planned checks, asserts one `asset_check_executions` row per `(event, partition)` at status `PLANNED`.
  - `test_store_event_batch_mixed_planned` -- both event types in one batch, asserts both side tables populate.
  - `test_create_run_batches_planned_events_without_env_var` -- end-to-end regression test that explicitly clears `DAGSTER_EVENT_BATCH_SIZE` and confirms planned events still persist.
- [x] New Postgres-specific tests in `dagster_postgres_tests/test_event_log.py`:
  - `test_store_planned_events_batch_on_conflict_updates_asset_keys` -- exercises `ON CONFLICT DO UPDATE` by re-inserting the same key.
  - `test_store_planned_events_batch_rolls_back_on_partial_failure` -- verifies `conn.begin()` rollback under partial failure (event-log rows must not survive).

Postgres-specific tests run in CI against the real Postgres testcontainer.

## Changelog

[dagster-postgres] Batch-write planned `ASSET_MATERIALIZATION_PLANNED` and `ASSET_CHECK_EVALUATION_PLANNED` events on run launch; run-launch time on jobs with hundreds of asset checks drops from minutes to seconds.