### PR TITLE
test: add unit tests for snakecase

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_snakecase.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_snakecase.py
@@ -1,0 +1,19 @@
+import pytest
+
+from dagster._utils import snakecase
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("MyClassName", "my_class_name"),
+        ("already_snake", "already_snake"),
+        ("with-dashes", "with_dashes"),
+        ("with spaces", "with_spaces"),
+        ("foo123Bar", "foo123_bar"),
+        # Each capital in a run gets its own underscore boundary.
+        ("HTTPServer", "h_t_t_p_server"),
+    ],
+)
+def test_snakecase(value, expected):
+    assert snakecase(value) == expected


### PR DESCRIPTION
## Summary

`dagster/_utils.snakecase` was untested (its sibling `camelcase` has tests). This adds `dagster_tests/general_tests/utils_tests/test_snakecase.py` covering CamelCase, already-snake, dashes, spaces, alphanumeric boundaries, and a run of capitals.

No source changes.

## Verification

The parametrized cases pass against the current implementation; `ruff check` / `ruff format --check` clean.
