### PR TITLE
feat: make Postgres connection pool settings configurable (pgBouncer transaction-mode / NullPool support)  

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/postgresql.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/postgresql.py
@@ -7,6 +7,13 @@ class Service(BaseModel):
     port: int
 
 
+class Pool(BaseModel):
+    size: int | None = None
+    maxOverflow: int | None = None
+    recycle: int | None = None
+    mode: str | None = None
+
+
 class PostgreSQL(BaseModel):
     image: ExternalImage
     enabled: bool
@@ -17,3 +24,4 @@ class PostgreSQL(BaseModel):
     postgresqlParams: dict
     postgresqlScheme: str | None = None
     service: Service
+    pool: Pool | None = None

--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -42,6 +42,7 @@ class Webserver(BaseModel, extra="forbid"):
     dbStatementTimeout: int | None = None
     dbPoolRecycle: int | None = None
     dbPoolMaxOverflow: int | None = None
+    dbPoolSize: int | None = None
     logLevel: str | None = None
     logFormat: str | None = None
     schedulerName: str | None = None

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -312,6 +312,20 @@ def test_webserver_db_pool_max_overflow(deployment_template: HelmTemplate):
     assert f"--db-pool-max-overflow {pool_max_overflow_s}" in command
 
 
+def test_webserver_db_pool_size(deployment_template: HelmTemplate):
+    # Use 0 specifically to verify that zero (disabling persistent connections for pgBouncer
+    # transaction-mode compatibility) is correctly passed through and not skipped.
+    pool_size = 0
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct(dbPoolSize=pool_size)
+    )
+
+    webserver_deployments = deployment_template.render(helm_values)
+    command = " ".join(webserver_deployments[0].spec.template.spec.containers[0].command)
+
+    assert f"--db-pool-size {pool_size}" in command
+
+
 def test_webserver_log_level(deployment_template: HelmTemplate):
     log_level = "trace"
     helm_values = DagsterHelmValues.construct(

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -33,7 +33,7 @@ from schema.charts.dagster.subschema.daemon import (
     RunCoordinatorType,
     TagConcurrencyLimit,
 )
-from schema.charts.dagster.subschema.postgresql import PostgreSQL, Service
+from schema.charts.dagster.subschema.postgresql import Pool, PostgreSQL, Service
 from schema.charts.dagster.subschema.python_logs import PythonLogs
 from schema.charts.dagster.subschema.retention import Retention, TickRetention, TickRetentionByType
 from schema.charts.dagster.subschema.run_launcher import (
@@ -109,6 +109,42 @@ def test_storage_postgres_db_config(template: HelmTemplate, postgresql_scheme: s
         assert "scheme" not in postgres_db
     else:
         assert postgres_db["scheme"] == postgresql_scheme
+
+
+@pytest.mark.parametrize("storage", ["schedule_storage", "run_storage", "event_log_storage"])
+def test_storage_postgres_pool_config(template: HelmTemplate, storage: str):
+    # pool_size=0 is the critical case: it disables persistent connections for pgBouncer
+    # transaction-mode pooling compatibility and must not be silently skipped.
+    helm_values = DagsterHelmValues.construct(
+        postgresql=PostgreSQL.construct(
+            pool=Pool(size=0, maxOverflow=10, recycle=3600),
+            service=Service(port=5432),
+        )
+    )
+
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    config = instance[storage]["config"]
+    assert config["pool_size"] == 0
+    assert config["max_overflow"] == 10
+    assert config["pool_recycle"] == 3600
+
+
+@pytest.mark.parametrize("storage", ["schedule_storage", "run_storage", "event_log_storage"])
+def test_storage_postgres_pool_mode(template: HelmTemplate, storage: str):
+    helm_values = DagsterHelmValues.construct(
+        postgresql=PostgreSQL.construct(
+            pool=Pool(mode="transaction"),
+            service=Service(port=5432),
+        )
+    )
+
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    config = instance[storage]["config"]
+    assert config["pool_mode"] == "transaction"
 
 
 def test_k8s_run_launcher_config(template: HelmTemplate):

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -57,6 +57,7 @@ If release name contains chart name it will be used as a full name.
 {{- with $_.Values.dagsterWebserver.dbStatementTimeout }} --db-statement-timeout {{ . }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbPoolRecycle }} --db-pool-recycle {{ . }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbPoolMaxOverflow }} --db-pool-max-overflow {{ . }} {{- end -}}
+{{- if not (kindIs "invalid" $_.Values.dagsterWebserver.dbPoolSize) }} --db-pool-size {{ $_.Values.dagsterWebserver.dbPoolSize }} {{- end -}}
 {{- if $_.Values.dagsterWebserver.pathPrefix }} --path-prefix {{ $_.Values.dagsterWebserver.pathPrefix }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.logLevel }} --log-level {{ . }} {{- end -}}
 {{- if .webserverReadOnly }} --read-only {{- end -}}

