### PR TITLE
[components] register fields added by undecorated Resolvable dataclass subclasses

### DIFF
--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -1,6 +1,6 @@
 import inspect
 from collections.abc import Mapping, Sequence
-from dataclasses import MISSING, fields, is_dataclass
+from dataclasses import MISSING, dataclass, fields, is_dataclass
 from enum import Enum, auto
 from functools import partial
 from types import UnionType
@@ -8,6 +8,7 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    ClassVar,
     Final,
     Literal,
     Optional,
@@ -313,12 +314,67 @@ class AnnotationInfo:
     field_info: FieldInfo | None
 
 
+def _is_classvar(annotation: Any) -> bool:
+    # Handles both real ``typing.ClassVar[...]`` annotations and string annotations
+    # (e.g. under ``from __future__ import annotations``), which dataclasses also treats
+    # as ClassVars by name.
+    if get_origin(annotation) is ClassVar or annotation is ClassVar:
+        return True
+    if isinstance(annotation, str):
+        return annotation.startswith("ClassVar") or annotation.startswith("typing.ClassVar")
+    return False
+
+
+def _ensure_dataclass_fields_registered(target_type: type) -> type:
+    """Register fields added by a subclass that inherits ``@dataclass``-ness but was not
+    itself re-decorated.
+
+    A subclass of a ``@dataclass`` ``Resolvable`` inherits ``__dataclass_fields__``, so
+    ``is_dataclass`` is True, but ``dataclasses.fields`` only returns the fields the
+    decorator registered. Any field the subclass declares is therefore silently dropped
+    from the resolution schema (and from the generated ``__init__``), which surfaces as a
+    confusing "Extra inputs are not permitted" error from yaml. Re-applying ``@dataclass``
+    here picks those fields up and regenerates ``__init__``, matching how pydantic Model
+    subclasses pick up new fields automatically. See
+    https://github.com/dagster-io/dagster/issues/33889.
+    """
+    own_annotations = target_type.__dict__.get("__annotations__", {})
+    if not own_annotations:
+        return target_type
+
+    registered = {f.name for f in fields(target_type)}
+    unregistered = [
+        name
+        for name, annotation in own_annotations.items()
+        if name not in registered and not _is_classvar(annotation)
+    ]
+    if not unregistered:
+        return target_type
+
+    # Mirror the inherited dataclass config so we don't change frozen/kw_only semantics or
+    # raise on a frozen/non-frozen mismatch.
+    params = getattr(target_type, "__dataclass_params__", None)
+    try:
+        return dataclass(
+            frozen=bool(getattr(params, "frozen", False)),
+            kw_only=bool(getattr(params, "kw_only", False)),
+        )(target_type)
+    except TypeError as e:
+        raise ResolutionException(
+            f"Could not register field(s) {unregistered} added by {target_type.__name__}. "
+            "When subclassing a @dataclass Resolvable to add fields, the new fields must be "
+            "declared with defaults (or the base must use kw_only) so a valid __init__ can be "
+            "generated. See https://github.com/dagster-io/dagster/issues/33889."
+        ) from e
+
+
 def _get_annotations(
     resolved_type: type[Resolvable],
 ) -> dict[str, AnnotationInfo]:
     annotations: dict[str, AnnotationInfo] = {}
     init_kwargs = _get_init_kwargs(resolved_type)
     if is_dataclass(resolved_type):
