### PR TITLE
fix(dagster-cloud-cli): resolve duplicate CLI option aliases

### DIFF
--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/serverless/__init__.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/commands/serverless/__init__.py
@@ -27,7 +27,7 @@ _BUILD_OPTIONS = {
         Option(
             None,
             "--source-directory",
-            "-d",
+            "-s",
             exists=False,
             help="Source directory to build for the image.",
         ),

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/config_utils.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/config_utils.py
@@ -199,7 +199,6 @@ URL_OPTION = Option(
 LOCATION_LOAD_TIMEOUT_OPTION = Option(
     get_location_load_timeout(),
     f"--{LOCATION_LOAD_TIMEOUT_CLI_ARGUMENT}",
-    "--location-timeout",
     help=(
         "After making changes to the workspace. how long in seconds to wait for the location to"
         " load before timing out with an error"

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/config_utils.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/config_utils.py
@@ -199,7 +199,7 @@ URL_OPTION = Option(
 LOCATION_LOAD_TIMEOUT_OPTION = Option(
     get_location_load_timeout(),
     f"--{LOCATION_LOAD_TIMEOUT_CLI_ARGUMENT}",
-    "--agent-timeout",
+    "--location-timeout",
     help=(
         "After making changes to the workspace. how long in seconds to wait for the location to"
         " load before timing out with an error"
@@ -349,7 +349,7 @@ DEPLOYMENT_METADATA_OPTIONS = {
         Option(
             None,
             "--working-directory",
-            "-d",
+            "-w",
             help="Base directory to use for local imports when loading the repositories.",
         ),
     ),


### PR DESCRIPTION
Problem

  Running dagster-cloud deployment add-location emits Click/Typer warnings:

  ▎ UserWarning: The parameter -d is used more than once.
  ▎ UserWarning: The parameter --agent-timeout is used more than once.

  Root cause: three duplicate CLI option aliases in dagster-cloud-cli.

  Solution

  - --working-directory used -d (conflicted with --deployment -d) → changed to -w
  - --source-directory used -d (same conflict) → changed to -s
  - LOCATION_LOAD_TIMEOUT_OPTION had --agent-timeout as a secondary alias, which conflicted with the --agent-timeout on
  AGENT_HEARTBEAT_TIMEOUT_OPTION → removed the duplicate alias. The option is now exclusively --location-load-timeout
  (its original primary name, unchanged).

  Test Plan

  The warnings no longer appear when running dagster-cloud deployment add-location --help.

  Migration Note

  --agent-timeout previously controlled both the location-load timeout and the agent heartbeat timeout. After this fix,
  it only controls the heartbeat timeout. To set the location-load timeout, use --location-load-timeout instead.

  Closes #33869