--- a/helm/dagster/templates/helpers/instance/_postgresql.tpl
+++ b/helm/dagster/templates/helpers/instance/_postgresql.tpl
@@ -30,4 +30,18 @@ auth_provider:
     region: {{ .Values.postgresql.authProvider.awsRegion | quote }}
   {{- end }}
 {{- end }}
+{{- if .Values.postgresql.pool }}
+{{- if not (kindIs "invalid" .Values.postgresql.pool.size) }}
+pool_size: {{ .Values.postgresql.pool.size }}
+{{- end }}
+{{- if not (kindIs "invalid" .Values.postgresql.pool.maxOverflow) }}
+max_overflow: {{ .Values.postgresql.pool.maxOverflow }}
+{{- end }}
+{{- if not (kindIs "invalid" .Values.postgresql.pool.recycle) }}
+pool_recycle: {{ .Values.postgresql.pool.recycle }}
+{{- end }}
+{{- with .Values.postgresql.pool.mode }}
+pool_mode: {{ . }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1868,6 +1868,60 @@
             "title": "PodSecurityContext",
             "type": "object"
         },
+        "Pool": {
+            "properties": {
+                "size": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Size"
+                },
+                "maxOverflow": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Maxoverflow"
+                },
+                "recycle": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Recycle"
+                },
+                "mode": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Mode"
+                }
+            },
+            "title": "Pool",
+            "type": "object"
+        },
         "PostgreSQL": {
             "properties": {
                 "image": {
@@ -1912,6 +1966,17 @@
                 },
                 "service": {
                     "$ref": "#/$defs/schema__charts__dagster__subschema__postgresql__Service"
+                },
+                "pool": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Pool"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
                 }
             },
             "required": [
@@ -3677,6 +3742,18 @@
                     ],
                     "default": null,
                     "title": "Dbpoolmaxoverflow"
