### PR TITLE
[ui] fix backfill progress not 100% until all runs are completed

### DIFF
--- a/js_modules/ui-core/src/instance/backfill/BackfillAssetPartitionsTable.tsx
+++ b/js_modules/ui-core/src/instance/backfill/BackfillAssetPartitionsTable.tsx
@@ -267,7 +267,7 @@ export function StatusBar({
   const pctFailed = (100 * failed) / targeted;
   const pctInProgress = (100 * inProgress) / targeted;
 
-  const pctFinal = Math.ceil(pctSucceeded + pctFailed);
+  const pctFinal = Math.floor(pctSucceeded + pctFailed);
 
   return (
     <Box flex={{direction: 'column', alignItems: 'flex-end', gap: 2}}>

--- a/js_modules/ui-core/src/instance/backfill/__tests__/BackfillAssetPartitionsTable.test.tsx
+++ b/js_modules/ui-core/src/instance/backfill/__tests__/BackfillAssetPartitionsTable.test.tsx
@@ -1,0 +1,30 @@
+import {render, screen} from '@testing-library/react';
+
+import {StatusBar} from '../BackfillAssetPartitionsTable';
+
+describe('StatusBar', () => {
+  it('does not show 100% completed while partitions are still in progress', () => {
+    render(<StatusBar targeted={364} inProgress={1} succeeded={362} failed={0} />);
+    expect(screen.getByText('99% completed')).toBeInTheDocument();
+  });
+
+  it('shows 100% completed only when all targeted partitions are done', () => {
+    render(<StatusBar targeted={364} inProgress={0} succeeded={364} failed={0} />);
+    expect(screen.getByText('100% completed')).toBeInTheDocument();
+  });
+
+  it('counts failed partitions as completed', () => {
+    render(<StatusBar targeted={100} inProgress={0} succeeded={90} failed={10} />);
+    expect(screen.getByText('100% completed')).toBeInTheDocument();
+  });
+
+  it('floors fractional percentages instead of rounding up', () => {
+    render(<StatusBar targeted={1000} inProgress={1} succeeded={998} failed={0} />);
+    expect(screen.getByText('99% completed')).toBeInTheDocument();
+  });
+
+  it('shows 0% completed when nothing has finished', () => {
+    render(<StatusBar targeted={10} inProgress={2} succeeded={0} failed={0} />);
+    expect(screen.getByText('0% completed')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary & Motivation
This is confusing:
<img width="1534" height="344" alt="Screenshot 2026-05-28 at 9 53 43" src="https://github.com/user-attachments/assets/ac9ae3b6-6832-4a86-be92-6cb160e7765b" />

