### PR TITLE
Fix WIF run launcher postgres secret config

### DIFF
--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -262,6 +262,22 @@ def test_k8s_run_launcher_job_image(template: HelmTemplate):
     assert run_launcher_config["config"]["job_image"] == "test_repo:test_tag"
 
 
+def test_k8s_run_launcher_omits_postgres_password_secret_with_wif_auth(
+    template: HelmTemplate,
+):
+    configmaps = template.render(
+        values_dict={
+            "global": {"postgresqlAuthWifEnabled": True},
+            "postgresql": {"authProvider": {"type": "azure_wif"}},
+            "runLauncher": {"type": "K8sRunLauncher"},
+        }
+    )
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+    run_launcher_config = instance["run_launcher"]
+
+    assert "postgres_password_secret" not in run_launcher_config["config"]
+
+
 def _check_valid_run_launcher_yaml(dagster_config, instance_class=K8sRunLauncher):
     with environ(
         {
@@ -527,6 +543,22 @@ def test_celery_k8s_run_launcher_config(template: HelmTemplate):
     instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
     run_launcher_config = instance["run_launcher"]
     assert run_launcher_config["config"]["fail_pod_on_run_failure"]
+
+
+def test_celery_k8s_run_launcher_omits_postgres_password_secret_with_wif_auth(
+    template: HelmTemplate,
+):
+    configmaps = template.render(
+        values_dict={
+            "global": {"postgresqlAuthWifEnabled": True},
+            "postgresql": {"authProvider": {"type": "azure_wif"}},
+            "runLauncher": {"type": "CeleryK8sRunLauncher"},
+        }
+    )
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+    run_launcher_config = instance["run_launcher"]
+
+    assert "postgres_password_secret" not in run_launcher_config["config"]
 
 
 def test_celery_k8s_run_launcher_default_namespace(template: HelmTemplate):

--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -5,9 +5,9 @@ class: CeleryK8sRunLauncher
 config:
   dagster_home: {{ .Values.global.dagsterHome | quote }}
   instance_config_map: "{{ template "dagster.fullname" .}}-instance"
-  {{- if not .Values.global.postgresqlAuthWifEnabled }}
+  {{ if not .Values.global.postgresqlAuthWifEnabled }}
   postgres_password_secret: {{ include "dagster.postgresql.secretName" . | quote }}
-  {{- end }}
+  {{ end }}
   job_namespace: {{ $celeryK8sRunLauncherConfig.jobNamespace | default .Release.Namespace }}
   broker:
     env: DAGSTER_CELERY_BROKER_URL
@@ -83,9 +83,9 @@ config:
   {{- end }}
   dagster_home: {{ .Values.global.dagsterHome | quote }}
   instance_config_map: "{{ template "dagster.fullname" .}}-instance"
-  {{- if not .Values.global.postgresqlAuthWifEnabled }}
+  {{ if not .Values.global.postgresqlAuthWifEnabled }}
   postgres_password_secret: {{ include "dagster.postgresql.secretName" . | quote }}
-  {{- end }}
+  {{ end }}
   {{- if $k8sRunLauncherConfig.envConfigMaps }}
   env_config_maps:
     {{- range $envConfigMap := $k8sRunLauncherConfig.envConfigMaps }}

--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -5,7 +5,9 @@ class: CeleryK8sRunLauncher
 config:
   dagster_home: {{ .Values.global.dagsterHome | quote }}
   instance_config_map: "{{ template "dagster.fullname" .}}-instance"
+  {{- if not .Values.global.postgresqlAuthWifEnabled }}
   postgres_password_secret: {{ include "dagster.postgresql.secretName" . | quote }}
+  {{- end }}
   job_namespace: {{ $celeryK8sRunLauncherConfig.jobNamespace | default .Release.Namespace }}
   broker:
     env: DAGSTER_CELERY_BROKER_URL
@@ -81,7 +83,9 @@ config:
   {{- end }}
   dagster_home: {{ .Values.global.dagsterHome | quote }}
   instance_config_map: "{{ template "dagster.fullname" .}}-instance"
+  {{- if not .Values.global.postgresqlAuthWifEnabled }}
   postgres_password_secret: {{ include "dagster.postgresql.secretName" . | quote }}
+  {{- end }}
   {{- if $k8sRunLauncherConfig.envConfigMaps }}
   env_config_maps:
     {{- range $envConfigMap := $k8sRunLauncherConfig.envConfigMaps }}


### PR DESCRIPTION
## Summary

Fix the Dagster Helm chart run launcher configuration for PostgreSQL Workload Identity Federation authentication.

## Problem

When `global.postgresqlAuthWifEnabled` is enabled, the chart does not create a PostgreSQL password secret. The run launcher templates still emitted `postgres_password_secret`, which could point the generated `dagster.yaml` at a secret that does not exist.

## Solution

- Omit `postgres_password_secret` for `K8sRunLauncher` when WIF PostgreSQL auth is enabled.
- Apply the same guard for `CeleryK8sRunLauncher`.
- Preserve valid Helm/YAML whitespace in both the WIF and default-auth render paths.
- Match the existing chart behavior used by other templates that respect `global.postgresqlAuthWifEnabled`.
- Add Helm rendering tests for both affected run launcher configurations.

## Validation

- Rendered `K8sRunLauncher` with WIF auth enabled and verified `postgres_password_secret` is omitted.
- Rendered `CeleryK8sRunLauncher` with WIF auth enabled and verified `postgres_password_secret` is omitted.
- Rendered both run launcher modes with default auth and verified `postgres_password_secret` is still present.

Fixes #33968