+                },
+                "dbPoolSize": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Dbpoolsize"
                 },
                 "logLevel": {
                     "anyOf": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -95,6 +95,14 @@ dagsterWebserver:
   # The maximum overflow size of the sqlalchemy pool. Set to -1 to disable.
   dbPoolMaxOverflow: ~
 
+  # The number of connections to keep open in the sqlalchemy connection pool.
+  # Defaults to 1 if not set.
+  # Note: this maps to SQLAlchemy QueuePool's pool_size, where 0 means *no limit*
+  # (unlimited persistent connections), not "disabled". To disable persistent
+  # connections for pgBouncer transaction-mode pooling, use postgresql.pool.mode
+  # ("transaction") below instead, which switches to a NullPool.
+  dbPoolSize: ~
+
   # The log level of the uvicorn web server, defaults to warning if not set
   logLevel: ~
 
@@ -852,6 +860,21 @@ postgresql:
     azureScope: "https://ossrdbms-aad.database.windows.net/.default"
     # AWS-specific: the RDS region
     awsRegion: ""
+
+  # Connection pool settings written into dagster.yaml.
+  # These take precedence over the --db-pool-* CLI flags on the webserver.
+  pool:
+    # Number of persistent connections (SQLAlchemy QueuePool pool_size). Note that 0 means
+    # *no limit*, not "disabled" — to disable persistent connections for pgBouncer
+    # transaction-mode pooling, set mode: "transaction" below instead.
+    size: ~
+    # Max overflow connections beyond pool size.
+    maxOverflow: ~
+    # Max connection age in seconds before recycling. Set to -1 to disable.
+    recycle: ~
+    # Set to "transaction" to use NullPool (no persistent connections), required for pgBouncer
+    # in transaction-mode pooling. Set to "session" or leave unset for QueuePool (default).
+    mode: ~
 
 # Whether to generate a secret resource for the PostgreSQL password. Useful if
 # global.postgresqlSecretName is managed outside of this helm chart.

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -44,6 +44,7 @@ DEFAULT_WEBSERVER_PORT = 3000
 DEFAULT_DB_STATEMENT_TIMEOUT = 15000  # 15 sec
 DEFAULT_POOL_RECYCLE = 3600  # 1 hr
 DEFAULT_POOL_MAX_OVERFLOW = 20
+DEFAULT_POOL_SIZE = 1
 
 
 @click.command(
@@ -133,6 +134,17 @@ DEFAULT_POOL_MAX_OVERFLOW = 20
     show_default=True,
 )
 @click.option(
+    "--db-pool-size",
+    help=(
+        "The number of connections to keep open in the sqlalchemy pool. Set to 0 to disable "
+        "persistent connections, which is required for pgBouncer transaction-mode pooling. "
+        "Not respected in all configurations."
+    ),
+    default=DEFAULT_POOL_SIZE,
+    type=click.INT,
+    show_default=True,
+)
+@click.option(
     "--read-only",
     help=(
         "Start server in read-only mode, where all mutations such as launching runs and "
@@ -208,6 +220,7 @@ def dagster_webserver(
     db_statement_timeout: int,
     db_pool_recycle: int,
     db_pool_max_overflow: int,
+    db_pool_size: int,
     read_only: bool,
     suppress_warnings: bool,
     uvicorn_log_level: str,
@@ -249,7 +262,9 @@ def dagster_webserver(
             )
         )
         # Allow the instance components to change behavior in the context of a long running server process
-        instance.optimize_for_webserver(db_statement_timeout, db_pool_recycle, db_pool_max_overflow)
+        instance.optimize_for_webserver(
+            db_statement_timeout, db_pool_recycle, db_pool_max_overflow, db_pool_size
+        )
 
         with WorkspaceProcessContext(
             instance,

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -136,9 +136,10 @@ DEFAULT_POOL_SIZE = 1
 @click.option(
     "--db-pool-size",
     help=(
-        "The number of connections to keep open in the sqlalchemy pool. Set to 0 to disable "
-        "persistent connections, which is required for pgBouncer transaction-mode pooling. "
-        "Not respected in all configurations."
+        "The number of connections to keep open in the sqlalchemy QueuePool. Note that 0 means "
+        "*no limit* (unlimited persistent connections), not disabled. To drop persistent "
+        "connections for pgBouncer transaction-mode pooling, set pool_mode: transaction in the "
+        "postgres storage config instead (uses a NullPool). Not respected in all configurations."
     ),
     default=DEFAULT_POOL_SIZE,
     type=click.INT,

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -129,6 +129,15 @@ _CHECK_SUBPROCESS_INTERVAL = 5
     default=None,
     type=click.INT,
 )
+@click.option(
+    "--db-pool-size",
+    help=(
+        "The number of connections to keep open in the sqlalchemy pool. Set to 0 to disable "
+        "persistent connections, which is required for pgBouncer transaction-mode pooling."
+    ),
+    default=None,
+    type=click.INT,
+)
 @workspace_options
 @deprecated(
     breaking_version="2.0", subject="--dagit-port and --dagit-host args", emit_runtime_warning=False
@@ -150,6 +159,7 @@ def dev_command(
     db_statement_timeout: int | None,
     db_pool_recycle: int | None,
     db_pool_max_overflow: int | None,
+    db_pool_size: int | None,
     **other_opts: object,
 ) -> None:
     workspace_opts = WorkspaceOpts.extract_from_cli_options(other_opts)
@@ -169,6 +179,7 @@ def dev_command(
         db_statement_timeout=db_statement_timeout,
         db_pool_recycle=db_pool_recycle,
         db_pool_max_overflow=db_pool_max_overflow,
+        db_pool_size=db_pool_size,
     )
 
 
@@ -186,6 +197,7 @@ def dev_command_impl(
     db_statement_timeout: int | None = None,
     db_pool_recycle: int | None = None,
     db_pool_max_overflow: int | None = None,
+    db_pool_size: int | None = None,
 ) -> None:
     # check if dagster-webserver installed, crash if not
     try:
@@ -267,6 +279,7 @@ def dev_command_impl(
                     if db_pool_max_overflow is not None
                     else []
                 )
+                + (["--db-pool-size", str(db_pool_size)] if db_pool_size is not None else [])
                 + ["--shutdown-pipe", str(webserver_read_fd)]
                 + args,
                 pass_fds=[webserver_read_fd],

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -132,8 +132,10 @@ _CHECK_SUBPROCESS_INTERVAL = 5
 @click.option(
     "--db-pool-size",
     help=(
-        "The number of connections to keep open in the sqlalchemy pool. Set to 0 to disable "
-        "persistent connections, which is required for pgBouncer transaction-mode pooling."
+        "The number of connections to keep open in the sqlalchemy QueuePool. Note that 0 means "
+        "*no limit* (unlimited persistent connections), not disabled. To drop persistent "
+        "connections for pgBouncer transaction-mode pooling, set pool_mode: transaction in the "
+        "postgres storage config instead (uses a NullPool)."
     ),
     default=None,
     type=click.INT,

--- a/python_modules/dagster/dagster/_core/instance/methods/storage_methods.py
+++ b/python_modules/dagster/dagster/_core/instance/methods/storage_methods.py
@@ -75,22 +75,26 @@ class StorageMethods:
         statement_timeout: int,
         pool_recycle: int,
         max_overflow: int,
+        pool_size: int = 1,
     ) -> None:
         if self._schedule_storage:
             self._schedule_storage.optimize_for_webserver(
                 statement_timeout=statement_timeout,
                 pool_recycle=pool_recycle,
                 max_overflow=max_overflow,
+                pool_size=pool_size,
             )
         self._run_storage.optimize_for_webserver(
             statement_timeout=statement_timeout,
             pool_recycle=pool_recycle,
             max_overflow=max_overflow,
+            pool_size=pool_size,
         )
         self._event_storage.optimize_for_webserver(
             statement_timeout=statement_timeout,
             pool_recycle=pool_recycle,
             max_overflow=max_overflow,
+            pool_size=pool_size,
         )
 
     def reindex(self, print_fn: PrintFn = lambda _: None) -> None:

--- a/python_modules/dagster/dagster/_core/storage/config.py
+++ b/python_modules/dagster/dagster/_core/storage/config.py
@@ -36,6 +36,10 @@ class PostgresStorageConfig(TypedDict, total=False):
     postgres_url: str
     postgres_db: "PostgresStorageConfigDb"
     auth_provider: dict[str, object]
+    pool_size: int
+    max_overflow: int
+    pool_recycle: int
+    pool_mode: str
 
 
 class PostgresStorageConfigDb(TypedDict, total=False):
@@ -85,5 +89,9 @@ def pg_config() -> UserConfigSchema:
             ),
             is_required=False,
         ),
+        "pool_size": Field(IntSource, is_required=False),
+        "max_overflow": Field(IntSource, is_required=False),
+        "pool_recycle": Field(IntSource, is_required=False),
+        "pool_mode": Field(StringSource, is_required=False),
         "should_autocreate_tables": Field(bool, is_required=False, default_value=True),
     }

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -330,7 +330,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """Explicit lifecycle management."""
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int, pool_size: int = 1
     ) -> None:
         """Allows for optimizing database connection / use in the context of a long lived webserver process."""
 

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -310,10 +310,10 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
         return self._storage.run_storage.dispose()
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int, pool_size: int = 1
     ) -> None:
         return self._storage.run_storage.optimize_for_webserver(
-            statement_timeout, pool_recycle, max_overflow
+            statement_timeout, pool_recycle, max_overflow, pool_size
         )
 
     def add_daemon_heartbeat(self, daemon_heartbeat: "DaemonHeartbeat") -> None:
