### PR TITLE
helm: explicitly set metadata.namespace to .Release.Namespace on all namespaced resources

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-shared.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-shared.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "dagster.fullname" $ -}}-user-deployments-shared-env
+  namespace: {{ $.Release.Namespace }}
   labels:
     app: {{ template "dagster.name" $ }}
     chart: {{ template "dagster.chart" $ }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-user.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "dagster.fullname" $ -}}-{{- $deployment.name }}-user-env
+  namespace: {{ $.Release.Namespace }}
   labels:
     app: {{ template "dagster.name" $ }}
     chart: {{ template "dagster.chart" $ }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -8,6 +8,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "dagster.fullname" $ -}}-{{- $deployment.name }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "dagster.labels" $ | nindent 4 }}
     component: user-deployments

--- a/helm/dagster/charts/dagster-user-deployments/templates/role.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/role.yaml
@@ -3,6 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "dagster.fullname" . }}-role
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "dagster.labels" . | nindent 4 }}
 
 # Allow the Dagster service account to read and write Kubernetes jobs, deployments, pods, and events.

--- a/helm/dagster/charts/dagster-user-deployments/templates/rolebinding.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "dagster.fullname" . }}-rolebinding
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "dagster.labels" . | nindent 4 }}
 
 subjects:

--- a/helm/dagster/charts/dagster-user-deployments/templates/service-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/service-user.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $deployment.name }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "dagster.labels" $ | nindent 4 }}
     component: user-deployments

--- a/helm/dagster/charts/dagster-user-deployments/templates/serviceaccount.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/serviceaccount.yaml
@@ -9,6 +9,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "dagsterUserDeployments.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "dagster.labels" . | nindent 4 }}
   annotations: {{- .Values.serviceAccount.annotations | toYaml | nindent 4 }}
 automountServiceAccountToken: false

--- a/helm/dagster/templates/configmap-celery.yaml
+++ b/helm/dagster/templates/configmap-celery.yaml
@@ -8,6 +8,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "dagster.fullname" $ }}-celery-{{- $queue.name }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     app: {{ template "dagster.name" $ }}
     chart: {{ template "dagster.chart" $ }}

--- a/helm/dagster/templates/configmap-env-celery.yaml
+++ b/helm/dagster/templates/configmap-env-celery.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "dagster.fullname" . }}-celery-worker-env
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "dagster.name" . }}
     chart: {{ template "dagster.chart" . }}

--- a/helm/dagster/templates/configmap-env-daemon.yaml
+++ b/helm/dagster/templates/configmap-env-daemon.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "dagster.fullname" $ -}}-daemon-env
+  namespace: {{ $.Release.Namespace }}
   labels:
     app: {{ template "dagster.name" $ }}
     chart: {{ template "dagster.chart" $ }}

--- a/helm/dagster/templates/configmap-env-flower.yaml
+++ b/helm/dagster/templates/configmap-env-flower.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "dagster.fullname" . }}-flower-env
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "dagster.name" . }}
     chart: {{ template "dagster.chart" . }}

--- a/helm/dagster/templates/configmap-env-pipeline-run.yaml
+++ b/helm/dagster/templates/configmap-env-pipeline-run.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "dagster.fullname" . }}-pipeline-env
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "dagster.name" . }}
     chart: {{ template "dagster.chart" . }}

--- a/helm/dagster/templates/configmap-env-webserver.yaml
+++ b/helm/dagster/templates/configmap-env-webserver.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "dagster.fullname" . }}-webserver-env
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "dagster.name" . }}
     chart: {{ template "dagster.chart" . }}

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "dagster.fullname" . }}-instance
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "dagster.name" . }}
     chart: {{ template "dagster.chart" . }}

--- a/helm/dagster/templates/configmap-workspace.yaml
+++ b/helm/dagster/templates/configmap-workspace.yaml
@@ -20,6 +20,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "dagster.workspace.configmapName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "dagster.name" . }}
     chart: {{ template "dagster.chart" . }}

