### PR TITLE
[dagster-dbt] Honor DBT_PROFILE/DBT_TARGET in the in-process adapter

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -386,7 +386,16 @@ class DbtCliResource(ConfigurableResource):
         set_from_args(Namespace(profiles_dir=profiles_dir), None)
         flags = get_flags()
 
-        profile = load_profile(self.project_dir, cli_vars, self.profile, self.target)
+        # Mirror dbt's CLI flag/env-var resolution. dbt only reads DBT_PROFILE /
+        # DBT_TARGET at its Click CLI layer (dbt/cli/params.py), so the `dbt`
+        # subprocess this resource spawns honors them, but the in-process adapter
+        # used for metadata calls (e.g. column metadata) does not. Fall back to the
+        # env vars when the resource does not set profile/target explicitly so both
+        # paths resolve the same profile. Explicit resource config still wins.
+        # Fixes https://github.com/dagster-io/dagster/issues/33818
+        profile_override = self.profile or os.getenv("DBT_PROFILE")
+        target_override = self.target or os.getenv("DBT_TARGET")
+        profile = load_profile(self.project_dir, cli_vars, profile_override, target_override)
         project = load_project(self.project_dir, False, profile, cli_vars)
         config = RuntimeConfig.from_parts(project, profile, flags)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -265,6 +265,67 @@ def test_dbt_profile_configuration() -> None:
 
 
 @pytest.mark.parametrize(
+    ("explicit_profile", "explicit_target", "env", "expected_profile", "expected_target"),
+    [
+        # DBT_PROFILE / DBT_TARGET are honored when the resource sets neither, so the
+        # in-process adapter resolves the same profile as the dbt subprocess.
+        (None, None, {"DBT_PROFILE": "env_profile", "DBT_TARGET": "prod"}, "env_profile", "prod"),
+        # Explicit resource config always wins over the env vars.
+        (
+            "arg_profile",
+            "arg_target",
+            {"DBT_PROFILE": "env_profile", "DBT_TARGET": "prod"},
+            "arg_profile",
+            "arg_target",
+        ),
+        # Nothing set: pass None through so dbt applies its own profiles.yml default.
+        (None, None, {}, None, None),
+    ],
+    ids=["env_var_honored", "explicit_arg_wins", "no_override"],
+)
+def test_initialize_dbt_core_adapter_honors_target_profile_env_vars(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+    explicit_profile: str | None,
+    explicit_target: str | None,
+    env: dict[str, str],
+    expected_profile: str | None,
+    expected_target: str | None,
+) -> None:
+    # https://github.com/dagster-io/dagster/issues/33818 - the in-process adapter
+    # used for metadata calls ignored DBT_PROFILE / DBT_TARGET while the dbt
+    # subprocess honored them (via dbt's own CLI layer), so the two paths could
+    # resolve different profiles/targets.
+    class _StopAdapterInit(Exception):
+        """Raised to short-circuit adapter init right after profile resolution."""
+
+    monkeypatch.delenv("DBT_PROFILE", raising=False)
+    monkeypatch.delenv("DBT_TARGET", raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    # Capture the overrides Dagster passes to dbt, then stop before any real
+    # adapter / warehouse connection is created.
+    mock_load_profile = mocker.patch(
+        "dbt.config.runtime.load_profile", side_effect=_StopAdapterInit
+    )
+
+    resource = DbtCliResource(
+        project_dir=os.fspath(test_jaffle_shop_path),
+        profile=explicit_profile,
+        target=explicit_target,
+    )
+
+    with pytest.raises(_StopAdapterInit):
+        resource._initialize_dbt_core_adapter(["run"])  # noqa: SLF001
+
+    # load_profile(project_dir, cli_vars, profile_name_override, target_override)
+    _, _, passed_profile, passed_target = mock_load_profile.call_args.args
+    assert passed_profile == expected_profile
+    assert passed_target == expected_target
+
+
+@pytest.mark.parametrize(
     "profiles_dir", [None, test_jaffle_shop_path, os.fspath(test_jaffle_shop_path)]
 )
 def test_dbt_profiles_dir_configuration(profiles_dir: str | Path) -> None:


### PR DESCRIPTION
## Summary & Motivation

Fixes #33818.

`DbtCliResource` resolves the dbt profile/target in two different places:

- **Subprocess path** (`dbt run`, `dbt build`, …): the subprocess inherits `os.environ`, so dbt's own CLI layer reads `DBT_PROFILE` / `DBT_TARGET` (see `dbt/cli/params.py`) and selects that profile/target.
- **In-process adapter path** (`_initialize_dbt_core_adapter`, used for metadata calls such as column metadata): calls dbt's `load_profile(self.project_dir, cli_vars, self.profile, self.target)`. `self.profile`/`self.target` are `None` unless explicitly set on the resource, and dbt's `load_profile` does **not** read the env vars itself — only its Click CLI layer does.

As a result, with `DBT_TARGET=prod` set in the environment, the subprocess uses `prod` while the in-process adapter falls back to the `profiles.yml` default (e.g. `dev`), so metadata calls connect to the wrong warehouse/credentials. This is the exact symptom reported in #33818.

The fix mirrors dbt's CLI resolution: fall back to `DBT_PROFILE` / `DBT_TARGET` when the resource does not set profile/target explicitly. **Explicit resource configuration still takes precedence**, matching dbt's documented `--profile`/`--target` override semantics.

```python
profile_override = self.profile or os.getenv("DBT_PROFILE")
target_override = self.target or os.getenv("DBT_TARGET")
profile = load_profile(self.project_dir, cli_vars, profile_override, target_override)
```

(`DBT_PROFILES_DIR` is a separate, lower-priority gap mentioned in the issue title; the reproduced symptom is `DBT_TARGET`/`DBT_PROFILE`, so this PR is kept minimal to those.)

## How I Tested These Changes

Added a parametrized unit test in `dagster_dbt_tests/core/test_resource.py` that patches dbt's `load_profile` and asserts the exact `profile`/`target` overrides Dagster passes to it, then short-circuits before any real adapter/warehouse connection:

- `DBT_PROFILE`/`DBT_TARGET` are honored when the resource sets neither;
- explicit `profile=`/`target=` on the resource win over the env vars;
- with neither set, `None` is passed through so dbt applies its own default resolution.

`ruff check` and `ruff format --check` pass on both changed files.

> Disclosure: I could not execute pytest locally because dbt fails to import in my environment (`mashumaro UnserializableField` on Python 3.14). The test is designed to need no working warehouse/dbt CLI — only an importable `dbt` — so it is expected to run in CI on the supported Python matrix. Please flag if CI surfaces anything.

## Changelog

`[dagster-dbt]` `DbtCliResource` now honors the `DBT_PROFILE` and `DBT_TARGET` environment variables in its in-process adapter (used for metadata), matching how the dbt subprocess already resolves them. Explicit `profile`/`target` configuration still takes precedence.

---
_Prepared with AI assistance (Claude Code)._