### PR TITLE
Handle missing failures field in dbt Fusion test results

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -216,8 +216,9 @@ class DbtCloudJobRunResults:
                         get_completed_at_timestamp(result=result)
                     ),
                 }
-                if result["failures"] is not None:
-                    metadata["dagster_dbt/failed_row_count"] = result["failures"]
+                failures = result.get("failures")
+                if failures is not None:
+                    metadata["dagster_dbt/failed_row_count"] = failures
 
                 asset_check_key = get_asset_check_key_for_test(
                     manifest=manifest,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
@@ -36,3 +36,29 @@ def test_default_asset_events_from_run_results(
     first_check_eval = next(check_eval for check_eval in sorted(asset_check_evaluations))
     assert first_check_eval.check_name == "not_null_customers_customer_id"
     assert first_check_eval.asset_key.path == ["customers"]
+
+
+def test_default_asset_events_handles_missing_failures(
+    workspace: DbtCloudWorkspace,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+):
+    run_results_json = get_sample_run_results_json()
+
+    for result in run_results_json["results"]:
+        if result.get("unique_id", "").startswith("test."):
+            result.pop("failures", None)
+            result["status"] = "skipped"
+            break
+
+    run_results = DbtCloudJobRunResults.from_run_results_json(
+        run_results_json=run_results_json
+    )
+
+    events = list(
+        run_results.to_default_asset_events(
+            client=workspace.get_client(),
+            manifest=workspace.get_or_fetch_workspace_data().manifest,
+        )
+    )
+
+    assert len(events) > 0

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
@@ -1,5 +1,5 @@
 import responses
-from dagster import AssetCheckEvaluation, AssetMaterialization
+from dagster import AssetCheckEvaluation, AssetMaterialization, MetadataValue
 from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace
 from dagster_dbt.cloud_v2.run_handler import DbtCloudJobRunResults
 
@@ -64,7 +64,11 @@ def test_default_asset_events_handles_missing_failures(
     assert len(events) > 0
 
     check_evals = [e for e in events if isinstance(e, AssetCheckEvaluation)]
-    skipped_evals = [e for e in check_evals if e.metadata.get("status") == "skipped"]
+    skipped_evals = [
+        e
+        for e in check_evals
+        if e.metadata.get("status") == MetadataValue.text("skipped")
+    ]
 
-    if skipped_evals:
-        assert "dagster_dbt/failed_row_count" not in skipped_evals[0].metadata
+    assert len(skipped_evals) > 0
+    assert "dagster_dbt/failed_row_count" not in skipped_evals[0].metadata

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
@@ -62,3 +62,9 @@ def test_default_asset_events_handles_missing_failures(
     )
 
     assert len(events) > 0
+
+    check_evals = [e for e in events if isinstance(e, AssetCheckEvaluation)]
+    skipped_evals = [e for e in check_evals if e.metadata.get("status") == "skipped"]
+
+    if skipped_evals:
+        assert "dagster_dbt/failed_row_count" not in skipped_evals[0].metadata


### PR DESCRIPTION
## Summary & Motivation
This change updates DbtCloudJobRunResults.to_default_asset_events() to safely handle dbt fusion test results where the failures field may be omitted for skipped tests.

## Test Plan
- Added a regression test that removes the failures key from a skipped test result.
- Ran:  uv run pytest python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
- All tests passed.

## Changelog
Fixed an issue where dagster-dbt cloud_v2 sensors could crash when processing dbt Fusion skipped tests that omit the failures field.