### PR TITLE
Fix job backfill status with autoretry

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -23,7 +23,6 @@ from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.storage.dagster_run import (
     CANCELABLE_RUN_STATUSES,
     NOT_FINISHED_STATUSES,
-    DagsterRun,
     RunPartitionData,
     RunsFilter,
 )
@@ -451,9 +450,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         else:
             self._partition_run_data = (
                 graphene_info.context.instance.run_storage.get_run_partition_data(
-                    runs_filter=RunsFilter(
-                        tags=DagsterRun.tags_for_backfill_id(self._backfill_job.backfill_id)
-                    )
+                    runs_filter=RunsFilter(backfill_id=self._backfill_job.backfill_id)
                 )
             )
         return self._partition_run_data
@@ -462,9 +459,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         self, instance: DagsterInstance, partition_set: RemotePartitionSet
     ) -> Sequence[RunPartitionData]:
         partitions_def = partition_set.get_partitions_definition()
-        records = instance.get_run_records(
-            RunsFilter(tags=DagsterRun.tags_for_backfill_id(self._backfill_job.backfill_id))
-        )
+        records = instance.get_run_records(RunsFilter(backfill_id=self._backfill_job.backfill_id))
         with partition_loading_context(dynamic_partitions_store=instance):
             return [
                 RunPartitionData(
@@ -495,7 +490,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         instance = graphene_info.context.instance
         records = instance.get_run_records(
             filters=RunsFilter(
-                tags=DagsterRun.tags_for_backfill_id(self._backfill_job.backfill_id),
+                backfill_id=self._backfill_job.backfill_id,
                 statuses=NOT_FINISHED_STATUSES,
             ),
             limit=limit,
@@ -510,7 +505,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         instance = graphene_info.context.instance
         records = instance.get_run_records(
             filters=RunsFilter(
-                tags=DagsterRun.tags_for_backfill_id(self._backfill_job.backfill_id),
+                backfill_id=self._backfill_job.backfill_id,
                 statuses=CANCELABLE_RUN_STATUSES,
             ),
             limit=limit,
@@ -526,7 +521,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         if limit is None:
             limit = instance.get_default_graphql_run_records_limit()
         records = instance.get_run_records(
-            filters=RunsFilter.for_backfill(self._backfill_job.backfill_id),
+            filters=RunsFilter(backfill_id=self._backfill_job.backfill_id),
             limit=limit,
         )
         return [GrapheneRun(record) for record in records]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -600,7 +600,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
                 time.sleep(0.1)
                 assert time.time() - start < 60, "timed out waiting for file"
 
-        runs = graphql_context.instance.get_runs(RunsFilter(tags={BACKFILL_ID_TAG: backfill_id}))
+        runs = graphql_context.instance.get_runs(RunsFilter(backfill_id=backfill_id))
         assert len(runs) == 1
         assert runs[0].status == DagsterRunStatus.STARTED
 
@@ -629,7 +629,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             _execute_job_backfill_iteration_with_side_effects(graphql_context, backfill_id)
             assert time.time() - start < 60, "timed out waiting for backfill to cancel"
 
-        runs = graphql_context.instance.get_runs(RunsFilter(tags={BACKFILL_ID_TAG: backfill_id}))
+        runs = graphql_context.instance.get_runs(RunsFilter(backfill_id=backfill_id))
         assert len(runs) == 1
         assert runs[0].status == DagsterRunStatus.CANCELED
 
@@ -792,7 +792,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
                 time.sleep(0.1)
                 assert time.time() - start < 60, "timed out waiting for file"
 
-        runs = graphql_context.instance.get_runs(RunsFilter(tags={BACKFILL_ID_TAG: backfill_id}))
+        runs = graphql_context.instance.get_runs(RunsFilter(backfill_id=backfill_id))
         assert len(runs) == 1
         assert runs[0].status == DagsterRunStatus.STARTED
 
@@ -817,7 +817,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             _execute_job_backfill_iteration_with_side_effects(graphql_context, backfill_id)
             assert time.time() - start < 60, "timed out waiting for backfill to fail"
 
-        runs = graphql_context.instance.get_runs(RunsFilter(tags={BACKFILL_ID_TAG: backfill_id}))
+        runs = graphql_context.instance.get_runs(RunsFilter(backfill_id=backfill_id))
         assert len(runs) == 1
         assert runs[0].status == DagsterRunStatus.CANCELED
 
@@ -903,9 +903,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
                 _execute_backfill_iteration_with_side_effects(graphql_context, backfill_id)
                 assert time.time() - start < 60, "timed out waiting for backfill to cancel"
 
-            runs = graphql_context.instance.get_runs(
-                RunsFilter(tags={BACKFILL_ID_TAG: backfill_id})
-            )
+            runs = graphql_context.instance.get_runs(RunsFilter(backfill_id=backfill_id))
             assert len(runs) == 1
             assert runs[0].status == DagsterRunStatus.CANCELED
 
@@ -980,9 +978,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             ):
                 _execute_backfill_iteration_with_side_effects(graphql_context, backfill_id)
 
-            runs = graphql_context.instance.get_runs(
-                RunsFilter(tags={BACKFILL_ID_TAG: backfill_id})
-            )
+            runs = graphql_context.instance.get_runs(RunsFilter(backfill_id=backfill_id))
             assert len(runs) == 1
             assert runs[0].status == DagsterRunStatus.CANCELED
 
@@ -1080,9 +1076,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
                 _execute_backfill_iteration_with_side_effects(graphql_context, backfill_id)
                 assert time.time() - start < 60, "timed out waiting for backfill to fail"
 
-            runs = graphql_context.instance.get_runs(
-                RunsFilter(tags={BACKFILL_ID_TAG: backfill_id})
-            )
+            runs = graphql_context.instance.get_runs(RunsFilter(backfill_id=backfill_id))
             assert len(runs) == 1
             assert runs[0].status == DagsterRunStatus.CANCELED
 

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -964,7 +964,7 @@ def backfill_is_complete(
             instance.get_run_ids(
                 filters=RunsFilter(
                     statuses=NOT_FINISHED_STATUSES,
-                    tags={BACKFILL_ID_TAG: backfill_id},
+                    backfill_id=backfill_id,
                 ),
                 limit=1,
             )
@@ -978,7 +978,8 @@ def backfill_is_complete(
         run.run_id
         for run in instance.get_runs(
             filters=RunsFilter(
-                tags={BACKFILL_ID_TAG: backfill_id, WILL_RETRY_TAG: "true"},
+                backfill_id=backfill_id,
+                tags={WILL_RETRY_TAG: "true"},
                 statuses=[DagsterRunStatus.FAILURE],
             )
         )
@@ -2161,7 +2162,7 @@ def _get_failed_asset_graph_subset(
 
     runs = instance_queryer.instance.get_runs(
         filters=RunsFilter(
-            tags={BACKFILL_ID_TAG: backfill_id},
+            backfill_id=backfill_id,
             statuses=[DagsterRunStatus.CANCELED, DagsterRunStatus.FAILURE],
         )
     )

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -29,7 +29,7 @@ from dagster._core.storage.dagster_run import (
     DagsterRunStatus,
     RunsFilter,
 )
-from dagster._core.storage.tags import BACKFILL_ID_TAG, USER_TAG
+from dagster._core.storage.tags import USER_TAG
 from dagster._core.workspace.context import BaseWorkspaceRequestContext
 from dagster._record import record
 from dagster._serdes import whitelist_for_serdes
@@ -561,9 +561,7 @@ def cancel_backfill_runs_and_cancellation_complete(
         runs_to_cancel_in_iteration = instance.run_storage.get_runs(
             filters=RunsFilter(
                 statuses=[DagsterRunStatus.QUEUED],
-                tags={
-                    BACKFILL_ID_TAG: backfill_id,
-                },
+                backfill_id=backfill_id,
             ),
             limit=CANCELABLE_RUNS_BATCH_SIZE,
             ascending=True,
@@ -574,9 +572,7 @@ def cancel_backfill_runs_and_cancellation_complete(
             runs_to_cancel_in_iteration = instance.run_storage.get_runs(
                 filters=RunsFilter(
                     statuses=CANCELABLE_RUN_STATUSES,
-                    tags={
-                        BACKFILL_ID_TAG: backfill_id,
-                    },
+                    backfill_id=backfill_id,
                 ),
                 limit=CANCELABLE_RUNS_BATCH_SIZE,
                 ascending=True,
@@ -610,7 +606,7 @@ def cancel_backfill_runs_and_cancellation_complete(
     # then we want to wait for them to reach a terminal state before the backfill is marked CANCELED.
     run_waiting_to_cancel = instance.get_run_ids(
         RunsFilter(
-            tags={BACKFILL_ID_TAG: backfill_id},
+            backfill_id=backfill_id,
             statuses=NOT_FINISHED_STATUSES,
         ),
         limit=1,

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -33,6 +33,7 @@ from dagster._core.storage.tags import (
     PARTITION_NAME_TAG,
     PARTITION_SET_TAG,
     ROOT_RUN_ID_TAG,
+    WILL_RETRY_TAG,
 )
 from dagster._core.telemetry import BACKFILL_RUN_CREATED, hash_name, log_action
 from dagster._core.utils import make_new_run_id
@@ -137,49 +138,86 @@ def execute_job_backfill_iteration(
                 backfill.with_partition_checkpoint(checkpoint).with_failure_count(0)
             )
             time.sleep(CHECKPOINT_INTERVAL)
-        else:
-            unfinished_runs = instance.get_runs(
-                RunsFilter(
-                    tags=DagsterRun.tags_for_backfill_id(backfill.backfill_id),
-                    statuses=NOT_FINISHED_STATUSES,
-                ),
-                limit=1,
-            )
-            if unfinished_runs:
-                logger.info(
-                    f"Backfill {backfill.backfill_id} has unfinished runs. Status will be updated when all runs are finished."
-                )
-                instance.update_backfill(
-                    backfill.with_partition_checkpoint(checkpoint).with_failure_count(0)
-                )
-                return
-            partition_names = cast("Sequence[str]", backfill.partition_names)
+            continue
+
+        # All backfill runs have been submitted, check backfill status
+        unfinished_runs = instance.get_runs(
+            RunsFilter(
+                tags=DagsterRun.tags_for_backfill_id(backfill.backfill_id),
+                statuses=NOT_FINISHED_STATUSES,
+            ),
+            limit=1,
+        )
+        if unfinished_runs:
             logger.info(
-                f"Backfill completed for {backfill.backfill_id} for"
-                f" {len(partition_names)} partitions"
+                f"Backfill {backfill.backfill_id} has unfinished runs. Status will be updated when all runs are finished."
             )
-            if (
-                len(
-                    instance.get_run_ids(
-                        filters=RunsFilter(
-                            tags=DagsterRun.tags_for_backfill_id(backfill.backfill_id),
-                            statuses=[DagsterRunStatus.FAILURE, DagsterRunStatus.CANCELED],
-                        )
-                    )
+            instance.update_backfill(
+                backfill.with_partition_checkpoint(checkpoint).with_failure_count(0)
+            )
+            return
+
+        # The auto-reexecution daemon marks failed runs with WILL_RETRY_TAG=true
+        # *before* it creates the retry. If we evaluated the final status now we would
+        # race the retry daemon and mark the backfill COMPLETED_FAILED before the retry
+        # ever lands. Defer one more iteration until those retries are launched (and
+        # show up as either in-progress or terminal runs).
+        runs_waiting_to_retry = [
+            run
+            for run in instance.get_runs(
+                filters=RunsFilter(
+                    tags={
+                        **DagsterRun.tags_for_backfill_id(backfill.backfill_id),
+                        WILL_RETRY_TAG: "true",
+                    },
+                    statuses=[DagsterRunStatus.FAILURE],
                 )
-                > 0
-            ):
-                instance.update_backfill(
-                    backfill.with_status(BulkActionStatus.COMPLETED_FAILED).with_end_timestamp(
-                        get_current_timestamp()
-                    )
-                )
-            else:
-                instance.update_backfill(
-                    backfill.with_status(BulkActionStatus.COMPLETED_SUCCESS).with_end_timestamp(
-                        get_current_timestamp()
-                    )
-                )
+            )
+            if run.is_complete_and_waiting_to_retry
+        ]
+        if runs_waiting_to_retry:
+            logger.info(
+                f"Backfill {backfill.backfill_id} has {len(runs_waiting_to_retry)} failed "
+                "run(s) waiting to be retried. Status will be updated when retries complete."
+            )
+            instance.update_backfill(
+                backfill.with_partition_checkpoint(checkpoint).with_failure_count(0)
+            )
+            return
+
+        partition_names = cast("Sequence[str]", backfill.partition_names)
+        logger.info(
+            f"Backfill completed for {backfill.backfill_id} for {len(partition_names)} partitions"
+        )
+
+        # Group runs by their retry chain (root run id) so that a successful retry
+        # supersedes the original failed attempt. Without this, a run retried by the
+        # run_retries daemon that ultimately succeeded would still mark the backfill
+        # as failed because the original run keeps its FAILURE status forever.
+        # Iterate oldest-first so each root_id ends up mapped to the status of the
+        # newest run in its retry chain.
+        backfill_runs = instance.get_runs(
+            filters=RunsFilter(
+                tags=DagsterRun.tags_for_backfill_id(backfill.backfill_id),
+            ),
+            ascending=True,
+        )
+        latest_status_by_root: dict[str, DagsterRunStatus] = {}
+        for run in backfill_runs:
+            root_id = run.root_run_id or run.run_id
+            latest_status_by_root[root_id] = run.status
+
+        if any(
+            status in (DagsterRunStatus.FAILURE, DagsterRunStatus.CANCELED)
+            for status in latest_status_by_root.values()
+        ):
+            final_backfill_status = BulkActionStatus.COMPLETED_FAILED
+        else:
+            final_backfill_status = BulkActionStatus.COMPLETED_SUCCESS
+
+        instance.update_backfill(
+            backfill.with_status(final_backfill_status).with_end_timestamp(get_current_timestamp())
+        )
 
 
 def _get_partition_set(

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -143,7 +143,7 @@ def execute_job_backfill_iteration(
         # All backfill runs have been submitted, check backfill status
         unfinished_runs = instance.get_runs(
             RunsFilter(
-                tags=DagsterRun.tags_for_backfill_id(backfill.backfill_id),
+                backfill_id=backfill.backfill_id,
                 statuses=NOT_FINISHED_STATUSES,
             ),
             limit=1,
@@ -166,10 +166,8 @@ def execute_job_backfill_iteration(
             run
             for run in instance.get_runs(
                 filters=RunsFilter(
-                    tags={
-                        **DagsterRun.tags_for_backfill_id(backfill.backfill_id),
-                        WILL_RETRY_TAG: "true",
-                    },
+                    backfill_id=backfill.backfill_id,
+                    tags={WILL_RETRY_TAG: "true"},
                     statuses=[DagsterRunStatus.FAILURE],
                 )
             )
@@ -197,9 +195,7 @@ def execute_job_backfill_iteration(
         # Iterate oldest-first so each root_id ends up mapped to the status of the
         # newest run in its retry chain.
         backfill_runs = instance.get_runs(
-            filters=RunsFilter(
-                tags=DagsterRun.tags_for_backfill_id(backfill.backfill_id),
-            ),
+            filters=RunsFilter(backfill_id=backfill.backfill_id),
             ascending=True,
         )
         latest_status_by_root: dict[str, DagsterRunStatus] = {}
@@ -282,9 +278,7 @@ def _get_partitions_chunk(
         partition_names = partition_names[index + 1 :]
 
     # for idempotence, fetch all runs with the current backfill id
-    backfill_runs = instance.get_runs(
-        RunsFilter(tags=DagsterRun.tags_for_backfill_id(backfill_job.backfill_id))
-    )
+    backfill_runs = instance.get_runs(RunsFilter(backfill_id=backfill_job.backfill_id))
     # fetching the partitions def of a legacy dynamic partitioned op-job will raise an error
     # so guard against it by checking if the partitions def exists first
     partitions_def = (

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -689,10 +689,6 @@ class RunsFilter(IHaveNew):
     ) -> "RunsFilter":
         return RunsFilter(tags=DagsterRun.tags_for_sensor(sensor))
 
-    @staticmethod
-    def for_backfill(backfill_id: str) -> "RunsFilter":
-        return RunsFilter(tags=DagsterRun.tags_for_backfill_id(backfill_id))
-
 
 class JobBucket(NamedTuple):
     job_names: list[str]

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -629,6 +629,9 @@ class RunsFilter(IHaveNew):
         updated_after (Optional[DateTime]): Filter by runs that were last updated before this datetime.
         created_before (Optional[DateTime]): Filter by runs that were created before this datetime.
         exclude_subruns (Optional[bool]): If true, runs that were launched to backfill historical data will be excluded from results.
+        backfill_id (Optional[str]): Filter by the id of the backfill that launched the run. Prefer this
+            to filtering by the ``dagster/backfill`` tag — when the storage migration has been built it
+            uses the indexed ``runs.backfill_id`` column instead of joining ``run_tags``.
     """
 
     run_ids: Sequence[str] | None
@@ -641,6 +644,7 @@ class RunsFilter(IHaveNew):
     created_after: datetime | None
     created_before: datetime | None
     exclude_subruns: bool | None
+    backfill_id: str | None
 
     def __new__(
         cls,
@@ -654,6 +658,7 @@ class RunsFilter(IHaveNew):
         created_after: datetime | None = None,
         created_before: datetime | None = None,
         exclude_subruns: bool | None = None,
+        backfill_id: str | None = None,
     ):
         check.invariant(run_ids != [], "When filtering on run ids, a non-empty list must be used.")
 
@@ -669,6 +674,7 @@ class RunsFilter(IHaveNew):
             created_after=created_after,
             created_before=created_before,
             exclude_subruns=exclude_subruns,
+            backfill_id=backfill_id,
         )
 
     @staticmethod

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -433,7 +433,7 @@ def migrate_backfill_end_timestamp(storage: RunStorage, print_fn: PrintFn | None
 
 def get_end_timestamp_for_backfill(run_storage: RunStorage, backfill: PartitionBackfill) -> float:
     assert backfill.status in BULK_ACTION_TERMINAL_STATUSES
-    filters = RunsFilter.for_backfill(backfill.backfill_id)
+    filters = RunsFilter(backfill_id=backfill.backfill_id)
     run_records = run_storage.get_run_records(filters=filters)
     if len(run_records) == 0:
         # backfill was moved to a terminal state before any runs were launched. We cannot

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -346,6 +346,18 @@ class SqlRunStorage(RunStorage):
                 )
                 query = query.where(RunsTable.c.run_id.notin_(runs_in_backfills))
 
+        if filters.backfill_id:
+            if self.has_built_index(RUN_BACKFILL_ID):
+                query = query.where(RunsTable.c.backfill_id == filters.backfill_id)
+            else:
+                runs_in_backfill = db_select([RunTagsTable.c.run_id]).where(
+                    db.and_(
+                        RunTagsTable.c.key == BACKFILL_ID_TAG,
+                        RunTagsTable.c.value == filters.backfill_id,
+                    )
+                )
+                query = query.where(RunsTable.c.run_id.in_(runs_in_backfill))
+
         return query
 
     def _runs_query(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -52,6 +52,7 @@ from dagster._core.storage.tags import (
     BACKFILL_TAGS,
     MAX_RETRIES_TAG,
     PARTITION_NAME_TAG,
+    WILL_RETRY_TAG,
 )
 from dagster._core.test_utils import (
     create_run_for_test,
@@ -949,6 +950,121 @@ def test_job_backfill_status(
     assert backfill
     assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
     assert backfill.backfill_end_timestamp is not None
+
+
+def test_job_backfill_status_with_successful_retry(
+    instance: DagsterInstance,
+    workspace_context: WorkspaceProcessContext,
+    remote_repo: RemoteRepository,
+):
+    # Regression: when a backfill run fails and is then successfully retried (e.g. via
+    # the auto-reexecution daemon with `run_retries.enabled=true`), the original FAILURE
+    # run keeps its status forever. The backfill must still resolve to COMPLETED_SUCCESS
+    # because every partition ultimately succeeded.
+    partition_set = remote_repo.get_partition_set("the_job_partition_set")
+    backfill_id = "retry_success"
+    instance.add_backfill(
+        PartitionBackfill(
+            backfill_id=backfill_id,
+            partition_set_origin=partition_set.get_remote_origin(),
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["one", "two", "three"],
+            from_failure=False,
+            reexecution_steps=None,
+            tags=None,
+            backfill_timestamp=get_current_timestamp(),
+        )
+    )
+
+    # Partition "one" failed on the first attempt and was then successfully retried.
+    failed_run = create_run_for_test(
+        instance=instance,
+        status=DagsterRunStatus.FAILURE,
+        tags={
+            **DagsterRun.tags_for_backfill_id(backfill_id),
+            PARTITION_NAME_TAG: "one",
+        },
+    )
+    create_run_for_test(
+        instance=instance,
+        status=DagsterRunStatus.SUCCESS,
+        tags={
+            **DagsterRun.tags_for_backfill_id(backfill_id),
+            PARTITION_NAME_TAG: "one",
+        },
+        root_run_id=failed_run.run_id,
+        parent_run_id=failed_run.run_id,
+    )
+    # Partitions "two" and "three" succeeded on the first attempt.
+    for partition in ("two", "three"):
+        create_run_for_test(
+            instance=instance,
+            status=DagsterRunStatus.SUCCESS,
+            tags={
+                **DagsterRun.tags_for_backfill_id(backfill_id),
+                PARTITION_NAME_TAG: partition,
+            },
+        )
+
+    list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
+
+    backfill = instance.get_backfill(backfill_id)
+    assert backfill
+    assert backfill.status == BulkActionStatus.COMPLETED_SUCCESS
+    assert backfill.backfill_end_timestamp is not None
+
+
+def test_job_backfill_status_waits_for_pending_retry(
+    instance: DagsterInstance,
+    workspace_context: WorkspaceProcessContext,
+    remote_repo: RemoteRepository,
+):
+    # Regression: when a backfill run fails and the auto-reexecution daemon has marked it
+    # with WILL_RETRY_TAG=true but hasn't yet created the retry run, the backfill must stay
+    # REQUESTED. Marking COMPLETED_FAILED here would race the retry daemon and the retry
+    # run would be orphaned outside the backfill's terminal state.
+    partition_set = remote_repo.get_partition_set("the_job_partition_set")
+    backfill_id = "retry_pending"
+    instance.add_backfill(
+        PartitionBackfill(
+            backfill_id=backfill_id,
+            partition_set_origin=partition_set.get_remote_origin(),
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["one", "two", "three"],
+            from_failure=False,
+            reexecution_steps=None,
+            tags=None,
+            backfill_timestamp=get_current_timestamp(),
+        )
+    )
+
+    # Partition "one" failed and is flagged for retry, but the retry run has not been
+    # created yet (no AUTO_RETRY_RUN_ID_TAG). This is the exact window the race exploits.
+    create_run_for_test(
+        instance=instance,
+        status=DagsterRunStatus.FAILURE,
+        tags={
+            **DagsterRun.tags_for_backfill_id(backfill_id),
+            PARTITION_NAME_TAG: "one",
+            WILL_RETRY_TAG: "true",
+        },
+    )
+    for partition in ("two", "three"):
+        create_run_for_test(
+            instance=instance,
+            status=DagsterRunStatus.SUCCESS,
+            tags={
+                **DagsterRun.tags_for_backfill_id(backfill_id),
+                PARTITION_NAME_TAG: partition,
+            },
+        )
+
+    list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
+
+    backfill = instance.get_backfill(backfill_id)
+    assert backfill
+    assert backfill.status == BulkActionStatus.REQUESTED
+    assert backfill.backfill_end_timestamp is None
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="flaky in windows")

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -866,7 +866,7 @@ def test_failure_backfill(
     wait_for_all_runs_to_start(instance)
 
     assert instance.get_runs_count() == 6
-    from_failure_filter = dg.RunsFilter(tags={BACKFILL_ID_TAG: "fromfailure"})
+    from_failure_filter = dg.RunsFilter(backfill_id="fromfailure")
     assert instance.get_runs_count(filters=from_failure_filter) == 3
 
     runs = instance.get_runs(filters=from_failure_filter)
@@ -1139,7 +1139,7 @@ def test_partial_backfill(
     wait_for_all_runs_to_start(instance)
 
     assert instance.get_runs_count() == 5
-    partial_filter = dg.RunsFilter(tags={BACKFILL_ID_TAG: "partial"})
+    partial_filter = dg.RunsFilter(backfill_id="partial")
     assert instance.get_runs_count(filters=partial_filter) == 3
     runs = instance.get_runs(filters=partial_filter)
     three, two, one = runs
@@ -4437,7 +4437,7 @@ def test_run_retry_not_part_of_completed_backfill(
     assert backfill.backfill_end_timestamp is not None
 
     assert retried_run.run_id not in [
-        r.run_id for r in instance.get_runs(filters=RunsFilter.for_backfill(backfill_id))
+        r.run_id for r in instance.get_runs(filters=RunsFilter(backfill_id=backfill_id))
     ]
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_asset_backfill.py
@@ -1459,7 +1459,7 @@ def test_do_not_rerequest_while_existing_run_in_progress():
     )
 
     # Run for 2023-01-01 exists and is in progress, but has not materialized
-    backfill_runs = instance.get_runs(dg.RunsFilter(tags={BACKFILL_ID_TAG: backfill_id}))
+    backfill_runs = instance.get_runs(dg.RunsFilter(backfill_id=backfill_id))
     assert len(backfill_runs) == 1
     assert backfill_runs[0].tags.get(PARTITION_NAME_TAG) == "2023-01-01"
     assert backfill_runs[0].status == DagsterRunStatus.NOT_STARTED
@@ -1476,7 +1476,7 @@ def test_do_not_rerequest_while_existing_run_in_progress():
     )
 
     # Confirm that no additional runs for 2023-01-02 are kicked off
-    assert len(instance.get_runs(dg.RunsFilter(tags={BACKFILL_ID_TAG: backfill_id}))) == 1
+    assert len(instance.get_runs(dg.RunsFilter(backfill_id=backfill_id))) == 1
 
 
 def make_backfill_data(

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1740,7 +1740,7 @@ def test_add_backfill_end_timestamp():
                 )
             completed_backfill_run_end_times = []
             for run in instance.get_runs(
-                filters=RunsFilter.for_backfill(completed_backfill.backfill_id)
+                filters=RunsFilter(backfill_id=completed_backfill.backfill_id)
             ):
                 dagster_event = dg.DagsterEvent(
                     event_type_value=DagsterEventType.RUN_SUCCESS.value,
@@ -1755,7 +1755,7 @@ def test_add_backfill_end_timestamp():
                 )
 
             for run in instance.get_runs(
-                filters=RunsFilter.for_backfill(in_progress_backfill.backfill_id)
+                filters=RunsFilter(backfill_id=in_progress_backfill.backfill_id)
             ):
                 dagster_event = dg.DagsterEvent(
                     event_type_value=DagsterEventType.RUN_SUCCESS.value,

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1407,6 +1407,57 @@ class TestRunStorage:
         assert len(runs_not_in_backfill) == 1
         assert runs_not_in_backfill[0].dagster_run.run_id == run_not_in_backfill_id
 
+    def test_get_runs_by_backfill_id(self, storage: RunStorage):
+        origin = self.fake_partition_set_origin("fake_partition_set")
+        backfill = PartitionBackfill(
+            "bf_one",
+            partition_set_origin=origin,
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["a", "b"],
+            from_failure=False,
+            tags={},
+            backfill_timestamp=time.time(),
+        )
+        storage.add_backfill(backfill)
+
+        in_backfill_id = make_new_run_id()
+        storage.add_run(
+            create_dagster_run(
+                run_id=in_backfill_id,
+                job_name="some_pipeline",
+                status=DagsterRunStatus.SUCCESS,
+                tags={BACKFILL_ID_TAG: backfill.backfill_id},
+            )
+        )
+        other_backfill_id = make_new_run_id()
+        storage.add_run(
+            create_dagster_run(
+                run_id=other_backfill_id,
+                job_name="some_pipeline",
+                status=DagsterRunStatus.SUCCESS,
+                tags={BACKFILL_ID_TAG: "some_other_backfill"},
+            )
+        )
+        no_backfill_id = make_new_run_id()
+        storage.add_run(
+            create_dagster_run(
+                run_id=no_backfill_id,
+                job_name="some_pipeline",
+                status=DagsterRunStatus.SUCCESS,
+            )
+        )
+
+        runs = storage.get_runs(filters=dg.RunsFilter(backfill_id=backfill.backfill_id))
+        assert {r.run_id for r in runs} == {in_backfill_id}
+
+        # combines with other filters
+        runs = storage.get_runs(
+            filters=dg.RunsFilter(
+                backfill_id=backfill.backfill_id, statuses=[DagsterRunStatus.SUCCESS]
+            )
+        )
+        assert {r.run_id for r in runs} == {in_backfill_id}
+
     def test_backfill(self, storage: RunStorage):
         origin = self.fake_partition_set_origin("fake_partition_set")
         backfills = storage.get_backfills()

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -866,7 +866,7 @@ def test_add_backfill_end_timestamp(conn_string):
                 )
             completed_backfill_run_end_times = []
             for run in instance.get_runs(
-                filters=RunsFilter.for_backfill(completed_backfill.backfill_id)
+                filters=RunsFilter(backfill_id=completed_backfill.backfill_id)
             ):
                 dagster_event = DagsterEvent(
                     event_type_value=DagsterEventType.RUN_SUCCESS.value,
@@ -881,7 +881,7 @@ def test_add_backfill_end_timestamp(conn_string):
                 )
 
             for run in instance.get_runs(
-                filters=RunsFilter.for_backfill(in_progress_backfill.backfill_id)
+                filters=RunsFilter(backfill_id=in_progress_backfill.backfill_id)
             ):
                 dagster_event = DagsterEvent(
                     event_type_value=DagsterEventType.RUN_SUCCESS.value,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -1273,7 +1273,7 @@ def test_add_backfill_end_timestamp(hostname, conn_string):
                 )
             completed_backfill_run_end_times = []
             for run in instance.get_runs(
-                filters=RunsFilter.for_backfill(completed_backfill.backfill_id)
+                filters=RunsFilter(backfill_id=completed_backfill.backfill_id)
             ):
                 dagster_event = DagsterEvent(
                     event_type_value=DagsterEventType.RUN_SUCCESS.value,
@@ -1288,7 +1288,7 @@ def test_add_backfill_end_timestamp(hostname, conn_string):
                 )
 
             for run in instance.get_runs(
-                filters=RunsFilter.for_backfill(in_progress_backfill.backfill_id)
+                filters=RunsFilter(backfill_id=in_progress_backfill.backfill_id)
             ):
                 dagster_event = DagsterEvent(
                     event_type_value=DagsterEventType.RUN_SUCCESS.value,


### PR DESCRIPTION
## Summary & Motivation
Hello again :)

We are running a lot of job backfills on Dagster OSS with `dagsterDaemon.runRetries.enabled=True`.
I noticed that some backfills have status **Failed**, but all runs are completed.
<img width="1550" height="319" alt="Screenshot 2026-05-19 at 21 58 07" src="https://github.com/user-attachments/assets/d420066a-0397-4bce-9445-09aff6aec160" />

I advise to review it per commit as the changes make more sense that way.

## Test Plan
I added tests to cover expected behavior, then fixed the logic.

## Changelog
