### PR TITLE
Export DagsterLibraryRegistry from dagster package (#33412)

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -38,7 +38,7 @@ import sys
 # ##### DYNAMIC IMPORTS
 # ########################
 from dagster_shared.error import DagsterError as DagsterError
-from dagster_shared.libraries import DagsterLibraryRegistry
+from dagster_shared.libraries import DagsterLibraryRegistry as DagsterLibraryRegistry
 from dagster_shared.serdes import (
     deserialize_value as deserialize_value,
     serialize_value as serialize_value,

--- a/python_modules/dagster/dagster_tests/utils_tests/test_libraries.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_libraries.py
@@ -1,2 +1,5 @@
 def test_legacy_registry_import_still_works():
     from dagster._core.libraries import DagsterLibraryRegistry  # noqa
+
+def test_dagster_library_registry_import_from_dagster():
+    from dagster import DagsterLibraryRegistry # noqa

--- a/python_modules/dagster/dagster_tests/utils_tests/test_libraries.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_libraries.py
@@ -1,5 +1,6 @@
 def test_legacy_registry_import_still_works():
     from dagster._core.libraries import DagsterLibraryRegistry  # noqa
 
+
 def test_dagster_library_registry_import_from_dagster():
     from dagster import DagsterLibraryRegistry # noqa


### PR DESCRIPTION
## Summary & Motivation
Issue: #33412 - Export dagster_shared.libraries.DagsterLibraryRegistry from dagster
Changes: Exported DagsterLibraryRegistry from dagster's __init__.py file, such that DagsterLibraryRegistry could be imported from dagster.
## Tests
Added a test for the import in test_libraries.py, (test_dagster_library_registry_import_from_dagster()).




