### PR TITLE
fix: Exclude deleted connections in airbyte

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -525,7 +525,7 @@ class BaseAirbyteWorkspace(ConfigurableResource):
         description=(
             "If set to True, connections with a 'deprecated' status in Airbyte "
             "will be excluded when fetching workspace data. Deprecated connections are those "
-            "that have been deleted in Airbyte. Defaults to false."
+            "that have been deleted in Airbyte. Defaults to False."
         ),
     )
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -520,6 +520,14 @@ class BaseAirbyteWorkspace(ConfigurableResource):
             "and begin polling it instead of starting a new sync."
         ),
     )
+    filter_deprecated_connections: bool = Field(
+        default=False,
+        description=(
+            "If set to True, connections with a 'deprecated' status in Airbyte "
+            "will be excluded when fetching workspace data. Deprecated connections are those "
+            "that have been deleted in Airbyte. Defaults to false."
+        ),
+    )
 
     _client: AirbyteClient = PrivateAttr(default=None)  # type: ignore
 
@@ -545,6 +553,11 @@ class BaseAirbyteWorkspace(ConfigurableResource):
         connections = client.get_connections()
 
         for partial_connection_details in connections:
+            if (
+                self.filter_deprecated_connections
+                and partial_connection_details.get("status") == "deprecated"
+            ):
+                continue
             full_connection_details = client.get_connection_details(
                 connection_id=partial_connection_details["connectionId"]
             )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -520,7 +520,7 @@ class BaseAirbyteWorkspace(ConfigurableResource):
             "and begin polling it instead of starting a new sync."
         ),
     )