@@ -471,12 +471,13 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         return self._storage.event_log_storage.dispose()
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int, pool_size: int = 1
     ) -> None:
         return self._storage.event_log_storage.optimize_for_webserver(
             statement_timeout,
             pool_recycle,
             max_overflow,
+            pool_size,
         )
 
     def get_event_records(  # ty: ignore[invalid-method-override]
@@ -925,12 +926,13 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
         return self._storage.schedule_storage.optimize(print_fn, force_rebuild_all)
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int, pool_size: int = 1
     ) -> None:
         return self._storage.schedule_storage.optimize_for_webserver(
             statement_timeout,
             pool_recycle,
             max_overflow,
+            pool_size,
         )
 
     def dispose(self) -> None:

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -330,7 +330,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """Explicit lifecycle management."""
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int, pool_size: int = 1
     ) -> None:
         """Allows for optimizing database connection / use in the context of a long lived webserver process."""
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -205,7 +205,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """Call this method to run any optional data migrations for optimized reads."""
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int, pool_size: int = 1
     ) -> None:
         """Allows for optimizing database connection / use in the context of a long lived webserver process."""
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/dev.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/dev.py
@@ -87,6 +87,15 @@ T = TypeVar("T")
     type=click.INT,
 )
 @click.option(
+    "--db-pool-size",
+    help=(
+        "The number of connections to keep open in the sqlalchemy pool. Set to 0 to disable "
+        "persistent connections, which is required for pgBouncer transaction-mode pooling."
+    ),
+    default=None,
+    type=click.INT,
+)
+@click.option(
     "--check-yaml/--no-check-yaml",
     flag_value=True,
     help="Whether to schema-check defs.yaml files for the project before starting the dev server.",
@@ -107,6 +116,7 @@ def dev_command(
     db_statement_timeout: int | None,
     db_pool_recycle: int | None,
     db_pool_max_overflow: int | None,
+    db_pool_size: int | None,
     check_yaml: bool | None,
     target_path: Path,
     verbose: bool,  # from dg_global_options
@@ -140,6 +150,7 @@ def dev_command(
             db_statement_timeout=db_statement_timeout,
             db_pool_recycle=db_pool_recycle,
             db_pool_max_overflow=db_pool_max_overflow,
+            db_pool_size=db_pool_size,
         )
 
     # If not, use dg config to construct a workspace file and do a yaml check before
@@ -204,4 +215,5 @@ def dev_command(
             db_statement_timeout=db_statement_timeout,
             db_pool_recycle=db_pool_recycle,
             db_pool_max_overflow=db_pool_max_overflow,
+            db_pool_size=db_pool_size,
         )

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/dev.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/dev.py
@@ -89,8 +89,10 @@ T = TypeVar("T")
 @click.option(
     "--db-pool-size",
     help=(
-        "The number of connections to keep open in the sqlalchemy pool. Set to 0 to disable "
-        "persistent connections, which is required for pgBouncer transaction-mode pooling."
+        "The number of connections to keep open in the sqlalchemy QueuePool. Note that 0 means "
+        "*no limit* (unlimited persistent connections), not disabled. To drop persistent "
+        "connections for pgBouncer transaction-mode pooling, set pool_mode: transaction in the "
+        "postgres storage config instead (uses a NullPool)."
     ),
     default=None,
     type=click.INT,

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -88,14 +88,14 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int, pool_size: int = 1
     ) -> None:
         # When running in dagster-webserver, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
             self.mysql_url,
             isolation_level=mysql_isolation_level(),
-            pool_size=1,
+            pool_size=pool_size,
             pool_recycle=pool_recycle,
             max_overflow=max_overflow,
         )

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -91,14 +91,14 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
             stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int, pool_size: int = 1
     ) -> None:
         # When running in dagster-webserver, hold 1 open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
             self.mysql_url,
             isolation_level=mysql_isolation_level(),
