### PR TITLE
[helm] Support a name-keyed map for dagster-user-deployments.deployments

### DIFF
--- a/docs/docs/deployment/oss/deployment-options/kubernetes/customizing-your-deployment.md
+++ b/docs/docs/deployment/oss/deployment-options/kubernetes/customizing-your-deployment.md
@@ -229,6 +229,26 @@ global:
 generatePostgresqlPasswordSecret: false
 ```
 
+## Defining user code deployments as a map
+
+The `dagster-user-deployments.deployments` value accepts either a list (the default) or a map keyed by deployment name:
+
+```yaml
+dagster-user-deployments:
+  deployments:
+    k8s-example-user-code-1:
+      image:
+        repository: 'docker.io/dagster/user-code-example'
+        tag: ~
+        pullPolicy: Always
+      dagsterApiGrpcArgs:
+        - '--python-file'
+        - '/example_project/example_repo/repo.py'
+      port: 3030
+```
+
+The map form is useful when you layer values files — for example a base file plus a per-environment override. Helm merges maps by key but replaces lists wholesale, so with the map form an override file can change a single field of a single deployment instead of restating the entire list. When the map form is used, the map key is the deployment name and the per-entry `name` field is optional. Note that Helm renders map keys in alphabetical order, so deployments are always emitted in sorted key order rather than declaration order.
+
 ## Security
 
 Users will likely want to permission a ServiceAccount bound to a properly scoped Role to launch Jobs and create other Kubernetes resources.

--- a/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-user.yaml
@@ -1,4 +1,4 @@
-{{ range $deployment := .Values.deployments }}
+{{ range $deployment := (include "dagsterUserDeployments.deploymentsList" .Values.deployments | fromYamlArray) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -1,5 +1,5 @@
 {{- $celeryConfigSecretName := .Values.global.celeryConfigSecretName | default .Values.celeryConfigSecretName }}
-{{ range $deployment := .Values.deployments }}
+{{ range $deployment := (include "dagsterUserDeployments.deploymentsList" .Values.deployments | fromYamlArray) }}
 {{- $userDeploymentChecksum := $deployment | toJson | sha256sum }}
 {{- if and $deployment.codeServerArgs (gt (int ($deployment.replicaCount | default 1)) 1) }}
 {{- fail (printf "deployment %q: codeServerArgs cannot be used with replicaCount > 1. A reloadable code server cannot be reloaded consistently across multiple replicas behind a round-robin service." $deployment.name) }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -7,6 +7,34 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Normalize the user-code deployments value into a list.
+Accepts either a list of deployment entries or a map keyed by deployment name.
+For the map form, the key becomes each entry's `name` (the key wins over any `name` field).
+Emits YAML that call sites parse with `fromYamlArray`.
+
+NOTE: this helper is intentionally duplicated verbatim in
+  helm/dagster/templates/helpers/_helpers.tpl
+so it is available whether the subchart is rendered under the umbrella chart or
+standalone. Keep both copies in sync when making changes.
+*/}}
+{{- define "dagsterUserDeployments.deploymentsList" -}}
+{{- $deployments := . -}}
+{{- if kindIs "map" $deployments -}}
+{{- $list := list -}}
+{{- range $name, $deployment := $deployments -}}
+{{- $entry := merge (dict "name" $name) (deepCopy $deployment) -}}
+{{- $list = append $list $entry -}}
+{{- end -}}
+{{- $list | toYaml -}}
+{{- else -}}
+{{- range $deployment := (default (list) $deployments) -}}
+{{- if not $deployment.name }}{{ fail "each user deployment must set 'name' (or be provided as a name-keyed map)" }}{{- end }}
+{{- end -}}
+{{- (default (list) $deployments) | toYaml -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/helm/dagster/charts/dagster-user-deployments/templates/service-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/service-user.yaml
@@ -1,4 +1,4 @@
-{{ range $deployment := .Values.deployments }}
+{{ range $deployment := (include "dagsterUserDeployments.deploymentsList" .Values.deployments | fromYamlArray) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -309,8 +309,16 @@
         "UserDeployment": {
             "properties": {
                 "name": {
-                    "title": "Name",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Name"
                 },
                 "image": {
                     "$ref": "#/$defs/Image"
@@ -646,7 +654,6 @@
                 }
             },
             "required": [
-                "name",
                 "image",
                 "port"
             ],
@@ -700,11 +707,30 @@
             "type": "boolean"
         },
         "deployments": {
-            "items": {
-                "$ref": "#/$defs/UserDeployment"
-            },
-            "title": "Deployments",
-            "type": "array"
+            "anyOf": [
+                {
+                    "items": {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/UserDeployment"
+                            },
+                            {
+                                "required": [
+                                    "name"
+                                ]
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/UserDeployment"
+                    },
+                    "type": "object"
+                }
+            ],
+            "title": "Deployments"
         },
         "imagePullSecrets": {
             "items": {

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -28,6 +28,25 @@ includeInstance: false
 # pipeline execution use the same image, we recommend using a unique tag (ie not "latest").
 #
 # All user code will be invoked within the images.
+#
+# "deployments" may be provided either as a list (shown below) or as a map keyed by
+# deployment name. The map form lets layered values files (e.g. a base file plus a
+# per-environment override) deep-merge by key instead of replacing the whole list, so
+# an override can change a single field of a single deployment. When the map form is
+# used, the map key is the deployment name and the per-entry "name" field is optional.
+#
+# Example map form:
+#
+# deployments:
+#   k8s-example-user-code-1:
+#     image:
+#       repository: "docker.io/dagster/user-code-example"
+#       tag: ~
+#       pullPolicy: Always
+#     dagsterApiGrpcArgs:
+#       - "-f"
+#       - "/example_project/example_repo/repo.py"
+#     port: 3030
 ####################################################################################################
 deployments:
   - name: "k8s-example-user-code-1"

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -1,6 +1,24 @@
-from pydantic import BaseModel, Field, create_model
+from typing import Annotated
+
+from pydantic import BaseModel, Field, GetJsonSchemaHandler, create_model
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema
 
 from schema.charts.utils import kubernetes
+
+
+class _RequireName:
+    """Annotation that overlays ``required: ["name"]`` onto a ``UserDeployment``'s JSON
+    schema. Applied only to the list form of ``deployments`` so that a missing ``name`` in
+    an array entry is still caught by schema validation (``helm lint``), while the map form
+    — where the map key supplies the name — leaves ``name`` optional. Reuses the shared
+    ``UserDeployment`` ``$def`` via ``allOf`` rather than duplicating it.
+    """
+
+    def __get_pydantic_json_schema__(
+        self, core_schema: CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        return {"allOf": [handler(core_schema), {"required": ["name"]}]}
 
 
 class UserDeploymentIncludeConfigInLaunchedRuns(BaseModel):
@@ -13,7 +31,9 @@ ReadinessProbeWithEnabled = create_model(
 
 
 class UserDeployment(BaseModel):
-    name: str
+    # Optional so that deployments can be supplied as a name-keyed map, where the
+    # map key provides the name. For the list form, the Helm templates require a name.
+    name: str | None = None
     image: kubernetes.Image
     dagsterApiGrpcArgs: list[str] | None = None
     codeServerArgs: list[str] | None = None
@@ -45,8 +65,13 @@ class UserDeployment(BaseModel):
     deploymentStrategy: kubernetes.DeploymentStrategy | None = None
 
 
+# `deployments` may be either a list of deployments (each requiring a `name`) or a map
+# keyed by deployment name (where the key supplies the name, so `name` is optional).
+UserDeploymentsValue = list[Annotated[UserDeployment, _RequireName()]] | dict[str, UserDeployment]
+
+
 class UserDeployments(BaseModel):
     enabled: bool
     enableSubchart: bool
     imagePullSecrets: list[kubernetes.SecretRef]
-    deployments: list[UserDeployment]
+    deployments: UserDeploymentsValue

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/values.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/values.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field
 
 from schema.charts.dagster.subschema import Global, ServiceAccount
-from schema.charts.dagster_user_deployments.subschema.user_deployments import UserDeployment
+from schema.charts.dagster_user_deployments.subschema.user_deployments import UserDeploymentsValue
 from schema.charts.utils import kubernetes
 
 
@@ -12,7 +12,7 @@ class DagsterUserDeploymentsHelmValues(BaseModel):
     postgresqlSecretName: str
     celeryConfigSecretName: str
     includeInstance: bool
-    deployments: list[UserDeployment]
+    deployments: UserDeploymentsValue
     imagePullSecrets: list[kubernetes.SecretRef]
     serviceAccount: ServiceAccount
     global_: Global = Field(..., alias="global")

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -1959,3 +1959,123 @@ def test_include_instance(subchart_template: HelmTemplate, include_instance: boo
         )
     else:
         assert "dagster-instance" not in volume_names
+
+
+@pytest.fixture(name="service_template")
+def service_helm_template() -> HelmTemplate:
+    return HelmTemplate(
+        helm_dir_path="helm/dagster",
+        subchart_paths=["charts/dagster-user-deployments"],
+        output="charts/dagster-user-deployments/templates/service-user.yaml",
+        model=models.V1Service,
+    )
+
+
+def _map_helm_values(deployments: dict[str, UserDeployment]) -> DagsterHelmValues:
+    return DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(
+            enabled=True,
+            enableSubchart=True,
+            deployments=deployments,
+        )
+    )
+
+
+def test_deployments_map_render(template: HelmTemplate):
+    # deployments provided as a name-keyed map; the key becomes each deployment's name.
+    deployments = {
+        "deployment-one": create_simple_user_deployment("deployment-one"),
+        "deployment-two": create_complex_user_deployment("deployment-two"),
+    }
+    user_deployments = template.render(_map_helm_values(deployments))
+
+    assert len(user_deployments) == len(deployments)
+
+    # Helm ranges maps in sorted-key order.
+    for user_deployment, name in zip(user_deployments, sorted(deployments)):
+        assert user_deployment.metadata.name.endswith(name)
+        assert user_deployment.metadata.labels["deployment"] == name
+        assert user_deployment.spec.template.metadata.labels["deployment"] == name
+
+
+def test_deployments_map_matches_list(template: HelmTemplate):
+    # The same deployment expressed as a single-entry list vs a single-entry map should
+    # render an identical Deployment (including the config checksum annotation).
+    list_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(
+            enabled=True,
+            enableSubchart=True,
+            deployments=[create_complex_user_deployment("deployment-one")],
+        )
+    )
+    map_values = _map_helm_values(
+        {"deployment-one": create_complex_user_deployment("deployment-one")}
+    )
+
+    [from_list] = template.render(list_values)
+    [from_map] = template.render(map_values)
+
+    assert template.api_client.sanitize_for_serialization(
+        from_list
+    ) == template.api_client.sanitize_for_serialization(from_map)
+
+
+def test_deployments_map_key_wins_over_name(template: HelmTemplate):
+    # When both a map key and an entry-level `name` are present, the key is authoritative.
+    deployment = create_simple_user_deployment("ignored-name")
+    user_deployments = template.render(_map_helm_values({"key-name": deployment}))
+
+    [user_deployment] = user_deployments
+    assert user_deployment.metadata.name.endswith("key-name")
+    assert user_deployment.metadata.labels["deployment"] == "key-name"
+
+
+def test_deployments_map_service(service_template: HelmTemplate):
+    deployments = {
+        "deployment-one": create_simple_user_deployment("deployment-one"),
+        "deployment-two": create_simple_user_deployment("deployment-two"),
+    }
+    services = service_template.render(_map_helm_values(deployments))
+
+    assert len(services) == len(deployments)
+    for service, name in zip(services, sorted(deployments)):
+        assert service.metadata.name == name
+        assert service.spec.selector["deployment"] == name
+
+
+def test_deployments_map_configmap_env(user_deployment_configmap_template: HelmTemplate):
+    deployment = UserDeployment(
+        image=kubernetes.Image(repository="repo/a", tag="tag1", pullPolicy="Always"),
+        dagsterApiGrpcArgs=["-m", "a"],
+        port=3030,
+        env={"FOO": "bar"},
+    )
+    configmaps = user_deployment_configmap_template.render(_map_helm_values({"code-a": deployment}))
+
+    [configmap] = configmaps
+    assert configmap.metadata.name.endswith("-code-a-user-env")
+    assert configmap.data["FOO"] == "bar"
+
+
+def test_deployments_list_missing_name_fails(template: HelmTemplate, capfd):
+    # A list entry without a name is invalid (only the map form can omit it). The schema
+    # requires `name` for the array branch, so this fails at values-validation time; the
+    # template also guards it as a backstop when schema validation is skipped.
+    nameless = UserDeployment.construct(
+        image=kubernetes.Image(repository="repo/x", tag="tag1", pullPolicy="Always"),
+        dagsterApiGrpcArgs=["-m", "x"],
+        port=3030,
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        template.render(
+            DagsterHelmValues.construct(
+                dagsterUserDeployments=UserDeployments.construct(
+                    enabled=True,
+                    enableSubchart=True,
+                    deployments=[nameless],
+                )
+            )
+        )
+
+    _, err = capfd.readouterr()
+    assert "name is required" in err

--- a/helm/dagster/schema/schema_tests/test_workspace.py
+++ b/helm/dagster/schema/schema_tests/test_workspace.py
@@ -86,6 +86,38 @@ def test_workspace_renders_from_helm_user_deployments(template: HelmTemplate):
         assert grpc_server["grpc_server"]["location_name"] == deployment.name
 
 
+def test_workspace_renders_from_helm_user_deployments_map(template: HelmTemplate):
+    # deployments provided as a name-keyed map instead of a list; the map key is the name.
+    deployments = {
+        "deployment-one": create_simple_user_deployment("deployment-one"),
+        "deployment-two": create_simple_user_deployment("deployment-two"),
+    }
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(
+            enabled=True,
+            enableSubchart=True,
+            deployments=deployments,
+        )
+    )
+
+    workspace_templates = template.render(helm_values)
+
+    assert len(workspace_templates) == 1
+
+    workspace_template = workspace_templates[0]
+
+    workspace = yaml.full_load(workspace_template.data["workspace.yaml"])
+    grpc_servers = workspace["load_from"]
+
+    assert len(grpc_servers) == len(deployments)
+
+    # Helm ranges maps in sorted-key order.
+    for grpc_server, name in zip(grpc_servers, sorted(deployments)):
+        assert grpc_server["grpc_server"]["host"] == name
+        assert grpc_server["grpc_server"]["port"] == deployments[name].port
+        assert grpc_server["grpc_server"]["location_name"] == name
+
+
 def test_workspace_renders_from_helm_webserver(template: HelmTemplate):
     servers = [
         Server(host="another-deployment-one", port=4000, name="deployment one"),

--- a/helm/dagster/templates/configmap-workspace.yaml
+++ b/helm/dagster/templates/configmap-workspace.yaml
@@ -27,7 +27,7 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   workspace.yaml: |
-    {{- $deployments := ternary $webserverWorkspace.servers $userDeployments.deployments $webserverWorkspace.enabled }}
+    {{- $deployments := ternary $webserverWorkspace.servers (include "dagsterUserDeployments.deploymentsList" $userDeployments.deployments | fromYamlArray) $webserverWorkspace.enabled }}
     {{- if $deployments }}
     load_from:
       {{- range $deployment := $deployments }}

--- a/helm/dagster/templates/deployment-daemon.yaml
+++ b/helm/dagster/templates/deployment-daemon.yaml
@@ -65,7 +65,7 @@ spec:
             {{- toYaml .Values.dagsterDaemon.initContainerResources | nindent 12 }}
         {{- end }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
-        {{- range $deployment := $userDeployments.deployments }}
+        {{- range $deployment := (include "dagsterUserDeployments.deploymentsList" $userDeployments.deployments | fromYamlArray) }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
           image: {{ include "dagster.externalImage.name" $.Values.busybox.image | quote }}
           command: ['sh', '-c', "until nslookup {{ $deployment.name -}}; do echo waiting for user service; sleep 2; done"]

--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -65,7 +65,7 @@ spec:
           {{- end }}
         {{- end }}
         {{- if (and $userDeployments.enabled $userDeployments.enableSubchart) }}
-        {{- range $deployment := $userDeployments.deployments }}
+        {{- range $deployment := (include "dagsterUserDeployments.deploymentsList" $userDeployments.deployments | fromYamlArray) }}
         - name: "init-user-deployment-{{- $deployment.name -}}"
           image: {{ include "dagster.externalImage.name" $.Values.busybox.image | quote }}
           command: ['sh', '-c', "until nslookup {{ $deployment.name -}}; do echo waiting for user service; sleep 2; done"]

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -8,6 +8,34 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Normalize the user-code deployments value into a list.
+Accepts either a list of deployment entries or a map keyed by deployment name.
+For the map form, the key becomes each entry's `name` (the key wins over any `name` field).
+Emits YAML that call sites parse with `fromYamlArray`.
+
+NOTE: this helper is intentionally duplicated verbatim in
+  helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+so it is available whether the subchart is rendered under the umbrella chart or
+standalone. Keep both copies in sync when making changes.
+*/}}
+{{- define "dagsterUserDeployments.deploymentsList" -}}
+{{- $deployments := . -}}
+{{- if kindIs "map" $deployments -}}
+{{- $list := list -}}
+{{- range $name, $deployment := $deployments -}}
+{{- $entry := merge (dict "name" $name) (deepCopy $deployment) -}}
+{{- $list = append $list $entry -}}
+{{- end -}}
+{{- $list | toYaml -}}
+{{- else -}}
+{{- range $deployment := (default (list) $deployments) -}}
+{{- if not $deployment.name }}{{ fail "each user deployment must set 'name' (or be provided as a name-keyed map)" }}{{- end }}
+{{- end -}}
+{{- (default (list) $deployments) | toYaml -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -3102,8 +3102,16 @@
         "UserDeployment": {
             "properties": {
                 "name": {
-                    "title": "Name",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Name"
                 },
                 "image": {
                     "$ref": "#/$defs/Image"
@@ -3439,7 +3447,6 @@
                 }
             },
             "required": [
-                "name",
                 "image",
                 "port"
             ],
@@ -3477,11 +3484,30 @@
                     "type": "array"
                 },
                 "deployments": {
-                    "items": {
-                        "$ref": "#/$defs/UserDeployment"
-                    },
-                    "title": "Deployments",
-                    "type": "array"
+                    "anyOf": [
+                        {
+                            "items": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/$defs/UserDeployment"
+                                    },
+                                    {
+                                        "required": [
+                                            "name"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "additionalProperties": {
+                                "$ref": "#/$defs/UserDeployment"
+                            },
+                            "type": "object"
+                        }
+                    ],
+                    "title": "Deployments"
                 }
             },
             "required": [

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -334,7 +334,24 @@ dagster-user-deployments:
   # https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
   imagePullSecrets: []
 
-  # List of unique deployments
+  # List of unique deployments.
+  #
+  # "deployments" may also be provided as a map keyed by deployment name instead of a
+  # list. The map form lets layered values files (e.g. a base file plus a per-environment
+  # override) deep-merge by key rather than replacing the whole list, so an override can
+  # change a single field of a single deployment. When the map form is used, the map key
+  # is the deployment name and the per-entry "name" field is optional. Example:
+  #
+  # deployments:
+  #   k8s-example-user-code-1:
+  #     image:
+  #       repository: "docker.io/dagster/user-code-example"
+  #       tag: ~
+  #       pullPolicy: Always
+  #     dagsterApiGrpcArgs:
+  #       - "--python-file"
+  #       - "/example_project/example_repo/repo.py"
+  #     port: 3030
   deployments:
     - name: "k8s-example-user-code-1"
       image:


### PR DESCRIPTION
## Summary & Motivation

The Dagster Helm chart only accepts `dagster-user-deployments.deployments` as a **YAML array**. Helm merges arrays by *replacement*, not by key, so a base `values.yaml` plus per-environment overlays force you to duplicate every deployment entry in full for each environment.

This PR makes `deployments` accept **either** the existing array **or** a **map keyed by deployment name**. The map form lets Helm deep-merge overlays by key — so an override file (e.g. a per-environment layer, as used with an ArgoCD `ApplicationSet`) can change a single field of a single deployment instead of restating the whole list. Existing array users are unaffected.

### How it works

- A new template helper `dagsterUserDeployments.deploymentsList` normalizes the value (list **or** map) into a canonical list. When a map is used, the **map key becomes the deployment name** (the per-entry `name` is then optional; the key wins if both are present).
- Every existing `range` over deployments is routed through the helper — the three subchart templates (`deployment-user`, `service-user`, `configmap-env-user`) and the parent chart's `configmap-workspace`, `deployment-daemon` init containers, and webserver init containers.
- The helper is defined identically in both the umbrella and subchart `_helpers.tpl` (mirroring how `dagster.fullname`/`dagster.labels` are already shared), so it's available whether the subchart is rendered via the umbrella or standalone — the subchart is conditional (`condition: dagster-user-deployments.enableSubchart`), so a helper defined only there would be unavailable to the parent when the subchart is disabled, and the parent's helpers are unavailable when the subchart is rendered on its own.
- Because the array path passes straight through the helper, **array-form output is byte-for-byte identical** to before this change.

### Example

```yaml
dagster-user-deployments:
  deployments:
    k8s-example-user-code-1:
      image:
        repository: "docker.io/dagster/user-code-example"
        pullPolicy: Always
      dagsterApiGrpcArgs: ["--python-file", "/example_project/example_repo/repo.py"]
      port: 3030
