### PR TITLE
Feat: BQ io_manager to allow allow column case presevetion

### DIFF
--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas/bigquery/bigquery_pandas_type_handler.py
@@ -11,6 +11,19 @@ from dagster_gcp.bigquery.io_manager import (
 )
 
 
+def _should_uppercase_column_names(context: InputContext | OutputContext) -> bool:
+    """Whether to uppercase column names on write and lowercase them back on read.
+
+    Defaults to True for backwards compatibility with existing BigQuery tables/pipelines --
+    BigQuery itself does not require uppercase column names. Set the
+    ``uppercase_column_names`` config value to False on the BigQuery I/O manager to disable
+    this and preserve the DataFrame's original column casing on both write and read.
+    """
+    if not context.resource_config:
+        return True
+    return bool(context.resource_config.get("uppercase_column_names", True))
+
+
 class BigQueryPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
     """Plugin for the BigQuery I/O Manager that can store and load Pandas DataFrames as BigQuery tables.
 
@@ -50,10 +63,12 @@ class BigQueryPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
                 "Skipping BigQuery write for empty DataFrame. An empty table will not be created."
             )
         else:
-            with_uppercase_cols = obj.rename(columns=str.upper)
+            df_to_load = (
+                obj.rename(columns=str.upper) if _should_uppercase_column_names(context) else obj
+            )
 
             job = connection.load_table_from_dataframe(
-                dataframe=with_uppercase_cols,
+                dataframe=df_to_load,
                 destination=f"{table_slice.schema}.{table_slice.table}",
                 project=table_slice.database,
                 location=context.resource_config.get("location")
@@ -96,7 +111,8 @@ class BigQueryPandasTypeHandler(DbTypeHandler[pd.DataFrame]):
             timeout=context.resource_config.get("timeout") if context.resource_config else None,
         ).to_dataframe()
 
-        result.columns = map(str.lower, result.columns)
+        if _should_uppercase_column_names(context):
+            result.columns = map(str.lower, result.columns)
         return result
 
     @property
@@ -201,6 +217,18 @@ Examples:
     unset. The key must be base64 encoded to avoid issues with newlines in the keys. You can retrieve
     the base64 encoded key with this shell command: cat $GOOGLE_APPLICATION_CREDENTIALS | base64
 
+    By default, DataFrame column names are uppercased before loading into BigQuery and
+    lowercased back when read (this is only for backwards compatibility -- BigQuery does not
+    require uppercase column names). Set ``uppercase_column_names=False`` to turn this off and
+    preserve the original casing of your DataFrame's column names instead:
+
+    .. code-block:: python
+
+        bigquery_pandas_io_manager.configured({
+            "project": {"env": "GCP_PROJECT"},
+            "uppercase_column_names": False,
+        })
+
 """
 
 
@@ -291,6 +319,15 @@ class BigQueryPandasIOManager(BigQueryIOManager):
         After the run completes, the file will be deleted, and GOOGLE_APPLICATION_CREDENTIALS will be
         unset. The key must be base64 encoded to avoid issues with newlines in the keys. You can retrieve
         the base64 encoded key with this shell command: cat $GOOGLE_APPLICATION_CREDENTIALS | base64
