### PR TITLE
docs: document S3-compatible endpoints for dagster-aws

### DIFF
--- a/docs/docs/integrations/libraries/aws/s3.md
+++ b/docs/docs/integrations/libraries/aws/s3.md
@@ -23,6 +23,28 @@ Here is an example of how to use the `S3Resource` in a Dagster job to interact w
 
 <CodeExample path="docs_snippets/docs_snippets/integrations/aws-s3.py" language="python" />
 
+## Using S3-compatible endpoints
+
+To point `dagster-aws` at an S3-compatible object store — [MinIO](https://min.io/), [Tigris](https://www.tigrisdata.com), [Cloudflare R2](https://developers.cloudflare.com/r2/), or another — set `endpoint_url` on `S3Resource`. The rest of your pipeline stays the same; reads and writes just go to your chosen store instead of AWS.
+
+```python
+from dagster import Definitions
+from dagster_aws.s3 import S3Resource
+
+defs = Definitions(
+    resources={
+        "s3": S3Resource(
+            endpoint_url="https://t3.storage.dev",
+            aws_access_key_id="tid_your_access_key_id",
+            aws_secret_access_key="tsec_your_secret_access_key",
+            region_name="auto",
+        ),
+    }
+)
+```
+
+With Tigris, one bucket URL works from every region and there's no egress on cross-region reads, so you can re-materialize the same assets from jobs running anywhere without paying for transfer.
+
 ## About AWS S3
 
 **AWS S3** is an object storage service that offers industry-leading scalability, data availability, security, and performance. This means customers of all sizes and industries can use it to store and protect any amount of data for a range of use cases, such as data lakes, websites, mobile applications, backup and restore, archive, enterprise applications, IoT devices, and big data analytics. Amazon S3 provides easy-to-use management features so you can organize your data and configure finely tuned access controls to meet your specific business, organizational, and compliance requirements.

--- a/docs/docs/integrations/libraries/obstore.md
+++ b/docs/docs/integrations/libraries/obstore.md
@@ -39,7 +39,7 @@ compute_logs:
     allow_invalid_certificates: false
     timeout: "60s"  # Timeout for obstore requests
     region: "us-west-1"
-# Use S3 with custom endpoint (Minio, Cloudflare R2 etc.)
+# Use S3 with custom endpoint (Minio, Tigris, Cloudflare R2 etc.)
 compute_logs:
   module:  dagster_obstore.s3.compute_log_manager
   class: S3ComputeLogManager


### PR DESCRIPTION
## Summary & Motivation

`S3Resource` and the other S3 integrations in `dagster-aws` already accept an `endpoint_url` field (see `S3Resource` in `python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py`), but the docs never mention it. Users on MinIO, Tigris, Cloudflare R2, or any other S3-compatible store have no path in the integration docs — they have to read source to figure out that a plain `S3Resource` with `endpoint_url` already works.

Adds a short "Using S3-compatible endpoints" section to `aws/s3.md` with a runnable `S3Resource` example, and updates the existing `obstore.md` comment that already lists MinIO and Cloudflare R2 to also include Tigris.

Docs only; no code changes.

## Test Plan

Docs-only change. The `endpoint_url` field on `S3Resource` is exercised by existing tests in `python_modules/libraries/dagster-aws/dagster_aws_tests/`.

## Changelog

Docs: add S3-compatible endpoint example to the `dagster-aws` S3 integration page.