### PR TITLE
feat(io-managers): add partition_* aliases, deprecate asset_partition_* on context objects

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -338,6 +338,27 @@ class InputContext:
 
     @public
     @property
+    def asset_partition_key(self) -> str:
+        """The partition key for input asset.
+
+        Raises an error if the input asset has no partitioning, or if the run covers a partition
+        range for the input asset.
+        """
+        subset = self._asset_partitions_subset
+        if subset is None:
+            check.failed("The input does not correspond to a partitioned asset.")
+
+        keys_iter = iter(subset.get_partition_keys())
+        first = next(keys_iter, None)
+        if first is not None and next(keys_iter, None) is None:
+            return first
+        check.failed(
+            f"Tried to access partition key for asset '{self.asset_key}', "
+            f"but the number of input partitions != 1: '{subset}'."
+        )
+
+    @public
+    @property
     def partition_key_range(self) -> PartitionKeyRange:
         """The partition key range for input asset.
 

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -338,7 +338,7 @@ class InputContext:
 
     @public
     @property
-    def asset_partition_key(self) -> str:
+    def partition_key(self) -> str:
         """The partition key for input asset.
 
         Raises an error if the input asset has no partitioning, or if the run covers a partition
@@ -358,9 +358,16 @@ class InputContext:
             f"but the number of input partitions != 1: '{subset}'."
         )
 
+    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partition_key` instead.")
     @public
     @property
-    def asset_partition_key_range(self) -> PartitionKeyRange:
+    def asset_partition_key(self) -> str:
+        """The partition key for input asset. Deprecated: use `partition_key`."""
+        return self.partition_key
+
+    @public
+    @property
+    def partition_key_range(self) -> PartitionKeyRange:
         """The partition key range for input asset.
 
         Raises an error if the input asset has no partitioning.
@@ -369,7 +376,7 @@ class InputContext:
 
         if subset is None:
             check.failed(
-                "Tried to access asset_partition_key_range, but the asset is not partitioned.",
+                "Tried to access partition_key_range, but the asset is not partitioned.",
             )
 
         with partition_loading_context(dynamic_partitions_store=self._instance):
@@ -378,29 +385,43 @@ class InputContext:
             )
         if len(partition_key_ranges) != 1:
             check.failed(
-                "Tried to access asset_partition_key_range, but there are "
+                "Tried to access partition_key_range, but there are "
                 f"({len(partition_key_ranges)}) key ranges associated with this input.",
             )
 
         return partition_key_ranges[0]
 
+    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partition_key_range` instead.")
     @public
     @property
-    def asset_partition_keys(self) -> Sequence[str]:
+    def asset_partition_key_range(self) -> PartitionKeyRange:
+        """The partition key range for input asset. Deprecated: use `partition_key_range`."""
+        return self.partition_key_range
+
+    @public
+    @property
+    def partition_keys(self) -> Sequence[str]:
         """The partition keys for input asset.
 
         Raises an error if the input asset has no partitioning.
         """
         if self._asset_partitions_subset is None:
             check.failed(
-                "Tried to access asset_partition_keys, but the asset is not partitioned.",
+                "Tried to access partition_keys, but the asset is not partitioned.",
             )
 
         return list(self._asset_partitions_subset.get_partition_keys())
 
+    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partition_keys` instead.")
     @public
     @property
-    def asset_partitions_time_window(self) -> TimeWindow:
+    def asset_partition_keys(self) -> Sequence[str]:
+        """The partition keys for input asset. Deprecated: use `partition_keys`."""
+        return self.partition_keys
+
+    @public
+    @property
+    def partitions_time_window(self) -> TimeWindow:
         """The time window for the partitions of the input asset.
 
         Raises an error if either of the following are true:
@@ -412,7 +433,7 @@ class InputContext:
 
         if subset is None:
             check.failed(
-                "Tried to access asset_partitions_time_window, but the asset is not partitioned.",
+                "Tried to access partitions_time_window, but the asset is not partitioned.",
             )
 
         partitions_def = self._asset_partitions_def
@@ -428,7 +449,14 @@ class InputContext:
                 " to a partitioned asset that is not time-partitioned."
             )
 
-        return time_window_for_partition_key_range(partitions_def, self.asset_partition_key_range)
+        return time_window_for_partition_key_range(partitions_def, self.partition_key_range)
+
+    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partitions_time_window` instead.")
+    @public
+    @property
+    def asset_partitions_time_window(self) -> TimeWindow:
+        """The time window for partitions of the input asset. Deprecated: use `partitions_time_window`."""
+        return self.partitions_time_window
 
     @public
     def get_identifier(self) -> Sequence[str]:

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -183,7 +183,7 @@ class InputContext:
         """The config attached to the input that we're loading."""
         return self._config
 