+        resolved_type = _ensure_dataclass_fields_registered(resolved_type)
         for f in fields(resolved_type):
             has_default = f.default is not MISSING or f.default_factory is not MISSING
             annotations[f.name] = AnnotationInfo(

--- a/python_modules/dagster/dagster/components/resolved/base.py
+++ b/python_modules/dagster/dagster/components/resolved/base.py
@@ -351,14 +351,15 @@ def _ensure_dataclass_fields_registered(target_type: type) -> type:
     if not unregistered:
         return target_type
 
-    # Mirror the inherited dataclass config so we don't change frozen/kw_only semantics or
-    # raise on a frozen/non-frozen mismatch.
+    # Mirror the inherited dataclass config so re-decorating doesn't silently change
+    # semantics (e.g. eq/order/frozen) or raise on a frozen/non-frozen mismatch. `slots`
+    # and `weakref_slot` are intentionally omitted: `@dataclass(slots=True)` returns a new
+    # class object, which would break the in-place mutation the caller relies on.
     params = getattr(target_type, "__dataclass_params__", None)
+    forwarded = ("init", "repr", "eq", "order", "unsafe_hash", "frozen", "match_args", "kw_only")
+    dataclass_kwargs = {name: getattr(params, name) for name in forwarded if hasattr(params, name)}
     try:
-        return dataclass(
-            frozen=bool(getattr(params, "frozen", False)),
-            kw_only=bool(getattr(params, "kw_only", False)),
-        )(target_type)
+        return dataclass(**dataclass_kwargs)(target_type)
     except TypeError as e:
         raise ResolutionException(
             f"Could not register field(s) {unregistered} added by {target_type.__name__}. "

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_field_utilites.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_field_utilites.py
@@ -54,6 +54,22 @@ def test_inheritance_dataclass_classvar_not_treated_as_field() -> None:
     assert "not_a_field" not in resolvers
 
 
+def test_inheritance_dataclass_preserves_dataclass_params() -> None:
+    # Re-decorating an undecorated subclass must preserve the base's dataclass config
+    # (eq/order/etc.) rather than resetting it to the @dataclass defaults.
+    @dataclass(order=True)
+    class Base(dg.Resolvable):
+        base_field: int
+
+    class Derived(Base):
+        derived_field: str = "default"
+
+    # accessing the annotations triggers the re-decoration
+    resolvers = _get_annotations(Derived)
+    assert "derived_field" in resolvers
+    assert Derived.__dataclass_params__.order is True
+
+
 def test_inheritance_frozen_dataclass_without_redecoration() -> None:
     @dataclass(frozen=True)
     class Base(dg.Resolvable):
@@ -67,6 +83,7 @@ def test_inheritance_frozen_dataclass_without_redecoration() -> None:
     assert "derived_field" in resolvers
 
     resolved = Derived.resolve_from_dict({"base_field": 1, "derived_field": "from_yaml"})
+    assert resolved.base_field == 1
     assert resolved.derived_field == "from_yaml"
 
 

--- a/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_field_utilites.py
+++ b/python_modules/dagster/dagster_tests/components_tests/resolution_tests/test_field_utilites.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Annotated
+from typing import Annotated, ClassVar
 
 import dagster as dg
 from dagster.components.resolved.base import _get_annotations, _get_resolver
@@ -18,6 +18,56 @@ def test_inheritance_dataclass() -> None:
     resolvers = _get_annotations(Derived)
     assert "base_field" in resolvers
     assert "derived_field" in resolvers
+
+
+def test_inheritance_dataclass_without_redecoration() -> None:
+    # A subclass that adds a field without re-applying @dataclass should still pick up the
+    # new field, matching how pydantic Model subclasses behave. See
+    # https://github.com/dagster-io/dagster/issues/33889.
+    @dataclass
+    class Base(dg.Resolvable):
+        base_field: int
+
+    class Derived(Base):
+        derived_field: str = "default"
+
+    resolvers = _get_annotations(Derived)
+    assert "base_field" in resolvers
+    assert "derived_field" in resolvers
+
+    # the new field resolves end-to-end (and the yaml value wins over the class default)
+    resolved = Derived.resolve_from_dict({"base_field": 1, "derived_field": "from_yaml"})
+    assert resolved.base_field == 1
+    assert resolved.derived_field == "from_yaml"
+
+
+def test_inheritance_dataclass_classvar_not_treated_as_field() -> None:
+    @dataclass
+    class Base(dg.Resolvable):
+        base_field: int
+
+    class Derived(Base):
+        not_a_field: ClassVar[str] = "constant"
+
+    resolvers = _get_annotations(Derived)
+    assert "base_field" in resolvers
+    assert "not_a_field" not in resolvers
+
+
+def test_inheritance_frozen_dataclass_without_redecoration() -> None:
+    @dataclass(frozen=True)
+    class Base(dg.Resolvable):
+        base_field: int
+
+    class Derived(Base):
+        derived_field: str = "default"
+
+    resolvers = _get_annotations(Derived)
+    assert "base_field" in resolvers
+    assert "derived_field" in resolvers
+
+    resolved = Derived.resolve_from_dict({"base_field": 1, "derived_field": "from_yaml"})
+    assert resolved.derived_field == "from_yaml"
 
 
 def test_inheritance_pydantic() -> None:


### PR DESCRIPTION
## Summary

Subclassing a `@dataclass`-based Component (e.g. `SlingReplicationCollectionComponent`) and adding a field throws `Extra inputs are not permitted` when loading from yaml. Reported in #33889.

## Root cause

`SlingReplicationCollectionComponent` is a `@dataclass`. A subclass that adds a field without re-applying `@dataclass` inherits `__dataclass_fields__`, so `is_dataclass()` returns True, but `dataclasses.fields()` only returns the fields the decorator registered. In `_get_annotations` (python_modules/dagster/dagster/components/resolved/base.py) this means the subclass's new field never reaches the generated `__init__` or the derived resolution model, so the yaml loader rejects it as an extra input.

This only affects dataclass-based components. pydantic-Model-based `Resolvable` subclasses already pick up new fields on subclassing (`test_inheritance_pydantic`), so the two behave inconsistently today.

## Fix

`_get_annotations` now detects fields that a subclass declared but that aren't registered, and re-applies `@dataclass` to the subclass (preserving the inherited `frozen` / `kw_only` config) so the new fields are registered and `__init__` is regenerated. ClassVar annotations are excluded so they aren't treated as fields. If a valid `__init__` can't be generated (e.g. a non-default field added after defaulted base fields without `kw_only`), it raises a `ResolutionException` with guidance instead of the previous opaque error.

Net effect: the reporter's original snippet works as written, and dataclass components now match pydantic ones.

Tradeoff worth calling out: this re-decorates the subclass in place during schema derivation, which is the same effect as the user adding `@dataclass` to the subclass themselves. That felt acceptable for parity with pydantic, but happy to switch to a hard error pointing users to `@dataclass` if you'd prefer not to mutate the class.

## Tests

Added to `test_field_utilites.py`:
- `test_inheritance_dataclass_without_redecoration` — subclass adds a field with no `@dataclass`; resolves end-to-end and the yaml value wins over the class default.
- `test_inheritance_dataclass_classvar_not_treated_as_field` — ClassVars are not registered as fields.
- `test_inheritance_frozen_dataclass_without_redecoration` — frozen base stays resolvable.

Verified locally: 61 resolution tests and 26 `dagster-sling` component tests pass; ruff clean. Also confirmed the exact reporter scenario (subclassing `SlingReplicationCollectionComponent` with an `extra_value` field, no `@dataclass`) now resolves with the yaml value applied.

Fixes #33889
