### PR TITLE
fix(aws): resolve EcsRunLauncher task definition at launch time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 1.13.15 (core) / 0.29.15 (libraries)
-
-### Bugfixes
-
-- [dagster-aws] Fixed an issue where `EcsRunLauncher` configured with a task definition family (or family ARN without revision) would pin to the revision resolved at daemon startup. It now resolves to the latest active revision at run launch time. (Fixes [#17607](https://github.com/dagster-io/dagster/issues/17607))
-
 ## 1.13.14 (core) / 0.29.14 (libraries)
 
 ### Bugfixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.13.15 (core) / 0.29.15 (libraries)
+
+### Bugfixes
+
+- [dagster-aws] Fixed an issue where `EcsRunLauncher` configured with a task definition family (or family ARN without revision) would pin to the revision resolved at daemon startup. It now resolves to the latest active revision at run launch time. (Fixes [#17607](https://github.com/dagster-io/dagster/issues/17607))
+
 ## 1.13.14 (core) / 0.29.14 (libraries)
 
 ### Bugfixes

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/container_context.py
@@ -348,7 +348,8 @@ class EcsContainerContext(
                     secrets=run_launcher.secrets,
                     secrets_tags=run_launcher.secrets_tags,
                     env_vars=run_launcher.env_vars,
-                    task_definition_arn=run_launcher.task_definition,  # run launcher converts this from short name to ARN in constructor
+                    # Resolves family → latest active revision ARN at access time
+                    task_definition_arn=run_launcher.task_definition,
                     run_resources=run_launcher.run_resources,
                     task_role_arn=run_launcher.task_role_arn,
                     execution_role_arn=run_launcher.execution_role_arn,

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -138,10 +138,13 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
             "Task definition prefix must be no more than 16 characters",
         )
 
-        self.task_definition = None
+        # Keep the configured family name / ARN as-is. Resolve to a concrete revision ARN
+        # via the task_definition property at access time so family configs pick up the
+        # latest active revision without restarting the daemon.
+        self._task_definition_identifier = None
         self.task_definition_dict = {}
         if isinstance(task_definition, str):
-            self.task_definition = task_definition
+            self._task_definition_identifier = task_definition
         elif task_definition and "env" in task_definition:
             check.invariant(
                 len(task_definition) == 1,
@@ -149,8 +152,8 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
                 " key.",
             )
             env_var = task_definition["env"]
-            self.task_definition = os.getenv(env_var)
-            if not self.task_definition:
+            self._task_definition_identifier = os.getenv(env_var)
+            if not self._task_definition_identifier:
                 raise Exception(
                     f"You have attempted to fetch the environment variable {env_var} which is not"
                     " set."
@@ -181,18 +184,19 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         self.secrets_tags = [secrets_tag] if secrets_tag else []
         self.include_sidecars = include_sidecars
 
-        if self.task_definition:
-            task_definition = self.ecs.describe_task_definition(taskDefinition=self.task_definition)
+        if self._task_definition_identifier:
+            described_task_definition = self.ecs.describe_task_definition(
+                taskDefinition=self._task_definition_identifier
+            )
             container_names = [
                 container.get("name")
-                for container in task_definition["taskDefinition"]["containerDefinitions"]
+                for container in described_task_definition["taskDefinition"]["containerDefinitions"]
             ]
             check.invariant(
                 container_name in container_names,
                 f"Cannot override container '{container_name}' in task definition "
-                f"'{self.task_definition}' because the container is not defined.",
+                f"'{self._task_definition_identifier}' because the container is not defined.",
             )
-            self.task_definition = task_definition["taskDefinition"]["taskDefinitionArn"]
 
         self.use_current_ecs_task_config = check.opt_bool_param(
             use_current_ecs_task_config, "use_current_ecs_task_config"
@@ -249,6 +253,20 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
     @property
     def inst_data(self):
         return self._inst_data
+
+    @property
+    def task_definition(self) -> str | None:
+        """Resolved task definition ARN for the configured identifier.
+
+        When configured with a family name or family ARN (no revision), this returns the
+        ARN of the latest active revision at access time. When configured with a
+        revision-pinned ARN, that exact revision is returned.
+        """
+        if not self._task_definition_identifier:
+            return None
+        return self.ecs.describe_task_definition(taskDefinition=self._task_definition_identifier)[
+            "taskDefinition"
+        ]["taskDefinitionArn"]
 
     @property
     def task_role_arn(self) -> str | None:

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -185,6 +185,10 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         self.include_sidecars = include_sidecars
 
         if self._task_definition_identifier:
+            # Validate the container name against the current latest revision at startup.
+            # Note: this describe call is intentionally separate from the task_definition
+            # property; the property re-fetches at launch time to pick up newer revisions,
+            # so the ARN resolved here is not stored.
             described_task_definition = self.ecs.describe_task_definition(
                 taskDefinition=self._task_definition_identifier
             )
@@ -261,6 +265,10 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         When configured with a family name or family ARN (no revision), this returns the
         ARN of the latest active revision at access time. When configured with a
         revision-pinned ARN, that exact revision is returned.
+
+        Container-name fail-fast validation runs once at launcher startup against the
+        then-latest revision. Later revisions that remove or rename that container are
+        not re-checked here; ECS will reject the RunTask call instead.
         """
         if not self._task_definition_identifier:
             return None

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -951,6 +951,84 @@ def test_launching_custom_task_definition(ecs, instance_cm, run, workspace, job,
         assert run.run_id in str(override["command"])
 
 
+def test_launching_picks_latest_task_definition_revision(
+    ecs, instance_cm, workspace, job, remote_job
+):
+    """Family configs resolve to the latest active revision at each launch, without recreating
+    the launcher. Revision-pinned ARNs keep launching that exact revision.
+    """
+    container_name = "override_container"
+
+    revision_1 = ecs.register_task_definition(
+        family="override",
+        containerDefinitions=[{"name": container_name, "image": "hello:v1"}],
+        networkMode="bridge",
+        memory="512",
+        cpu="256",
+    )["taskDefinition"]
+    revision_1_arn = revision_1["taskDefinitionArn"]
+
+    with instance_cm({"task_definition": "override", "container_name": container_name}) as instance:
+        assert instance.run_launcher.task_definition == revision_1_arn
+
+        run_1 = instance.create_run_for_job(
+            job,
+            remote_job_origin=remote_job.get_remote_origin(),
+            job_code_origin=remote_job.get_python_origin(),
+        )
+        initial_tasks = ecs.list_tasks()["taskArns"]
+        instance.launch_run(run_1.run_id, workspace)
+
+        tasks = ecs.list_tasks()["taskArns"]
+        task_arn = next(iter(set(tasks).difference(initial_tasks)))
+        task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
+        assert task["taskDefinitionArn"] == revision_1_arn
+
+        # Register a new revision of the same family while the launcher stays alive
+        revision_2 = ecs.register_task_definition(
+            family="override",
+            containerDefinitions=[{"name": container_name, "image": "hello:v2"}],
+            networkMode="bridge",
+            memory="512",
+            cpu="256",
+        )["taskDefinition"]
+        revision_2_arn = revision_2["taskDefinitionArn"]
+        assert revision_2_arn != revision_1_arn
+        assert instance.run_launcher.task_definition == revision_2_arn
+
+        run_2 = instance.create_run_for_job(
+            job,
+            remote_job_origin=remote_job.get_remote_origin(),
+            job_code_origin=remote_job.get_python_origin(),
+        )
+        tasks_before_second_launch = ecs.list_tasks()["taskArns"]
+        instance.launch_run(run_2.run_id, workspace)
+
+        tasks = ecs.list_tasks()["taskArns"]
+        task_arn = next(iter(set(tasks).difference(tasks_before_second_launch)))
+        task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
+        assert task["taskDefinitionArn"] == revision_2_arn
+
+    # A revision-pinned ARN keeps launching that exact revision even after a newer one exists
+    with instance_cm(
+        {"task_definition": revision_1_arn, "container_name": container_name}
+    ) as instance:
+        assert instance.run_launcher.task_definition == revision_1_arn
+
+        run_3 = instance.create_run_for_job(
+            job,
+            remote_job_origin=remote_job.get_remote_origin(),
+            job_code_origin=remote_job.get_python_origin(),
+        )
+        tasks_before_pinned_launch = ecs.list_tasks()["taskArns"]
+        instance.launch_run(run_3.run_id, workspace)
+
+        tasks = ecs.list_tasks()["taskArns"]
+        task_arn = next(iter(set(tasks).difference(tasks_before_pinned_launch)))
+        task = ecs.describe_tasks(tasks=[task_arn])["tasks"][0]
+        assert task["taskDefinitionArn"] == revision_1_arn
+
+
 def test_eventual_consistency(ecs, instance, workspace, run, monkeypatch):
     initial_tasks = ecs.list_tasks()["taskArns"]
 


### PR DESCRIPTION
## Summary

- Fixes [#17607](https://github.com/dagster-io/dagster/issues/17607): when `EcsRunLauncher` is configured with a **task definition family** (or family ARN without revision), each run now uses the **latest active revision** at launch time — without restarting the daemon/webserver.
- The configured identifier is stored as-is; `task_definition` is a property that re-describes via the ECS API on access. Fail-fast container-name validation in `__init__` is unchanged.
- Revision-pinned ARNs still resolve to that exact revision (no accidental “always latest” when pinned).

## Before / after

| Config | Before | After |
| --- | --- | --- |
| Family name / family ARN | Pinned to revision seen at launcher `__init__` | Latest active revision at each access/launch |
| Revision-pinned ARN | That exact revision | That exact revision (unchanged) |

## Changelog (please add on merge)

```
- [dagster-aws] Fixed an issue where `EcsRunLauncher` configured with a task definition family (or family ARN without revision) would pin to the revision resolved at daemon startup. It now resolves to the latest active revision at run launch time. (Fixes #17607)
```

(Not included in this PR: editing `CHANGES.md` from a fork triggers Deploy Docs, which fails without Vercel secrets.)

## Test plan

- [x] `pytest …/test_launching.py …/test_instance.py -k "custom_task_definition or picks_latest or task_definition_config"`
- [x] New regression test: family → rev1 launch, register rev2 without recreating launcher, second launch uses rev2; pinned ARN still uses rev1 after rev2 exists