-    @deprecated(breaking_version="2.0.0", additional_warn_text="Use definition_metadata instead")
+    @deprecated(breaking_version="2.0", additional_warn_text="Use definition_metadata instead")
     @public
     @property
     def metadata(self) -> ArbitraryMetadataMapping | None:
@@ -338,35 +338,6 @@ class InputContext:
 
     @public
     @property
-    def partition_key(self) -> str:
-        """The partition key for input asset.
-
-        Raises an error if the input asset has no partitioning, or if the run covers a partition
-        range for the input asset.
-        """
-        subset = self._asset_partitions_subset
-
-        if subset is None:
-            check.failed("The input does not correspond to a partitioned asset.")
-
-        keys_iter = iter(subset.get_partition_keys())
-        first = next(keys_iter, None)
-        if first is not None and next(keys_iter, None) is None:
-            return first
-        check.failed(
-            f"Tried to access partition key for asset '{self.asset_key}', "
-            f"but the number of input partitions != 1: '{subset}'."
-        )
-
-    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partition_key` instead.")
-    @public
-    @property
-    def asset_partition_key(self) -> str:
-        """The partition key for input asset. Deprecated: use `partition_key`."""
-        return self.partition_key
-
-    @public
-    @property
     def partition_key_range(self) -> PartitionKeyRange:
         """The partition key range for input asset.
 
@@ -391,7 +362,7 @@ class InputContext:
 
         return partition_key_ranges[0]
 
-    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partition_key_range` instead.")
+    @deprecated(breaking_version="2.0", additional_warn_text="Use `partition_key_range` instead.")
     @public
     @property
     def asset_partition_key_range(self) -> PartitionKeyRange:
@@ -412,7 +383,7 @@ class InputContext:
 
         return list(self._asset_partitions_subset.get_partition_keys())
 
-    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partition_keys` instead.")
+    @deprecated(breaking_version="2.0", additional_warn_text="Use `partition_keys` instead.")
     @public
     @property
     def asset_partition_keys(self) -> Sequence[str]:
@@ -451,7 +422,7 @@ class InputContext:
 
         return time_window_for_partition_key_range(partitions_def, self.partition_key_range)
 
-    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partitions_time_window` instead.")
+    @deprecated(breaking_version="2.0", additional_warn_text="Use `partitions_time_window` instead.")
     @public
     @property
     def asset_partitions_time_window(self) -> TimeWindow:

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -237,7 +237,7 @@ class OutputContext:
 
         return self._run_id
 
-    @deprecated(breaking_version="2.0.0", additional_warn_text="Use definition_metadata instead")
+    @deprecated(breaking_version="2.0", additional_warn_text="Use definition_metadata instead")
     @public
     @property
     def metadata(self) -> ArbitraryMetadataMapping | None:
@@ -466,42 +466,6 @@ class OutputContext:
 
     @public
     @property
-    def partition_key(self) -> str:
-        """The partition key for output asset.
-
-        Raises an error if the output asset has no partitioning, or if the run covers a partition
-        range for the output asset.
-        """
-        if self._warn_on_step_context_use:
-            warnings.warn(
-                "You are using InputContext.upstream_output.partition_key. "
-                "This use on upstream_output is deprecated and will fail in the future. "
-                "Try to obtain what you need directly from InputContext. "
-                "For more details: https://github.com/dagster-io/dagster/issues/7900"
-            )
-
-        subset = self._asset_partitions_subset
-        if subset is None:
-            check.failed("The output does not correspond to a partitioned asset.")
-
-        keys_iter = iter(subset.get_partition_keys())
-        first = next(keys_iter, None)
-        if first is not None and next(keys_iter, None) is None:
-            return first
-        check.failed(
-            f"Tried to access partition key for asset '{self._asset_key}', "
-            f"but the number of output partitions != 1: '{subset}'."
-        )
-
-    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partition_key` instead.")
-    @public
-    @property
-    def asset_partition_key(self) -> str:
-        """The partition key for output asset. Deprecated: use `partition_key`."""
-        return self.partition_key
-
-    @public
-    @property
     def partition_key_range(self) -> PartitionKeyRange:
         """The partition key range for output asset.
 
@@ -532,7 +496,7 @@ class OutputContext:
 
         return partition_key_ranges[0]
 
-    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partition_key_range` instead.")
+    @deprecated(breaking_version="2.0", additional_warn_text="Use `partition_key_range` instead.")
     @public
     @property
     def asset_partition_key_range(self) -> PartitionKeyRange:
