### PR TITLE
helm: fix dbStatementTimeout/dbPoolRecycle/dbPoolMaxOverflow silently dropped when set to 0

### DIFF
--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -312,6 +312,41 @@ def test_webserver_db_pool_max_overflow(deployment_template: HelmTemplate):
     assert f"--db-pool-max-overflow {pool_max_overflow_s}" in command
 
 
+def test_webserver_db_flags_zero_values(deployment_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct(
+            dbStatementTimeout=0,
+            dbPoolRecycle=0,
+            dbPoolMaxOverflow=0,
+        )
+    )
+
+    webserver_deployments = deployment_template.render(helm_values)
+    command = " ".join(webserver_deployments[0].spec.template.spec.containers[0].command)
+
+    assert "--db-statement-timeout 0" in command
+    assert "--db-pool-recycle 0" in command
+    assert "--db-pool-max-overflow 0" in command
+
+
+def test_webserver_db_flags_large_values(deployment_template: HelmTemplate):
+    large_value = 2147483647
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct(
+            dbStatementTimeout=large_value,
+            dbPoolRecycle=large_value,
+            dbPoolMaxOverflow=large_value,
+        )
+    )
+
+    webserver_deployments = deployment_template.render(helm_values)
+    command = " ".join(webserver_deployments[0].spec.template.spec.containers[0].command)
+
+    assert f"--db-statement-timeout {large_value}" in command
+    assert f"--db-pool-recycle {large_value}" in command
+    assert f"--db-pool-max-overflow {large_value}" in command
+
+
 def test_webserver_log_level(deployment_template: HelmTemplate):
     log_level = "trace"
     helm_values = DagsterHelmValues.construct(

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -54,9 +54,9 @@ If release name contains chart name it will be used as a full name.
 {{- $userDeployments := index .Values "dagster-user-deployments" }}
 {{- printf "dagster-webserver -h 0.0.0.0 -p"}} {{ $_.Values.dagsterWebserver.service.port }}
 {{- if $userDeployments.enabled }} -w /dagster-workspace/workspace.yaml {{- end -}}
-{{- with $_.Values.dagsterWebserver.dbStatementTimeout }} --db-statement-timeout {{ . }} {{- end -}}
-{{- with $_.Values.dagsterWebserver.dbPoolRecycle }} --db-pool-recycle {{ . }} {{- end -}}
-{{- with $_.Values.dagsterWebserver.dbPoolMaxOverflow }} --db-pool-max-overflow {{ . }} {{- end -}}
+{{- if not (kindIs "invalid" $_.Values.dagsterWebserver.dbStatementTimeout) }} --db-statement-timeout {{ $_.Values.dagsterWebserver.dbStatementTimeout | int64 }} {{- end -}}
+{{- if not (kindIs "invalid" $_.Values.dagsterWebserver.dbPoolRecycle) }} --db-pool-recycle {{ $_.Values.dagsterWebserver.dbPoolRecycle | int64 }} {{- end -}}
+{{- if not (kindIs "invalid" $_.Values.dagsterWebserver.dbPoolMaxOverflow) }} --db-pool-max-overflow {{ $_.Values.dagsterWebserver.dbPoolMaxOverflow | int64 }} {{- end -}}
 {{- if $_.Values.dagsterWebserver.pathPrefix }} --path-prefix {{ $_.Values.dagsterWebserver.pathPrefix }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.logLevel }} --log-level {{ . }} {{- end -}}
 {{- if .webserverReadOnly }} --read-only {{- end -}}


### PR DESCRIPTION
## Problem

Setting `dagsterWebserver.dbStatementTimeout: 0` in Helm values has no effect — the `--db-statement-timeout 0` flag never appears in the rendered webserver container args.

Root cause: the template uses `{{- with value }}` blocks, and Go's `text/template` treats the integer `0` as falsy. So `with 0` skips the block entirely.

`0` is a meaningful value for PostgreSQL's `statement_timeout` — it disables the timeout. Without this fix there is no way to pass `--db-statement-timeout 0` through the chart.

The same bug affects `dbPoolRecycle` and `dbPoolMaxOverflow`.

A secondary issue: large integers like `2147483647` (max int32) are rendered as `2.147483647e+09` because Helm parses YAML integers as `float64` and the default formatter switches to scientific notation at large values.

## Reproduce

```yaml
# values.yaml
dagsterWebserver:
  dbStatementTimeout: 0
```

```bash
helm template dagster dagster/dagster -f values.yaml | grep db-statement-timeout
# expected: --db-statement-timeout 0
# actual:   (no output — flag is absent)
```

## Fix

Replace `{{- with value }}` with `{{- if not (kindIs "invalid" value) }}`. The `kindIs "invalid"` predicate returns true only for nil/null values, correctly distinguishing between "not set" (null/omitted) and "set to zero". Piping through `int64` ensures decimal formatting for all integer magnitudes.

Applied to all three flags: `dbStatementTimeout`, `dbPoolRecycle`, `dbPoolMaxOverflow`.

Fixes #33821