### PR TITLE
Normalize dbt manifest artifact keys

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/integrations/dbt.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/plus/integrations/dbt.py
@@ -115,7 +115,7 @@ def manage_manifest_command(
             continue
 
         download_path = project.state_path.joinpath("manifest.json")
-        key = f"{key_prefix}{os.fspath(download_path)}"
+        key = f"{key_prefix}{os.fspath(download_path.resolve())}"
 
         if is_branch:
             click.echo(f"Downloading {source_deployment} manifest for branch deployment.")
@@ -205,7 +205,7 @@ def download_manifest_command(
     for project in projects_with_state:
         assert project.state_path is not None
         download_path = project.state_path.joinpath("manifest.json")
-        key = f"{key_prefix}{os.fspath(download_path)}"
+        key = f"{key_prefix}{os.fspath(download_path.resolve())}"
         dest = output_path if output_path else download_path
 
         dest.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary & Motivation
Normalizes manifest artifact paths before generating artifact keys in both manage_manifest_command and download_manifest_command.

This prevent artifacts keys from containing un-normalized .. path segments, which can lead to S3 signature mismatches when downloading manifests through presigned URLs.

## Test Plan
- Ran `ruff check .`
- Verified the updated code paths normalize artifact keys using `Path.resolve()`.

## Changelog
- Normalize download_path using Path.resolve() before generating artifact keys.
-  Apply the change in both:
    - manage_manifest_command
    - download_manifest_command