@@ -559,7 +523,7 @@ class OutputContext:
 
         return list(self._asset_partitions_subset.get_partition_keys())
 
-    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partition_keys` instead.")
+    @deprecated(breaking_version="2.0", additional_warn_text="Use `partition_keys` instead.")
     @public
     @property
     def asset_partition_keys(self) -> Sequence[str]:
@@ -604,7 +568,7 @@ class OutputContext:
 
         return time_window_for_partition_key_range(partitions_def, self.partition_key_range)
 
-    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partitions_time_window` instead.")
+    @deprecated(breaking_version="2.0", additional_warn_text="Use `partitions_time_window` instead.")
     @public
     @property
     def asset_partitions_time_window(self) -> TimeWindow:

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -466,6 +466,35 @@ class OutputContext:
 
     @public
     @property
+    def asset_partition_key(self) -> str:
+        """The partition key for output asset.
+
+        Raises an error if the output asset has no partitioning, or if the run covers a partition
+        range for the output asset.
+        """
+        if self._warn_on_step_context_use:
+            warnings.warn(
+                "You are using InputContext.upstream_output.asset_partition_key. "
+                "This use on upstream_output is deprecated and will fail in the future. "
+                "Try to obtain what you need directly from InputContext. "
+                "For more details: https://github.com/dagster-io/dagster/issues/7900"
+            )
+
+        subset = self._asset_partitions_subset
+        if subset is None:
+            check.failed("The output does not correspond to a partitioned asset.")
+
+        keys_iter = iter(subset.get_partition_keys())
+        first = next(keys_iter, None)
+        if first is not None and next(keys_iter, None) is None:
+            return first
+        check.failed(
+            f"Tried to access partition key for asset '{self._asset_key}', "
+            f"but the number of output partitions != 1: '{subset}'."
+        )
+
+    @public
+    @property
     def partition_key_range(self) -> PartitionKeyRange:
         """The partition key range for output asset.
 

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -466,7 +466,7 @@ class OutputContext:
 
     @public
     @property
-    def asset_partition_key(self) -> str:
+    def partition_key(self) -> str:
         """The partition key for output asset.
 
         Raises an error if the output asset has no partitioning, or if the run covers a partition
