### PR TITLE
[core] Add asset_group_name to IO contexts

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -208,6 +208,26 @@ class InputContext:
 
     @public
     @property
+    def asset_group_name(self) -> str:
+        """The group name of the asset being loaded."""
+        if self._upstream_output is not None:
+            return self._upstream_output.asset_group_name
+
+        if self._asset_key is not None and self._step_context is not None:
+            return self._step_context.job_def.asset_layer.get(self._asset_key).group_name
+
+        if self._asset_key is not None:
+            raise DagsterInvariantViolationError(
+                "Attempting to access asset_group_name, but it was not provided when constructing"
+                " the InputContext"
+            )
+
+        raise DagsterInvariantViolationError(
+            "Attempting to access asset_group_name, but input does not correspond to an asset"
+        )
+
+    @public
+    @property
     def dagster_type(self) -> "DagsterType":
         """The type of this input.
         Dagster types do not propagate from an upstream output to downstream inputs,

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -24,6 +24,7 @@ from dagster._core.definitions.partitions.utils import (
     has_one_dimension_time_window_partitioning,
     time_window_for_partition_key_range,
 )
+from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.errors import DagsterInvalidMetadata, DagsterInvariantViolationError
 from dagster._core.execution.context.input import KeyRangeNoPartitionsDefPartitionsSubset
 from dagster._core.execution.plan.utils import build_resources_for_manager
@@ -395,6 +396,26 @@ class OutputContext:
                 " OutputContext"
             )
         return self._asset_spec
+
+    @public
+    @property
+    def asset_group_name(self) -> str:
+        """The group name of the asset that is being stored as an output."""
+        if self._asset_spec is not None:
+            return self._asset_spec.group_name or DEFAULT_GROUP_NAME
+
+        if self._asset_key is not None and self._step_context is not None:
+            return self._step_context.job_def.asset_layer.get(self._asset_key).group_name
+
+        if self._asset_key is not None:
+            raise DagsterInvariantViolationError(
+                "Attempting to access asset_group_name, but it was not provided when constructing"
+                " the OutputContext"
+            )
+
+        raise DagsterInvariantViolationError(
+            "Attempting to access asset_group_name, but output does not correspond to an asset"
+        )
 
     @property
     def step_context(self) -> "StepExecutionContext":

--- a/python_modules/dagster/dagster_tests/execution_tests/context_tests/test_output.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/context_tests/test_output.py
@@ -30,6 +30,49 @@ def test_build_output_context_asset_spec():
     dg.materialize([asset_spec], resources={"io_manager": TestIOManager()})
 
 
+def test_build_output_context_asset_group_name():
+    asset_spec = dg.AssetSpec(key="key", group_name="group")
+    assert (
+        dg.build_output_context(asset_key="key", asset_spec=asset_spec).asset_group_name == "group"
+    )
+
+
+def test_build_output_context_asset_group_name_defaults():
+    asset_spec = dg.AssetSpec(key="key")
+    assert (
+        dg.build_output_context(asset_key="key", asset_spec=asset_spec).asset_group_name
+        == "default"
+    )
+
+
+def test_build_input_context_asset_group_name_from_upstream_output():
+    upstream_output = dg.build_output_context(
+        asset_key="key",
+        asset_spec=dg.AssetSpec(key="key", group_name="group"),
+    )
+    assert (
+        dg.build_input_context(asset_key="key", upstream_output=upstream_output).asset_group_name
+        == "group"
+    )
+
+
+def test_build_input_context_asset_group_name_defaults_from_upstream_output():
+    upstream_output = dg.build_output_context(asset_key="key", asset_spec=dg.AssetSpec(key="key"))
+    assert (
+        dg.build_input_context(asset_key="key", upstream_output=upstream_output).asset_group_name
+        == "default"
+    )
+
+
+def test_build_input_context_asset_group_name_delegates_to_upstream_output():
+    class UpstreamOutput(dg.OutputContext):
+        @property
+        def asset_group_name(self) -> str:
+            return "group"
+
+    assert dg.build_input_context(upstream_output=UpstreamOutput()).asset_group_name == "group"
+
+
 def test_build_output_context_with_output_metadata():
     expected_metadata = {"foo": "bar"}
     output_context = dg.build_output_context(output_metadata=expected_metadata)


### PR DESCRIPTION
## Summary & Motivation

Adds `asset_group_name` to both `OutputContext` and `InputContext` so IO managers can access an asset's group directly without reaching through `step_context` internals.

This matches the use case described in #13945 and keeps the group lookup available at the same public context boundary as other asset metadata.

## Changelog

- Added `asset_group_name` property to `OutputContext`
- Added `asset_group_name` property to `InputContext`
- Added focused tests for explicit and default group names

## Test Plan

- Attempted: `PYTHONPATH=python_modules/dagster:python_modules/libraries/dagster-shared python3.12 -m pytest python_modules/dagster/dagster_tests/execution_tests/context_tests/test_output.py -q`
- Blocked locally because the required test environment dependencies are not installed in this host Python setup