### PR TITLE
[dagster-postgres][dagster-mysql] Add pool_pre_ping for webserver DBs to reduce connection errors

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -42,6 +42,7 @@ class Webserver(BaseModel, extra="forbid"):
     dbStatementTimeout: int | None = None
     dbPoolRecycle: int | None = None
     dbPoolMaxOverflow: int | None = None
+    dbPoolPrePing: bool | None = None
     logLevel: str | None = None
     logFormat: str | None = None
     schedulerName: str | None = None

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -300,6 +300,17 @@ def test_webserver_db_pool_recycle(deployment_template: HelmTemplate):
     assert f"--db-pool-recycle {pool_recycle_s}" in command
 
 
+def test_webserver_db_pool_pre_ping(deployment_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct(dbPoolPrePing=False)
+    )
+
+    webserver_deployments = deployment_template.render(helm_values)
+    command = " ".join(webserver_deployments[0].spec.template.spec.containers[0].command)
+
+    assert "--no-db-pool-pre-ping" in command
+
+
 def test_webserver_db_pool_max_overflow(deployment_template: HelmTemplate):
     pool_max_overflow_s = 30
     helm_values = DagsterHelmValues.construct(

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -57,6 +57,7 @@ If release name contains chart name it will be used as a full name.
 {{- with $_.Values.dagsterWebserver.dbStatementTimeout }} --db-statement-timeout {{ . }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbPoolRecycle }} --db-pool-recycle {{ . }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbPoolMaxOverflow }} --db-pool-max-overflow {{ . }} {{- end -}}
+{{- if kindIs "bool" $_.Values.dagsterWebserver.dbPoolPrePing }}{{ if $_.Values.dagsterWebserver.dbPoolPrePing }} --db-pool-pre-ping{{ else }} --no-db-pool-pre-ping{{ end }}{{ end -}}
 {{- if $_.Values.dagsterWebserver.pathPrefix }} --path-prefix {{ $_.Values.dagsterWebserver.pathPrefix }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.logLevel }} --log-level {{ . }} {{- end -}}
 {{- if .webserverReadOnly }} --read-only {{- end -}}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -95,6 +95,9 @@ dagsterWebserver:
   # The maximum overflow size of the sqlalchemy pool. Set to -1 to disable.
   dbPoolMaxOverflow: ~
 
+  # Enable SQLAlchemy pool pre-ping on checkout. Unset uses webserver default (true).
+  dbPoolPrePing: ~
+
   # The log level of the uvicorn web server, defaults to warning if not set
   logLevel: ~
 

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -44,6 +44,7 @@ DEFAULT_WEBSERVER_PORT = 3000
 DEFAULT_DB_STATEMENT_TIMEOUT = 15000  # 15 sec
 DEFAULT_POOL_RECYCLE = 3600  # 1 hr
 DEFAULT_POOL_MAX_OVERFLOW = 20
