### PR TITLE
fix: serialize dbt prepare dependencies and parsing

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -96,6 +96,13 @@ class DagsterDbtProjectPreparer(DbtProjectPreparer):
             project (DbtProject):
                 The dbt project to be prepared.
         """
+        run_with_concurrent_update_guard(
+            project.manifest_path,
+            self._prepare,
+            project=project,
+        )
+
+    def _prepare(self, project: "DbtProject") -> None:
         # Always run dbt deps when dependency files exist, not just when
         # packages appear uninstalled. The has_uninstalled_deps check uses a
         # heuristic (dbt_packages dir existence) that can incorrectly skip
@@ -106,17 +113,9 @@ class DagsterDbtProjectPreparer(DbtProjectPreparer):
             or project.project_dir.joinpath("packages.yml").exists()
         )
         if has_deps_files:
-            run_with_concurrent_update_guard(
-                project.project_dir.joinpath("package-lock.yml"),
-                self._prepare_packages,
-                project=project,
-            )
+            self._prepare_packages(project)
 
-        run_with_concurrent_update_guard(
-            project.manifest_path,
-            self._prepare_manifest,
-            project=project,
-        )
+        self._prepare_manifest(project)
 
     def _prepare_packages(self, project: "DbtProject") -> None:
         from dagster_dbt.core.resource import DbtCliResource

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -50,6 +50,7 @@ class DagsterDbtProjectPreparer(DbtProjectPreparer):
     def __init__(
         self,
         prepare_project_cli_args: Sequence[str] | None = None,
+        guard_timeout_seconds: float = 120,
     ):
         """The default DbtProjectPreparer, this handler provides an experience of:
             * During development, reload the manifest at run time to pick up any changes.
@@ -59,8 +60,13 @@ class DagsterDbtProjectPreparer(DbtProjectPreparer):
             prepare_project_cli_args (Sequence[str]):
                 The arguments to pass to the dbt cli to generate a manifest.json.
                 Default: ["parse", "--quiet"]
+            guard_timeout_seconds (float):
+                The maximum time to wait for another process to finish preparing the project.
+                The default preserves the former 60-second wait budget for each of the
+                dependency-installation and manifest-generation stages.
         """
         self._prepare_project_cli_args = prepare_project_cli_args or ["parse", "--quiet"]
+        self._guard_timeout_seconds = guard_timeout_seconds
 
     @public
     def prepare_if_dev(self, project: "DbtProject"):
@@ -99,6 +105,7 @@ class DagsterDbtProjectPreparer(DbtProjectPreparer):
         run_with_concurrent_update_guard(
             project.manifest_path,
             self._prepare,
+            guard_timeout_seconds=self._guard_timeout_seconds,
             project=project,
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
@@ -89,6 +89,32 @@ def test_concurrent_processes(project_dir):
         assert my_project.manifest_path.exists()
 
 
+def test_prepare_guards_deps_and_parse_with_the_same_lock(project_dir, monkeypatch) -> None:
+    """Ensure deps cannot mutate dbt_packages while another process is parsing."""
+    (Path(project_dir) / "packages.yml").write_text("packages: []\n", encoding="utf-8")
+    my_project = DbtProject(project_dir)
+    preparer = DagsterDbtProjectPreparer()
+    guarded_paths = []
+    prepared_steps = []
+
+    def record_guard(target_file_path, update_fn, **kwargs) -> None:
+        guarded_paths.append(target_file_path)
+        update_fn(**kwargs)
+
+    monkeypatch.setattr("dagster_dbt.dbt_project.run_with_concurrent_update_guard", record_guard)
+    monkeypatch.setattr(
+        preparer, "_prepare_packages", lambda project: prepared_steps.append("deps")
+    )
+    monkeypatch.setattr(
+        preparer, "_prepare_manifest", lambda project: prepared_steps.append("parse")
+    )
+
+    preparer.prepare(my_project)
+
+    assert guarded_paths == [my_project.manifest_path]
+    assert prepared_steps == ["deps", "parse"]
+
+
 def test_invalidate_seeds_in_partial_parse(project_dir) -> None:
     """Test that seed file checksums are invalidated in partial_parse.msgpack after preparation.
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
@@ -89,30 +89,35 @@ def test_concurrent_processes(project_dir):
         assert my_project.manifest_path.exists()
 
 
-def test_prepare_guards_deps_and_parse_with_the_same_lock(project_dir, monkeypatch) -> None:
+def test_prepare_guards_deps_and_parse_with_the_same_lock(monkeypatch) -> None:
     """Ensure deps cannot mutate dbt_packages while another process is parsing."""
-    (Path(project_dir) / "packages.yml").write_text("packages: []\n", encoding="utf-8")
-    my_project = DbtProject(project_dir)
-    preparer = DagsterDbtProjectPreparer()
-    guarded_paths = []
-    prepared_steps = []
+    # Keep the dependency marker out of the session-scoped project fixture so this
+    # test cannot cause later tests to invoke a real `dbt deps` command.
+    with copy_directory(test_jaffle_shop_path) as project_dir:
+        (Path(project_dir) / "packages.yml").write_text("packages: []\n", encoding="utf-8")
+        my_project = DbtProject(project_dir)
+        preparer = DagsterDbtProjectPreparer()
+        guarded_paths = []
+        prepared_steps = []
 
