### PR TITLE
Optimize asset/check builds by memoizing signatures

### DIFF
--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -72,7 +72,7 @@ def _is_param_valid(param: Parameter, expected_positional: str) -> bool:
 # weak-referenced are not cached.
 #
 # This assumes a callable's signature and annotations are not mutated between asset builds.
-_signature_cache: dict[int, "inspect.Signature"] = {}
+_function_params_cache: dict[int, tuple[Parameter, ...]] = {}
 _type_hints_cache: dict[int, Mapping[str, Any]] = {}
 
 
@@ -93,8 +93,12 @@ def _cached_by_identity(
     return value
 
 
+def _compute_function_params(fn: Callable[..., Any]) -> tuple[Parameter, ...]:
+    return tuple(signature(fn).parameters.values())
+
+
 def get_function_params(fn: Callable[..., Any]) -> Sequence[Parameter]:
-    return list(_cached_by_identity(_signature_cache, fn, signature).parameters.values())
+    return _cached_by_identity(_function_params_cache, fn, _compute_function_params)
 
 
 def get_type_hints(fn: Callable[..., Any]) -> Mapping[str, Any]:

--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -17,7 +17,7 @@ from typing import (  # noqa: UP035
     cast,
     get_type_hints as typing_get_type_hints,
 )
-from weakref import WeakKeyDictionary
+from weakref import finalize
 
 from typing_extensions import ParamSpec
 
@@ -66,37 +66,39 @@ def _is_param_valid(param: Parameter, expected_positional: str) -> bool:
 
 # ``inspect.signature`` and ``typing.get_type_hints`` are pure functions of a callable, but each is
 # individually expensive and is invoked many times on the same function while a single
-# @op/@asset/@asset_check definition is built. Memoize per callable so that work happens once.
-# Keyed weakly, so entries drop when the function is garbage-collected. Callables that can't be weak-referenced
-# or hashed fall back to the uncached path.
-_signature_cache: "WeakKeyDictionary[Callable[..., Any], inspect.Signature]" = WeakKeyDictionary()
-_type_hints_cache: "WeakKeyDictionary[Callable[..., Any], Mapping[str, Any]]" = WeakKeyDictionary()
+# @op/@asset/@asset_check definition is built.
+#
+# Memoize the result per callable. Entries are keyed by object identity. Callables that cannot be
+# weak-referenced are not cached.
+#
+# This assumes a callable's signature and annotations are not mutated between asset builds.
+_signature_cache: dict[int, "inspect.Signature"] = {}
+_type_hints_cache: dict[int, Mapping[str, Any]] = {}
 
 
-def _cached_signature(fn: Callable[..., Any]) -> inspect.Signature:
+def _cached_by_identity(
+    cache: dict[int, T],
+    fn: Callable[..., Any],
+    compute: Callable[[Callable[..., Any]], T],
+) -> T:
+    key = id(fn)
+    if key in cache:
+        return cache[key]
+    value = compute(fn)
     try:
-        cached = _signature_cache.get(fn)
-    except TypeError:  # not weak-referenceable or unhashable
-        return signature(fn)
-    if cached is None:
-        cached = signature(fn)
-        _signature_cache[fn] = cached
-    return cached
+        finalize(fn, cache.pop, key, None)
+    except TypeError:  # fn is not weak-referenceable, do not cache
+        return value
+    cache[key] = value
+    return value
 
 
 def get_function_params(fn: Callable[..., Any]) -> Sequence[Parameter]:
-    return list(_cached_signature(fn).parameters.values())
+    return list(_cached_by_identity(_signature_cache, fn, signature).parameters.values())
 
 
 def get_type_hints(fn: Callable[..., Any]) -> Mapping[str, Any]:
-    try:
-        cached = _type_hints_cache.get(fn)
-    except TypeError:  # not weak-referenceable or unhashable
-        return _compute_type_hints(fn)
-    if cached is None:
-        cached = _compute_type_hints(fn)
-        _type_hints_cache[fn] = cached
-    return cached
+    return _cached_by_identity(_type_hints_cache, fn, _compute_type_hints)
 
 
 def _compute_type_hints(fn: Callable[..., Any]) -> Mapping[str, Any]:

--- a/python_modules/dagster/dagster/_core/decorator_utils.py
+++ b/python_modules/dagster/dagster/_core/decorator_utils.py
@@ -17,6 +17,7 @@ from typing import (  # noqa: UP035
     cast,
     get_type_hints as typing_get_type_hints,
 )
+from weakref import WeakKeyDictionary
 
 from typing_extensions import ParamSpec
 
@@ -63,11 +64,42 @@ def _is_param_valid(param: Parameter, expected_positional: str) -> bool:
     )
 
 
