### PR TITLE
[helm] Expose user deployment replicaCount

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
   annotations: {{ $deployment.annotations | toYaml | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ $deployment.replicaCount | default 1 }}
   {{- if $deployment.deploymentStrategy }}
   strategy:
     {{- toYaml $deployment.deploymentStrategy | nindent 4 }}

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -372,6 +372,12 @@
                     "title": "Port",
                     "type": "integer"
                 },
+                "replicaCount": {
+                    "default": 1,
+                    "exclusiveMinimum": 0,
+                    "title": "Replicacount",
+                    "type": "integer"
+                },
                 "env": {
                     "anyOf": [
                         {

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -58,6 +58,9 @@ deployments:
       - "/example_project/example_repo/repo.py"
     port: 3030
 
+    # Number of replicas of the user code gRPC server Deployment.
+    replicaCount: 1
+
     # Whether or not to include configuration specified for this user code deployment in the pods
     # launched for runs from that deployment
     includeConfigInLaunchedRuns:

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, create_model
+from pydantic import BaseModel, Field, create_model
 
 from schema.charts.utils import kubernetes
 
@@ -20,6 +20,7 @@ class UserDeployment(BaseModel):
     includeConfigInLaunchedRuns: UserDeploymentIncludeConfigInLaunchedRuns | None = None
     deploymentNamespace: str | None = None
     port: int
+    replicaCount: int = Field(default=1, gt=0)
     env: dict[str, str] | list[kubernetes.EnvVar] | None = None
     envConfigMaps: list[kubernetes.ConfigMapEnvSource] | None = None
     envSecrets: list[kubernetes.SecretEnvSource] | None = None

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -857,6 +857,41 @@ def _assert_has_container_context(user_deployment):
     assert "DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT" in env_names
 
 
+def test_user_deployment_replica_count_default_is_one(template: HelmTemplate):
+    deployment = create_simple_user_deployment("foo")
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    user_deployments = template.render(helm_values)
+    assert len(user_deployments) == 1
+    assert user_deployments[0].spec.replicas == 1
+
+
+@pytest.mark.parametrize("replica_count", [1, 2])
+def test_user_deployment_replica_count(template: HelmTemplate, replica_count: int):
+    deployment = create_simple_user_deployment("foo")
+    deployment.replicaCount = replica_count
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    user_deployments = template.render(helm_values)
+    assert len(user_deployments) == 1
+    assert user_deployments[0].spec.replicas == replica_count
+
+
+def test_user_deployment_replica_count_rejects_zero():
+    with pytest.raises(Exception):
+        UserDeployment(
+            name="foo",
+            image=kubernetes.Image(repository="repo/foo", tag="tag1", pullPolicy="Always"),
+            dagsterApiGrpcArgs=["-m", "foo"],
+            port=3030,
+            replicaCount=0,
+        )
+
+
 def test_user_deployment_image(template: HelmTemplate):
     deployment = create_simple_user_deployment("foo")
     helm_values = DagsterHelmValues.construct(

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -3165,6 +3165,12 @@
                     "title": "Port",
                     "type": "integer"
                 },
+                "replicaCount": {
+                    "default": 1,
+                    "exclusiveMinimum": 0,
+                    "title": "Replicacount",
+                    "type": "integer"
+                },
                 "env": {
                     "anyOf": [
                         {

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -365,6 +365,9 @@ dagster-user-deployments:
         - "/example_project/example_repo/repo.py"
       port: 3030
 
+      # Number of replicas of the user code gRPC server Deployment.
+      replicaCount: 1
+
       # Whether or not to include configuration specified for this user code deployment in the pods
       # launched for runs from that deployment
       includeConfigInLaunchedRuns:


### PR DESCRIPTION
## Summary & Motivation
I noticed that https://github.com/dagster-io/dagster/releases/tag/1.13.8 mentions multi-replica code locations for Dagster Cloud.
Having multiple user deployment replicas with readiness probes enabled could improve stability and decrease occurrences of `DagsterUserCodeUnreachableError`.
Dagster controller already connects to user deployment via k8s service, so this change is minimal. :)

## Test Plan
Added tests to cover basic scenarios.

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
