### PR TITLE
docs: fix invalid pool config in dbt snapshot component examples

### DIFF
--- a/examples/docs_snippets/docs_snippets/integrations/dbt/component/snapshot/snapshot.yaml
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/component/snapshot/snapshot.yaml
@@ -3,9 +3,5 @@ type: dagster_dbt.DbtProjectComponent
 attributes:
   project: '{{ project_root }}/dbt'
   select: "resource_type:snapshot"
-
-post_processing:
-  assets:
-    - target: "*"
-      attributes:
-        pool: "dbt-snapshots"
+  op:
+    pool: "dbt-snapshots"

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/component/snapshot/snapshot_inventory.yaml
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/component/snapshot/snapshot_inventory.yaml
@@ -3,9 +3,5 @@ type: dagster_dbt.DbtProjectComponent
 attributes:
   project: '{{ project_root }}/dbt'
   select: "resource_type:snapshot,path:snapshots/inventory/*"
-
-post_processing:
-  assets:
-    - target: "*"
-      attributes:
-        pool: "inventory-snapshots"
+  op:
+    pool: "inventory-snapshots"

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/component/snapshot/snapshot_sales.yaml
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/component/snapshot/snapshot_sales.yaml
@@ -3,9 +3,5 @@ type: dagster_dbt.DbtProjectComponent
 attributes:
   project: '{{ project_root }}/dbt'
   select: "resource_type:snapshot,path:snapshots/sales/*"
-
-post_processing:
-  assets:
-    - target: "*"
-      attributes:
-        pool: "sales-snapshots"
+  op:
+    pool: "sales-snapshots"


### PR DESCRIPTION
## Summary

The "Preventing concurrent dbt snapshots" section of the dbt patterns docs shows how to put dbt snapshots in a concurrency pool. The example component YAMLs set the pool via `post_processing` asset attributes:

```yaml
post_processing:
  assets:
    - target: "*"
      attributes:
        pool: "dbt-snapshots"
```

This doesn't work: `pool` is **not** a valid asset attribute (it is op-level). Loading such a component raises a pydantic `ValidationError`:

```
Extra inputs are not permitted [type=extra_forbidden]  # on AssetSpecUpdateKwargsModel, field "pool"
```

so the examples as written fail to load.

## Fix

Set the pool via `attributes.op.pool`, which `DbtProjectComponent` applies to the generated multi-asset op (`pool=op_spec.pool`):

```yaml
attributes:
  project: '{{ project_root }}/dbt'
  select: "resource_type:snapshot"
  op:
    pool: "dbt-snapshots"
```

Updated three snippet files referenced by `docs/docs/integrations/libraries/dbt/dbt-patterns.md`:

- `integrations/dbt/component/snapshot/snapshot.yaml`
- `integrations/dbt/component/snapshot/snapshot_sales.yaml`
- `integrations/dbt/component/snapshot/snapshot_inventory.yaml`

A separate snippet (`pythonic/custom_component_incremental_defs.yaml`) uses `post_processing` with `partitions_def`, which **is** a valid asset attribute, and is left unchanged.

Verified against dagster 1.13.9 / dagster-dbt 0.29.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)