### PR TITLE
fix(dagster-dbt): improve error messages for missing dbt adapter and invalid target_path

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/compat.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/compat.py
@@ -40,11 +40,19 @@ if TYPE_CHECKING:
     REFABLE_NODE_TYPES: list[str] = []
 else:
     if DBT_PYTHON_VERSION is not None:
-        from dbt.adapters.base.impl import (
-            BaseAdapter as BaseAdapter,
-            BaseColumn as BaseColumn,
-            BaseRelation as BaseRelation,
-        )
+        try:
+            from dbt.adapters.base.impl import (
+                BaseAdapter as BaseAdapter,
+                BaseColumn as BaseColumn,
+                BaseRelation as BaseRelation,
+            )
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "A dbt adapter package could not be found.\n\n"
+                "Please install the appropriate dbt adapter for your data platform "
+                "(for example: dbt-postgres, dbt-bigquery, or dbt-snowflake).\n\n"
+                f"Original error:\n{e}"
+            ) from e
         from dbt.contracts.results import NodeStatus, TestStatus
         from dbt.node_types import NodeType as NodeType
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -361,15 +361,7 @@ class DbtCliResource(ConfigurableResource):
         return current_target_path.joinpath(path)
 
     def _initialize_dbt_core_adapter(self, args: Sequence[str]) -> BaseAdapter:
-        try:
-            from dbt.adapters.factory import get_adapter, register_adapter, reset_adapters
-        except ModuleNotFoundError as e:
-            raise ModuleNotFoundError(
-                "A dbt adapter package could not be found.\n\n"
-                "Please install the appropriate dbt adapter for your data platform "
-                "(for example: dbt-postgres, dbt-bigquery, or dbt-snowflake).\n\n"
-                f"Original error:\n{e}"
-            ) from e
+        from dbt.adapters.factory import get_adapter, register_adapter, reset_adapters
         from dbt.config import RuntimeConfig
         from dbt.config.runtime import load_profile, load_project
         from dbt.config.utils import parse_cli_vars
@@ -732,7 +724,7 @@ class DbtCliResource(ConfigurableResource):
                 try:
                     adapter = self._initialize_dbt_core_adapter(args)
                 except ModuleNotFoundError as e:
-                    if "dbt.adapters" in str(e) or "dbt-" in str(e):
+                    if "dbt.adapters" in str(e):
                         logger.warning(
                             "A dbt adapter package could not be loaded. Please install the"
                             " appropriate dbt adapter for your data platform (for example:"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -361,7 +361,15 @@ class DbtCliResource(ConfigurableResource):
         return current_target_path.joinpath(path)
 
     def _initialize_dbt_core_adapter(self, args: Sequence[str]) -> BaseAdapter:
-        from dbt.adapters.factory import get_adapter, register_adapter, reset_adapters
+        try:
+            from dbt.adapters.factory import get_adapter, register_adapter, reset_adapters
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "A dbt adapter package could not be found.\n\n"
+                "Please install the appropriate dbt adapter for your data platform "
+                "(for example: dbt-postgres, dbt-bigquery, or dbt-snowflake).\n\n"
+                f"Original error:\n{e}"
+            ) from e
         from dbt.config import RuntimeConfig
         from dbt.config.runtime import load_profile, load_project
         from dbt.config.utils import parse_cli_vars
@@ -646,7 +654,13 @@ class DbtCliResource(ConfigurableResource):
         dagster_dbt_translator = updated_params.dagster_dbt_translator
         selection_args = updated_params.selection_args
         indirect_selection = updated_params.indirect_selection
-        target_path = target_path or self._get_unique_target_path(context=context)
+        raw_target_path = target_path or self._get_unique_target_path(context=context)
+        if not isinstance(raw_target_path, Path):
+            raise ValueError(
+                f"The 'target_path' argument must be a pathlib.Path, not {type(raw_target_path).__name__!r}."
+                " Pass a Path object, for example: target_path=Path('target')."
+            )
+        target_path = raw_target_path
         project_dir = Path(
             updated_params.dbt_project.project_dir
             if updated_params.dbt_project
@@ -717,7 +731,22 @@ class DbtCliResource(ConfigurableResource):
             if self._cli_version.major < 2:
                 try:
                     adapter = self._initialize_dbt_core_adapter(args)
-                except:
+                except ModuleNotFoundError as e:
+                    if "dbt.adapters" in str(e) or "dbt-" in str(e):
+                        logger.warning(
+                            "A dbt adapter package could not be loaded. Please install the"
+                            " appropriate dbt adapter for your data platform (for example:"
+                            " dbt-postgres, dbt-bigquery, or dbt-snowflake). Some Dagster"
+                            " features that require a live connection to your data platform"
+                            " will be unavailable.\n\nOriginal error: %s",
+                            e,
+                        )
+                    else:
+                        logger.warning(
+                            "An error was encountered when creating a handle to the dbt adapter in Dagster.",
+                            exc_info=True,
+                        )
+                except Exception:
                     logger.warning(
                         "An error was encountered when creating a handle to the dbt adapter in Dagster.",
                         exc_info=True,


### PR DESCRIPTION
## Summary & Motivation

`dagster-dbt` currently surfaces common setup failures as low-level Python
exceptions with no guidance on how to fix them. This PR improves the
developer experience by replacing those raw errors with actionable messages.

Changes:
- **Missing dbt adapter at import time** (`compat.py`): wraps the
  `dbt.adapters.base.impl` import in a `try/except ModuleNotFoundError`
  that tells users exactly which package to install (e.g. `dbt-postgres`,
  `dbt-bigquery`, `dbt-snowflake`).
- **Missing dbt adapter at runtime** (`_initialize_dbt_core_adapter`):
  applies the same guard to the `dbt.adapters.factory` import so the
  helpful message is shown regardless of which code path triggers the error.
- **Adapter init warning** (`cli()`): replaces the bare `except:` with a
  split handler — a `ModuleNotFoundError` branch that emits a targeted
  installation hint, and an `Exception` fallback that preserves the
  original generic warning for unrelated failures.
- **Invalid `target_path` type** (`cli()`): adds an explicit `isinstance`
  check that raises a clear `ValueError` when a `str` is passed instead of
  a `Path`, preventing the confusing
  `AttributeError: 'str' object has no attribute 'is_absolute'`.

## Test Plan

- [ ] Uninstall a dbt adapter package (e.g. `pip uninstall dbt-postgres`)
  and confirm the new `ModuleNotFoundError` message is shown at import time
  and during `DbtCliResource.cli()`.
- [ ] Pass `target_path="target"` (a string) to `DbtCliResource.cli()` and
  confirm a `ValueError` with the descriptive message is raised instead of
  an `AttributeError`.
- [ ] Run existing dagster-dbt tests to confirm no regressions:



## Changelog

Improved error messages in `dagster-dbt` for missing dbt adapter packages
and invalid `target_path` arguments. Users now receive actionable guidance
(e.g. which adapter package to install) instead of raw Python exceptions.


