### PR TITLE
[automation] Add max_entities_per_run to bound the size of automation-emitted runs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -8,7 +8,7 @@ from dagster._core.definitions.asset_selection import AssetSelection, CoercibleT
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
 )
-from dagster._core.definitions.metadata import RawMetadataMapping
+from dagster._core.definitions.metadata import IntMetadataValue, RawMetadataMapping
 from dagster._core.definitions.run_request import SensorResult
 from dagster._core.definitions.sensor_definition import (
     DefaultSensorStatus,
@@ -24,6 +24,7 @@ from dagster._utils.tags import normalize_tags
 
 MAX_ENTITIES = 500
 EMIT_BACKFILLS_METADATA_KEY = "dagster/emit_backfills"
+MAX_ENTITIES_PER_RUN_METADATA_KEY = "dagster/max_entities_per_run"
 DEFAULT_AUTOMATION_CONDITION_SENSOR_NAME = "default_automation_condition_sensor"
 
 
@@ -53,6 +54,7 @@ def _evaluate(sensor_def: "AutomationConditionSensorDefinition", context: Sensor
         asset_selection=sensor_def.asset_selection,
         emit_backfills=sensor_def.emit_backfills,
         default_condition=sensor_def.default_condition,
+        max_entities_per_run=sensor_def.max_entities_per_run,
         logger=context.log,
     )
     if evaluation_context.total_keys > MAX_ENTITIES:
@@ -81,6 +83,7 @@ def not_supported(context) -> None:
 @public
 @beta_param(param="use_user_code_server")
 @beta_param(param="default_condition")
+@beta_param(param="max_entities_per_run")
 class AutomationConditionSensorDefinition(SensorDefinition, IHasInternalInit):
     """Targets a set of assets and repeatedly evaluates all the AutomationConditions on all of
     those assets to determine which to request runs for.
@@ -102,6 +105,11 @@ class AutomationConditionSensorDefinition(SensorDefinition, IHasInternalInit):
         description (Optional[str]): A human-readable description of the sensor.
         emit_backfills (bool): If set to True, will emit a backfill on any tick where more than one partition
             of any single asset is requested, rather than individual runs. Defaults to True.
+        max_entities_per_run (Optional[int]): (Beta) If set, runs launched by this sensor will
+            target at most this many assets or checks each. Entities requested on the same
+            evaluation beyond this limit are split into additional runs deterministically. Asset
+            checks are always kept in the same run as the asset they target. Does not apply to
+            backfills emitted when `emit_backfills` is set to True.
         use_user_code_server (bool): (Beta) If set to True, this sensor will be evaluated in the user
             code server, rather than the AssetDaemon. This enables evaluating custom AutomationCondition
             subclasses, and ensures that the condition definitions will remain in sync with your user code
@@ -159,9 +167,19 @@ class AutomationConditionSensorDefinition(SensorDefinition, IHasInternalInit):
         emit_backfills: bool = True,
         use_user_code_server: bool = False,
         default_condition: AutomationCondition | None = None,
+        max_entities_per_run: int | None = None,
     ):
         self._use_user_code_server = use_user_code_server
         check.bool_param(emit_backfills, "allow_backfills")
+
+        self._max_entities_per_run = check.opt_int_param(
+            max_entities_per_run, "max_entities_per_run"
+        )
+        check.param_invariant(
+            self._max_entities_per_run is None or self._max_entities_per_run > 0,
+            "max_entities_per_run",
+            "`max_entities_per_run` must be a positive integer.",
+        )
 
         self._default_condition = check.opt_inst_param(
             default_condition, "default_condition", AutomationCondition
@@ -179,6 +197,14 @@ class AutomationConditionSensorDefinition(SensorDefinition, IHasInternalInit):
         # only store this value in the metadata if it's True
         if emit_backfills:
             metadata = {**(metadata or {}), EMIT_BACKFILLS_METADATA_KEY: True}
+
+        # stored in metadata so that the value is accessible to the AssetDaemon when this
+        # sensor is not evaluated in the user code server
+        if self._max_entities_per_run is not None:
+            metadata = {
+                **(metadata or {}),
+                MAX_ENTITIES_PER_RUN_METADATA_KEY: self._max_entities_per_run,
+            }
 
         super().__init__(
             name=check_valid_name(name),
@@ -208,6 +234,11 @@ class AutomationConditionSensorDefinition(SensorDefinition, IHasInternalInit):
         return EMIT_BACKFILLS_METADATA_KEY in self.metadata
 
     @property
+    def max_entities_per_run(self) -> int | None:
+        value = self.metadata.get(MAX_ENTITIES_PER_RUN_METADATA_KEY)
+        return value.value if isinstance(value, IntMetadataValue) else None
+
+    @property
     def default_condition(self) -> AutomationCondition | None:
         return self._default_condition
 
@@ -229,6 +260,7 @@ class AutomationConditionSensorDefinition(SensorDefinition, IHasInternalInit):
         emit_backfills: bool,
         use_user_code_server: bool,
         default_condition: AutomationCondition | None,
+        max_entities_per_run: int | None = None,
     ) -> "AutomationConditionSensorDefinition":
         return AutomationConditionSensorDefinition(
             name=name,
@@ -242,6 +274,7 @@ class AutomationConditionSensorDefinition(SensorDefinition, IHasInternalInit):
             emit_backfills=emit_backfills,
             use_user_code_server=use_user_code_server,
             default_condition=default_condition,
+            max_entities_per_run=max_entities_per_run,
         )
 
     def with_attributes(
@@ -266,4 +299,5 @@ class AutomationConditionSensorDefinition(SensorDefinition, IHasInternalInit):
             emit_backfills=self._emit_backfills,
             use_user_code_server=self._use_user_code_server,
             default_condition=self._default_condition,
+            max_entities_per_run=self._max_entities_per_run,
         )

--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -55,6 +55,7 @@ class AutomationTickEvaluationContext:
         emit_backfills: bool,
         default_condition: AutomationCondition | None = None,
         evaluation_time: datetime.datetime | None = None,
+        max_entities_per_run: int | None = None,
     ):
         resolved_entity_keys = {
             entity_key
@@ -78,6 +79,7 @@ class AutomationTickEvaluationContext:
         )
         self._materialize_run_tags = materialize_run_tags
         self._observe_run_tags = observe_run_tags
+        self._max_entities_per_run = max_entities_per_run
         self._auto_observe_asset_keys = auto_observe_asset_keys or set()
         self._partition_loading_context = self._evaluator.asset_graph_view.partition_loading_context
         self._logger = logger
@@ -137,6 +139,7 @@ class AutomationTickEvaluationContext:
             asset_graph=self.asset_graph,
             run_tags=self._materialize_run_tags,
             emit_backfills=self._evaluator.emit_backfills,
+            max_entities_per_run=self._max_entities_per_run,
         )
 
     def _get_updated_cursor(
@@ -315,9 +318,12 @@ def build_run_requests(
     asset_graph: BaseAssetGraph,
     run_tags: Mapping[str, str] | None,
     emit_backfills: bool,
+    max_entities_per_run: int | None = None,
 ) -> Sequence[RunRequest]:
     """For a single asset in a given tick, the asset will only be part of a run or a backfill, not both.
     If the asset is targetd by a backfill, there will only be one backfill that targets the asset.
+    If max_entities_per_run is provided, runs (but not backfills) will target at most that many
+    assets or checks each.
     """
     if emit_backfills:
         backfill_run_request, entity_subsets = _build_backfill_request(
@@ -330,6 +336,7 @@ def build_run_requests(
         _get_mapping_from_entity_subsets(entity_subsets, asset_graph),
         asset_graph,
         run_tags,
+        max_entities_per_run=max_entities_per_run,
     )
     if backfill_run_request:
         run_requests = [backfill_run_request, *run_requests]
@@ -337,10 +344,66 @@ def build_run_requests(
     return run_requests
 
 
+def _chunked_entity_keys_for_runs(
+    entity_keys: Iterable[EntityKey], max_entities_per_run: int | None
+) -> Sequence[Sequence[EntityKey]]:
+    """Splits a collection of entity keys into deterministically-ordered chunks containing at
+    most max_entities_per_run keys each. AssetCheckKeys are always placed in the same chunk as
+    the asset they target (when that asset is also present), even if this causes a chunk to
+    slightly exceed the maximum size.
+    """
+    entity_keys = list(entity_keys)
+    if max_entities_per_run is None:
+        return [entity_keys]
+
+    asset_keys = sorted(
+        (key for key in entity_keys if isinstance(key, AssetKey)),
+        key=lambda key: key.to_user_string(),
+    )
+    asset_key_set = set(asset_keys)
+
+    def _check_key_sort_key(key: AssetCheckKey) -> tuple[str, str]:
+        return (key.asset_key.to_user_string(), key.name)
+
+    check_keys_by_asset_key: dict[AssetKey, list[AssetCheckKey]] = defaultdict(list)
+    standalone_check_keys: list[AssetCheckKey] = []
+    for key in entity_keys:
+        if isinstance(key, AssetCheckKey):
+            if key.asset_key in asset_key_set:
+                check_keys_by_asset_key[key.asset_key].append(key)
+            else:
+                standalone_check_keys.append(key)
+
+    # a unit is a set of keys that must be executed in the same run: an asset along with any
+    # of its asset checks that were requested on the same tick
+    units: list[list[EntityKey]] = [
+        [asset_key, *sorted(check_keys_by_asset_key[asset_key], key=_check_key_sort_key)]
+        for asset_key in asset_keys
+    ]
+    units.extend([key] for key in sorted(standalone_check_keys, key=_check_key_sort_key))
+
+    # When the selection fits in a single run, still emit the keys in the same deterministic
+    # order used for the split case, so ordering does not depend on whether splitting occurred.
+    if len(entity_keys) <= max_entities_per_run:
+        return [[key for unit in units for key in unit]]
+
+    chunks: list[list[EntityKey]] = []
+    current_chunk: list[EntityKey] = []
+    for unit in units:
+        if current_chunk and len(current_chunk) + len(unit) > max_entities_per_run:
+            chunks.append(current_chunk)
+            current_chunk = []
+        current_chunk.extend(unit)
+    if current_chunk:
+        chunks.append(current_chunk)
+    return chunks
+
+
 def _build_run_requests_from_partitions_def_mapping(
     mapping: _PartitionsDefKeyMapping,
     asset_graph: BaseAssetGraph,
     run_tags: Mapping[str, str] | None,
+    max_entities_per_run: int | None = None,
 ) -> Sequence[RunRequest]:
     run_requests = []
 
@@ -352,21 +415,24 @@ def _build_run_requests_from_partitions_def_mapping(
             tags.update({**partitions_def.get_tags_for_partition_key(partition_key)})
 
         for entity_keys_for_repo in asset_graph.split_entity_keys_by_repository(entity_keys):
-            asset_check_keys = [k for k in entity_keys_for_repo if isinstance(k, AssetCheckKey)]
-            run_requests.append(
-                # Do not call run_request.with_resolved_tags_and_config as the partition key is
-                # valid and there is no config.
-                # Calling with_resolved_tags_and_config is costly in asset reconciliation as it
-                # checks for valid partition keys.
-                RunRequest(
-                    asset_selection=[k for k in entity_keys_for_repo if isinstance(k, AssetKey)],
-                    partition_key=partition_key,
-                    tags=tags,
-                    # if selecting no asset_check_keys, just pass in `None` to allow required
-                    # checks to be included
-                    asset_check_keys=asset_check_keys or None,
+            for chunked_entity_keys in _chunked_entity_keys_for_runs(
+                entity_keys_for_repo, max_entities_per_run
+            ):
+                asset_check_keys = [k for k in chunked_entity_keys if isinstance(k, AssetCheckKey)]
+                run_requests.append(
+                    # Do not call run_request.with_resolved_tags_and_config as the partition key is
+                    # valid and there is no config.
+                    # Calling with_resolved_tags_and_config is costly in asset reconciliation as it
+                    # checks for valid partition keys.
+                    RunRequest(
+                        asset_selection=[k for k in chunked_entity_keys if isinstance(k, AssetKey)],
+                        partition_key=partition_key,
+                        tags=tags,
+                        # if selecting no asset_check_keys, just pass in `None` to allow required
+                        # checks to be included
+                        asset_check_keys=asset_check_keys or None,
+                    )
                 )
-            )
 
     # We don't make public guarantees about sort order, but make an effort to provide a consistent
     # ordering that puts earlier time partitions before later time partitions. Note that, with dates

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -29,6 +29,7 @@ from dagster._core.definitions.assets.graph.base_asset_graph import BaseAssetGra
 from dagster._core.definitions.assets.graph.remote_asset_graph import RemoteWorkspaceAssetGraph
 from dagster._core.definitions.automation_condition_sensor_definition import (
     EMIT_BACKFILLS_METADATA_KEY,
+    MAX_ENTITIES_PER_RUN_METADATA_KEY,
 )
 from dagster._core.definitions.automation_tick_evaluation_context import (
     AutomationTickEvaluationContext,
@@ -1168,6 +1169,16 @@ class AssetDaemon(DagsterDaemon):
                 *{key for key in auto_materialize_entity_keys if isinstance(key, AssetCheckKey)}
             )
 
+            max_entities_per_run_metadata_value = getattr(
+                (
+                    sensor.metadata.standard_metadata.get(MAX_ENTITIES_PER_RUN_METADATA_KEY)
+                    if sensor and sensor.metadata and sensor.metadata.standard_metadata
+                    else None
+                ),
+                "value",
+                None,
+            )
+
             run_requests, new_cursor, evaluations = await AutomationTickEvaluationContext(
                 evaluation_id=evaluation_id,
                 asset_graph=asset_graph,
@@ -1187,6 +1198,11 @@ class AssetDaemon(DagsterDaemon):
                     and sensor.metadata
                     and sensor.metadata.standard_metadata
                     and EMIT_BACKFILLS_METADATA_KEY in sensor.metadata.standard_metadata
+                ),
+                max_entities_per_run=(
+                    max_entities_per_run_metadata_value
+                    if isinstance(max_entities_per_run_metadata_value, int)
+                    else None
                 ),
                 auto_observe_asset_keys=auto_observe_asset_keys,
                 logger=self._logger,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_automation_run_request_chunking.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_automation_run_request_chunking.py
@@ -1,0 +1,94 @@
+import dagster as dg
+from dagster import AutomationCondition, DagsterInstance
+from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey
+from dagster._core.definitions.automation_tick_evaluation_context import (
+    _chunked_entity_keys_for_runs,
+    build_run_requests,
+)
+
+
+def _asset_key(i: int) -> AssetKey:
+    return AssetKey(f"asset_{i:03}")
+
+
+def test_chunked_entity_keys_for_runs() -> None:
+    keys = [_asset_key(i) for i in range(10)]
+    # intentionally unsorted input, so the sort-ordering assertions below are not vacuous
+    shuffled = list(reversed(keys))
+
+    # no limit -> single chunk containing everything, in the original (unsorted) order
+    assert _chunked_entity_keys_for_runs(shuffled, None) == [shuffled]
+
+    # at or under the limit -> single chunk, in deterministic (sorted) order
+    assert _chunked_entity_keys_for_runs(shuffled, 10) == [keys]
+
+    chunks = _chunked_entity_keys_for_runs(shuffled, 4)
+    assert [len(chunk) for chunk in chunks] == [4, 4, 2]
+    # deterministic ordering (unsorted input -> sorted output), disjoint, complete
+    assert [key for chunk in chunks for key in chunk] == keys
+
+    # check keys ride with their asset, even if the unit exceeds the limit
+    check_keys = [AssetCheckKey(_asset_key(0), f"check_{i}") for i in range(4)]
+    chunks = _chunked_entity_keys_for_runs([*keys[:3], *check_keys], 3)
+    assert [len(chunk) for chunk in chunks] == [5, 2]
+    assert chunks[0][0] == _asset_key(0)
+    assert set(chunks[0][1:]) == set(check_keys)
+
+    # a check key whose asset is not requested becomes its own unit
+    orphan_check_key = AssetCheckKey(AssetKey("not_requested"), "check")
+    chunks = _chunked_entity_keys_for_runs([*keys[:2], orphan_check_key], 2)
+    assert [len(chunk) for chunk in chunks] == [2, 1]
+    assert chunks[-1] == [orphan_check_key]
+
+
+def _build_defs(num_assets: int) -> dg.Definitions:
+    assets = []
+    for i in range(num_assets):
+
+        @dg.asset(name=f"asset_{i:03}", automation_condition=AutomationCondition.missing())
+        def _the_asset() -> None: ...
+
+        assets.append(_the_asset)
+    return dg.Definitions(assets=assets)
+
+
+def test_build_run_requests_max_entities_per_run() -> None:
+    defs = _build_defs(12)
+    result = dg.evaluate_automation_conditions(defs=defs, instance=DagsterInstance.ephemeral())
+    entity_subsets = [r.true_subset for r in result.results if not r.true_subset.is_empty]
+    assert len(entity_subsets) == 12
+
+    # without a limit: a single run targeting everything
+    run_requests = build_run_requests(
+        entity_subsets=entity_subsets,
+        asset_graph=defs.resolve_asset_graph(),
+        run_tags={},
+        emit_backfills=False,
+    )
+    assert len(run_requests) == 1
+
+    # with a limit: deterministic chunks of at most 5
+    run_requests = build_run_requests(
+        entity_subsets=entity_subsets,
+        asset_graph=defs.resolve_asset_graph(),
+        run_tags={"foo": "bar"},
+        emit_backfills=False,
+        max_entities_per_run=5,
+    )
+    assert [len(run_request.asset_selection or []) for run_request in run_requests] == [5, 5, 2]
+    all_keys = [key for run_request in run_requests for key in (run_request.asset_selection or [])]
+    assert len(set(all_keys)) == 12
+    assert all(run_request.tags.get("foo") == "bar" for run_request in run_requests)
+
+
+def test_max_entities_per_run_metadata_round_trip() -> None:
+    # The asset daemon reads max_entities_per_run back from the sensor's stored metadata when the
+    # sensor is not evaluated in the user code server. Guard that round-trip so a regression in the
+    # metadata key or value type does not silently disable chunking.
+    sensor = dg.AutomationConditionSensorDefinition(
+        "s", target=dg.AssetSelection.all(), max_entities_per_run=5
+    )
+    assert sensor.max_entities_per_run == 5
+
+    unset = dg.AutomationConditionSensorDefinition("s2", target=dg.AssetSelection.all())
+    assert unset.max_entities_per_run is None


### PR DESCRIPTION
## Summary & Motivation

Declarative Automation groups all unpartitioned entities that evaluate true on the same tick into a single `RunRequest` (`_build_run_requests_from_partitions_def_mapping` buckets by `(partitions_def, partition_key)`), with no way to bound run size — the docs note that with DA "you have less control over run boundaries than with explicit RunRequest objects". A large backlog (e.g. after daemon downtime) or a cron-synchronized condition across many assets produces one unbounded run targeting everything at once.

This adds an opt-in `max_entities_per_run` setting:

- `AutomationConditionSensorDefinition(max_entities_per_run=N)` — stored in sensor metadata (same mechanism as `emit_backfills`) so BOTH evaluation paths honor it: the user-code-server sensor and the AssetDaemon.
- Requested entities are split into deterministically-ordered chunks of at most N, with `AssetCheckKey`s always kept in the same run as the asset they target (an oversized asset+checks unit stays whole rather than being split).
- Backfill requests (`emit_backfills=True`) are unaffected — this mirrors the precedent of `BackfillPolicy.max_partitions_per_run`, which already chunks along the partition dimension in this same module.
- Default behavior is unchanged (`None` = current single-run grouping).

## Test Plan

New `dagster_tests/definitions_tests/test_automation_run_request_chunking.py`:
- pure chunk-helper coverage: no-limit/under-limit passthrough, deterministic ordering + disjoint/complete coverage, check keys riding with their asset (including an oversized unit), orphan check keys becoming their own unit
- end-to-end: `evaluate_automation_conditions` over 12 unpartitioned assets → `build_run_requests` produces 1 run without a limit and `[5, 5, 2]` runs with `max_entities_per_run=5`, with run tags preserved on every chunk

Both tests pass locally.

## Changelog

`AutomationConditionSensorDefinition` now accepts an optional `max_entities_per_run` parameter (beta). When set, runs launched by Declarative Automation will target at most that many assets or checks each, with asset checks kept in the same run as the asset they target. Backfill requests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)