### PR TITLE
[dagster-aws] Tag the S3 client user-agent and document S3-compatible storage

### DIFF
--- a/docs/docs/integrations/libraries/aws/s3-compatible.md
+++ b/docs/docs/integrations/libraries/aws/s3-compatible.md
@@ -1,0 +1,33 @@
+---
+title: Dagster & S3-compatible storage
+sidebar_label: S3-compatible storage
+sidebar_position: 10
+description: Use Dagster's S3 resource with Amazon S3 or any S3-compatible object store by setting the endpoint URL.
+tags: [dagster-supported, storage]
+source: https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-aws
+pypi: https://pypi.org/project/dagster-aws/
+sidebar_custom_props:
+  logo: images/integrations/aws-s3.svg
+---
+
+<p>{frontMatter.description}</p>
+
+## Installation
+
+<PackageInstallInstructions packageName="dagster-aws" />
+
+## Configuration
+
+`S3Resource` (from `dagster_aws.s3`) talks to Amazon S3 by default. Because it is built on boto3, it also works with any S3-compatible object store (for example, Backblaze B2, Cloudflare R2, or MinIO): set the `endpoint_url` field to the provider's S3 endpoint and pass the provider's credentials as `aws_access_key_id` and `aws_secret_access_key`.
+
+Endpoint URLs, region strings, and credential formats vary by provider. Refer to your provider's S3-compatible API documentation for the correct values.
+
+## Example
+
+The example below mirrors the [Amazon S3 example](/integrations/libraries/aws/s3) but points `S3Resource` at an S3-compatible store by setting `endpoint_url`:
+
+<CodeExample path="docs_snippets/docs_snippets/integrations/aws-s3-compatible.py" language="python" />
+
+## Drop-in compatibility with `dagster-aws`
+
+`S3Resource` is the same resource consumed by every `dagster-aws` IO manager, file manager, and compute log manager. That means `S3PickleIOManager`, `S3ComputeLogManager`, `S3FileManager`, and the other resources in `dagster_aws.s3` work against Amazon S3 or any S3-compatible store through the same `endpoint_url` configuration. You do not need a provider-specific IO manager or file manager.

--- a/docs/docs/integrations/libraries/aws/s3.md
+++ b/docs/docs/integrations/libraries/aws/s3.md
@@ -23,6 +23,8 @@ Here is an example of how to use the `S3Resource` in a Dagster job to interact w
 
 <CodeExample path="docs_snippets/docs_snippets/integrations/aws-s3.py" language="python" />
 
+`S3Resource` is not limited to Amazon S3. It also works with any S3-compatible object store (for example, Backblaze B2, Cloudflare R2, or MinIO) by setting the `endpoint_url` field. See [Dagster & S3-compatible storage](/integrations/libraries/aws/s3-compatible) for a worked example.
+
 ## About AWS S3
 
 **AWS S3** is an object storage service that offers industry-leading scalability, data availability, security, and performance. This means customers of all sizes and industries can use it to store and protect any amount of data for a range of use cases, such as data lakes, websites, mobile applications, backup and restore, archive, enterprise applications, IoT devices, and big data analytics. Amazon S3 provides easy-to-use management features so you can organize your data and configure finely tuned access controls to meet your specific business, organizational, and compliance requirements.

--- a/docs/docs/integrations/libraries/aws/secretsmanager.md
+++ b/docs/docs/integrations/libraries/aws/secretsmanager.md
@@ -1,7 +1,7 @@
 ---
 title: Dagster & AWS Secrets Manager
 sidebar_label: Secrets Manager
-sidebar_position: 10
+sidebar_position: 11
 description: This integration allows you to manage, retrieve, and rotate credentials, API keys, and other secrets using AWS Secrets Manager.
 tags: [dagster-supported]
 source: https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-aws

--- a/docs/docs/integrations/libraries/aws/ssm.md
+++ b/docs/docs/integrations/libraries/aws/ssm.md
@@ -1,7 +1,7 @@
 ---
 title: Dagster & AWS Systems Parameter Store
 sidebar_label: Systems Parameter Store
