### PR TITLE
Fix Helm db statement timeout rendering

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -1,5 +1,11 @@
+from typing import Annotated
+
+from pydantic import Field
+
 from schema.charts.utils import kubernetes
 from schema.charts.utils.utils import BaseModel
+
+DbStatementTimeout = int | Annotated[str, Field(pattern=r"^-?\d+$")]
 
 
 class Server(BaseModel):
@@ -39,7 +45,7 @@ class Webserver(BaseModel, extra="forbid"):
     startupProbe: kubernetes.StartupProbe
     annotations: kubernetes.Annotations
     enableReadOnly: bool
-    dbStatementTimeout: int | None = None
+    dbStatementTimeout: DbStatementTimeout | None = None
     dbPoolRecycle: int | None = None
     dbPoolMaxOverflow: int | None = None
     logLevel: str | None = None

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -276,8 +276,10 @@ def test_webserver_service_read_only(service_template):
     ]
 
 
-def test_webserver_db_statement_timeout(deployment_template: HelmTemplate):
-    db_statement_timeout_ms = 9000
+@pytest.mark.parametrize("db_statement_timeout_ms", [0, 9000, 2147483647, "2147483647"])
+def test_webserver_db_statement_timeout(
+    deployment_template: HelmTemplate, db_statement_timeout_ms: int | str
+):
     helm_values = DagsterHelmValues.construct(
         dagsterWebserver=Webserver.construct(dbStatementTimeout=db_statement_timeout_ms)
     )

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -54,7 +54,7 @@ If release name contains chart name it will be used as a full name.
 {{- $userDeployments := index .Values "dagster-user-deployments" }}
 {{- printf "dagster-webserver -h 0.0.0.0 -p"}} {{ $_.Values.dagsterWebserver.service.port }}
 {{- if $userDeployments.enabled }} -w /dagster-workspace/workspace.yaml {{- end -}}
-{{- with $_.Values.dagsterWebserver.dbStatementTimeout }} --db-statement-timeout {{ . }} {{- end -}}
+{{- if ne $_.Values.dagsterWebserver.dbStatementTimeout nil }} --db-statement-timeout {{ $_.Values.dagsterWebserver.dbStatementTimeout | int64 }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbPoolRecycle }} --db-pool-recycle {{ . }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbPoolMaxOverflow }} --db-pool-max-overflow {{ . }} {{- end -}}
 {{- if $_.Values.dagsterWebserver.pathPrefix }} --path-prefix {{ $_.Values.dagsterWebserver.pathPrefix }} {{- end -}}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -3648,6 +3648,10 @@
                             "type": "integer"
                         },
                         {
+                            "pattern": "^-?\\d+$",
+                            "type": "string"
+                        },
+                        {
                             "type": "null"
                         }
                     ],


### PR DESCRIPTION
## Summary & Motivation

Fixes #33821.

The Dagster Helm chart used a Go template `with` block for `dagsterWebserver.dbStatementTimeout`, which treats `0` as empty and omitted the `--db-statement-timeout 0` flag. This changes the template to render any non-null value, formats numeric values without scientific notation, and allows numeric string values through the chart schema.

## Test Plan

- `uvx ruff==0.15.0 check helm/dagster/schema/schema/charts/dagster/subschema/webserver.py helm/dagster/schema/schema_tests/test_dagit.py`
- `uvx ruff==0.15.0 format --check helm/dagster/schema/schema/charts/dagster/subschema/webserver.py helm/dagster/schema/schema_tests/test_dagit.py`
- `uv run --frozen --project helm/dagster/schema --group test pytest helm/dagster/schema/schema_tests/test_dagit.py -q`
- `helm lint helm/dagster --set dagsterWebserver.dbStatementTimeout=0`
- `helm lint helm/dagster --set-string dagsterWebserver.dbStatementTimeout=2147483647`
- `helm template` checks for `0`, large integer, numeric string, default, and null values

## Changelog

Fixed the Helm chart so `dagsterWebserver.dbStatementTimeout: 0` renders `--db-statement-timeout 0` instead of being omitted.
