### PR TITLE
Refresh defs state in a worker thread when an event loop is already running

### DIFF
--- a/python_modules/dagster/dagster/components/component/state_backed_component.py
+++ b/python_modules/dagster/dagster/components/component/state_backed_component.py
@@ -1,11 +1,13 @@
 import asyncio
+import contextvars
 import inspect
 import shutil
 import tempfile
 from abc import abstractmethod
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Coroutine
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional, TypeVar
 from uuid import uuid4
 
 from dagster_shared import check
@@ -32,6 +34,27 @@ from dagster.components.utils.project_paths import get_local_state_path
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
+
+
+_T = TypeVar("_T")
+
+
+def _run_coroutine_sync(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Run a coroutine to completion from synchronous code.
+
+    Uses ``asyncio.run`` when no event loop is running. When called from within a
+    running loop (e.g. ``dg utils refresh-defs-state``), ``asyncio.run`` raises
+    ``RuntimeError``, so run the coroutine in a worker thread with its own event
+    loop, copying the current context so ContextVars propagate to it.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    context = contextvars.copy_context()
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(context.run, asyncio.run, coro).result()
 
 
 @public
@@ -217,7 +240,7 @@ class StateBackedComponent(Component):
                 # automatically refresh in local dev unless the user opts out
                 (using_dagster_dev() and self.defs_state_config.refresh_if_dev)
             ):
-                version = asyncio.run(self.refresh_state(context.project_root))
+                version = _run_coroutine_sync(self.refresh_state(context.project_root))
                 defs_load_context.add_defs_state_info(key, version)
 
         with DefinitionsLoadContext.get().state_path(

--- a/python_modules/dagster/dagster_tests/components_tests/state_backed_component_tests/test_state_backed_component.py
+++ b/python_modules/dagster/dagster_tests/components_tests/state_backed_component_tests/test_state_backed_component.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import contextvars
 import json
 import random
 import shutil
@@ -13,7 +14,10 @@ from dagster._core.instance_for_test import instance_for_test
 from dagster._core.storage.defs_state.base import DefsStateStorage
 from dagster._utils.env import environ
 from dagster._utils.test.definitions import scoped_definitions_load_context
-from dagster.components.component.state_backed_component import StateBackedComponent
+from dagster.components.component.state_backed_component import (
+    StateBackedComponent,
+    _run_coroutine_sync,
+)
 from dagster.components.core.component_tree_state import DuplicateDefsStateKeyWarning
 from dagster.components.testing.utils import create_defs_folder_sandbox
 from dagster.components.utils.defs_state import (
@@ -498,3 +502,36 @@ def test_state_backed_component_migration_from_versioned_to_local_storage() -> N
             assert dev_metadata_value != "initial"
             # Should be different from the versioned value since it's a new random value
             assert dev_metadata_value != versioned_metadata_value
+
+
+def test_run_coroutine_sync_outside_running_loop() -> None:
+    async def sample() -> str:
+        return "value"
+
+    assert _run_coroutine_sync(sample()) == "value"
+
+
+def test_run_coroutine_sync_inside_running_loop() -> None:
+    # Regression test for #33790: build_defs is synchronous but refreshes state
+    # via a coroutine, and `dg utils refresh-defs-state` invokes it from inside a
+    # running event loop, where a bare asyncio.run raises RuntimeError.
+    async def sample() -> str:
+        return "value"
+
+    async def call_from_running_loop() -> str:
+        return _run_coroutine_sync(sample())
+
+    assert asyncio.run(call_from_running_loop()) == "value"
+
+
+def test_run_coroutine_sync_propagates_contextvars() -> None:
+    var: contextvars.ContextVar[str] = contextvars.ContextVar("var", default="unset")
+    var.set("set-value")
+
+    async def read_var() -> str:
+        return var.get()
+
+    async def call_from_running_loop() -> str:
+        return _run_coroutine_sync(read_var())
+
+    assert asyncio.run(call_from_running_loop()) == "set-value"


### PR DESCRIPTION
`StateBackedComponent.build_defs` is synchronous but refreshes state via `asyncio.run(...)`, which can't be called from inside a running event loop. So `dg utils refresh-defs-state` (which calls `build_defs` from within a loop) crashed with `RuntimeError: asyncio.run() cannot be called from a running event loop`.

Fixes #33790.

When a loop is already running, the coroutine now runs in a worker thread with its own loop, copying the current context so ContextVars (e.g. `DefsStateStorage`) propagate. The no-running-loop path is unchanged.

## How I Tested These Changes

Three unit tests in `test_state_backed_component.py` for the extracted `_run_coroutine_sync` helper: no running loop, called from inside a running loop (the #33790 repro), and ContextVar propagation. They pass with the fix and fail without it; `make ruff` clean.

## Changelog

Fixed a `RuntimeError: asyncio.run() cannot be called from a running event loop` when a `StateBackedComponent` refreshes its defs state from within a running event loop (e.g. `dg utils refresh-defs-state`).