### PR TITLE
Route asset-group lineage edges around group boundaries

### DIFF
--- a/js_modules/ui-core/package.json
+++ b/js_modules/ui-core/package.json
@@ -8,6 +8,7 @@
     "find-dead-code": "yarn ts-prune --ignore 'types.ts|stories.ts|mocks.ts|__stories__|__fixtures__|__mocks__'",
     "jest": "jest",
     "jest-all-silent": "yarn jest --silent --watchAll=false --maxWorkers=50%",
+    "benchmark:asset-group-lineage-routing": "node --expose-gc -e \"require('ts-node').register({compilerOptions:{module:'commonjs'}}); require('./src/asset-graph/__benchmarks__/assetGroupLineageRouting.benchmark.ts')\"",
     "jest:debug": "node --inspect-brk ./node_modules/.bin/jest --runInBand --no-cache",
     "lint": "eslint src/ --fix",
     "lint:ci": "eslint src/",

--- a/js_modules/ui-core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/ui-core/src/asset-graph/AssetEdges.tsx
@@ -10,7 +10,7 @@ import {
 import {AssetLayoutDirection, AssetLayoutEdge} from './layout';
 import {useUpdatingRef} from '../hooks/useUpdatingRef';
 
-const MAX_EDGES = 200;
+export const MAX_EDGES = 200;
 
 interface AssetEdgesProps {
   edges: AssetLayoutEdge[];
@@ -21,7 +21,7 @@ interface AssetEdgesProps {
   viewportRect: {top: number; left: number; right: number; bottom: number};
 }
 
-function getEdgesToShow({
+export function getEdgesToShow({
   viewportRect,
   highlighted,
   selected,

--- a/js_modules/ui-core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/ui-core/src/asset-graph/AssetEdges.tsx
@@ -2,7 +2,11 @@ import {Colors} from '@dagster-io/ui-components';
 import {useWorker} from '@koale/useworker';
 import {Fragment, memo, useEffect, useRef, useState} from 'react';
 
-import {buildSVGPathHorizontal, buildSVGPathVertical} from './Utils';
+import {
+  buildSVGPathHorizontal,
+  buildSVGPathVertical,
+  buildSVGPathWithBoundaryCorridors,
+} from './Utils';
 import {AssetLayoutDirection, AssetLayoutEdge} from './layout';
 import {useUpdatingRef} from '../hooks/useUpdatingRef';
 
@@ -225,9 +229,19 @@ const AssetEdgeSet = memo(({edges, color, strokeWidth, direction}: AssetEdgeSetP
       <path
         key={idx}
         d={
-          (direction === 'horizontal'
-            ? buildSVGPathHorizontal({source: edge.from, target: edge.to})
-            : buildSVGPathVertical({source: edge.from, target: edge.to})) ?? undefined
+          (edge.sourceBoundary !== undefined && edge.targetBoundary !== undefined
+            ? buildSVGPathWithBoundaryCorridors(
+                {
+                  from: edge.from,
+                  to: edge.to,
+                  sourceBoundary: edge.sourceBoundary,
+                  targetBoundary: edge.targetBoundary,
+                },
+                direction,
+              )
+            : direction === 'horizontal'
+              ? buildSVGPathHorizontal({source: edge.from, target: edge.to})
+              : buildSVGPathVertical({source: edge.from, target: edge.to})) ?? undefined
         }
         stroke={color}
         strokeWidth={strokeWidth}

--- a/js_modules/ui-core/src/asset-graph/AssetEdges.tsx
+++ b/js_modules/ui-core/src/asset-graph/AssetEdges.tsx
@@ -21,12 +21,18 @@ interface AssetEdgesProps {
   viewportRect: {top: number; left: number; right: number; bottom: number};
 }
 
-export function getEdgesToShow({
-  viewportRect,
-  highlighted,
-  selected,
-  edges,
-}: Pick<AssetEdgesProps, 'viewportRect' | 'selected' | 'edges' | 'highlighted'>) {
+export function getEdgesToShow(
+  {
+    viewportRect,
+    highlighted,
+    selected,
+    edges,
+  }: Pick<AssetEdgesProps, 'viewportRect' | 'selected' | 'edges' | 'highlighted'>,
+  // Required, not defaulted: this runs as a serialized worker with no module closure, so the cap
+  // must arrive as an argument. A required parameter makes a missing cap a compile error rather
+  // than a silent runtime failure, and keeps MAX_EDGES the single source of truth at the caller.
+  maxEdges: number,
+) {
   try {
     const viewportDistance =
       Math.pow(viewportRect.right - viewportRect.left, 2) +
@@ -86,7 +92,7 @@ export function getEdgesToShow({
           doesViewportContainPoint(edge.from, viewportRect) ||
           doesViewportContainPoint(edge.to, viewportRect),
       );
-      if (visibleToFromEdges.length < MAX_EDGES) {
+      if (visibleToFromEdges.length < maxEdges) {
         return visibleToFromEdges;
       }
       const center = {
@@ -106,7 +112,7 @@ export function getEdgesToShow({
         };
       });
       edgesWithDistance.sort((a, b) => a.distance - b.distance);
-      return edgesWithDistance.slice(0, MAX_EDGES).map((item) => item.edge);
+      return edgesWithDistance.slice(0, maxEdges).map((item) => item.edge);
     })();
 
     const selectedSet = new Set(selected ?? []);
@@ -134,7 +140,7 @@ export function getEdgesToShow({
         };
       });
       edgesWithDistance.sort((a, b) => a.distance - b.distance);
-      return edgesWithDistance.slice(0, MAX_EDGES).map((item) => item.edge);
+      return edgesWithDistance.slice(0, maxEdges).map((item) => item.edge);
     })();
     return {edgesToShow, selectedOrHighlightedEdges};
   } catch (e) {
@@ -170,7 +176,9 @@ export const AssetEdges = ({
         while (needsUpdate.current) {
           needsUpdate.current = false;
           try {
-            const edgesToShow = await getEdgesToShowWorker(currentStateRef.current);
+            // The worker runs a serialized copy of getEdgesToShow with no module closure, so the
+            // edge cap must be passed as an argument rather than read from module scope.
+            const edgesToShow = await getEdgesToShowWorker(currentStateRef.current, MAX_EDGES);
             setEdges(edgesToShow);
           } catch {
             // Worker was aborted (component unmounted or deps changed) — expected, stop the loop

--- a/js_modules/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/ui-core/src/asset-graph/Utils.tsx
@@ -171,6 +171,27 @@ export const buildSVGPathVertical = pathVerticalDiagonal({
   y: (s: any) => s.y,
 });
 
+export const buildSVGPathWithBoundaryCorridors = (
+  {
+    from,
+    to,
+    sourceBoundary,
+    targetBoundary,
+  }: {
+    from: {x: number; y: number};
+    to: {x: number; y: number};
+    sourceBoundary: number;
+    targetBoundary: number;
+  },
+  direction: 'horizontal' | 'vertical',
+) => {
+  const middle = (sourceBoundary + targetBoundary) / 2;
+  if (direction === 'horizontal') {
+    return `M${from.x},${from.y}L${sourceBoundary},${from.y}C${middle},${from.y} ${middle},${to.y} ${targetBoundary},${to.y}L${to.x},${to.y}`;
+  }
+  return `M${from.x},${from.y}L${from.x},${sourceBoundary}C${from.x},${middle} ${to.x},${middle} ${to.x},${targetBoundary}L${to.x},${to.y}`;
+};
+
 export interface LiveDataForNode {
   stepKey: string;
   unstartedRunIds: string[]; // run in progress and step not started

--- a/js_modules/ui-core/src/asset-graph/__benchmarks__/assetGroupLineageRouting.benchmark.ts
+++ b/js_modules/ui-core/src/asset-graph/__benchmarks__/assetGroupLineageRouting.benchmark.ts
@@ -14,6 +14,13 @@ const WARMUP_COUNT = 3;
 const SAMPLE_COUNT = 7;
 const MAX_MEDIAN_MS = 50;
 const MAX_MEDIAN_HEAP_MB = 10;
+const CANONICAL_COMMAND =
+  'yarn node --expose-gc -r ts-node/register src/asset-graph/__benchmarks__/assetGroupLineageRouting.benchmark.ts';
+
+if (!global.gc) {
+  throw new Error(`Benchmark requires exposed garbage collection. Run: ${CANONICAL_COMMAND}`);
+}
+const forceGc = global.gc;
 
 const groupId = (index: number) => `group-${index.toString().padStart(4, '0')}`;
 const nodeId = (index: number) => `node-${index.toString().padStart(4, '0')}`;
@@ -126,7 +133,14 @@ const createDeepFixture = (): {
   };
 };
 
-const median = (values: number[]) => [...values].sort((a, b) => a - b)[3]!;
+const median = (values: number[]) => {
+  assert.ok(
+    values.length > 0 && values.length % 2 === 1,
+    'Median requires a positive odd sample count',
+  );
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)]!;
+};
 
 const normal = createNormalFixture();
 for (let index = 0; index < WARMUP_COUNT; index++) {
@@ -140,14 +154,14 @@ const retainedHeapSamples: number[] = [];
 const retainedResults: RoutingLayout[] = [];
 for (let index = 0; index < SAMPLE_COUNT; index++) {
   retainedResults.length = 0;
-  global.gc?.();
+  forceGc();
   const heapBefore = process.memoryUsage().heapUsed;
   const startedAt = performance.now();
   const result = applyAssetGroupLineageRouting(normal.layout, normal.options);
   const elapsed = performance.now() - startedAt;
   const rawHeapDelta = process.memoryUsage().heapUsed - heapBefore;
   retainedResults.push(result);
-  global.gc?.();
+  forceGc();
   const retainedHeapDelta = process.memoryUsage().heapUsed - heapBefore;
   const retainedResult = retainedResults[0];
   assert.equal(retainedResult, result);
@@ -158,6 +172,32 @@ for (let index = 0; index < SAMPLE_COUNT; index++) {
   elapsedSamples.push(elapsed);
   rawHeapSamples.push(rawHeapDelta / (1024 * 1024));
   retainedHeapSamples.push(retainedHeapDelta / (1024 * 1024));
+}
+
+const measuredResult = retainedResults[0]!;
+const firstEdge = measuredResult.edges[0]!;
+assert.deepEqual(firstEdge, {
+  fromId: nodeId(0),
+  toId: nodeId(1),
+  from: {x: 4, y: 5},
+  to: {x: 66, y: 5},
+  sourceBoundary: 5,
+  targetBoundary: 65,
+});
+const lastEdge = measuredResult.edges[EDGE_COUNT - 1]!;
+assert.deepEqual(lastEdge, {
+  fromId: nodeId(8000),
+  toId: nodeId(8002),
+  from: {x: 520_004, y: 5},
+  to: {x: 520_131, y: 5},
+  sourceBoundary: 520_005,
+  targetBoundary: 520_130,
+});
+for (const edge of [firstEdge, lastEdge]) {
+  assert.ok(edge.sourceBoundary !== undefined && edge.targetBoundary !== undefined);
+  assert.ok(edge.from.x <= edge.sourceBoundary);
+  assert.ok(edge.sourceBoundary + 60 <= edge.targetBoundary);
+  assert.ok(edge.targetBoundary <= edge.to.x);
 }
 
 const deep = createDeepFixture();

--- a/js_modules/ui-core/src/asset-graph/__benchmarks__/assetGroupLineageRouting.benchmark.ts
+++ b/js_modules/ui-core/src/asset-graph/__benchmarks__/assetGroupLineageRouting.benchmark.ts
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import {performance} from 'node:perf_hooks';
+
+import {
+  applyAssetGroupLineageRouting,
+  type ApplyAssetGroupRoutingOptions,
+  type RoutingLayout,
+} from '../assetGroupLineageRouting';
+
+const GROUP_COUNT = 9_999;
+const EDGE_COUNT = 17_999;
+const WARMUP_COUNT = 3;
+const SAMPLE_COUNT = 7;
+const MAX_MEDIAN_MS = 50;
+const MAX_MEDIAN_HEAP_MB = 10;
+
+const groupId = (index: number) => `group-${index.toString().padStart(4, '0')}`;
+const nodeId = (index: number) => `node-${index.toString().padStart(4, '0')}`;
+
+const createNormalFixture = (): {
+  layout: RoutingLayout;
+  options: ApplyAssetGroupRoutingOptions;
+} => {
+  const groups: RoutingLayout['groups'] = {};
+  const nodes: RoutingLayout['nodes'] = {};
+  const groupParentById: ApplyAssetGroupRoutingOptions['groupParentById'] = {};
+  const ownerGroupByNodeId: ApplyAssetGroupRoutingOptions['ownerGroupByNodeId'] = {};
+  const endpointGroupById: ApplyAssetGroupRoutingOptions['endpointGroupById'] = {};
+
+  for (let index = 0; index < GROUP_COUNT; index++) {
+    const currentGroupId = groupId(index);
+    const currentNodeId = nodeId(index);
+    const x = index * 10;
+    groups[currentGroupId] = {
+      id: currentGroupId,
+      bounds: {x, y: 0, width: 5, height: 10},
+      expanded: true,
+    };
+    nodes[currentNodeId] = {
+      id: currentNodeId,
+      bounds: {x: x + 1, y: 1, width: 3, height: 8},
+    };
+    groupParentById[currentGroupId] = null;
+    ownerGroupByNodeId[currentNodeId] = currentGroupId;
+    endpointGroupById[currentNodeId] = currentGroupId;
+  }
+
+  const edges: RoutingLayout['edges'] = [];
+  const addEdge = (sourceIndex: number, targetIndex: number) => {
+    edges.push({
+      fromId: nodeId(sourceIndex),
+      toId: nodeId(targetIndex),
+      from: {x: sourceIndex * 10 + 4, y: 5},
+      to: {x: targetIndex * 10 + 1, y: 5},
+    });
+  };
+  for (let index = 0; index < GROUP_COUNT - 1; index++) {
+    addEdge(index, index + 1);
+  }
+  for (let index = 0; edges.length < EDGE_COUNT; index++) {
+    addEdge(index, index + 2);
+  }
+
+  assert.equal(Object.keys(groups).length, GROUP_COUNT);
+  assert.equal(Object.keys(nodes).length, GROUP_COUNT);
+  assert.equal(edges.length, EDGE_COUNT);
+
+  return {
+    layout: {width: GROUP_COUNT * 10, height: 10, groups, nodes, edges},
+    options: {
+      direction: 'horizontal',
+      ranksep: 60,
+      trailingGroupPadding: 15,
+      margin: 100,
+      groupParentById,
+      ownerGroupByNodeId,
+      endpointGroupById,
+    },
+  };
+};
+
+const createDeepFixture = (): {
+  layout: RoutingLayout;
+  options: ApplyAssetGroupRoutingOptions;
+} => {
+  const groups: RoutingLayout['groups'] = {};
+  const groupParentById: ApplyAssetGroupRoutingOptions['groupParentById'] = {};
+  for (let depth = 0; depth < 300; depth++) {
+    const id = `nested-${depth}`;
+    groups[id] = {
+      id,
+      bounds: {x: depth, y: depth, width: 500 - depth, height: 500 - depth},
+      expanded: true,
+    };
+    groupParentById[id] = depth === 0 ? null : `nested-${depth - 1}`;
+  }
+  groups.target = {
+    id: 'target',
+    bounds: {x: 1000, y: 0, width: 5, height: 10},
+    expanded: true,
+  };
+  groupParentById.target = null;
+
+  const nodes: RoutingLayout['nodes'] = {
+    source: {id: 'source', bounds: {x: 300, y: 300, width: 5, height: 5}},
+    target: {id: 'target', bounds: {x: 1001, y: 1, width: 3, height: 8}},
+  };
+  return {
+    layout: {
+      width: 1100,
+      height: 500,
+      groups,
+      nodes,
+      edges: [{fromId: 'source', toId: 'target', from: {x: 305, y: 302}, to: {x: 1001, y: 5}}],
+    },
+    options: {
+      direction: 'horizontal',
+      ranksep: 60,
+      trailingGroupPadding: 15,
+      margin: 100,
+      groupParentById,
+      ownerGroupByNodeId: {source: 'nested-299', target: 'target'},
+      endpointGroupById: {source: 'nested-299', target: 'target'},
+    },
+  };
+};
+
+const median = (values: number[]) => [...values].sort((a, b) => a - b)[3]!;
+
+const normal = createNormalFixture();
+for (let index = 0; index < WARMUP_COUNT; index++) {
+  const result = applyAssetGroupLineageRouting(normal.layout, normal.options);
+  assert.equal(result.edges.length, EDGE_COUNT);
+}
+
+const elapsedSamples: number[] = [];
+const rawHeapSamples: number[] = [];
+const retainedHeapSamples: number[] = [];
+const retainedResults: RoutingLayout[] = [];
+for (let index = 0; index < SAMPLE_COUNT; index++) {
+  retainedResults.length = 0;
+  global.gc?.();
+  const heapBefore = process.memoryUsage().heapUsed;
+  const startedAt = performance.now();
+  const result = applyAssetGroupLineageRouting(normal.layout, normal.options);
+  const elapsed = performance.now() - startedAt;
+  const rawHeapDelta = process.memoryUsage().heapUsed - heapBefore;
+  retainedResults.push(result);
+  global.gc?.();
+  const retainedHeapDelta = process.memoryUsage().heapUsed - heapBefore;
+  const retainedResult = retainedResults[0];
+  assert.equal(retainedResult, result);
+  assert.notEqual(result, normal.layout);
+  assert.equal(retainedResult.edges.length, EDGE_COUNT);
+  assert.equal(Object.keys(retainedResult.groups).length, GROUP_COUNT);
+  assert.equal(Object.keys(retainedResult.nodes).length, GROUP_COUNT);
+  elapsedSamples.push(elapsed);
+  rawHeapSamples.push(rawHeapDelta / (1024 * 1024));
+  retainedHeapSamples.push(retainedHeapDelta / (1024 * 1024));
+}
+
+const deep = createDeepFixture();
+const depthStartedAt = performance.now();
+const deepResult = applyAssetGroupLineageRouting(deep.layout, deep.options);
+const depth300Ms = performance.now() - depthStartedAt;
+assert.notEqual(deepResult, deep.layout);
+assert.equal(deepResult.edges.length, 1);
+
+const medianMs = median(elapsedSamples);
+const medianRawHeapMb = median(rawHeapSamples);
+const medianRetainedHeapMb = median(retainedHeapSamples);
+const output = {
+  node: process.version,
+  cpu: os.cpus()[0]?.model ?? 'unknown',
+  groups: GROUP_COUNT,
+  edges: EDGE_COUNT,
+  medianMs,
+  medianHeapMb: medianRetainedHeapMb,
+  medianRawHeapMb,
+  medianRetainedHeapMb,
+  depth300Ms,
+};
+console.log(output);
+
+assert.ok(medianMs <= MAX_MEDIAN_MS, `Median ${medianMs.toFixed(2)}ms exceeds ${MAX_MEDIAN_MS}ms`);
+assert.ok(
+  medianRetainedHeapMb <= MAX_MEDIAN_HEAP_MB,
+  `Median retained heap delta ${medianRetainedHeapMb.toFixed(2)}MB exceeds ${MAX_MEDIAN_HEAP_MB}MB`,
+);

--- a/js_modules/ui-core/src/asset-graph/__benchmarks__/assetGroupLineageRouting.benchmark.ts
+++ b/js_modules/ui-core/src/asset-graph/__benchmarks__/assetGroupLineageRouting.benchmark.ts
@@ -14,8 +14,7 @@ const WARMUP_COUNT = 3;
 const SAMPLE_COUNT = 7;
 const MAX_MEDIAN_MS = 50;
 const MAX_MEDIAN_HEAP_MB = 10;
-const CANONICAL_COMMAND =
-  'yarn node --expose-gc -r ts-node/register src/asset-graph/__benchmarks__/assetGroupLineageRouting.benchmark.ts';
+const CANONICAL_COMMAND = 'yarn benchmark:asset-group-lineage-routing';
 
 if (!global.gc) {
   throw new Error(`Benchmark requires exposed garbage collection. Run: ${CANONICAL_COMMAND}`);

--- a/js_modules/ui-core/src/asset-graph/__tests__/AssetEdges.test.tsx
+++ b/js_modules/ui-core/src/asset-graph/__tests__/AssetEdges.test.tsx
@@ -1,0 +1,43 @@
+import {MAX_EDGES, getEdgesToShow} from '../AssetEdges';
+import {AssetLayoutEdge} from '../layout';
+
+const viewportRect = {top: 0, left: 0, right: 1000, bottom: 1000};
+
+const buildEdges = (): AssetLayoutEdge[] =>
+  Array.from({length: 250}, (_, index) => ({
+    from: {x: index, y: index},
+    fromId: `from-${index}`,
+    to: {x: index + 1, y: index + 1},
+    toId: `to-${index}`,
+    sourceBoundary: 400,
+    targetBoundary: 600,
+  }));
+
+describe('getEdgesToShow', () => {
+  it('caps visible edges and retains routed geometry metadata', () => {
+    const {edgesToShow} = getEdgesToShow({
+      edges: buildEdges(),
+      highlighted: null,
+      selected: null,
+      viewportRect,
+    });
+
+    expect(MAX_EDGES).toBe(200);
+    expect(edgesToShow).toHaveLength(200);
+    expect(edgesToShow[0]).toEqual(
+      expect.objectContaining({sourceBoundary: 400, targetBoundary: 600}),
+    );
+  });
+
+  it('caps selected or highlighted edges', () => {
+    const edges = buildEdges();
+    const {selectedOrHighlightedEdges} = getEdgesToShow({
+      edges,
+      highlighted: edges.map(({fromId}) => fromId),
+      selected: null,
+      viewportRect,
+    });
+
+    expect(selectedOrHighlightedEdges).toHaveLength(MAX_EDGES);
+  });
+});

--- a/js_modules/ui-core/src/asset-graph/__tests__/AssetEdges.test.tsx
+++ b/js_modules/ui-core/src/asset-graph/__tests__/AssetEdges.test.tsx
@@ -15,12 +15,15 @@ const buildEdges = (): AssetLayoutEdge[] =>
 
 describe('getEdgesToShow', () => {
   it('caps visible edges and retains routed geometry metadata', () => {
-    const {edgesToShow} = getEdgesToShow({
-      edges: buildEdges(),
-      highlighted: null,
-      selected: null,
-      viewportRect,
-    });
+    const {edgesToShow} = getEdgesToShow(
+      {
+        edges: buildEdges(),
+        highlighted: null,
+        selected: null,
+        viewportRect,
+      },
+      MAX_EDGES,
+    );
 
     expect(MAX_EDGES).toBe(200);
     expect(edgesToShow).toHaveLength(200);
@@ -31,13 +34,34 @@ describe('getEdgesToShow', () => {
 
   it('caps selected or highlighted edges', () => {
     const edges = buildEdges();
-    const {selectedOrHighlightedEdges} = getEdgesToShow({
-      edges,
-      highlighted: edges.map(({fromId}) => fromId),
-      selected: null,
-      viewportRect,
-    });
+    const {selectedOrHighlightedEdges} = getEdgesToShow(
+      {
+        edges,
+        highlighted: edges.map(({fromId}) => fromId),
+        selected: null,
+        viewportRect,
+      },
+      MAX_EDGES,
+    );
 
     expect(selectedOrHighlightedEdges).toHaveLength(MAX_EDGES);
+  });
+
+  // getEdgesToShow runs inside a web worker via @koale/useworker, which serializes it with
+  // fn.toString() and runs it with no module closure. Any module-scope identifier it references
+  // becomes a ReferenceError in the worker, is swallowed by its try/catch, and every edge
+  // disappears. Reconstructing the function in global-only scope reproduces the worker exactly.
+  it('does not depend on module scope when serialized into a worker', () => {
+    const edges = buildEdges();
+    const serialized = getEdgesToShow.toString();
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const reconstructed = new Function(`return (${serialized})`)() as typeof getEdgesToShow;
+
+    const {edgesToShow} = reconstructed(
+      {edges, highlighted: null, selected: null, viewportRect},
+      MAX_EDGES,
+    );
+
+    expect(edgesToShow).toHaveLength(MAX_EDGES);
   });
 });

--- a/js_modules/ui-core/src/asset-graph/__tests__/Utils.test.tsx
+++ b/js_modules/ui-core/src/asset-graph/__tests__/Utils.test.tsx
@@ -1,6 +1,52 @@
 import {buildMaterializationEvent, buildRun} from '../../graphql/builders';
 import {RunStatus} from '../../graphql/types';
-import {shouldDisplayRunFailure, tokenForAssetKey, tokenToAssetKey} from '../Utils';
+import {
+  buildSVGPathHorizontal,
+  buildSVGPathVertical,
+  buildSVGPathWithBoundaryCorridors,
+  shouldDisplayRunFailure,
+  tokenForAssetKey,
+  tokenToAssetKey,
+} from '../Utils';
+
+describe('SVG path builders', () => {
+  it('builds a horizontal path with boundary corridors', () => {
+    expect(
+      buildSVGPathWithBoundaryCorridors(
+        {
+          from: {x: 10, y: 20},
+          to: {x: 130, y: 80},
+          sourceBoundary: 40,
+          targetBoundary: 100,
+        },
+        'horizontal',
+      ),
+    ).toBe('M10,20L40,20C70,20 70,80 100,80L130,80');
+  });
+
+  it('builds a vertical path with boundary corridors', () => {
+    expect(
+      buildSVGPathWithBoundaryCorridors(
+        {
+          from: {x: 20, y: 10},
+          to: {x: 80, y: 130},
+          sourceBoundary: 40,
+          targetBoundary: 100,
+        },
+        'vertical',
+      ),
+    ).toBe('M20,10L20,40C20,70 80,70 80,100L80,130');
+  });
+
+  it('keeps legacy path builders unchanged', () => {
+    expect(buildSVGPathHorizontal({source: {x: 0, y: 0}, target: {x: 100, y: 50}})).toBe(
+      'M0,0C50,0,50,50,100,50',
+    );
+    expect(buildSVGPathVertical({source: {x: 0, y: 0}, target: {x: 50, y: 100}})).toBe(
+      'M0,0C0,50,50,50,50,100',
+    );
+  });
+});
 
 describe('shouldDisplayRunFailure', () => {
   it('should return false if the latest materialization is from the latest run', () => {

--- a/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
@@ -341,6 +341,93 @@ describe('applyAssetGroupLineageRouting', () => {
     });
   });
 
+  it('falls back atomically when routing would partially translate a grouped-to-ungrouped edge', () => {
+    const layout: RoutingLayout = {
+      width: 500,
+      height: 300,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, 80, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(220, 120, 80, 40)},
+        ungroupedNode: {id: 'ungroupedNode', bounds: bounds(400, 120, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(200, 100, 120, 100), expanded: true},
+      },
+      edges: [
+        {from: {x: 100, y: 40}, fromId: 'sourceNode', to: {x: 220, y: 140}, toId: 'targetNode'},
+        {
+          from: {x: 300, y: 140},
+          fromId: 'targetNode',
+          to: {x: 400, y: 140},
+          toId: 'ungroupedNode',
+        },
+      ],
+    };
+
+    expect(
+      applyAssetGroupLineageRouting(
+        layout,
+        routingOptions({
+          ownerGroupByNodeId: {
+            sourceNode: 'source',
+            targetNode: 'target',
+            ungroupedNode: null,
+          },
+          endpointGroupById: {
+            sourceNode: 'source',
+            targetNode: 'target',
+            ungroupedNode: null,
+          },
+        }),
+      ),
+    ).toBe(layout);
+  });
+
+  it('allows a grouped-to-ungrouped edge when both endpoint translations are zero', () => {
+    const layout: RoutingLayout = {
+      width: 600,
+      height: 300,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, 80, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(320, 120, 80, 40)},
+        ungroupedNode: {id: 'ungroupedNode', bounds: bounds(500, 120, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(300, 100, 120, 100), expanded: true},
+      },
+      edges: [
+        {from: {x: 100, y: 40}, fromId: 'sourceNode', to: {x: 320, y: 140}, toId: 'targetNode'},
+        {
+          from: {x: 400, y: 140},
+          fromId: 'targetNode',
+          to: {x: 500, y: 140},
+          toId: 'ungroupedNode',
+        },
+      ],
+    };
+
+    const result = applyAssetGroupLineageRouting(
+      layout,
+      routingOptions({
+        ownerGroupByNodeId: {
+          sourceNode: 'source',
+          targetNode: 'target',
+          ungroupedNode: null,
+        },
+        endpointGroupById: {
+          sourceNode: 'source',
+          targetNode: 'target',
+          ungroupedNode: null,
+        },
+      }),
+    );
+
+    expect(result).not.toBe(layout);
+    expect(result.edges[1]).toEqual(layout.edges[1]);
+  });
+
   it('returns the exact input object for invalid options', () => {
     const layout: RoutingLayout = {
       width: 100,

--- a/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
@@ -203,4 +203,83 @@ describe('solveAssetGroupConstraints', () => {
     expect(solution.shiftByGroupId.b).toBe(20);
     expect(solution.componentByGroupId.a).toBe(solution.componentByGroupId.b);
   });
+
+  it('moves a parent and child atomically when they share a lineage component', () => {
+    const solution = solveAssetGroupConstraints({
+      direction: 'vertical',
+      ranksep: 20,
+      trailingGroupPadding: 16,
+      groups: {
+        upstream: {bounds: bounds(0, 0, 100, 100), expanded: false},
+        parent: {bounds: bounds(0, 100, 100, 100), expanded: true},
+        child: {bounds: bounds(0, 120, 100, 100), expanded: false},
+      },
+      parentById: {upstream: null, parent: null, child: 'parent'},
+      constraints: [
+        {
+          sourceBranchId: 'parent',
+          targetBranchId: 'child',
+          sourceUsesGroupEnd: true,
+          sourceBaseExit: 200,
+          targetBaseEntry: 120,
+        },
+        {
+          sourceBranchId: 'child',
+          targetBranchId: 'parent',
+          sourceUsesGroupEnd: true,
+          sourceBaseExit: 220,
+          targetBaseEntry: 100,
+        },
+        {
+          sourceBranchId: 'upstream',
+          targetBranchId: 'parent',
+          sourceUsesGroupEnd: true,
+          sourceBaseExit: 100,
+          targetBaseEntry: 100,
+        },
+      ],
+    });
+
+    expect(solution.shiftByGroupId.parent).toBe(20);
+    expect(solution.shiftByGroupId.child).toBe(20);
+    expect(solution.componentByGroupId.parent).toBe(solution.componentByGroupId.child);
+    expect(solution.endByGroupId.parent).toBe(256);
+  });
+
+  it('compacts duplicate parallel constraints using their maximum weight', () => {
+    const input = {
+      direction: 'horizontal' as const,
+      ranksep: 60,
+      trailingGroupPadding: 15,
+      groups: {
+        source: {bounds: bounds(0, 0, 100, 100), expanded: false},
+        target: {bounds: bounds(200, 0, 100, 100), expanded: false},
+      },
+      parentById: {source: null, target: null},
+      constraints: [
+        {
+          sourceBranchId: 'source',
+          targetBranchId: 'target',
+          sourceUsesGroupEnd: false,
+          sourceBaseExit: 100,
+          targetBaseEntry: 200,
+        },
+        {
+          sourceBranchId: 'source',
+          targetBranchId: 'target',
+          sourceUsesGroupEnd: false,
+          sourceBaseExit: 170,
+          targetBaseEntry: 200,
+        },
+      ],
+    };
+    const withoutDuplicates = solveAssetGroupConstraints(input);
+    const withDuplicates = solveAssetGroupConstraints({
+      ...input,
+      constraints: [...input.constraints, input.constraints[0]!, input.constraints[1]!],
+    });
+
+    expect(withDuplicates.shiftByGroupId).toEqual(withoutDuplicates.shiftByGroupId);
+    expect(withDuplicates.shiftByGroupId.target).toBe(30);
+  });
 });

--- a/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
@@ -445,6 +445,34 @@ describe('applyAssetGroupLineageRouting', () => {
     );
   });
 
+  it('returns the exact input object when routed canvas arithmetic overflows', () => {
+    const layout: RoutingLayout = {
+      width: 100,
+      height: 100,
+      nodes: {},
+      groups: {
+        source: {
+          id: 'source',
+          bounds: bounds(Number.MAX_VALUE, 0, 0, 10),
+          expanded: true,
+        },
+      },
+      edges: [],
+    };
+
+    expect(
+      applyAssetGroupLineageRouting(
+        layout,
+        routingOptions({
+          margin: Number.MAX_VALUE,
+          groupParentById: {source: null},
+          ownerGroupByNodeId: {},
+          endpointGroupById: {},
+        }),
+      ),
+    ).toBe(layout);
+  });
+
   it('supports TB routing without changing perpendicular node coordinates', () => {
     const layout: RoutingLayout = {
       width: 300,

--- a/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
@@ -1,0 +1,26 @@
+import {buildGroupAncestryIndex} from '../assetGroupLineageRouting';
+
+describe('buildGroupAncestryIndex', () => {
+  it('finds common ancestors and branches below ancestors', () => {
+    const index = buildGroupAncestryIndex({
+      source: null,
+      'source/inner': 'source',
+      'source/inner/leaf': 'source/inner',
+      target: null,
+      'target/leaf': 'target',
+    });
+
+    expect(index.lowestCommonAncestor('source/inner', 'source/inner/leaf')).toBe(
+      'source/inner',
+    );
+    expect(index.lowestCommonAncestor('source/inner/leaf', 'target/leaf')).toBe(null);
+    expect(index.branchBelow('source/inner/leaf', 'source')).toBe('source/inner');
+    expect(index.branchBelow('target/leaf', null)).toBe('target');
+  });
+
+  it('rejects cycles in the visible asset group parent hierarchy', () => {
+    expect(() => buildGroupAncestryIndex({a: 'b', b: 'a'})).toThrow(
+      'Asset group parent cycle',
+    );
+  });
+});

--- a/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
@@ -350,6 +350,9 @@ describe('applyAssetGroupLineageRouting', () => {
     expect(applyAssetGroupLineageRouting(layout, routingOptions({ranksep: Number.NaN}))).toBe(
       layout,
     );
+    expect(applyAssetGroupLineageRouting(layout, routingOptions({trailingGroupPadding: -1}))).toBe(
+      layout,
+    );
   });
 
   it('supports TB routing without changing perpendicular node coordinates', () => {
@@ -572,6 +575,33 @@ describe('applyAssetGroupLineageRouting', () => {
           to: {x: 320, y: 140},
           toId: 'targetNode',
           sourceBoundary: 180,
+        },
+      ],
+    };
+
+    expect(applyAssetGroupLineageRouting(layout, routingOptions())).toBe(layout);
+  });
+
+  it('falls back for paired input corridors that violate primary-axis separation', () => {
+    const layout: RoutingLayout = {
+      width: 500,
+      height: 300,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, 80, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(320, 120, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(300, 100, 120, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 40},
+          fromId: 'sourceNode',
+          to: {x: 320, y: 140},
+          toId: 'targetNode',
+          sourceBoundary: 180,
+          targetBoundary: 230,
         },
       ],
     };

--- a/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
@@ -255,7 +255,7 @@ describe('solveAssetGroupConstraints', () => {
     expect(solution.endByGroupId.parent).toBe(256);
   });
 
-  it('compacts duplicate parallel constraints using their maximum weight', () => {
+  it('preserves the least solution when parallel constraints are duplicated', () => {
     const input = {
       direction: 'horizontal' as const,
       ranksep: 60,
@@ -507,6 +507,206 @@ describe('applyAssetGroupLineageRouting', () => {
       sourceBoundary: 180,
       targetBoundary: 200,
     });
+  });
+
+  it('routes LR from an ancestor endpoint into only the crossed child boundary', () => {
+    const layout: RoutingLayout = {
+      width: 500,
+      height: 300,
+      nodes: {
+        ancestorNode: {id: 'ancestorNode', bounds: bounds(20, 20, 80, 40)},
+        descendantNode: {id: 'descendantNode', bounds: bounds(140, 60, 40, 40)},
+      },
+      groups: {
+        a: {id: 'a', bounds: bounds(0, 0, 300, 200), expanded: true},
+        'a/b': {id: 'a/b', bounds: bounds(120, 40, 100, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 40},
+          fromId: 'ancestorNode',
+          to: {x: 140, y: 80},
+          toId: 'descendantNode',
+        },
+      ],
+    };
+    const result = applyAssetGroupLineageRouting(
+      layout,
+      routingOptions({
+        groupParentById: {a: null, 'a/b': 'a'},
+        ownerGroupByNodeId: {ancestorNode: 'a', descendantNode: 'a/b'},
+        endpointGroupById: {ancestorNode: 'a', descendantNode: 'a/b'},
+      }),
+    );
+
+    expect(result.groups['a/b']!.bounds).toEqual(bounds(160, 40, 100, 100));
+    expect(result.nodes.descendantNode!.bounds.y).toBe(60);
+    expect(result.edges[0]).toMatchObject({
+      from: {x: 100, y: 40},
+      to: {x: 180, y: 80},
+      sourceBoundary: 100,
+      targetBoundary: 160,
+    });
+    expect(result.edges[0]!.sourceBoundary).not.toBe(300);
+  });
+
+  it('routes TB from an ancestor endpoint into only the crossed child boundary', () => {
+    const layout: RoutingLayout = {
+      width: 300,
+      height: 500,
+      nodes: {
+        ancestorNode: {id: 'ancestorNode', bounds: bounds(20, 20, 40, 80)},
+        descendantNode: {id: 'descendantNode', bounds: bounds(60, 130, 40, 40)},
+      },
+      groups: {
+        a: {id: 'a', bounds: bounds(0, 0, 200, 300), expanded: true},
+        'a/b': {id: 'a/b', bounds: bounds(40, 110, 100, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 40, y: 100},
+          fromId: 'ancestorNode',
+          to: {x: 80, y: 130},
+          toId: 'descendantNode',
+        },
+      ],
+    };
+    const result = applyAssetGroupLineageRouting(
+      layout,
+      routingOptions({
+        direction: 'vertical',
+        ranksep: 20,
+        trailingGroupPadding: 16,
+        groupParentById: {a: null, 'a/b': 'a'},
+        ownerGroupByNodeId: {ancestorNode: 'a', descendantNode: 'a/b'},
+        endpointGroupById: {ancestorNode: 'a', descendantNode: 'a/b'},
+      }),
+    );
+
+    expect(result.groups['a/b']!.bounds).toEqual(bounds(40, 120, 100, 100));
+    expect(result.nodes.descendantNode!.bounds.x).toBe(60);
+    expect(result.edges[0]).toMatchObject({
+      from: {x: 40, y: 100},
+      to: {x: 80, y: 140},
+      sourceBoundary: 100,
+      targetBoundary: 120,
+    });
+    expect(result.edges[0]!.sourceBoundary).not.toBe(300);
+  });
+
+  it('keeps edges within the same exact endpoint group on the legacy path', () => {
+    const layout: RoutingLayout = {
+      width: 300,
+      height: 200,
+      nodes: {
+        first: {id: 'first', bounds: bounds(20, 20, 40, 40)},
+        second: {id: 'second', bounds: bounds(160, 20, 40, 40)},
+      },
+      groups: {a: {id: 'a', bounds: bounds(0, 0, 240, 100), expanded: true}},
+      edges: [{from: {x: 60, y: 40}, fromId: 'first', to: {x: 160, y: 40}, toId: 'second'}],
+    };
+    const result = applyAssetGroupLineageRouting(
+      layout,
+      routingOptions({
+        groupParentById: {a: null},
+        ownerGroupByNodeId: {first: 'a', second: 'a'},
+        endpointGroupById: {first: 'a', second: 'a'},
+      }),
+    );
+
+    expect(result.edges[0]).toEqual(layout.edges[0]);
+    expect(result.edges[0]!.sourceBoundary).toBeUndefined();
+    expect(result.edges[0]!.targetBoundary).toBeUndefined();
+  });
+
+  it('routes descendant exit to an ancestor endpoint only when baseline clearance is sufficient', () => {
+    const sufficient: RoutingLayout = {
+      width: 500,
+      height: 300,
+      nodes: {
+        descendantNode: {id: 'descendantNode', bounds: bounds(40, 40, 60, 40)},
+        ancestorNode: {id: 'ancestorNode', bounds: bounds(220, 120, 40, 40)},
+      },
+      groups: {
+        a: {id: 'a', bounds: bounds(0, 0, 300, 200), expanded: true},
+        'a/b': {id: 'a/b', bounds: bounds(20, 20, 100, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 60},
+          fromId: 'descendantNode',
+          to: {x: 220, y: 140},
+          toId: 'ancestorNode',
+        },
+      ],
+    };
+    const options = routingOptions({
+      groupParentById: {a: null, 'a/b': 'a'},
+      ownerGroupByNodeId: {ancestorNode: 'a', descendantNode: 'a/b'},
+      endpointGroupById: {ancestorNode: 'a', descendantNode: 'a/b'},
+    });
+
+    const result = applyAssetGroupLineageRouting(sufficient, options);
+    expect(result.edges[0]).toMatchObject({sourceBoundary: 120, targetBoundary: 220});
+    expect(result.edges[0]!.targetBoundary).not.toBe(0);
+
+    const insufficient: RoutingLayout = {
+      ...sufficient,
+      nodes: {
+        ...sufficient.nodes,
+        ancestorNode: {id: 'ancestorNode', bounds: bounds(150, 120, 40, 40)},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 60},
+          fromId: 'descendantNode',
+          to: {x: 150, y: 140},
+          toId: 'ancestorNode',
+        },
+      ],
+    };
+    expect(applyAssetGroupLineageRouting(insufficient, options)).toBe(insufficient);
+  });
+
+  it('terminates opposite ancestor-descendant routing with atomic fallback', () => {
+    const layout: RoutingLayout = {
+      width: 500,
+      height: 300,
+      nodes: {
+        ancestorNode: {id: 'ancestorNode', bounds: bounds(20, 20, 80, 40)},
+        descendantNode: {id: 'descendantNode', bounds: bounds(140, 60, 40, 40)},
+      },
+      groups: {
+        a: {id: 'a', bounds: bounds(0, 0, 300, 200), expanded: true},
+        'a/b': {id: 'a/b', bounds: bounds(120, 40, 100, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 40},
+          fromId: 'ancestorNode',
+          to: {x: 140, y: 80},
+          toId: 'descendantNode',
+        },
+        {
+          from: {x: 180, y: 80},
+          fromId: 'descendantNode',
+          to: {x: 100, y: 40},
+          toId: 'ancestorNode',
+        },
+      ],
+    };
+
+    expect(
+      applyAssetGroupLineageRouting(
+        layout,
+        routingOptions({
+          groupParentById: {a: null, 'a/b': 'a'},
+          ownerGroupByNodeId: {ancestorNode: 'a', descendantNode: 'a/b'},
+          endpointGroupById: {ancestorNode: 'a', descendantNode: 'a/b'},
+        }),
+      ),
+    ).toBe(layout);
+    expect(layout.groups['a/b']!.bounds.x).toBe(120);
   });
 
   it('uses outer divergent branches and leaves unrelated rectangles untouched', () => {

--- a/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
@@ -23,4 +23,61 @@ describe('buildGroupAncestryIndex', () => {
       'Asset group parent cycle',
     );
   });
+
+  it('finds sibling and cousin common ancestors', () => {
+    const index = buildGroupAncestryIndex({
+      root: null,
+      left: 'root',
+      'left/one': 'left',
+      'left/two': 'left',
+      right: 'root',
+      'right/one': 'right',
+    });
+
+    expect(index.lowestCommonAncestor('left/one', 'left/two')).toBe('left');
+    expect(index.lowestCommonAncestor('left/one', 'right/one')).toBe('root');
+  });
+
+  it('handles roots, identical groups, and non-ancestor branches', () => {
+    const index = buildGroupAncestryIndex({
+      root: null,
+      left: 'root',
+      'left/leaf': 'left',
+      right: 'root',
+    });
+
+    expect(index.lowestCommonAncestor('root', 'root')).toBe('root');
+    expect(index.lowestCommonAncestor('left/leaf', 'left/leaf')).toBe('left/leaf');
+    expect(index.branchBelow('root', 'root')).toBe(null);
+    expect(index.branchBelow('left/leaf', 'right')).toBe(null);
+  });
+
+  it('rejects missing parents and unknown lookup groups', () => {
+    expect(() => buildGroupAncestryIndex({child: 'missing'})).toThrow(
+      'Missing visible asset group parent: missing',
+    );
+
+    const index = buildGroupAncestryIndex({root: null});
+    expect(() => index.lowestCommonAncestor('root', 'missing')).toThrow(
+      'Unknown visible asset group: missing',
+    );
+    expect(() => index.branchBelow('root', 'missing')).toThrow(
+      'Unknown visible asset group: missing',
+    );
+  });
+
+  it('indexes deep hierarchies without recursive stack growth', () => {
+    const parentById: Record<string, string | null> = {};
+    const groupId = (index: number) => `group-${index.toString().padStart(5, '0')}`;
+    const groupCount = 20_000;
+    for (let index = 0; index < groupCount; index++) {
+      parentById[groupId(index)] = index === 0 ? null : groupId(index - 1);
+    }
+
+    const index = buildGroupAncestryIndex(parentById);
+    expect(index.lowestCommonAncestor(groupId(groupCount - 1), groupId(10_000))).toBe(
+      groupId(10_000),
+    );
+    expect(index.branchBelow(groupId(groupCount - 1), groupId(0))).toBe(groupId(1));
+  });
 });

--- a/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
@@ -1,4 +1,13 @@
-import {buildGroupAncestryIndex} from '../assetGroupLineageRouting';
+import type {IBounds} from '../../graph/common';
+
+import {buildGroupAncestryIndex, solveAssetGroupConstraints} from '../assetGroupLineageRouting';
+
+const bounds = (x: number, y: number, width: number, height: number): IBounds => ({
+  x,
+  y,
+  width,
+  height,
+});
 
 describe('buildGroupAncestryIndex', () => {
   it('finds common ancestors and branches below ancestors', () => {
@@ -10,18 +19,14 @@ describe('buildGroupAncestryIndex', () => {
       'target/leaf': 'target',
     });
 
-    expect(index.lowestCommonAncestor('source/inner', 'source/inner/leaf')).toBe(
-      'source/inner',
-    );
+    expect(index.lowestCommonAncestor('source/inner', 'source/inner/leaf')).toBe('source/inner');
     expect(index.lowestCommonAncestor('source/inner/leaf', 'target/leaf')).toBe(null);
     expect(index.branchBelow('source/inner/leaf', 'source')).toBe('source/inner');
     expect(index.branchBelow('target/leaf', null)).toBe('target');
   });
 
   it('rejects cycles in the visible asset group parent hierarchy', () => {
-    expect(() => buildGroupAncestryIndex({a: 'b', b: 'a'})).toThrow(
-      'Asset group parent cycle',
-    );
+    expect(() => buildGroupAncestryIndex({a: 'b', b: 'a'})).toThrow('Asset group parent cycle');
   });
 
   it('finds sibling and cousin common ancestors', () => {
@@ -79,5 +84,123 @@ describe('buildGroupAncestryIndex', () => {
       groupId(10_000),
     );
     expect(index.branchBelow(groupId(groupCount - 1), groupId(0))).toBe(groupId(1));
+  });
+});
+
+describe('solveAssetGroupConstraints', () => {
+  it('uses maximum horizontal fan-in and propagates only the minimum shift', () => {
+    const solution = solveAssetGroupConstraints({
+      direction: 'horizontal',
+      ranksep: 60,
+      trailingGroupPadding: 15,
+      groups: {
+        a: {bounds: bounds(0, 0, 100, 100), expanded: false},
+        b: {bounds: bounds(20, 150, 130, 100), expanded: false},
+        c: {bounds: bounds(180, 0, 100, 100), expanded: false},
+        d: {bounds: bounds(300, 0, 100, 100), expanded: false},
+      },
+      parentById: {a: null, b: null, c: null, d: null},
+      constraints: [
+        {
+          sourceBranchId: 'a',
+          targetBranchId: 'c',
+          sourceUsesGroupEnd: true,
+          sourceBaseExit: 100,
+          targetBaseEntry: 180,
+        },
+        {
+          sourceBranchId: 'b',
+          targetBranchId: 'c',
+          sourceUsesGroupEnd: true,
+          sourceBaseExit: 150,
+          targetBaseEntry: 180,
+        },
+        {
+          sourceBranchId: 'c',
+          targetBranchId: 'd',
+          sourceUsesGroupEnd: true,
+          sourceBaseExit: 280,
+          targetBaseEntry: 300,
+        },
+      ],
+    });
+
+    expect(solution.shiftByGroupId).toEqual({a: 0, b: 0, c: 30, d: 70});
+  });
+
+  it('extends a parent envelope when a nested child moves', () => {
+    const solution = solveAssetGroupConstraints({
+      direction: 'horizontal',
+      ranksep: 60,
+      trailingGroupPadding: 15,
+      groups: {
+        source: {bounds: bounds(0, 0, 100, 100), expanded: false},
+        parent: {bounds: bounds(150, 0, 200, 200), expanded: true},
+        child: {bounds: bounds(160, 40, 100, 100), expanded: false},
+        downstream: {bounds: bounds(400, 0, 100, 100), expanded: false},
+      },
+      parentById: {source: null, parent: null, child: 'parent', downstream: null},
+      constraints: [
+        {
+          sourceBranchId: 'source',
+          targetBranchId: 'child',
+          sourceUsesGroupEnd: true,
+          sourceBaseExit: 100,
+          targetBaseEntry: 160,
+        },
+        {
+          sourceBranchId: 'parent',
+          targetBranchId: 'downstream',
+          sourceUsesGroupEnd: true,
+          sourceBaseExit: 350,
+          targetBaseEntry: 400,
+        },
+      ],
+    });
+
+    expect(solution.shiftByGroupId.child).toBe(0);
+    expect(solution.endByGroupId.parent).toBe(350);
+    expect(solution.shiftByGroupId.downstream).toBe(10);
+  });
+
+  it('collapses a pseudo-cycle and ignores its internal cyclic clearance', () => {
+    const solution = solveAssetGroupConstraints({
+      direction: 'vertical',
+      ranksep: 20,
+      trailingGroupPadding: 16,
+      groups: {
+        upstream: {bounds: bounds(0, 0, 100, 100), expanded: false},
+        a: {bounds: bounds(0, 100, 100, 100), expanded: false},
+        b: {bounds: bounds(150, 100, 100, 100), expanded: false},
+      },
+      parentById: {upstream: null, a: null, b: null},
+      constraints: [
+        {
+          sourceBranchId: 'a',
+          targetBranchId: 'b',
+          sourceUsesGroupEnd: true,
+          sourceBaseExit: 200,
+          targetBaseEntry: 100,
+        },
+        {
+          sourceBranchId: 'b',
+          targetBranchId: 'a',
+          sourceUsesGroupEnd: true,
+          sourceBaseExit: 200,
+          targetBaseEntry: 100,
+        },
+        {
+          sourceBranchId: 'upstream',
+          targetBranchId: 'a',
+          sourceUsesGroupEnd: true,
+          sourceBaseExit: 100,
+          targetBaseEntry: 100,
+        },
+      ],
+    });
+
+    expect(solution.shiftByGroupId.a).toBe(20);
+    expect(solution.shiftByGroupId.b).toBe(20);
+    expect(solution.componentByGroupId.a).toBe(solution.componentByGroupId.b);
   });
 });

--- a/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
@@ -140,7 +140,7 @@ describe('solveAssetGroupConstraints', () => {
       ranksep: 60,
       trailingGroupPadding: 15,
       groups: {
-        source: {bounds: bounds(0, 0, 100, 100), expanded: false},
+        source: {bounds: bounds(0, 0, 180, 100), expanded: false},
         parent: {bounds: bounds(150, 0, 200, 200), expanded: true},
         child: {bounds: bounds(160, 40, 100, 100), expanded: false},
         downstream: {bounds: bounds(400, 0, 100, 100), expanded: false},
@@ -151,7 +151,7 @@ describe('solveAssetGroupConstraints', () => {
           sourceBranchId: 'source',
           targetBranchId: 'child',
           sourceUsesGroupEnd: true,
-          sourceBaseExit: 100,
+          sourceBaseExit: 180,
           targetBaseEntry: 160,
         },
         {
@@ -164,9 +164,12 @@ describe('solveAssetGroupConstraints', () => {
       ],
     });
 
-    expect(solution.shiftByGroupId.child).toBe(0);
-    expect(solution.endByGroupId.parent).toBe(350);
-    expect(solution.shiftByGroupId.downstream).toBe(10);
+    // 180 + 60 - 160 moves only the child by 80. Its new end (340) plus 15 padding
+    // extends the parent end to 355, which then pushes downstream by 355 + 60 - 400 = 15.
+    expect(solution.shiftByGroupId.parent).toBe(0);
+    expect(solution.shiftByGroupId.child).toBe(80);
+    expect(solution.endByGroupId.parent).toBe(355);
+    expect(solution.shiftByGroupId.downstream).toBe(15);
   });
 
   it('collapses a pseudo-cycle and ignores its internal cyclic clearance', () => {
@@ -487,11 +490,46 @@ describe('applyAssetGroupLineageRouting', () => {
         {from: {x: 100, y: 40}, fromId: 'sourceNode', to: {x: 320, y: 140}, toId: 'targetNode'},
       ],
     };
+    const originalSnapshot = JSON.parse(JSON.stringify(layout));
 
     const result = applyAssetGroupLineageRouting(layout, routingOptions());
+    const repeated = applyAssetGroupLineageRouting(result, routingOptions());
+
     expect(result.groups.target!.bounds.x).toBe(300);
+    expect(repeated.groups.target!.bounds).toEqual(result.groups.target!.bounds);
+    expect(repeated.nodes.targetNode!.bounds).toEqual(result.nodes.targetNode!.bounds);
+    expect(repeated.edges).toEqual(result.edges);
+    expect(layout).toEqual(originalSnapshot);
     expect(JSON.parse(JSON.stringify(result))).toEqual(result);
   });
+
+  it('routes layouts larger than the engine argument limit without atomic fallback', () => {
+    const nodes: RoutingLayout['nodes'] = {
+      sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, 80, 40)},
+      targetNode: {id: 'targetNode', bounds: bounds(220, 120, 80, 40)},
+    };
+    for (let index = 0; index < 150_000; index++) {
+      const id = `filler-${index}`;
+      nodes[id] = {id, bounds: bounds(0, 250, 1, 1)};
+    }
+    const layout: RoutingLayout = {
+      width: 400,
+      height: 300,
+      nodes,
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(200, 100, 120, 100), expanded: true},
+      },
+      edges: [
+        {from: {x: 100, y: 40}, fromId: 'sourceNode', to: {x: 220, y: 140}, toId: 'targetNode'},
+      ],
+    };
+
+    const result = applyAssetGroupLineageRouting(layout, routingOptions());
+
+    expect(result.groups.target!.bounds.x).toBe(240);
+    expect(result.edges[0]!.targetBoundary).toBe(240);
+  }, 30_000);
 
   it('covers every nested boundary with the outer three-level divergent branches', () => {
     const layout: RoutingLayout = {

--- a/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
@@ -1,6 +1,12 @@
 import type {IBounds} from '../../graph/common';
 
-import {buildGroupAncestryIndex, solveAssetGroupConstraints} from '../assetGroupLineageRouting';
+import {
+  applyAssetGroupLineageRouting,
+  buildGroupAncestryIndex,
+  solveAssetGroupConstraints,
+  type ApplyAssetGroupRoutingOptions,
+  type RoutingLayout,
+} from '../assetGroupLineageRouting';
 
 const bounds = (x: number, y: number, width: number, height: number): IBounds => ({
   x,
@@ -281,5 +287,295 @@ describe('solveAssetGroupConstraints', () => {
 
     expect(withDuplicates.shiftByGroupId).toEqual(withoutDuplicates.shiftByGroupId);
     expect(withDuplicates.shiftByGroupId.target).toBe(30);
+  });
+});
+
+const routingOptions = (
+  overrides: Partial<ApplyAssetGroupRoutingOptions> = {},
+): ApplyAssetGroupRoutingOptions => ({
+  direction: 'horizontal',
+  ranksep: 60,
+  trailingGroupPadding: 15,
+  margin: 100,
+  groupParentById: {source: null, target: null},
+  ownerGroupByNodeId: {sourceNode: 'source', targetNode: 'target'},
+  endpointGroupById: {sourceNode: 'source', targetNode: 'target'},
+  ...overrides,
+});
+
+describe('applyAssetGroupLineageRouting', () => {
+  it('moves an LR target branch and adds scalar boundary corridors', () => {
+    const layout: RoutingLayout = {
+      width: 400,
+      height: 300,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, 80, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(220, 120, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(200, 100, 120, 100), expanded: true},
+      },
+      edges: [
+        {from: {x: 100, y: 40}, fromId: 'sourceNode', to: {x: 220, y: 140}, toId: 'targetNode'},
+      ],
+    };
+
+    const result = applyAssetGroupLineageRouting(layout, routingOptions());
+
+    expect(result).not.toBe(layout);
+    expect(result.groups.source!.bounds).toEqual(bounds(0, 0, 180, 100));
+    expect(result.groups.target!.bounds).toEqual(bounds(240, 100, 120, 100));
+    expect(result.nodes.sourceNode!.bounds).toEqual(bounds(20, 20, 80, 40));
+    expect(result.nodes.targetNode!.bounds).toEqual(bounds(260, 120, 80, 40));
+    expect(result.edges[0]).toEqual({
+      from: {x: 100, y: 40},
+      fromId: 'sourceNode',
+      to: {x: 260, y: 140},
+      toId: 'targetNode',
+      sourceBoundary: 180,
+      targetBoundary: 240,
+    });
+  });
+
+  it('returns the exact input object for invalid options', () => {
+    const layout: RoutingLayout = {
+      width: 100,
+      height: 100,
+      nodes: {},
+      groups: {},
+      edges: [],
+    };
+
+    expect(applyAssetGroupLineageRouting(layout, routingOptions({ranksep: Number.NaN}))).toBe(
+      layout,
+    );
+  });
+
+  it('supports TB routing without changing perpendicular node coordinates', () => {
+    const layout: RoutingLayout = {
+      width: 300,
+      height: 500,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, 40, 80)},
+        targetNode: {id: 'targetNode', bounds: bounds(120, 220, 40, 80)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 100, 180), expanded: true},
+        target: {id: 'target', bounds: bounds(100, 200, 100, 120), expanded: true},
+      },
+      edges: [
+        {from: {x: 40, y: 100}, fromId: 'sourceNode', to: {x: 140, y: 220}, toId: 'targetNode'},
+      ],
+    };
+
+    const result = applyAssetGroupLineageRouting(
+      layout,
+      routingOptions({direction: 'vertical', ranksep: 20, trailingGroupPadding: 16}),
+    );
+
+    expect(result.groups.source!.bounds).toEqual(bounds(0, 0, 100, 180));
+    expect(result.groups.target!.bounds).toEqual(bounds(100, 200, 100, 120));
+    expect(result.nodes.sourceNode!.bounds.x).toBe(20);
+    expect(result.nodes.targetNode!.bounds.x).toBe(120);
+    expect(result.edges[0]).toEqual({
+      from: {x: 40, y: 100},
+      fromId: 'sourceNode',
+      to: {x: 140, y: 220},
+      toId: 'targetNode',
+      sourceBoundary: 180,
+      targetBoundary: 200,
+    });
+  });
+
+  it('uses outer divergent branches and leaves unrelated rectangles untouched', () => {
+    const layout: RoutingLayout = {
+      width: 500,
+      height: 500,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(30, 30, 60, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(230, 130, 60, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 200), expanded: true},
+        sourceLeaf: {id: 'sourceLeaf', bounds: bounds(20, 20, 120, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(200, 100, 140, 160), expanded: true},
+        targetLeaf: {id: 'targetLeaf', bounds: bounds(220, 120, 100, 100), expanded: true},
+        unrelated: {id: 'unrelated', bounds: bounds(185, 280, 100, 100), expanded: true},
+      },
+      edges: [
+        {from: {x: 90, y: 50}, fromId: 'sourceNode', to: {x: 230, y: 150}, toId: 'targetNode'},
+      ],
+    };
+    const result = applyAssetGroupLineageRouting(
+      layout,
+      routingOptions({
+        groupParentById: {
+          source: null,
+          sourceLeaf: 'source',
+          target: null,
+          targetLeaf: 'target',
+          unrelated: null,
+        },
+        ownerGroupByNodeId: {sourceNode: 'sourceLeaf', targetNode: 'targetLeaf'},
+        endpointGroupById: {sourceNode: 'sourceLeaf', targetNode: 'targetLeaf'},
+      }),
+    );
+
+    expect(result.groups.target!.bounds.x).toBe(240);
+    expect(result.groups.unrelated).toEqual(layout.groups.unrelated);
+    expect(result.edges[0]).toEqual({
+      from: {x: 90, y: 50},
+      fromId: 'sourceNode',
+      to: {x: 270, y: 150},
+      toId: 'targetNode',
+      sourceBoundary: 180,
+      targetBoundary: 240,
+    });
+    expect(Object.keys(result.edges[0]!).sort()).toEqual(
+      ['from', 'fromId', 'sourceBoundary', 'targetBoundary', 'to', 'toId'].sort(),
+    );
+  });
+
+  it('keeps pseudo-cycle geometry and omits corridors for SCC-internal edges', () => {
+    const layout: RoutingLayout = {
+      width: 500,
+      height: 300,
+      nodes: {
+        aNode: {id: 'aNode', bounds: bounds(20, 20, 40, 40)},
+        bNode: {id: 'bNode', bounds: bounds(220, 20, 40, 40)},
+      },
+      groups: {
+        a: {id: 'a', bounds: bounds(0, 0, 100, 100), expanded: true},
+        b: {id: 'b', bounds: bounds(200, 0, 100, 100), expanded: true},
+      },
+      edges: [
+        {from: {x: 60, y: 40}, fromId: 'aNode', to: {x: 220, y: 40}, toId: 'bNode'},
+        {from: {x: 260, y: 60}, fromId: 'bNode', to: {x: 20, y: 60}, toId: 'aNode'},
+      ],
+    };
+    const result = applyAssetGroupLineageRouting(
+      layout,
+      routingOptions({
+        groupParentById: {a: null, b: null},
+        ownerGroupByNodeId: {aNode: 'a', bNode: 'b'},
+        endpointGroupById: {aNode: 'a', bNode: 'b'},
+      }),
+    );
+
+    expect(result.groups.b!.bounds.x - result.groups.a!.bounds.x).toBe(200);
+    expect(result.edges).toEqual(layout.edges);
+    expect(result.edges.every((edge) => edge.sourceBoundary === undefined)).toBe(true);
+  });
+
+  it('is stateless across calls and returns worker-serializable output', () => {
+    const layout: RoutingLayout = {
+      width: 500,
+      height: 300,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, 80, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(320, 120, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(300, 100, 120, 100), expanded: true},
+      },
+      edges: [
+        {from: {x: 100, y: 40}, fromId: 'sourceNode', to: {x: 320, y: 140}, toId: 'targetNode'},
+      ],
+    };
+
+    const result = applyAssetGroupLineageRouting(layout, routingOptions());
+    expect(result.groups.target!.bounds.x).toBe(300);
+    expect(JSON.parse(JSON.stringify(result))).toEqual(result);
+  });
+
+  it('covers every nested boundary with the outer three-level divergent branches', () => {
+    const layout: RoutingLayout = {
+      width: 600,
+      height: 300,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(40, 40, 40, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(240, 40, 40, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 180), expanded: true},
+        sourceMid: {id: 'sourceMid', bounds: bounds(20, 20, 130, 130), expanded: true},
+        sourceLeaf: {id: 'sourceLeaf', bounds: bounds(30, 30, 80, 80), expanded: true},
+        target: {id: 'target', bounds: bounds(200, 0, 150, 180), expanded: true},
+        targetMid: {id: 'targetMid', bounds: bounds(220, 20, 110, 130), expanded: true},
+        targetLeaf: {id: 'targetLeaf', bounds: bounds(230, 30, 80, 80), expanded: true},
+      },
+      edges: [
+        {from: {x: 80, y: 60}, fromId: 'sourceNode', to: {x: 240, y: 60}, toId: 'targetNode'},
+      ],
+    };
+    const result = applyAssetGroupLineageRouting(
+      layout,
+      routingOptions({
+        groupParentById: {
+          source: null,
+          sourceMid: 'source',
+          sourceLeaf: 'sourceMid',
+          target: null,
+          targetMid: 'target',
+          targetLeaf: 'targetMid',
+        },
+        ownerGroupByNodeId: {sourceNode: 'sourceLeaf', targetNode: 'targetLeaf'},
+        endpointGroupById: {sourceNode: 'sourceLeaf', targetNode: 'targetLeaf'},
+      }),
+    );
+
+    expect(result.edges[0]!.sourceBoundary).toBe(180);
+    expect(result.edges[0]!.targetBoundary).toBe(240);
+    expect(result.groups.target!.bounds.x).toBe(240);
+    expect(result.groups.targetMid!.bounds.x).toBe(260);
+    expect(result.groups.targetLeaf!.bounds.x).toBe(270);
+  });
+
+  it('falls back atomically when the layout is invalid', () => {
+    const layout: RoutingLayout = {
+      width: 500,
+      height: 300,
+      nodes: {sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, -1, 40)}},
+      groups: {source: {id: 'source', bounds: bounds(0, 0, 180, 100), expanded: true}},
+      edges: [],
+    };
+    expect(
+      applyAssetGroupLineageRouting(
+        layout,
+        routingOptions({
+          groupParentById: {source: null},
+          ownerGroupByNodeId: {sourceNode: 'source'},
+          endpointGroupById: {sourceNode: 'source'},
+        }),
+      ),
+    ).toBe(layout);
+  });
+
+  it('falls back rather than partially repairing one-sided corridor metadata', () => {
+    const layout: RoutingLayout = {
+      width: 500,
+      height: 300,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, 80, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(320, 120, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(300, 100, 120, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 40},
+          fromId: 'sourceNode',
+          to: {x: 320, y: 140},
+          toId: 'targetNode',
+          sourceBoundary: 180,
+        },
+      ],
+    };
+
+    expect(applyAssetGroupLineageRouting(layout, routingOptions())).toBe(layout);
   });
 });

--- a/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/assetGroupLineageRouting.test.ts
@@ -1,11 +1,10 @@
 import type {IBounds} from '../../graph/common';
-
 import {
+  type ApplyAssetGroupRoutingOptions,
+  type RoutingLayout,
   applyAssetGroupLineageRouting,
   buildGroupAncestryIndex,
   solveAssetGroupConstraints,
-  type ApplyAssetGroupRoutingOptions,
-  type RoutingLayout,
 } from '../assetGroupLineageRouting';
 
 const bounds = (x: number, y: number, width: number, height: number): IBounds => ({
@@ -960,5 +959,287 @@ describe('applyAssetGroupLineageRouting', () => {
     };
 
     expect(applyAssetGroupLineageRouting(layout, routingOptions())).toBe(layout);
+  });
+});
+
+describe('applyAssetGroupLineageRouting secondary-axis alignment', () => {
+  const alignedOptions = (
+    overrides: Partial<ApplyAssetGroupRoutingOptions> = {},
+  ): ApplyAssetGroupRoutingOptions =>
+    routingOptions({alignGroupsOnSecondaryAxis: true, ...overrides});
+
+  it('leaves the secondary axis untouched when alignment is not requested', () => {
+    const layout: RoutingLayout = {
+      width: 600,
+      height: 700,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, 80, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(320, 420, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(300, 400, 180, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 40},
+          fromId: 'sourceNode',
+          to: {x: 320, y: 440},
+          toId: 'targetNode',
+          sourceBoundary: 180,
+          targetBoundary: 300,
+        },
+      ],
+    };
+
+    const result = applyAssetGroupLineageRouting(layout, routingOptions());
+
+    expect(result.groups.target!.bounds).toEqual(bounds(300, 400, 180, 100));
+    expect(result.nodes.targetNode!.bounds).toEqual(bounds(320, 420, 80, 40));
+    expect(result.edges[0]!.to).toEqual({x: 320, y: 440});
+  });
+
+  it('slides a downstream group onto the secondary axis position of its upstream endpoint', () => {
+    const layout: RoutingLayout = {
+      width: 600,
+      height: 700,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, 80, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(320, 420, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(300, 400, 180, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 40},
+          fromId: 'sourceNode',
+          to: {x: 320, y: 440},
+          toId: 'targetNode',
+          sourceBoundary: 180,
+          targetBoundary: 300,
+        },
+      ],
+    };
+
+    const result = applyAssetGroupLineageRouting(layout, alignedOptions());
+
+    expect(result.groups.source!.bounds).toEqual(bounds(0, 0, 180, 100));
+    expect(result.groups.target!.bounds).toEqual(bounds(300, 0, 180, 100));
+    expect(result.nodes.targetNode!.bounds).toEqual(bounds(320, 20, 80, 40));
+    expect(result.edges[0]!.from).toEqual({x: 100, y: 40});
+    expect(result.edges[0]!.to).toEqual({x: 320, y: 40});
+  });
+
+  it('preserves the primary-axis corridor while aligning the secondary axis', () => {
+    const layout: RoutingLayout = {
+      width: 600,
+      height: 700,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, 80, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(320, 420, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(300, 400, 180, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 40},
+          fromId: 'sourceNode',
+          to: {x: 320, y: 440},
+          toId: 'targetNode',
+          sourceBoundary: 180,
+          targetBoundary: 300,
+        },
+      ],
+    };
+
+    const result = applyAssetGroupLineageRouting(layout, alignedOptions());
+    const edge = result.edges[0]!;
+
+    expect(edge.sourceBoundary).toBe(180);
+    expect(edge.targetBoundary).toBe(300);
+    expect(edge.from.x).toBeLessThanOrEqual(edge.sourceBoundary!);
+    expect(edge.sourceBoundary! + 60).toBeLessThanOrEqual(edge.targetBoundary!);
+    expect(edge.targetBoundary!).toBeLessThanOrEqual(edge.to.x);
+  });
+
+  it('cascades same-column groups apart instead of overlapping them', () => {
+    const layout: RoutingLayout = {
+      width: 700,
+      height: 900,
+      nodes: {
+        a: {id: 'a', bounds: bounds(20, 20, 80, 40)},
+        b: {id: 'b', bounds: bounds(20, 80, 80, 40)},
+        t1n: {id: 't1n', bounds: bounds(320, 420, 80, 40)},
+        t2n: {id: 't2n', bounds: bounds(320, 620, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 300), expanded: true},
+        t1: {id: 't1', bounds: bounds(300, 400, 180, 100), expanded: true},
+        t2: {id: 't2', bounds: bounds(300, 600, 180, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 40},
+          fromId: 'a',
+          to: {x: 320, y: 440},
+          toId: 't1n',
+          sourceBoundary: 180,
+          targetBoundary: 300,
+        },
+        {
+          from: {x: 100, y: 100},
+          fromId: 'b',
+          to: {x: 320, y: 640},
+          toId: 't2n',
+          sourceBoundary: 180,
+          targetBoundary: 300,
+        },
+      ],
+    };
+
+    const result = applyAssetGroupLineageRouting(
+      layout,
+      alignedOptions({
+        groupParentById: {source: null, t1: null, t2: null},
+        ownerGroupByNodeId: {a: 'source', b: 'source', t1n: 't1', t2n: 't2'},
+        endpointGroupById: {a: 'source', b: 'source', t1n: 't1', t2n: 't2'},
+      }),
+    );
+
+    // t2 wants y 60, which overlaps t1, so it cascades below t1's original 100px gap.
+    expect(result.groups.t1!.bounds).toEqual(bounds(300, 0, 180, 100));
+    expect(result.groups.t2!.bounds).toEqual(bounds(300, 200, 180, 100));
+    expect(result.nodes.t2n!.bounds).toEqual(bounds(320, 220, 80, 40));
+    expect(result.edges[1]!.to).toEqual({x: 320, y: 240});
+  });
+
+  it('preserves the upstream group order when cascading', () => {
+    const layout: RoutingLayout = {
+      width: 700,
+      height: 900,
+      nodes: {
+        a: {id: 'a', bounds: bounds(20, 20, 80, 40)},
+        b: {id: 'b', bounds: bounds(20, 80, 80, 40)},
+        t1n: {id: 't1n', bounds: bounds(320, 420, 80, 40)},
+        t2n: {id: 't2n', bounds: bounds(320, 620, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 300), expanded: true},
+        t1: {id: 't1', bounds: bounds(300, 400, 180, 100), expanded: true},
+        t2: {id: 't2', bounds: bounds(300, 600, 180, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 100},
+          fromId: 'b',
+          to: {x: 320, y: 440},
+          toId: 't1n',
+          sourceBoundary: 180,
+          targetBoundary: 300,
+        },
+        {
+          from: {x: 100, y: 40},
+          fromId: 'a',
+          to: {x: 320, y: 640},
+          toId: 't2n',
+          sourceBoundary: 180,
+          targetBoundary: 300,
+        },
+      ],
+    };
+
+    const result = applyAssetGroupLineageRouting(
+      layout,
+      alignedOptions({
+        groupParentById: {source: null, t1: null, t2: null},
+        ownerGroupByNodeId: {a: 'source', b: 'source', t1n: 't1', t2n: 't2'},
+        endpointGroupById: {a: 'source', b: 'source', t1n: 't1', t2n: 't2'},
+      }),
+    );
+
+    expect(result.groups.t1!.bounds.y).toBeLessThan(result.groups.t2!.bounds.y);
+    expect(result.groups.t1!.bounds.y + result.groups.t1!.bounds.height).toBeLessThanOrEqual(
+      result.groups.t2!.bounds.y,
+    );
+  });
+
+  it('skips alignment when an edge endpoint has no owning group', () => {
+    const layout: RoutingLayout = {
+      width: 700,
+      height: 900,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(20, 20, 80, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(320, 420, 80, 40)},
+        ungroupedNode: {id: 'ungroupedNode', bounds: bounds(560, 420, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 0, 180, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(300, 400, 180, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 40},
+          fromId: 'sourceNode',
+          to: {x: 320, y: 440},
+          toId: 'targetNode',
+          sourceBoundary: 180,
+          targetBoundary: 300,
+        },
+        {from: {x: 480, y: 440}, fromId: 'targetNode', to: {x: 560, y: 440}, toId: 'ungroupedNode'},
+      ],
+    };
+
+    const result = applyAssetGroupLineageRouting(
+      layout,
+      alignedOptions({
+        ownerGroupByNodeId: {
+          sourceNode: 'source',
+          targetNode: 'target',
+          ungroupedNode: null,
+        },
+        endpointGroupById: {
+          sourceNode: 'source',
+          targetNode: 'target',
+          ungroupedNode: null,
+        },
+      }),
+    );
+
+    expect(result.groups.target!.bounds).toEqual(bounds(300, 400, 180, 100));
+    expect(result.nodes.targetNode!.bounds).toEqual(bounds(320, 420, 80, 40));
+  });
+
+  it('grows the canvas when alignment pushes a group past the original extent', () => {
+    const layout: RoutingLayout = {
+      width: 600,
+      height: 260,
+      nodes: {
+        sourceNode: {id: 'sourceNode', bounds: bounds(20, 120, 80, 40)},
+        targetNode: {id: 'targetNode', bounds: bounds(320, 20, 80, 40)},
+      },
+      groups: {
+        source: {id: 'source', bounds: bounds(0, 100, 180, 100), expanded: true},
+        target: {id: 'target', bounds: bounds(300, 0, 180, 100), expanded: true},
+      },
+      edges: [
+        {
+          from: {x: 100, y: 140},
+          fromId: 'sourceNode',
+          to: {x: 320, y: 40},
+          toId: 'targetNode',
+          sourceBoundary: 180,
+          targetBoundary: 300,
+        },
+      ],
+    };
+
+    const result = applyAssetGroupLineageRouting(layout, alignedOptions());
+
+    expect(result.groups.target!.bounds).toEqual(bounds(300, 100, 180, 100));
+    expect(result.height).toBeGreaterThanOrEqual(300);
   });
 });

--- a/js_modules/ui-core/src/asset-graph/__tests__/layout.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/layout.test.ts
@@ -1,0 +1,82 @@
+import {FeatureFlag} from '@shared/FeatureFlags';
+
+import {getCurrentFeatureFlags, setFeatureFlags} from '../../app/Flags';
+import {
+  buildAssetKey,
+  buildAssetNode,
+  buildRepository,
+  buildRepositoryLocation,
+} from '../../graphql/builders';
+import {layoutAssetGraphImpl} from '../layout';
+import {GraphData, GraphNode, groupIdForNode, toGraphId} from '../Utils';
+
+describe('layoutAssetGraphImpl', () => {
+  const featureFlags = getCurrentFeatureFlags();
+
+  beforeEach(() => {
+    setFeatureFlags({...featureFlags, [FeatureFlag.flagAssetGraphGroupsPerCodeLocation]: false});
+  });
+
+  afterEach(() => {
+    setFeatureFlags(featureFlags);
+  });
+
+  const graphNode = (name: string, groupName: string): GraphNode => {
+    const assetKey = buildAssetKey({path: [name]});
+    return {
+      id: toGraphId(assetKey),
+      assetKey,
+      definition: buildAssetNode({
+        assetKey,
+        groupName,
+        repository: buildRepository({
+          name: 'repository',
+          location: buildRepositoryLocation({name: 'location'}),
+        }),
+      }),
+    };
+  };
+
+  it('routes lineage from an expanded group into a collapsed downstream group', () => {
+    const first = graphNode('first', 'source');
+    const second = graphNode('second', 'source');
+    const third = graphNode('third', 'source');
+    const target = graphNode('target', 'downstream');
+    const graphData: GraphData = {
+      nodes: {
+        [first.id]: first,
+        [second.id]: second,
+        [third.id]: third,
+        [target.id]: target,
+      },
+      downstream: {
+        [first.id]: {[second.id]: true},
+        [second.id]: {[third.id]: true},
+        [third.id]: {[target.id]: true},
+        [target.id]: {},
+      },
+      upstream: {
+        [first.id]: {},
+        [second.id]: {[first.id]: true},
+        [third.id]: {[second.id]: true},
+        [target.id]: {[third.id]: true},
+      },
+      expandedGroups: [groupIdForNode(first)],
+    };
+
+    const layout = layoutAssetGraphImpl(graphData, {
+      direction: 'horizontal',
+      facets: [],
+      flagAssetGraphGroupsPerCodeLocation: false,
+    });
+    const edge = layout.edges.find(({toId}) => toId === groupIdForNode(target));
+    const thirdLayout = layout.nodes[third.id];
+
+    expect(edge).toBeDefined();
+    expect(edge?.fromId).toBe(third.id);
+    expect(edge?.sourceBoundary).toBeDefined();
+    expect(edge?.targetBoundary).toBeDefined();
+    expect(edge!.targetBoundary! - edge!.sourceBoundary!).toBeGreaterThanOrEqual(60);
+    expect(edge?.from.y).toBe(thirdLayout!.bounds.y + thirdLayout!.bounds.height / 2);
+  });
+});

--- a/js_modules/ui-core/src/asset-graph/__tests__/layout.test.ts
+++ b/js_modules/ui-core/src/asset-graph/__tests__/layout.test.ts
@@ -79,4 +79,49 @@ describe('layoutAssetGraphImpl', () => {
     expect(edge!.targetBoundary! - edge!.sourceBoundary!).toBeGreaterThanOrEqual(60);
     expect(edge?.from.y).toBe(thirdLayout!.bounds.y + thirdLayout!.bounds.height / 2);
   });
+
+  it.each(['horizontal', 'vertical'] as const)(
+    'routes %s lineage from an ancestor asset through only the child boundary',
+    (direction) => {
+      const ancestorAsset = graphNode('ancestor-asset', 'a');
+      const descendantAsset = graphNode('descendant-asset', 'a/b');
+      const graphData: GraphData = {
+        nodes: {
+          [ancestorAsset.id]: ancestorAsset,
+          [descendantAsset.id]: descendantAsset,
+        },
+        downstream: {
+          [ancestorAsset.id]: {[descendantAsset.id]: true},
+          [descendantAsset.id]: {},
+        },
+        upstream: {
+          [ancestorAsset.id]: {},
+          [descendantAsset.id]: {[ancestorAsset.id]: true},
+        },
+        expandedGroups: [groupIdForNode(descendantAsset)],
+      };
+
+      const layout = layoutAssetGraphImpl(graphData, {
+        direction,
+        facets: [],
+        flagAssetGraphGroupsPerCodeLocation: false,
+      });
+      const edge = layout.edges.find(
+        ({fromId, toId}) => fromId === ancestorAsset.id && toId === descendantAsset.id,
+      );
+      const ancestorGroup = layout.groups[groupIdForNode(ancestorAsset)]!;
+      const childGroup = layout.groups[groupIdForNode(descendantAsset)]!;
+      const sourceEndpoint = direction === 'horizontal' ? edge?.from.x : edge?.from.y;
+      const childStart = direction === 'horizontal' ? childGroup.bounds.x : childGroup.bounds.y;
+      const sharedAncestorEnd =
+        direction === 'horizontal'
+          ? ancestorGroup.bounds.x + ancestorGroup.bounds.width
+          : ancestorGroup.bounds.y + ancestorGroup.bounds.height;
+
+      expect(edge).toBeDefined();
+      expect(edge?.sourceBoundary).toBe(sourceEndpoint);
+      expect(edge?.targetBoundary).toBe(childStart);
+      expect(edge?.sourceBoundary).not.toBe(sharedAncestorEnd);
+    },
+  );
 });

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -783,20 +783,31 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
     };
   });
 
-  const forwardEnds = [
-    ...Object.values(groups).map((group) => primaryEnd(group.bounds, options.direction)),
-    ...Object.values(nodes).map((node) => primaryEnd(node.bounds, options.direction)),
-  ];
-  const maximumForwardEnd = forwardEnds.length ? Math.max(...forwardEnds) : 0;
+  let maximumForwardEnd: number | undefined;
+  for (const id in groups) {
+    const group = groups[id];
+    if (group) {
+      const end = primaryEnd(group.bounds, options.direction);
+      maximumForwardEnd = maximumForwardEnd === undefined ? end : Math.max(maximumForwardEnd, end);
+    }
+  }
+  for (const id in nodes) {
+    const node = nodes[id];
+    if (node) {
+      const end = primaryEnd(node.bounds, options.direction);
+      maximumForwardEnd = maximumForwardEnd === undefined ? end : Math.max(maximumForwardEnd, end);
+    }
+  }
+  const forwardEnd = maximumForwardEnd ?? 0;
   const result = {
     ...layout,
     width:
       options.direction === 'horizontal'
-        ? Math.max(layout.width, maximumForwardEnd + options.margin)
+        ? Math.max(layout.width, forwardEnd + options.margin)
         : layout.width,
     height:
       options.direction === 'vertical'
-        ? Math.max(layout.height, maximumForwardEnd + options.margin)
+        ? Math.max(layout.height, forwardEnd + options.margin)
         : layout.height,
     nodes,
     groups,

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -196,8 +196,8 @@ const buildConstraintComponents = (
   constraints: BranchConstraint[],
 ): Record<string, string> => {
   const idSet = new Set(ids);
-  const adjacency = new Map(ids.map((id) => [id, [] as string[]]));
-  const reverse = new Map(ids.map((id) => [id, [] as string[]]));
+  const adjacencySets = new Map(ids.map((id) => [id, new Set<string>()]));
+  const reverseSets = new Map(ids.map((id) => [id, new Set<string>()]));
 
   for (const constraint of constraints) {
     if (!idSet.has(constraint.sourceBranchId)) {
@@ -206,13 +206,11 @@ const buildConstraintComponents = (
     if (!idSet.has(constraint.targetBranchId)) {
       throw new Error(`Unknown asset group constraint endpoint: ${constraint.targetBranchId}`);
     }
-    adjacency.get(constraint.sourceBranchId)!.push(constraint.targetBranchId);
-    reverse.get(constraint.targetBranchId)!.push(constraint.sourceBranchId);
+    adjacencySets.get(constraint.sourceBranchId)!.add(constraint.targetBranchId);
+    reverseSets.get(constraint.targetBranchId)!.add(constraint.sourceBranchId);
   }
-  for (const id of ids) {
-    adjacency.get(id)!.sort();
-    reverse.get(id)!.sort();
-  }
+  const adjacency = new Map(ids.map((id) => [id, [...adjacencySets.get(id)!].sort()] as const));
+  const reverse = new Map(ids.map((id) => [id, [...reverseSets.get(id)!].sort()] as const));
 
   const visited = new Set<string>();
   const finishOrder: string[] = [];
@@ -347,16 +345,19 @@ export const solveAssetGroupConstraints = ({
     nodes.add(endNode(id));
   }
 
-  const edges: WeightedEdge[] = [];
-  const edgeKeys = new Set<string>();
+  const edgeWeightByNodes = new Map<string, Map<string, number>>();
   const addEdge = (from: string, to: string, weight: number) => {
     if (!Number.isFinite(weight)) {
       throw new Error('Non-finite asset group constraint');
     }
-    const key = JSON.stringify([from, to, weight]);
-    if (!edgeKeys.has(key)) {
-      edgeKeys.add(key);
-      edges.push({from, to, weight});
+    let weightByTarget = edgeWeightByNodes.get(from);
+    if (!weightByTarget) {
+      weightByTarget = new Map();
+      edgeWeightByNodes.set(from, weightByTarget);
+    }
+    const previousWeight = weightByTarget.get(to);
+    if (previousWeight === undefined || weight > previousWeight) {
+      weightByTarget.set(to, weight);
     }
   };
 
@@ -373,7 +374,10 @@ export const solveAssetGroupConstraints = ({
       if (!idSet.has(parentId)) {
         throw new Error(`Missing visible asset group parent: ${parentId}`);
       }
-      addEdge(moveNode(componentByGroupId[parentId]!), componentMove, 0);
+      const parentMove = moveNode(componentByGroupId[parentId]!);
+      if (parentMove !== componentMove) {
+        addEdge(parentMove, componentMove, 0);
+      }
       addEdge(endNode(id), endNode(parentId), trailingGroupPadding);
     }
   }
@@ -399,6 +403,9 @@ export const solveAssetGroupConstraints = ({
     }
   }
 
+  const edges = [...edgeWeightByNodes].flatMap(([from, weightByTarget]) =>
+    [...weightByTarget].map(([to, weight]) => ({from, to, weight})),
+  );
   edges.sort(
     (left, right) =>
       compareStrings(left.from, right.from) ||

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -19,6 +19,9 @@ export const buildGroupAncestryIndex = (
     if (parentId === null) {
       continue;
     }
+    if (parentId === undefined) {
+      throw new Error('Missing visible asset group parent: undefined');
+    }
     const parentIndex = indexById.get(parentId);
     if (parentIndex === undefined) {
       throw new Error(`Missing visible asset group parent: ${parentId}`);

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -493,10 +493,11 @@ const solveAssetGroupConstraintsNumeric = (
     ) {
       const target = targetByAdjacency[edgeIndex]!;
       if (Number.isFinite(fromDistance)) {
-        distance[target] = Math.max(
-          distance[target]!,
-          fromDistance + weightByAdjacency[edgeIndex]!,
-        );
+        const candidate = fromDistance + weightByAdjacency[edgeIndex]!;
+        if (!Number.isFinite(candidate)) {
+          throw new Error('Non-finite asset group constraint solution');
+        }
+        distance[target] = Math.max(distance[target]!, candidate);
       }
       const nextIndegree = indegree[target]! - 1;
       indegree[target] = nextIndegree;
@@ -516,8 +517,11 @@ const solveAssetGroupConstraintsNumeric = (
     const component = componentByIndex[index]!;
     const shift = distance[moveNode(component)]!;
     const end = distance[endNode(index)]!;
-    shiftByIndex[index] = Number.isFinite(shift) ? shift : 0;
-    endByIndex[index] = Number.isFinite(end) ? end : primaryEnd(groups[id]!.bounds, direction);
+    if (!Number.isFinite(shift) || !Number.isFinite(end)) {
+      throw new Error('Non-finite asset group constraint solution');
+    }
+    shiftByIndex[index] = shift;
+    endByIndex[index] = end;
   }
   return {ids, indexById, shiftByIndex, endByIndex, componentByIndex, componentIdIndex};
 };
@@ -546,15 +550,25 @@ const translatePoint = (
   point: {x: number; y: number},
   amount: number,
   direction: RoutingDirection,
-) =>
-  direction === 'horizontal'
-    ? {x: point.x + amount, y: point.y}
-    : {x: point.x, y: point.y + amount};
+) => {
+  const translatedPrimary = pointPrimary(point, direction) + amount;
+  if (!Number.isFinite(translatedPrimary)) {
+    throw new Error('Non-finite asset group routed edge endpoint');
+  }
+  return direction === 'horizontal'
+    ? {x: translatedPrimary, y: point.y}
+    : {x: point.x, y: translatedPrimary};
+};
 
-const translateBounds = (bounds: IBounds, amount: number, direction: RoutingDirection): IBounds =>
-  direction === 'horizontal'
-    ? {x: bounds.x + amount, y: bounds.y, width: bounds.width, height: bounds.height}
-    : {x: bounds.x, y: bounds.y + amount, width: bounds.width, height: bounds.height};
+const translateBounds = (bounds: IBounds, amount: number, direction: RoutingDirection): IBounds => {
+  const translatedPrimary = primaryStart(bounds, direction) + amount;
+  if (!Number.isFinite(translatedPrimary)) {
+    throw new Error('Non-finite routed asset bounds');
+  }
+  return direction === 'horizontal'
+    ? {x: translatedPrimary, y: bounds.y, width: bounds.width, height: bounds.height}
+    : {x: bounds.x, y: translatedPrimary, width: bounds.width, height: bounds.height};
+};
 
 type ConstraintColumns = {
   count: number;
@@ -573,6 +587,24 @@ const validBounds = (value: IBounds) =>
   value.width >= 0 &&
   value.height >= 0;
 
+const assertValidOutputCorridor = (
+  edge: RoutingLayoutEdge,
+  direction: RoutingDirection,
+  ranksep: number,
+) => {
+  const sourceBoundary = edge.sourceBoundary!;
+  const targetBoundary = edge.targetBoundary!;
+  if (
+    !Number.isFinite(sourceBoundary) ||
+    !Number.isFinite(targetBoundary) ||
+    pointPrimary(edge.from, direction) > sourceBoundary ||
+    sourceBoundary + ranksep > targetBoundary ||
+    targetBoundary > pointPrimary(edge.to, direction)
+  ) {
+    throw new Error('Invalid asset group routed edge corridor');
+  }
+};
+
 const validateInputCorridors = (layout: RoutingLayout, options: ApplyAssetGroupRoutingOptions) => {
   if (
     !Number.isFinite(layout.width) ||
@@ -583,12 +615,18 @@ const validateInputCorridors = (layout: RoutingLayout, options: ApplyAssetGroupR
     return false;
   }
   for (const id in layout.groups) {
+    if (!Object.prototype.hasOwnProperty.call(layout.groups, id)) {
+      continue;
+    }
     const group = layout.groups[id];
     if (!group || !validBounds(group.bounds)) {
       return false;
     }
   }
   for (const id in layout.nodes) {
+    if (!Object.prototype.hasOwnProperty.call(layout.nodes, id)) {
+      continue;
+    }
     const node = layout.nodes[id];
     if (!node || !validBounds(node.bounds)) {
       return false;
@@ -749,20 +787,35 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
 
   const groups: RoutingLayout['groups'] = {};
   for (const id in layout.groups) {
+    if (!Object.prototype.hasOwnProperty.call(layout.groups, id)) {
+      continue;
+    }
     const group = layout.groups[id]!;
     const solutionIndex = requireSolutionIndex(id);
     const shift = solution.shiftByIndex[solutionIndex]!;
     const end = solution.endByIndex[solutionIndex]!;
     const bounds = group.bounds;
+    const translatedStart = primaryStart(bounds, options.direction) + shift;
+    const translatedSize = end - translatedStart;
+    if (
+      !Number.isFinite(translatedStart) ||
+      !Number.isFinite(translatedSize) ||
+      translatedSize < 0
+    ) {
+      throw new Error('Invalid routed asset group bounds');
+    }
     const translatedBounds =
       options.direction === 'horizontal'
-        ? {x: bounds.x + shift, y: bounds.y, width: end - bounds.x - shift, height: bounds.height}
-        : {x: bounds.x, y: bounds.y + shift, width: bounds.width, height: end - bounds.y - shift};
+        ? {x: translatedStart, y: bounds.y, width: translatedSize, height: bounds.height}
+        : {x: bounds.x, y: translatedStart, width: bounds.width, height: translatedSize};
     groups[id] = {...group, bounds: translatedBounds};
   }
 
   const nodes: RoutingLayout['nodes'] = {};
   for (const id in layout.nodes) {
+    if (!Object.prototype.hasOwnProperty.call(layout.nodes, id)) {
+      continue;
+    }
     const node = layout.nodes[id]!;
     const ownerGroupId = options.ownerGroupByNodeId[id];
     const shift =
@@ -783,26 +836,26 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
     delete translated.targetBoundary;
     const constraintIndex = constraintIndexByEdge[index]!;
     if (
-      constraintIndex === -1 ||
+      constraintIndex !== -1 &&
       solution.componentByIndex[
         requireSolutionIndex(constraintColumns.sourceBranchIds[constraintIndex]!)
-      ] ===
+      ] !==
         solution.componentByIndex[
           requireSolutionIndex(constraintColumns.targetBranchIds[constraintIndex]!)
         ]
     ) {
-      return translated;
+      const sourceBranchIndex = requireSolutionIndex(
+        constraintColumns.sourceBranchIds[constraintIndex]!,
+      );
+      const sourceBranchShift = solution.shiftByIndex[sourceBranchIndex]!;
+      const targetBranchShift = shiftForGroup(constraintColumns.targetBranchIds[constraintIndex]!);
+      translated.sourceBoundary = constraintColumns.sourceUsesGroupEnd[constraintIndex]
+        ? solution.endByIndex[sourceBranchIndex]!
+        : constraintColumns.sourceBaseExit[constraintIndex]! + sourceBranchShift;
+      translated.targetBoundary =
+        constraintColumns.targetBaseEntry[constraintIndex]! + targetBranchShift;
+      assertValidOutputCorridor(translated, options.direction, options.ranksep);
     }
-    const sourceBranchIndex = requireSolutionIndex(
-      constraintColumns.sourceBranchIds[constraintIndex]!,
-    );
-    const sourceBranchShift = solution.shiftByIndex[sourceBranchIndex]!;
-    const targetBranchShift = shiftForGroup(constraintColumns.targetBranchIds[constraintIndex]!);
-    translated.sourceBoundary = constraintColumns.sourceUsesGroupEnd[constraintIndex]
-      ? solution.endByIndex[sourceBranchIndex]!
-      : constraintColumns.sourceBaseExit[constraintIndex]! + sourceBranchShift;
-    translated.targetBoundary =
-      constraintColumns.targetBaseEntry[constraintIndex]! + targetBranchShift;
     return translated;
   });
 
@@ -836,6 +889,14 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
     groups,
     edges,
   } as T;
+  if (
+    !Number.isFinite(result.width) ||
+    !Number.isFinite(result.height) ||
+    result.width <= 0 ||
+    result.height <= 0
+  ) {
+    throw new Error('Invalid routed asset graph canvas');
+  }
   return result;
 };
 

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -735,6 +735,14 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
   const ancestry = hasNestedGroups ? buildGroupAncestryIndex(options.groupParentById) : undefined;
   const constraintIndexByEdge = new Int32Array(layout.edges.length);
   constraintIndexByEdge.fill(-1);
+  const hasRouteByEdge = ancestry ? new Uint8Array(layout.edges.length) : undefined;
+  const routeSourceGroupIds: string[] | undefined = ancestry ? [] : undefined;
+  const routeTargetGroupIds: string[] | undefined = ancestry ? [] : undefined;
+  const routeSourceUsesEndpoint = ancestry ? new Uint8Array(layout.edges.length) : undefined;
+  const routeTargetUsesEndpoint = ancestry ? new Uint8Array(layout.edges.length) : undefined;
+  const routeSourceUsesGroupEnd = ancestry ? new Uint8Array(layout.edges.length) : undefined;
+  const routeSourceBaseExit = ancestry ? new Float64Array(layout.edges.length) : undefined;
+  const routeTargetBaseEntry = ancestry ? new Float64Array(layout.edges.length) : undefined;
   const constraintColumns: ConstraintColumns = {
     count: 0,
     sourceBranchIds: [],
@@ -759,36 +767,79 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
       return;
     }
 
-    const lca =
-      ancestry?.lowestCommonAncestor(sourceEndpointGroupId, targetEndpointGroupId) ?? null;
-    const sourceBranchId = ancestry
-      ? ancestry.branchBelow(sourceEndpointGroupId, lca)
-      : sourceEndpointGroupId;
-    const targetBranchId = ancestry
-      ? ancestry.branchBelow(targetEndpointGroupId, lca)
-      : targetEndpointGroupId;
-    if (!sourceBranchId || !targetBranchId || sourceBranchId === targetBranchId) {
+    if (!ancestry) {
+      const sourceGroup = layout.groups[sourceEndpointGroupId];
+      const targetGroup = layout.groups[targetEndpointGroupId];
+      if (!sourceGroup || !targetGroup) {
+        throw new Error('Missing asset group routing branch');
+      }
+      const sourceUsesGroupEnd = sourceGroup.expanded || edge.fromId !== sourceEndpointGroupId;
+      const targetUsesGroupStart = targetGroup.expanded || edge.toId !== targetEndpointGroupId;
+      const constraintIndex = constraintColumns.count++;
+      constraintIndexByEdge[index] = constraintIndex;
+      constraintColumns.sourceBranchIds.push(sourceEndpointGroupId);
+      constraintColumns.targetBranchIds.push(targetEndpointGroupId);
+      constraintColumns.sourceUsesGroupEnd[constraintIndex] = sourceUsesGroupEnd ? 1 : 0;
+      constraintColumns.sourceBaseExit[constraintIndex] = sourceUsesGroupEnd
+        ? primaryEnd(sourceGroup.bounds, options.direction)
+        : pointPrimary(edge.from, options.direction);
+      constraintColumns.targetBaseEntry[constraintIndex] = targetUsesGroupStart
+        ? primaryStart(targetGroup.bounds, options.direction)
+        : pointPrimary(edge.to, options.direction);
       return;
     }
-    const sourceGroup = layout.groups[sourceBranchId];
-    const targetGroup = layout.groups[targetBranchId];
+
+    const lca = ancestry.lowestCommonAncestor(sourceEndpointGroupId, targetEndpointGroupId);
+    const crossedSourceBranchId = ancestry.branchBelow(sourceEndpointGroupId, lca);
+    const crossedTargetBranchId = ancestry.branchBelow(targetEndpointGroupId, lca);
+    if (
+      crossedSourceBranchId !== null &&
+      crossedTargetBranchId !== null &&
+      crossedSourceBranchId === crossedTargetBranchId
+    ) {
+      return;
+    }
+    const sourceRouteGroupId = crossedSourceBranchId ?? sourceEndpointGroupId;
+    const targetRouteGroupId = crossedTargetBranchId ?? targetEndpointGroupId;
+    const sourceGroup = layout.groups[sourceRouteGroupId];
+    const targetGroup = layout.groups[targetRouteGroupId];
     if (!sourceGroup || !targetGroup) {
       throw new Error('Missing asset group routing branch');
     }
 
-    const sourceUsesGroupEnd = sourceGroup.expanded || edge.fromId !== sourceBranchId;
-    const targetUsesGroupStart = targetGroup.expanded || edge.toId !== targetBranchId;
-    const constraintIndex = constraintColumns.count++;
-    constraintIndexByEdge[index] = constraintIndex;
-    constraintColumns.sourceBranchIds.push(sourceBranchId);
-    constraintColumns.targetBranchIds.push(targetBranchId);
-    constraintColumns.sourceUsesGroupEnd[constraintIndex] = sourceUsesGroupEnd ? 1 : 0;
-    constraintColumns.sourceBaseExit[constraintIndex] = sourceUsesGroupEnd
+    const sourceUsesEndpoint = crossedSourceBranchId === null;
+    const targetUsesEndpoint = crossedTargetBranchId === null;
+    const sourceUsesGroupEnd =
+      !sourceUsesEndpoint && (sourceGroup.expanded || edge.fromId !== sourceRouteGroupId);
+    const targetUsesGroupStart =
+      !targetUsesEndpoint && (targetGroup.expanded || edge.toId !== targetRouteGroupId);
+    const sourceBaseExit = sourceUsesGroupEnd
       ? primaryEnd(sourceGroup.bounds, options.direction)
       : pointPrimary(edge.from, options.direction);
-    constraintColumns.targetBaseEntry[constraintIndex] = targetUsesGroupStart
+    const targetBaseEntry = targetUsesGroupStart
       ? primaryStart(targetGroup.bounds, options.direction)
       : pointPrimary(edge.to, options.direction);
+    hasRouteByEdge![index] = 1;
+    routeSourceGroupIds![index] = sourceRouteGroupId;
+    routeTargetGroupIds![index] = targetRouteGroupId;
+    routeSourceUsesEndpoint![index] = sourceUsesEndpoint ? 1 : 0;
+    routeTargetUsesEndpoint![index] = targetUsesEndpoint ? 1 : 0;
+    routeSourceUsesGroupEnd![index] = sourceUsesGroupEnd ? 1 : 0;
+    routeSourceBaseExit![index] = sourceBaseExit;
+    routeTargetBaseEntry![index] = targetBaseEntry;
+
+    // A descendant-to-ancestor constraint would oppose the hierarchy's parent-to-child
+    // movement edge. It cannot improve separation, so validate it only after other shifts.
+    if (targetUsesEndpoint) {
+      return;
+    }
+    const constraintIndex = constraintColumns.count++;
+    constraintIndexByEdge[index] = constraintIndex;
+    constraintColumns.sourceBranchIds.push(sourceRouteGroupId);
+    constraintColumns.targetBranchIds.push(targetRouteGroupId);
+    constraintColumns.sourceUsesGroupEnd[constraintIndex] = sourceUsesGroupEnd ? 1 : 0;
+    constraintColumns.sourceBaseExit[constraintIndex] = sourceBaseExit;
+    constraintColumns.targetBaseEntry[constraintIndex] = targetBaseEntry;
   });
 
   const solution = solveAssetGroupConstraintsNumeric(
@@ -877,20 +928,26 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
 
   const edges = layout.edges.map((edge, index) => {
     const constraintIndex = constraintIndexByEdge[index]!;
-    const sourceBranchIndex =
-      constraintIndex === -1
-        ? -1
-        : requireSolutionIndex(constraintColumns.sourceBranchIds[constraintIndex]!);
-    const targetBranchIndex =
-      constraintIndex === -1
-        ? -1
-        : requireSolutionIndex(constraintColumns.targetBranchIds[constraintIndex]!);
     const flatRoutedEdge = ancestry === undefined && constraintIndex !== -1;
-    const sourceEndpointGroupId = flatRoutedEdge
+    const nestedRoutedEdge = ancestry !== undefined && hasRouteByEdge![index] === 1;
+    const hasRoute = flatRoutedEdge || nestedRoutedEdge;
+    const sourceRouteGroupId = flatRoutedEdge
       ? constraintColumns.sourceBranchIds[constraintIndex]!
+      : nestedRoutedEdge
+        ? routeSourceGroupIds![index]!
+        : undefined;
+    const targetRouteGroupId = flatRoutedEdge
+      ? constraintColumns.targetBranchIds[constraintIndex]!
+      : nestedRoutedEdge
+        ? routeTargetGroupIds![index]!
+        : undefined;
+    const sourceBranchIndex = sourceRouteGroupId ? requireSolutionIndex(sourceRouteGroupId) : -1;
+    const targetBranchIndex = targetRouteGroupId ? requireSolutionIndex(targetRouteGroupId) : -1;
+    const sourceEndpointGroupId = flatRoutedEdge
+      ? sourceRouteGroupId
       : options.endpointGroupById[edge.fromId];
     const targetEndpointGroupId = flatRoutedEdge
-      ? constraintColumns.targetBranchIds[constraintIndex]!
+      ? targetRouteGroupId
       : options.endpointGroupById[edge.toId];
     const sourceShift = sourceEndpointGroupId
       ? solution.shiftByIndex[
@@ -908,16 +965,27 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
     delete translated.sourceBoundary;
     delete translated.targetBoundary;
     if (
-      constraintIndex !== -1 &&
+      hasRoute &&
       solution.componentByIndex[sourceBranchIndex] !== solution.componentByIndex[targetBranchIndex]
     ) {
       const sourceBranchShift = solution.shiftByIndex[sourceBranchIndex]!;
       const targetBranchShift = solution.shiftByIndex[targetBranchIndex]!;
-      translated.sourceBoundary = constraintColumns.sourceUsesGroupEnd[constraintIndex]
-        ? solution.endByIndex[sourceBranchIndex]!
-        : constraintColumns.sourceBaseExit[constraintIndex]! + sourceBranchShift;
-      translated.targetBoundary =
-        constraintColumns.targetBaseEntry[constraintIndex]! + targetBranchShift;
+      if (flatRoutedEdge) {
+        translated.sourceBoundary = constraintColumns.sourceUsesGroupEnd[constraintIndex]
+          ? solution.endByIndex[sourceBranchIndex]!
+          : constraintColumns.sourceBaseExit[constraintIndex]! + sourceBranchShift;
+        translated.targetBoundary =
+          constraintColumns.targetBaseEntry[constraintIndex]! + targetBranchShift;
+      } else {
+        translated.sourceBoundary = routeSourceUsesEndpoint![index]
+          ? pointPrimary(from, options.direction)
+          : routeSourceUsesGroupEnd![index]
+            ? solution.endByIndex[sourceBranchIndex]!
+            : routeSourceBaseExit![index]! + sourceBranchShift;
+        translated.targetBoundary = routeTargetUsesEndpoint![index]
+          ? pointPrimary(to, options.direction)
+          : routeTargetBaseEntry![index]! + targetBranchShift;
+      }
       assertValidOutputCorridor(translated, options.direction, options.ranksep);
     }
     return translated;

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -14,6 +14,35 @@ export type BranchConstraint = {
   targetBaseEntry: number;
 };
 
+export type EdgeRouteInfo = BranchConstraint;
+
+export type RoutingLayoutEdge = {
+  from: {x: number; y: number};
+  fromId: string;
+  to: {x: number; y: number};
+  toId: string;
+  sourceBoundary?: number;
+  targetBoundary?: number;
+};
+
+export type RoutingLayout = {
+  width: number;
+  height: number;
+  nodes: Record<string, {id: string; bounds: IBounds}>;
+  groups: Record<string, {id: string; bounds: IBounds; expanded: boolean}>;
+  edges: RoutingLayoutEdge[];
+};
+
+export type ApplyAssetGroupRoutingOptions = {
+  direction: RoutingDirection;
+  ranksep: number;
+  trailingGroupPadding: number;
+  margin: number;
+  groupParentById: GroupParentById;
+  ownerGroupByNodeId: Record<string, string | null>;
+  endpointGroupById: Record<string, string | null>;
+};
+
 export type AssetGroupConstraintInput = {
   direction: RoutingDirection;
   ranksep: number;
@@ -455,4 +484,305 @@ export const solveAssetGroupConstraints = ({
     endByGroupId[id] = Number.isFinite(end) ? end! : primaryEnd(groups[id]!.bounds, direction);
   }
   return {shiftByGroupId, endByGroupId, componentByGroupId};
+};
+
+const pointPrimary = (point: {x: number; y: number}, direction: RoutingDirection) =>
+  direction === 'horizontal' ? point.x : point.y;
+
+const translatePoint = (
+  point: {x: number; y: number},
+  amount: number,
+  direction: RoutingDirection,
+) =>
+  direction === 'horizontal' ? {...point, x: point.x + amount} : {...point, y: point.y + amount};
+
+const translateBounds = (bounds: IBounds, amount: number, direction: RoutingDirection): IBounds =>
+  direction === 'horizontal'
+    ? {...bounds, x: bounds.x + amount}
+    : {...bounds, y: bounds.y + amount};
+
+const withForwardEnd = (bounds: IBounds, end: number, direction: RoutingDirection): IBounds =>
+  direction === 'horizontal'
+    ? {...bounds, width: end - bounds.x}
+    : {...bounds, height: end - bounds.y};
+
+type InternalEdgeRouteInfo = EdgeRouteInfo;
+
+const validBounds = (value: IBounds) =>
+  Number.isFinite(value.x) &&
+  Number.isFinite(value.y) &&
+  Number.isFinite(value.width) &&
+  Number.isFinite(value.height) &&
+  value.width >= 0 &&
+  value.height >= 0;
+
+const sameKeys = (left: Record<string, unknown>, right: Record<string, unknown>) => {
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  return (
+    leftKeys.length === rightKeys.length && leftKeys.every((key, index) => key === rightKeys[index])
+  );
+};
+
+const validateRoutingResult = (
+  original: RoutingLayout,
+  result: RoutingLayout,
+  options: ApplyAssetGroupRoutingOptions,
+) => {
+  if (
+    !Number.isFinite(original.width) ||
+    !Number.isFinite(original.height) ||
+    original.width <= 0 ||
+    original.height <= 0 ||
+    !Number.isFinite(result.width) ||
+    !Number.isFinite(result.height) ||
+    result.width <= 0 ||
+    result.height <= 0 ||
+    !sameKeys(original.nodes, result.nodes) ||
+    !sameKeys(original.groups, result.groups) ||
+    original.edges.length !== result.edges.length
+  ) {
+    return false;
+  }
+
+  for (const id of Object.keys(original.groups)) {
+    const before = original.groups[id];
+    const after = result.groups[id];
+    if (!before || !after || !validBounds(before.bounds) || !validBounds(after.bounds)) {
+      return false;
+    }
+    if (
+      (options.direction === 'horizontal' &&
+        (before.bounds.y !== after.bounds.y || before.bounds.height !== after.bounds.height)) ||
+      (options.direction === 'vertical' &&
+        (before.bounds.x !== after.bounds.x || before.bounds.width !== after.bounds.width))
+    ) {
+      return false;
+    }
+  }
+
+  for (const id of Object.keys(original.nodes)) {
+    const before = original.nodes[id];
+    const after = result.nodes[id];
+    if (!before || !after || !validBounds(before.bounds) || !validBounds(after.bounds)) {
+      return false;
+    }
+    if (
+      (options.direction === 'horizontal' &&
+        (before.bounds.y !== after.bounds.y || before.bounds.height !== after.bounds.height)) ||
+      (options.direction === 'vertical' &&
+        (before.bounds.x !== after.bounds.x || before.bounds.width !== after.bounds.width))
+    ) {
+      return false;
+    }
+  }
+
+  for (let index = 0; index < result.edges.length; index++) {
+    const before = original.edges[index];
+    const edge = result.edges[index];
+    if (!before || !edge || before.fromId !== edge.fromId || before.toId !== edge.toId) {
+      return false;
+    }
+    const originalHasSourceBoundary = before.sourceBoundary !== undefined;
+    const originalHasTargetBoundary = before.targetBoundary !== undefined;
+    if (
+      originalHasSourceBoundary !== originalHasTargetBoundary ||
+      (originalHasSourceBoundary &&
+        (!Number.isFinite(before.sourceBoundary) || !Number.isFinite(before.targetBoundary)))
+    ) {
+      return false;
+    }
+    if (
+      !Number.isFinite(edge.from.x) ||
+      !Number.isFinite(edge.from.y) ||
+      !Number.isFinite(edge.to.x) ||
+      !Number.isFinite(edge.to.y)
+    ) {
+      return false;
+    }
+    const hasSourceBoundary = edge.sourceBoundary !== undefined;
+    const hasTargetBoundary = edge.targetBoundary !== undefined;
+    if (hasSourceBoundary !== hasTargetBoundary) {
+      return false;
+    }
+    if (hasSourceBoundary) {
+      const sourceBoundary = edge.sourceBoundary!;
+      const targetBoundary = edge.targetBoundary!;
+      if (
+        !Number.isFinite(sourceBoundary) ||
+        !Number.isFinite(targetBoundary) ||
+        pointPrimary(edge.from, options.direction) > sourceBoundary ||
+        sourceBoundary + options.ranksep > targetBoundary ||
+        targetBoundary > pointPrimary(edge.to, options.direction)
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
+  layout: T,
+  options: ApplyAssetGroupRoutingOptions,
+): T => {
+  if (
+    (options.direction !== 'horizontal' && options.direction !== 'vertical') ||
+    !Number.isFinite(options.ranksep) ||
+    options.ranksep < 0 ||
+    !Number.isFinite(options.trailingGroupPadding) ||
+    !Number.isFinite(options.margin) ||
+    options.margin < 0
+  ) {
+    throw new Error('Invalid asset group routing options');
+  }
+
+  const ancestry = buildGroupAncestryIndex(options.groupParentById);
+  const routeInfoByEdge = new Map<number, InternalEdgeRouteInfo>();
+  const constraints: BranchConstraint[] = [];
+
+  layout.edges.forEach((edge, index) => {
+    const sourceEndpointGroupId = options.endpointGroupById[edge.fromId];
+    const targetEndpointGroupId = options.endpointGroupById[edge.toId];
+    if (
+      !sourceEndpointGroupId ||
+      !targetEndpointGroupId ||
+      sourceEndpointGroupId === targetEndpointGroupId
+    ) {
+      return;
+    }
+
+    const lca = ancestry.lowestCommonAncestor(sourceEndpointGroupId, targetEndpointGroupId);
+    const sourceBranchId = ancestry.branchBelow(sourceEndpointGroupId, lca);
+    const targetBranchId = ancestry.branchBelow(targetEndpointGroupId, lca);
+    if (!sourceBranchId || !targetBranchId || sourceBranchId === targetBranchId) {
+      return;
+    }
+    const sourceGroup = layout.groups[sourceBranchId];
+    const targetGroup = layout.groups[targetBranchId];
+    if (!sourceGroup || !targetGroup) {
+      throw new Error('Missing asset group routing branch');
+    }
+
+    const sourceUsesGroupEnd = sourceGroup.expanded || edge.fromId !== sourceBranchId;
+    const targetUsesGroupStart = targetGroup.expanded || edge.toId !== targetBranchId;
+    const routeInfo: InternalEdgeRouteInfo = {
+      sourceBranchId,
+      targetBranchId,
+      sourceUsesGroupEnd,
+      sourceBaseExit: sourceUsesGroupEnd
+        ? primaryEnd(sourceGroup.bounds, options.direction)
+        : pointPrimary(edge.from, options.direction),
+      targetBaseEntry: targetUsesGroupStart
+        ? primaryStart(targetGroup.bounds, options.direction)
+        : pointPrimary(edge.to, options.direction),
+    };
+    routeInfoByEdge.set(index, routeInfo);
+    constraints.push(routeInfo);
+  });
+
+  const solution = solveAssetGroupConstraints({
+    direction: options.direction,
+    ranksep: options.ranksep,
+    trailingGroupPadding: options.trailingGroupPadding,
+    groups: layout.groups,
+    parentById: options.groupParentById,
+    constraints,
+  });
+
+  const groups: RoutingLayout['groups'] = {};
+  for (const [id, group] of Object.entries(layout.groups)) {
+    const shift = solution.shiftByGroupId[id];
+    const end = solution.endByGroupId[id];
+    if (shift === undefined || end === undefined) {
+      throw new Error('Missing solved asset group geometry');
+    }
+    groups[id] = {
+      ...group,
+      bounds: withForwardEnd(
+        translateBounds(group.bounds, shift, options.direction),
+        end,
+        options.direction,
+      ),
+    };
+  }
+
+  const nodes: RoutingLayout['nodes'] = {};
+  for (const [id, node] of Object.entries(layout.nodes)) {
+    const ownerGroupId = options.ownerGroupByNodeId[id];
+    const shift =
+      ownerGroupId === null || ownerGroupId === undefined
+        ? 0
+        : solution.shiftByGroupId[ownerGroupId];
+    if (shift === undefined) {
+      throw new Error('Missing node owner asset group');
+    }
+    nodes[id] = {...node, bounds: translateBounds(node.bounds, shift, options.direction)};
+  }
+
+  const edges = layout.edges.map((edge, index) => {
+    const sourceEndpointGroupId = options.endpointGroupById[edge.fromId];
+    const targetEndpointGroupId = options.endpointGroupById[edge.toId];
+    const sourceShift = sourceEndpointGroupId ? solution.shiftByGroupId[sourceEndpointGroupId] : 0;
+    const targetShift = targetEndpointGroupId ? solution.shiftByGroupId[targetEndpointGroupId] : 0;
+    if (sourceShift === undefined || targetShift === undefined) {
+      throw new Error('Missing edge endpoint asset group');
+    }
+    const {sourceBoundary: _sourceBoundary, targetBoundary: _targetBoundary, ...legacyEdge} = edge;
+    const translated = {
+      ...legacyEdge,
+      from: translatePoint(edge.from, sourceShift, options.direction),
+      to: translatePoint(edge.to, targetShift, options.direction),
+    };
+    const routeInfo = routeInfoByEdge.get(index);
+    if (
+      !routeInfo ||
+      solution.componentByGroupId[routeInfo.sourceBranchId] ===
+        solution.componentByGroupId[routeInfo.targetBranchId]
+    ) {
+      return translated;
+    }
+    const sourceBranchShift = solution.shiftByGroupId[routeInfo.sourceBranchId]!;
+    const targetBranchShift = solution.shiftByGroupId[routeInfo.targetBranchId]!;
+    return {
+      ...translated,
+      sourceBoundary: routeInfo.sourceUsesGroupEnd
+        ? solution.endByGroupId[routeInfo.sourceBranchId]!
+        : routeInfo.sourceBaseExit + sourceBranchShift,
+      targetBoundary: routeInfo.targetBaseEntry + targetBranchShift,
+    };
+  });
+
+  const forwardEnds = [
+    ...Object.values(groups).map((group) => primaryEnd(group.bounds, options.direction)),
+    ...Object.values(nodes).map((node) => primaryEnd(node.bounds, options.direction)),
+  ];
+  const maximumForwardEnd = forwardEnds.length ? Math.max(...forwardEnds) : 0;
+  const result = {
+    ...layout,
+    width:
+      options.direction === 'horizontal'
+        ? Math.max(layout.width, maximumForwardEnd + options.margin)
+        : layout.width,
+    height:
+      options.direction === 'vertical'
+        ? Math.max(layout.height, maximumForwardEnd + options.margin)
+        : layout.height,
+    nodes,
+    groups,
+    edges,
+  } as T;
+  return result;
+};
+
+export const applyAssetGroupLineageRouting = <T extends RoutingLayout>(
+  layout: T,
+  options: ApplyAssetGroupRoutingOptions,
+): T => {
+  try {
+    const result = applyAssetGroupLineageRoutingImpl(layout, options);
+    return validateRoutingResult(layout, result, options) ? result : layout;
+  } catch {
+    return layout;
+  }
 };

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -524,6 +524,35 @@ const sameKeys = (left: Record<string, unknown>, right: Record<string, unknown>)
   );
 };
 
+const validateInputCorridors = (layout: RoutingLayout, options: ApplyAssetGroupRoutingOptions) => {
+  for (const edge of layout.edges) {
+    const hasSourceBoundary = edge.sourceBoundary !== undefined;
+    const hasTargetBoundary = edge.targetBoundary !== undefined;
+    if (hasSourceBoundary !== hasTargetBoundary) {
+      return false;
+    }
+    if (!hasSourceBoundary) {
+      continue;
+    }
+    const sourceBoundary = edge.sourceBoundary!;
+    const targetBoundary = edge.targetBoundary!;
+    const sourceEndpoint = pointPrimary(edge.from, options.direction);
+    const targetEndpoint = pointPrimary(edge.to, options.direction);
+    if (
+      !Number.isFinite(sourceEndpoint) ||
+      !Number.isFinite(targetEndpoint) ||
+      !Number.isFinite(sourceBoundary) ||
+      !Number.isFinite(targetBoundary) ||
+      sourceEndpoint > sourceBoundary ||
+      sourceBoundary + options.ranksep > targetBoundary ||
+      targetBoundary > targetEndpoint
+    ) {
+      return false;
+    }
+  }
+  return true;
+};
+
 const validateRoutingResult = (
   original: RoutingLayout,
   result: RoutingLayout,
@@ -631,6 +660,7 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
     !Number.isFinite(options.ranksep) ||
     options.ranksep < 0 ||
     !Number.isFinite(options.trailingGroupPadding) ||
+    options.trailingGroupPadding < 0 ||
     !Number.isFinite(options.margin) ||
     options.margin < 0
   ) {
@@ -780,6 +810,9 @@ export const applyAssetGroupLineageRouting = <T extends RoutingLayout>(
   options: ApplyAssetGroupRoutingOptions,
 ): T => {
   try {
+    if (!validateInputCorridors(layout, options)) {
+      return layout;
+    }
     const result = applyAssetGroupLineageRoutingImpl(layout, options);
     return validateRoutingResult(layout, result, options) ? result : layout;
   } catch {

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -41,6 +41,7 @@ export type ApplyAssetGroupRoutingOptions = {
   groupParentById: GroupParentById;
   ownerGroupByNodeId: Record<string, string | null>;
   endpointGroupById: Record<string, string | null>;
+  alignGroupsOnSecondaryAxis?: boolean;
 };
 
 export type AssetGroupConstraintInput = {
@@ -709,6 +710,293 @@ const validateInputCorridors = (layout: RoutingLayout, options: ApplyAssetGroupR
   return true;
 };
 
+const secondaryStart = (bounds: IBounds, direction: RoutingDirection) =>
+  direction === 'horizontal' ? bounds.y : bounds.x;
+
+const secondarySize = (bounds: IBounds, direction: RoutingDirection) =>
+  direction === 'horizontal' ? bounds.height : bounds.width;
+
+const pointSecondary = (point: {x: number; y: number}, direction: RoutingDirection) =>
+  direction === 'horizontal' ? point.y : point.x;
+
+const translateSecondaryBounds = (
+  bounds: IBounds,
+  amount: number,
+  direction: RoutingDirection,
+): IBounds =>
+  direction === 'horizontal'
+    ? {x: bounds.x, y: bounds.y + amount, width: bounds.width, height: bounds.height}
+    : {x: bounds.x + amount, y: bounds.y, width: bounds.width, height: bounds.height};
+
+const translateSecondaryPoint = (
+  point: {x: number; y: number},
+  amount: number,
+  direction: RoutingDirection,
+) =>
+  direction === 'horizontal'
+    ? {x: point.x, y: point.y + amount}
+    : {x: point.x + amount, y: point.y};
+
+const median = (values: number[]) => {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = sorted.length >> 1;
+  return sorted.length % 2 === 1 ? sorted[middle]! : (sorted[middle - 1]! + sorted[middle]!) / 2;
+};
+
+const alignGroupsOnSecondaryAxis = <T extends RoutingLayout>(
+  layout: T,
+  options: ApplyAssetGroupRoutingOptions,
+): T => {
+  const groupIds = Object.keys(layout.groups);
+  if (groupIds.length === 0) {
+    return layout;
+  }
+
+  // Moving a group would drag its edges away from ungrouped endpoints, which cannot follow.
+  for (const id in layout.nodes) {
+    if (!Object.prototype.hasOwnProperty.call(layout.nodes, id)) {
+      continue;
+    }
+    const ownerGroupId = options.ownerGroupByNodeId[id];
+    if (!ownerGroupId || !layout.groups[ownerGroupId]) {
+      return layout;
+    }
+  }
+  for (const edge of layout.edges) {
+    const sourceGroupId = options.endpointGroupById[edge.fromId];
+    const targetGroupId = options.endpointGroupById[edge.toId];
+    if (!sourceGroupId || !targetGroupId) {
+      return layout;
+    }
+    if (!layout.groups[sourceGroupId] || !layout.groups[targetGroupId]) {
+      return layout;
+    }
+  }
+
+  const rootByGroupId = new Map<string, string>();
+  const resolveRoot = (groupId: string) => {
+    const cached = rootByGroupId.get(groupId);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const chain: string[] = [];
+    let current = groupId;
+    for (let steps = 0; steps <= groupIds.length; steps++) {
+      const memoized = rootByGroupId.get(current);
+      if (memoized !== undefined) {
+        current = memoized;
+        break;
+      }
+      chain.push(current);
+      const parent = options.groupParentById[current];
+      if (!parent || !layout.groups[parent]) {
+        break;
+      }
+      current = parent;
+    }
+    for (const id of chain) {
+      rootByGroupId.set(id, current);
+    }
+    return current;
+  };
+
+  const rootIds = groupIds.filter((id) => resolveRoot(id) === id);
+  if (rootIds.length < 2) {
+    return layout;
+  }
+
+  const rootBounds = new Map<string, IBounds>();
+  for (const id of rootIds) {
+    rootBounds.set(id, layout.groups[id]!.bounds);
+  }
+
+  const primaryOrder = [...rootIds].sort((a, b) => {
+    const delta =
+      primaryStart(rootBounds.get(a)!, options.direction) -
+      primaryStart(rootBounds.get(b)!, options.direction);
+    return delta !== 0 ? delta : a < b ? -1 : a > b ? 1 : 0;
+  });
+  const primaryRankByRoot = new Map<string, number>();
+  primaryOrder.forEach((id, index) => primaryRankByRoot.set(id, index));
+
+  type Connection = {upstreamRoot: string; upstreamSecondary: number; ownSecondary: number};
+  const connectionsByRoot = new Map<string, Connection[]>();
+  for (const edge of layout.edges) {
+    const sourceRoot = resolveRoot(options.endpointGroupById[edge.fromId]!);
+    const targetRoot = resolveRoot(options.endpointGroupById[edge.toId]!);
+    if (sourceRoot === targetRoot) {
+      continue;
+    }
+    const sourceRank = primaryRankByRoot.get(sourceRoot)!;
+    const targetRank = primaryRankByRoot.get(targetRoot)!;
+    const sourceIsUpstream = sourceRank < targetRank;
+    const ownRoot = sourceIsUpstream ? targetRoot : sourceRoot;
+    const connection: Connection = {
+      upstreamRoot: sourceIsUpstream ? sourceRoot : targetRoot,
+      upstreamSecondary: pointSecondary(sourceIsUpstream ? edge.from : edge.to, options.direction),
+      ownSecondary: pointSecondary(sourceIsUpstream ? edge.to : edge.from, options.direction),
+    };
+    const existing = connectionsByRoot.get(ownRoot);
+    if (existing) {
+      existing.push(connection);
+    } else {
+      connectionsByRoot.set(ownRoot, [connection]);
+    }
+  }
+
+  const shiftByRoot = new Map<string, number>();
+  for (const id of primaryOrder) {
+    const connections = connectionsByRoot.get(id);
+    if (!connections || connections.length === 0) {
+      shiftByRoot.set(id, 0);
+      continue;
+    }
+    const deltas: number[] = [];
+    for (const connection of connections) {
+      const upstreamShift = shiftByRoot.get(connection.upstreamRoot);
+      if (upstreamShift === undefined) {
+        continue;
+      }
+      deltas.push(connection.upstreamSecondary + upstreamShift - connection.ownSecondary);
+    }
+    shiftByRoot.set(id, median(deltas));
+  }
+
+  const componentByRoot = new Map<string, number>();
+  let componentCount = 0;
+  let componentEnd = -Infinity;
+  for (const id of primaryOrder) {
+    const bounds = rootBounds.get(id)!;
+    const start = primaryStart(bounds, options.direction);
+    if (start >= componentEnd) {
+      componentCount++;
+      componentEnd = -Infinity;
+    }
+    componentByRoot.set(id, componentCount - 1);
+    componentEnd = Math.max(componentEnd, primaryEnd(bounds, options.direction));
+  }
+
+  const rootsByComponent: string[][] = Array.from({length: componentCount}, () => []);
+  for (const id of rootIds) {
+    rootsByComponent[componentByRoot.get(id)!]!.push(id);
+  }
+
+  for (const component of rootsByComponent) {
+    component.sort((a, b) => {
+      const delta =
+        secondaryStart(rootBounds.get(a)!, options.direction) -
+        secondaryStart(rootBounds.get(b)!, options.direction);
+      return delta !== 0 ? delta : a < b ? -1 : a > b ? 1 : 0;
+    });
+    let previousEnd: number | undefined;
+    let previousOriginalEnd: number | undefined;
+    for (const id of component) {
+      const bounds = rootBounds.get(id)!;
+      const originalStart = secondaryStart(bounds, options.direction);
+      const size = secondarySize(bounds, options.direction);
+      const desiredStart = originalStart + shiftByRoot.get(id)!;
+      const minimumStart =
+        previousEnd === undefined
+          ? desiredStart
+          : previousEnd + Math.max(0, originalStart - previousOriginalEnd!);
+      const nextStart = Math.max(desiredStart, minimumStart);
+      shiftByRoot.set(id, nextStart - originalStart);
+      previousEnd = nextStart + size;
+      previousOriginalEnd = originalStart + size;
+    }
+  }
+
+  let originalMinimumStart = Infinity;
+  let alignedMinimumStart = Infinity;
+  for (const id of rootIds) {
+    const originalStart = secondaryStart(rootBounds.get(id)!, options.direction);
+    originalMinimumStart = Math.min(originalMinimumStart, originalStart);
+    alignedMinimumStart = Math.min(alignedMinimumStart, originalStart + shiftByRoot.get(id)!);
+  }
+  if (alignedMinimumStart < originalMinimumStart) {
+    const correction = originalMinimumStart - alignedMinimumStart;
+    for (const id of rootIds) {
+      shiftByRoot.set(id, shiftByRoot.get(id)! + correction);
+    }
+  }
+
+  const shiftForGroup = (groupId: string) => {
+    const shift = shiftByRoot.get(resolveRoot(groupId));
+    if (shift === undefined || !Number.isFinite(shift)) {
+      throw new Error('Invalid asset group secondary-axis shift');
+    }
+    return shift;
+  };
+
+  let maximumSecondaryEnd = 0;
+  const groups: RoutingLayout['groups'] = {};
+  for (const id in layout.groups) {
+    if (!Object.prototype.hasOwnProperty.call(layout.groups, id)) {
+      continue;
+    }
+    const group = layout.groups[id]!;
+    const bounds = translateSecondaryBounds(group.bounds, shiftForGroup(id), options.direction);
+    if (!validBounds(bounds)) {
+      throw new Error('Invalid secondary-aligned asset group bounds');
+    }
+    groups[id] = {...group, bounds};
+    maximumSecondaryEnd = Math.max(
+      maximumSecondaryEnd,
+      secondaryStart(bounds, options.direction) + secondarySize(bounds, options.direction),
+    );
+  }
+
+  const nodes: RoutingLayout['nodes'] = {};
+  for (const id in layout.nodes) {
+    if (!Object.prototype.hasOwnProperty.call(layout.nodes, id)) {
+      continue;
+    }
+    const node = layout.nodes[id]!;
+    const bounds = translateSecondaryBounds(
+      node.bounds,
+      shiftForGroup(options.ownerGroupByNodeId[id]!),
+      options.direction,
+    );
+    if (!validBounds(bounds)) {
+      throw new Error('Invalid secondary-aligned asset bounds');
+    }
+    nodes[id] = {...node, bounds};
+    maximumSecondaryEnd = Math.max(
+      maximumSecondaryEnd,
+      secondaryStart(bounds, options.direction) + secondarySize(bounds, options.direction),
+    );
+  }
+
+  const edges = layout.edges.map((edge) => ({
+    ...edge,
+    from: translateSecondaryPoint(
+      edge.from,
+      shiftForGroup(options.endpointGroupById[edge.fromId]!),
+      options.direction,
+    ),
+    to: translateSecondaryPoint(
+      edge.to,
+      shiftForGroup(options.endpointGroupById[edge.toId]!),
+      options.direction,
+    ),
+  }));
+
+  const secondaryExtent = maximumSecondaryEnd + options.margin;
+  return {
+    ...layout,
+    width:
+      options.direction === 'vertical' ? Math.max(layout.width, secondaryExtent) : layout.width,
+    height:
+      options.direction === 'horizontal' ? Math.max(layout.height, secondaryExtent) : layout.height,
+    nodes,
+    groups,
+    edges,
+  } as T;
+};
+
 const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
   layout: T,
   options: ApplyAssetGroupRoutingOptions,
@@ -1014,7 +1302,7 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
   ) {
     throw new Error('Invalid routed asset graph canvas');
   }
-  return result;
+  return options.alignGroupsOnSecondaryAxis ? alignGroupsOnSecondaryAxis(result, options) : result;
 };
 
 export const applyAssetGroupLineageRouting = <T extends RoutingLayout>(

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -64,8 +64,6 @@ const primaryStart = (bounds: IBounds, direction: RoutingDirection) =>
 const primaryEnd = (bounds: IBounds, direction: RoutingDirection) =>
   primaryStart(bounds, direction) + (direction === 'horizontal' ? bounds.width : bounds.height);
 
-const compareStrings = (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0);
-
 export type GroupAncestryIndex = {
   lowestCommonAncestor: (a: string, b: string) => string | null;
   branchBelow: (groupId: string, ancestorId: string | null) => string | null;
@@ -73,11 +71,15 @@ export type GroupAncestryIndex = {
 
 export const buildGroupAncestryIndex = (parentById: GroupParentById): GroupAncestryIndex => {
   const ids = Object.keys(parentById).sort();
-  const indexById = new Map(ids.map((id, index) => [id, index]));
+  const indexById = new Map<string, number>();
+  for (let index = 0; index < ids.length; index++) {
+    indexById.set(ids[index]!, index);
+  }
   const groupCount = ids.length;
 
   const parent = new Int32Array(groupCount);
   parent.fill(-1);
+  let hasNestedGroups = false;
   for (let index = 0; index < groupCount; index++) {
     const parentId = parentById[ids[index]!];
     if (parentId === null) {
@@ -91,6 +93,32 @@ export const buildGroupAncestryIndex = (parentById: GroupParentById): GroupAnces
       throw new Error(`Missing visible asset group parent: ${parentId}`);
     }
     parent[index] = parentIndex;
+    hasNestedGroups = true;
+  }
+
+  const requireIndex = (id: string) => {
+    const index = indexById.get(id);
+    if (index === undefined) {
+      throw new Error(`Unknown visible asset group: ${id}`);
+    }
+    return index;
+  };
+
+  if (!hasNestedGroups) {
+    return {
+      lowestCommonAncestor: (a, b) => {
+        requireIndex(a);
+        requireIndex(b);
+        return a === b ? a : null;
+      },
+      branchBelow: (groupId, ancestorId) => {
+        requireIndex(groupId);
+        if (ancestorId !== null) {
+          requireIndex(ancestorId);
+        }
+        return ancestorId === null ? groupId : null;
+      },
+    };
   }
 
   const depth = new Int32Array(groupCount);
@@ -144,14 +172,6 @@ export const buildGroupAncestryIndex = (parentById: GroupParentById): GroupAnces
     }
     ancestors.push(current);
   }
-
-  const requireIndex = (id: string) => {
-    const index = indexById.get(id);
-    if (index === undefined) {
-      throw new Error(`Unknown visible asset group: ${id}`);
-    }
-    return index;
-  };
 
   const lift = (index: number, distance: number) => {
     let current = index;
@@ -222,266 +242,299 @@ export const buildGroupAncestryIndex = (parentById: GroupParentById): GroupAnces
 
 const buildConstraintComponents = (
   ids: string[],
+  indexById: Map<string, number>,
   constraints: BranchConstraint[],
-): Record<string, string> => {
-  const idSet = new Set(ids);
-  const adjacencySets = new Map(ids.map((id) => [id, new Set<string>()]));
-  const reverseSets = new Map(ids.map((id) => [id, new Set<string>()]));
-
-  for (const constraint of constraints) {
-    if (!idSet.has(constraint.sourceBranchId)) {
-      throw new Error(`Unknown asset group constraint endpoint: ${constraint.sourceBranchId}`);
+  columns?: ConstraintColumns,
+) => {
+  const groupCount = ids.length;
+  const edgeCount = columns?.count ?? constraints.length;
+  const sourceByEdge = new Int32Array(edgeCount);
+  const targetByEdge = new Int32Array(edgeCount);
+  const outgoingCount = new Int32Array(groupCount);
+  const incomingCount = new Int32Array(groupCount);
+  for (let edgeIndex = 0; edgeIndex < edgeCount; edgeIndex++) {
+    const sourceBranchId = columns
+      ? columns.sourceBranchIds[edgeIndex]!
+      : constraints[edgeIndex]!.sourceBranchId;
+    const targetBranchId = columns
+      ? columns.targetBranchIds[edgeIndex]!
+      : constraints[edgeIndex]!.targetBranchId;
+    const source = indexById.get(sourceBranchId);
+    const target = indexById.get(targetBranchId);
+    if (source === undefined) {
+      throw new Error(`Unknown asset group constraint endpoint: ${sourceBranchId}`);
     }
-    if (!idSet.has(constraint.targetBranchId)) {
-      throw new Error(`Unknown asset group constraint endpoint: ${constraint.targetBranchId}`);
+    if (target === undefined) {
+      throw new Error(`Unknown asset group constraint endpoint: ${targetBranchId}`);
     }
-    adjacencySets.get(constraint.sourceBranchId)!.add(constraint.targetBranchId);
-    reverseSets.get(constraint.targetBranchId)!.add(constraint.sourceBranchId);
+    sourceByEdge[edgeIndex] = source;
+    targetByEdge[edgeIndex] = target;
+    outgoingCount[source] = outgoingCount[source]! + 1;
+    incomingCount[target] = incomingCount[target]! + 1;
   }
-  const adjacency = new Map(ids.map((id) => [id, [...adjacencySets.get(id)!].sort()] as const));
-  const reverse = new Map(ids.map((id) => [id, [...reverseSets.get(id)!].sort()] as const));
 
-  const visited = new Set<string>();
-  const finishOrder: string[] = [];
-  for (const start of ids) {
-    if (visited.has(start)) {
+  const offsets = (counts: Int32Array) => {
+    const result = new Int32Array(groupCount + 1);
+    for (let index = 0; index < groupCount; index++) {
+      result[index + 1] = result[index]! + counts[index]!;
+    }
+    return result;
+  };
+  const outgoingOffset = offsets(outgoingCount);
+  const incomingOffset = offsets(incomingCount);
+  const outgoingCursor = outgoingOffset.slice(0, groupCount);
+  const incomingCursor = incomingOffset.slice(0, groupCount);
+  const outgoing = new Int32Array(edgeCount);
+  const incoming = new Int32Array(edgeCount);
+  for (let edgeIndex = 0; edgeIndex < edgeCount; edgeIndex++) {
+    const source = sourceByEdge[edgeIndex]!;
+    const target = targetByEdge[edgeIndex]!;
+    const outgoingIndex = outgoingCursor[source]!;
+    const incomingIndex = incomingCursor[target]!;
+    outgoing[outgoingIndex] = target;
+    incoming[incomingIndex] = source;
+    outgoingCursor[source] = outgoingIndex + 1;
+    incomingCursor[target] = incomingIndex + 1;
+  }
+
+  const visited = new Uint8Array(groupCount);
+  const finishOrder = new Int32Array(groupCount);
+  const stackNode = new Int32Array(groupCount);
+  const stackEdge = new Int32Array(groupCount);
+  let finishedCount = 0;
+  for (let start = 0; start < groupCount; start++) {
+    if (visited[start]) {
       continue;
     }
-    visited.add(start);
-    const frames = [{id: start, next: 0}];
-    while (frames.length) {
-      const frame = frames[frames.length - 1]!;
-      const neighbors = adjacency.get(frame.id)!;
-      if (frame.next < neighbors.length) {
-        const neighbor = neighbors[frame.next++]!;
-        if (!visited.has(neighbor)) {
-          visited.add(neighbor);
-          frames.push({id: neighbor, next: 0});
+    let stackSize = 1;
+    stackNode[0] = start;
+    stackEdge[0] = outgoingOffset[start]!;
+    visited[start] = 1;
+    while (stackSize) {
+      const frame = stackSize - 1;
+      const node = stackNode[frame]!;
+      const nextEdge = stackEdge[frame]!;
+      if (nextEdge < outgoingOffset[node + 1]!) {
+        const neighbor = outgoing[nextEdge]!;
+        stackEdge[frame] = nextEdge + 1;
+        if (!visited[neighbor]) {
+          visited[neighbor] = 1;
+          stackNode[stackSize] = neighbor;
+          stackEdge[stackSize] = outgoingOffset[neighbor]!;
+          stackSize++;
         }
       } else {
-        finishOrder.push(frame.id);
-        frames.pop();
+        finishOrder[finishedCount++] = node;
+        stackSize--;
       }
     }
   }
 
-  const assigned = new Set<string>();
-  const components: string[][] = [];
-  for (let index = finishOrder.length - 1; index >= 0; index--) {
-    const start = finishOrder[index]!;
-    if (assigned.has(start)) {
+  const componentByIndex = new Int32Array(groupCount);
+  componentByIndex.fill(-1);
+  const componentIdIndex = new Int32Array(groupCount);
+  let componentCount = 0;
+  for (let orderIndex = finishedCount - 1; orderIndex >= 0; orderIndex--) {
+    const start = finishOrder[orderIndex]!;
+    if (componentByIndex[start] !== -1) {
       continue;
     }
-    assigned.add(start);
-    const component: string[] = [];
-    const stack = [start];
-    while (stack.length) {
-      const id = stack.pop()!;
-      component.push(id);
-      for (const neighbor of reverse.get(id)!) {
-        if (!assigned.has(neighbor)) {
-          assigned.add(neighbor);
-          stack.push(neighbor);
+    let stackSize = 1;
+    stackNode[0] = start;
+    componentByIndex[start] = componentCount;
+    let minimumIndex = start;
+    while (stackSize) {
+      const node = stackNode[--stackSize]!;
+      minimumIndex = Math.min(minimumIndex, node);
+      for (
+        let edgeIndex = incomingOffset[node]!;
+        edgeIndex < incomingOffset[node + 1]!;
+        edgeIndex++
+      ) {
+        const neighbor = incoming[edgeIndex]!;
+        if (componentByIndex[neighbor] === -1) {
+          componentByIndex[neighbor] = componentCount;
+          stackNode[stackSize++] = neighbor;
         }
       }
     }
-    component.sort();
-    components.push(component);
+    componentIdIndex[componentCount++] = minimumIndex;
   }
-  components.sort((left, right) => compareStrings(left[0]!, right[0]!));
-
-  const componentByGroupId: Record<string, string> = {};
-  for (const component of components) {
-    const componentId = component[0]!;
-    for (const id of component) {
-      componentByGroupId[id] = componentId;
-    }
-  }
-  return componentByGroupId;
+  return {componentByIndex, componentIdIndex, componentCount, sourceByEdge, targetByEdge};
 };
 
-class StringMinHeap {
-  private values: string[] = [];
-
-  public push(value: string) {
-    this.values.push(value);
-    let index = this.values.length - 1;
-    while (index > 0) {
-      const parent = Math.floor((index - 1) / 2);
-      if (compareStrings(this.values[parent]!, value) <= 0) {
-        break;
-      }
-      this.values[index] = this.values[parent]!;
-      index = parent;
-    }
-    this.values[index] = value;
-  }
-
-  public pop() {
-    if (this.values.length === 0) {
-      return undefined;
-    }
-    const minimum = this.values[0]!;
-    const last = this.values.pop()!;
-    if (this.values.length === 0) {
-      return minimum;
-    }
-
-    let index = 0;
-    while (true) {
-      const left = index * 2 + 1;
-      if (left >= this.values.length) {
-        break;
-      }
-      const right = left + 1;
-      const child =
-        right < this.values.length && compareStrings(this.values[right]!, this.values[left]!) < 0
-          ? right
-          : left;
-      if (compareStrings(this.values[child]!, last) >= 0) {
-        break;
-      }
-      this.values[index] = this.values[child]!;
-      index = child;
-    }
-    this.values[index] = last;
-    return minimum;
-  }
-}
-
-type WeightedEdge = {from: string; to: string; weight: number};
-
-export const solveAssetGroupConstraints = ({
-  direction,
-  ranksep,
-  trailingGroupPadding,
-  groups,
-  parentById,
-  constraints,
-}: AssetGroupConstraintInput): AssetGroupConstraintSolution => {
+const solveAssetGroupConstraintsNumeric = (
+  {
+    direction,
+    ranksep,
+    trailingGroupPadding,
+    groups,
+    parentById,
+    constraints,
+  }: AssetGroupConstraintInput,
+  columns?: ConstraintColumns,
+) => {
   const ids = Object.keys(groups).sort();
-  const idSet = new Set(ids);
-  const componentByGroupId = buildConstraintComponents(ids, constraints);
-  const componentIds = [...new Set(ids.map((id) => componentByGroupId[id]!))];
-  const zeroNode = '$zero';
-  const moveNode = (componentId: string) => `move:${componentId}`;
-  const endNode = (groupId: string) => `end:${groupId}`;
-  const nodes = new Set<string>([zeroNode]);
-  for (const componentId of componentIds) {
-    nodes.add(moveNode(componentId));
+  const indexById = new Map<string, number>();
+  for (let index = 0; index < ids.length; index++) {
+    indexById.set(ids[index]!, index);
   }
-  for (const id of ids) {
-    nodes.add(endNode(id));
-  }
-
-  const edgeWeightByNodes = new Map<string, Map<string, number>>();
-  const addEdge = (from: string, to: string, weight: number) => {
+  const {componentByIndex, componentIdIndex, componentCount, sourceByEdge, targetByEdge} =
+    buildConstraintComponents(ids, indexById, constraints, columns);
+  const groupCount = ids.length;
+  const constraintCount = columns?.count ?? constraints.length;
+  const zeroNode = 0;
+  const moveNode = (component: number) => 1 + component;
+  const endNode = (groupIndex: number) => 1 + componentCount + groupIndex;
+  const nodeCount = 1 + componentCount + groupCount;
+  const edgeCapacity = groupCount * 4 + constraintCount;
+  const edgeFrom = new Int32Array(edgeCapacity);
+  const edgeTo = new Int32Array(edgeCapacity);
+  const edgeWeight = new Float64Array(edgeCapacity);
+  let edgeCount = 0;
+  const addEdge = (from: number, to: number, weight: number) => {
     if (!Number.isFinite(weight)) {
       throw new Error('Non-finite asset group constraint');
     }
-    let weightByTarget = edgeWeightByNodes.get(from);
-    if (!weightByTarget) {
-      weightByTarget = new Map();
-      edgeWeightByNodes.set(from, weightByTarget);
-    }
-    const previousWeight = weightByTarget.get(to);
-    if (previousWeight === undefined || weight > previousWeight) {
-      weightByTarget.set(to, weight);
-    }
+    edgeFrom[edgeCount] = from;
+    edgeTo[edgeCount] = to;
+    edgeWeight[edgeCount] = weight;
+    edgeCount++;
   };
 
-  for (const id of ids) {
-    const componentMove = moveNode(componentByGroupId[id]!);
+  for (let index = 0; index < groupCount; index++) {
+    const id = ids[index]!;
+    const componentMove = moveNode(componentByIndex[index]!);
     addEdge(zeroNode, componentMove, 0);
-    addEdge(componentMove, endNode(id), primaryEnd(groups[id]!.bounds, direction));
+    addEdge(componentMove, endNode(index), primaryEnd(groups[id]!.bounds, direction));
 
     const parentId = parentById[id];
     if (parentId === undefined) {
       throw new Error(`Missing visible asset group parent: undefined`);
     }
     if (parentId !== null) {
-      if (!idSet.has(parentId)) {
+      const parentIndex = indexById.get(parentId);
+      if (parentIndex === undefined) {
         throw new Error(`Missing visible asset group parent: ${parentId}`);
       }
-      const parentMove = moveNode(componentByGroupId[parentId]!);
+      const parentMove = moveNode(componentByIndex[parentIndex]!);
       if (parentMove !== componentMove) {
         addEdge(parentMove, componentMove, 0);
       }
-      addEdge(endNode(id), endNode(parentId), trailingGroupPadding);
+      addEdge(endNode(index), endNode(parentIndex), trailingGroupPadding);
     }
   }
 
-  for (const constraint of constraints) {
-    const sourceComponent = componentByGroupId[constraint.sourceBranchId]!;
-    const targetComponent = componentByGroupId[constraint.targetBranchId]!;
+  for (let index = 0; index < constraintCount; index++) {
+    const constraint = columns ? undefined : constraints[index]!;
+    const sourceComponent = componentByIndex[sourceByEdge[index]!]!;
+    const targetComponent = componentByIndex[targetByEdge[index]!]!;
     if (sourceComponent === targetComponent) {
       continue;
     }
-    if (constraint.sourceUsesGroupEnd) {
-      addEdge(
-        endNode(constraint.sourceBranchId),
-        moveNode(targetComponent),
-        ranksep - constraint.targetBaseEntry,
-      );
+    const sourceUsesGroupEnd = columns
+      ? columns.sourceUsesGroupEnd[index] === 1
+      : constraint!.sourceUsesGroupEnd;
+    const sourceBaseExit = columns ? columns.sourceBaseExit[index]! : constraint!.sourceBaseExit;
+    const targetBaseEntry = columns ? columns.targetBaseEntry[index]! : constraint!.targetBaseEntry;
+    if (sourceUsesGroupEnd) {
+      addEdge(endNode(sourceByEdge[index]!), moveNode(targetComponent), ranksep - targetBaseEntry);
     } else {
       addEdge(
         moveNode(sourceComponent),
         moveNode(targetComponent),
-        constraint.sourceBaseExit + ranksep - constraint.targetBaseEntry,
+        sourceBaseExit + ranksep - targetBaseEntry,
       );
     }
   }
 
-  const edges = [...edgeWeightByNodes].flatMap(([from, weightByTarget]) =>
-    [...weightByTarget].map(([to, weight]) => ({from, to, weight})),
-  );
-  edges.sort(
-    (left, right) =>
-      compareStrings(left.from, right.from) ||
-      compareStrings(left.to, right.to) ||
-      left.weight - right.weight,
-  );
-  const adjacency = new Map([...nodes].map((node) => [node, [] as WeightedEdge[]]));
-  const indegree = new Map([...nodes].map((node) => [node, 0]));
-  for (const edge of edges) {
-    adjacency.get(edge.from)!.push(edge);
-    indegree.set(edge.to, indegree.get(edge.to)! + 1);
+  const outgoingCount = new Int32Array(nodeCount);
+  const indegree = new Int32Array(nodeCount);
+  for (let index = 0; index < edgeCount; index++) {
+    const from = edgeFrom[index]!;
+    const to = edgeTo[index]!;
+    outgoingCount[from] = outgoingCount[from]! + 1;
+    indegree[to] = indegree[to]! + 1;
+  }
+  const outgoingOffset = new Int32Array(nodeCount + 1);
+  for (let index = 0; index < nodeCount; index++) {
+    outgoingOffset[index + 1] = outgoingOffset[index]! + outgoingCount[index]!;
+  }
+  const cursor = outgoingOffset.slice(0, nodeCount);
+  const targetByAdjacency = new Int32Array(edgeCount);
+  const weightByAdjacency = new Float64Array(edgeCount);
+  for (let index = 0; index < edgeCount; index++) {
+    const from = edgeFrom[index]!;
+    const adjacencyIndex = cursor[from]!;
+    cursor[from] = adjacencyIndex + 1;
+    targetByAdjacency[adjacencyIndex] = edgeTo[index]!;
+    weightByAdjacency[adjacencyIndex] = edgeWeight[index]!;
   }
 
-  const ready = new StringMinHeap();
-  for (const node of nodes) {
-    if (indegree.get(node) === 0) {
-      ready.push(node);
+  const ready = new Int32Array(nodeCount);
+  let readyCount = 0;
+  for (let node = 0; node < nodeCount; node++) {
+    if (indegree[node] === 0) {
+      ready[readyCount++] = node;
     }
   }
-  const distance = new Map([...nodes].map((node) => [node, Number.NEGATIVE_INFINITY]));
-  distance.set(zeroNode, 0);
+  const distance = new Float64Array(nodeCount);
+  distance.fill(Number.NEGATIVE_INFINITY);
+  distance[zeroNode] = 0;
   let visitedCount = 0;
-  for (let node = ready.pop(); node !== undefined; node = ready.pop()) {
+  while (readyCount) {
+    const node = ready[--readyCount]!;
     visitedCount++;
-    const fromDistance = distance.get(node)!;
-    for (const edge of adjacency.get(node)!) {
+    const fromDistance = distance[node]!;
+    for (
+      let edgeIndex = outgoingOffset[node]!;
+      edgeIndex < outgoingOffset[node + 1]!;
+      edgeIndex++
+    ) {
+      const target = targetByAdjacency[edgeIndex]!;
       if (Number.isFinite(fromDistance)) {
-        distance.set(edge.to, Math.max(distance.get(edge.to)!, fromDistance + edge.weight));
+        distance[target] = Math.max(
+          distance[target]!,
+          fromDistance + weightByAdjacency[edgeIndex]!,
+        );
       }
-      const nextIndegree = indegree.get(edge.to)! - 1;
-      indegree.set(edge.to, nextIndegree);
+      const nextIndegree = indegree[target]! - 1;
+      indegree[target] = nextIndegree;
       if (nextIndegree === 0) {
-        ready.push(edge.to);
+        ready[readyCount++] = target;
       }
     }
   }
-  if (visitedCount !== nodes.size) {
+  if (visitedCount !== nodeCount) {
     throw new Error('Cyclic asset group constraint graph after SCC collapse');
   }
 
+  const shiftByIndex = new Float64Array(groupCount);
+  const endByIndex = new Float64Array(groupCount);
+  for (let index = 0; index < groupCount; index++) {
+    const id = ids[index]!;
+    const component = componentByIndex[index]!;
+    const shift = distance[moveNode(component)]!;
+    const end = distance[endNode(index)]!;
+    shiftByIndex[index] = Number.isFinite(shift) ? shift : 0;
+    endByIndex[index] = Number.isFinite(end) ? end : primaryEnd(groups[id]!.bounds, direction);
+  }
+  return {ids, indexById, shiftByIndex, endByIndex, componentByIndex, componentIdIndex};
+};
+
+export const solveAssetGroupConstraints = (
+  input: AssetGroupConstraintInput,
+): AssetGroupConstraintSolution => {
+  const solution = solveAssetGroupConstraintsNumeric(input);
   const shiftByGroupId: Record<string, number> = {};
   const endByGroupId: Record<string, number> = {};
-  for (const id of ids) {
-    const shift = distance.get(moveNode(componentByGroupId[id]!));
-    const end = distance.get(endNode(id));
-    shiftByGroupId[id] = Number.isFinite(shift) ? shift! : 0;
-    endByGroupId[id] = Number.isFinite(end) ? end! : primaryEnd(groups[id]!.bounds, direction);
+  const componentByGroupId: Record<string, string> = {};
+  for (let index = 0; index < solution.ids.length; index++) {
+    const id = solution.ids[index]!;
+    const component = solution.componentByIndex[index]!;
+    shiftByGroupId[id] = solution.shiftByIndex[index]!;
+    endByGroupId[id] = solution.endByIndex[index]!;
+    componentByGroupId[id] = solution.ids[solution.componentIdIndex[component]!]!;
   }
   return {shiftByGroupId, endByGroupId, componentByGroupId};
 };
@@ -494,19 +547,23 @@ const translatePoint = (
   amount: number,
   direction: RoutingDirection,
 ) =>
-  direction === 'horizontal' ? {...point, x: point.x + amount} : {...point, y: point.y + amount};
+  direction === 'horizontal'
+    ? {x: point.x + amount, y: point.y}
+    : {x: point.x, y: point.y + amount};
 
 const translateBounds = (bounds: IBounds, amount: number, direction: RoutingDirection): IBounds =>
   direction === 'horizontal'
-    ? {...bounds, x: bounds.x + amount}
-    : {...bounds, y: bounds.y + amount};
+    ? {x: bounds.x + amount, y: bounds.y, width: bounds.width, height: bounds.height}
+    : {x: bounds.x, y: bounds.y + amount, width: bounds.width, height: bounds.height};
 
-const withForwardEnd = (bounds: IBounds, end: number, direction: RoutingDirection): IBounds =>
-  direction === 'horizontal'
-    ? {...bounds, width: end - bounds.x}
-    : {...bounds, height: end - bounds.y};
-
-type InternalEdgeRouteInfo = EdgeRouteInfo;
+type ConstraintColumns = {
+  count: number;
+  sourceBranchIds: string[];
+  targetBranchIds: string[];
+  sourceUsesGroupEnd: Uint8Array;
+  sourceBaseExit: Float64Array;
+  targetBaseEntry: Float64Array;
+};
 
 const validBounds = (value: IBounds) =>
   Number.isFinite(value.x) &&
@@ -516,19 +573,39 @@ const validBounds = (value: IBounds) =>
   value.width >= 0 &&
   value.height >= 0;
 
-const sameKeys = (left: Record<string, unknown>, right: Record<string, unknown>) => {
-  const leftKeys = Object.keys(left).sort();
-  const rightKeys = Object.keys(right).sort();
-  return (
-    leftKeys.length === rightKeys.length && leftKeys.every((key, index) => key === rightKeys[index])
-  );
-};
-
 const validateInputCorridors = (layout: RoutingLayout, options: ApplyAssetGroupRoutingOptions) => {
+  if (
+    !Number.isFinite(layout.width) ||
+    !Number.isFinite(layout.height) ||
+    layout.width <= 0 ||
+    layout.height <= 0
+  ) {
+    return false;
+  }
+  for (const id in layout.groups) {
+    const group = layout.groups[id];
+    if (!group || !validBounds(group.bounds)) {
+      return false;
+    }
+  }
+  for (const id in layout.nodes) {
+    const node = layout.nodes[id];
+    if (!node || !validBounds(node.bounds)) {
+      return false;
+    }
+  }
   for (const edge of layout.edges) {
     const hasSourceBoundary = edge.sourceBoundary !== undefined;
     const hasTargetBoundary = edge.targetBoundary !== undefined;
     if (hasSourceBoundary !== hasTargetBoundary) {
+      return false;
+    }
+    if (
+      !Number.isFinite(edge.from.x) ||
+      !Number.isFinite(edge.from.y) ||
+      !Number.isFinite(edge.to.x) ||
+      !Number.isFinite(edge.to.y)
+    ) {
       return false;
     }
     if (!hasSourceBoundary) {
@@ -553,104 +630,6 @@ const validateInputCorridors = (layout: RoutingLayout, options: ApplyAssetGroupR
   return true;
 };
 
-const validateRoutingResult = (
-  original: RoutingLayout,
-  result: RoutingLayout,
-  options: ApplyAssetGroupRoutingOptions,
-) => {
-  if (
-    !Number.isFinite(original.width) ||
-    !Number.isFinite(original.height) ||
-    original.width <= 0 ||
-    original.height <= 0 ||
-    !Number.isFinite(result.width) ||
-    !Number.isFinite(result.height) ||
-    result.width <= 0 ||
-    result.height <= 0 ||
-    !sameKeys(original.nodes, result.nodes) ||
-    !sameKeys(original.groups, result.groups) ||
-    original.edges.length !== result.edges.length
-  ) {
-    return false;
-  }
-
-  for (const id of Object.keys(original.groups)) {
-    const before = original.groups[id];
-    const after = result.groups[id];
-    if (!before || !after || !validBounds(before.bounds) || !validBounds(after.bounds)) {
-      return false;
-    }
-    if (
-      (options.direction === 'horizontal' &&
-        (before.bounds.y !== after.bounds.y || before.bounds.height !== after.bounds.height)) ||
-      (options.direction === 'vertical' &&
-        (before.bounds.x !== after.bounds.x || before.bounds.width !== after.bounds.width))
-    ) {
-      return false;
-    }
-  }
-
-  for (const id of Object.keys(original.nodes)) {
-    const before = original.nodes[id];
-    const after = result.nodes[id];
-    if (!before || !after || !validBounds(before.bounds) || !validBounds(after.bounds)) {
-      return false;
-    }
-    if (
-      (options.direction === 'horizontal' &&
-        (before.bounds.y !== after.bounds.y || before.bounds.height !== after.bounds.height)) ||
-      (options.direction === 'vertical' &&
-        (before.bounds.x !== after.bounds.x || before.bounds.width !== after.bounds.width))
-    ) {
-      return false;
-    }
-  }
-
-  for (let index = 0; index < result.edges.length; index++) {
-    const before = original.edges[index];
-    const edge = result.edges[index];
-    if (!before || !edge || before.fromId !== edge.fromId || before.toId !== edge.toId) {
-      return false;
-    }
-    const originalHasSourceBoundary = before.sourceBoundary !== undefined;
-    const originalHasTargetBoundary = before.targetBoundary !== undefined;
-    if (
-      originalHasSourceBoundary !== originalHasTargetBoundary ||
-      (originalHasSourceBoundary &&
-        (!Number.isFinite(before.sourceBoundary) || !Number.isFinite(before.targetBoundary)))
-    ) {
-      return false;
-    }
-    if (
-      !Number.isFinite(edge.from.x) ||
-      !Number.isFinite(edge.from.y) ||
-      !Number.isFinite(edge.to.x) ||
-      !Number.isFinite(edge.to.y)
-    ) {
-      return false;
-    }
-    const hasSourceBoundary = edge.sourceBoundary !== undefined;
-    const hasTargetBoundary = edge.targetBoundary !== undefined;
-    if (hasSourceBoundary !== hasTargetBoundary) {
-      return false;
-    }
-    if (hasSourceBoundary) {
-      const sourceBoundary = edge.sourceBoundary!;
-      const targetBoundary = edge.targetBoundary!;
-      if (
-        !Number.isFinite(sourceBoundary) ||
-        !Number.isFinite(targetBoundary) ||
-        pointPrimary(edge.from, options.direction) > sourceBoundary ||
-        sourceBoundary + options.ranksep > targetBoundary ||
-        targetBoundary > pointPrimary(edge.to, options.direction)
-      ) {
-        return false;
-      }
-    }
-  }
-  return true;
-};
-
 const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
   layout: T,
   options: ApplyAssetGroupRoutingOptions,
@@ -667,13 +646,32 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
     throw new Error('Invalid asset group routing options');
   }
 
-  const ancestry = buildGroupAncestryIndex(options.groupParentById);
-  const routeInfoByEdge = new Map<number, InternalEdgeRouteInfo>();
-  const constraints: BranchConstraint[] = [];
+  let hasNestedGroups = false;
+  for (const id in options.groupParentById) {
+    if (options.groupParentById[id] !== null) {
+      hasNestedGroups = true;
+      break;
+    }
+  }
+  const ancestry = hasNestedGroups ? buildGroupAncestryIndex(options.groupParentById) : undefined;
+  const constraintIndexByEdge = new Int32Array(layout.edges.length);
+  constraintIndexByEdge.fill(-1);
+  const constraintColumns: ConstraintColumns = {
+    count: 0,
+    sourceBranchIds: [],
+    targetBranchIds: [],
+    sourceUsesGroupEnd: new Uint8Array(layout.edges.length),
+    sourceBaseExit: new Float64Array(layout.edges.length),
+    targetBaseEntry: new Float64Array(layout.edges.length),
+  };
+  let hasPartiallyGroupedEdge = false;
 
   layout.edges.forEach((edge, index) => {
     const sourceEndpointGroupId = options.endpointGroupById[edge.fromId];
     const targetEndpointGroupId = options.endpointGroupById[edge.toId];
+    if (!!sourceEndpointGroupId !== !!targetEndpointGroupId) {
+      hasPartiallyGroupedEdge = true;
+    }
     if (
       !sourceEndpointGroupId ||
       !targetEndpointGroupId ||
@@ -682,9 +680,14 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
       return;
     }
 
-    const lca = ancestry.lowestCommonAncestor(sourceEndpointGroupId, targetEndpointGroupId);
-    const sourceBranchId = ancestry.branchBelow(sourceEndpointGroupId, lca);
-    const targetBranchId = ancestry.branchBelow(targetEndpointGroupId, lca);
+    const lca =
+      ancestry?.lowestCommonAncestor(sourceEndpointGroupId, targetEndpointGroupId) ?? null;
+    const sourceBranchId = ancestry
+      ? ancestry.branchBelow(sourceEndpointGroupId, lca)
+      : sourceEndpointGroupId;
+    const targetBranchId = ancestry
+      ? ancestry.branchBelow(targetEndpointGroupId, lca)
+      : targetEndpointGroupId;
     if (!sourceBranchId || !targetBranchId || sourceBranchId === targetBranchId) {
       return;
     }
@@ -696,104 +699,111 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
 
     const sourceUsesGroupEnd = sourceGroup.expanded || edge.fromId !== sourceBranchId;
     const targetUsesGroupStart = targetGroup.expanded || edge.toId !== targetBranchId;
-    const routeInfo: InternalEdgeRouteInfo = {
-      sourceBranchId,
-      targetBranchId,
-      sourceUsesGroupEnd,
-      sourceBaseExit: sourceUsesGroupEnd
-        ? primaryEnd(sourceGroup.bounds, options.direction)
-        : pointPrimary(edge.from, options.direction),
-      targetBaseEntry: targetUsesGroupStart
-        ? primaryStart(targetGroup.bounds, options.direction)
-        : pointPrimary(edge.to, options.direction),
-    };
-    routeInfoByEdge.set(index, routeInfo);
-    constraints.push(routeInfo);
+    const constraintIndex = constraintColumns.count++;
+    constraintIndexByEdge[index] = constraintIndex;
+    constraintColumns.sourceBranchIds.push(sourceBranchId);
+    constraintColumns.targetBranchIds.push(targetBranchId);
+    constraintColumns.sourceUsesGroupEnd[constraintIndex] = sourceUsesGroupEnd ? 1 : 0;
+    constraintColumns.sourceBaseExit[constraintIndex] = sourceUsesGroupEnd
+      ? primaryEnd(sourceGroup.bounds, options.direction)
+      : pointPrimary(edge.from, options.direction);
+    constraintColumns.targetBaseEntry[constraintIndex] = targetUsesGroupStart
+      ? primaryStart(targetGroup.bounds, options.direction)
+      : pointPrimary(edge.to, options.direction);
   });
 
-  const solution = solveAssetGroupConstraints({
-    direction: options.direction,
-    ranksep: options.ranksep,
-    trailingGroupPadding: options.trailingGroupPadding,
-    groups: layout.groups,
-    parentById: options.groupParentById,
-    constraints,
-  });
-
-  for (const edge of layout.edges) {
-    const sourceEndpointGroupId = options.endpointGroupById[edge.fromId];
-    const targetEndpointGroupId = options.endpointGroupById[edge.toId];
-    if (!!sourceEndpointGroupId === !!targetEndpointGroupId) {
-      continue;
+  const solution = solveAssetGroupConstraintsNumeric(
+    {
+      direction: options.direction,
+      ranksep: options.ranksep,
+      trailingGroupPadding: options.trailingGroupPadding,
+      groups: layout.groups,
+      parentById: options.groupParentById,
+      constraints: [],
+    },
+    constraintColumns,
+  );
+  const requireSolutionIndex = (groupId: string) => {
+    const index = solution.indexById.get(groupId);
+    if (index === undefined) {
+      throw new Error('Missing solved asset group geometry');
     }
-    const sourceShift = sourceEndpointGroupId ? solution.shiftByGroupId[sourceEndpointGroupId] : 0;
-    const targetShift = targetEndpointGroupId ? solution.shiftByGroupId[targetEndpointGroupId] : 0;
-    if (sourceShift === undefined || targetShift === undefined || sourceShift !== targetShift) {
-      throw new Error('Cannot partially translate an edge outside asset groups');
+    return index;
+  };
+  const shiftForGroup = (groupId: string) => solution.shiftByIndex[requireSolutionIndex(groupId)]!;
+
+  if (hasPartiallyGroupedEdge) {
+    for (const edge of layout.edges) {
+      const sourceEndpointGroupId = options.endpointGroupById[edge.fromId];
+      const targetEndpointGroupId = options.endpointGroupById[edge.toId];
+      if (!!sourceEndpointGroupId === !!targetEndpointGroupId) {
+        continue;
+      }
+      const sourceShift = sourceEndpointGroupId ? shiftForGroup(sourceEndpointGroupId) : 0;
+      const targetShift = targetEndpointGroupId ? shiftForGroup(targetEndpointGroupId) : 0;
+      if (sourceShift !== targetShift) {
+        throw new Error('Cannot partially translate an edge outside asset groups');
+      }
     }
   }
 
   const groups: RoutingLayout['groups'] = {};
-  for (const [id, group] of Object.entries(layout.groups)) {
-    const shift = solution.shiftByGroupId[id];
-    const end = solution.endByGroupId[id];
-    if (shift === undefined || end === undefined) {
-      throw new Error('Missing solved asset group geometry');
-    }
-    groups[id] = {
-      ...group,
-      bounds: withForwardEnd(
-        translateBounds(group.bounds, shift, options.direction),
-        end,
-        options.direction,
-      ),
-    };
+  for (const id in layout.groups) {
+    const group = layout.groups[id]!;
+    const solutionIndex = requireSolutionIndex(id);
+    const shift = solution.shiftByIndex[solutionIndex]!;
+    const end = solution.endByIndex[solutionIndex]!;
+    const bounds = group.bounds;
+    const translatedBounds =
+      options.direction === 'horizontal'
+        ? {x: bounds.x + shift, y: bounds.y, width: end - bounds.x - shift, height: bounds.height}
+        : {x: bounds.x, y: bounds.y + shift, width: bounds.width, height: end - bounds.y - shift};
+    groups[id] = {...group, bounds: translatedBounds};
   }
 
   const nodes: RoutingLayout['nodes'] = {};
-  for (const [id, node] of Object.entries(layout.nodes)) {
+  for (const id in layout.nodes) {
+    const node = layout.nodes[id]!;
     const ownerGroupId = options.ownerGroupByNodeId[id];
     const shift =
-      ownerGroupId === null || ownerGroupId === undefined
-        ? 0
-        : solution.shiftByGroupId[ownerGroupId];
-    if (shift === undefined) {
-      throw new Error('Missing node owner asset group');
-    }
-    nodes[id] = {...node, bounds: translateBounds(node.bounds, shift, options.direction)};
+      ownerGroupId === null || ownerGroupId === undefined ? 0 : shiftForGroup(ownerGroupId);
+    const bounds = translateBounds(node.bounds, shift, options.direction);
+    nodes[id] = {...node, bounds};
   }
 
   const edges = layout.edges.map((edge, index) => {
     const sourceEndpointGroupId = options.endpointGroupById[edge.fromId];
     const targetEndpointGroupId = options.endpointGroupById[edge.toId];
-    const sourceShift = sourceEndpointGroupId ? solution.shiftByGroupId[sourceEndpointGroupId] : 0;
-    const targetShift = targetEndpointGroupId ? solution.shiftByGroupId[targetEndpointGroupId] : 0;
-    if (sourceShift === undefined || targetShift === undefined) {
-      throw new Error('Missing edge endpoint asset group');
-    }
-    const {sourceBoundary: _sourceBoundary, targetBoundary: _targetBoundary, ...legacyEdge} = edge;
-    const translated = {
-      ...legacyEdge,
-      from: translatePoint(edge.from, sourceShift, options.direction),
-      to: translatePoint(edge.to, targetShift, options.direction),
-    };
-    const routeInfo = routeInfoByEdge.get(index);
+    const sourceShift = sourceEndpointGroupId ? shiftForGroup(sourceEndpointGroupId) : 0;
+    const targetShift = targetEndpointGroupId ? shiftForGroup(targetEndpointGroupId) : 0;
+    const from = translatePoint(edge.from, sourceShift, options.direction);
+    const to = translatePoint(edge.to, targetShift, options.direction);
+    const translated = {...edge, from, to};
+    delete translated.sourceBoundary;
+    delete translated.targetBoundary;
+    const constraintIndex = constraintIndexByEdge[index]!;
     if (
-      !routeInfo ||
-      solution.componentByGroupId[routeInfo.sourceBranchId] ===
-        solution.componentByGroupId[routeInfo.targetBranchId]
+      constraintIndex === -1 ||
+      solution.componentByIndex[
+        requireSolutionIndex(constraintColumns.sourceBranchIds[constraintIndex]!)
+      ] ===
+        solution.componentByIndex[
+          requireSolutionIndex(constraintColumns.targetBranchIds[constraintIndex]!)
+        ]
     ) {
       return translated;
     }
-    const sourceBranchShift = solution.shiftByGroupId[routeInfo.sourceBranchId]!;
-    const targetBranchShift = solution.shiftByGroupId[routeInfo.targetBranchId]!;
-    return {
-      ...translated,
-      sourceBoundary: routeInfo.sourceUsesGroupEnd
-        ? solution.endByGroupId[routeInfo.sourceBranchId]!
-        : routeInfo.sourceBaseExit + sourceBranchShift,
-      targetBoundary: routeInfo.targetBaseEntry + targetBranchShift,
-    };
+    const sourceBranchIndex = requireSolutionIndex(
+      constraintColumns.sourceBranchIds[constraintIndex]!,
+    );
+    const sourceBranchShift = solution.shiftByIndex[sourceBranchIndex]!;
+    const targetBranchShift = shiftForGroup(constraintColumns.targetBranchIds[constraintIndex]!);
+    translated.sourceBoundary = constraintColumns.sourceUsesGroupEnd[constraintIndex]
+      ? solution.endByIndex[sourceBranchIndex]!
+      : constraintColumns.sourceBaseExit[constraintIndex]! + sourceBranchShift;
+    translated.targetBoundary =
+      constraintColumns.targetBaseEntry[constraintIndex]! + targetBranchShift;
+    return translated;
   });
 
   let maximumForwardEnd: number | undefined;
@@ -837,8 +847,7 @@ export const applyAssetGroupLineageRouting = <T extends RoutingLayout>(
     if (!validateInputCorridors(layout, options)) {
       return layout;
     }
-    const result = applyAssetGroupLineageRoutingImpl(layout, options);
-    return validateRoutingResult(layout, result, options) ? result : layout;
+    return applyAssetGroupLineageRoutingImpl(layout, options);
   } catch {
     return layout;
   }

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -720,6 +720,19 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
     constraints,
   });
 
+  for (const edge of layout.edges) {
+    const sourceEndpointGroupId = options.endpointGroupById[edge.fromId];
+    const targetEndpointGroupId = options.endpointGroupById[edge.toId];
+    if (!!sourceEndpointGroupId === !!targetEndpointGroupId) {
+      continue;
+    }
+    const sourceShift = sourceEndpointGroupId ? solution.shiftByGroupId[sourceEndpointGroupId] : 0;
+    const targetShift = targetEndpointGroupId ? solution.shiftByGroupId[targetEndpointGroupId] : 0;
+    if (sourceShift === undefined || targetShift === undefined || sourceShift !== targetShift) {
+      throw new Error('Cannot partially translate an edge outside asset groups');
+    }
+  }
+
   const groups: RoutingLayout['groups'] = {};
   for (const [id, group] of Object.entries(layout.groups)) {
     const shift = solution.shiftByGroupId[id];

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -1,13 +1,48 @@
+import type {IBounds} from '../graph/common';
+
 export type GroupParentById = Record<string, string | null>;
+
+export type RoutingDirection = 'horizontal' | 'vertical';
+
+export type RoutingGroup = {bounds: IBounds; expanded: boolean};
+
+export type BranchConstraint = {
+  sourceBranchId: string;
+  targetBranchId: string;
+  sourceUsesGroupEnd: boolean;
+  sourceBaseExit: number;
+  targetBaseEntry: number;
+};
+
+export type AssetGroupConstraintInput = {
+  direction: RoutingDirection;
+  ranksep: number;
+  trailingGroupPadding: number;
+  groups: Record<string, RoutingGroup>;
+  parentById: GroupParentById;
+  constraints: BranchConstraint[];
+};
+
+export type AssetGroupConstraintSolution = {
+  shiftByGroupId: Record<string, number>;
+  endByGroupId: Record<string, number>;
+  componentByGroupId: Record<string, string>;
+};
+
+const primaryStart = (bounds: IBounds, direction: RoutingDirection) =>
+  direction === 'horizontal' ? bounds.x : bounds.y;
+
+const primaryEnd = (bounds: IBounds, direction: RoutingDirection) =>
+  primaryStart(bounds, direction) + (direction === 'horizontal' ? bounds.width : bounds.height);
+
+const compareStrings = (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0);
 
 export type GroupAncestryIndex = {
   lowestCommonAncestor: (a: string, b: string) => string | null;
   branchBelow: (groupId: string, ancestorId: string | null) => string | null;
 };
 
-export const buildGroupAncestryIndex = (
-  parentById: GroupParentById,
-): GroupAncestryIndex => {
+export const buildGroupAncestryIndex = (parentById: GroupParentById): GroupAncestryIndex => {
   const ids = Object.keys(parentById).sort();
   const indexById = new Map(ids.map((id, index) => [id, index]));
   const groupCount = ids.length;
@@ -154,4 +189,263 @@ export const buildGroupAncestryIndex = (
   };
 
   return {lowestCommonAncestor, branchBelow};
+};
+
+const buildConstraintComponents = (
+  ids: string[],
+  constraints: BranchConstraint[],
+): Record<string, string> => {
+  const idSet = new Set(ids);
+  const adjacency = new Map(ids.map((id) => [id, [] as string[]]));
+  const reverse = new Map(ids.map((id) => [id, [] as string[]]));
+
+  for (const constraint of constraints) {
+    if (!idSet.has(constraint.sourceBranchId)) {
+      throw new Error(`Unknown asset group constraint endpoint: ${constraint.sourceBranchId}`);
+    }
+    if (!idSet.has(constraint.targetBranchId)) {
+      throw new Error(`Unknown asset group constraint endpoint: ${constraint.targetBranchId}`);
+    }
+    adjacency.get(constraint.sourceBranchId)!.push(constraint.targetBranchId);
+    reverse.get(constraint.targetBranchId)!.push(constraint.sourceBranchId);
+  }
+  for (const id of ids) {
+    adjacency.get(id)!.sort();
+    reverse.get(id)!.sort();
+  }
+
+  const visited = new Set<string>();
+  const finishOrder: string[] = [];
+  for (const start of ids) {
+    if (visited.has(start)) {
+      continue;
+    }
+    visited.add(start);
+    const frames = [{id: start, next: 0}];
+    while (frames.length) {
+      const frame = frames[frames.length - 1]!;
+      const neighbors = adjacency.get(frame.id)!;
+      if (frame.next < neighbors.length) {
+        const neighbor = neighbors[frame.next++]!;
+        if (!visited.has(neighbor)) {
+          visited.add(neighbor);
+          frames.push({id: neighbor, next: 0});
+        }
+      } else {
+        finishOrder.push(frame.id);
+        frames.pop();
+      }
+    }
+  }
+
+  const assigned = new Set<string>();
+  const components: string[][] = [];
+  for (let index = finishOrder.length - 1; index >= 0; index--) {
+    const start = finishOrder[index]!;
+    if (assigned.has(start)) {
+      continue;
+    }
+    assigned.add(start);
+    const component: string[] = [];
+    const stack = [start];
+    while (stack.length) {
+      const id = stack.pop()!;
+      component.push(id);
+      for (const neighbor of reverse.get(id)!) {
+        if (!assigned.has(neighbor)) {
+          assigned.add(neighbor);
+          stack.push(neighbor);
+        }
+      }
+    }
+    component.sort();
+    components.push(component);
+  }
+  components.sort((left, right) => compareStrings(left[0]!, right[0]!));
+
+  const componentByGroupId: Record<string, string> = {};
+  for (const component of components) {
+    const componentId = component[0]!;
+    for (const id of component) {
+      componentByGroupId[id] = componentId;
+    }
+  }
+  return componentByGroupId;
+};
+
+class StringMinHeap {
+  private values: string[] = [];
+
+  public push(value: string) {
+    this.values.push(value);
+    let index = this.values.length - 1;
+    while (index > 0) {
+      const parent = Math.floor((index - 1) / 2);
+      if (compareStrings(this.values[parent]!, value) <= 0) {
+        break;
+      }
+      this.values[index] = this.values[parent]!;
+      index = parent;
+    }
+    this.values[index] = value;
+  }
+
+  public pop() {
+    if (this.values.length === 0) {
+      return undefined;
+    }
+    const minimum = this.values[0]!;
+    const last = this.values.pop()!;
+    if (this.values.length === 0) {
+      return minimum;
+    }
+
+    let index = 0;
+    while (true) {
+      const left = index * 2 + 1;
+      if (left >= this.values.length) {
+        break;
+      }
+      const right = left + 1;
+      const child =
+        right < this.values.length && compareStrings(this.values[right]!, this.values[left]!) < 0
+          ? right
+          : left;
+      if (compareStrings(this.values[child]!, last) >= 0) {
+        break;
+      }
+      this.values[index] = this.values[child]!;
+      index = child;
+    }
+    this.values[index] = last;
+    return minimum;
+  }
+}
+
+type WeightedEdge = {from: string; to: string; weight: number};
+
+export const solveAssetGroupConstraints = ({
+  direction,
+  ranksep,
+  trailingGroupPadding,
+  groups,
+  parentById,
+  constraints,
+}: AssetGroupConstraintInput): AssetGroupConstraintSolution => {
+  const ids = Object.keys(groups).sort();
+  const idSet = new Set(ids);
+  const componentByGroupId = buildConstraintComponents(ids, constraints);
+  const componentIds = [...new Set(ids.map((id) => componentByGroupId[id]!))];
+  const zeroNode = '$zero';
+  const moveNode = (componentId: string) => `move:${componentId}`;
+  const endNode = (groupId: string) => `end:${groupId}`;
+  const nodes = new Set<string>([zeroNode]);
+  for (const componentId of componentIds) {
+    nodes.add(moveNode(componentId));
+  }
+  for (const id of ids) {
+    nodes.add(endNode(id));
+  }
+
+  const edges: WeightedEdge[] = [];
+  const edgeKeys = new Set<string>();
+  const addEdge = (from: string, to: string, weight: number) => {
+    if (!Number.isFinite(weight)) {
+      throw new Error('Non-finite asset group constraint');
+    }
+    const key = JSON.stringify([from, to, weight]);
+    if (!edgeKeys.has(key)) {
+      edgeKeys.add(key);
+      edges.push({from, to, weight});
+    }
+  };
+
+  for (const id of ids) {
+    const componentMove = moveNode(componentByGroupId[id]!);
+    addEdge(zeroNode, componentMove, 0);
+    addEdge(componentMove, endNode(id), primaryEnd(groups[id]!.bounds, direction));
+
+    const parentId = parentById[id];
+    if (parentId === undefined) {
+      throw new Error(`Missing visible asset group parent: undefined`);
+    }
+    if (parentId !== null) {
+      if (!idSet.has(parentId)) {
+        throw new Error(`Missing visible asset group parent: ${parentId}`);
+      }
+      addEdge(moveNode(componentByGroupId[parentId]!), componentMove, 0);
+      addEdge(endNode(id), endNode(parentId), trailingGroupPadding);
+    }
+  }
+
+  for (const constraint of constraints) {
+    const sourceComponent = componentByGroupId[constraint.sourceBranchId]!;
+    const targetComponent = componentByGroupId[constraint.targetBranchId]!;
+    if (sourceComponent === targetComponent) {
+      continue;
+    }
+    if (constraint.sourceUsesGroupEnd) {
+      addEdge(
+        endNode(constraint.sourceBranchId),
+        moveNode(targetComponent),
+        ranksep - constraint.targetBaseEntry,
+      );
+    } else {
+      addEdge(
+        moveNode(sourceComponent),
+        moveNode(targetComponent),
+        constraint.sourceBaseExit + ranksep - constraint.targetBaseEntry,
+      );
+    }
+  }
+
+  edges.sort(
+    (left, right) =>
+      compareStrings(left.from, right.from) ||
+      compareStrings(left.to, right.to) ||
+      left.weight - right.weight,
+  );
+  const adjacency = new Map([...nodes].map((node) => [node, [] as WeightedEdge[]]));
+  const indegree = new Map([...nodes].map((node) => [node, 0]));
+  for (const edge of edges) {
+    adjacency.get(edge.from)!.push(edge);
+    indegree.set(edge.to, indegree.get(edge.to)! + 1);
+  }
+
+  const ready = new StringMinHeap();
+  for (const node of nodes) {
+    if (indegree.get(node) === 0) {
+      ready.push(node);
+    }
+  }
+  const distance = new Map([...nodes].map((node) => [node, Number.NEGATIVE_INFINITY]));
+  distance.set(zeroNode, 0);
+  let visitedCount = 0;
+  for (let node = ready.pop(); node !== undefined; node = ready.pop()) {
+    visitedCount++;
+    const fromDistance = distance.get(node)!;
+    for (const edge of adjacency.get(node)!) {
+      if (Number.isFinite(fromDistance)) {
+        distance.set(edge.to, Math.max(distance.get(edge.to)!, fromDistance + edge.weight));
+      }
+      const nextIndegree = indegree.get(edge.to)! - 1;
+      indegree.set(edge.to, nextIndegree);
+      if (nextIndegree === 0) {
+        ready.push(edge.to);
+      }
+    }
+  }
+  if (visitedCount !== nodes.size) {
+    throw new Error('Cyclic asset group constraint graph after SCC collapse');
+  }
+
+  const shiftByGroupId: Record<string, number> = {};
+  const endByGroupId: Record<string, number> = {};
+  for (const id of ids) {
+    const shift = distance.get(moveNode(componentByGroupId[id]!));
+    const end = distance.get(endNode(id));
+    shiftByGroupId[id] = Number.isFinite(shift) ? shift! : 0;
+    endByGroupId[id] = Number.isFinite(end) ? end! : primaryEnd(groups[id]!.bounds, direction);
+  }
+  return {shiftByGroupId, endByGroupId, componentByGroupId};
 };

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -297,6 +297,47 @@ const buildConstraintComponents = (
     incomingCursor[target] = incomingIndex + 1;
   }
 
+  const remainingIncoming = incomingCount.slice();
+  const acyclicReady = new Int32Array(groupCount);
+  let acyclicReadyCount = 0;
+  for (let index = 0; index < groupCount; index++) {
+    if (remainingIncoming[index] === 0) {
+      acyclicReady[acyclicReadyCount++] = index;
+    }
+  }
+  let acyclicVisitedCount = 0;
+  while (acyclicReadyCount) {
+    const node = acyclicReady[--acyclicReadyCount]!;
+    acyclicVisitedCount++;
+    for (
+      let edgeIndex = outgoingOffset[node]!;
+      edgeIndex < outgoingOffset[node + 1]!;
+      edgeIndex++
+    ) {
+      const target = outgoing[edgeIndex]!;
+      const nextIncoming = remainingIncoming[target]! - 1;
+      remainingIncoming[target] = nextIncoming;
+      if (nextIncoming === 0) {
+        acyclicReady[acyclicReadyCount++] = target;
+      }
+    }
+  }
+  if (acyclicVisitedCount === groupCount) {
+    const componentByIndex = new Int32Array(groupCount);
+    const componentIdIndex = new Int32Array(groupCount);
+    for (let index = 0; index < groupCount; index++) {
+      componentByIndex[index] = index;
+      componentIdIndex[index] = index;
+    }
+    return {
+      componentByIndex,
+      componentIdIndex,
+      componentCount: groupCount,
+      sourceByEdge,
+      targetByEdge,
+    };
+  }
+
   const visited = new Uint8Array(groupCount);
   const finishOrder = new Int32Array(groupCount);
   const stackNode = new Int32Array(groupCount);
@@ -785,13 +826,17 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
     }
   }
 
+  let maximumForwardEnd: number | undefined;
   const groups: RoutingLayout['groups'] = {};
+  let groupIterationIndex = 0;
   for (const id in layout.groups) {
     if (!Object.prototype.hasOwnProperty.call(layout.groups, id)) {
       continue;
     }
     const group = layout.groups[id]!;
-    const solutionIndex = requireSolutionIndex(id);
+    const solutionIndex =
+      solution.ids[groupIterationIndex] === id ? groupIterationIndex : requireSolutionIndex(id);
+    groupIterationIndex++;
     const shift = solution.shiftByIndex[solutionIndex]!;
     const end = solution.endByIndex[solutionIndex]!;
     const bounds = group.bounds;
@@ -809,6 +854,9 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
         ? {x: translatedStart, y: bounds.y, width: translatedSize, height: bounds.height}
         : {x: bounds.x, y: translatedStart, width: bounds.width, height: translatedSize};
     groups[id] = {...group, bounds: translatedBounds};
+    const forwardEnd = primaryEnd(translatedBounds, options.direction);
+    maximumForwardEnd =
+      maximumForwardEnd === undefined ? forwardEnd : Math.max(maximumForwardEnd, forwardEnd);
   }
 
   const nodes: RoutingLayout['nodes'] = {};
@@ -822,33 +870,49 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
       ownerGroupId === null || ownerGroupId === undefined ? 0 : shiftForGroup(ownerGroupId);
     const bounds = translateBounds(node.bounds, shift, options.direction);
     nodes[id] = {...node, bounds};
+    const forwardEnd = primaryEnd(bounds, options.direction);
+    maximumForwardEnd =
+      maximumForwardEnd === undefined ? forwardEnd : Math.max(maximumForwardEnd, forwardEnd);
   }
 
   const edges = layout.edges.map((edge, index) => {
-    const sourceEndpointGroupId = options.endpointGroupById[edge.fromId];
-    const targetEndpointGroupId = options.endpointGroupById[edge.toId];
-    const sourceShift = sourceEndpointGroupId ? shiftForGroup(sourceEndpointGroupId) : 0;
-    const targetShift = targetEndpointGroupId ? shiftForGroup(targetEndpointGroupId) : 0;
+    const constraintIndex = constraintIndexByEdge[index]!;
+    const sourceBranchIndex =
+      constraintIndex === -1
+        ? -1
+        : requireSolutionIndex(constraintColumns.sourceBranchIds[constraintIndex]!);
+    const targetBranchIndex =
+      constraintIndex === -1
+        ? -1
+        : requireSolutionIndex(constraintColumns.targetBranchIds[constraintIndex]!);
+    const flatRoutedEdge = ancestry === undefined && constraintIndex !== -1;
+    const sourceEndpointGroupId = flatRoutedEdge
+      ? constraintColumns.sourceBranchIds[constraintIndex]!
+      : options.endpointGroupById[edge.fromId];
+    const targetEndpointGroupId = flatRoutedEdge
+      ? constraintColumns.targetBranchIds[constraintIndex]!
+      : options.endpointGroupById[edge.toId];
+    const sourceShift = sourceEndpointGroupId
+      ? solution.shiftByIndex[
+          flatRoutedEdge ? sourceBranchIndex : requireSolutionIndex(sourceEndpointGroupId)
+        ]!
+      : 0;
+    const targetShift = targetEndpointGroupId
+      ? solution.shiftByIndex[
+          flatRoutedEdge ? targetBranchIndex : requireSolutionIndex(targetEndpointGroupId)
+        ]!
+      : 0;
     const from = translatePoint(edge.from, sourceShift, options.direction);
     const to = translatePoint(edge.to, targetShift, options.direction);
     const translated = {...edge, from, to};
     delete translated.sourceBoundary;
     delete translated.targetBoundary;
-    const constraintIndex = constraintIndexByEdge[index]!;
     if (
       constraintIndex !== -1 &&
-      solution.componentByIndex[
-        requireSolutionIndex(constraintColumns.sourceBranchIds[constraintIndex]!)
-      ] !==
-        solution.componentByIndex[
-          requireSolutionIndex(constraintColumns.targetBranchIds[constraintIndex]!)
-        ]
+      solution.componentByIndex[sourceBranchIndex] !== solution.componentByIndex[targetBranchIndex]
     ) {
-      const sourceBranchIndex = requireSolutionIndex(
-        constraintColumns.sourceBranchIds[constraintIndex]!,
-      );
       const sourceBranchShift = solution.shiftByIndex[sourceBranchIndex]!;
-      const targetBranchShift = shiftForGroup(constraintColumns.targetBranchIds[constraintIndex]!);
+      const targetBranchShift = solution.shiftByIndex[targetBranchIndex]!;
       translated.sourceBoundary = constraintColumns.sourceUsesGroupEnd[constraintIndex]
         ? solution.endByIndex[sourceBranchIndex]!
         : constraintColumns.sourceBaseExit[constraintIndex]! + sourceBranchShift;
@@ -859,21 +923,6 @@ const applyAssetGroupLineageRoutingImpl = <T extends RoutingLayout>(
     return translated;
   });
 
-  let maximumForwardEnd: number | undefined;
-  for (const id in groups) {
-    const group = groups[id];
-    if (group) {
-      const end = primaryEnd(group.bounds, options.direction);
-      maximumForwardEnd = maximumForwardEnd === undefined ? end : Math.max(maximumForwardEnd, end);
-    }
-  }
-  for (const id in nodes) {
-    const node = nodes[id];
-    if (node) {
-      const end = primaryEnd(node.bounds, options.direction);
-      maximumForwardEnd = maximumForwardEnd === undefined ? end : Math.max(maximumForwardEnd, end);
-    }
-  }
   const forwardEnd = maximumForwardEnd ?? 0;
   const result = {
     ...layout,

--- a/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
+++ b/js_modules/ui-core/src/asset-graph/assetGroupLineageRouting.ts
@@ -1,0 +1,154 @@
+export type GroupParentById = Record<string, string | null>;
+
+export type GroupAncestryIndex = {
+  lowestCommonAncestor: (a: string, b: string) => string | null;
+  branchBelow: (groupId: string, ancestorId: string | null) => string | null;
+};
+
+export const buildGroupAncestryIndex = (
+  parentById: GroupParentById,
+): GroupAncestryIndex => {
+  const ids = Object.keys(parentById).sort();
+  const indexById = new Map(ids.map((id, index) => [id, index]));
+  const groupCount = ids.length;
+
+  const parent = new Int32Array(groupCount);
+  parent.fill(-1);
+  for (let index = 0; index < groupCount; index++) {
+    const parentId = parentById[ids[index]!];
+    if (parentId === null) {
+      continue;
+    }
+    const parentIndex = indexById.get(parentId);
+    if (parentIndex === undefined) {
+      throw new Error(`Missing visible asset group parent: ${parentId}`);
+    }
+    parent[index] = parentIndex;
+  }
+
+  const depth = new Int32Array(groupCount);
+  const root = new Int32Array(groupCount);
+  const visiting = new Uint8Array(groupCount);
+  depth.fill(-1);
+  root.fill(-1);
+
+  for (let start = 0; start < groupCount; start++) {
+    if (visiting[start] === 2) {
+      continue;
+    }
+
+    const path: number[] = [];
+    let current = start;
+    while (current !== -1 && visiting[current] === 0) {
+      visiting[current] = 1;
+      path.push(current);
+      current = parent[current]!;
+    }
+
+    if (current !== -1 && visiting[current] === 1) {
+      throw new Error('Asset group parent cycle');
+    }
+
+    for (let pathIndex = path.length - 1; pathIndex >= 0; pathIndex--) {
+      const groupIndex = path[pathIndex]!;
+      const parentIndex = parent[groupIndex]!;
+      if (parentIndex === -1) {
+        depth[groupIndex] = 0;
+        root[groupIndex] = groupIndex;
+      } else {
+        depth[groupIndex] = depth[parentIndex]! + 1;
+        root[groupIndex] = root[parentIndex]!;
+      }
+      visiting[groupIndex] = 2;
+    }
+  }
+
+  const levelCount = Math.ceil(Math.log2(Math.max(1, groupCount))) + 1;
+  const ancestors: Int32Array[] = [parent];
+  for (let level = 1; level < levelCount; level++) {
+    const previous = ancestors[level - 1]!;
+    const current = new Int32Array(groupCount);
+    current.fill(-1);
+    for (let index = 0; index < groupCount; index++) {
+      const previousAncestor = previous[index]!;
+      if (previousAncestor !== -1) {
+        current[index] = previous[previousAncestor]!;
+      }
+    }
+    ancestors.push(current);
+  }
+
+  const requireIndex = (id: string) => {
+    const index = indexById.get(id);
+    if (index === undefined) {
+      throw new Error(`Unknown visible asset group: ${id}`);
+    }
+    return index;
+  };
+
+  const lift = (index: number, distance: number) => {
+    let current = index;
+    let remaining = distance;
+    let level = 0;
+    while (remaining > 0 && current !== -1) {
+      if (remaining % 2 === 1) {
+        current = ancestors[level]![current]!;
+      }
+      remaining = Math.floor(remaining / 2);
+      level++;
+    }
+    return current;
+  };
+
+  const lowestCommonAncestorIndex = (a: number, b: number) => {
+    if (root[a] !== root[b]) {
+      return -1;
+    }
+
+    let left = a;
+    let right = b;
+    if (depth[left]! < depth[right]!) {
+      right = lift(right, depth[right]! - depth[left]!);
+    } else if (depth[left]! > depth[right]!) {
+      left = lift(left, depth[left]! - depth[right]!);
+    }
+    if (left === right) {
+      return left;
+    }
+
+    for (let level = levelCount - 1; level >= 0; level--) {
+      const leftAncestor = ancestors[level]![left]!;
+      const rightAncestor = ancestors[level]![right]!;
+      if (leftAncestor !== rightAncestor) {
+        left = leftAncestor;
+        right = rightAncestor;
+      }
+    }
+    return parent[left]!;
+  };
+
+  const lowestCommonAncestor = (a: string, b: string) => {
+    const ancestorIndex = lowestCommonAncestorIndex(requireIndex(a), requireIndex(b));
+    return ancestorIndex === -1 ? null : ids[ancestorIndex]!;
+  };
+
+  const branchBelow = (groupId: string, ancestorId: string | null) => {
+    const groupIndex = requireIndex(groupId);
+    if (ancestorId === null) {
+      return ids[root[groupIndex]!]!;
+    }
+
+    const ancestorIndex = requireIndex(ancestorId);
+    if (groupIndex === ancestorIndex) {
+      return null;
+    }
+    if (lowestCommonAncestorIndex(groupIndex, ancestorIndex) !== ancestorIndex) {
+      return null;
+    }
+
+    const branchIndex = lift(groupIndex, depth[groupIndex]! - depth[ancestorIndex]! - 1);
+    return ids[branchIndex]!;
+  };
+
+  return {lowestCommonAncestor, branchBelow};
+};

--- a/js_modules/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/ui-core/src/asset-graph/layout.ts
@@ -461,6 +461,7 @@ export const layoutAssetGraphImpl = (
     groupParentById,
     ownerGroupByNodeId,
     endpointGroupById,
+    alignGroupsOnSecondaryAxis: groupsPresent,
   });
 };
 

--- a/js_modules/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/ui-core/src/asset-graph/layout.ts
@@ -9,6 +9,7 @@ import {
   isGroupId,
   parseGroupId,
 } from './Utils';
+import {applyAssetGroupLineageRouting} from './assetGroupLineageRouting';
 import type {IBounds, IPoint} from '../graph/common';
 
 export type AssetLayoutDirection = 'vertical' | 'horizontal';
@@ -33,6 +34,8 @@ export type AssetLayoutEdge = {
   fromId: string;
   to: IPoint;
   toId: string;
+  sourceBoundary?: number;
+  targetBoundary?: number;
 };
 
 export type AssetGraphLayout = {
@@ -412,13 +415,53 @@ export const layoutAssetGraphImpl = (
     }
   }
 
-  return {
+  const finalGroups = groupsPresent ? visibleGroups : {};
+  const finalVisibleGroupIds = new Set(Object.keys(finalGroups));
+  const groupParentById: Record<string, string | null> = {};
+  for (const id of finalVisibleGroupIds) {
+    const ancestors = ancestorGroupIds(id);
+    const immediateParent = ancestors[ancestors.length - 1];
+    groupParentById[id] =
+      immediateParent !== undefined && finalVisibleGroupIds.has(immediateParent)
+        ? immediateParent
+        : null;
+  }
+
+  const ownerGroupByNodeId: Record<string, string | null> = {};
+  for (const node of renderedNodes) {
+    if (!nodes[node.id]) {
+      continue;
+    }
+    const leafId = node.definition.groupName ? groupIdForNode(node) : null;
+    ownerGroupByNodeId[node.id] = leafId && finalVisibleGroupIds.has(leafId) ? leafId : null;
+  }
+
+  const endpointGroupById: Record<string, string | null> = {};
+  for (const edge of edges) {
+    for (const endpointId of [edge.fromId, edge.toId]) {
+      endpointGroupById[endpointId] = isGroupId(endpointId)
+        ? endpointId
+        : (ownerGroupByNodeId[endpointId] ?? null);
+    }
+  }
+
+  const baseline: AssetGraphLayout = {
     nodes,
     edges,
     width: maxWidth + MARGIN,
     height: maxHeight + MARGIN,
-    groups: groupsPresent ? visibleGroups : {},
+    groups: finalGroups,
   };
+
+  return applyAssetGroupLineageRouting(baseline, {
+    direction: opts.direction,
+    ranksep: Number(config.ranksep ?? Config[opts.direction].ranksep),
+    trailingGroupPadding: opts.direction === 'horizontal' ? 15 : Number(config.groupPaddingBottom),
+    margin: MARGIN,
+    groupParentById,
+    ownerGroupByNodeId,
+    endpointGroupById,
+  });
 };
 
 export const ASSET_LINK_NAME_MAX_LENGTH = 30;

--- a/js_modules/ui-core/src/graph/asyncGraphLayout.ts
+++ b/js_modules/ui-core/src/graph/asyncGraphLayout.ts
@@ -71,7 +71,7 @@ const _assetLayoutCacheKey = weakMapMemoize(
     // IMPORTANT: hashObject internally uses weakmapMemoize to avoid re-calculating
     // the hash for the same object twice. Hashing individual objects and joining the
     // strings allows this Weakmap to re-use `graphData` hashes.
-    return hashObject(graphData) + hashObject(opts) + 'version:6';
+    return hashObject(graphData) + hashObject(opts) + 'version:7';
   },
 );
 


### PR DESCRIPTION
## Summary & Motivation

Asset lineage edges can cross unrelated or nested asset-group containers after
Dagre layout, and connected groups can sit far apart on the cross axis, making
complex asset graphs hard to read.

This change adds a post-layout routing stage that runs after Dagre and before
the graph is rendered. It:

- builds an asset-group ancestry index;
- derives minimal routing constraints;
- handles nested ancestor and descendant relationships;
- supports group-level pseudo-cycles while preserving the asset DAG;
- routes lineage edges through group-boundary corridors;
- **aligns connected groups on the secondary (cross) axis** — each top-level
  group slides toward the median position of the endpoints connecting it to its
  upstream groups, so lineage edges stay short instead of spanning the full
  canvas height. Collisions cascade later groups away while preserving Dagre's
  cross-axis order and spacing; nested groups move with their root ancestor. The
  primary axis, corridor boundaries, and group sizes are left untouched.
- preserves mixed routed and non-routed edge geometry;
- retains existing edge-filtering behavior;
- runs as part of the graph-layout worker.

It also fixes a bug where lineage edges could disappear entirely in dev builds:
`getEdgesToShow` runs in a serialized web worker with no module closure, so its
reference to the module-scope `MAX_EDGES` threw and was swallowed by the
function's `try/catch`, dropping every edge. The cap is now passed in as a
required argument at the worker call site.

This PR is independent of the separate
`feature/asset-group-lineage-anchor` branch (#34038): the two branch from the
same point on `master` and modify disjoint files, so they can merge in any order
without conflict. This PR is the sole owner of the `MAX_EDGES` worker fix above.

## Test Plan

Automated validation:

- Focused suites pass: asset-group routing (37), asset-edge rendering (3),
  layout (3); full `asset-graph` suite (111) passes.
- `tsgo` (worker TypeScript) passes.
- Added coverage for:
  - nested asset groups;
  - ancestor and descendant relationships;
  - group-level pseudo-cycles;
  - left-to-right and top-to-bottom layouts;
  - unrelated group avoidance;
  - mixed routed and original edge geometry;
  - asset-edge filtering;
  - invalid inputs and fallback behavior;
  - deterministic routing;
  - secondary-axis alignment: median placement, corridor preservation,
    same-column cascade, order preservation, ungrouped-endpoint skip, and
    canvas growth;
  - worker serialization: `getEdgesToShow` reconstructed in global-only scope
    still returns edges (guards against the module-scope regression).

Performance fixture (routing pass):

- 9,999 groups
- 17,999 edges
- nesting depth 300
- ~38.9 ms CPU
- ~7.5 MB retained heap

The secondary-axis alignment adds an O((G + E) log G) pass.

## Changelog

Improved asset graph lineage rendering: edges route around nested asset-group
boundaries, and connected groups align on the cross axis so lineage edges stay
short.

### Before / After

Before — Dagre placed connected groups at unrelated cross-axis offsets, so
`ANALYTICS` floated far above `CLEANED` and the lineage edge between them swept
vertically across the canvas:

BEFORE
<img width="1282" height="921" alt="Screenshot 2026-07-23 153515" src="https://github.com/user-attachments/assets/5d264e80-09eb-4749-8fd1-f205fc7b814e" />


After — the secondary-axis alignment slides `ANALYTICS` down so `orders_augmented`
lines up with `orders_aggregated` in `CLEANED`, keeping cross-group edges short
and horizontal:

AFTER
<img width="2768" height="1041" alt="image" src="https://github.com/user-attachments/assets/c0a1bac3-e1b9-48be-9124-fe5e115d4309" />


