### PR TITLE
[core] Fix is_valid_email rejecting valid emails with long TLDs

### DIFF
--- a/python_modules/dagster/dagster/_core/utils.py
+++ b/python_modules/dagster/dagster/_core/utils.py
@@ -169,7 +169,7 @@ class InheritContextThreadPoolExecutor(FuturesAwareThreadPoolExecutor):
 
 
 def is_valid_email(email: str) -> bool:
-    regex = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b"
+    regex = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"
     return bool(re.fullmatch(regex, email))
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2183,6 +2183,17 @@ def test_asset_owners():
     assert asset3.specs_by_key[asset3.key].owners == []
 
 
+def test_asset_owner_email_with_long_tld():
+    # TLDs longer than a handful of characters (e.g. ".software", ".international") are valid
+    owners = ["devs@example.software", "jane.doe@acme.international"]
+
+    @dg.asset(owners=owners)
+    def my_asset():
+        pass
+
+    assert my_asset.specs_by_key[my_asset.key].owners == owners
+
+
 def test_invalid_asset_owners():
     with pytest.raises(
         dg.DagsterInvalidDefinitionError,

--- a/python_modules/dagster/dagster_tests/core_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_utils.py
@@ -4,7 +4,7 @@ from contextvars import ContextVar
 
 import pytest
 from dagster._core.test_utils import environ
-from dagster._core.utils import InheritContextThreadPoolExecutor, parse_env_var
+from dagster._core.utils import InheritContextThreadPoolExecutor, is_valid_email, parse_env_var
 from dagster._utils.merger import merge_dicts
 
 
@@ -87,3 +87,39 @@ def test_merge():
     assert merge_dicts({}, {}, {}) == {}
     assert merge_dicts({1: 2}, {2: 3}, {3: 4}) == {1: 2, 2: 3, 3: 4}
     assert merge_dicts({1: 2}, {1: 3}, {1: 4}) == {1: 4}
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "user@example.com",
+        "user@example.io",
+        "first.last@sub.example.co.uk",
+        "user+tag@example.org",
+        # TLDs longer than 7 characters are valid and must be accepted
+        "user@example.software",
+        "user@example.solutions",
+        "jane.doe@acme.international",
+        "user@example.technology",
+    ],
+)
+def test_is_valid_email_accepts_valid_addresses(email):
+    assert is_valid_email(email)
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "not an email",
+        "notvalid",
+        "notanemail@com",
+        "user@example",
+        "user@.com",
+        "@example.com",
+        "user@example.c",
+        # a pipe is not a valid TLD character
+        "user@example.a|b",
+    ],
+)
+def test_is_valid_email_rejects_invalid_addresses(email):
+    assert not is_valid_email(email)


### PR DESCRIPTION
The owner-validation email regex capped the TLD at 7 characters and had a stray `|` in its character class (`[A-Z|a-z]{2,7}`), so valid owner emails like `user@example.software` or `jane.doe@acme.international` were rejected with a `DagsterInvalidDefinitionError` — and a literal `|` was wrongly accepted as a TLD character.

`is_valid_email` feeds `is_valid_owner` → `validate_asset_owner` / `validate_definition_owner` / `validate_component_owner`, so this fires at definition time for any asset, `AssetSpec`, job, schedule, or sensor with a long-TLD owner email:

```python
@dg.asset(owners=["jane.doe@acme.software"])   # -> DagsterInvalidDefinitionError
```

This allows TLDs of any length and drops the erroneous pipe (`[A-Za-z]{2,}`), with unit tests (valid long-TLD addresses + malformed inputs incl. the pipe) and an end-to-end `@dg.asset(owners=[...])` acceptance test.
