### PR TITLE
[docs] Add dagster-elasticsearch integration reference

### DIFF
--- a/docs/docs/integrations/libraries/elasticsearch.md
+++ b/docs/docs/integrations/libraries/elasticsearch.md
@@ -1,0 +1,87 @@
+---
+title: Dagster & Elasticsearch
+sidebar_label: Elasticsearch
+sidebar_position: 1
+description: The community-supported Elasticsearch integration provides a resource for interacting with Elasticsearch clusters and an IO manager for bulk-indexing Dagster asset outputs as searchable documents.
+tags: [community-supported, storage]
+source: https://github.com/dagster-io/community-integrations/tree/main/libraries/dagster-elasticsearch
+pypi: https://pypi.org/project/dagster-elasticsearch/
+sidebar_custom_props:
+  logo: images/integrations/elasticsearch.svg
+  community: true
+partnerlink: https://www.elastic.co/elasticsearch
+---
+
+import CommunityIntegration from '@site/docs/partials/\_CommunityIntegration.md';
+
+<CommunityIntegration />
+
+<p>{frontMatter.description}</p>
+
+## Installation
+
+<PackageInstallInstructions packageName="dagster-elasticsearch" />
+
+Optional extras are available for table-like asset outputs:
+
+```shell
+uv add 'dagster-elasticsearch[pandas]'
+uv add 'dagster-elasticsearch[polars]'
+uv add 'dagster-elasticsearch[arrow]'
+```
+
+The underlying `elasticsearch` Python client must match the major version of your Elasticsearch cluster. Pin the client major version in your project if needed, for example `elasticsearch>=8.10,<9` for Elasticsearch 8.x.
+
+## Example
+
+<CodeExample path="docs_snippets/docs_snippets/integrations/elasticsearch.py" language="python" />
+
+## Using the Elasticsearch resource
+
+Use `ElasticsearchResource` when an asset or op needs direct access to an Elasticsearch client. Configure it with either:
+
+- `HostsConfig` for self-hosted or generic Elasticsearch endpoints
+- `CloudConfig` for Elastic Cloud deployments
+
+Both configuration types support API-key authentication or basic authentication with a username and password. `HostsConfig` also supports bearer auth, certificate authorities, and certificate verification settings.
+
+## Using the Elasticsearch IO manager
+
+Use `ElasticsearchIOManager` to bulk-index asset outputs into Elasticsearch. It supports outputs such as dictionaries, lists of dictionaries, pandas DataFrames, Polars DataFrames or LazyFrames, and PyArrow tables. The `id_field` option, which defaults to `_id`, is used as the Elasticsearch document ID when present.
+
+Common IO manager options include:
+
+| Option | Description |
+| --- | --- |
+| `index` | Target index name. When `use_alias=True`, this is the stable alias name. |
+| `bulk_chunk_size` | Number of documents per bulk request. |
+| `max_chunk_bytes` | Optional maximum bulk request size in bytes. |
+| `refresh` | Whether to refresh the index after writes. |
+| `lazy_load` | Return an iterator from `load_input` instead of loading all hits eagerly. |
+| `scan_size` | Page size for scroll-based reads. |
+
+Most IO manager settings can be overridden for individual assets with asset metadata, including `index`, `id_field`, `bulk_chunk_size`, `max_chunk_bytes`, `refresh`, `rollover_strategy`, and `index_config`.
+
+## Alias rollover
+
+Set `use_alias=True` to write each materialization to a fresh physical index and atomically swap a stable alias to the new index. This lets readers and downstream assets query the alias while avoiding partial updates.
+
+Rollover strategies include:
+
+| Strategy | Behavior |
+| --- | --- |
+| `auto` | Uses the partition key for partitioned assets, otherwise a timestamp. |
+| `timestamp` | Appends a UTC timestamp suffix. |
+| `run_id` | Appends the Dagster run ID. |
+| `partition` | Appends a slugified partition key. |
+| `none` | Uses no suffix. |
+
+Use `keep_last` to delete older rollover indices after successful alias swaps.
+
+## Asset checks
+
+The IO manager records materialization metadata such as `index`, `indexed`, `failures`, and `alias`. Use `build_indexed_asset_check` to assert that a materialization indexed at least a minimum number of documents and did not exceed a maximum failure count.
+
+## About Elasticsearch
+
+Elasticsearch is a distributed search and analytics engine for indexing, searching, and analyzing large volumes of data in near real time. Learn more in the [Elasticsearch documentation](https://www.elastic.co/docs/solutions/search).

--- a/docs/docs/integrations/libraries/elasticsearch.md
+++ b/docs/docs/integrations/libraries/elasticsearch.md
@@ -51,14 +51,14 @@ Use `ElasticsearchIOManager` to bulk-index asset outputs into Elasticsearch. It 
 
 Common IO manager options include:
 
-| Option | Description |
-| --- | --- |
-| `index` | Target index name. When `use_alias=True`, this is the stable alias name. |
-| `bulk_chunk_size` | Number of documents per bulk request. |
-| `max_chunk_bytes` | Optional maximum bulk request size in bytes. |
-| `refresh` | Whether to refresh the index after writes. |
-| `lazy_load` | Return an iterator from `load_input` instead of loading all hits eagerly. |
-| `scan_size` | Page size for scroll-based reads. |
+| Option            | Description                                                               |
+| ----------------- | ------------------------------------------------------------------------- |
+| `index`           | Target index name. When `use_alias=True`, this is the stable alias name.  |
+| `bulk_chunk_size` | Number of documents per bulk request.                                     |
+| `max_chunk_bytes` | Optional maximum bulk request size in bytes.                              |
+| `refresh`         | Whether to refresh the index after writes.                                |
+| `lazy_load`       | Return an iterator from `load_input` instead of loading all hits eagerly. |
+| `scan_size`       | Page size for scroll-based reads.                                         |
 
 Most IO manager settings can be overridden for individual assets with asset metadata, including `index`, `id_field`, `bulk_chunk_size`, `max_chunk_bytes`, `refresh`, `rollover_strategy`, and `index_config`.
 
@@ -68,13 +68,13 @@ Set `use_alias=True` to write each materialization to a fresh physical index and
 
 Rollover strategies include:
 
-| Strategy | Behavior |
-| --- | --- |
-| `auto` | Uses the partition key for partitioned assets, otherwise a timestamp. |
-| `timestamp` | Appends a UTC timestamp suffix. |
-| `run_id` | Appends the Dagster run ID. |
-| `partition` | Appends a slugified partition key. |
-| `none` | Uses no suffix. |
+| Strategy    | Behavior                                                              |
+| ----------- | --------------------------------------------------------------------- |
+| `auto`      | Uses the partition key for partitioned assets, otherwise a timestamp. |
+| `timestamp` | Appends a UTC timestamp suffix.                                       |
+| `run_id`    | Appends the Dagster run ID.                                           |
+| `partition` | Appends a slugified partition key.                                    |
+| `none`      | Uses no suffix.                                                       |
 
 Use `keep_last` to delete older rollover indices after successful alias swaps.
 

--- a/docs/docs/integrations/libraries/elasticsearch.md
+++ b/docs/docs/integrations/libraries/elasticsearch.md
@@ -22,13 +22,13 @@ import CommunityIntegration from '@site/docs/partials/\_CommunityIntegration.md'
 
 <PackageInstallInstructions packageName="dagster-elasticsearch" />
 
-Optional extras are available for table-like asset outputs:
+Optional extras are available for table-like asset outputs. Install the extras that match the data types your assets return:
 
-```shell
-uv add 'dagster-elasticsearch[pandas]'
-uv add 'dagster-elasticsearch[polars]'
-uv add 'dagster-elasticsearch[arrow]'
-```
+<PackageInstallInstructions packageName="dagster-elasticsearch[pandas]" />
+
+<PackageInstallInstructions packageName="dagster-elasticsearch[polars]" />
+
+<PackageInstallInstructions packageName="dagster-elasticsearch[arrow]" />
 
 The underlying `elasticsearch` Python client must match the major version of your Elasticsearch cluster. Pin the client major version in your project if needed, for example `elasticsearch>=8.10,<9` for Elasticsearch 8.x.
 

--- a/docs/docs/integrations/libraries/openlineage.md
+++ b/docs/docs/integrations/libraries/openlineage.md
@@ -26,12 +26,12 @@ import CommunityIntegration from '@site/docs/partials/\_CommunityIntegration.md'
 
 `dagster-openlineage` v0.2 provides two emission mechanisms — configure **exactly one** per deployment:
 
-| Environment | Mechanism A (storage wrapper) | Mechanism B (sensor) |
-|---|---|---|
-| OSS Dagster (self-hosted) | ✅ | ✅ |
-| Dagster+ Hybrid | ❌ | ✅ |
-| Dagster+ Serverless | ❌ | ✅ |
-| Dagster+ Branch Deployments | ❌ | ✅ |
+| Environment                 | Mechanism A (storage wrapper) | Mechanism B (sensor) |
+| --------------------------- | ----------------------------- | -------------------- |
+| OSS Dagster (self-hosted)   | ✅                            | ✅                   |
+| Dagster+ Hybrid             | ❌                            | ✅                   |
+| Dagster+ Serverless         | ❌                            | ✅                   |
+| Dagster+ Branch Deployments | ❌                            | ✅                   |
 
 - **You control `instance.yaml`** → use Mechanism A. Every event is emitted as it is persisted; no daemon dependency.
 - **You run on Dagster+** → use Mechanism B. The sensor polls the event log and converts asset events to OpenLineage emissions.

--- a/docs/static/images/integrations/elasticsearch.svg
+++ b/docs/static/images/integrations/elasticsearch.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Elasticsearch">
+  <rect width="64" height="64" rx="12" fill="#fff"/>
+  <path d="M12 32c0-11 9-20 20-20h8c6.6 0 12 5.4 12 12 0 3.1-1.2 5.9-3.1 8 1.9 2.1 3.1 4.9 3.1 8 0 6.6-5.4 12-12 12h-8c-11 0-20-9-20-20z" fill="#00BFB3"/>
+  <path d="M13.8 24C17 16.9 24 12 32 12h8c6.6 0 12 5.4 12 12H13.8z" fill="#FEC514"/>
+  <path d="M13.8 40H52c0 6.6-5.4 12-12 12h-8c-8 0-15-4.9-18.2-12z" fill="#F04E98"/>
+  <path d="M20 28h28c1.1 0 2 .9 2 2v4c0 1.1-.9 2-2 2H20c-1.1 0-2-.9-2-2v-4c0-1.1.9-2 2-2z" fill="#343741"/>
+</svg>

--- a/examples/docs_snippets/docs_snippets/integrations/elasticsearch.py
+++ b/examples/docs_snippets/docs_snippets/integrations/elasticsearch.py
@@ -23,25 +23,27 @@ def search_docs() -> list[dict[str, str]]:
     ]
 
 
