### PR TITLE
test: add unit tests for merge_dicts and reverse_dict

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_merger.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_merger.py
@@ -1,0 +1,39 @@
+from dagster._utils.merger import merge_dicts, reverse_dict
+
+
+def test_merge_dicts_combines_keys():
+    assert merge_dicts({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+
+
+def test_merge_dicts_later_values_win():
+    # When a key appears in more than one input, the last one takes priority.
+    assert merge_dicts({"a": 1, "b": 2}, {"a": 3}) == {"a": 3, "b": 2}
+
+
+def test_merge_dicts_single_dict():
+    assert merge_dicts({"a": 1}) == {"a": 1}
+
+
+def test_merge_dicts_ignores_empty_dicts():
+    assert merge_dicts({"a": 1}, {}, {"c": 3}) == {"a": 1, "c": 3}
+
+
+def test_merge_dicts_does_not_mutate_inputs():
+    first = {"a": 1}
+    second = {"b": 2}
+    merge_dicts(first, second)
+    assert first == {"a": 1}
+    assert second == {"b": 2}
+
+
+def test_reverse_dict_swaps_keys_and_values():
+    assert reverse_dict({"a": 1, "b": 2}) == {1: "a", 2: "b"}
+
+
+def test_reverse_dict_empty():
+    assert reverse_dict({}) == {}
+
+
+def test_reverse_dict_duplicate_values_keep_last_key():
+    # Two keys map to the same value: the last key encountered wins.
+    assert reverse_dict({"a": 1, "b": 1}) == {1: "b"}


### PR DESCRIPTION
## Summary

`dagster/_utils/merger.py` (`merge_dicts`, `reverse_dict`) had no dedicated test module. This adds `dagster_tests/general_tests/utils_tests/test_merger.py` covering:

- `merge_dicts` combining keys, later values winning on conflict, single-dict and empty-dict inputs, and not mutating its inputs
- `reverse_dict` swapping keys/values, the empty case, and duplicate values keeping the last key

No source changes.

## Verification

The assertions pass against the current implementations; `ruff check` / `ruff format --check` clean.
