### PR TITLE
[dagster-graphql] Tolerate deleted partitions in historical automation evaluations

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
@@ -11,6 +11,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionEvaluation,
     get_expanded_label,
 )
+from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.scheduler.instigation import AutoMaterializeAssetEvaluationRecord
 
 from dagster_graphql.implementation.events import iterate_metadata_entries
@@ -49,10 +50,10 @@ class GrapheneUnpartitionedAssetConditionEvaluationNode(graphene.ObjectType):
 
     def __init__(self, evaluation: AutomationConditionEvaluation):
         self._evaluation = evaluation
-        if evaluation.true_subset.size > 0:
+        if _get_historical_subset_size(evaluation.true_subset) > 0:
             status = AssetConditionEvaluationStatus.TRUE
         elif isinstance(evaluation.candidate_subset, SerializableEntitySubset) and (
-            evaluation.candidate_subset.size > 0
+            _get_historical_subset_size(evaluation.candidate_subset) > 0
         ):
             status = AssetConditionEvaluationStatus.FALSE
         else:
@@ -110,11 +111,11 @@ class GraphenePartitionedAssetConditionEvaluationNode(graphene.ObjectType):
         )
 
     def resolve_numTrue(self, graphene_info: ResolveInfo) -> int | None:
-        return self._evaluation.true_subset.size
+        return _get_historical_subset_size(self._evaluation.true_subset)
 
     def resolve_numCandidates(self, graphene_info: ResolveInfo) -> int | None:
         return (
-            self._evaluation.candidate_subset.size
+            _get_historical_subset_size(self._evaluation.candidate_subset)
             if isinstance(self._evaluation.candidate_subset, SerializableEntitySubset)
             else None
         )
@@ -143,12 +144,11 @@ class GrapheneSpecificPartitionAssetConditionEvaluationNode(graphene.ObjectType)
             # where a sub-condition is not partitioned. In these cases, we can treat the expression
             # as SKIPPED
             status = AssetConditionEvaluationStatus.SKIPPED
-        elif partition_key in evaluation.true_subset.subset_value:
+        elif _historical_subset_contains_partition(evaluation.true_subset, partition_key):
             status = AssetConditionEvaluationStatus.TRUE
-        elif (
-            not isinstance(evaluation.candidate_subset, SerializableEntitySubset)
-            or partition_key in evaluation.candidate_subset.subset_value
-        ):
+        elif not isinstance(
+            evaluation.candidate_subset, SerializableEntitySubset
+        ) or _historical_subset_contains_partition(evaluation.candidate_subset, partition_key):
             status = AssetConditionEvaluationStatus.FALSE
         else:
             status = AssetConditionEvaluationStatus.SKIPPED
@@ -171,7 +171,7 @@ class GrapheneSpecificPartitionAssetConditionEvaluationNode(graphene.ObjectType)
             (
                 subset.metadata
                 for subset in self._evaluation.subsets_with_metadata
-                if self._partition_key in subset.subset.subset_value
+                if _historical_subset_contains_partition(subset.subset, self._partition_key)
             ),
             {},
         )
@@ -281,11 +281,11 @@ class GrapheneAutomationConditionEvaluationNode(graphene.ObjectType):
         )
 
     def resolve_numTrue(self, graphene_info: ResolveInfo) -> int | None:
-        return self._evaluation.true_subset.size
+        return _get_historical_subset_size(self._evaluation.true_subset)
 
     def resolve_numCandidates(self, graphene_info: ResolveInfo) -> int | None:
         return (
-            self._evaluation.candidate_subset.size
+            _get_historical_subset_size(self._evaluation.candidate_subset)
             if isinstance(self._evaluation.candidate_subset, SerializableEntitySubset)
             else None
         )
@@ -362,7 +362,7 @@ class GrapheneAssetConditionEvaluationRecord(graphene.ObjectType):
         )
 
     def resolve_numRequested(self, graphene_info: ResolveInfo) -> int | None:
