### PR TITLE
Skip corrupt backfill rows when listing backfills

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -913,7 +913,9 @@ class SqlRunStorage(RunStorage):
         return table
 
     def _backfills_query(self, filters: BulkActionsFilter | None = None):
-        query = db_select([BulkActionsTable.c.body, BulkActionsTable.c.timestamp])
+        query = db_select(
+            [BulkActionsTable.c.key, BulkActionsTable.c.body, BulkActionsTable.c.timestamp]
+        )
         if filters and filters.tags:
             if not self.has_built_index(BACKFILL_JOB_NAME_AND_TAGS):
                 # if the migration was run, we added the query for tags filtering in _add_backfill_filters_to_table
@@ -1008,6 +1010,22 @@ class SqlRunStorage(RunStorage):
 
         return [backfill for backfill in backfills if _matches_backfill(backfill, tags)]
 
+    def _deserialize_backfill_rows(
+        self, rows: Sequence[Mapping[str, Any]]
+    ) -> Sequence[PartitionBackfill]:
+        backfills = []
+        for row in rows:
+            try:
+                backfills.append(deserialize_value(row["body"], PartitionBackfill))
+            except Exception:
+                logging.getLogger("dagster").warning(
+                    "Skipping backfill %s because it could not be deserialized.",
+                    row["key"],
+                    exc_info=True,
+                )
+
+        return backfills
+
     def get_backfills(
         self,
         filters: BulkActionsFilter | None = None,
@@ -1016,7 +1034,6 @@ class SqlRunStorage(RunStorage):
         status: BulkActionStatus | None = None,
     ) -> Sequence[PartitionBackfill]:
         check.opt_inst_param(status, "status", BulkActionStatus)