-sidebar_position: 11
+sidebar_position: 12
 description: The Dagster AWS Systems Manager (SSM) Parameter Store integration allows you to manage and retrieve parameters stored in AWS SSM Parameter Store directly within your Dagster pipelines. This integration provides resources to fetch parameters by name, tags, or paths, and optionally set them as environment variables for your operations.
 tags: [dagster-supported]
 source: https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-aws

--- a/examples/docs_snippets/docs_snippets/integrations/aws-s3-compatible.py
+++ b/examples/docs_snippets/docs_snippets/integrations/aws-s3-compatible.py
@@ -1,0 +1,34 @@
+import pandas as pd
+from dagster_aws.s3 import S3Resource
+
+import dagster as dg
+
+
+@dg.asset
+def my_s3_compatible_asset(s3: S3Resource):
+    df = pd.DataFrame({"column1": [1, 2, 3], "column2": ["A", "B", "C"]})
+
+    csv_data = df.to_csv(index=False)
+
+    s3_compatible_client = s3.get_client()
+
+    s3_compatible_client.put_object(
+        Bucket="my-cool-bucket",
+        Key="path/to/my_dataframe.csv",
+        Body=csv_data,
+    )
+
+
+# ``S3Resource`` works with any S3-compatible object store (for example,
+# Backblaze B2, Cloudflare R2, or MinIO) by setting ``endpoint_url`` to the
+# provider's S3 endpoint. Replace the placeholder below with that endpoint.
+defs = dg.Definitions(
+    assets=[my_s3_compatible_asset],
+    resources={
+        "s3": S3Resource(
+            endpoint_url="https://your-s3-endpoint.example.com",
+            aws_access_key_id="<your-access-key-id>",
+            aws_secret_access_key="<your-secret-access-key>",
+        )
+    },
+)

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -48,6 +48,13 @@ class ResourceWithS3Configuration(ConfigurableResource):
     aws_session_token: str | None = Field(
         default=None, description="AWS session token to use when creating the boto3 session."
     )
+    user_agent_extra: str | None = Field(
+        default=None,
+        description=(
+            "Optional value appended to the boto3 ``User-Agent`` via "
+            "``botocore.config.Config(user_agent_extra=...)``."
+        ),
+    )
 
 
 class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext):
@@ -97,6 +104,7 @@ class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext)
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
             aws_session_token=self.aws_session_token,
+            user_agent_extra=self.user_agent_extra,
         )
 
     def get_object_to_set_on_execution_context(self) -> Any:
@@ -196,6 +204,7 @@ class S3FileManagerResource(ResourceWithS3Configuration, IAttachDifferentObjectT
                 aws_access_key_id=self.aws_access_key_id,
                 aws_secret_access_key=self.aws_secret_access_key,
                 aws_session_token=self.aws_session_token,
+                user_agent_extra=self.user_agent_extra,
             ),
             s3_bucket=self.s3_bucket,
             s3_base_key=self.s3_prefix,

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
@@ -1,8 +1,16 @@
+from importlib.metadata import PackageNotFoundError, version
+
 import boto3
 import dagster._check as check
+from botocore.config import Config
 from botocore.handlers import disable_signing
 
 from dagster_aws.utils import construct_boto_client_retry_config
+
+try:
+    _DAGSTER_AWS_PRODUCT = f"dagster-aws/{version('dagster-aws')}"
+except PackageNotFoundError:
+    _DAGSTER_AWS_PRODUCT = "dagster-aws/dev"
 
 
 class S3Callback:
@@ -33,6 +41,7 @@ def construct_s3_client(
     aws_access_key_id: str | None = None,
     aws_secret_access_key: str | None = None,
     aws_session_token: str | None = None,
+    user_agent_extra: str | None = None,
 ):
     check.int_param(max_attempts, "max_attempts")
     check.opt_str_param(region_name, "region_name")
