### PR TITLE
[dagster-dg] cap typer below 0.26 to fix empty `dg --help` output

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_custom_help_format.py
@@ -167,6 +167,29 @@ def test_sub_command_with_option_help_message():
     )
 
 
+def test_typer_rich_help_remains_click_compatible():
+    """`dg --help` is rendered through typer.rich_utils.rich_format_help, which only
+    discovers options and commands that subclass click's own Option/Group types. typer
+    0.26 vendored its own click fork (typer._click), so on that release dg's click-based
+    options and command groups silently disappear from the help output (see
+    https://github.com/dagster-io/dagster/issues/33893). dagster-dg-core caps typer below
+    0.26 for this reason; if that cap is ever raised past an incompatible release, this
+    guard fails here rather than letting `dg --help` quietly regress to an empty body.
+    """
+    from typer.core import TyperGroup, TyperOption
+
+    assert issubclass(TyperGroup, click.Group), (
+        "Installed typer's TyperGroup is not a click.Group subclass, so dg help output "
+        "will drop its Commands panel. Keep typer pinned below an incompatible release. "
+        "See https://github.com/dagster-io/dagster/issues/33893."
+    )
+    assert issubclass(TyperOption, click.Option), (
+        "Installed typer's TyperOption is not a click.Option subclass, so dg help output "
+        "will drop its Options panels. Keep typer pinned below an incompatible release. "
+        "See https://github.com/dagster-io/dagster/issues/33893."
+    )
+
+
 def test_dynamic_subcommand_help_message():
     with (
         ProxyRunner.test(use_fixed_test_components=True) as runner,

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_custom_help_format.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_custom_help_format.py
@@ -176,7 +176,16 @@ def test_typer_rich_help_remains_click_compatible():
     0.26 for this reason; if that cap is ever raised past an incompatible release, this
     guard fails here rather than letting `dg --help` quietly regress to an empty body.
     """
-    from typer.core import TyperGroup, TyperOption
+    # typer.core is effectively private; if a future typer reshuffles it the import itself
+    # can break. Surface that as the same actionable failure rather than a bare ImportError.
+    try:
+        from typer.core import TyperGroup, TyperOption
+    except ImportError as exc:
+        raise AssertionError(
+            "Could not import TyperGroup/TyperOption from typer.core; typer's internals "
+            "changed and dg help rendering may no longer be compatible with click. "
+            "See https://github.com/dagster-io/dagster/issues/33893."
+        ) from exc
 
     assert issubclass(TyperGroup, click.Group), (
         "Installed typer's TyperGroup is not a click.Group subclass, so dg help output "

--- a/python_modules/libraries/dagster-dg-cli/pyproject.toml
+++ b/python_modules/libraries/dagster-dg-cli/pyproject.toml
@@ -15,7 +15,10 @@ dependencies = [
     "dagster-rest-resources==1!0+dev",
     "dagster==1!0+dev",
     "requests",
-    "typer",
+    # Kept in sync with dagster-dg-core's cap: typer 0.26 vendored its own click fork and
+    # breaks our click-based `dg --help` rendering (typer.rich_utils is consumed directly
+    # here too). See https://github.com/dagster-io/dagster/issues/33893.
+    "typer<0.26",
 ]
 
 [project.urls]

--- a/python_modules/libraries/dagster-dg-core/pyproject.toml
+++ b/python_modules/libraries/dagster-dg-core/pyproject.toml
@@ -25,7 +25,11 @@ dependencies = [
     "setuptools",  # Needed to parse setup.cfg
     "packaging",
     "python-dotenv",
-    "typer>=0.15.1,<1.0",
+    # Capped below 0.26: that release vendored its own click fork (typer._click), so
+    # typer.rich_utils.rich_format_help no longer recognizes our click-based options and
+    # command groups and silently drops them from `dg --help` output. See
+    # https://github.com/dagster-io/dagster/issues/33893.
+    "typer>=0.15.1,<0.26",
     "dagster-shared==1!0+dev",
     "dagster-cloud-cli==1!0+dev",
 ]


### PR DESCRIPTION
## Summary

`dg` and `dg -h` print only the usage line and description, with no Options or Commands sections. Reported in #33893.

## Root cause

dg renders help through `typer.rich_utils.rich_format_help`. typer 0.26 (released 2026-05-28) vendored its own click fork into `typer._click` and dropped the external click dependency. As a result `rich_format_help` only collects params that are `TyperOption`/`TyperArgument`, and only prints the Commands panel when the group is a `TyperGroup`. dg's options are plain `click.Option` and its groups inherit from `ClickAliasedGroup`, so on typer 0.26 both fall through the isinstance checks and disappear from the output.

The repo's lockfiles resolve typer 0.25.1 (still click-based), so CI never saw this. A fresh install resolves 0.26.x and breaks. The dividing line is exactly 0.26: in 0.25.x `TyperGroup` is a `click.Group` subclass, in 0.26 it is not.

## Fix

Cap `typer>=0.15.1,<0.26` in dagster-dg-core (the package that consumes `rich_format_help`). Reverting to click's default formatter, as suggested in the issue, would drop the "Global options" grouping that the existing snapshot tests assert. A code bridge to typer 0.26 is not practical because it vendored click entirely, so click objects can't satisfy its type checks.

## Tests

Added `test_typer_rich_help_remains_click_compatible`, which asserts typer's command/param types still subclass click's. It passes on the pinned typer and fails on 0.26.x, so if the cap is ever raised past an incompatible release this fails instead of help silently going blank.

Note: the existing `match_terminal_box_output` helper only compares lines up to the length of the actual output, so when help is empty it skips the missing panels and the snapshot tests pass anyway. That is why the regression slipped through. Worth tightening separately.

Verified in a real dagster-dg-cli env: full help-format suite passes on typer 0.25.1; forcing typer 0.26.3 reproduces the empty help and fails the new guard.

Fixes #33893
