### PR TITLE
Fix parameter name mismatches in docstrings

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -902,7 +902,7 @@ def do_composition(
         config_mapping (Any): Config mapping provided to decorator by user. In
             job/graph case, this would have been constructed from a user-provided
             config_schema and config_fn.
-        ignore_output_from_composite_fn(Bool): Because of backwards compatibility
+        ignore_output_from_composition_fn(Bool): Because of backwards compatibility
             issues, jobs ignore the return value out of the mapping if
             the user has not explicitly provided the output definitions.
             This should be removed in 0.11.0.

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -230,10 +230,10 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
 
     @abstractmethod
     def has_job_snapshot(self, job_snapshot_id: str) -> bool:
-        """Check to see if storage contains a pipeline snapshot.
+        """Check to see if storage contains a job snapshot.
 
         Args:
-            pipeline_snapshot_id (str): The id of the run.
+            job_snapshot_id (str): The id of the job snapshot.
 
         Returns:
             bool

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -171,7 +171,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """Get the policy evaluations for a given asset.
 
         Args:
-            asset_key (AssetKey): The asset key to query
+            key (T_EntityKey): The entity key to query
             limit (Optional[int]): The maximum number of evaluations to return
             cursor (Optional[int]): The cursor to paginate from
         """

--- a/python_modules/dagster/dagster/_core/types/decorator.py
+++ b/python_modules/dagster/dagster/_core/types/decorator.py
@@ -37,7 +37,6 @@ def usable_as_dagster_type(
     make them dagster types whose typecheck is an isinstance check against that python class.
 
     Args:
-        python_type (cls): The python type to make usable as python type.
         name (Optional[str]): Name of the new Dagster type. If ``None``, the name (``__name__``) of
             the ``python_type`` will be used.
         description (Optional[str]): A user-readable description of the type.


### PR DESCRIPTION
## Summary & Motivation

Fixes four docstrings where the documented parameter name does not match the actual function signature:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `_core/storage/runs/base.py` | `has_job_snapshot` | `pipeline_snapshot_id` | `job_snapshot_id` |
| `_core/storage/schedules/base.py` | `get_auto_materialize_asset_evaluations` | `asset_key` | `key` |
| `_core/definitions/composition.py` | `do_composition` | `ignore_output_from_composite_fn` | `ignore_output_from_composition_fn` |
| `_core/types/decorator.py` | `usable_as_dagster_type` | stale `python_type` | not a parameter (the class is passed via `name`) |

Doc-only change; no behavior modified. The `usable_as_dagster_type` docstring is public-facing API documentation.

## How I Tested These Changes

Verified each docstring against the function signature; no code changes.