-        return self._root_evaluation.true_subset.size
+        return _get_historical_subset_size(self._root_evaluation.true_subset)
 
 
 class GrapheneAssetConditionEvaluationRecords(graphene.ObjectType):
@@ -388,3 +388,19 @@ def _flatten_evaluation(
     import itertools
 
     return list(itertools.chain([e], *(_flatten_evaluation(ce) for ce in e.child_evaluations)))
+
+
+def _get_historical_subset_size(subset: SerializableEntitySubset) -> int:
+    try:
+        return subset.size
+    except DagsterInvalidInvocationError:
+        return 0
+
+
+def _historical_subset_contains_partition(
+    subset: SerializableEntitySubset, partition_key: str
+) -> bool:
+    try:
+        return subset.is_partitioned and partition_key in subset.subset_value
+    except DagsterInvalidInvocationError:
+        return False

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -17,11 +17,16 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     HistoricalAllPartitionsSubsetSentinel,
 )
 from dagster._core.definitions.partitions.definition import (
+    DynamicPartitionsDefinition,
     PartitionsDefinition,
     StaticPartitionsDefinition,
 )
+from dagster._core.definitions.partitions.partition_key_range import PartitionKeyRange
+from dagster._core.definitions.partitions.snap import PartitionsSnap
+from dagster._core.definitions.partitions.subset.key_ranges import KeyRangesPartitionsSubset
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.sensor_definition import SensorType
+from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_origin import RemoteInstigatorOrigin
 from dagster._core.scheduler.instigation import (
@@ -527,6 +532,34 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
             subsets_with_metadata=[],
         )
 
+    def _get_key_range_condition_evaluation(
+        self,
+        asset_key: AssetKey,
+        description: str,
+        partition_key_ranges: Sequence[PartitionKeyRange],
+    ) -> AutomationConditionEvaluation:
+        partitions_snap = PartitionsSnap.from_def(DynamicPartitionsDefinition(name="dynamic"))
+        subset = SerializableEntitySubset(
+            key=asset_key,
+            value=KeyRangesPartitionsSubset(
+                partitions_snap=partitions_snap,
+                key_ranges=partition_key_ranges,
+            ),
+        )
+        return AutomationConditionEvaluation(
+            condition_snapshot=AutomationConditionNodeSnapshot(
+                class_name="...",
+                description=description,
+                unique_id=str(random.randint(0, 100000000)),
+            ),
+            true_subset=subset,
+            candidate_subset=HistoricalAllPartitionsSubsetSentinel(),
+            start_timestamp=123,
+            end_timestamp=456,
+            child_evaluations=[],
+            subsets_with_metadata=[],
+        )
+
     def test_get_evaluations_with_partitions(self, graphql_context: WorkspaceRequestContext):
         asset_key = AssetKey("upstream_static_partitioned_asset")
         partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d", "e", "f"])
@@ -821,6 +854,86 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
             "c",
             "d",
         }
