### PR TITLE
test: cover event log has_table connection lifetime

### DIFF
--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -360,7 +360,8 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     yield conn
 
     def has_table(self, table_name: str) -> bool:
-        return bool(self._engine.dialect.has_table(self._engine.connect(), table_name))
+        with self._engine.connect() as connection:
+            return bool(self._engine.dialect.has_table(connection, table_name))
 
     def has_secondary_index(self, name: str) -> bool:
         if name not in self._secondary_index_cache:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -360,8 +360,8 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     yield conn
 
     def has_table(self, table_name: str) -> bool:
-        with self._engine.connect() as connection:
-            return bool(self._engine.dialect.has_table(connection, table_name))
+        with self._connect() as conn:
+            return bool(self._engine.dialect.has_table(conn, table_name))
 
     def has_secondary_index(self, name: str) -> bool:
         if name not in self._secondary_index_cache:

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -1,6 +1,7 @@
 import gc
 import time
 from contextlib import contextmanager
+from unittest.mock import patch
 
 import objgraph
 import pytest
@@ -20,6 +21,7 @@ from dagster._core.utils import make_new_run_id
 from dagster_postgres.event_log import PostgresEventLogStorage
 from dagster_shared.yaml_utils import safe_load_yaml
 from sqlalchemy import create_engine
+from sqlalchemy.engine import Connection
 from sqlalchemy.pool import QueuePool
 
 ensure_dagster_tests_import()
@@ -160,23 +162,29 @@ def test_has_table_returns_connection_to_pool() -> None:
         poolclass=QueuePool,
         pool_size=1,
         max_overflow=0,
-        pool_timeout=0.01,
+        pool_timeout=0.1,
     )
     pool = engine.pool
     assert isinstance(pool, QueuePool)
     storage = object.__new__(PostgresEventLogStorage)
     storage._engine = engine  # noqa: SLF001
+    # Keep each Connection alive so the test fails unless has_table explicitly closes it.
+    retained_connections: list[Connection] = []
+    engine_connect = engine.connect
 
-    gc_was_enabled = gc.isenabled()
-    gc.disable()
+    def connect_and_retain() -> Connection:
+        connection = engine_connect()
+        retained_connections.append(connection)
+        return connection
+
     try:
-        for _ in range(2):
-            assert not storage.has_table("event_logs")
-            assert pool.checkedout() == 0
+        with patch.object(engine, "connect", side_effect=connect_and_retain):
+            for _ in range(2):
+                assert not storage.has_table("event_logs")
+                assert pool.checkedout() == 0
     finally:
-        if gc_was_enabled:
-            gc.enable()
-        gc.collect()
+        for connection in retained_connections:
+            connection.close()
         engine.dispose()
 
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -19,6 +19,8 @@ from dagster._core.test_utils import ensure_dagster_tests_import, instance_for_t
 from dagster._core.utils import make_new_run_id
 from dagster_postgres.event_log import PostgresEventLogStorage
 from dagster_shared.yaml_utils import safe_load_yaml
+from sqlalchemy import create_engine
+from sqlalchemy.pool import QueuePool
 
 ensure_dagster_tests_import()
 from dagster_tests.storage_tests.utils.event_log_storage import (
@@ -150,6 +152,32 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
                 from_explicit = explicit_instance._event_storage  # noqa: SLF001
 
                 assert from_url.postgres_url == from_explicit.postgres_url  # ty: ignore[unresolved-attribute]
+
+
+def test_has_table_returns_connection_to_pool() -> None:
+    engine = create_engine(
+        "sqlite://",
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.01,
+    )
+    pool = engine.pool
+    assert isinstance(pool, QueuePool)
+    storage = object.__new__(PostgresEventLogStorage)
+    storage._engine = engine  # noqa: SLF001
+
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        for _ in range(2):
+            assert not storage.has_table("event_logs")
+            assert pool.checkedout() == 0
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+        gc.collect()
+        engine.dispose()
 
 
 def test_all_asset_keys_excludes_wiped_asset_on_legacy_index_path(conn_string):

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -1,6 +1,7 @@
 import gc
 import time
 from contextlib import contextmanager
+from unittest.mock import patch
 
 import objgraph
 import pytest
@@ -19,6 +20,8 @@ from dagster._core.test_utils import ensure_dagster_tests_import, instance_for_t
 from dagster._core.utils import make_new_run_id
 from dagster_postgres.event_log import PostgresEventLogStorage
 from dagster_shared.yaml_utils import safe_load_yaml
+from sqlalchemy.engine import Connection
+from sqlalchemy.pool import QueuePool
 
 ensure_dagster_tests_import()
 from dagster_tests.storage_tests.utils.event_log_storage import (
@@ -150,6 +153,35 @@ class TestPostgresEventLogStorage(TestEventLogStorage):
                 from_explicit = explicit_instance._event_storage  # noqa: SLF001
 
                 assert from_url.postgres_url == from_explicit.postgres_url  # ty: ignore[unresolved-attribute]
+
+
+def test_has_table_returns_connection_to_pool(conn_string):
+    # Mirrors the webserver's pooling, where a connection left checked out by has_table()
+    # starves every other event log query until cyclic GC happens to reclaim it.
+    with _clean_storage(conn_string) as storage:
+        storage.optimize_for_webserver(statement_timeout=5000, pool_recycle=3600, max_overflow=0)
+        engine = storage._engine  # noqa: SLF001
+        pool = engine.pool
+        assert isinstance(pool, QueuePool)
+        assert pool.size() == 1
+
+        # Retain every Connection so refcounting cannot return one to the pool and hide a leak.
+        retained_connections: list[Connection] = []
+        engine_connect = engine.connect
+
+        def connect_and_retain() -> Connection:
+            connection = engine_connect()
+            retained_connections.append(connection)
+            return connection
+
+        try:
+            with patch.object(engine, "connect", side_effect=connect_and_retain):
+                for _ in range(2):
+                    assert storage.has_table("event_logs")
+                    assert pool.checkedout() == 0
+        finally:
+            for connection in retained_connections:
+                connection.close()
 
 
 def test_all_asset_keys_excludes_wiped_asset_on_legacy_index_path(conn_string):


### PR DESCRIPTION
## Summary & Motivation

The production fix this PR originally carried — routing `PostgresEventLogStorage.has_table()` through the context-managed `self._connect()` so its connection returns to the pool deterministically instead of at cyclic GC — landed independently in #34154. This PR has been rebased onto master and reduced to the part that is still missing: the regression test.

Nothing currently guards that fix. The test builds a real storage, configures it through `optimize_for_webserver`, and so runs against the same `pool_size=1` `QueuePool` the webserver uses — the configuration the reported incident actually ran under. It calls `has_table()` repeatedly and asserts `checkedout() == 0` after each call, retaining a reference to every `Connection` handed out so refcounting cannot quietly return one and mask a regression.

Relates to #34020 and #34153, both of which report the leak this test covers. Neither is closed by this PR — the fix itself shipped in #34154.

## Test Plan

- `test_has_table_returns_connection_to_pool` passes against master's implementation and fails against the pre-fix one, verified on PostgreSQL 14.24 with SQLAlchemy 2.0.52.
- Ran under pytest against a live Postgres, plus `ruff format` and `ruff check`.

## Changelog

NOCHANGELOG