-            pool_size=1,
+            pool_size=pool_size,
             pool_recycle=pool_recycle,
             max_overflow=max_overflow,
         )

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -89,14 +89,14 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.optimize()
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int, pool_size: int = 1
     ) -> None:
         # When running in dagster-webserver, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
         self._engine = create_engine(
             self.mysql_url,
             isolation_level=mysql_isolation_level(),
-            pool_size=1,
+            pool_size=pool_size,
             pool_recycle=pool_recycle,
             max_overflow=max_overflow,
         )

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -86,6 +86,10 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         should_autocreate_tables: bool = True,
         inst_data: ConfigurableClassData | None = None,
         token_provider: "PgTokenProvider | None" = None,
+        pool_size: int | None = None,
+        max_overflow: int | None = None,
+        pool_recycle: int | None = None,
+        pool_mode: str | None = None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.postgres_url = check.str_param(postgres_url, "postgres_url")
@@ -93,6 +97,10 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             should_autocreate_tables, "should_autocreate_tables"
         )
         self._token_provider = token_provider
+        self._config_pool_size = pool_size
+        self._config_max_overflow = max_overflow
+        self._config_pool_recycle = pool_recycle
+        self._config_pool_mode = pool_mode
 
         # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
         self._engine = create_pg_engine(
@@ -123,16 +131,32 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int, pool_size: int = 1
     ) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
-        kwargs: dict[str, Any] = {
-            "isolation_level": "AUTOCOMMIT",
-            "pool_size": 1,
-            "pool_recycle": pool_recycle,
-            "max_overflow": max_overflow,
-        }
         existing_options = self._engine.url.query.get("options")