```

### Schema

`UserDeployments.deployments` and `DagsterUserDeploymentsHelmValues.deployments` become `list[UserDeployment] | dict[str, UserDeployment]`, and `UserDeployment.name` becomes optional (the map key supplies it; the templates `fail` if a **list** entry omits `name`). Both `values.schema.json` files were regenerated with `dagster-helm schema apply` — the `deployments` property now renders as an `anyOf` of array/object.

## Test Plan

- `helm lint helm/dagster --with-subcharts --strict` — 0 failures.
- Rendered the **map** form end-to-end and confirmed names derive from keys: Deployments `dagster-<key>`, Services `<key>`, workspace `load_from` with `location_name=<key>`, and daemon/webserver init containers `init-user-deployment-<key>`.
- Confirmed the **array** form renders byte-for-byte identically to `master`.
- Confirmed `dagster-helm schema apply` is idempotent (CI's `git diff --exit-code` gate passes).
- New pytest coverage in `test_user_deployments.py` and `test_workspace.py`: map rendering, deployment/service/configmap/workspace/daemon naming from keys, array↔map equivalence (including the config checksum annotation), key-wins-over-`name`, and a guard that a list entry without `name` fails.
- Full schema suite: **279 passed**. `ruff` check + format clean.

## Changelog

The Helm chart's `dagster-user-deployments.deployments` value now also accepts a map keyed by deployment name (in addition to a list), making it easier to override individual deployments across layered values files.
