### PR TITLE
docs: treat freshness policies as GA, drop preview enablement

### DIFF
--- a/docs/docs/guides/observe/asset-freshness-policies.md
+++ b/docs/docs/guides/observe/asset-freshness-policies.md
@@ -24,12 +24,9 @@ You can set an [asset freshness alert](/guides/observe/alerts/creating-alerts) t
 
 ### Enabling freshness policies
 
-Freshness policies are not enabled by default while in preview. To use them in open source and local development, add the following to your `dagster.yaml`:
+Since Dagster 1.12, freshness policies are generally available and evaluated by the `FreshnessDaemon` **by default**. You do not need a `dagster.yaml` switch to turn them on.
 
-```
-freshness:
-  enabled: True
-```
+If you previously set `freshness.enabled` during the preview period, that configuration is no longer required and can be removed.
 
 ### Relationship to existing `FreshnessPolicy`
 

--- a/docs/docs/partials/_FreshnessPoliciesPreview.md
+++ b/docs/docs/partials/_FreshnessPoliciesPreview.md
@@ -1,5 +1,5 @@
 :::info
 
-Freshness policies are under active development. You may encounter feature gaps and the APIs may change.
+Freshness policies are generally available. The `FreshnessDaemon` evaluates them by default — no `dagster.yaml` switch is required.
 
 :::


### PR DESCRIPTION
## Summary

The [asset freshness policy guide](https://docs.dagster.io/guides/observe/asset-freshness-policies) still presented freshness policies as **preview** and told users to set `freshness.enabled: true` in `dagster.yaml`. That conflicts with the Dagster 1.12 announcement: the new `FreshnessPolicy` API is GA and evaluated by a `FreshnessDaemon` that runs by default.

## Changes

- `_FreshnessPoliciesPreview.md`: state GA + default daemon evaluation
- Guide “Enabling freshness policies”: remove preview-only enablement instructions; note that prior `freshness.enabled` config can be dropped

## Linked Issue

Closes #34019
