### PR TITLE
[dagster-postgres] use portable diag.sqlstate instead of psycopg2-only pgcode

### DIFF
--- a/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/utils.py
@@ -83,7 +83,7 @@ def retry_pg_creation_fn(fn: Callable[[], T], retry_limit: int = 5, retry_wait: 
             if (
                 isinstance(exc, sqlalchemy.exc.ProgrammingError)
                 and exc.orig
-                and exc.orig.pgcode != "42P07"
+                and exc.orig.diag.sqlstate != "42P07"
             ):
                 raise
 


### PR DESCRIPTION
## What

`retry_pg_creation_fn` in `dagster_postgres/utils.py` inspects `exc.orig.pgcode` to detect the DuplicateTable (`42P07`) race during table autocreation. `pgcode` exists only on **psycopg2** exception objects. Under the **psycopg3** dialect (`postgresql+psycopg`), `exc.orig` has no `pgcode` attribute, so this line raises `AttributeError` instead of retrying.

This switches to `exc.orig.diag.sqlstate`, which carries the same SQLSTATE and is available on **both** psycopg2 and psycopg3 error objects.

## Why

A small, self-contained step toward making `dagster-postgres` usable with psycopg3 (see #33958). It's behavior-preserving for psycopg2 users and can land independently of the larger driver-optional discussion.

## Verification

Tested against a real Postgres with both drivers (SQLAlchemy 2.0, psycopg2-binary 2.9.12, psycopg 3.3.4):

- **psycopg2**: `exc.orig.pgcode == exc.orig.diag.sqlstate == "42P07"` — the swap is exactly equivalent, no behavior change.
- **psycopg3**: the previous `exc.orig.pgcode` access raises `AttributeError`; `exc.orig.diag.sqlstate` returns `"42P07"`.
- Both drivers: a non-duplicate `ProgrammingError` (e.g. `42P01`) still re-raises as before.

Refs #33958.