-    filter_deprecated_connections: bool = Field(
+    exclude_deprecated_connections: bool = Field(
         default=False,
         description=(
             "If set to True, connections with a 'deprecated' status in Airbyte "
@@ -554,7 +554,7 @@ class BaseAirbyteWorkspace(ConfigurableResource):
 
         for partial_connection_details in connections:
             if (
-                self.filter_deprecated_connections
+                self.exclude_deprecated_connections
                 and partial_connection_details.get("status") == "deprecated"
             ):
                 continue

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/conftest.py
@@ -403,6 +403,38 @@ def resource(rest_api_url: str, config_api_url: str) -> AirbyteWorkspace | Airby
 
 
 @pytest.fixture
+def resource_exclude_deprecated(
+    rest_api_url: str, config_api_url: str
+) -> AirbyteWorkspace | AirbyteCloudWorkspace:
+    """Returns the appropriate workspace type with exclude_deprecated_connections=True."""
+    if (
+        rest_api_url == AIRBYTE_CLOUD_REST_API_BASE_URL
+        and config_api_url == AIRBYTE_CLOUD_CONFIGURATION_API_BASE_URL
+    ):
+        return AirbyteCloudWorkspace(
+            workspace_id=TEST_WORKSPACE_ID,
+            client_id=TEST_CLIENT_ID,
+            client_secret=TEST_CLIENT_SECRET,
+            max_items_per_page=5,
+            poll_interval=0,
+            cancel_on_termination=False,
+            exclude_deprecated_connections=True,
+        )
+    else:
+        return AirbyteWorkspace(
+            rest_api_base_url=rest_api_url,
+            configuration_api_base_url=config_api_url,
+            workspace_id=TEST_WORKSPACE_ID,
+            client_id=TEST_CLIENT_ID,
+            client_secret=TEST_CLIENT_SECRET,
+            max_items_per_page=5,
+            poll_interval=0,
+            cancel_on_termination=False,
+            exclude_deprecated_connections=True,
+        )
+
+
+@pytest.fixture
 def another_resource(
     rest_api_url: str, config_api_url: str
 ) -> AirbyteWorkspace | AirbyteCloudWorkspace:

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/conftest.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/conftest.py
@@ -47,6 +47,7 @@ TEST_AIRBYTE_OSS_REST_API_BASE_URL = "http://localhost:8000/api/public/v1"
 TEST_AIRBYTE_OSS_CONFIGURATION_API_BASE_URL = "http://localhost:8000/api/v1"
 
 TEST_UNRECOGNIZED_AIRBYTE_JOB_STATUS_TYPE = "unrecognized"
+TEST_DEPRECATED_CONNECTION_ID = "aaaabbbb-0000-1111-2222-c2c9766f7da5"
 
 TEST_AIRBYTE_CONNECTION_TABLE_PROPS = AirbyteConnectionTableProps(
     table_name=f"{TEST_STREAM_PREFIX}{TEST_STREAM_NAME}",
@@ -84,6 +85,38 @@ def get_sample_connections() -> Mapping[str, Any]:
                     "schedule_type": "cron",
                 },
             }
+        ],
+    }
+
+
+def get_sample_connections_with_deprecated() -> Mapping[str, Any]:
+    """Returns a page of connections that includes one active and one deprecated (deleted) connection."""
+    return {
+        "next": "http://incorrect-url:9999/api/public/v1/connections?limit=5&offset=10",
+        "previous": "http://incorrect-url:9999/api/public/v1/connections?limit=5&offset=0",
+        "data": [
+            {
+                "connectionId": TEST_CONNECTION_ID,
+                "workspaceId": "744cc0ed-7f05-4949-9e60-2a814f90c035",
+                "name": TEST_CONNECTION_NAME,
+                "sourceId": "0c31738c-0b2d-4887-b506-e2cd1c39cc35",
+                "destinationId": TEST_DESTINATION_ID,
+                "status": "active",
+                "schedule": {
+                    "schedule_type": "cron",
+                },
+            },
+            {
+                "connectionId": TEST_DEPRECATED_CONNECTION_ID,
+                "workspaceId": "744cc0ed-7f05-4949-9e60-2a814f90c035",
+                "name": "Deprecated Connection",
+                "sourceId": "0c31738c-0b2d-4887-b506-e2cd1c39cc35",
+                "destinationId": TEST_DESTINATION_ID,
+                "status": "deprecated",
+                "schedule": {
+                    "schedule_type": "cron",
+                },
+            },
         ],
     }
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_asset_specs.py
@@ -21,7 +21,6 @@ from dagster_airbyte.translator import (
 from responses import matchers
 
 from dagster_airbyte_tests.beta.conftest import (
-    SAMPLE_ACCESS_TOKEN,
     SAMPLE_ANOTHER_WORKSPACE_RESPOMSE,
     SAMPLE_CONNECTION_DETAILS,
     SAMPLE_DESTINATION_DETAILS,
@@ -47,13 +46,13 @@ def test_fetch_airbyte_workspace_data(
     assert len(actual_workspace_data.destinations_by_id) == 1
 
 
-def test_fetch_airbyte_workspace_data_filters_deprecated_connections(
+def test_fetch_airbyte_workspace_data_excludes_deprecated_connections(
     base_api_mocks: responses.RequestsMock,
     rest_api_url: str,
     config_api_url: str,
-    resource: AirbyteCloudWorkspace | AirbyteWorkspace,
+    resource_exclude_deprecated: AirbyteCloudWorkspace | AirbyteWorkspace,
 ) -> None:
-    """Deprecated (deleted) connections are excluded by default and included when opted in."""
+    """When exclude_deprecated_connections=True, deprecated connections are filtered out."""
     base_api_mocks.add(
         method=responses.GET,
         url=f"{rest_api_url}/workspaces/{TEST_WORKSPACE_ID}",
@@ -91,8 +90,7 @@ def test_fetch_airbyte_workspace_data_filters_deprecated_connections(
         status=200,
     )
 
-    # Default behavior: deprecated connections are filtered out
-    workspace_data = resource.fetch_airbyte_workspace_data()
+    workspace_data = resource_exclude_deprecated.fetch_airbyte_workspace_data()
     assert TEST_CONNECTION_ID in workspace_data.connections_by_id
     assert TEST_DEPRECATED_CONNECTION_ID not in workspace_data.connections_by_id
     assert len(workspace_data.connections_by_id) == 1

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_asset_specs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_asset_specs.py
@@ -21,12 +21,20 @@ from dagster_airbyte.translator import (
 from responses import matchers
 
 from dagster_airbyte_tests.beta.conftest import (
+    SAMPLE_ACCESS_TOKEN,
     SAMPLE_ANOTHER_WORKSPACE_RESPOMSE,
+    SAMPLE_CONNECTION_DETAILS,
+    SAMPLE_DESTINATION_DETAILS,
+    SAMPLE_WORKSPACE_RESPOMSE,
     TEST_ANOTHER_WORKSPACE_ID,
     TEST_CONNECTION_ID,
+    TEST_DEPRECATED_CONNECTION_ID,
+    TEST_DESTINATION_ID,
     TEST_DESTINATION_TYPE,
+    TEST_WORKSPACE_ID,
     get_sample_connections,
     get_sample_connections_next_page,
+    get_sample_connections_with_deprecated,
 )
 
 
@@ -37,6 +45,57 @@ def test_fetch_airbyte_workspace_data(
     actual_workspace_data = resource.fetch_airbyte_workspace_data()
     assert len(actual_workspace_data.connections_by_id) == 1
     assert len(actual_workspace_data.destinations_by_id) == 1
+
+
+def test_fetch_airbyte_workspace_data_filters_deprecated_connections(
+    base_api_mocks: responses.RequestsMock,
+    rest_api_url: str,
+    config_api_url: str,
+    resource: AirbyteCloudWorkspace | AirbyteWorkspace,
+) -> None:
+    """Deprecated (deleted) connections are excluded by default and included when opted in."""
+    base_api_mocks.add(
+        method=responses.GET,
+        url=f"{rest_api_url}/workspaces/{TEST_WORKSPACE_ID}",
+        json=SAMPLE_WORKSPACE_RESPOMSE,
+        status=200,
+    )
+    base_api_mocks.add(
+        method=responses.GET,
+        url=f"{rest_api_url}/connections",
+        json=get_sample_connections_with_deprecated(),
+        status=200,
+        match=[matchers.query_param_matcher({"limit": 5, "workspaceIds": TEST_WORKSPACE_ID})],
+    )
+    base_api_mocks.add(
+        method=responses.GET,
+        url=f"{rest_api_url}/connections",
+        json=get_sample_connections_next_page(),
+        status=200,
+        match=[
+            matchers.query_param_matcher(
+                {"limit": 5, "offset": 10, "workspaceIds": TEST_WORKSPACE_ID}
+            )
+        ],
+    )
+    base_api_mocks.add(
+        method=responses.POST,
+        url=f"{config_api_url}/connections/get",
+        json=SAMPLE_CONNECTION_DETAILS,
+        status=200,
+    )
+    base_api_mocks.add(
+        method=responses.GET,
+        url=f"{rest_api_url}/destinations/{TEST_DESTINATION_ID}",
+        json=SAMPLE_DESTINATION_DETAILS,
+        status=200,
+    )
+
+    # Default behavior: deprecated connections are filtered out
+    workspace_data = resource.fetch_airbyte_workspace_data()
+    assert TEST_CONNECTION_ID in workspace_data.connections_by_id
+    assert TEST_DEPRECATED_CONNECTION_ID not in workspace_data.connections_by_id
+    assert len(workspace_data.connections_by_id) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary & Motivation
The airbyte connection selector currently returns deprecated (deleted) connections from airbyte. This causes issues when existing connections are replaced, as dagster sometimes tries to start a sync for a connection that has been deleted.