-    def record_guard(target_file_path, update_fn, **kwargs) -> None:
-        guarded_paths.append(target_file_path)
-        update_fn(**kwargs)
+        def record_guard(target_file_path, update_fn, **kwargs) -> None:
+            guarded_paths.append(target_file_path)
+            update_fn(**kwargs)
 
-    monkeypatch.setattr("dagster_dbt.dbt_project.run_with_concurrent_update_guard", record_guard)
-    monkeypatch.setattr(
-        preparer, "_prepare_packages", lambda project: prepared_steps.append("deps")
-    )
-    monkeypatch.setattr(
-        preparer, "_prepare_manifest", lambda project: prepared_steps.append("parse")
-    )
+        monkeypatch.setattr(
+            "dagster_dbt.dbt_project.run_with_concurrent_update_guard", record_guard
+        )
+        monkeypatch.setattr(
+            preparer, "_prepare_packages", lambda project: prepared_steps.append("deps")
+        )
+        monkeypatch.setattr(
+            preparer, "_prepare_manifest", lambda project: prepared_steps.append("parse")
+        )
 
-    preparer.prepare(my_project)
+        preparer.prepare(my_project)
 
-    assert guarded_paths == [my_project.manifest_path]
-    assert prepared_steps == ["deps", "parse"]
+        assert guarded_paths == [my_project.manifest_path]
+        assert prepared_steps == ["deps", "parse"]
 
 
 def test_invalidate_seeds_in_partial_parse(project_dir) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_project.py
@@ -98,10 +98,12 @@ def test_prepare_guards_deps_and_parse_with_the_same_lock(monkeypatch) -> None:
         my_project = DbtProject(project_dir)
         preparer = DagsterDbtProjectPreparer()
         guarded_paths = []
+        guard_timeouts = []
         prepared_steps = []
 
-        def record_guard(target_file_path, update_fn, **kwargs) -> None:
+        def record_guard(target_file_path, update_fn, *, guard_timeout_seconds, **kwargs) -> None:
             guarded_paths.append(target_file_path)
+            guard_timeouts.append(guard_timeout_seconds)
             update_fn(**kwargs)
 
         monkeypatch.setattr(
@@ -117,7 +119,30 @@ def test_prepare_guards_deps_and_parse_with_the_same_lock(monkeypatch) -> None:
         preparer.prepare(my_project)
 
         assert guarded_paths == [my_project.manifest_path]
+        # deps and parse now share one guard. Preserve the former 60-second
+        # wait budget for each stage by allowing 120 seconds in total.
+        assert guard_timeouts == [120]
         assert prepared_steps == ["deps", "parse"]
+
+
+def test_prepare_uses_configured_guard_timeout(monkeypatch) -> None:
+    with copy_directory(test_jaffle_shop_path) as project_dir:
+        my_project = DbtProject(project_dir)
+        preparer = DagsterDbtProjectPreparer(guard_timeout_seconds=15)
+        guard_timeouts = []
+
+        def record_guard(target_file_path, update_fn, *, guard_timeout_seconds, **kwargs) -> None:
+            guard_timeouts.append(guard_timeout_seconds)
+            update_fn(**kwargs)
+
+        monkeypatch.setattr(
+            "dagster_dbt.dbt_project.run_with_concurrent_update_guard", record_guard
+        )
+        monkeypatch.setattr(preparer, "_prepare_manifest", lambda project: None)
+
+        preparer.prepare(my_project)
+
+        assert guard_timeouts == [15]
 
 
 def test_invalidate_seeds_in_partial_parse(project_dir) -> None:


### PR DESCRIPTION
## Summary

Make `DagsterDbtProjectPreparer.prepare()` use one manifest-scoped concurrent-update guard around both `dbt deps` and `dbt parse`.

## Root cause

`dbt deps` previously used `package-lock.yml` as its guard while `dbt parse` used `manifest.json`. Concurrent preparers could therefore run the two commands at the same time, letting dependency mutation race parsing during parallel backfills.

## Change

- Guard the complete preparation sequence with `project.manifest_path`.
- Keep the existing dependency-file behavior, but execute both preparation steps inside that shared guard.
- Add a regression test proving both steps use the same lock and run in order.

## Validation

- `pytest -c pyproject.toml -o 'markers=core: core dagster-dbt tests' dagster_dbt_tests/core/test_project.py -k 'same_lock or concurrent_processes' -q`
- `ruff check dagster_dbt/dbt_project.py dagster_dbt_tests/core/test_project.py`
- `ruff format --check dagster_dbt/dbt_project.py dagster_dbt_tests/core/test_project.py`

Fixes #33993.
