### PR TITLE
Fail STARTING runs fast when run worker is already dead

### DIFF
--- a/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
+++ b/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
@@ -31,6 +31,30 @@ def monitor_starting_run(
     run = run_record.dagster_run
     check.invariant(run.status in {DagsterRunStatus.STARTING, DagsterRunStatus.NOT_STARTED})
 
+    # Fail fast if the run worker has already died while starting up, rather than waiting for
+    # run_monitoring_start_timeout_seconds to elapse.
+    if instance.run_launcher.supports_check_run_worker_health:
+        check_health_result = instance.run_launcher.check_run_worker_health(run)
+        if check_health_result.status == WorkerStatus.FAILED:
+            recheck_run = check.not_none(instance.get_run_by_id(run.run_id))
+            if run.status != recheck_run.status:
+                logger.info(
+                    "Detected run status changed during monitoring loop: "
+                    f"{run.status} -> {recheck_run.status}, disregarding for now"
+                )
+                return
+            msg = (
+                f"Detected run worker status {check_health_result} while run was starting up."
+                f" Marking run {run.run_id} as failed."
+            )
+            logger.info(msg)
+            instance.report_run_failed(
+                run,
+                msg,
+                JobFailureData(error=None, failure_reason=RunFailureReason.UNEXPECTED_TERMINATION),
+            )
+            return
+
     if run.status == DagsterRunStatus.STARTING:
         run_stats = instance.get_run_stats(run.run_id)
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -253,6 +253,42 @@ def test_monitor_starting(instance: DagsterInstance, logger: Logger):
     assert run.tags[RUN_FAILURE_REASON_TAG] == RunFailureReason.START_TIMEOUT.value
 
 
+@pytest.mark.parametrize(
+    "worker_status,should_fail",
+    [
+        # Worker already dead while starting up -> fail fast, don't wait for the start timeout.
+        (WorkerStatus.FAILED, True),
+        # Pod not yet visible to the API / still being scheduled -> leave to the timeout backstop.
+        (WorkerStatus.UNKNOWN, False),
+        (WorkerStatus.NOT_FOUND, False),
+        (WorkerStatus.RUNNING, False),
+    ],
+)
+def test_monitor_starting_worker_health(
+    instance: DagsterInstance, logger: Logger, worker_status: WorkerStatus, should_fail: bool
+):
+    run = create_run_for_test(instance, job_name="foo")
+    # Not timed out, so only the worker-health check can fail it.
+    report_starting_event(instance, run, timestamp=time.time())
+
+    instance.run_launcher.check_run_worker_health = lambda _run: CheckRunHealthResult(  # type: ignore
+        worker_status, "worker gone"
+    )
+
+    monitor_starting_run(
+        instance,
+        check.not_none(instance.get_run_record_by_id(run.run_id)),
+        logger,
+    )
+
+    run = check.not_none(instance.get_run_by_id(run.run_id))
+    if should_fail:
+        assert run.status == DagsterRunStatus.FAILURE
+        assert run.tags[RUN_FAILURE_REASON_TAG] == RunFailureReason.UNEXPECTED_TERMINATION.value
+    else:
+        assert run.status == DagsterRunStatus.STARTING
+
+
 def test_monitor_canceling(instance: DagsterInstance, logger: Logger):
     run = create_run_for_test(
         instance,


### PR DESCRIPTION
## Summary & Motivation
We have quite high `startTimeoutSeconds: 1800` (because AKS takes up to 15+ minutes to scale very high memory node pool up).
We also have time critical jobs, that should start ASAP and which run on much smaller nodes.
Sometimes pod fails in Kubernetes while scheduling and Dagster finds out about it only 30min later -> retry detection takes a long time.
As `startTimeoutSeconds` is set globally, we don't have any option to significantly decrease it while not prematurely failing runs on nodes that are being scaled up.
This feature adds check on STARTING runs to detect unexpectedly FAILED pods fast.

UNKNOWN (job not yet visible) and RUNNING (pod still scheduling) fall through to the existing timeout backstop to avoid false-positives on runs whose pods are still being created. A run-status recheck guards against clobbering a run that legitimately transitioned out of STARTING while the health check was in flight, mirroring monitor_started_run.

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
