### PR TITLE
fix: per-backend partition_expr quoting (addresses CVE-2026-41490 pat…

### DIFF
--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/io_manager.py
@@ -15,7 +15,7 @@ from dagster._core.storage.db_io_manager import (
     DbTypeHandler,
     TablePartitionDimension,
     TableSlice,
-    static_where_clause,
+    escape_sql_string_literal,
 )
 from pydantic import Field
 
@@ -242,6 +242,20 @@ class DeltaLakeDbClient(DbClient):
         yield conn
 
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier using Delta Lake / Spark SQL backtick escaping."""
+    return f"`{name.replace('`', '``')}`"
+
+
+def _static_where_clause(table_partition: TablePartitionDimension) -> str:
+    """SQL-injection-safe static partition WHERE clause for Delta Lake."""
+    partition_keys = cast("Sequence[str]", table_partition.partitions)
+    partitions = ", ".join(
+        f"'{escape_sql_string_literal(p)}'" for p in partition_keys
+    )
+    return f"{_quote_ident(table_partition.partition_expr)} in ({partitions})"
+
+
 def _partition_where_clause(
     partition_dimensions: Sequence[TablePartitionDimension],
 ) -> str:
@@ -249,7 +263,7 @@ def _partition_where_clause(
         (
             _time_window_where_clause(partition_dimension)
             if isinstance(partition_dimension.partitions, TimeWindow)
-            else static_where_clause(partition_dimension)
+            else _static_where_clause(partition_dimension)
         )
         for partition_dimension in partition_dimensions
     )
@@ -260,4 +274,5 @@ def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(DELTA_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(DELTA_DATETIME_FORMAT)
-    return f"""{table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
+    expr = _quote_ident(table_partition.partition_expr)
+    return f"""{expr} >= '{start_dt_str}' AND {expr} < '{end_dt_str}'"""

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -13,7 +13,7 @@ from dagster._core.storage.db_io_manager import (
     DbTypeHandler,
     TablePartitionDimension,
     TableSlice,
-    static_where_clause,
+    escape_sql_string_literal,
 )
 from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._utils.backoff import backoff
@@ -319,12 +319,26 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
         return f"DELETE FROM {table_slice.schema}.{table_slice.table}"
 
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier using DuckDB double-quote escaping."""
+    return f'"{name.replace(chr(34), chr(34) * 2)}"'
+
+
+def _static_where_clause(table_partition: TablePartitionDimension) -> str:
+    """SQL-injection-safe static partition WHERE clause for DuckDB."""
+    partition_keys = cast("Sequence[str]", table_partition.partitions)
+    partitions = ", ".join(
+        f"'{escape_sql_string_literal(p)}'" for p in partition_keys
+    )
+    return f"{_quote_ident(table_partition.partition_expr)} in ({partitions})"
+
+
 def _partition_where_clause(partition_dimensions: Sequence[TablePartitionDimension]) -> str:
     return " AND\n".join(
         (
             _time_window_where_clause(partition_dimension)
             if isinstance(partition_dimension.partitions, TimeWindow)
-            else static_where_clause(partition_dimension)
+            else _static_where_clause(partition_dimension)
         )
         for partition_dimension in partition_dimensions
     )
@@ -335,4 +349,5 @@ def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(DUCKDB_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(DUCKDB_DATETIME_FORMAT)
-    return f"""{table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
+    expr = _quote_ident(table_partition.partition_expr)
+    return f"""{expr} >= '{start_dt_str}' AND {expr} < '{end_dt_str}'"""

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -13,7 +13,7 @@ from dagster._core.storage.db_io_manager import (
     DbTypeHandler,
     TablePartitionDimension,
     TableSlice,
-    static_where_clause,
+    escape_sql_string_literal,
 )
 from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from google.api_core.exceptions import NotFound
@@ -451,12 +451,29 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
         return f"TRUNCATE TABLE `{table_slice.database}.{table_slice.schema}.{table_slice.table}`"
 
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier using BigQuery backtick escaping.
+
+    BigQuery uses backslash-backtick to escape literal backticks inside identifiers.
+    """
+    return f"`{name.replace('`', '\\`')}`"
+
+
+def _static_where_clause(table_partition: TablePartitionDimension) -> str:
+    """SQL-injection-safe static partition WHERE clause for BigQuery."""
+    partition_keys = cast("Sequence[str]", table_partition.partitions)
+    partitions = ", ".join(
+        f"'{escape_sql_string_literal(p)}'" for p in partition_keys
+    )
+    return f"{_quote_ident(table_partition.partition_expr)} in ({partitions})"
+
+
 def _partition_where_clause(partition_dimensions: Sequence[TablePartitionDimension]) -> str:
     return " AND\n".join(
         (
             _time_window_where_clause(partition_dimension)
             if isinstance(partition_dimension.partitions, TimeWindow)
-            else static_where_clause(partition_dimension)
+            else _static_where_clause(partition_dimension)
         )
         for partition_dimension in partition_dimensions
     )
@@ -467,4 +484,5 @@ def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(BIGQUERY_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(BIGQUERY_DATETIME_FORMAT)
-    return f"""{table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
+    expr = _quote_ident(table_partition.partition_expr)
+    return f"""{expr} >= '{start_dt_str}' AND {expr} < '{end_dt_str}'"""

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -12,7 +12,7 @@ from dagster._core.storage.db_io_manager import (
     DbTypeHandler,
     TablePartitionDimension,
     TableSlice,
-    static_where_clause,
+    escape_sql_string_literal,
 )
 from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from pydantic import Field
@@ -411,12 +411,30 @@ def _get_cleanup_statement(table_slice: TableSlice) -> str:
         return f"DELETE FROM {table_slice.database}.{table_slice.schema}.{table_slice.table}"
 
 
+def _quote_ident(name: str) -> str:
+    """Quote a SQL identifier using Snowflake double-quote escaping.
+
+    Snowflake folds unquoted identifiers to uppercase at storage time. We uppercase
+    before quoting so "event_date" resolves to the stored column EVENT_DATE.
+    """
+    return f'"{name.upper().replace(chr(34), chr(34) * 2)}"'
+
+
+def _static_where_clause(table_partition: TablePartitionDimension) -> str:
+    """SQL-injection-safe static partition WHERE clause for Snowflake."""
+    partition_keys = cast("Sequence[str]", table_partition.partitions)
+    partitions = ", ".join(
+        f"'{escape_sql_string_literal(p)}'" for p in partition_keys
+    )
+    return f"{_quote_ident(table_partition.partition_expr)} in ({partitions})"
+
+
 def partition_where_clause(partition_dimensions: Sequence[TablePartitionDimension]) -> str:
     return " AND\n".join(
         (
             _time_window_where_clause(partition_dimension)
             if isinstance(partition_dimension.partitions, TimeWindow)
-            else static_where_clause(partition_dimension)
+            else _static_where_clause(partition_dimension)
         )
         for partition_dimension in partition_dimensions
     )
@@ -427,6 +445,7 @@ def _time_window_where_clause(table_partition: TablePartitionDimension) -> str:
     start_dt, end_dt = partition
     start_dt_str = start_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
     end_dt_str = end_dt.strftime(SNOWFLAKE_DATETIME_FORMAT)
+    expr = _quote_ident(table_partition.partition_expr)
     # Snowflake BETWEEN is inclusive; start <= partition expr <= end. We don't want to remove the next partition so we instead
     # write this as start <= partition expr < end.
-    return f"""{table_partition.partition_expr} >= '{start_dt_str}' AND {table_partition.partition_expr} < '{end_dt_str}'"""
+    return f"""{expr} >= '{start_dt_str}' AND {expr} < '{end_dt_str}'"""


### PR DESCRIPTION
## Summary

Completes the fix for CVE-2026-41490 by adding dialect-appropriate SQL identifier quoting to each database backend that was missed in the original ClickHouse-only fix.

Each backend now has its own `_quote_ident()` + `_static_where_clause()`, following the same pattern already used by the ClickHouse backend:

| Backend | Quoting | Notes |
|---------|---------|-------|
| ClickHouse | Backtick | Already fixed (existing) |
| Snowflake | Double-quote | Uppercased before quoting for case-folding compat |
| DuckDB | Double-quote | DuckDB is case-insensitive |
| BigQuery | Backtick | Uses \` escaping per BigQuery spec |
| Delta Lake | Backtick | Spark SQL compatible |

## Changes

- Core `db_io_manager.py`: **intentionally unchanged** — each backend is responsible for its own dialect quoting
- Each backend adds `_quote_ident()`, `_static_where_clause()`, and updates `_time_window_where_clause()`

## Security Impact

Without these fixes, `partition_expr` metadata values are interpolated into SQL without quoting, enabling SQL injection in static and time-window partition WHERE clauses across all four backends.