### PR TITLE
[webserver] follow symlinks when serving static files

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -257,9 +257,12 @@ class DagsterWebserver(
             )
 
         def _static_dir(mount_path: str, full_path: str, name: str) -> Mount:
+            # follow_symlink=True so build environments that symlink individual
+            # files into the bundled `webapp/build/` tree (e.g. Bazel sandboxes)
+            # still serve them. See #33851.
             return Mount(
                 mount_path,
-                StaticFiles(directory=full_path),
+                StaticFiles(directory=full_path, follow_symlink=True),
                 name=name,
             )
 

--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
@@ -1,19 +1,26 @@
 import gc
+import os
+import sys
+from pathlib import Path
 
 import objgraph
 import pytest
 from dagster import (
+    DagsterInstance,
     __version__ as dagster_version,
     job,
     op,
 )
+from dagster._cli.workspace.cli_target import WorkspaceOpts, workspace_opts_to_load_target
 from dagster._core.events import DagsterEventType
+from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._serdes import unpack_value
 from dagster._utils.error import SerializableErrorInfo
 from dagster_graphql.version import __version__ as dagster_graphql_version
 from dagster_shared.seven import json
 from dagster_webserver.graphql import GraphQLWS
 from dagster_webserver.version import __version__ as dagster_webserver_version
+from dagster_webserver.webserver import DagsterWebserver
 from starlette.testclient import TestClient
 
 EVENT_LOG_SUBSCRIPTION = """
@@ -84,6 +91,45 @@ def test_static_resources(test_client: TestClient):
     response = test_client.get("/vendor/graphiql/graphiql.min.css")
     assert response.status_code == 200, response.text
     assert response.headers["content-type"] != "text/html"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="creating symlinks on Windows requires elevated privileges",
+)
+def test_static_resources_follow_symlinks(tmp_path: Path):
+    # Regression test for #33851: build environments such as Bazel materialize
+    # the bundled webapp/build/ tree by symlinking each file into a sandbox
+    # whose targets live outside the served directory. Starlette's StaticFiles
+    # rejects such symlinks unless follow_symlink=True is passed.
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    real_file = outside_dir / "main.css"
+    real_file.write_text("/* css */")
+
+    build_dir = tmp_path / "webapp" / "build"
+    static_subdir = build_dir / "static"
+    static_subdir.mkdir(parents=True)
+    os.symlink(real_file, static_subdir / "main.css")
+    (build_dir / "index.html").write_text("<html></html>")
+    (build_dir / "csp-header.txt").write_text("")
+
+    class _SymlinkAwareWebserver(DagsterWebserver):
+        def relative_path(self, rel: str) -> str:
+            return str(tmp_path / rel)
+
+    process_context = WorkspaceProcessContext(
+        instance=DagsterInstance.local_temp(),
+        version=dagster_version,
+        read_only=False,
+        workspace_load_target=workspace_opts_to_load_target(
+            WorkspaceOpts(empty_workspace=True),
+        ),
+    )
+    client = TestClient(_SymlinkAwareWebserver(process_context).create_asgi_app(debug=True))
+    response = client.get("/static/main.css")
+    assert response.status_code == 200, response.text
+    assert response.text == "/* css */"
 
 
 # https://graphql.org/learn/serving-over-http/


### PR DESCRIPTION
## Summary

Build environments such as Bazel materialize the bundled `webapp/build/` tree by symlinking each individual file into a sandbox whose targets live *outside* the served directory. Starlette's `StaticFiles` rejects such symlinks by default — so dagster-webserver returns `404 Not Found` for every static asset under Bazel and the UI loads as a blank page.

This regressed when `build_static_routes` moved from per-file `Route(FileResponse(...))` (which transparently followed symlinks) to a directory `Mount(StaticFiles(...))` in #21048.

Pass `follow_symlink=True` so the directory mount serves symlinked files normally. The served directory is curated by the build system, so this does not expand the exposure surface beyond what the previous `FileResponse`-per-file implementation already accepted.

## Changes

- `dagster_webserver/webserver.py`: add `follow_symlink=True` to the `StaticFiles(...)` call inside `_static_dir`. Inline comment links to the issue.
- `dagster_webserver_tests/webserver/test_app.py`: add `test_static_resources_follow_symlinks` regression test that creates a tmp `webapp/build/` with a symlinked CSS file whose target lives outside the served tree (mirroring Bazel's sandbox layout) and asserts the webserver serves it with status 200 and the correct body.

## Test plan

- [x] New regression test fails on master without the patch (`404 Not Found` for the symlinked file).
- [x] New regression test passes with the patch.
- [x] Existing `test_static_resources` continues to pass.
- [x] `ruff check` / `ruff format` clean.
- [x] Test is skipped on Windows (creating symlinks requires elevated privileges there).

Fixes #33851