### PR TITLE
Fix celery docker env var parsing

### DIFF
--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py
@@ -16,6 +16,7 @@ from dagster._cli.api import ExecuteStepArgs
 from dagster._core.events import EngineEventData
 from dagster._core.events.utils import filter_dagster_events_from_cli_logs
 from dagster._core.execution.retries import RetryMode
+from dagster._core.utils import parse_env_var
 from dagster._serdes import pack_value, serialize_value, unpack_value
 from dagster._utils.merger import merge_dicts
 from dagster_celery.config import DEFAULT_CONFIG, dict_wrapper
@@ -292,7 +293,7 @@ def create_docker_task(celery_app, **task_kwargs):
                 docker_env.update(e_vars)
             else:
                 for v in e_vars:  # ty: ignore[not-iterable]
-                    key, val = v.split("=")
+                    key, val = parse_env_var(v)
                     docker_env[key] = val
             del container_kwargs["environment"]
 

--- a/python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_executor.py
+++ b/python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_executor.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+import dagster_celery_docker.executor as celery_docker_executor
+
+
+def test_container_kwargs_environment_values_can_contain_equals(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        celery_docker_executor,
+        "unpack_value",
+        lambda _packed, as_type: SimpleNamespace(
+            instance_ref="ref",
+            run_id="run-id",
+            step_keys_to_execute=["step"],
+            get_command_args=lambda: ["dagster", "api", "execute_step"],
+        ),
+    )
+    monkeypatch.setattr(celery_docker_executor, "serialize_value", lambda value: value)
+    monkeypatch.setattr(celery_docker_executor, "filter_dagster_events_from_cli_logs", lambda _: [])
+    monkeypatch.setattr(
+        celery_docker_executor,
+        "DagsterInstance",
+        SimpleNamespace(
+            from_ref=lambda _ref: SimpleNamespace(
+                get_run_by_id=lambda _run_id: SimpleNamespace(),
+                report_engine_event=lambda *_args, **_kwargs: "engine-event",
+            )
+        ),
+    )
+
+    def fake_run(*_args, **kwargs):
+        captured["environment"] = kwargs["environment"]
+        return b""
+
+    monkeypatch.setattr(
+        celery_docker_executor.docker.client,
+        "from_env",
+        lambda: SimpleNamespace(containers=SimpleNamespace(run=fake_run)),
+    )
+
+    class FakeCeleryApp:
+        def task(self, **_kwargs):
+            return lambda fn: fn
+
+    task = celery_docker_executor.create_docker_task(FakeCeleryApp())
+    task(
+        SimpleNamespace(request=SimpleNamespace(hostname="worker")),
+        {},
+        {"image": "busybox", "container_kwargs": {"environment": ["TOKEN=a=b"]}},
+    )
+
+    assert captured["environment"]["TOKEN"] == "a=b"


### PR DESCRIPTION
## Summary & Motivation

Fixes #34006.

`dagster-celery-docker` manually split list-form `container_kwargs.environment` entries on every `=`, so valid values like `TOKEN=a=b` crashed with `ValueError: too many values to unpack`. This reuses Dagster's existing `parse_env_var()` helper so only the first `=` separates the key from the value.

## Test Plan

- `UV_CACHE_DIR=/tmp/uv-cache uv run --frozen --project python_modules/libraries/dagster-celery-docker --group test pytest python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_executor.py -q` — passed, `1 passed in 0.06s`
- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx ruff==0.15.15 check python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_executor.py` — passed
- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx ruff==0.15.15 format --check python_modules/libraries/dagster-celery-docker/dagster_celery_docker/executor.py python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests/test_executor.py` — passed, `2 files already formatted`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --frozen --project python_modules/libraries/dagster-celery-docker --group test pytest python_modules/libraries/dagster-celery-docker/dagster_celery_docker_tests -q` — attempted; local run reached `3 passed, 2 errors`, with both errors in Docker Compose fixture setup because the `docker` executable is unavailable locally (`FileNotFoundError: [Errno 2] No such file or directory: 'docker'`)

## Changelog

Fixed `dagster-celery-docker` handling of list-form Docker environment values that contain additional equals signs.