### PR TITLE
[ui] Make "Scaffold all default config" work for backfill

### DIFF
--- a/js_modules/ui-core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/ui-core/src/launchpad/LaunchpadRoot.tsx
@@ -115,8 +115,14 @@ export const BackfillLaunchpad = ({
     );
   }
 
-  // Use the saved config's runConfigYaml as rootDefaultYaml if available
-  const rootDefaultYaml = savedConfig?.runConfigYaml;
+  // Use the saved config's runConfigYaml as rootDefaultYaml if available,
+  // otherwise fall back to the schema's defaults so that "Scaffold all default
+  // config" / "Expand defaults" work in the backfill config editor.
+  const rootDefaultYaml =
+    savedConfig?.runConfigYaml ??
+    (result.data?.runConfigSchemaOrError.__typename === 'RunConfigSchema'
+      ? result.data.runConfigSchemaOrError.rootDefaultYaml
+      : undefined);
 
   return (
     <Dialog


### PR DESCRIPTION
## Summary & Motivation
In the Backfill Config Editor (opened via Materialize → Config → Add config on a partitioned asset), the "Scaffold all default config" button is always disabled, even though the asset has config fields with defaults. 
The same button works correctly in the regular Launchpad.

## Test Plan
```python
class GreeterConfig(Config):
    greeting: str = "Hello"
    name: str = "World"
    suffix: str = "!"


@asset(partitions_def=DailyPartitionsDefinition(start_date="2024-01-01"))
def configurable_partitioned_asset(config: GreeterConfig) -> str:
    return f"{config.greeting}, {config.name}{config.suffix}"


defs = Definitions(assets=[configurable_partitioned_asset])
```
Run it
```sh
# Terminal 1 — backend
dagster-webserver -p 3333 -f test_backfill.py
```

```sh
# Terminal 2 — dev UI
cd js_modules
make dev_webapp
open http://localhost:3000
```

Steps

1. Navigate to the asset configurable_partitioned_asset.
2. Click Materialize → pick a range of at least 2 partitions (so backfill mode kicks in).
3. In the launch dialog, expand the Config section → click Add config.
4. In the Config Editor, observe the "Scaffold all default config" button.

Before:
**Incorrectly shows that all defaults are expanded!**
<img width="1370" height="915" alt="Screenshot 2026-06-14 at 23 03 53" src="https://github.com/user-attachments/assets/cce6d061-6585-4bb3-a1ea-bcd9c4beaaee" />


After:
<img width="1379" height="920" alt="Screenshot 2026-06-14 at 23 02 58" src="https://github.com/user-attachments/assets/59abbeb9-6608-473c-857e-c3f09389de7e" />

