### PR TITLE
Fix/dagster airbyte single request retry loop

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -259,7 +259,7 @@ class AirbyteClient(DagsterModel):
                 self._log.error(
                     f"Request to Airbyte API failed for url {url} with method {method} : {e}"
                 )
-                if num_retries == self.request_max_retries:
+                if num_retries >= self.request_max_retries:
                     break
                 num_retries += 1
                 time.sleep(self.request_retry_delay)

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -264,9 +264,7 @@ class AirbyteClient(DagsterModel):
                 num_retries += 1
                 time.sleep(self.request_retry_delay)
 
-            raise Failure(f"Max retries ({self.request_max_retries}) exceeded with url: {url}.")
-
-        return {}
+        raise Failure(f"Max retries ({self.request_max_retries}) exceeded with url: {url}.")
 
     def _paginated_request(
         self,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/beta/test_resources.py
@@ -140,6 +140,79 @@ def test_refresh_access_token(
         assert_api_call(base_url=rest_api_url, call=api_calls[0], endpoint="test")
 
 
+def test_single_request_retries_on_transient_failure(
+    base_api_mocks: responses.RequestsMock,
+    resource: AirbyteCloudWorkspace | AirbyteWorkspace,
+    rest_api_url: str,
+) -> None:
+    """Tests that `_single_request` retries transient `RequestException`s up to
+    `request_max_retries` times before giving up, and returns the payload once
+    the request succeeds.
+    """
+    client = resource.get_client()
+
+    # base_api_mocks already registered one 201 token response; drop it and script
+    # a fail-fail-success sequence so we can pin the retry cadence.
+    base_api_mocks.reset()
+    base_api_mocks.add(
+        method=responses.POST,
+        url=f"{client.rest_api_base_url}/applications/token",
+        status=502,
+    )
+    base_api_mocks.add(
+        method=responses.POST,
+        url=f"{client.rest_api_base_url}/applications/token",
+        status=502,
+    )
+    base_api_mocks.add(
+        method=responses.POST,
+        url=f"{client.rest_api_base_url}/applications/token",
+        json=SAMPLE_ACCESS_TOKEN,
+        status=201,
+    )
+
+    client._refresh_access_token()  # noqa
+
+    # All three responses should have been consumed: two 502s then the 201.
+    assert len(base_api_mocks.calls) == 3
+    for call in base_api_mocks.calls:
+        assert call.request.url == f"{rest_api_url}/applications/token"
+    # And the token endpoint eventually succeeded, so the client holds the token.
+    assert client._access_token_value == TEST_ACCESS_TOKEN  # noqa
+
+
+def test_single_request_raises_after_exhausting_retries(
+    base_api_mocks: responses.RequestsMock,
+    resource: AirbyteCloudWorkspace | AirbyteWorkspace,
+    rest_api_url: str,
+) -> None:
+    """Tests that `_single_request` raises `Failure` after exhausting
+    `request_max_retries` retries against a persistently failing endpoint,
+    and that it makes exactly `request_max_retries + 1` attempts.
+    """
+    client = resource.get_client()
+
+    base_api_mocks.reset()
+    # request_max_retries=3 by default -> 4 total attempts (1 initial + 3 retries).
+    for _ in range(client.request_max_retries + 1):
+        base_api_mocks.add(
+            method=responses.POST,
+            url=f"{client.rest_api_base_url}/applications/token",
+            status=502,
+        )
+
+    with pytest.raises(
+        Failure,
+        match=re.escape(
+            f"Max retries ({client.request_max_retries}) exceeded with url: "
+            f"{client.rest_api_base_url}/applications/token."
+        ),
+    ):
+        client._refresh_access_token()  # noqa
+
+    assert len(base_api_mocks.calls) == client.request_max_retries + 1
+
+
 def test_basic_resource_request(
     all_api_mocks: responses.RequestsMock,
     resource: AirbyteCloudWorkspace | AirbyteWorkspace,


### PR DESCRIPTION
## Summary & Motivation

`AirbyteClient._single_request` in `dagster_airbyte/resources.py` placed `raise Failure` inside the `while` loop at the same indent as `try/except`, so on any `RequestException` the function raised after one attempt instead of retrying up to `request_max_retries` times. The `"Max retries (N) exceeded"` message read the config value via f-string (not the actual attempt count), which masked the bug at runtime.

Anyone using `dagster-airbyte` with `request_max_retries > 0` (default 3) did not receive retry protection despite the config suggesting otherwise. In production, this caused a scheduled sync to be cancelled after ~10 seconds on a single 502 from Airbyte Cloud's `/v1/applications/token` endpoint, instead of the expected seconds of retry tolerance.

This PR moves `raise Failure` outside the loop (matching the working `legacy_resources.py:149` pattern) and drops the now-unreachable `return {}`.

Fixes #34031.

## Test Plan

Two new tests in `dagster_airbyte_tests/beta/test_resources.py`, both parametrized across the `cloud` and `oss` fixtures:

- **`test_single_request_retries_on_transient_failure`**: scripts a fail-fail-success sequence on the token endpoint and asserts (a) the retry loop iterates through the retries, (b) all three registered responses are consumed, (c) the client ends up with the refreshed token.
- **`test_single_request_raises_after_exhausting_retries`**: registers `request_max_retries + 1` persistent 502s and asserts `Failure` is raised with the exact expected message + the correct total number of attempts.

Existing tests (`test_refresh_access_token`, `test_basic_resource_request`) continue to pass, confirming no regression on the healthy path.

Ran locally:

```
uv run pytest dagster_airbyte_tests/beta/test_resources.py -k "test_refresh_access_token or test_single_request or test_basic_resource_request"
```

All 8 tests pass (4 tests × cloud/oss parametrization).

## Changelog

[dagster-airbyte] Fixed a bug where `AirbyteClient._single_request` raised `Failure` after one attempt instead of retrying up to `request_max_retries` times on transient `RequestException`.

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
