### PR TITLE
fix(k8s): run launcher run_k8s_config takes precedence over user depl…

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
@@ -36,8 +36,6 @@ def _dedupe_list(values):
     return new_list
 
 
-# Lists that don't make sense to append when they're set from two different raw k8s configs,
-# even if deep-merging
 ALWAYS_SHALLOW_MERGE_LIST_FIELDS = {
     "command",
     "args",
@@ -107,7 +105,7 @@ class K8sContainerContext(
         )
 
         run_k8s_config = K8sContainerContext._merge_k8s_config(
-            top_level_k8s_config._replace(  # remove k8s service/deployment fields
+            top_level_k8s_config._replace(
                 deployment_metadata={},
                 service_metadata={},
                 service_spec_config={},
@@ -116,7 +114,7 @@ class K8sContainerContext(
         )
 
         server_k8s_config = K8sContainerContext._merge_k8s_config(
-            top_level_k8s_config._replace(  # remove k8s job fields
+            top_level_k8s_config._replace(
                 job_config={},
                 job_metadata={},
                 job_spec_config={},
@@ -218,7 +216,6 @@ class K8sContainerContext(
         onto_config: UserDefinedDagsterK8sConfig,
         from_config: UserDefinedDagsterK8sConfig,
     ) -> UserDefinedDagsterK8sConfig:
-        # Keys are always the same and initialized in constructor
         merge_behavior = from_config.merge_behavior
         onto_dict = onto_config.to_dict()
         from_dict = from_config.to_dict()
@@ -267,8 +264,7 @@ class K8sContainerContext(
         self,
         other: "K8sContainerContext",
     ) -> "K8sContainerContext":
-        # Lists of attributes that can be combined are combined, scalar values are replaced
-        # prefering the passed in container context
+
         return K8sContainerContext(
             server_k8s_config=self._merge_k8s_config(
                 self.server_k8s_config, other.server_k8s_config
@@ -500,7 +496,6 @@ class K8sContainerContext(
                 K8sContainerContext(run_k8s_config=user_defined_k8s_config)
             )
 
-        # If there's an allowlist, make sure user_defined_container_context doesn't violate it
         if run_launcher:
             user_defined_container_context = (
                 user_defined_container_context.validate_user_k8s_config_for_run(
@@ -509,7 +504,7 @@ class K8sContainerContext(
                 )
             )
 
-        return context.merge(user_defined_container_context)
+        return user_defined_container_context.merge(context)
 
     @staticmethod
     def create_from_config(run_container_context) -> "K8sContainerContext":

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
@@ -945,3 +945,30 @@ def test_launcher_run_k8s_config_precedence_preserves_non_conflicting_fields(
     pod_spec = result.run_k8s_config.pod_spec_config
     assert pod_spec.get("node_selector") == {"pool": "autoscaling-pool"}
     assert pod_spec.get("dns_policy") == "ClusterFirst"
+
+
+def test_launcher_run_k8s_config_takes_precedence_with_run_tags(
+    kubeconfig_file,
+):
+    launcher = K8sRunLauncher(
+        service_account_name="webserver-admin",
+        instance_config_map="dagster-instance",
+        dagster_home="/opt/dagster/dagster_home",
+        job_image="fake_job_image",
+        load_incluster_config=False,
+        kubeconfig_file=kubeconfig_file,
+        run_k8s_config={"pod_spec_config": {"node_selector": {"pool": "autoscaling-pool"}}},
+    )
+
+    run = _run_with_container_context(
+        {
+            "k8s": {
+                "run_k8s_config": {"pod_spec_config": {"node_selector": {"pool": "default-pool"}}}
+            }
+        }
+    )
+
+    result = K8sContainerContext.create_for_run(run, launcher, include_run_tags=True)
+
+    node_selector = result.run_k8s_config.pod_spec_config.get("node_selector")
+    assert node_selector == {"pool": "autoscaling-pool"}

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py
@@ -1,5 +1,9 @@
 import pytest
+from dagster._core.code_pointer import ModuleCodePointer
 from dagster._core.errors import DagsterInvalidConfigError
+from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
+from dagster._core.storage.dagster_run import DagsterRun
+from dagster_k8s import K8sRunLauncher
 from dagster_k8s.container_context import K8sConfigMergeBehavior, K8sContainerContext
 from dagster_k8s.job import (
     DagsterK8sJobConfig,
@@ -871,3 +875,73 @@ def test_env_var_precedence():
         {"name": "FOO", "value": "outercontainerconfig", "value_from": None},
         {"name": "FOO", "value": "innerenvvars", "value_from": None},
     ]
+
+
+def _run_with_container_context(container_context: dict) -> DagsterRun:
+    repo_origin = RepositoryPythonOrigin(
+        executable_path="/usr/bin/python",
+        code_pointer=ModuleCodePointer("fake_module", "fake_repo"),
+        container_context=container_context,
+    )
+    job_origin = JobPythonOrigin(job_name="fake_job", repository_origin=repo_origin)
+    return DagsterRun(job_name="fake_job", job_code_origin=job_origin)
+
+
+def test_launcher_run_k8s_config_takes_precedence_over_container_context(
+    kubeconfig_file,
+):
+    launcher = K8sRunLauncher(
+        service_account_name="webserver-admin",
+        instance_config_map="dagster-instance",
+        dagster_home="/opt/dagster/dagster_home",
+        job_image="fake_job_image",
+        load_incluster_config=False,
+        kubeconfig_file=kubeconfig_file,
+        run_k8s_config={"pod_spec_config": {"node_selector": {"pool": "autoscaling-pool"}}},
+    )
+
+    run = _run_with_container_context(
+        {
+            "k8s": {
+                "run_k8s_config": {"pod_spec_config": {"node_selector": {"pool": "default-pool"}}}
+            }
+        }
+    )
+
+    result = K8sContainerContext.create_for_run(run, launcher, include_run_tags=False)
+
+    node_selector = result.run_k8s_config.pod_spec_config.get("node_selector")
+    assert node_selector == {"pool": "autoscaling-pool"}
+
+
+def test_launcher_run_k8s_config_precedence_preserves_non_conflicting_fields(
+    kubeconfig_file,
+):
+    launcher = K8sRunLauncher(
+        service_account_name="webserver-admin",
+        instance_config_map="dagster-instance",
+        dagster_home="/opt/dagster/dagster_home",
+        job_image="fake_job_image",
+        load_incluster_config=False,
+        kubeconfig_file=kubeconfig_file,
+        run_k8s_config={"pod_spec_config": {"node_selector": {"pool": "autoscaling-pool"}}},
+    )
+
+    run = _run_with_container_context(
+        {
+            "k8s": {
+                "run_k8s_config": {
+                    "pod_spec_config": {
+                        "node_selector": {"pool": "default-pool"},
+                        "dns_policy": "ClusterFirst",
+                    }
+                }
+            }
+        }
+    )
+
+    result = K8sContainerContext.create_for_run(run, launcher, include_run_tags=False)
+
+    pod_spec = result.run_k8s_config.pod_spec_config
+    assert pod_spec.get("node_selector") == {"pool": "autoscaling-pool"}
+    assert pod_spec.get("dns_policy") == "ClusterFirst"


### PR DESCRIPTION
…oyment config

## Summary & Motivation

When includeConfigInLaunchedRuns.enabled: true is set in the Helm chart, run pods ignore the nodeSelector configured in runLauncher.config.k8sRunLauncher.runK8sConfig.podSpecConfig and instead inherit the nodeSelector from the user deployment pod. This means operators who want run pods on a different node pool (e.g. autoscaling GPU nodes) than their user deployment pods (e.g. cheap always-on nodes) have no way to enforce that.

Root cause

K8sContainerContext.create_for_run() in container_context.py builds two contexts:

context — from the run launcher config
user_defined_container_context — from the run's code origin, which is populated with user deployment config when includeConfigInLaunchedRuns is enabled

The final line was: 

> return context.merge(user_defined_container_context)

K8sContainerContext.merge() is defined to prefer the passed-in argument (other). So user_defined_container_context was always winning for any conflicting scalar fields like pod_spec_config.node_selector, regardless of what the run launcher explicitly configured.

Fix
Flip the merge order so the launcher config is applied last and wins on conflicts: 

> return user_defined_container_context.merge(context)

Non-conflicting fields from both sides are still preserved — the deep merge behavior is unchanged. Only fields that exist in both configs are now resolved in favour of the launcher, which is the correct precedence for an operator-level setting.

Files changed:

1. python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py — one line changed in create_for_run()

2. python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_container_context.py — two regression tests added

## Test Plan

All 24 existing tests continue to pass
test_launcher_run_k8s_config_takes_precedence_over_container_context — verifies launcher node_selector wins over a conflicting user deployment node_selector
test_launcher_run_k8s_config_precedence_preserves_non_conflicting_fields — verifies that fields only present in the user deployment config (e.g. dns_policy) still come through after the merge

Fixes #33900

p.s open to reviews and any suggestiosn and help

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
