### PR TITLE
[docs] add missing virtual env creation step in installation guide

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -77,7 +77,7 @@ If you prefer to set up Dagster manually or are installing it into an existing p
 
 To verify that Dagster is installed correctly, run the commands below. You should see the version number of `dg` in your environment.
 
-If you scaffolded your project with `uvx create-dagster`, a virtual environment was created automatically by `uv sync` and you only need to activate it. If you installed `create-dagster` with `pip`, `brew`, or `curl` (or installed Dagster manually with `pip`), you must create the virtual environment yourself before activating it.
+If you scaffolded your project with `uvx create-dagster`, a virtual environment was created and dependencies were installed automatically by `uv sync`, so you only need to activate it. If you installed `create-dagster` with `pip`, `brew`, or `curl`, you must create the virtual environment yourself and install the scaffolded project into it before `dg` becomes available.
 
 <Tabs groupId="package-manager">
   <TabItem value="uv" label="uv">
@@ -99,27 +99,37 @@ If you scaffolded your project with `uvx create-dagster`, a virtual environment 
       </TabItem>
     </Tabs>
   </TabItem>
-  <TabItem value="pip" label="pip">
+  <TabItem value="pip" label="pip / brew / curl">
     <Tabs groupId="os">
       <TabItem value="mac" label="Mac">
         <CliInvocationExample contents="cd my-project" />
         <CliInvocationExample contents="python -m venv .venv" />
         <CliInvocationExample contents="source .venv/bin/activate" />
+        <CliInvocationExample contents="pip install --editable . --group dev" />
         <CliInvocationExample contents="dg --version" />
       </TabItem>
       <TabItem value="windows" label="Windows">
         <CliInvocationExample contents="cd my-project" />
         <CliInvocationExample contents="python -m venv .venv" />
         <CliInvocationExample contents=".venv\Scripts\activate" />
+        <CliInvocationExample contents="pip install --editable . --group dev" />
         <CliInvocationExample contents="dg --version" />
       </TabItem>
       <TabItem value="linux" label="Linux">
         <CliInvocationExample contents="cd my-project" />
         <CliInvocationExample contents="python -m venv .venv" />
         <CliInvocationExample contents="source .venv/bin/activate" />
+        <CliInvocationExample contents="pip install --editable . --group dev" />
         <CliInvocationExample contents="dg --version" />
       </TabItem>
     </Tabs>
+
+:::note
+
+The `--group` argument requires pip 25.1 or higher. On older pip, upgrade with `pip install --upgrade pip`, or omit `--group dev` and install the CLI separately with `pip install dagster-dg-cli`.
+
+:::
+
   </TabItem>
 </Tabs>
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -77,21 +77,49 @@ If you prefer to set up Dagster manually or are installing it into an existing p
 
 To verify that Dagster is installed correctly, run the commands below. You should see the version number of `dg` in your environment.
 
-<Tabs groupId="os">
-  <TabItem value="mac" label="Mac">
-    <CliInvocationExample contents="cd my-project" />
-    <CliInvocationExample contents="source .venv/bin/activate" />
-    <CliInvocationExample contents="dg --version" />
+If you scaffolded your project with `uvx create-dagster`, a virtual environment was created automatically by `uv sync` and you only need to activate it. If you installed `create-dagster` with `pip`, `brew`, or `curl` (or installed Dagster manually with `pip`), you must create the virtual environment yourself before activating it.
+
+<Tabs groupId="package-manager">
+  <TabItem value="uv" label="uv">
+    <Tabs groupId="os">
+      <TabItem value="mac" label="Mac">
+        <CliInvocationExample contents="cd my-project" />
+        <CliInvocationExample contents="source .venv/bin/activate" />
+        <CliInvocationExample contents="dg --version" />
+      </TabItem>
+      <TabItem value="windows" label="Windows">
+        <CliInvocationExample contents="cd my-project" />
+        <CliInvocationExample contents=".venv\Scripts\activate" />
+        <CliInvocationExample contents="dg --version" />
+      </TabItem>
+      <TabItem value="linux" label="Linux">
+        <CliInvocationExample contents="cd my-project" />
+        <CliInvocationExample contents="source .venv/bin/activate" />
+        <CliInvocationExample contents="dg --version" />
+      </TabItem>
+    </Tabs>
   </TabItem>
-  <TabItem value="windows" label="Windows">
-    <CliInvocationExample contents="cd my-project" />
-    <CliInvocationExample contents=".venv\Scripts\activate" />
-    <CliInvocationExample contents="dg --version" />
-  </TabItem>
-  <TabItem value="linux" label="Linux">
-    <CliInvocationExample contents="cd my-project" />
-    <CliInvocationExample contents="source .venv/bin/activate" />
-    <CliInvocationExample contents="dg --version" />
+  <TabItem value="pip" label="pip">
+    <Tabs groupId="os">
+      <TabItem value="mac" label="Mac">
+        <CliInvocationExample contents="cd my-project" />
+        <CliInvocationExample contents="python -m venv .venv" />
+        <CliInvocationExample contents="source .venv/bin/activate" />
+        <CliInvocationExample contents="dg --version" />
+      </TabItem>
+      <TabItem value="windows" label="Windows">
+        <CliInvocationExample contents="cd my-project" />
+        <CliInvocationExample contents="python -m venv .venv" />
+        <CliInvocationExample contents=".venv\Scripts\activate" />
+        <CliInvocationExample contents="dg --version" />
+      </TabItem>
+      <TabItem value="linux" label="Linux">
+        <CliInvocationExample contents="cd my-project" />
+        <CliInvocationExample contents="python -m venv .venv" />
+        <CliInvocationExample contents="source .venv/bin/activate" />
+        <CliInvocationExample contents="dg --version" />
+      </TabItem>
+    </Tabs>
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## Summary

The "Verifying your Dagster installation" section in `docs/docs/getting-started/installation.md` tells users to run `source .venv/bin/activate`, but the `.venv` directory only exists if the project was scaffolded with `uvx create-dagster` (which runs `uv sync` automatically). Users who installed `create-dagster` via `brew`, `curl`, or `pip` end up with no `.venv` and the activate step fails.

The sibling `quickstart.md` page already documents the missing `python -m venv .venv` step — this PR mirrors that pattern in `installation.md`.

## Changes

- Wrap the verification block in an outer `Tabs groupId="package-manager"` with `uv` and `pip` tabs (matching `quickstart.md`).
- Add `python -m venv .venv` to the pip path across Mac, Linux, and Windows.
- Add a short sentence explaining when the manual venv-creation step is needed.
- No behavioural change to the `uv` path.

## Test plan

- [x] Reproduced the original failure by following the `brew`/`curl` install path through to `source .venv/bin/activate`.
- [x] Verified the new `pip` tab's commands produce a working `.venv` and `dg --version` outputs the installed version.
- [ ] Local Docusaurus preview (`yarn start`) renders the nested tabs correctly.

Fixes #33850