-defs = dg.Definitions(
-    assets=[indexed_doc, search_docs],
-    asset_checks=[build_indexed_asset_check(asset=search_docs, min_indexed=1)],
-    resources={
-        "es": ElasticsearchResource(
-            connection_config=HostsConfig(
-                hosts=["https://es.example.com:9200"],
-                api_key=dg.EnvVar("ELASTICSEARCH_API_KEY"),
+@dg.definitions
+def defs() -> dg.Definitions:
+    return dg.Definitions(
+        assets=[indexed_doc, search_docs],
+        asset_checks=[build_indexed_asset_check(asset=search_docs, min_indexed=1)],
+        resources={
+            "es": ElasticsearchResource(
+                connection_config=HostsConfig(
+                    hosts=["https://es.example.com:9200"],
+                    api_key=dg.EnvVar("ELASTICSEARCH_API_KEY"),
+                ),
             ),
-        ),
-        "elasticsearch_io_manager": ElasticsearchIOManager(
-            connection_config=HostsConfig(
-                hosts=["https://es.example.com:9200"],
-                api_key=dg.EnvVar("ELASTICSEARCH_API_KEY"),
+            "elasticsearch_io_manager": ElasticsearchIOManager(
+                connection_config=HostsConfig(
+                    hosts=["https://es.example.com:9200"],
+                    api_key=dg.EnvVar("ELASTICSEARCH_API_KEY"),
+                ),
+                index="docs",
+                use_alias=True,
+                rollover_strategy="auto",
+                keep_last=3,
             ),
-            index="docs",
-            use_alias=True,
-            rollover_strategy="auto",
-            keep_last=3,
-        ),
-    },
-)
+        },
+    )

--- a/examples/docs_snippets/docs_snippets/integrations/elasticsearch.py
+++ b/examples/docs_snippets/docs_snippets/integrations/elasticsearch.py
@@ -1,0 +1,47 @@
+from dagster_elasticsearch import (
+    ElasticsearchIOManager,
+    ElasticsearchResource,
+    HostsConfig,
+    build_indexed_asset_check,
+)
+
+import dagster as dg
+
+
+@dg.asset(compute_kind="elasticsearch")
+def indexed_doc(es: ElasticsearchResource) -> None:
+    with es.get_client() as client:
+        client.index(index="docs", id="hello", document={"title": "hello"})
+        client.indices.refresh(index="docs")
+
+
+@dg.asset(io_manager_key="elasticsearch_io_manager")
+def search_docs() -> list[dict[str, str]]:
+    return [
+        {"_id": "1", "title": "hello"},
+        {"_id": "2", "title": "world"},
+    ]
+
+
+defs = dg.Definitions(
+    assets=[indexed_doc, search_docs],
+    asset_checks=[build_indexed_asset_check(asset=search_docs, min_indexed=1)],
+    resources={
+        "es": ElasticsearchResource(
+            connection_config=HostsConfig(
+                hosts=["https://es.example.com:9200"],
+                api_key=dg.EnvVar("ELASTICSEARCH_API_KEY"),
+            ),
+        ),
+        "elasticsearch_io_manager": ElasticsearchIOManager(
+            connection_config=HostsConfig(
+                hosts=["https://es.example.com:9200"],
+                api_key=dg.EnvVar("ELASTICSEARCH_API_KEY"),
+            ),
+            index="docs",
+            use_alias=True,
+            rollover_strategy="auto",
+            keep_last=3,
+        ),
+    },
+)

--- a/examples/docs_snippets/pyproject.toml
+++ b/examples/docs_snippets/pyproject.toml
@@ -121,6 +121,7 @@ test = [
     "opentelemetry-sdk",
     "pytest_httpserver",
     # Community integrations
+    "dagster-elasticsearch @ git+https://github.com/dagster-io/community-integrations.git#subdirectory=libraries/dagster-elasticsearch",
     "dagster-iceberg @ git+https://github.com/dagster-io/community-integrations.git#subdirectory=libraries/dagster-iceberg",
 ]
 test-docs-snapshot = [

--- a/examples/docs_snippets/tox.ini
+++ b/examples/docs_snippets/tox.ini
@@ -33,13 +33,13 @@ commands =
   # install cloud packages out of band due to version conflicts between pypi and source
   all: uv pip install dagster-cloud --no-deps
   all: uv pip install path
-  all: /bin/bash -c '! uv pip list --exclude-editable | grep -e dagster | grep -v -e dagster-cloud -e dagster-iceberg'
+  all: /bin/bash -c '! uv pip list --exclude-editable | grep -e dagster | grep -v -e dagster-cloud -e dagster-iceberg -e dagster-elasticsearch'
   all: pytest -vv {posargs} --ignore=docs_snippets_tests/test_integration_files_load.py --ignore=docs_snippets_tests/snippet_checks
 
   integrations: uv pip install dagster-cloud-cli --no-deps
   integrations: uv pip install dagster-cloud --no-deps
   integrations: uv pip install path
-  integrations: /bin/bash -c '! uv pip list --exclude-editable | grep -e dagster | grep -v -e dagster-cloud -e dagster-iceberg'
+  integrations: /bin/bash -c '! uv pip list --exclude-editable | grep -e dagster | grep -v -e dagster-cloud -e dagster-iceberg -e dagster-elasticsearch'
   integrations: pytest -vv {posargs} docs_snippets_tests/test_integration_files_load.py
 
   docs_snapshot_test: sh ./docs_snippets_tests/ensure_snapshot_deps.sh

--- a/examples/docs_snippets/uv.lock
+++ b/examples/docs_snippets/uv.lock
@@ -8,6 +8,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-05-22T00:00:00Z"
+
 [[package]]
 name = "agate"
 version = "1.9.1"

--- a/examples/docs_snippets/uv.lock
+++ b/examples/docs_snippets/uv.lock
@@ -8,10 +8,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "PT48H"
-
 [[package]]
 name = "agate"
 version = "1.9.1"
@@ -228,6 +224,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "anysqlite"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4b/cd5d66b9f87e773bc71344a368b9472987e33514e6627e28342b9c3e7c43/anysqlite-0.0.5.tar.gz", hash = "sha256:9dfcf87baf6b93426ad1d9118088c41dbf24ef01b445eea4a5d486bac2755cce", size = 3432, upload-time = "2023-10-02T13:49:25.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/31/349eae2bc9d9331dd8951684cf94528d91efaa71129dc30822ac111dfc66/anysqlite-0.0.5-py3-none-any.whl", hash = "sha256:cb345dc4f76f6b37f768d7a0b3e9cf5c700dfcb7a6356af8ab46a11f666edbe7", size = 3907, upload-time = "2023-10-02T13:49:26.943Z" },
 ]
 
 [[package]]
@@ -2087,7 +2095,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.2.1,!=1.6.3,!=1.7.0,!=1.11.0" },
-    { name = "antlr4-python3-runtime" },
+    { name = "antlr4-python3-runtime", specifier = "<4.14" },
     { name = "boto3-stubs", extras = ["essential"], marker = "extra == 'ty'" },
     { name = "click", specifier = ">=5.0,<9.0" },
     { name = "coloredlogs", specifier = ">=6.1,<=14.0" },
@@ -2133,8 +2141,8 @@ requires-dist = [
     { name = "requests" },
     { name = "responses", marker = "extra == 'test'", specifier = "<=0.23.1" },
     { name = "rich" },
-    { name = "ruff", marker = "extra == 'ruff'", specifier = "==0.15.0" },
-    { name = "ruff", marker = "extra == 'test'", specifier = "==0.15.0" },
+    { name = "ruff", marker = "extra == 'ruff'", specifier = "==0.15.13" },
+    { name = "ruff", marker = "extra == 'test'", specifier = "==0.15.13" },
     { name = "six" },
     { name = "sqlalchemy", specifier = ">=1.0,<3" },
     { name = "structlog" },
@@ -2146,7 +2154,7 @@ requires-dist = [
     { name = "tox", marker = "extra == 'test'", specifier = ">=4.22" },
     { name = "tox-uv", marker = "extra == 'test'", specifier = ">=1.16" },
     { name = "tqdm", specifier = "<5" },
-    { name = "ty", marker = "extra == 'ty'", specifier = "==0.0.35" },
+    { name = "ty", marker = "extra == 'ty'", specifier = "==0.0.38" },
     { name = "types-backports", marker = "extra == 'pyright'" },
     { name = "types-backports", marker = "extra == 'ty'" },
     { name = "types-certifi", marker = "extra == 'pyright'" },
@@ -2833,6 +2841,7 @@ dependencies = [
     { name = "dagster-cloud-cli" },
     { name = "dagster-dg-core" },
     { name = "dagster-rest-resources" },
+    { name = "githubkit" },
     { name = "typer" },
 ]
 
@@ -2844,6 +2853,7 @@ requires-dist = [
     { name = "dagster-cloud-cli", editable = "../../python_modules/libraries/dagster-cloud-cli" },
     { name = "dagster-dg-core", editable = "../../python_modules/libraries/dagster-dg-core" },
     { name = "dagster-rest-resources", editable = "../../python_modules/libraries/dagster-rest-resources" },
+    { name = "githubkit" },
     { name = "typer" },
 ]
 provides-extras = ["ai"]
@@ -3121,6 +3131,15 @@ test = [
 ]
 
 [[package]]
+name = "dagster-elasticsearch"
+version = "0.0.1"
+source = { git = "https://github.com/dagster-io/community-integrations.git?subdirectory=libraries%2Fdagster-elasticsearch#5c45448ff73fe5c7dec4553fcb6e864937c75443" }
+dependencies = [
+    { name = "dagster" },
+    { name = "elasticsearch" },
+]
+
+[[package]]
 name = "dagster-fivetran"
 version = "1!0+dev"
 source = { editable = "../../python_modules/libraries/dagster-fivetran" }
@@ -3304,8 +3323,8 @@ test-postgres = [{ name = "dagster-postgres", editable = "../../python_modules/l
 
 [[package]]
 name = "dagster-iceberg"
-version = "0.3.11"
-source = { git = "https://github.com/dagster-io/community-integrations.git?subdirectory=libraries%2Fdagster-iceberg#df10fb226b5c03c44f353f258390edf8373f5253" }
+version = "0.3.12"
+source = { git = "https://github.com/dagster-io/community-integrations.git?subdirectory=libraries%2Fdagster-iceberg#5c45448ff73fe5c7dec4553fcb6e864937c75443" }
 dependencies = [
     { name = "dagster" },
     { name = "pendulum" },
@@ -3346,7 +3365,9 @@ test = [
     { name = "dagster-shared", editable = "../../python_modules/libraries/dagster-shared" },
     { name = "dagster-test", editable = "../../python_modules/dagster-test" },
 ]
-test-old-kubernetes = [{ name = "kubernetes", specifier = "==12.0.0" }]
+test-kubernetes-12 = [{ name = "kubernetes", specifier = "==12.0.0" }]
+test-kubernetes-35 = [{ name = "kubernetes", specifier = ">=35.0.0,<36" }]
+test-kubernetes-36 = [{ name = "kubernetes", specifier = ">=36.0.0,<37" }]
 
 [[package]]
 name = "dagster-looker"
@@ -4585,6 +4606,7 @@ test = [
     { name = "dagster-duckdb-pandas" },
     { name = "dagster-duckdb-polars" },
     { name = "dagster-duckdb-pyspark" },
+    { name = "dagster-elasticsearch" },
     { name = "dagster-fivetran" },
     { name = "dagster-gcp" },
     { name = "dagster-gcp-pandas" },
@@ -4693,6 +4715,7 @@ test = [
     { name = "dagster-duckdb-pandas", editable = "../../python_modules/libraries/dagster-duckdb-pandas" },
     { name = "dagster-duckdb-polars", editable = "../../python_modules/libraries/dagster-duckdb-polars" },
     { name = "dagster-duckdb-pyspark", editable = "../../python_modules/libraries/dagster-duckdb-pyspark" },
+    { name = "dagster-elasticsearch", git = "https://github.com/dagster-io/community-integrations.git?subdirectory=libraries%2Fdagster-elasticsearch" },
     { name = "dagster-fivetran", editable = "../../python_modules/libraries/dagster-fivetran" },
     { name = "dagster-gcp", editable = "../../python_modules/libraries/dagster-gcp" },
     { name = "dagster-gcp-pandas", editable = "../../python_modules/libraries/dagster-gcp-pandas" },
@@ -4793,6 +4816,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
+name = "elastic-transport"
+version = "9.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "sniffio" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/3f/076b7cdc93ff4c7953a76e8e64830e6ff0352cd713d338abc601f142b75f/elastic_transport-9.4.0.tar.gz", hash = "sha256:4eff263c8011dd950451b72be567a2484b814a89c70081053d6ae6addeab52e2", size = 77819, upload-time = "2026-05-05T14:40:54.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/17/8d6ee5cd6218f03b195cc017e9e8e09b3df48ebc307903d09cf9f04ff0fe/elastic_transport-9.4.0-py3-none-any.whl", hash = "sha256:2dbb907ededa14e6ff5be058f8737bbba3926bd1b1a40dbc98a471285fa2cb3c", size = 65358, upload-time = "2026-05-05T14:40:52.545Z" },
+]
+
+[[package]]
+name = "elasticsearch"
+version = "9.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "elastic-transport" },
+    { name = "python-dateutil" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/2d/413775b172c6983c7cdbbdc3ac2be71eb00679510a536081801b387a2c8c/elasticsearch-9.4.0.tar.gz", hash = "sha256:95e38e130b1d01438b19343dfa0458e1857a7df8e2e30cbf23a72182b03f05ff", size = 907191, upload-time = "2026-05-06T11:12:51.996Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/a1/193be12421e0db8e786c1592b449f9cadef240970d391bf94b7bb07ca195/elasticsearch-9.4.0-py3-none-any.whl", hash = "sha256:e20095ba40229f4562f7cc951883c7c62a017435f94dbe0c21526f58ba411885", size = 992735, upload-time = "2026-05-06T11:12:48.267Z" },
 ]
 
 [[package]]
@@ -5187,6 +5240,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/91/603bcaf8cd1b3927de64bf56c3a8915f6653ea7281919140c5bcff2bfe7b/github3.py-4.0.1.tar.gz", hash = "sha256:30d571076753efc389edc7f9aaef338a4fcb24b54d8968d5f39b1342f45ddd36", size = 36214038, upload-time = "2023-04-26T17:56:37.677Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/2394d4fb542574678b0ba342daf734d4d811768da3c2ee0c84d509dcb26c/github3.py-4.0.1-py3-none-any.whl", hash = "sha256:a89af7de25650612d1da2f0609622bcdeb07ee8a45a1c06b2d16a05e4234e753", size = 151800, upload-time = "2023-04-26T17:56:25.015Z" },
+]
+
+[[package]]
+name = "githubkit"
+version = "0.15.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "hishel" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/ac/857b78d82bf95a91413322614d6751db2f55ab214b24239f31729d8821e6/githubkit-0.15.5.tar.gz", hash = "sha256:5ee487b77d3f4332c73fe5dbc69f932d8012ff0bb1aa9c544c238aef74ef1ae0", size = 5550333, upload-time = "2026-05-01T08:57:12.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/ed/d08de6b425a6cce4554ea70a559e03d545058881b5b1d2d0a193d886d3a8/githubkit-0.15.5-py3-none-any.whl", hash = "sha256:69934fdce7e4f197f24d85ea91d808ef245f4463bb982e4c19ac32d827bc7a40", size = 13436716, upload-time = "2026-05-01T08:57:07.644Z" },
 ]
 
 [[package]]
@@ -5673,6 +5742,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hishel"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "anysqlite" },
+    { name = "httpx" },
+    { name = "msgpack" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/64/a104ccac48f123f853254483617b16e0efc1649bd7e35bcdc5a5a5ef0ae2/hishel-0.1.5.tar.gz", hash = "sha256:9d40c682cd94fd6e1394fb05713ae20a75ed8aeba6f5272380444039ce6257f2", size = 75468, upload-time = "2025-10-18T13:32:41.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/83/4f8b77839e62114bb034375ee8e08cfb6af1164754b925b271d3f1ec06ee/hishel-0.1.5-py3-none-any.whl", hash = "sha256:0bfbe9a2b9342090eba82ba6de88258092e1c4c7b730cd4cb4b570e4b40e44a7", size = 92486, upload-time = "2025-10-18T13:32:40.333Z" },
 ]
 
 [[package]]
@@ -9525,27 +9610,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.0"
+version = "0.15.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/39/5cee96809fbca590abea6b46c6d1c586b49663d1d2830a751cc8fc42c666/ruff-0.15.0.tar.gz", hash = "sha256:6bdea47cdbea30d40f8f8d7d69c0854ba7c15420ec75a26f463290949d7f7e9a", size = 4524893, upload-time = "2026-02-03T17:53:35.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/88/3fd1b0aa4b6330d6aaa63a285bc96c9f71970351579152d231ed90914586/ruff-0.15.0-py3-none-linux_armv6l.whl", hash = "sha256:aac4ebaa612a82b23d45964586f24ae9bc23ca101919f5590bdb368d74ad5455", size = 10354332, upload-time = "2026-02-03T17:52:54.892Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f6/62e173fbb7eb75cc29fe2576a1e20f0a46f671a2587b5f604bfb0eaf5f6f/ruff-0.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dcd4be7cc75cfbbca24a98d04d0b9b36a270d0833241f776b788d59f4142b14d", size = 10767189, upload-time = "2026-02-03T17:53:19.778Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e4/968ae17b676d1d2ff101d56dc69cf333e3a4c985e1ec23803df84fc7bf9e/ruff-0.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d747e3319b2bce179c7c1eaad3d884dc0a199b5f4d5187620530adf9105268ce", size = 10075384, upload-time = "2026-02-03T17:53:29.241Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/bf/9843c6044ab9e20af879c751487e61333ca79a2c8c3058b15722386b8cae/ruff-0.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:650bd9c56ae03102c51a5e4b554d74d825ff3abe4db22b90fd32d816c2e90621", size = 10481363, upload-time = "2026-02-03T17:52:43.332Z" },
-    { url = "https://files.pythonhosted.org/packages/55/d9/4ada5ccf4cd1f532db1c8d44b6f664f2208d3d93acbeec18f82315e15193/ruff-0.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6664b7eac559e3048223a2da77769c2f92b43a6dfd4720cef42654299a599c9", size = 10187736, upload-time = "2026-02-03T17:53:00.522Z" },
-    { url = "https://files.pythonhosted.org/packages/86/e2/f25eaecd446af7bb132af0a1d5b135a62971a41f5366ff41d06d25e77a91/ruff-0.15.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f811f97b0f092b35320d1556f3353bf238763420ade5d9e62ebd2b73f2ff179", size = 10968415, upload-time = "2026-02-03T17:53:15.705Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/dc/f06a8558d06333bf79b497d29a50c3a673d9251214e0d7ec78f90b30aa79/ruff-0.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:761ec0a66680fab6454236635a39abaf14198818c8cdf691e036f4bc0f406b2d", size = 11809643, upload-time = "2026-02-03T17:53:23.031Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/45/0ece8db2c474ad7df13af3a6d50f76e22a09d078af63078f005057ca59eb/ruff-0.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:940f11c2604d317e797b289f4f9f3fa5555ffe4fb574b55ed006c3d9b6f0eb78", size = 11234787, upload-time = "2026-02-03T17:52:46.432Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/d9/0e3a81467a120fd265658d127db648e4d3acfe3e4f6f5d4ea79fac47e587/ruff-0.15.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcbca3d40558789126da91d7ef9a7c87772ee107033db7191edefa34e2c7f1b4", size = 11112797, upload-time = "2026-02-03T17:52:49.274Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/cb/8c0b3b0c692683f8ff31351dfb6241047fa873a4481a76df4335a8bff716/ruff-0.15.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a121a96db1d75fa3eb39c4539e607f628920dd72ff1f7c5ee4f1b768ac62d6e", size = 11033133, upload-time = "2026-02-03T17:53:33.105Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5e/23b87370cf0f9081a8c89a753e69a4e8778805b8802ccfe175cc410e50b9/ruff-0.15.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5298d518e493061f2eabd4abd067c7e4fb89e2f63291c94332e35631c07c3662", size = 10442646, upload-time = "2026-02-03T17:53:06.278Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/9a/3c94de5ce642830167e6d00b5c75aacd73e6347b4c7fc6828699b150a5ee/ruff-0.15.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afb6e603d6375ff0d6b0cee563fa21ab570fd15e65c852cb24922cef25050cf1", size = 10195750, upload-time = "2026-02-03T17:53:26.084Z" },
-    { url = "https://files.pythonhosted.org/packages/30/15/e396325080d600b436acc970848d69df9c13977942fb62bb8722d729bee8/ruff-0.15.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:77e515f6b15f828b94dc17d2b4ace334c9ddb7d9468c54b2f9ed2b9c1593ef16", size = 10676120, upload-time = "2026-02-03T17:53:09.363Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/c9/229a23d52a2983de1ad0fb0ee37d36e0257e6f28bfd6b498ee2c76361874/ruff-0.15.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6f6e80850a01eb13b3e42ee0ebdf6e4497151b48c35051aab51c101266d187a3", size = 11201636, upload-time = "2026-02-03T17:52:57.281Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
-    { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
+    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a community-supported integration reference for `dagster-elasticsearch`

<img width="1378" height="1358" alt="image" src="https://github.com/user-attachments/assets/bc243e56-41f4-45f3-babc-5187db3a6500" />

## Changelog

- [docs] Added documentation for community integration `dagster-elasticsearch`