### PR TITLE
fix(components): avoid RuntimeError when refresh_state is called inside a running event loop

### DIFF
--- a/python_modules/dagster/dagster/components/component/state_backed_component.py
+++ b/python_modules/dagster/dagster/components/component/state_backed_component.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import contextvars
 import inspect
 import shutil
 import tempfile
@@ -227,9 +228,12 @@ class StateBackedComponent(Component):
                     # Called from within a running event loop (e.g. `dg utils
                     # refresh-defs-state`). asyncio.run() cannot be used here, so
                     # delegate to a worker thread that spins up its own event loop.
+                    # copy_context() propagates ContextVars (e.g. DefsStateStorage)
+                    # to the worker, which ThreadPoolExecutor does not do on Python <3.12.
+                    ctx = contextvars.copy_context()
                     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                         version = pool.submit(
-                            asyncio.run, self.refresh_state(context.project_root)
+                            ctx.run, asyncio.run, self.refresh_state(context.project_root)
                         ).result()
                 else:
                     version = asyncio.run(self.refresh_state(context.project_root))

--- a/python_modules/dagster/dagster/components/component/state_backed_component.py
+++ b/python_modules/dagster/dagster/components/component/state_backed_component.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import inspect
 import shutil
 import tempfile
@@ -217,7 +218,17 @@ class StateBackedComponent(Component):
                 # automatically refresh in local dev unless the user opts out
                 (using_dagster_dev() and self.defs_state_config.refresh_if_dev)
             ):
-                version = asyncio.run(self.refresh_state(context.project_root))
+                try:
+                    asyncio.get_running_loop()
+                    # Called from within a running event loop (e.g. `dg utils
+                    # refresh-defs-state`). asyncio.run() would raise RuntimeError
+                    # in this case, so delegate to a worker thread instead.
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                        version = pool.submit(
+                            asyncio.run, self.refresh_state(context.project_root)
+                        ).result()
+                except RuntimeError:
+                    version = asyncio.run(self.refresh_state(context.project_root))
                 defs_load_context.add_defs_state_info(key, version)
 
         with DefinitionsLoadContext.get().state_path(

--- a/python_modules/dagster/dagster/components/component/state_backed_component.py
+++ b/python_modules/dagster/dagster/components/component/state_backed_component.py
@@ -219,15 +219,19 @@ class StateBackedComponent(Component):
                 (using_dagster_dev() and self.defs_state_config.refresh_if_dev)
             ):
                 try:
-                    asyncio.get_running_loop()
+                    running_loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    running_loop = None
+
+                if running_loop is not None:
                     # Called from within a running event loop (e.g. `dg utils
-                    # refresh-defs-state`). asyncio.run() would raise RuntimeError
-                    # in this case, so delegate to a worker thread instead.
+                    # refresh-defs-state`). asyncio.run() cannot be used here, so
+                    # delegate to a worker thread that spins up its own event loop.
                     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                         version = pool.submit(
                             asyncio.run, self.refresh_state(context.project_root)
                         ).result()
-                except RuntimeError:
+                else:
                     version = asyncio.run(self.refresh_state(context.project_root))
                 defs_load_context.add_defs_state_info(key, version)
 


### PR DESCRIPTION
Fixes #33790

## Problem

`StateBackedComponent.build_defs()` is a synchronous method that calls `asyncio.run()` to refresh component state on initialization:

```python
version = asyncio.run(self.refresh_state(context.project_root))
```

When `dg utils refresh-defs-state` is run, it invokes this method from within an already-running event loop. `asyncio.run()` does not support nested event loops and raises:

```
RuntimeError: asyncio.run() cannot be called from a running event loop
```

The bug does not reproduce with `dg dev` because in that path the call happens in a synchronous context.

## Fix

1. **Detect the event loop** via `asyncio.get_running_loop()` in an isolated `try/except RuntimeError` — the scope is tight: only the "no running loop" signal from `get_running_loop` itself can raise `RuntimeError` here.
2. **If a loop is active**, delegate to a `ThreadPoolExecutor` worker that runs its own event loop. `contextvars.copy_context()` propagates ContextVars (e.g. `DefsStateStorage`) to the worker thread — `ThreadPoolExecutor` does not do this automatically on Python < 3.12.
3. **Otherwise**, fall back to `asyncio.run()` as before.

```python
try:
    running_loop = asyncio.get_running_loop()
except RuntimeError:
    running_loop = None

if running_loop is not None:
    ctx = contextvars.copy_context()
    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
        version = pool.submit(
            ctx.run, asyncio.run, self.refresh_state(context.project_root)
        ).result()
else:
    version = asyncio.run(self.refresh_state(context.project_root))
```

## Testing

1. Set up a Dagster workspace with a `StateBackedComponent` (e.g. the PowerBI integration from the docs)
2. Run `dg utils refresh-defs-state`
3. **Before:** `RuntimeError: asyncio.run() cannot be called from a running event loop`
4. **After:** state refreshes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)