### PR TITLE
[dagster-dbt] Surface isolated dbt-fusion models in asset selection

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -203,7 +203,33 @@ def _select_unique_ids_from_manifest(
 
     child_map = manifest_json["child_map"]
 
-    graph = graph_selector.Graph(DiGraph(incoming_graph_data=child_map))
+    digraph = DiGraph(incoming_graph_data=child_map)
+
+    # dbt-fusion manifests (manifest schema v2+) omit nodes that have neither
+    # parents nor children from `child_map`, whereas dbt-core keys `child_map`
+    # by every node. As a result a node with no `source()`/`ref()` calls (and
+    # nothing referencing it) never lands in the selection graph, so
+    # `NodeSelector` silently drops it from the asset graph with no error.
+    # Add any selectable unique_ids that are missing from the graph so isolated
+    # nodes stay selectable. This is a no-op for well-formed dbt-core manifests.
+    # See https://github.com/dagster-io/dagster/issues/33801.
+    selectable_unique_ids = {
+        unique_id
+        for collection in (
+            "nodes",
+            "sources",
+            "exposures",
+            "metrics",
+            "semantic_models",
+            "saved_queries",
+            "unit_tests",
+            "functions",
+        )
+        for unique_id in manifest_json.get(collection, {})
+    }
+    digraph.add_nodes_from(selectable_unique_ids - set(digraph.nodes))
+
+    graph = graph_selector.Graph(digraph)
 
     # create a parsed selection from the select string
     _set_flag_attrs(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -432,3 +432,60 @@ def test_dbt_asset_selection_selector_invalid(
             selector="fake_selector_does_not_exist",
         )
         def selected_dbt_assets(): ...
+
+
+def _model_node(unique_id: str, name: str) -> dict[str, Any]:
+    return {
+        "unique_id": unique_id,
+        "resource_type": "model",
+        "name": name,
+        "package_name": "test",
+        "fqn": ["test", name],
+        "path": f"{name}.sql",
+        "original_file_path": f"models/{name}.sql",
+        "tags": [],
+        "config": {"enabled": True, "tags": [], "materialized": "table"},
+        "depends_on": {"nodes": [], "macros": []},
+    }
+
+
+def test_select_unique_ids_includes_isolated_fusion_models() -> None:
+    """A dbt model with no ``source()``/``ref()`` calls (and nothing referencing it)
+    is omitted from ``child_map`` by dbt-fusion manifests, unlike dbt-core which keys
+    ``child_map`` by every node. Selection must still surface such isolated nodes
+    rather than silently dropping them.
+
+    Regression test for https://github.com/dagster-io/dagster/issues/33801.
+    """
+    from dagster_dbt.utils import _select_unique_ids_from_manifest
+
+    manifest_json: dict[str, Any] = {
+        "nodes": {
+            "model.test.parent": _model_node("model.test.parent", "parent"),
+            "model.test.child": _model_node("model.test.child", "child"),
+            "model.test.isolated": _model_node("model.test.isolated", "isolated"),
+        },
+        "sources": {},
+        "metrics": {},
+        "exposures": {},
+        # dbt-fusion-style child_map: the isolated model appears neither as a key
+        # nor as a value, because it has no parents and no children.
+        "child_map": {
+            "model.test.parent": ["model.test.child"],
+            "model.test.child": [],
+        },
+        "parent_map": {
+            "model.test.parent": [],
+            "model.test.child": ["model.test.parent"],
+        },
+    }
+
+    selected = _select_unique_ids_from_manifest(
+        select="fqn:*", exclude="", selector="", manifest_json=manifest_json
+    )
+
+    assert selected == {
+        "model.test.parent",
+        "model.test.child",
+        "model.test.isolated",
+    }

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -449,7 +449,39 @@ def _model_node(unique_id: str, name: str) -> dict[str, Any]:
     }
 
 
-def test_select_unique_ids_includes_isolated_fusion_models() -> None:
+def _source_node(unique_id: str, source_name: str, name: str) -> dict[str, Any]:
+    return {
+        "unique_id": unique_id,
+        "resource_type": "source",
+        "source_name": source_name,
+        "name": name,
+        "package_name": "test",
+        "fqn": ["test", source_name, name],
+        "path": "sources.yml",
+        "original_file_path": "models/sources.yml",
+        "tags": [],
+        "config": {"enabled": True, "tags": []},
+    }
+
+
+@pytest.mark.parametrize(
+    "select, expected_unique_ids",
+    [
+        pytest.param("isolated", {"model.test.isolated"}, id="isolated-model-alone"),
+        pytest.param(
+            "fqn:*",
+            {
+                "model.test.parent",
+                "model.test.child",
+                "model.test.isolated",
+            },
+            id="broader-selector",
+        ),
+    ],
+)
+def test_select_unique_ids_includes_isolated_fusion_models(
+    select: str, expected_unique_ids: set[str]
+) -> None:
     """A dbt model with no ``source()``/``ref()`` calls (and nothing referencing it)
     is omitted from ``child_map`` by dbt-fusion manifests, unlike dbt-core which keys
     ``child_map`` by every node. Selection must still surface such isolated nodes
@@ -481,11 +513,47 @@ def test_select_unique_ids_includes_isolated_fusion_models() -> None:
     }
 
     selected = _select_unique_ids_from_manifest(
+        select=select, exclude="", selector="", manifest_json=manifest_json
+    )
+
+    assert selected == expected_unique_ids
+
+
+def test_select_unique_ids_includes_isolated_fusion_models_with_ref_source_graph() -> None:
+    from dagster_dbt.utils import _select_unique_ids_from_manifest
+
+    manifest_json: dict[str, Any] = {
+        "nodes": {
+            "model.test.uses_source": {
+                **_model_node("model.test.uses_source", "uses_source"),
+                "depends_on": {"nodes": ["source.test.raw.customers"], "macros": []},
+            },
+            "model.test.isolated": _model_node("model.test.isolated", "isolated"),
+        },
+        "sources": {
+            "source.test.raw.customers": _source_node(
+                "source.test.raw.customers", "raw", "customers"
+            ),
+        },
+        "metrics": {},
+        "exposures": {},
+        # Mixed dbt-fusion-style graph: one model is connected to a source, while the
+        # isolated model is absent from child_map because it has no parents or children.
+        "child_map": {
+            "source.test.raw.customers": ["model.test.uses_source"],
+            "model.test.uses_source": [],
+        },
+        "parent_map": {
+            "source.test.raw.customers": [],
+            "model.test.uses_source": ["source.test.raw.customers"],
+        },
+    }
+
+    selected = _select_unique_ids_from_manifest(
         select="fqn:*", exclude="", selector="", manifest_json=manifest_json
     )
 
     assert selected == {
-        "model.test.parent",
-        "model.test.child",
+        "model.test.uses_source",
         "model.test.isolated",
     }


### PR DESCRIPTION
## Summary

`DbtProjectComponent` (and any selection that goes through `select_unique_ids`) silently drops dbt models that contain no `source()`/`ref()` calls when the project is compiled with **dbt-fusion** (manifest schema v2+). The model is present and `enabled` in `manifest["nodes"]`, yet it never appears as a Dagster asset and no error is raised.

## Root cause

`_select_unique_ids_from_manifest` in `dagster_dbt/utils.py` builds the selection graph solely from `manifest["child_map"]`:

```python
graph = graph_selector.Graph(DiGraph(incoming_graph_data=child_map))
```

dbt-core keys `child_map` by **every** node, but dbt-fusion omits any node that has neither parents nor children. A model with no `source()`/`ref()` calls (and nothing referencing it) is therefore absent from the `DiGraph`. `NodeSelector` intersects matched nodes with the graph's node set, so a node that is missing from the graph can never be selected — it is silently dropped.

## Fix

After constructing the graph from `child_map`, add any selectable `unique_id`s from the manifest that are missing from the graph. This is a no-op for well-formed dbt-core manifests (where `child_map` already contains every node) and only repairs fusion manifests.

## Testing

Added `test_select_unique_ids_includes_isolated_fusion_models`, which builds a manifest where an isolated model is absent from `child_map` (the exact dbt-fusion shape from the issue) and asserts the model is still selected. Verified the test fails without the fix and passes with it. `ruff` clean.

closes: #33801

---

##### Was generative AI tooling used to author this PR?

Yes — Claude Code (Opus 4.8). Generated-by: Claude Code (Opus 4.8)