+# ``inspect.signature`` and ``typing.get_type_hints`` are pure functions of a callable, but each is
+# individually expensive and is invoked many times on the same function while a single
+# @op/@asset/@asset_check definition is built. Memoize per callable so that work happens once.
+# Keyed weakly, so entries drop when the function is garbage-collected. Callables that can't be weak-referenced
+# or hashed fall back to the uncached path.
+_signature_cache: "WeakKeyDictionary[Callable[..., Any], inspect.Signature]" = WeakKeyDictionary()
+_type_hints_cache: "WeakKeyDictionary[Callable[..., Any], Mapping[str, Any]]" = WeakKeyDictionary()
+
+
+def _cached_signature(fn: Callable[..., Any]) -> inspect.Signature:
+    try:
+        cached = _signature_cache.get(fn)
+    except TypeError:  # not weak-referenceable or unhashable
+        return signature(fn)
+    if cached is None:
+        cached = signature(fn)
+        _signature_cache[fn] = cached
+    return cached
+
+
 def get_function_params(fn: Callable[..., Any]) -> Sequence[Parameter]:
-    return list(signature(fn).parameters.values())
+    return list(_cached_signature(fn).parameters.values())
 
 
 def get_type_hints(fn: Callable[..., Any]) -> Mapping[str, Any]:
+    try:
+        cached = _type_hints_cache.get(fn)
+    except TypeError:  # not weak-referenceable or unhashable
+        return _compute_type_hints(fn)
+    if cached is None:
+        cached = _compute_type_hints(fn)
+        _type_hints_cache[fn] = cached
+    return cached
+
+
+def _compute_type_hints(fn: Callable[..., Any]) -> Mapping[str, Any]:
     if isinstance(fn, functools.partial):
         target = fn.func
     elif inspect.isfunction(fn):

--- a/python_modules/dagster/dagster/_core/definitions/inference.py
+++ b/python_modules/dagster/dagster/_core/definitions/inference.py
@@ -5,7 +5,7 @@ from typing import Any
 from dagster_shared.record import record
 from docstring_parser import parse
 
-from dagster._core.decorator_utils import get_type_hints
+from dagster._core.decorator_utils import get_function_params, get_type_hints
 from dagster._core.definitions.utils import NoValueSentinel
 
 
@@ -103,8 +103,7 @@ def _infer_inputs_from_params(
 def infer_input_props(
     fn: Callable[..., Any], context_arg_provided: bool
 ) -> Sequence[InferredInputProps]:
-    sig = signature(fn)
-    params = list(sig.parameters.values())
+    params = list(get_function_params(fn))
     type_hints = get_type_hints(fn)
     descriptions = _infer_input_description_from_docstring(fn)
     params_to_infer = params[1:] if context_arg_provided else params

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_build_perf.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_build_perf.py
@@ -1,0 +1,57 @@
+import time
+
+import dagster as dg
+import pytest
+
+
+class _Resource(dg.ConfigurableResource):
+    pass
+
+
+def _build_asset(i: int) -> dg.AssetsDefinition:
+    @dg.asset(
+        key_prefix=["prefix", "group"],
+        name=f"asset_{i}",
+        group_name="group",
+        owners=["team:perf"],
+        tags={"a": "1", "b": "2"},
+        metadata={"m": "v"},
+    )
+    def _a(context: dg.AssetExecutionContext, resource: _Resource) -> int:
+        return 1
+
+    return _a
+
+
+def _build_check(i: int, asset_def: dg.AssetsDefinition) -> dg.AssetChecksDefinition:
+    @dg.asset_check(asset=asset_def, name=f"check_{i}", metadata={"m": "v"})
+    def _c(resource: _Resource) -> dg.AssetCheckResult:
+        return dg.AssetCheckResult(passed=True)
+
+    return _c
+
+
+def test_construction_scales(capsys: pytest.CaptureFixture) -> None:
+    """Build many asset/check definitions, and check it is not too slow.
+
+    Run with ``-s`` to see the per-definition timing.
+    """
+    n = 1000
+
+    _build_check(n, _build_asset(n)) # Warm up import/first-call costs
+
+    start = time.perf_counter()
+    assets = [_build_asset(i) for i in range(n)]
+    for i, asset_def in enumerate(assets):
+        _build_check(i, asset_def)
+    elapsed = time.perf_counter() - start
+
+    per_def_us = elapsed / (2 * n) * 1e6
+    with capsys.disabled():
+        print(  # noqa: T201, used for benchmarking
+            f"\nbuilt {n} assets + {n} checks in {elapsed * 1e3:.0f} ms ({per_def_us:.1f} us/def)"
+        )
+
+    # Very rough upper bound: construction should be ~0.1-0.3 ms/def,
+    # 5 ms/def should indicate a real regression.
+    assert elapsed < 2 * n * 5e-3, f"definition construction is too slow: {per_def_us:.1f} us/def"


### PR DESCRIPTION
While profiling asset and asset check definitions build, I noticed we're spending significant time in `get_function_params` and `get_type_hints`. In my tests:

- `@asset` calls `inspect.signature` 16× and `typing.get_type_hints` 8× on the same function
- `@asset_check` does 17× and 9×, respectively.

This adds up when we have 1000s of assets. This PR tries to optimize this my memoizing these.

I added a small micro-benchmark -- very rough, but it shows building assets and checks is about 33% faster with memoization (from 0.158ms per def to 0.103ms per def).