+
+    def test_get_evaluations_tolerates_deleted_historical_partition_size(
+        self, graphql_context: WorkspaceRequestContext
+    ):
+        asset_key = AssetKey("dynamic_partitioned_asset")
+        graphql_context.instance.add_dynamic_partitions("dynamic", ["a"])
+        evaluation = self._get_key_range_condition_evaluation(
+            asset_key,
+            "stale historical subset",
+            [PartitionKeyRange("a", "a")],
+        )
+
+        check.not_none(
+            graphql_context.instance.schedule_storage
+        ).add_auto_materialize_asset_evaluations(
+            evaluation_id=201,
+            asset_evaluations=[
+                AutomationConditionEvaluationWithRunIds(evaluation=evaluation, run_ids=frozenset())
+            ],
+        )
+
+        with patch.object(
+            KeyRangesPartitionsSubset,
+            "__len__",
+            side_effect=DagsterInvalidInvocationError("Partition key was deleted."),
+        ):
+            results = execute_dagster_graphql(
+                graphql_context,
+                QUERY,
+                variables={
+                    "assetKey": {"path": ["dynamic_partitioned_asset"]},
+                    "limit": 10,
+                    "cursor": None,
+                },
+            )
+
+        assert not results.errors
+        records = results.data["assetConditionEvaluationRecordsOrError"]["records"]
+        assert len(records) == 1
+        assert records[0]["numRequested"] == 0
+        assert records[0]["evaluationNodes"][0]["numTrue"] == 0
+
+    def test_get_partition_evaluation_tolerates_deleted_historical_partition_membership(
+        self, graphql_context: WorkspaceRequestContext
+    ):
+        asset_key = AssetKey("dynamic_partitioned_asset")
+        graphql_context.instance.add_dynamic_partitions("dynamic", ["a"])
+        evaluation = self._get_key_range_condition_evaluation(
+            asset_key,
+            "stale historical subset",
+            [PartitionKeyRange("a", "a")],
+        )
+
+        check.not_none(
+            graphql_context.instance.schedule_storage
+        ).add_auto_materialize_asset_evaluations(
+            evaluation_id=202,
+            asset_evaluations=[
+                AutomationConditionEvaluationWithRunIds(evaluation=evaluation, run_ids=frozenset())
+            ],
+        )
+
+        with patch.object(
+            KeyRangesPartitionsSubset,
+            "__contains__",
+            side_effect=DagsterInvalidInvocationError("Partition key was deleted."),
+        ):
+            results = execute_dagster_graphql(
+                graphql_context,
+                LEGACY_QUERY_FOR_SPECIFIC_PARTITION,
+                variables={
+                    "assetKey": {"path": ["dynamic_partitioned_asset"]},
+                    "partition": "a",
+                    "evaluationId": 202,
+                },
+            )
+
+        assert not results.errors
+        evaluation = results.data["assetConditionEvaluationForPartition"]
+        assert evaluation["evaluationNodes"][0]["status"] == "FALSE"
 
     def test_since_metadata_field(self, graphql_context: WorkspaceRequestContext):
         """Test that the sinceMetadata field is correctly populated for SinceCondition evaluations."""


### PR DESCRIPTION
## Summary & Motivation

When a partition is manually removed (e.g. a dynamic partition is deleted), opening the Automation tab of a downstream asset raises a GraphQL error and the tab fails to load (#33910).

Historical automation-condition evaluation records store partition subsets that were captured at evaluation time. After a partition is deleted, materializing those stored subsets — `subset.size` and `partition_key in subset.subset_value` — raises `DagsterInvalidInvocationError` because the partition no longer exists in the partitions definition. The GraphQL resolvers in `asset_condition_evaluations.py` call those properties directly while building `GrapheneAssetConditionEvaluation` / per-partition nodes, so the error propagates out of the query and breaks the whole tab.

## Fix

Wrap the two access patterns in small helpers that tolerate stale historical subsets:

- `_get_historical_subset_size(subset)` returns `subset.size`, falling back to `0` if the subset can no longer be materialized.
- `_historical_subset_contains_partition(subset, key)` returns `subset.is_partitioned and key in subset.subset_value`, falling back to `False`.

A deleted partition is therefore treated as "no longer true / not a candidate" instead of crashing the query. This is a no-op for all non-stale subsets — behaviour only changes on the error path that previously 500'd.

## Test Plan

Added two regression tests in `dagster_graphql_tests/graphql/test_asset_condition_evaluations.py` that build a `KeyRangesPartitionsSubset` and patch its `__len__` / `__contains__` to raise `DagsterInvalidInvocationError` (the deleted-partition shape), then assert the records query and the per-partition query both resolve with `numRequested`/`numTrue == 0` instead of erroring.

Verified locally: both tests pass on the sqlite GraphQL context variants (`4 passed, 4 skipped` — postgres/code-server variants skip on local Docker/gRPC constraints). `ruff` (pinned `0.15.15`) check + format clean.

closes: #33910

---

##### Was generative AI tooling used to author this PR?

Yes — Claude Code (Opus 4.8). Generated-by: Claude Code (Opus 4.8)