### PR TITLE
chore: improve dagster maintenance path

### DIFF
--- a/examples/deploy_ecs/tests/test_deploy.py
+++ b/examples/deploy_ecs/tests/test_deploy.py
@@ -24,11 +24,11 @@ def docker_context(test_id, monkeypatch, tmpdir):
 
     # Use ecs --local-simulation
     # https://docs.docker.com/cloud/ecs-integration/#local-simulation
-    subprocess.call(["docker", "context", "create", "ecs", "--local-simulation", test_id])
+    subprocess.run(["docker", "context", "create", "ecs", "--local-simulation", test_id], check=True)
 
     yield test_id
 
-    subprocess.call(["docker", "context", "rm", test_id])
+    subprocess.run(["docker", "context", "rm", test_id], check=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in examples/deploy_ecs/tests/test_deploy.py, helm/dagster/schema/schema_tests/utils.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.