@@ -474,7 +474,7 @@ class OutputContext:
         """
         if self._warn_on_step_context_use:
             warnings.warn(
-                "You are using InputContext.upstream_output.asset_partition_key. "
+                "You are using InputContext.upstream_output.partition_key. "
                 "This use on upstream_output is deprecated and will fail in the future. "
                 "Try to obtain what you need directly from InputContext. "
                 "For more details: https://github.com/dagster-io/dagster/issues/7900"
@@ -493,16 +493,23 @@ class OutputContext:
             f"but the number of output partitions != 1: '{subset}'."
         )
 
+    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partition_key` instead.")
     @public
     @property
-    def asset_partition_key_range(self) -> PartitionKeyRange:
+    def asset_partition_key(self) -> str:
+        """The partition key for output asset. Deprecated: use `partition_key`."""
+        return self.partition_key
+
+    @public
+    @property
+    def partition_key_range(self) -> PartitionKeyRange:
         """The partition key range for output asset.
 
         Raises an error if the output asset has no partitioning.
         """
         if self._warn_on_step_context_use:
             warnings.warn(
-                "You are using InputContext.upstream_output.asset_partition_key_range. "
+                "You are using InputContext.upstream_output.partition_key_range. "
                 "This use on upstream_output is deprecated and will fail in the future. "
                 "Try to obtain what you need directly from InputContext. "
                 "For more details: https://github.com/dagster-io/dagster/issues/7900"
@@ -519,22 +526,29 @@ class OutputContext:
             )
         if len(partition_key_ranges) != 1:
             check.failed(
-                "Tried to access asset_partition_key_range, but there are "
+                "Tried to access partition_key_range, but there are "
                 f"({len(partition_key_ranges)}) key ranges associated with this output.",
             )
 
         return partition_key_ranges[0]
 
+    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partition_key_range` instead.")
     @public
     @property
-    def asset_partition_keys(self) -> Sequence[str]:
+    def asset_partition_key_range(self) -> PartitionKeyRange:
+        """The partition key range for output asset. Deprecated: use `partition_key_range`."""
+        return self.partition_key_range
+
+    @public
+    @property
+    def partition_keys(self) -> Sequence[str]:
         """The partition keys for the output asset.
 
         Raises an error if the output asset has no partitioning.
         """
         if self._warn_on_step_context_use:
             warnings.warn(
-                "You are using InputContext.upstream_output.asset_partition_keys. "
+                "You are using InputContext.upstream_output.partition_keys. "
                 "This use on upstream_output is deprecated and will fail in the future. "
                 "Try to obtain what you need directly from InputContext. "
                 "For more details: https://github.com/dagster-io/dagster/issues/7900"
@@ -545,9 +559,16 @@ class OutputContext:
 
         return list(self._asset_partitions_subset.get_partition_keys())
 
+    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partition_keys` instead.")
     @public
     @property
-    def asset_partitions_time_window(self) -> TimeWindow:
+    def asset_partition_keys(self) -> Sequence[str]:
+        """The partition keys for the output asset. Deprecated: use `partition_keys`."""
+        return self.partition_keys
+
+    @public
+    @property
+    def partitions_time_window(self) -> TimeWindow:
         """The time window for the partitions of the output asset.
 
         Raises an error if either of the following are true:
@@ -557,7 +578,7 @@ class OutputContext:
         """
         if self._warn_on_step_context_use:
             warnings.warn(
-                "You are using InputContext.upstream_output.asset_partitions_time_window. "
+                "You are using InputContext.upstream_output.partitions_time_window. "
                 "This use on upstream_output is deprecated and will fail in the future. "
                 "Try to obtain what you need directly from InputContext. "
                 "For more details: https://github.com/dagster-io/dagster/issues/7900"
@@ -565,7 +586,7 @@ class OutputContext:
 
         if self._asset_partitions_subset is None:
             check.failed(
-                "Tried to access asset_partitions_time_window, but the asset is not partitioned.",
+                "Tried to access partitions_time_window, but the asset is not partitioned.",
             )
 
         partitions_def = self._asset_partitions_def
@@ -581,7 +602,14 @@ class OutputContext:
                 " to a partitioned asset that is not time-partitioned."
             )
 
-        return time_window_for_partition_key_range(partitions_def, self.asset_partition_key_range)
+        return time_window_for_partition_key_range(partitions_def, self.partition_key_range)
+
+    @deprecated(breaking_version="2.0.0", additional_warn_text="Use `partitions_time_window` instead.")
+    @public
+    @property
+    def asset_partitions_time_window(self) -> TimeWindow:
+        """The time window for partitions of the output asset. Deprecated: use `partitions_time_window`."""
+        return self.partitions_time_window
 
     def get_run_scoped_output_identifier(self) -> Sequence[str]:
         """Utility method to get a collection of identifiers that as a whole represent a unique


### PR DESCRIPTION
## Summary

Fixes #18330.

Adds shorter, unprefixed partition property names to both `OutputContext` and `InputContext`, stripping the redundant `asset_` prefix. The old names are marked `@deprecated(breaking_version="2.0.0")` and delegate to the new ones so existing code is unaffected until the 2.0 removal.

## New properties

| Deprecated (until 2.0) | New name |
|------------------------|----------|
| `asset_partition_key` | `partition_key` |
| `asset_partition_key_range` | `partition_key_range` |
| `asset_partition_keys` | `partition_keys` |
| `asset_partitions_time_window` | `partitions_time_window` |

Applied to both `OutputContext` and `InputContext`.

## Migration

```python
# Before
context.asset_partition_key
context.asset_partition_keys
context.asset_partition_key_range
context.asset_partitions_time_window

# After
context.partition_key
context.partition_keys
context.partition_key_range
context.partitions_time_window
```

## Test plan

- [ ] Existing partition-related tests pass
- [ ] Calling `context.asset_partition_key` emits a deprecation warning
- [ ] Calling `context.partition_key` returns the same value without a warning