+        if self._config_pool_mode == "transaction":
+            # NullPool: no persistent connections, required for pgBouncer transaction-mode pooling
+            kwargs: dict[str, Any] = {
+                "isolation_level": "AUTOCOMMIT",
+                "poolclass": db_pool.NullPool,
+            }
+        else:
+            effective_pool_size = (
+                self._config_pool_size if self._config_pool_size is not None else pool_size
+            )
+            effective_max_overflow = (
+                self._config_max_overflow if self._config_max_overflow is not None else max_overflow
+            )
+            effective_pool_recycle = (
+                self._config_pool_recycle if self._config_pool_recycle is not None else pool_recycle
+            )
+            kwargs = {
+                "isolation_level": "AUTOCOMMIT",
+                "pool_size": effective_pool_size,
+                "pool_recycle": effective_pool_recycle,
+                "max_overflow": effective_max_overflow,
+            }
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
         self._engine = create_pg_engine(self.postgres_url, self._token_provider, **kwargs)
@@ -164,6 +188,10 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             postgres_url=pg_url_from_config(config_value),
             should_autocreate_tables=config_value.get("should_autocreate_tables", True),
             token_provider=get_token_provider_from_config(config_value),
+            pool_size=config_value.get("pool_size"),
+            max_overflow=config_value.get("max_overflow"),
+            pool_recycle=config_value.get("pool_recycle"),
+            pool_mode=config_value.get("pool_mode"),
         )
 
     @staticmethod

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -78,6 +78,10 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
         should_autocreate_tables: bool = True,
         inst_data: ConfigurableClassData | None = None,
         token_provider: "PgTokenProvider | None" = None,
+        pool_size: int | None = None,
+        max_overflow: int | None = None,
+        pool_recycle: int | None = None,
+        pool_mode: str | None = None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.postgres_url = postgres_url
@@ -85,6 +89,10 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
             should_autocreate_tables, "should_autocreate_tables"
         )
         self._token_provider = token_provider
+        self._config_pool_size = pool_size
+        self._config_max_overflow = max_overflow
+        self._config_pool_recycle = pool_recycle
+        self._config_pool_mode = pool_mode
 
         # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
         self._engine = create_pg_engine(
@@ -117,16 +125,32 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int, pool_size: int = 1
     ) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
-        kwargs: dict[str, Any] = {
-            "isolation_level": "AUTOCOMMIT",
-            "pool_size": 1,
-            "pool_recycle": pool_recycle,
-            "max_overflow": max_overflow,
-        }
         existing_options = self._engine.url.query.get("options")
+        if self._config_pool_mode == "transaction":
+            # NullPool: no persistent connections, required for pgBouncer transaction-mode pooling
+            kwargs: dict[str, Any] = {
+                "isolation_level": "AUTOCOMMIT",
+                "poolclass": db_pool.NullPool,
+            }
+        else:
+            effective_pool_size = (
+                self._config_pool_size if self._config_pool_size is not None else pool_size
+            )
+            effective_max_overflow = (
+                self._config_max_overflow if self._config_max_overflow is not None else max_overflow
+            )
+            effective_pool_recycle = (
+                self._config_pool_recycle if self._config_pool_recycle is not None else pool_recycle
+            )
+            kwargs = {
+                "isolation_level": "AUTOCOMMIT",
+                "pool_size": effective_pool_size,
+                "pool_recycle": effective_pool_recycle,
+                "max_overflow": effective_max_overflow,
+            }
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
         self._engine = create_pg_engine(self.postgres_url, self._token_provider, **kwargs)
@@ -153,6 +177,10 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
             postgres_url=pg_url_from_config(config_value),
             should_autocreate_tables=config_value.get("should_autocreate_tables", True),
             token_provider=get_token_provider_from_config(config_value),
+            pool_size=config_value.get("pool_size"),
+            max_overflow=config_value.get("max_overflow"),
+            pool_recycle=config_value.get("pool_recycle"),
+            pool_mode=config_value.get("pool_mode"),
         )
 
     @staticmethod

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -78,6 +78,10 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         should_autocreate_tables: bool = True,
         inst_data: ConfigurableClassData | None = None,
         token_provider: "PgTokenProvider | None" = None,
+        pool_size: int | None = None,
+        max_overflow: int | None = None,
+        pool_recycle: int | None = None,
+        pool_mode: str | None = None,
     ):
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self.postgres_url = postgres_url
@@ -85,6 +89,10 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             should_autocreate_tables, "should_autocreate_tables"
         )
         self._token_provider = token_provider