--- a/helm/dagster/templates/deployment-celery-queues.yaml
+++ b/helm/dagster/templates/deployment-celery-queues.yaml
@@ -6,6 +6,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "dagster.workers.fullname" $ -}}-{{- $queue.name }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "dagster.labels" $ | nindent 4 }}
     component: celery

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "dagster.fullname" $ -}}-daemon
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "dagster.labels" $ | nindent 4 }}
     component: dagster-daemon

--- a/helm/dagster/templates/deployment-flower.yaml
+++ b/helm/dagster/templates/deployment-flower.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "dagster.flower.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dagster.labels" . | nindent 4 }}
     component: flower

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "dagster.webserver.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dagster.labels" . | nindent 4 }}
     component: {{ include "dagster.webserver.componentName" . }}

--- a/helm/dagster/templates/helpers/_service-webserver.tpl
+++ b/helm/dagster/templates/helpers/_service-webserver.tpl
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "dagster.webserver.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dagster.labels" . | nindent 4 }}
     component: {{ include "dagster.webserver.componentName" . }}

--- a/helm/dagster/templates/ingress.yaml
+++ b/helm/dagster/templates/ingress.yaml
@@ -8,6 +8,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "dagster.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dagster.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.ingress.labels }}

--- a/helm/dagster/templates/job-instance-migrate.yaml
+++ b/helm/dagster/templates/job-instance-migrate.yaml
@@ -4,6 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "dagster.webserver.migrate" . | quote }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- range $key, $value := $_.Values.dagsterWebserver.annotations }}
     {{ $key }}: {{ $value | squote }}

--- a/helm/dagster/templates/role.yaml
+++ b/helm/dagster/templates/role.yaml
@@ -3,6 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "dagster.fullname" . }}-role
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "dagster.name" . }}
     chart: {{ template "dagster.chart" .  }}

--- a/helm/dagster/templates/rolebinding.yaml
+++ b/helm/dagster/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "dagster.fullname" . }}-rolebinding
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "dagster.name" . }}
     chart: {{ template "dagster.chart" .  }}

--- a/helm/dagster/templates/secret-celery-config.yaml
+++ b/helm/dagster/templates/secret-celery-config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.global.celeryConfigSecretName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "dagster.name" . }}"
     chart: "{{ template "dagster.chart" . }}"

--- a/helm/dagster/templates/secret-postgres.yaml
+++ b/helm/dagster/templates/secret-postgres.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "dagster.postgresql.secretName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "dagster.name" . }}"
     chart: "{{ template "dagster.chart" . }}"

--- a/helm/dagster/templates/service-flower.yaml
+++ b/helm/dagster/templates/service-flower.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "dagster.fullname" . }}-flower-service
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dagster.labels" . | nindent 4 }}
     component: flower

--- a/helm/dagster/templates/serviceaccount.yaml
+++ b/helm/dagster/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "dagster.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "dagster.labels" . | nindent 4 }}
   annotations: {{- .Values.serviceAccount.annotations | toYaml | nindent 4 }}
 automountServiceAccountToken: false


### PR DESCRIPTION
## Summary

Without an explicit `namespace` in resource metadata, Kustomize's namespace transformer cannot reliably override the target namespace when this chart is applied via a Kustomization. The transformer matches on `metadata.namespace` being present; resources that omit it are skipped.

This PR adds `namespace: {{ .Release.Namespace }}` (or `{{ $.Release.Namespace }}` inside `range` loops where `.` is rebound) to the `metadata` section of every namespaced resource in both the `dagster` chart and the `dagster-user-deployments` subchart.

**Affected templates (28 files):**
- Deployments: `deployment-daemon`, `deployment-flower`, `deployment-celery-queues`, `_deployment-webserver.tpl`, `deployment-user`
- Services: `service-flower`, `_service-webserver.tpl`, `service-user`
- ConfigMaps: `configmap-instance`, `configmap-workspace`, `configmap-env-*`, `configmap-celery`, `configmap-env-shared`, `configmap-env-user`
- Secrets: `secret-postgres`, `secret-celery-config`
- RBAC: `role`, `rolebinding` (both charts)
- ServiceAccounts (both charts)
- Ingress
- Job: `job-instance-migrate`

## References

- Kustomize namespace transformer behaviour: https://github.com/kubernetes-sigs/kustomize/pull/5940