@@ -43,6 +52,14 @@ def construct_s3_client(
     check.opt_str_param(profile_name, "aws_access_key_id")
     check.opt_str_param(profile_name, "aws_secret_access_key")
     check.opt_str_param(profile_name, "aws_session_token")
+    check.opt_str_param(user_agent_extra, "user_agent_extra")
+    # Append any caller-supplied value after the product token, space-separated.
+    combined_user_agent_extra = (
+        f"{_DAGSTER_AWS_PRODUCT} {user_agent_extra}" if user_agent_extra else _DAGSTER_AWS_PRODUCT
+    )
+    config = construct_boto_client_retry_config(max_attempts).merge(
+        Config(user_agent_extra=combined_user_agent_extra)
+    )
 
     client_session = boto3.session.Session(profile_name=profile_name)
     s3_client = client_session.resource(
@@ -54,7 +71,7 @@ def construct_s3_client(
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         aws_session_token=aws_session_token,
-        config=construct_boto_client_retry_config(max_attempts),
+        config=config,
     ).meta.client
 
     if use_unsigned_session:

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_resources.py
@@ -1,0 +1,105 @@
+"""Tests for the ``dagster-aws/<version>`` product token and the optional
+``user_agent_extra`` knob on ``S3Resource`` / ``S3FileManagerResource``.
+
+Every boto3 S3 client constructed via these resources carries
+``dagster-aws/<version>`` in its ``user_agent_extra``, and works against Amazon
+S3 as well as any S3-compatible object store. Any caller-supplied
+``user_agent_extra`` is appended after the product token with a space
+separator, and never replaces it.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+from dagster_aws.s3 import S3Resource
+from dagster_aws.s3.resources import S3FileManagerResource
+from dagster_aws.s3.utils import construct_s3_client
+
+try:
+    DAGSTER_AWS_PRODUCT = f"dagster-aws/{version('dagster-aws')}"
+except PackageNotFoundError:
+    DAGSTER_AWS_PRODUCT = "dagster-aws/dev"
+
+
+def test_construct_s3_client_default_carries_product_token() -> None:
+    """With no caller-supplied extra, only ``dagster-aws/<version>`` is appended."""
+    client = construct_s3_client(max_attempts=5)
+    extra = client.meta.config.user_agent_extra or ""
+    assert extra.strip() == DAGSTER_AWS_PRODUCT
+    # The base SDK token is preserved, not replaced.
+    assert "Boto3/" in client.meta.config.user_agent
+    assert DAGSTER_AWS_PRODUCT in client.meta.config.user_agent
+
+
+def test_construct_s3_client_appends_user_agent_extra_after_product_token() -> None:
+    """Caller-supplied tokens are appended after the product token, not in place of it."""
+    caller_token = "my-platform/1.2.3"
+    client = construct_s3_client(max_attempts=5, user_agent_extra=caller_token)
+    extra = client.meta.config.user_agent_extra or ""
+    assert DAGSTER_AWS_PRODUCT in extra
+    assert caller_token in extra
+    # Order: product token first, caller token after, space-separated.
+    assert extra == f"{DAGSTER_AWS_PRODUCT} {caller_token}"
+    assert "Boto3/" in client.meta.config.user_agent
+    assert caller_token in client.meta.config.user_agent
+
+
+def test_construct_s3_client_empty_user_agent_extra_treated_as_unset() -> None:
+    """An empty string should not change behavior: only the product token is appended."""
+    client = construct_s3_client(max_attempts=5, user_agent_extra="")
+    extra = client.meta.config.user_agent_extra or ""
+    assert extra.strip() == DAGSTER_AWS_PRODUCT
+
+
+def test_construct_s3_client_preserves_retry_config() -> None:
+    """Merging the product token must not drop the retry config already in the chain."""
+    client = construct_s3_client(max_attempts=7, user_agent_extra="my-platform/1.2.3")
+    retries = client.meta.config.retries
+    # botocore records the initial call plus retries as ``total_max_attempts``.
+    assert retries["total_max_attempts"] == 8
+    assert retries["mode"] == "standard"
+    extra = client.meta.config.user_agent_extra or ""
+    assert DAGSTER_AWS_PRODUCT in extra
+    assert "my-platform/1.2.3" in extra
+
+
+def test_s3_resource_default_carries_product_token() -> None:
+    client = S3Resource().get_client()
+    extra = client.meta.config.user_agent_extra or ""
+    assert extra.strip() == DAGSTER_AWS_PRODUCT
+
+
+def test_s3_resource_threads_user_agent_extra_to_client() -> None:
+    client = S3Resource(user_agent_extra="my-platform/1.2.3").get_client()
+    extra = client.meta.config.user_agent_extra or ""
+    assert extra == f"{DAGSTER_AWS_PRODUCT} my-platform/1.2.3"
+
+
+def test_s3_resource_user_agent_extra_with_custom_endpoint() -> None:
+    """End-to-end shape a user of an S3-compatible object store would write."""
+    resource = S3Resource(
+        endpoint_url="https://your-s3-endpoint.example.com",
+        aws_access_key_id="<your-access-key-id>",
+        aws_secret_access_key="<your-secret-access-key>",
+        user_agent_extra="my-platform/1.2.3",
+    )
+    client = resource.get_client()
+    assert client.meta.endpoint_url == "https://your-s3-endpoint.example.com"
+    extra = client.meta.config.user_agent_extra or ""
+    assert DAGSTER_AWS_PRODUCT in extra
+    assert "my-platform/1.2.3" in extra
+
+
+def test_s3_file_manager_resource_threads_user_agent_extra() -> None:
+    file_manager = S3FileManagerResource(
+        s3_bucket="my-bucket",
+        user_agent_extra="my-platform/1.2.3",
+    ).get_client()
+    # ``S3FileManager`` stores the wrapped boto3 client as ``_s3_session``.
+    extra = file_manager._s3_session.meta.config.user_agent_extra or ""  # noqa: SLF001
+    assert extra == f"{DAGSTER_AWS_PRODUCT} my-platform/1.2.3"
+
+
+def test_s3_file_manager_resource_default_carries_product_token() -> None:
+    file_manager = S3FileManagerResource(s3_bucket="my-bucket").get_client()
+    extra = file_manager._s3_session.meta.config.user_agent_extra or ""  # noqa: SLF001
+    assert extra.strip() == DAGSTER_AWS_PRODUCT


### PR DESCRIPTION
## Summary & Motivation

`S3Resource` (and the IO managers, file manager, and compute log manager built on it) already targets Amazon S3 and, because boto3 lets you point at a custom endpoint, any S3-compatible object store. This PR makes that support explicit and observable, in two small, additive pieces:

1. Every boto3 S3 client built through `dagster_aws.s3` now carries a `dagster-aws/<version>` product token in its `User-Agent` (via `botocore.config.Config(user_agent_extra=...)`). This is the standard boto3 mechanism for identifying the calling tool, mirrors what other AWS SDK integrations do, and helps Amazon S3 and any S3-compatible endpoint attribute traffic coming from Dagster.
2. A new optional `user_agent_extra` field on `S3Resource` / `S3FileManagerResource` lets a caller append their own token after the product token (space separated). The product token is always present and is never replaced.

Alongside the code, this adds a short docs page, "Dagster & S3-compatible storage," showing that `S3Resource` works with Amazon S3 or with any S3-compatible object store (for example, Backblaze B2, Cloudflare R2, or MinIO) by setting `endpoint_url` to the provider's S3 endpoint. The existing Amazon S3 page gets a one-line pointer to it. Examples use a placeholder endpoint (`https://your-s3-endpoint.example.com`) so no provider is singled out.

The change is intentionally minimal and fully backward compatible: no public signatures change in an incompatible way (`user_agent_extra` defaults to `None`), no new dependencies are added (`botocore` is already required), and behavior for existing users is unchanged apart from the added product token.

## Test Plan

New unit tests in `python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_resources.py` cover the client builder and both resources:

```zsh
python -m pytest python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_resources.py
```

They assert that:

- the default client carries only `dagster-aws/<version>` in `user_agent_extra`, and the base SDK token (`Boto3/...`) is preserved, not replaced;
- a caller-supplied `user_agent_extra` is appended after the product token, space separated, and in that order;
- an empty string is treated as unset;
- merging the product token does not drop the existing retry config;
- `S3Resource` and `S3FileManagerResource` thread the value through to the underlying client, including the endpoint-override shape a user of an S3-compatible store would write.

The docs snippet (`examples/docs_snippets/docs_snippets/integrations/aws-s3-compatible.py`) is collected by the docs-snippets test suite, and `make ruff` was run over the changed Python.

## Changelog

- [dagster-aws] `S3Resource` now tags its boto3 client `User-Agent` with `dagster-aws/<version>` and accepts an optional `user_agent_extra`; added a docs page for using `S3Resource` with S3-compatible object storage.