+DEFAULT_POOL_PRE_PING = True
 
 
 @click.command(
@@ -133,6 +134,16 @@ DEFAULT_POOL_MAX_OVERFLOW = 20
     show_default=True,
 )
 @click.option(
+    "--db-pool-pre-ping/--no-db-pool-pre-ping",
+    help=(
+        "Whether to test sqlalchemy pool connections for liveness on each checkout, "
+        "transparently recovering from stale connections (e.g. dropped by the database, "
+        "a connection pooler, or a network timeout). Not respected in all configurations."
+    ),
+    default=DEFAULT_POOL_PRE_PING,
+    show_default=True,
+)
+@click.option(
     "--read-only",
     help=(
         "Start server in read-only mode, where all mutations such as launching runs and "
@@ -208,6 +219,7 @@ def dagster_webserver(
     db_statement_timeout: int,
     db_pool_recycle: int,
     db_pool_max_overflow: int,
+    db_pool_pre_ping: bool,
     read_only: bool,
     suppress_warnings: bool,
     uvicorn_log_level: str,
@@ -249,7 +261,9 @@ def dagster_webserver(
             )
         )
         # Allow the instance components to change behavior in the context of a long running server process
-        instance.optimize_for_webserver(db_statement_timeout, db_pool_recycle, db_pool_max_overflow)
+        instance.optimize_for_webserver(
+            db_statement_timeout, db_pool_recycle, db_pool_max_overflow, db_pool_pre_ping
+        )
 
         with WorkspaceProcessContext(
             instance,

--- a/python_modules/dagster/dagster/_cli/dev.py
+++ b/python_modules/dagster/dagster/_cli/dev.py
@@ -129,6 +129,15 @@ _CHECK_SUBPROCESS_INTERVAL = 5
     default=None,
     type=click.INT,
 )
+@click.option(
+    "--db-pool-pre-ping/--no-db-pool-pre-ping",
+    help=(
+        "Whether to test sqlalchemy pool connections for liveness on each checkout, "
+        "transparently recovering from stale connections (e.g. dropped by the database, "
+        "a connection pooler, or a network timeout)."
+    ),
+    default=None,
+)
 @workspace_options
 @deprecated(
     breaking_version="2.0", subject="--dagit-port and --dagit-host args", emit_runtime_warning=False
@@ -150,6 +159,7 @@ def dev_command(
     db_statement_timeout: int | None,
     db_pool_recycle: int | None,
     db_pool_max_overflow: int | None,
+    db_pool_pre_ping: bool | None,
     **other_opts: object,
 ) -> None:
     workspace_opts = WorkspaceOpts.extract_from_cli_options(other_opts)
@@ -169,6 +179,7 @@ def dev_command(
         db_statement_timeout=db_statement_timeout,
         db_pool_recycle=db_pool_recycle,
         db_pool_max_overflow=db_pool_max_overflow,
+        db_pool_pre_ping=db_pool_pre_ping,
     )
 
 
@@ -186,6 +197,7 @@ def dev_command_impl(
     db_statement_timeout: int | None = None,
     db_pool_recycle: int | None = None,
     db_pool_max_overflow: int | None = None,
+    db_pool_pre_ping: bool | None = None,
 ) -> None:
     # check if dagster-webserver installed, crash if not
     try:
@@ -265,6 +277,11 @@ def dev_command_impl(
                 + (
                     ["--db-pool-max-overflow", str(db_pool_max_overflow)]
                     if db_pool_max_overflow is not None
+                    else []
+                )
+                + (
+                    ["--db-pool-pre-ping" if db_pool_pre_ping else "--no-db-pool-pre-ping"]
+                    if db_pool_pre_ping is not None
                     else []
                 )
                 + ["--shutdown-pipe", str(webserver_read_fd)]

--- a/python_modules/dagster/dagster/_core/instance/methods/storage_methods.py
+++ b/python_modules/dagster/dagster/_core/instance/methods/storage_methods.py
@@ -75,22 +75,26 @@ class StorageMethods:
         statement_timeout: int,
         pool_recycle: int,
         max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         if self._schedule_storage:
             self._schedule_storage.optimize_for_webserver(
                 statement_timeout=statement_timeout,
                 pool_recycle=pool_recycle,
                 max_overflow=max_overflow,
+                pool_pre_ping=pool_pre_ping,
             )
         self._run_storage.optimize_for_webserver(
             statement_timeout=statement_timeout,
             pool_recycle=pool_recycle,
             max_overflow=max_overflow,
+            pool_pre_ping=pool_pre_ping,
         )
         self._event_storage.optimize_for_webserver(
             statement_timeout=statement_timeout,
             pool_recycle=pool_recycle,
             max_overflow=max_overflow,
+            pool_pre_ping=pool_pre_ping,
         )
 
     def reindex(self, print_fn: PrintFn = lambda _: None) -> None:

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -330,7 +330,11 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """Explicit lifecycle management."""
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self,
+        statement_timeout: int,
+        pool_recycle: int,
+        max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         """Allows for optimizing database connection / use in the context of a long lived webserver process."""
 

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -310,10 +310,14 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
         return self._storage.run_storage.dispose()
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self,
+        statement_timeout: int,
+        pool_recycle: int,
+        max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         return self._storage.run_storage.optimize_for_webserver(
-            statement_timeout, pool_recycle, max_overflow
+            statement_timeout, pool_recycle, max_overflow, pool_pre_ping
         )
 
     def add_daemon_heartbeat(self, daemon_heartbeat: "DaemonHeartbeat") -> None:
@@ -471,12 +475,17 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         return self._storage.event_log_storage.dispose()
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self,
+        statement_timeout: int,
+        pool_recycle: int,
+        max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         return self._storage.event_log_storage.optimize_for_webserver(
             statement_timeout,
             pool_recycle,
             max_overflow,
+            pool_pre_ping,
         )
 
     def get_event_records(  # ty: ignore[invalid-method-override]
@@ -925,12 +934,17 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
         return self._storage.schedule_storage.optimize(print_fn, force_rebuild_all)
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self,
+        statement_timeout: int,
+        pool_recycle: int,
+        max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         return self._storage.schedule_storage.optimize_for_webserver(
             statement_timeout,
             pool_recycle,
             max_overflow,
+            pool_pre_ping,
         )
 
     def dispose(self) -> None:

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -330,7 +330,11 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """Explicit lifecycle management."""
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self,
+        statement_timeout: int,
+        pool_recycle: int,
+        max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         """Allows for optimizing database connection / use in the context of a long lived webserver process."""
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -205,7 +205,11 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """Call this method to run any optional data migrations for optimized reads."""
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self,
+        statement_timeout: int,
+        pool_recycle: int,
+        max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         """Allows for optimizing database connection / use in the context of a long lived webserver process."""
 

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/dev.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli/cli/dev.py
@@ -87,6 +87,15 @@ T = TypeVar("T")
     type=click.INT,
 )
 @click.option(
+    "--db-pool-pre-ping/--no-db-pool-pre-ping",
+    help=(
+        "Whether to test sqlalchemy pool connections for liveness on each checkout, "
+        "transparently recovering from stale connections (e.g. dropped by the database, "
+        "a connection pooler, or a network timeout)."
+    ),
+    default=None,
+)
+@click.option(
     "--check-yaml/--no-check-yaml",
     flag_value=True,
     help="Whether to schema-check defs.yaml files for the project before starting the dev server.",
@@ -107,6 +116,7 @@ def dev_command(
     db_statement_timeout: int | None,
     db_pool_recycle: int | None,
     db_pool_max_overflow: int | None,
+    db_pool_pre_ping: bool | None,
     check_yaml: bool | None,
     target_path: Path,
     verbose: bool,  # from dg_global_options
@@ -140,6 +150,7 @@ def dev_command(
             db_statement_timeout=db_statement_timeout,
             db_pool_recycle=db_pool_recycle,
             db_pool_max_overflow=db_pool_max_overflow,
+            db_pool_pre_ping=db_pool_pre_ping,
         )
 
     # If not, use dg config to construct a workspace file and do a yaml check before
@@ -204,4 +215,5 @@ def dev_command(
             db_statement_timeout=db_statement_timeout,
             db_pool_recycle=db_pool_recycle,
             db_pool_max_overflow=db_pool_max_overflow,
+            db_pool_pre_ping=db_pool_pre_ping,
         )

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/event_log/event_log.py
@@ -88,7 +88,11 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self,
+        statement_timeout: int,
+        pool_recycle: int,
+        max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         # When running in dagster-webserver, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
@@ -98,6 +102,7 @@ class MySQLEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             pool_size=1,
             pool_recycle=pool_recycle,
             max_overflow=max_overflow,
+            pool_pre_ping=pool_pre_ping,
         )
 
     def upgrade(self) -> None:

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/run_storage/run_storage.py
@@ -91,7 +91,11 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
             stamp_alembic_rev(mysql_alembic_config(__file__), conn)
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self,
+        statement_timeout: int,
+        pool_recycle: int,
+        max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         # When running in dagster-webserver, hold 1 open connection
         # https://github.com/dagster-io/dagster/issues/3719
@@ -101,6 +105,7 @@ class MySQLRunStorage(SqlRunStorage, ConfigurableClass):
             pool_size=1,
             pool_recycle=pool_recycle,
             max_overflow=max_overflow,
+            pool_pre_ping=pool_pre_ping,
         )
 
     @property

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -89,7 +89,11 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.optimize()
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self,
+        statement_timeout: int,
+        pool_recycle: int,
+        max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         # When running in dagster-webserver, hold an open connection
         # https://github.com/dagster-io/dagster/issues/3719
@@ -99,6 +103,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             pool_size=1,
             pool_recycle=pool_recycle,
             max_overflow=max_overflow,
+            pool_pre_ping=pool_pre_ping,
         )
 
     @property

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_instance.py
@@ -149,3 +149,18 @@ def test_statement_timeouts(conn_string):
         with pytest.raises(db.exc.OperationalError, match="QueryCanceled"):
             with instance._schedule_storage.connect() as conn:  # noqa: SLF001  # ty: ignore[unresolved-attribute]
                 conn.execute(db.text("select sleep(1)")).fetchone()
+
+
+@pytest.mark.parametrize("pool_pre_ping", [True, False])
+def test_pool_pre_ping(conn_string, pool_pre_ping):
+    parse_result = urlparse(conn_string)
+    hostname = parse_result.hostname
+    port = parse_result.port
+
+    with instance_for_test(overrides=safe_load_yaml(full_mysql_config(hostname, port))) as instance:
+        instance.optimize_for_webserver(
+            statement_timeout=500, pool_recycle=-1, max_overflow=20, pool_pre_ping=pool_pre_ping
+        )
+        assert instance._run_storage._engine.pool._pre_ping is pool_pre_ping  # noqa: SLF001
+        assert instance._event_storage._engine.pool._pre_ping is pool_pre_ping  # noqa: SLF001
+        assert instance._schedule_storage._engine.pool._pre_ping is pool_pre_ping  # noqa: SLF001

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_wait_timeout.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_wait_timeout.py
@@ -6,9 +6,13 @@ import sqlalchemy.exc
 from dagster_mysql.run_storage import MySQLRunStorage
 
 
-def retry_connect(conn_string: str, num_retries: int = 5, pool_recycle=-1):
+def retry_connect(
+    conn_string: str, num_retries: int = 5, pool_recycle=-1, pool_pre_ping: bool = True
+):
     storage = MySQLRunStorage.create_clean_storage(conn_string)
-    storage.optimize_for_webserver(-1, pool_recycle=pool_recycle, max_overflow=20)
+    storage.optimize_for_webserver(
+        -1, pool_recycle=pool_recycle, max_overflow=20, pool_pre_ping=pool_pre_ping
+    )
 
     with storage.connect() as conn:
         conn.execute(db.text("SET SESSION wait_timeout = 2;"))
@@ -22,8 +26,10 @@ def retry_connect(conn_string: str, num_retries: int = 5, pool_recycle=-1):
 
 
 def test_pool_recycle_greater_than_wait_timeout(conn_string):
+    # Disable pre-ping so a server-side wait_timeout drop surfaces as OperationalError
+    # (with pre-ping the pool reconnects transparently).
     with pytest.raises(db.exc.OperationalError):
-        retry_connect(conn_string)
+        retry_connect(conn_string, pool_pre_ping=False)
 
 
 def test_pool_recycle_less_than_wait_timeout(conn_string):

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -123,7 +123,11 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self,
+        statement_timeout: int,
+        pool_recycle: int,
+        max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
         kwargs: dict[str, Any] = {
@@ -131,6 +135,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             "pool_size": 1,
             "pool_recycle": pool_recycle,
             "max_overflow": max_overflow,
+            "pool_pre_ping": pool_pre_ping,
         }
         existing_options = self._engine.url.query.get("options")
         if existing_options:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/run_storage/run_storage.py
@@ -117,7 +117,11 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
                 stamp_alembic_rev(pg_alembic_config(__file__), conn)
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self,
+        statement_timeout: int,
+        pool_recycle: int,
+        max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
         kwargs: dict[str, Any] = {
@@ -125,6 +129,7 @@ class PostgresRunStorage(SqlRunStorage, ConfigurableClass):
             "pool_size": 1,
             "pool_recycle": pool_recycle,
             "max_overflow": max_overflow,
+            "pool_pre_ping": pool_pre_ping,
         }
         existing_options = self._engine.url.query.get("options")
         if existing_options:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -115,7 +115,11 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
         self.optimize()
 
     def optimize_for_webserver(
-        self, statement_timeout: int, pool_recycle: int, max_overflow: int
+        self,
+        statement_timeout: int,
+        pool_recycle: int,
+        max_overflow: int,
+        pool_pre_ping: bool = True,
     ) -> None:
         # When running in dagster-webserver, hold an open connection and set statement_timeout
         kwargs: dict[str, Any] = {
@@ -123,6 +127,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             "pool_size": 1,
             "pool_recycle": pool_recycle,
             "max_overflow": max_overflow,
+            "pool_pre_ping": pool_pre_ping,
         }
         existing_options = self._engine.url.query.get("options")
         if existing_options:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py
@@ -218,6 +218,17 @@ def test_statement_timeouts(hostname):
                 conn.execute(db.text("select pg_sleep(1)")).fetchone()
 
 
+@pytest.mark.parametrize("pool_pre_ping", [True, False])
+def test_pool_pre_ping(hostname, pool_pre_ping):
+    with instance_for_test(overrides=safe_load_yaml(full_pg_config(hostname))) as instance:
+        instance.optimize_for_webserver(
+            statement_timeout=500, pool_recycle=-1, max_overflow=20, pool_pre_ping=pool_pre_ping
+        )
+        assert instance._run_storage._engine.pool._pre_ping is pool_pre_ping  # noqa: SLF001
+        assert instance._event_storage._engine.pool._pre_ping is pool_pre_ping  # noqa: SLF001
+        assert instance._schedule_storage._engine.pool._pre_ping is pool_pre_ping  # noqa: SLF001
+
+
 def test_skip_autocreate(hostname, conn_string):
     with instance_for_test(overrides=safe_load_yaml(unified_pg_config(hostname))) as instance:
         instance.run_storage.create_clean_storage(conn_string, should_autocreate_tables=False)  # ty: ignore[unresolved-attribute]


### PR DESCRIPTION
Closes #33879

Webserver Postgres/MySQL storage holds a single pooled connection (`optimize_for_webserver`, `pool_size=1`) but never set SQLAlchemy `pool_pre_ping`. If that connection dies while idle (DB timeout, pgbouncer, NAT), the next checkout uses a dead conn and requests fail (e.g. UI `JobMetadataQuery`)

This adds `pool_pre_ping` (default **true**) on that path for PG + MySQL, wired the same way as the existing pool knobs:
- `dagster-webserver --db-pool-pre-ping` / `--no-db-pool-pre-ping`
- forwarded from `dagster dev` / `dg dev` when set
- Helm `dagsterWebserver.dbPoolPrePing`

Daemon/default storage and SQLite are unchanged.

This matches Airflow and Prefect behavior (see refs below). Cost is basically one cheap liveness check per checkout on that held connection, it's supported to use `--no-db-pool-pre-ping` or `dbPoolPrePing: false` to opt out.

Upstreaming this from our internal deployment, we were getting very frequent connection errors on our webserver, and this tweak significantly reduced the occurrence for us.

Refs:
- [Airflow config default](https://github.com/apache/airflow/blob/a1daaf1b60ea30764e2f02a07fd27aa5146595f6/airflow-core/src/airflow/config_templates/config.yml#L681-L691) (`sql_alchemy_pool_pre_ping`) and [wiring code](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/settings.py)
- [Prefect DB config](https://github.com/PrefectHQ/prefect/blob/7f2538fd97ea6e7fa7c762949a8c937a5b4c4833/src/prefect/server/database/configurations.py#L339): (`pool_pre_ping=True` on Postgres)
- [SQLAlchemy pre-ping doc](https://docs.sqlalchemy.org/en/21/core/pooling.html#dealing-with-disconnects)

Tests/Validation

- [x] Postgres: `pytest -vv python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_instance.py` (compose fixtures, after docker compose ... down -v): 9 passed
- [x] [MySQL pytest -vv .../dagster_mysql_tests/test_instance.py: 4 passed, 1 skipped
- [x] Focused pytest -vv on both packages -k pool_pre_ping: 4 passed - asserts engine.pool._pre_ping on run/event/schedule for True and False
- [x] MySQL wait_timeout - Test updated to pass pool_pre_ping=False only for that case, since with default pre-ping, test_pool_recycle_greater_than_wait_timeout no longer raises due to the reconnect. Then pytest -vv .../test_wait_timeout.py: 2 passed