+
+        By default, DataFrame column names are uppercased before loading into BigQuery and
+        lowercased back when read (this is only for backwards compatibility -- BigQuery does not
+        require uppercase column names). Set ``uppercase_column_names=False`` to turn this off and
+        preserve the original casing of your DataFrame's column names instead:
+
+        .. code-block:: python
+
+            BigQueryPandasIOManager(project=EnvVar("GCP_PROJECT"), uppercase_column_names=False)
 
     """
 

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -18,6 +18,7 @@ from dagster import (
     Out,
     TimeWindowPartitionMapping,
     asset,
+    build_input_context,
     build_output_context,
     fs_io_manager,
     instance_for_test,
@@ -131,6 +132,23 @@ def test_handle_output_preserve_column_case():
 
     loaded_df = connection.load_table_from_dataframe.call_args.kwargs["dataframe"]
     assert list(loaded_df.columns) == ["Foo", "bar"]
+
+
+def test_load_input_preserve_column_case():
+    handler = BigQueryPandasTypeHandler()
+    connection = MagicMock()
+    connection.query.return_value.to_dataframe.return_value = pd.DataFrame(
+        {"Foo": ["a", "b"], "bar": [1, 2]}
+    )
+    input_context = build_input_context(resource_config={"uppercase_column_names": False})
+
+    result = handler.load_input(
+        input_context,
+        TableSlice(table="my_table", schema="my_schema", database="my_db"),
+        connection,
+    )
+
+    assert list(result.columns) == ["Foo", "bar"]
 
 
 @pytest.mark.skipif(

--- a/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
+++ b/python_modules/libraries/dagster-gcp-pandas/dagster_gcp_pandas_tests/bigquery/test_type_handler.py
@@ -116,6 +116,23 @@ def test_handle_output_nonempty_dataframe():
     mock_job.result.assert_called_once()
 
 
+def test_handle_output_preserve_column_case():
+    handler = BigQueryPandasTypeHandler()
+    df = pd.DataFrame({"Foo": ["a", "b"], "bar": [1, 2]})
+    connection = MagicMock()
+    output_context = build_output_context(resource_config={"uppercase_column_names": False})
+
+    handler.handle_output(
+        output_context,
+        TableSlice(table="my_table", schema="my_schema", database="my_db"),
+        df,
+        connection,
+    )
+
+    loaded_df = connection.load_table_from_dataframe.call_args.kwargs["dataframe"]
+    assert list(loaded_df.columns) == ["Foo", "bar"]
+
+
 @pytest.mark.skipif(
     not RUN_BUILDKITE_BIGQUERY_TESTS,
     reason="Requires Buildkite BigQuery credentials",

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -290,6 +290,24 @@ class BigQueryIOManager(ConfigurableIOManagerFactory):
                     )
                 }
             )
+
+        When using Pandas DataFrames, column names are uppercased before loading into BigQuery
+        and lowercased back on read by default. This is purely a historical default kept for
+        backwards compatibility with existing tables/pipelines -- BigQuery itself does not
+        require uppercase column names. Set ``uppercase_column_names=False`` to turn this off
+        and preserve the original casing of DataFrame column names on both write and read.
+
+        .. code-block:: python
+
+            defs = Definitions(
+                assets=[my_table],
+                resources={
+                    "io_manager": BigQueryIOManager(
+                        project=EnvVar("GCP_PROJECT"),
+                        uppercase_column_names=False,  # preserve DataFrame column casing as-is
+                    )
+                }
+            )
     """
 
     project: str = Field(description="The GCP project to use.")
@@ -335,6 +353,17 @@ class BigQueryIOManager(ConfigurableIOManagerFactory):
     write_mode: BigQueryWriteMode = Field(
         default=BigQueryWriteMode.TRUNCATE,
         description="Write mode to use for non-partitioned table cleanup: truncate, append, or replace.",
+    )
+    uppercase_column_names: bool = Field(
+        default=True,
+        description=(
+            "When using Pandas DataFrames, whether to uppercase column names before loading "
+            "into BigQuery, and lowercase them back on read. BigQuery does not require "
+            "uppercase column names; this defaults to True only for backwards compatibility "
+            "with existing tables and pipelines that already rely on this behavior. Set to "
+            "False to disable uppercasing and preserve the original casing of DataFrame "
+            "column names on both write and read."
+        ),
     )
 
     @staticmethod


### PR DESCRIPTION
- **io manger and bigquery_pandas_type_handler change to allow for lower case**
- **type_handler test added for column validation**

## Summary & Motivation
  - BigQueryPandasTypeHandler has always forced DataFrame column names to uppercase on write and lowercase on read, unconditionally
  - Not required by BigQuery — it's case-insensitive for matching but case-preserving in storage; the uppercasing was inherited from the Snowflake pandas type handler pattern, where it's load-bearing (Snowflake folds unquoted  identifiers to uppercase), but that reasoning doesn't apply to BigQuery
  - Adds uppercase_column_names config on BigQueryIOManager (defaults True, i.e.  today's behavior unchanged) — set False to preserve original DataFrame column casing end-to-end (write and read)
  - Purely additive/opt-in; zero behavior change for existing pipelines that  don't set it

## Test Plan
  - New unit test test_handle_output_preserve_column_case — mocked connection, no BigQuery/network dependency, asserts mixed-case column names ("Foo") pass through unchanged to load_table_from_dataframe when uppercase_column_names=False
  - Existing test_handle_output_empty_dataframe/test_handle_output_nonempty_dataframe continue to cover default (True) behavior
  - Ran full non-integration suite in dagster_gcp_pandas_tests/bigquery/test_type_handler.py

## Changelog
 - dagster-gcp / dagster-gcp-pandas: Added uppercase_column_names config option to BigQueryIOManager (and subclasses BigQueryPandasIOManager, bigquery_pandas_io_manager). Defaults to True to preserve existing behavior; set to False to preserve the original casing of Pandas DataFrame column names when writing to and reading from BigQuery.
