### PR TITLE
fix: use time.monotonic() for concurrency slot timeout tracking

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
@@ -102,7 +102,7 @@ class InstanceConcurrencyContext:
             return True
 
         if step_key in self._pending_claims:
-            if time.time() > self._pending_timeouts[step_key]:
+            if time.monotonic() > self._pending_timeouts[step_key]:
                 del self._pending_timeouts[step_key]
                 self._sync_pools()
             else:
@@ -144,7 +144,7 @@ class InstanceConcurrencyContext:
             interval = _calculate_timeout_interval(
                 claim_status.sleep_interval, self._pending_claim_counts[step_key]
             )
-            self._pending_timeouts[step_key] = time.time() + interval
+            self._pending_timeouts[step_key] = time.monotonic() + interval
             self._pending_claim_counts[step_key] += 1
             return False
 
@@ -158,7 +158,7 @@ class InstanceConcurrencyContext:
         if not self._pending_claims:
             return 0.0
 
-        now = time.time()
+        now = time.monotonic()
         return min([0, *[ready_at - now for ready_at in self._pending_timeouts.values()]])
 
     def pending_claim_steps(self) -> list[str]:


### PR DESCRIPTION
## Problem

`InstanceConcurrencyContext` uses `time.time()` to track when pending concurrency-slot claims should be retried. Wall-clock time can jump backward during NTP adjustments or leap-second corrections. When that happens:

- **Clock steps backward**: the stored deadline (`time.time() + interval`) is suddenly in the future again, so the retry is silently delayed beyond the intended interval. If the step is the last thing blocking a run, the run stalls until the clock catches up.
- **Clock steps forward**: the deadline is immediately in the past, causing an early database query.

The three call-sites affected are:

```python
# instance_concurrency_context.py
self._pending_timeouts[step_key] = time.time() + interval  # write deadline
...
if time.time() > self._pending_timeouts[step_key]:          # check deadline
...
now = time.time()                                           # compute remaining
```

## Fix

Replace all three occurrences with `time.monotonic()`. The monotonic clock is guaranteed to never go backward and is the right tool any time you want to measure elapsed time within a single process. `_pending_timeouts` is an in-memory dict that lives only inside a single `InstanceConcurrencyContext` instance, so there is no cross-process or cross-restart concern that would make monotonic time unsuitable.

## Testing

Existing tests in `test_instance_concurrency_context.py` already cover timeout behaviour using `time.sleep()`. Because `time.sleep()` advances both clocks by the same amount in normal operation, no test changes are needed — the tests continue to pass.