-        query = db_select([BulkActionsTable.c.body, BulkActionsTable.c.timestamp])
         if status and filters:
             raise DagsterInvariantViolationError(
                 "Cannot provide status and filters to get_backfills. Please use filters rather than status."
@@ -1030,7 +1047,7 @@ class SqlRunStorage(RunStorage):
         query = self._add_cursor_limit_to_backfills_query(query, cursor=cursor, limit=limit)
         query = query.order_by(BulkActionsTable.c.id.desc())
         rows = self.fetchall(query)
-        backfill_candidates = deserialize_values((row["body"] for row in rows), PartitionBackfill)
+        backfill_candidates = self._deserialize_backfill_rows(rows)
 
         if filters and filters.tags and not self.has_built_index(BACKFILL_JOB_NAME_AND_TAGS):
             # if we are still using the run tags table to get backfills by tag, we need to do an additional check.

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -1087,22 +1087,17 @@ class SqlRunStorage(RunStorage):
 
     def get_backfills_count(self, filters: BulkActionsFilter | None = None) -> int:
         check.opt_inst_param(filters, "filters", BulkActionsFilter)
+        query = self._backfills_query(filters=filters)
+        rows = self.fetchall(query)
+        backfill_candidates = self._deserialize_backfill_rows(rows)
         if filters and filters.tags:
             # runs can have more tags than the backfill that launched them. Since we filtered tags by
             # querying for runs with those tags, we need to do an additional check that the backfills
             # also have the requested tags. This requires fetching the backfills from the db and filtering them
-            query = self._backfills_query(filters=filters)
-            rows = self.fetchall(query)
-            backfill_candidates = self._deserialize_backfill_rows(rows)
-            return len(
-                self._apply_backfill_tags_filter_to_results(backfill_candidates, filters.tags)
+            backfill_candidates = self._apply_backfill_tags_filter_to_results(
+                backfill_candidates, filters.tags
             )
-
-        subquery = db_subquery(self._backfills_query(filters=filters))
-        query = db_select([db.func.count().label("count")]).select_from(subquery)
-        row = self.fetchone(query)
-        count = row["count"] if row else 0
-        return count
+        return len(backfill_candidates)
 
     def get_backfill(self, backfill_id: str) -> PartitionBackfill | None:
         check.str_param(backfill_id, "backfill_id")

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, ContextManager, NamedTuple, cast  # noqa: UP03
 
 import sqlalchemy as db
 import sqlalchemy.exc as db_exc
-from dagster_shared.serdes import deserialize_values
 from dagster_shared.seven import JSONDecodeError
 from sqlalchemy.engine import Connection
 
@@ -1094,9 +1093,7 @@ class SqlRunStorage(RunStorage):
             # also have the requested tags. This requires fetching the backfills from the db and filtering them
             query = self._backfills_query(filters=filters)
             rows = self.fetchall(query)
-            backfill_candidates = deserialize_values(
-                (row["body"] for row in rows), PartitionBackfill
-            )
+            backfill_candidates = self._deserialize_backfill_rows(rows)
             return len(
                 self._apply_backfill_tags_filter_to_results(backfill_candidates, filters.tags)
             )

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -914,7 +914,12 @@ class SqlRunStorage(RunStorage):
 
     def _backfills_query(self, filters: BulkActionsFilter | None = None):
         query = db_select(
-            [BulkActionsTable.c.key, BulkActionsTable.c.body, BulkActionsTable.c.timestamp]
+            [
+                BulkActionsTable.c.id,
+                BulkActionsTable.c.key,
+                BulkActionsTable.c.body,
+                BulkActionsTable.c.timestamp,
+            ]
         )
         if filters and filters.tags:
             if not self.has_built_index(BACKFILL_JOB_NAME_AND_TAGS):
@@ -1044,18 +1049,40 @@ class SqlRunStorage(RunStorage):
 
         table = self._add_backfill_filters_to_table(BulkActionsTable, filters)
         query = self._backfills_query(filters=filters).select_from(table)
-        query = self._add_cursor_limit_to_backfills_query(query, cursor=cursor, limit=limit)
+        query = self._add_cursor_limit_to_backfills_query(query, cursor=cursor)
         query = query.order_by(BulkActionsTable.c.id.desc())
-        rows = self.fetchall(query)
-        backfill_candidates = self._deserialize_backfill_rows(rows)
 
-        if filters and filters.tags and not self.has_built_index(BACKFILL_JOB_NAME_AND_TAGS):
-            # if we are still using the run tags table to get backfills by tag, we need to do an additional check.
-            # runs can have more tags than the backfill that launched them. Since we filtered tags by
-            # querying for runs with those tags, we need to do an additional check that the backfills
-            # also have the requested tags
-            backfill_candidates = self._apply_backfill_tags_filter_to_results(
-                backfill_candidates, filters.tags
+        def _filter_backfill_candidates(
+            backfill_candidates: Sequence[PartitionBackfill],
+        ) -> Sequence[PartitionBackfill]:
+            if not (filters and filters.tags and not self.has_built_index(BACKFILL_JOB_NAME_AND_TAGS)):
+                return backfill_candidates
+            # If we are still using the run tags table to get backfills by tag, we need to do an
+            # additional check. Runs can have more tags than the backfill that launched them. Since
+            # we filtered tags by querying for runs with those tags, verify that the backfills also
+            # have the requested tags.
+            return self._apply_backfill_tags_filter_to_results(backfill_candidates, filters.tags)
+
+        if not limit:
+            rows = self.fetchall(query)
+            backfill_candidates = self._deserialize_backfill_rows(rows)
+            return _filter_backfill_candidates(backfill_candidates)
+
+        backfill_candidates = []
+        last_row_id = None
+        while len(backfill_candidates) < limit:
+            page_query = query
+            if last_row_id is not None:
+                page_query = page_query.where(BulkActionsTable.c.id < last_row_id)
+            rows = self.fetchall(page_query.limit(limit - len(backfill_candidates)))
+            if not rows:
+                break
+
+            last_row_id = rows[-1]["id"]
+            backfill_candidates = list(
+                _filter_backfill_candidates(
+                    [*backfill_candidates, *self._deserialize_backfill_rows(rows)]
+                )
             )
         return backfill_candidates
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1466,6 +1466,50 @@ class TestRunStorage:
 
         assert "Skipping backfill corrupt because it could not be deserialized." in caplog.text
 
+    def test_get_backfills_limit_skips_corrupt_rows_without_shrinking_page(
+        self, storage: RunStorage, caplog: pytest.LogCaptureFixture
+    ):
+        if not isinstance(storage, SqlRunStorage):
+            pytest.skip("storage is not SQL-backed")
+
+        origin = self.fake_partition_set_origin("fake_partition_set")
+        older_backfill = PartitionBackfill(
+            "older",
+            partition_set_origin=origin,
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["a", "b", "c"],
+            from_failure=False,
+            tags={},
+            backfill_timestamp=time.time(),
+        )
+        storage.add_backfill(older_backfill)
+
+        with storage.connect() as conn:
+            conn.execute(
+                BulkActionsTable.insert().values(
+                    key="corrupt",
+                    status=BulkActionStatus.REQUESTED.value,
+                    timestamp=datetime_from_timestamp(time.time()),
+                    body='{"truncated"',
+                )
+            )
+
+        newer_backfill = PartitionBackfill(
+            "newer",
+            partition_set_origin=origin,
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["a", "b", "c"],
+            from_failure=False,
+            tags={},
+            backfill_timestamp=time.time(),
+        )
+        storage.add_backfill(newer_backfill)
+
+        with caplog.at_level("WARNING", logger="dagster"):
+            assert storage.get_backfills(limit=2) == [newer_backfill, older_backfill]
+
+        assert "Skipping backfill corrupt because it could not be deserialized." in caplog.text
+
     def test_backfill_status_filtering(self, storage: RunStorage):
         origin = self.fake_partition_set_origin("fake_partition_set")
         backfills = storage.get_backfills()

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -24,7 +24,7 @@ from dagster._core.storage.noop_compute_log_manager import NoOpComputeLogManager
 from dagster._core.storage.root import LocalArtifactStorage
 from dagster._core.storage.runs.base import RunStorage
 from dagster._core.storage.runs.migration import REQUIRED_DATA_MIGRATIONS
-from dagster._core.storage.runs.schema import BulkActionsTable
+from dagster._core.storage.runs.schema import BackfillTagsTable, BulkActionsTable
 from dagster._core.storage.runs.sql_run_storage import SqlRunStorage
 from dagster._core.storage.tags import (
     BACKFILL_ID_TAG,
@@ -1450,6 +1450,14 @@ class TestRunStorage:
             backfill_timestamp=time.time(),
         )
         storage.add_backfill(valid_backfill)
+        storage.add_run(
+            create_dagster_run(
+                run_id=make_new_run_id(),
+                job_name="some_pipeline",
+                status=DagsterRunStatus.SUCCESS,
+                tags={"foo": "bar", BACKFILL_ID_TAG: valid_backfill.backfill_id},
+            )
+        )
 
         with storage.connect() as conn:
             conn.execute(
@@ -1507,6 +1515,66 @@ class TestRunStorage:
 
         with caplog.at_level("WARNING", logger="dagster"):
             assert storage.get_backfills(limit=2) == [newer_backfill, older_backfill]
+
+        assert "Skipping backfill corrupt because it could not be deserialized." in caplog.text
+
+    def test_get_backfills_count_with_tags_skips_corrupt_rows(
+        self, storage: RunStorage, caplog: pytest.LogCaptureFixture
+    ):
+        if not isinstance(storage, SqlRunStorage):
+            pytest.skip("storage is not SQL-backed")
+        if not self.supports_backfill_tags_filtering_queries():
+            pytest.skip("storage does not support filtering backfills by tag")
+        if not self.supports_backfills_count():
+            pytest.skip("storage does not support backfill count")
+
+        origin = self.fake_partition_set_origin("fake_partition_set")
+        valid_backfill = PartitionBackfill(
+            "valid",
+            partition_set_origin=origin,
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["a", "b", "c"],
+            from_failure=False,
+            tags={"foo": "bar"},
+            backfill_timestamp=time.time(),
+        )
+        storage.add_backfill(valid_backfill)
+        storage.add_run(
+            create_dagster_run(
+                run_id=make_new_run_id(),
+                job_name="some_pipeline",
+                status=DagsterRunStatus.SUCCESS,
+                tags={"foo": "bar", BACKFILL_ID_TAG: valid_backfill.backfill_id},
+            )
+        )
+
+        with storage.connect() as conn:
+            conn.execute(
+                BulkActionsTable.insert().values(
+                    key="corrupt",
+                    status=BulkActionStatus.REQUESTED.value,
+                    timestamp=datetime_from_timestamp(time.time()),
+                    body='{"truncated"',
+                )
+            )
+            conn.execute(
+                BackfillTagsTable.insert().values(
+                    backfill_id="corrupt",
+                    key="foo",
+                    value="bar",
+                )
+            )
+        storage.add_run(
+            create_dagster_run(
+                run_id=make_new_run_id(),
+                job_name="some_pipeline",
+                status=DagsterRunStatus.SUCCESS,
+                tags={"foo": "bar", BACKFILL_ID_TAG: "corrupt"},
+            )
+        )
+
+        with caplog.at_level("WARNING", logger="dagster"):
+            assert storage.get_backfills_count(BulkActionsFilter(tags={"foo": "bar"})) == 1
 
         assert "Skipping backfill corrupt because it could not be deserialized." in caplog.text
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -24,6 +24,7 @@ from dagster._core.storage.noop_compute_log_manager import NoOpComputeLogManager
 from dagster._core.storage.root import LocalArtifactStorage
 from dagster._core.storage.runs.base import RunStorage
 from dagster._core.storage.runs.migration import REQUIRED_DATA_MIGRATIONS
+from dagster._core.storage.runs.schema import BulkActionsTable
 from dagster._core.storage.runs.sql_run_storage import SqlRunStorage
 from dagster._core.storage.tags import (
     BACKFILL_ID_TAG,
@@ -1431,6 +1432,39 @@ class TestRunStorage:
         storage.update_backfill(one.with_status(status=BulkActionStatus.COMPLETED_SUCCESS))
         assert len(storage.get_backfills()) == 1
         assert len(storage.get_backfills(status=BulkActionStatus.REQUESTED)) == 0
+
+    def test_get_backfills_skips_corrupt_backfill_rows(
+        self, storage: RunStorage, caplog: pytest.LogCaptureFixture
+    ):
+        if not isinstance(storage, SqlRunStorage):
+            pytest.skip("storage is not SQL-backed")
+
+        origin = self.fake_partition_set_origin("fake_partition_set")
+        valid_backfill = PartitionBackfill(
+            "valid",
+            partition_set_origin=origin,
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["a", "b", "c"],
+            from_failure=False,
+            tags={},
+            backfill_timestamp=time.time(),
+        )
+        storage.add_backfill(valid_backfill)
+
+        with storage.connect() as conn:
+            conn.execute(
+                BulkActionsTable.insert().values(
+                    key="corrupt",
+                    status=BulkActionStatus.REQUESTED.value,
+                    timestamp=datetime_from_timestamp(time.time()),
+                    body='{"truncated"',
+                )
+            )
+
+        with caplog.at_level("WARNING", logger="dagster"):
+            assert storage.get_backfills() == [valid_backfill]
+
+        assert "Skipping backfill corrupt because it could not be deserialized." in caplog.text
 
     def test_backfill_status_filtering(self, storage: RunStorage):
         origin = self.fake_partition_set_origin("fake_partition_set")

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1450,14 +1450,6 @@ class TestRunStorage:
             backfill_timestamp=time.time(),
         )
         storage.add_backfill(valid_backfill)
-        storage.add_run(
-            create_dagster_run(
-                run_id=make_new_run_id(),
-                job_name="some_pipeline",
-                status=DagsterRunStatus.SUCCESS,
-                tags={"foo": "bar", BACKFILL_ID_TAG: valid_backfill.backfill_id},
-            )
-        )
 
         with storage.connect() as conn:
             conn.execute(
@@ -1515,6 +1507,41 @@ class TestRunStorage:
 
         with caplog.at_level("WARNING", logger="dagster"):
             assert storage.get_backfills(limit=2) == [newer_backfill, older_backfill]
+
+        assert "Skipping backfill corrupt because it could not be deserialized." in caplog.text
+
+    def test_get_backfills_count_skips_corrupt_rows(
+        self, storage: RunStorage, caplog: pytest.LogCaptureFixture
+    ):
+        if not isinstance(storage, SqlRunStorage):
+            pytest.skip("storage is not SQL-backed")
+        if not self.supports_backfills_count():
+            pytest.skip("storage does not support backfill count")
+
+        origin = self.fake_partition_set_origin("fake_partition_set")
+        valid_backfill = PartitionBackfill(
+            "valid",
+            partition_set_origin=origin,
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["a", "b", "c"],
+            from_failure=False,
+            tags={},
+            backfill_timestamp=time.time(),
+        )
+        storage.add_backfill(valid_backfill)
+
+        with storage.connect() as conn:
+            conn.execute(
+                BulkActionsTable.insert().values(
+                    key="corrupt",
+                    status=BulkActionStatus.REQUESTED.value,
+                    timestamp=datetime_from_timestamp(time.time()),
+                    body='{"truncated"',
+                )
+            )
+
+        with caplog.at_level("WARNING", logger="dagster"):
+            assert storage.get_backfills_count() == 1
 
         assert "Skipping backfill corrupt because it could not be deserialized." in caplog.text
 


### PR DESCRIPTION
## Summary

Fixes #33946.

This updates SQL run storage so `get_backfills()` deserializes backfill rows independently. If a single `bulk_actions` row has a corrupt or otherwise unreadable serialized body, Dagster now logs the affected backfill key and skips that row instead of failing the entire Backfills page/query.

The change preserves the existing ordering/filtering behavior for readable rows and keeps the fallback tag filtering path unchanged.

## Tests

- `python3 -m py_compile python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py`
- `git diff --check`
- `UV_CACHE_DIR=/tmp/dagster-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/dagster-33946-venv RUFF_CACHE_DIR=/tmp/dagster-ruff-cache uv run --frozen --extra test ruff check dagster/_core/storage/runs/sql_run_storage.py dagster_tests/storage_tests/utils/run_storage.py`
- `UV_CACHE_DIR=/tmp/dagster-uv-cache UV_PROJECT_ENVIRONMENT=/tmp/dagster-33946-venv uv run --frozen --extra test --with ../dagster-test --with ../libraries/create-dagster pytest dagster_tests/storage_tests/test_run_storage.py -k get_backfills_skips_corrupt_backfill_rows -q`
