### PR TITLE
[core] Fix `AssetCheckKey.from_user_string` for asset keys containing colons

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_key.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_key.py
@@ -230,7 +230,11 @@ class AssetCheckKey(NamedTuple):
 
     @staticmethod
     def from_user_string(user_string: str) -> "AssetCheckKey":
-        asset_key_str, name = user_string.split(":")
+        # to_user_string() appends ":<name>" to the asset key's user string, and asset keys
+        # can themselves contain colons (e.g. dagster-looker emits keys like
+        # ["my_model::my_explore"]). Split off only the final segment so the asset key portion
+        # is preserved.
+        asset_key_str, name = user_string.rsplit(":", 1)
         return AssetCheckKey(AssetKey.from_user_string(asset_key_str), name)
 
     @staticmethod

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_entity_key.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_entity_key.py
@@ -50,6 +50,22 @@ def test_asset_job_key_user_string_roundtrip() -> None:
     assert AssetJobKey.from_user_string("my_job") == key
 
 
+@pytest.mark.parametrize(
+    "check_key",
+    [
+        dg.AssetCheckKey(dg.AssetKey("a"), "b"),
+        dg.AssetCheckKey(dg.AssetKey(["prefix", "asset1"]), "freshness_check"),
+        # Asset keys can contain colons. For example the dagster-looker integration emits
+        # keys such as AssetKey(["my_model::my_explore"]). The check name is a plain
+        # identifier, so the trailing ":<name>" segment is unambiguous.
+        dg.AssetCheckKey(dg.AssetKey(["my_model::my_explore"]), "freshness_check"),
+        dg.AssetCheckKey(dg.AssetKey(["snowflake", "db:schema:table"]), "row_count"),
+    ],
+)
+def test_asset_check_key_user_string_roundtrip(check_key: AssetCheckKey) -> None:
+    assert AssetCheckKey.from_user_string(check_key.to_user_string()) == check_key
+
+
 def test_asset_job_key_from_db_string_returns_none_for_non_matching() -> None:
     assert AssetJobKey.from_db_string('["a"]') is None
     assert AssetJobKey.from_db_string('{"asset_key": "[\\"a\\"]", "check_name": "b"}') is None


### PR DESCRIPTION

## Summary & Motivation

`AssetCheckKey.to_user_string()` renders a check key as `<asset_key>:<check_name>`, but `from_user_string()` parses it back with `user_string.split(":")` and unpacks the result into exactly two values. Asset keys can contain colons — the `dagster-looker` integration, for example, emits keys such as `AssetKey(["my_model::my_explore"])` — so parsing a check key on such an asset raises:

```
ValueError: too many values to unpack (expected 2)
```

This is reachable through the freshness-check sensor created by `build_sensor_for_freshness_checks`. The sensor stores the check key it left off at via `to_user_string()` as its cursor and reads it back with `from_user_string()` on the following tick. When the persisted cursor is a check on an asset whose key contains a colon, every subsequent tick fails while parsing the cursor.

`to_user_string()` always appends a single `:<name>` suffix, and check names are plain identifiers, so the final colon-delimited segment is unambiguously the check name. Parsing with `rsplit(":", 1)` recovers the asset key portion intact and leaves colon-free keys parsed exactly as before. The database-string form (`to_db_string`/`from_db_string`), which already round-trips colon-containing keys via JSON, is unchanged; this only aligns the user-string form with it.

## Test Plan

Added a parametrized round-trip test in `dagster_tests/definitions_tests/test_entity_key.py` covering a plain key, a multi-component key, a Looker-style `::` key, and a multi-component key whose component contains colons. The two colon cases fail on the current implementation with `ValueError: too many values to unpack (expected 2)` and pass after the change.

- `test_entity_key.py` — 15 passed.
- `dagster_tests/definitions_tests/freshness_checks_tests/test_sensor.py` — 9 passed; `test_sensor_cursor_recovery` exercises the sensor cursor round-trip that this affects.
- `ruff check` and `ruff format --check` pass on the changed files.

## Changelog

Fixed a `ValueError` raised when an asset check key whose asset key contains a colon (such as keys emitted by the `dagster-looker` integration) is round-tripped through `AssetCheckKey.to_user_string()` / `from_user_string()`, which could stall freshness-check sensors on their stored cursor.
