### PR TITLE
fix: quote partition_expr identifiers to prevent SQL injection

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/db_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/db_io_manager.py
@@ -34,6 +34,14 @@ class TableSlice(NamedTuple):
     partition_dimensions: Sequence[TablePartitionDimension] | None = None
 
 
+def _quote_sql_identifier(name: str) -> str:
+    """Quote a SQL identifier (e.g. column name) using ANSI SQL double-quote escaping.
+
+    Prevents SQL injection when partition expressions are interpolated into WHERE clauses.
+    """
+    return f'"{name.replace(chr(34), chr(34) * 2)}"'
+
+
 def escape_sql_string_literal(value: str) -> str:
     """Escape a string for safe inclusion in a SQL single-quoted literal.
 
@@ -47,7 +55,7 @@ def escape_sql_string_literal(value: str) -> str:
 def static_where_clause(table_partition: TablePartitionDimension) -> str:
     """Build a SQL WHERE clause fragment for static (non-time-window) partitions.
 
-    Escapes partition key values to prevent SQL injection.
+    Escapes partition key values and quotes partition expressions to prevent SQL injection.
     """
     check.invariant(
         not isinstance(table_partition.partitions, TimeWindow),
@@ -57,7 +65,7 @@ def static_where_clause(table_partition: TablePartitionDimension) -> str:
     partitions = ", ".join(
         f"'{escape_sql_string_literal(partition)}'" for partition in partition_keys
     )
-    return f"""{table_partition.partition_expr} in ({partitions})"""
+    return f"""{_quote_sql_identifier(table_partition.partition_expr)} in ({partitions})"""
 
 
 class DbTypeHandler(ABC, Generic[T]):

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
@@ -255,9 +255,15 @@ def _partition_where_clause(
     )
 
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier using Delta Lake / Spark SQL backtick escaping."""
+    return f"`{name.replace('`', '``')}`"
+
+
 def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
     partition = cast("TimeWindow", table_partition.partitions)
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(DELTA_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(DELTA_DATETIME_FORMAT)
-    return f"""{table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
+    expr = _quote_ident(table_partition.partition_expr)
+    return f"""{expr} >= '{start_dt_str}' AND {expr} < '{end_dt_str}'"""

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -330,9 +330,15 @@ def _partition_where_clause(partition_dimensions: Sequence[TablePartitionDimensi
     )
 
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier using DuckDB double-quote escaping."""
+    return f'"{name.replace(chr(34), chr(34) * 2)}"'
+
+
 def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
     partition = cast("TimeWindow", table_partition.partitions)
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(DUCKDB_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(DUCKDB_DATETIME_FORMAT)
-    return f"""{table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
+    expr = _quote_ident(table_partition.partition_expr)
+    return f"""{expr} >= '{start_dt_str}' AND {expr} < '{end_dt_str}'"""

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -462,9 +462,15 @@ def _partition_where_clause(partition_dimensions: Sequence[TablePartitionDimensi
     )
 
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier using BigQuery backtick escaping."""
+    return f"`{name.replace('`', '``')}`"
+
+
 def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
     partition = cast("TimeWindow", table_partition.partitions)
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(BIGQUERY_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(BIGQUERY_DATETIME_FORMAT)
-    return f"""{table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
+    expr = _quote_ident(table_partition.partition_expr)
+    return f"""{expr} >= '{start_dt_str}' AND {expr} < '{end_dt_str}'"""

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -422,11 +422,17 @@ def partition_where_clause(partition_dimensions: Sequence[TablePartitionDimensio
     )
 
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier using Snowflake double-quote escaping."""
+    return f'"{name.replace(chr(34), chr(34) * 2)}"'
+
+
 def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
     partition = cast("TimeWindow", table_partition.partitions)
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
+    expr = _quote_ident(table_partition.partition_expr)
     # Snowflake BETWEEN is inclusive; start <= partition expr <= end. We don't want to remove the next partition so we instead
     # write this as start <= partition expr < end.
-    return f"""{table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
+    return f"""{expr} >= '{start_dt_str}' AND {expr} < '{end_dt_str}'"""


### PR DESCRIPTION
## Summary

Completes the fix for CVE-2026-41490 by adding SQL identifier quoting to all database backends that were missed in the original ClickHouse-only fix.

The ClickHouse backend already properly quotes `partition_expr` via `_quote_ident()`. This PR applies the same fix to:
- **Core** `db_io_manager.py` — `static_where_clause()`
- **Snowflake** — `_time_window_where_clause()`
- **DuckDB** — `_time_window_where_clause()`
- **BigQuery** — `_time_window_where_clause()`
- **Delta Lake** — `_time_window_where_clause()`

## Changes

Each backend gains a `_quote_ident()` function that escapes identifier meta-characters, and the `partition_expr` column reference is wrapped before interpolation into generated SQL.

## Security Impact

Without this fix, a user with asset creation permissions can inject arbitrary SQL through the `partition_expr` metadata field, bypassing partition isolation and potentially accessing/modifying data across all partitions.