+        self._config_pool_size = pool_size
+        self._config_max_overflow = max_overflow
+        self._config_pool_recycle = pool_recycle
+        self._config_pool_mode = pool_mode
 
         # Default to not holding any connections open to prevent accumulating connections per DagsterInstance
         self._engine = create_pg_engine(
@@ -115,16 +123,32 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.optimize()
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self, statement_timeout: int, pool_recycle: int, max_overflow: int, pool_size: int = 1
     ) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
-        kwargs: dict[str, Any] = {
-            "isolation_level": "AUTOCOMMIT",
-            "pool_size": 1,
-            "pool_recycle": pool_recycle,
-            "max_overflow": max_overflow,
-        }
         existing_options = self._engine.url.query.get("options")
+        if self._config_pool_mode == "transaction":
+            # NullPool: no persistent connections, required for pgBouncer transaction-mode pooling
+            kwargs: dict[str, Any] = {
+                "isolation_level": "AUTOCOMMIT",
+                "poolclass": db_pool.NullPool,
+            }
+        else:
+            effective_pool_size = (
+                self._config_pool_size if self._config_pool_size is not None else pool_size
+            )
+            effective_max_overflow = (
+                self._config_max_overflow if self._config_max_overflow is not None else max_overflow
+            )
+            effective_pool_recycle = (
+                self._config_pool_recycle if self._config_pool_recycle is not None else pool_recycle
+            )
+            kwargs = {
+                "isolation_level": "AUTOCOMMIT",
+                "pool_size": effective_pool_size,
+                "pool_recycle": effective_pool_recycle,
+                "max_overflow": effective_max_overflow,
+            }
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
         self._engine = create_pg_engine(self.postgres_url, self._token_provider, **kwargs)
@@ -151,6 +175,10 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             postgres_url=pg_url_from_config(config_value),
             should_autocreate_tables=config_value.get("should_autocreate_tables", True),
             token_provider=get_token_provider_from_config(config_value),
+            pool_size=config_value.get("pool_size"),
+            max_overflow=config_value.get("max_overflow"),
+            pool_recycle=config_value.get("pool_recycle"),
+            pool_mode=config_value.get("pool_mode"),
         )
 
     @staticmethod

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/storage.py
@@ -43,6 +43,10 @@ class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
         should_autocreate_tables: bool = True,
         inst_data: ConfigurableClassData | None = None,
         token_provider: "PgTokenProvider | None" = None,
+        pool_size: int | None = None,
+        max_overflow: int | None = None,
+        pool_recycle: int | None = None,
+        pool_mode: str | None = None,
     ):
         self.postgres_url = postgres_url
         self.should_autocreate_tables = check.bool_param(
@@ -50,13 +54,31 @@ class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
         )
         self._inst_data = check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
         self._run_storage = PostgresRunStorage(
-            postgres_url, should_autocreate_tables, token_provider=token_provider
+            postgres_url,
+            should_autocreate_tables,
+            token_provider=token_provider,
+            pool_size=pool_size,
+            max_overflow=max_overflow,
+            pool_recycle=pool_recycle,
+            pool_mode=pool_mode,
         )
         self._event_log_storage = PostgresEventLogStorage(
-            postgres_url, should_autocreate_tables, token_provider=token_provider
+            postgres_url,
+            should_autocreate_tables,
+            token_provider=token_provider,
+            pool_size=pool_size,
+            max_overflow=max_overflow,
+            pool_recycle=pool_recycle,
+            pool_mode=pool_mode,
         )
         self._schedule_storage = PostgresScheduleStorage(
-            postgres_url, should_autocreate_tables, token_provider=token_provider
+            postgres_url,
+            should_autocreate_tables,
+            token_provider=token_provider,
+            pool_size=pool_size,
+            max_overflow=max_overflow,
+            pool_recycle=pool_recycle,
+            pool_mode=pool_mode,
         )
         super().__init__()
 
@@ -77,6 +99,10 @@ class DagsterPostgresStorage(DagsterStorage, ConfigurableClass):
             postgres_url=pg_url_from_config(config_value),
             should_autocreate_tables=config_value.get("should_autocreate_tables", True),
             token_provider=get_token_provider_from_config(config_value),
+            pool_size=config_value.get("pool_size"),
+            max_overflow=config_value.get("max_overflow"),
+            pool_recycle=config_value.get("pool_recycle"),
+            pool_mode=config_value.get("pool_mode"),
         )
 
     @property


### PR DESCRIPTION
## Summary & Motivation

Implements #33935.

Make the Postgres storage SQLAlchemy connection pool configurable, and add a `pool_mode: transaction` option that switches the engine to a `NullPool` so Dagster's Postgres storage can run behind pgBouncer in transaction-pooling
mode.

