### PR TITLE
Fix UnknownTimeZoneError in SnowflakeIOManager with ADBC connector

### DIFF
--- a/python_modules/libraries/dagster-snowflake-polars/dagster_snowflake_polars/snowflake_polars_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-polars/dagster_snowflake_polars/snowflake_polars_type_handler.py
@@ -13,10 +13,15 @@ from dagster_snowflake.snowflake_io_manager import (
 
 
 def _table_exists(table_slice: TableSlice, connection):
+    # Query information_schema.tables instead of using SHOW TABLES to avoid
+    # UnknownTimeZoneError with ADBC connections. SHOW TABLES returns TIMESTAMP_LTZ
+    # columns that cause pytz.timezone('Local') to fail when no session timezone is set.
+    # SELECT 1 ensures no timestamp columns appear in the result set.
     with connection.cursor() as cursor:
         cursor.execute(
-            f"SHOW TABLES LIKE '{table_slice.table}' IN SCHEMA"
-            f" {table_slice.database}.{table_slice.schema}"
+            f"SELECT 1 FROM {table_slice.database}.information_schema.tables"
+            f" WHERE LOWER(table_schema) = LOWER('{table_slice.schema}')"
+            f" AND LOWER(table_name) = LOWER('{table_slice.table}')"
         )
         tables = cursor.fetchall()
 

--- a/python_modules/libraries/dagster-snowflake-polars/dagster_snowflake_polars/snowflake_polars_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-polars/dagster_snowflake_polars/snowflake_polars_type_handler.py
@@ -20,8 +20,10 @@ def _table_exists(table_slice: TableSlice, connection):
     with connection.cursor() as cursor:
         cursor.execute(
             f"SELECT 1 FROM {table_slice.database}.information_schema.tables"
-            f" WHERE LOWER(table_schema) = LOWER('{table_slice.schema}')"
-            f" AND LOWER(table_name) = LOWER('{table_slice.table}')"
+            " WHERE LOWER(table_schema) = LOWER(%s)"
+            " AND LOWER(table_name) = LOWER(%s)"
+            " AND TABLE_TYPE = 'BASE TABLE'",
+            (table_slice.schema, table_slice.table),
         )
         tables = cursor.fetchall()
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -371,7 +371,8 @@ class SnowflakeDbClient(DbClient):
         with connection.cursor() as cursor:
             cursor.execute(
                 f"SELECT 1 FROM {table_slice.database}.information_schema.schemata"
-                f" WHERE LOWER(schema_name) = LOWER('{table_slice.schema}')"
+                " WHERE LOWER(schema_name) = LOWER(%s)",
+                (table_slice.schema,),
             )
             schemas = cursor.fetchall()
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -11,7 +11,7 @@ from dagster._core.storage.db_io_manager import (
     DbIOManager,
     DbTypeHandler,
     TablePartitionDimension,
-    TableSlice,
+    TableSlice,h
     static_where_clause,
 )
 from dagster._core.storage.io_manager import dagster_maintained_io_manager
@@ -364,9 +364,14 @@ class SnowflakeDbClient(DbClient):
 
     @staticmethod
     def ensure_schema_exists(context: OutputContext, table_slice: TableSlice, connection) -> None:
+        # Query information_schema.schemata instead of using SHOW SCHEMAS to avoid
+        # UnknownTimeZoneError with ADBC connections. SHOW SCHEMAS returns TIMESTAMP_LTZ
+        # columns that cause pytz.timezone('Local') to fail when no session timezone is set.
+        # SELECT 1 ensures no timestamp columns appear in the result set.
         with connection.cursor() as cursor:
             cursor.execute(
-                f"show schemas like '{table_slice.schema}' in database {table_slice.database}"
+                f"SELECT 1 FROM {table_slice.database}.information_schema.schemata"
+                f" WHERE LOWER(schema_name) = LOWER('{table_slice.schema}')"
             )
             schemas = cursor.fetchall()
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -11,7 +11,7 @@ from dagster._core.storage.db_io_manager import (
     DbIOManager,
     DbTypeHandler,
     TablePartitionDimension,
-    TableSlice,h
+    TableSlice,
     static_where_clause,
 )
 from dagster._core.storage.io_manager import dagster_maintained_io_manager

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
@@ -283,10 +283,12 @@ def test_ensure_schema_exists_creates_missing_schema():
     )
 
     assert mock_connection.cursor.call_count == 2
-    calls = [call[0][0] for call in mock_cursor.execute.call_args_list]
-    assert "information_schema.schemata" in calls[0]
-    assert "LOWER(schema_name) = LOWER('test_schema')" in calls[0]
-    assert "create schema test_schema" in calls[1]
+    schema_query, schema_params = mock_cursor.execute.call_args_list[0][0]
+    create_query = mock_cursor.execute.call_args_list[1][0][0]
+    assert "information_schema.schemata" in schema_query
+    assert "LOWER(schema_name) = LOWER(%s)" in schema_query
+    assert schema_params == ("test_schema",)
+    assert "create schema test_schema" in create_query
 
 
 def test_ensure_schema_exists_skips_create_when_schema_exists():
@@ -306,6 +308,7 @@ def test_ensure_schema_exists_skips_create_when_schema_exists():
     )
 
     assert mock_connection.cursor.call_count == 1
