### PR TITLE
Forward termination to steps when a user cancels a resumable run

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/methods/run_launcher_methods.py
+++ b/python_modules/dagster/dagster/_core/instance/methods/run_launcher_methods.py
@@ -204,6 +204,15 @@ class RunLauncherMethods:
 
     def run_will_resume(self, run_id: str) -> bool:
         """Check if run will resume."""
+        from dagster._core.storage.dagster_run import DagsterRunStatus
+
         if not self.run_monitoring_enabled:
+            return False
+        # A run that the user is canceling (or has already canceled) will not be resumed by the
+        # daemon, which only resumes runs that are still in the STARTED status. Treating such a run
+        # as resumable would suppress forwarding the termination signal to in-flight steps, leaving
+        # them running indefinitely.
+        run = self.get_run_by_id(run_id)
+        if run and run.status in (DagsterRunStatus.CANCELING, DagsterRunStatus.CANCELED):
             return False
         return self.count_resume_run_attempts(run_id) < self.run_monitoring_max_resume_run_attempts

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -286,6 +286,23 @@ def test_monitor_canceling(instance: DagsterInstance, logger: Logger):
     assert run.status == DagsterRunStatus.CANCELED
 
 
+def test_run_will_resume_with_canceling_run(instance: DagsterInstance):
+    # A started run that has not exhausted its resume attempts is resumable.
+    run = create_run_for_test(instance, job_name="foo", status=DagsterRunStatus.STARTED)
+    assert instance.run_will_resume(run.run_id)
+
+    # Once the user cancels the run it is no longer resumable, so the executor knows to
+    # forward the termination signal to in-flight steps instead of leaving them running.
+    report_canceling_event(instance, run, timestamp=time.time())
+    assert instance.get_run_by_id(run.run_id).status == DagsterRunStatus.CANCELING  # type: ignore
+    assert not instance.run_will_resume(run.run_id)
+
+
+def test_run_will_resume_with_canceled_run(instance: DagsterInstance):
+    run = create_run_for_test(instance, job_name="foo", status=DagsterRunStatus.CANCELED)
+    assert not instance.run_will_resume(run.run_id)
+
+
 def test_monitor_started(
     instance: DagsterInstance, workspace_context: WorkspaceProcessContext, logger: Logger
 ):


### PR DESCRIPTION
## Summary & Motivation

Fixes #33923.

When run monitoring is enabled with `maxResumeRunAttempts > 0`, cancelling a run from the UI left the running step going. The logs showed:

> Executor received termination signal, not forwarding to steps because run will be resumed

The step-delegating executor decides whether to forward a termination signal by calling `run_will_resume`, but that method only looked at whether monitoring was enabled and whether resume attempts were left — never the run status. So a user cancel was indistinguishable from a pod crash, and the signal got swallowed.

A cancel puts the run into `CANCELING` (or `CANCELED` on force-terminate) before the daemon sends SIGTERM, and `monitor_started_run` only ever resumes runs still in `STARTED`. So those statuses were never actually resumable. `run_will_resume` now returns `False` for them, which is the same status check `_resume_from_failure`/the `execute_run` finally block already does before falling back to `run_will_resume`.

## Test Plan

Added two unit tests in `test_monitoring_daemon.py`:
- a STARTED run with attempts remaining is resumable, but stops being resumable once it transitions to CANCELING
- a CANCELED run is not resumable

Full `test_monitoring_daemon.py` passes (10 tests); `ruff` clean.
