### PR TITLE
[dagster-shared] Fix format_duration printing "60.0s" at the minute boundary

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_timing.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_timing.py
@@ -11,6 +11,8 @@ def test_format_duration():
         (10.123, "10ms"),
         (533.12123, "533ms"),
         (4567.123123, "4.57s"),
+        (59994.0, "59.99s"),  # just under a minute, stays in seconds
+        (59999.0, "1m0s"),  # rounding must roll into minutes, not print "60.0s"
         (320000.1232, "5m20s"),
         (3910056.123, "1h5m"),
         (9022312.1233, "2h30m"),

--- a/python_modules/libraries/dagster-shared/dagster_shared/utils/timing.py
+++ b/python_modules/libraries/dagster-shared/dagster_shared/utils/timing.py
@@ -21,8 +21,11 @@ def format_duration(milliseconds: float) -> str:
     # between one second and one minute
     # ex: 5.6s
     if milliseconds < 1000 * 60:
-        seconds = milliseconds / 1000
-        return f"{round(seconds, 2)}s"
+        seconds = round(milliseconds / 1000, 2)
+        if seconds < 60:
+            return f"{seconds}s"
+        # rounding to 2 decimals pushed us up to a full minute (e.g. 59999 ms -> 60.0s)
+        return "1m0s"
 
     # between one minute and 60 minutes
     # 5m42s


### PR DESCRIPTION
## Summary & Motivation

`format_duration` renders the seconds bucket with `round(seconds, 2)`. For inputs in `[59995, 60000)` ms that rounds **up to `60.0`** while still inside the `< 60_000` branch, so it prints e.g. `"60.0s"` instead of rolling into the minutes bucket as `"1m0s"`:

```python
>>> from dagster_shared.utils.timing import format_duration
>>> format_duration(59999)
'60.0s'   # before
'1m0s'    # after
```

`format_duration` is used in user-facing execution logs (e.g. `dagster/_core/events/__init__.py`: `"Finished execution of step ... in {format_duration(...)}"`), so this surfaces as an odd `60.0s` in step timing.

## How I Tested These Changes

Extended `test_format_duration` with the near-minute boundary cases (`59994.0 -> "59.99s"`, `59999.0 -> "1m0s"`) — they fail before this change and pass after. Ran the existing pairs (all unchanged) and `ruff format`/`ruff check` (0.15.15) on both files.

## Changelog

Fixed `format_duration` printing `"60.0s"` instead of `"1m0s"` for durations that round up to a full minute.