-    calls = [call[0][0] for call in mock_cursor.execute.call_args_list]
-    assert len(calls) == 1
-    assert "information_schema.schemata" in calls[0]
+    schema_query, schema_params = mock_cursor.execute.call_args_list[0][0]
+    assert "information_schema.schemata" in schema_query
+    assert "LOWER(schema_name) = LOWER(%s)" in schema_query
+    assert schema_params == ("test_schema",)

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_snowflake_io_manager.py
@@ -262,3 +262,50 @@ def test_io_manager_snowflake_additional_snowflake_connection_args():
         materialize([return_one], resources={"io_manager": io_mgr})
         assert snowflake_conn_mock.call_count == 1
         assert snowflake_conn_mock.call_args[1]["foo"] == "bar"
+
+
+def test_ensure_schema_exists_creates_missing_schema():
+    """Tests that ensure_schema_exists queries information_schema.schemata and creates the
+    schema when it does not exist.
+    """
+    mock_cursor = mock.MagicMock()
+    mock_cursor.fetchall.return_value = []
+    mock_cursor.__enter__ = mock.MagicMock(return_value=mock_cursor)
+    mock_cursor.__exit__ = mock.MagicMock(return_value=False)
+
+    mock_connection = mock.MagicMock()
+    mock_connection.cursor.return_value = mock_cursor
+
+    table_slice = TableSlice(database="test_db", schema="test_schema", table="test_table")
+
+    SnowflakeDbClient.ensure_schema_exists(
+        context=mock.MagicMock(), table_slice=table_slice, connection=mock_connection
+    )
+
+    assert mock_connection.cursor.call_count == 2
+    calls = [call[0][0] for call in mock_cursor.execute.call_args_list]
+    assert "information_schema.schemata" in calls[0]
+    assert "LOWER(schema_name) = LOWER('test_schema')" in calls[0]
+    assert "create schema test_schema" in calls[1]
+
+
+def test_ensure_schema_exists_skips_create_when_schema_exists():
+    """Tests that ensure_schema_exists does not create the schema when it already exists."""
+    mock_cursor = mock.MagicMock()
+    mock_cursor.fetchall.return_value = [(1,)]
+    mock_cursor.__enter__ = mock.MagicMock(return_value=mock_cursor)
+    mock_cursor.__exit__ = mock.MagicMock(return_value=False)
+
+    mock_connection = mock.MagicMock()
+    mock_connection.cursor.return_value = mock_cursor
+
+    table_slice = TableSlice(database="test_db", schema="test_schema", table="test_table")
+
+    SnowflakeDbClient.ensure_schema_exists(
+        context=mock.MagicMock(), table_slice=table_slice, connection=mock_connection
+    )
+
+    assert mock_connection.cursor.call_count == 1
+    calls = [call[0][0] for call in mock_cursor.execute.call_args_list]
+    assert len(calls) == 1
+    assert "information_schema.schemata" in calls[0]


### PR DESCRIPTION
## Summary & Motivation

Closes #33750

When using `SnowflakePolarsIOManager` (which defaults to `connector = "adbc"`), asset writes fail on Windows with:

```
pytz.exceptions.UnknownTimeZoneError: 'Local'
```

The error originates in `SnowflakeDbClient.ensure_schema_exists`, which runs `SHOW SCHEMAS` via an ADBC cursor. The result set contains `TIMESTAMP_LTZ` columns. When no session-level `TIMEZONE` has been set, Snowflake reports the timezone as `'Local'` in the Arrow schema metadata. PyArrow calls `pytz.timezone('Local')` during `cursor.fetchall()`, which raises `UnknownTimeZoneError` because `'Local'` is not a valid IANA timezone identifier.

The native `snowflake-connector-python` handles this internally via a `tzlocal` fallback, but the ADBC path delegates timezone resolution to PyArrow + pytz which have no such fallback.

A second occurrence of the same pattern exists in `_table_exists` in the Polars type handler, which runs `SHOW TABLES` through the same ADBC cursor path.

### Fix

Replaced `SHOW SCHEMAS` and `SHOW TABLES` commands with equivalent `information_schema` queries:

- `ensure_schema_exists` in `snowflake_io_manager.py`: queries `information_schema.schemata` instead of `SHOW SCHEMAS`
- `_table_exists` in `snowflake_polars_type_handler.py`: queries `information_schema.tables` instead of `SHOW TABLES`
By selecting a constant (`SELECT 1`) rather than all columns, the result set contains no `TIMESTAMP_LTZ` values. PyArrow never encounters the `'Local'` timezone string, which eliminates the error regardless of session timezone configuration.

This approach:
- Does not modify any session state (no `ALTER SESSION SET TIMEZONE`)
- Does not change behavior for non-ADBC connectors
- Preserves case-insensitive schema/table name matching via `LOWER()`
- Works with the same permissions as `SHOW` commands since `information_schema` is accessible to all roles that have privileges on the referenced objects
## Test Plan

Added unit tests for `ensure_schema_exists`:
- `test_ensure_schema_exists_creates_missing_schema`: verifies `information_schema.schemata` is queried and schema is created when missing
- `test_ensure_schema_exists_skips_create_when_schema_exists`: verifies schema creation is skipped when schema already exists
## Changelog

Fix `UnknownTimeZoneError: 'Local'` when using `SnowflakePolarsIOManager` with ADBC connector on systems where no session timezone is set. Replaced `SHOW SCHEMAS` and `SHOW TABLES` commands with `information_schema` queries to avoid `TIMESTAMP_LTZ` columns in result sets.