Today, when `dagster-webserver` / `dagster dev` start, each storage rebuilds its engine in `optimize_for_webserver()` with a hardcoded `pool_size=1`, and only `pool_recycle` / `max_overflow` are tunable (webserver CLI flags only). There is no way to:
- set `pool_size`,
- configure any pool setting via `dagster.yaml` (so daemon / code-server processes have no available configuration), or
- opt out of persistent pooled connections, which is required for pgBouncer transaction pooling (a `QueuePool` holding sessions open is incompatible with transaction-level pooling).

This PR exposes the pool parameters as first-class config and threads them through the storages, CLIs, and Helm chart.

### Changes

- **`dagster.yaml` storage config** (`pg_config()` / `PostgresStorageConfig`): new optional `pool_size`, `max_overflow`, `pool_recycle`, `pool_mode` fields, read in `from_config_value()` and applied in `optimize_for_webserver()`.
  - `pool_mode == "transaction"` -> with `poolclass=NullPool` (no persistent connections; pgBouncer transaction-mode compatible).
  - otherwise `QueuePool` with the configured values, each falling back to the CLI-provided value when unset (config takes precedence over CLI flags).
- **CLI**: new `--db-pool-size` on `dagster-webserver`, `dagster dev`, and `dg dev`, threaded through `DagsterInstance.optimize_for_webserver()`. Defaults to `1`, preserving current behavior.
- **Helm chart**: `dagsterWebserver.dbPoolSize` maps to `--db-pool-size`, and `postgresql.pool.{size,maxOverflow,recycle,mode}` written into `dagster.yaml` (with `values.schema.json` updated).
- **MySQL storages**: `optimize_for_webserver` signature updated to accept the new `pool_size` param (default `1`) so the shared interface stays consistent. Required because `DagsterInstance.optimize_for_webserver` now forwards `pool_size` to every storage. Without this, MySQL deployments would raise `TypeError` at webserver startup (NullPool/pgBouncer semantics stay Postgres-specific.)

Backwards compatibility: defaults reproduce the previous behavior (`pool_size=1`, existing recycle/overflow defaults), so deployments that don't set any of the new options are unaffected.

**Note on `pool_size=0`** for SQLAlchemy `QueuePool`, `pool_size=0` means *no limit* (unlimited persistent connections), not disabled. To drop persistent connections for pgBouncer transaction mode, use `pool_mode: transaction` (aka `NullPool`), not `pool_size: 0`. CLI/Helm help text states this explicitly.

### Related issues

- This PR addresses the pooling/connection-management side of #33416 (pgbouncer transaction mode compatibility)
by adding the `NullPool` path. It does not by itself resolve the separate concern in that issue that statement timeouts are applied via a bare `SET statement_timeout = ...` (`set_pg_statement_timeout`), which pgBouncer transaction mode does not support (`SET LOCAL` would be needed). This change will be a follow-up PR.
- This PR also gives user a configuration relevant to #20325 and #8466.

## Test Plan

New Helm schema tests:

- `test_storage_postgres_pool_config` asserts `pool_size`/`max_overflow`/ `pool_recycle` (including the `pool_size=0` edge case) render into `dagster.yaml` for run / schedule / event-log storage.
- `test_storage_postgres_pool_mode` asserts `pool_mode: transaction` renders.
- `test_webserver_db_pool_size` asserts `--db-pool-size` is passed to the webserver command (incl. `0`).

`pytest python_modules/libraries/dagster-postgres/dagster_postgres_tests` and `.../dagster-mysql/dagster_mysql_tests` (verify `optimize_for_webserver` still works through `DagsterInstance` for both backends after the signature change).

Running `make ruff` locally produced a clean result, no changes needed.

Tests I ran locally:

| Test suite                                                                  | Result |
|-----------------------------------------------------------------------------|--------|
| `helm/dagster/schema/schema_tests/test_dagit.py` + `test_instance.py`       | passed |
| `python_modules/dagster/dagster_tests/core_tests/instance_tests/`           | passed |
| `dagster-postgres/dagster_postgres_tests/test_instance.py::test_conn_str`   | passed |
| Core storage tests (keyword `storage`)                                      | passed |

The DB-dependent postgres tests (`test_statement_timeouts`, `test_connection_leak`, etc) require a running PostgreSQL server and were skipped. All locally runnable tests for the pool mode feature have passed. 
