### PR TITLE
Keep asset group anchored in the viewport across expand/collapse

### DIFF
--- a/js_modules/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -49,6 +49,7 @@ import {AssetGraphLayout, GroupLayout} from './layout';
 import {AssetGraphExplorerSidebar} from './sidebar/Sidebar';
 import {AssetGraphQueryItem} from './types';
 import {AssetGraphFetchScope, useAssetGraphData, useFullAssetGraphData} from './useAssetGraphData';
+import {useAssetGroupViewportAnchor} from './useAssetGroupViewportAnchor';
 import {AssetLocation, useFindAssetLocation} from './useFindAssetLocation';
 import {useFullScreen, useFullScreenAllowedView} from '../app/AppTopNav/AppTopNavContext';
 import {useFeatureFlags} from '../app/useFeatureFlags';
@@ -202,8 +203,6 @@ const AssetGraphExplorerWithData = ({
     isEmptyState: (val) => val.length === 0,
   });
 
-  const focusGroupIdAfterLayoutRef = React.useRef('');
-
   const {
     layout,
     loading: layoutLoading,
@@ -225,6 +224,8 @@ const AssetGraphExplorerWithData = ({
   );
 
   const viewportEl = React.useRef<SVGViewportRef>();
+  const {anchorRefForGroup, captureBeforeToggle, consumeHandledLayout, isPendingGroup} =
+    useAssetGroupViewportAnchor({layout, expandedGroups, viewportRef: viewportEl});
 
   const selectedTokens =
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -347,17 +348,16 @@ const AssetGraphExplorerWithData = ({
       return;
     }
 
+    const directToggleHandled = consumeHandledLayout(layout);
+
     // After renders that result in a meaningfully new layout, autocenter or
     // focus on the selected node. (If selection was specified in the URL).
     // Don't animate this change.
-    if (layoutChangeShouldAdjustViewport(lastRenderedLayout.current, layout)) {
-      if (
-        focusGroupIdAfterLayoutRef.current &&
-        layout.groups[focusGroupIdAfterLayoutRef.current]?.expanded
-      ) {
-        zoomToGroup(focusGroupIdAfterLayoutRef.current, false, false);
-        focusGroupIdAfterLayoutRef.current = '';
-      } else if (lastSelectedNode) {
+    if (
+      layoutChangeShouldAdjustViewport(lastRenderedLayout.current, layout) &&
+      !directToggleHandled
+    ) {
+      if (lastSelectedNode) {
         const layoutNode = layout.nodes[lastSelectedNode.id];
         if (layoutNode) {
           viewportEl.current.zoomToSVGBox(layoutNode.bounds, false);
@@ -368,7 +368,7 @@ const AssetGraphExplorerWithData = ({
       }
     }
     lastRenderedLayout.current = layout;
-  }, [lastSelectedNode, layout, viewportEl, zoomToGroup]);
+  }, [consumeHandledLayout, lastSelectedNode, layout, viewportEl]);
 
   const onClickBackground = () =>
     onChangeExplorerPath(
@@ -511,7 +511,9 @@ const AssetGraphExplorerWithData = ({
       {({scale}, viewportRect) => (
         <svg className={styles.svgContainer} width={layout.width} height={layout.height}>
           {Object.values(layout.groups)
-            .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
+            .filter(
+              (group) => isPendingGroup(group.id) || !isNodeOffscreen(group.bounds, viewportRect),
+            )
             .filter((group) => group.expanded)
             .sort((a, b) => a.id.length - b.id.length)
             .map((group) => (
@@ -537,13 +539,16 @@ const AssetGraphExplorerWithData = ({
           />
 
           {Object.values(layout.groups)
-            .filter((node) => !isNodeOffscreen(node.bounds, viewportRect))
+            .filter(
+              (group) => isPendingGroup(group.id) || !isNodeOffscreen(group.bounds, viewportRect),
+            )
             .sort((a, b) => a.id.length - b.id.length)
             .map((group) =>
               group.expanded ? (
                 <foreignObject
                   key={group.id}
                   {...group.bounds}
+                  ref={anchorRefForGroup(group.id)}
                   className="group"
                   onDoubleClick={(e) => {
                     zoomToGroup(group.id);
@@ -566,7 +571,7 @@ const AssetGraphExplorerWithData = ({
                       if (next.length === expandedGroups.length) {
                         return;
                       }
-                      focusGroupIdAfterLayoutRef.current = group.id;
+                      captureBeforeToggle(group.id, false);
                       setExpandedGroups(next);
                     }}
                     toggleSelectAllNodes={(e: React.MouseEvent) => {
@@ -578,6 +583,7 @@ const AssetGraphExplorerWithData = ({
                 <foreignObject
                   key={group.id}
                   {...group.bounds}
+                  ref={anchorRefForGroup(group.id)}
                   className="group"
                   onMouseEnter={() => setHighlighted([group.id])}
                   onMouseLeave={() => setHighlighted(null)}
@@ -603,7 +609,7 @@ const AssetGraphExplorerWithData = ({
                       assets: groupedAssets[group.id] || [],
                     }}
                     onExpand={() => {
-                      focusGroupIdAfterLayoutRef.current = group.id;
+                      captureBeforeToggle(group.id, true);
                       setExpandedGroups([...expandedGroups, group.id]);
                     }}
                     toggleSelectAllNodes={(e: React.MouseEvent) => {

--- a/js_modules/ui-core/src/asset-graph/__tests__/useAssetGroupViewportAnchor.test.tsx
+++ b/js_modules/ui-core/src/asset-graph/__tests__/useAssetGroupViewportAnchor.test.tsx
@@ -78,7 +78,7 @@ describe('useAssetGroupViewportAnchor', () => {
       const ref = {current: viewport};
       const {result, rerender} = renderHook(
         ({currentLayout, expandedGroups}) =>
-          useAssetGroupViewportAnchor(currentLayout, expandedGroups, ref),
+          useAssetGroupViewportAnchor({layout: currentLayout, expandedGroups, viewportRef: ref}),
         {initialProps: {currentLayout: sourceLayout, expandedGroups: initiallyExpanded}},
       );
       const anchor = foreignObjectAt(before.left, before.top);
@@ -116,7 +116,11 @@ describe('useAssetGroupViewportAnchor', () => {
     const sourceLayout = layout({parent: true, 'parent/child': false});
     const viewport = viewportAtScale(1);
     const {result} = renderHook(() =>
-      useAssetGroupViewportAnchor(sourceLayout, ['parent'], {current: viewport}),
+      useAssetGroupViewportAnchor({
+        layout: sourceLayout,
+        expandedGroups: ['parent'],
+        viewportRef: {current: viewport},
+      }),
     );
 
     act(() => {
@@ -136,7 +140,7 @@ describe('useAssetGroupViewportAnchor', () => {
     const ref = {current: viewport};
     const {result, rerender} = renderHook(
       ({currentLayout, expandedGroups}) =>
-        useAssetGroupViewportAnchor(currentLayout, expandedGroups, ref),
+        useAssetGroupViewportAnchor({layout: currentLayout, expandedGroups, viewportRef: ref}),
       {initialProps: {currentLayout: sourceLayout, expandedGroups: [] as string[]}},
     );
     const anchor = foreignObjectAt(100, 200);
@@ -175,7 +179,7 @@ describe('useAssetGroupViewportAnchor', () => {
     const ref = {current: viewport};
     const {result, rerender} = renderHook(
       ({currentLayout, expandedGroups}) =>
-        useAssetGroupViewportAnchor(currentLayout, expandedGroups, ref),
+        useAssetGroupViewportAnchor({layout: currentLayout, expandedGroups, viewportRef: ref}),
       {initialProps: {currentLayout: sourceLayout, expandedGroups: [] as string[]}},
     );
     const parent = foreignObjectAt(20, 30);
@@ -216,7 +220,7 @@ describe('useAssetGroupViewportAnchor', () => {
     const ref = {current: viewport};
     const {result, rerender} = renderHook(
       ({currentLayout, expandedGroups}) =>
-        useAssetGroupViewportAnchor(currentLayout, expandedGroups, ref),
+        useAssetGroupViewportAnchor({layout: currentLayout, expandedGroups, viewportRef: ref}),
       {initialProps: {currentLayout: sourceLayout, expandedGroups: [] as string[]}},
     );
 
@@ -239,7 +243,7 @@ describe('useAssetGroupViewportAnchor', () => {
     const ref = {current: viewport};
     const {result, rerender} = renderHook(
       ({currentLayout, expandedGroups}) =>
-        useAssetGroupViewportAnchor(currentLayout, expandedGroups, ref),
+        useAssetGroupViewportAnchor({layout: currentLayout, expandedGroups, viewportRef: ref}),
       {initialProps: {currentLayout: sourceLayout, expandedGroups: [] as string[]}},
     );
 
@@ -257,7 +261,11 @@ describe('useAssetGroupViewportAnchor', () => {
   it('does not handle layouts when no direct toggle transaction is pending', () => {
     const currentLayout = layout({parent: false});
     const {result} = renderHook(() =>
-      useAssetGroupViewportAnchor(currentLayout, [], {current: viewportAtScale(1)}),
+      useAssetGroupViewportAnchor({
+        layout: currentLayout,
+        expandedGroups: [],
+        viewportRef: {current: viewportAtScale(1)},
+      }),
     );
 
     expect(result.current.consumeHandledLayout(currentLayout)).toBe(false);

--- a/js_modules/ui-core/src/asset-graph/__tests__/useAssetGroupViewportAnchor.test.tsx
+++ b/js_modules/ui-core/src/asset-graph/__tests__/useAssetGroupViewportAnchor.test.tsx
@@ -1,0 +1,265 @@
+import {act, renderHook} from '@testing-library/react';
+
+import {AssetGraphLayout} from '../layout';
+import {useAssetGroupViewportAnchor} from '../useAssetGroupViewportAnchor';
+
+type Viewport = {
+  getScale: jest.Mock<number, []>;
+  shiftXY: jest.Mock<void, [number, number]>;
+};
+
+const group = (id: string, expanded: boolean) => ({
+  id,
+  groupName: id,
+  repositoryName: 'repo',
+  repositoryLocationName: 'location',
+  bounds: {x: 0, y: 0, width: 100, height: 50},
+  expanded,
+  depth: id.split('/').length - 1,
+});
+
+const layout = (groups: Record<string, boolean>): AssetGraphLayout => ({
+  width: 500,
+  height: 500,
+  edges: [],
+  nodes: {},
+  groups: Object.fromEntries(
+    Object.entries(groups).map(([id, expanded]) => [id, group(id, expanded)]),
+  ),
+});
+
+const foreignObjectAt = (left: number, top: number) => {
+  const element = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject');
+  jest.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+    x: left,
+    y: top,
+    left,
+    top,
+    right: left + 100,
+    bottom: top + 50,
+    width: 100,
+    height: 50,
+    toJSON: () => ({}),
+  });
+  return element;
+};
+
+const viewportAtScale = (scale: number): Viewport => ({
+  getScale: jest.fn(() => scale),
+  shiftXY: jest.fn(),
+});
+
+describe('useAssetGroupViewportAnchor', () => {
+  it.each([
+    {
+      name: 'expansion',
+      initiallyExpanded: [] as string[],
+      expectedExpanded: true,
+      before: {left: -120, top: 80},
+      after: {left: -165, top: 50},
+      scale: 0.75,
+      shift: [45, 30],
+    },
+    {
+      name: 'collapse',
+      initiallyExpanded: ['parent'],
+      expectedExpanded: false,
+      before: {left: 240, top: -130},
+      after: {left: 280, top: -100},
+      scale: 1.4,
+      shift: [-40, -30],
+    },
+  ])(
+    'anchors a $name without changing the $scale viewport scale',
+    ({initiallyExpanded, expectedExpanded, before, after, scale, shift}) => {
+      const sourceLayout = layout({parent: !expectedExpanded});
+      const targetLayout = layout({parent: expectedExpanded});
+      const viewport = viewportAtScale(scale);
+      const ref = {current: viewport};
+      const {result, rerender} = renderHook(
+        ({currentLayout, expandedGroups}) =>
+          useAssetGroupViewportAnchor(currentLayout, expandedGroups, ref),
+        {initialProps: {currentLayout: sourceLayout, expandedGroups: initiallyExpanded}},
+      );
+      const anchor = foreignObjectAt(before.left, before.top);
+
+      act(() => {
+        result.current.anchorRefForGroup('parent')(anchor);
+        result.current.captureBeforeToggle('parent', expectedExpanded);
+      });
+
+      jest.spyOn(anchor, 'getBoundingClientRect').mockReturnValue({
+        x: after.left,
+        y: after.top,
+        left: after.left,
+        top: after.top,
+        right: after.left + 100,
+        bottom: after.top + 50,
+        width: 100,
+        height: 50,
+        toJSON: () => ({}),
+      });
+      rerender({
+        currentLayout: targetLayout,
+        expandedGroups: expectedExpanded ? ['parent'] : [],
+      });
+
+      expect(viewport.shiftXY).toHaveBeenCalledTimes(1);
+      expect(viewport.shiftXY).toHaveBeenCalledWith(...shift);
+      expect(viewport.getScale()).toBe(scale);
+      expect(result.current.consumeHandledLayout(targetLayout)).toBe(true);
+      expect(result.current.consumeHandledLayout(targetLayout)).toBe(false);
+    },
+  );
+
+  it('marks only the direct nested target as pending', () => {
+    const sourceLayout = layout({parent: true, 'parent/child': false});
+    const viewport = viewportAtScale(1);
+    const {result} = renderHook(() =>
+      useAssetGroupViewportAnchor(sourceLayout, ['parent'], {current: viewport}),
+    );
+
+    act(() => {
+      result.current.anchorRefForGroup('parent/child')(foreignObjectAt(30, 40));
+      result.current.captureBeforeToggle('parent/child', true);
+    });
+
+    expect(result.current.isPendingGroup('parent')).toBe(false);
+    expect(result.current.isPendingGroup('parent/child')).toBe(true);
+  });
+
+  it('waits through an intermediate layout whose group state does not match the toggle', () => {
+    const sourceLayout = layout({parent: false});
+    const intermediateLayout = layout({parent: false});
+    const targetLayout = layout({parent: true});
+    const viewport = viewportAtScale(1);
+    const ref = {current: viewport};
+    const {result, rerender} = renderHook(
+      ({currentLayout, expandedGroups}) =>
+        useAssetGroupViewportAnchor(currentLayout, expandedGroups, ref),
+      {initialProps: {currentLayout: sourceLayout, expandedGroups: [] as string[]}},
+    );
+    const anchor = foreignObjectAt(100, 200);
+
+    act(() => {
+      result.current.anchorRefForGroup('parent')(anchor);
+      result.current.captureBeforeToggle('parent', true);
+    });
+    rerender({currentLayout: intermediateLayout, expandedGroups: ['parent']});
+
+    expect(viewport.shiftXY).not.toHaveBeenCalled();
+    expect(result.current.isPendingGroup('parent')).toBe(true);
+
+    jest.spyOn(anchor, 'getBoundingClientRect').mockReturnValue({
+      x: 70,
+      y: 250,
+      left: 70,
+      top: 250,
+      right: 170,
+      bottom: 300,
+      width: 100,
+      height: 50,
+      toJSON: () => ({}),
+    });
+    rerender({currentLayout: targetLayout, expandedGroups: ['parent']});
+
+    expect(viewport.shiftXY).toHaveBeenCalledTimes(1);
+    expect(viewport.shiftXY).toHaveBeenCalledWith(30, -50);
+  });
+
+  it('lets a newer nested toggle supersede a parent toggle', () => {
+    const sourceLayout = layout({parent: false, 'parent/child': false});
+    const oldTargetLayout = layout({parent: true, 'parent/child': false});
+    const targetLayout = layout({parent: true, 'parent/child': true});
+    const viewport = viewportAtScale(1);
+    const ref = {current: viewport};
+    const {result, rerender} = renderHook(
+      ({currentLayout, expandedGroups}) =>
+        useAssetGroupViewportAnchor(currentLayout, expandedGroups, ref),
+      {initialProps: {currentLayout: sourceLayout, expandedGroups: [] as string[]}},
+    );
+    const parent = foreignObjectAt(20, 30);
+    const child = foreignObjectAt(-40, 90);
+
+    act(() => {
+      result.current.anchorRefForGroup('parent')(parent);
+      result.current.captureBeforeToggle('parent', true);
+      result.current.anchorRefForGroup('parent/child')(child);
+      result.current.captureBeforeToggle('parent/child', true);
+    });
+    rerender({currentLayout: oldTargetLayout, expandedGroups: ['parent', 'parent/child']});
+
+    expect(viewport.shiftXY).not.toHaveBeenCalled();
+    expect(result.current.isPendingGroup('parent/child')).toBe(true);
+
+    jest.spyOn(child, 'getBoundingClientRect').mockReturnValue({
+      x: -70,
+      y: 60,
+      left: -70,
+      top: 60,
+      right: 30,
+      bottom: 110,
+      width: 100,
+      height: 50,
+      toJSON: () => ({}),
+    });
+    rerender({currentLayout: targetLayout, expandedGroups: ['parent', 'parent/child']});
+
+    expect(viewport.shiftXY).toHaveBeenCalledTimes(1);
+    expect(viewport.shiftXY).toHaveBeenCalledWith(30, 30);
+  });
+
+  it('finishes without shifting when the target group is missing from the next layout', () => {
+    const sourceLayout = layout({parent: false});
+    const targetLayout = layout({});
+    const viewport = viewportAtScale(1);
+    const ref = {current: viewport};
+    const {result, rerender} = renderHook(
+      ({currentLayout, expandedGroups}) =>
+        useAssetGroupViewportAnchor(currentLayout, expandedGroups, ref),
+      {initialProps: {currentLayout: sourceLayout, expandedGroups: [] as string[]}},
+    );
+
+    act(() => {
+      result.current.anchorRefForGroup('parent')(foreignObjectAt(10, 10));
+      result.current.captureBeforeToggle('parent', true);
+    });
+    rerender({currentLayout: targetLayout, expandedGroups: ['parent']});
+
+    expect(viewport.shiftXY).not.toHaveBeenCalled();
+    expect(result.current.isPendingGroup('parent')).toBe(false);
+    expect(result.current.consumeHandledLayout(targetLayout)).toBe(true);
+    expect(result.current.consumeHandledLayout(targetLayout)).toBe(false);
+  });
+
+  it('preserves a newer viewport zoom instead of applying a stale anchor shift', () => {
+    const sourceLayout = layout({parent: false});
+    const targetLayout = layout({parent: true});
+    const viewport = viewportAtScale(0.75);
+    const ref = {current: viewport};
+    const {result, rerender} = renderHook(
+      ({currentLayout, expandedGroups}) =>
+        useAssetGroupViewportAnchor(currentLayout, expandedGroups, ref),
+      {initialProps: {currentLayout: sourceLayout, expandedGroups: [] as string[]}},
+    );
+
+    act(() => {
+      result.current.anchorRefForGroup('parent')(foreignObjectAt(10, 10));
+      result.current.captureBeforeToggle('parent', true);
+    });
+    viewport.getScale.mockReturnValue(1.4);
+    rerender({currentLayout: targetLayout, expandedGroups: ['parent']});
+
+    expect(viewport.shiftXY).not.toHaveBeenCalled();
+    expect(result.current.isPendingGroup('parent')).toBe(false);
+  });
+
+  it('does not handle layouts when no direct toggle transaction is pending', () => {
+    const currentLayout = layout({parent: false});
+    const {result} = renderHook(() =>
+      useAssetGroupViewportAnchor(currentLayout, [], {current: viewportAtScale(1)}),
+    );
+
+    expect(result.current.consumeHandledLayout(currentLayout)).toBe(false);
+  });
+});

--- a/js_modules/ui-core/src/asset-graph/__tests__/useAssetGroupViewportAnchor.test.tsx
+++ b/js_modules/ui-core/src/asset-graph/__tests__/useAssetGroupViewportAnchor.test.tsx
@@ -1,4 +1,5 @@
-import {act, renderHook} from '@testing-library/react';
+import {act, render, renderHook} from '@testing-library/react';
+import React from 'react';
 
 import {AssetGraphLayout} from '../layout';
 import {useAssetGroupViewportAnchor} from '../useAssetGroupViewportAnchor';
@@ -48,6 +49,88 @@ const viewportAtScale = (scale: number): Viewport => ({
   getScale: jest.fn(() => scale),
   shiftXY: jest.fn(),
 });
+
+const rectAt = (left: number, top: number) => ({
+  x: left,
+  y: top,
+  left,
+  top,
+  right: left + 100,
+  bottom: top + 50,
+  width: 100,
+  height: 50,
+  toJSON: () => ({}),
+});
+
+type AnchorHarnessProps = {
+  currentLayout: AssetGraphLayout;
+  expandedGroups: string[];
+  viewportRef: {current: Viewport};
+  anchorKey: string;
+  anchorPosition: {left: number; top: number};
+  onAnchorElement: (element: SVGForeignObjectElement) => void;
+  onAnchorReady: (anchor: ReturnType<typeof useAssetGroupViewportAnchor>) => void;
+  onAfterLayoutEffect: () => void;
+};
+
+const AnchorNode = ({
+  currentLayout,
+  expandedGroups,
+  viewportRef,
+  anchorKey,
+  anchorPosition,
+  onAnchorElement,
+  onAnchorReady,
+}: Omit<AnchorHarnessProps, 'onAfterLayoutEffect'>) => {
+  const anchor = useAssetGroupViewportAnchor({
+    layout: currentLayout,
+    expandedGroups,
+    viewportRef,
+  });
+  const groupRef = anchor.anchorRefForGroup('parent');
+  const ref = React.useCallback(
+    (element: SVGForeignObjectElement | null) => {
+      groupRef(element);
+      if (element) {
+        jest
+          .spyOn(element, 'getBoundingClientRect')
+          .mockReturnValue(rectAt(anchorPosition.left, anchorPosition.top));
+        onAnchorElement(element);
+      }
+    },
+    [anchorPosition.left, anchorPosition.top, groupRef, onAnchorElement],
+  );
+
+  React.useLayoutEffect(() => {
+    onAnchorReady(anchor);
+  }, [anchor, onAnchorReady]);
+
+  return (
+    <svg>
+      <foreignObject data-testid="group-anchor" key={anchorKey} ref={ref} />
+    </svg>
+  );
+};
+
+const LayoutEffectObserver = ({
+  layout,
+  onObserve,
+}: {
+  layout: AssetGraphLayout;
+  onObserve: () => void;
+}) => {
+  React.useLayoutEffect(() => {
+    onObserve();
+  }, [layout, onObserve]);
+  return null;
+};
+
+const AnchorHarness = ({onAfterLayoutEffect, ...anchorNodeProps}: AnchorHarnessProps) => (
+  <>
+    <AnchorNode {...anchorNodeProps} />
+    <LayoutEffectObserver layout={anchorNodeProps.currentLayout} onObserve={onAfterLayoutEffect} />
+  </>
+);
 
 describe('useAssetGroupViewportAnchor', () => {
   it.each([
@@ -111,6 +194,65 @@ describe('useAssetGroupViewportAnchor', () => {
       expect(result.current.consumeHandledLayout(targetLayout)).toBe(false);
     },
   );
+
+  it('uses the remounted SVG anchor before later layout effects observe the matching layout', () => {
+    const sourceLayout = layout({parent: false});
+    const targetLayout = layout({parent: true});
+    const viewport = viewportAtScale(1);
+    const viewportRef = {current: viewport};
+    const elements: SVGForeignObjectElement[] = [];
+    const layoutEffectShiftCounts: number[] = [];
+    let anchor: ReturnType<typeof useAssetGroupViewportAnchor> | undefined;
+    const onAnchorElement = jest.fn((element: SVGForeignObjectElement) => elements.push(element));
+    const onAnchorReady = jest.fn((nextAnchor: ReturnType<typeof useAssetGroupViewportAnchor>) => {
+      anchor = nextAnchor;
+    });
+    const onAfterLayoutEffect = jest.fn(() => {
+      layoutEffectShiftCounts.push(viewport.shiftXY.mock.calls.length);
+    });
+    const {rerender} = render(
+      <AnchorHarness
+        currentLayout={sourceLayout}
+        expandedGroups={[]}
+        viewportRef={viewportRef}
+        anchorKey="before"
+        anchorPosition={{left: 100, top: 200}}
+        onAnchorElement={onAnchorElement}
+        onAnchorReady={onAnchorReady}
+        onAfterLayoutEffect={onAfterLayoutEffect}
+      />,
+    );
+    const firstAnchorRef = anchor?.anchorRefForGroup('parent');
+
+    act(() => {
+      anchor?.captureBeforeToggle('parent', true);
+    });
+    const detachedElement = elements[0];
+    if (!detachedElement) {
+      throw new Error('Expected the initial anchor element');
+    }
+    jest.spyOn(detachedElement, 'getBoundingClientRect').mockImplementation(() => {
+      throw new Error('A detached anchor must not be measured');
+    });
+    rerender(
+      <AnchorHarness
+        currentLayout={targetLayout}
+        expandedGroups={['parent']}
+        viewportRef={viewportRef}
+        anchorKey="after"
+        anchorPosition={{left: 70, top: 250}}
+        onAnchorElement={onAnchorElement}
+        onAnchorReady={onAnchorReady}
+        onAfterLayoutEffect={onAfterLayoutEffect}
+      />,
+    );
+
+    expect(elements).toHaveLength(2);
+    expect(elements[1]).not.toBe(elements[0]);
+    expect(anchor?.anchorRefForGroup('parent')).toBe(firstAnchorRef);
+    expect(viewport.shiftXY).toHaveBeenCalledWith(30, -50);
+    expect(layoutEffectShiftCounts).toEqual([0, 1]);
+  });
 
   it('marks only the direct nested target as pending', () => {
     const sourceLayout = layout({parent: true, 'parent/child': false});
@@ -256,18 +398,51 @@ describe('useAssetGroupViewportAnchor', () => {
 
     expect(viewport.shiftXY).not.toHaveBeenCalled();
     expect(result.current.isPendingGroup('parent')).toBe(false);
+    expect(result.current.consumeHandledLayout(targetLayout)).toBe(true);
+    expect(result.current.consumeHandledLayout(targetLayout)).toBe(false);
   });
 
-  it('does not handle layouts when no direct toggle transaction is pending', () => {
-    const currentLayout = layout({parent: false});
-    const {result} = renderHook(() =>
-      useAssetGroupViewportAnchor({
-        layout: currentLayout,
-        expandedGroups: [],
-        viewportRef: {current: viewportAtScale(1)},
-      }),
+  it('cancels when the desired expanded state no longer matches the direct toggle', () => {
+    const sourceLayout = layout({parent: false});
+    const cancelledLayout = layout({parent: true});
+    const viewport = viewportAtScale(1);
+    const ref = {current: viewport};
+    const {result, rerender} = renderHook(
+      ({currentLayout, expandedGroups}) =>
+        useAssetGroupViewportAnchor({layout: currentLayout, expandedGroups, viewportRef: ref}),
+      {initialProps: {currentLayout: sourceLayout, expandedGroups: [] as string[]}},
     );
 
-    expect(result.current.consumeHandledLayout(currentLayout)).toBe(false);
+    act(() => {
+      result.current.anchorRefForGroup('parent')(foreignObjectAt(10, 10));
+      result.current.captureBeforeToggle('parent', true);
+    });
+    rerender({currentLayout: cancelledLayout, expandedGroups: []});
+
+    expect(viewport.shiftXY).not.toHaveBeenCalled();
+    expect(result.current.isPendingGroup('parent')).toBe(false);
+    expect(result.current.consumeHandledLayout(cancelledLayout)).toBe(true);
+    expect(result.current.consumeHandledLayout(cancelledLayout)).toBe(false);
+  });
+
+  it('ignores unrelated layouts when no direct toggle transaction is pending', () => {
+    const currentLayout = layout({parent: false});
+    const unrelatedLayout = layout({unrelated: true});
+    const viewport = viewportAtScale(1);
+    const {result, rerender} = renderHook(
+      ({currentLayout}) =>
+        useAssetGroupViewportAnchor({
+          layout: currentLayout,
+          expandedGroups: [],
+          viewportRef: {current: viewport},
+        }),
+      {initialProps: {currentLayout}},
+    );
+
+    rerender({currentLayout: unrelatedLayout});
+
+    expect(viewport.shiftXY).not.toHaveBeenCalled();
+    expect(result.current.isPendingGroup('parent')).toBe(false);
+    expect(result.current.consumeHandledLayout(unrelatedLayout)).toBe(false);
   });
 });

--- a/js_modules/ui-core/src/asset-graph/useAssetGroupViewportAnchor.ts
+++ b/js_modules/ui-core/src/asset-graph/useAssetGroupViewportAnchor.ts
@@ -26,17 +26,12 @@ export const useAssetGroupViewportAnchor = ({
   expandedGroups,
   viewportRef,
 }: UseAssetGroupViewportAnchorOptions) => {
-  const layoutRef = React.useRef(layout);
-  const viewportRefRef = React.useRef(viewportRef);
   const anchorElementsRef = React.useRef(new Map<string, SVGForeignObjectElement>());
   const anchorCallbacksRef = React.useRef(
     new Map<string, React.RefCallback<SVGForeignObjectElement>>(),
   );
   const pendingRef = React.useRef<PendingAnchor | undefined>();
   const handledLayoutsRef = React.useRef(new WeakSet<AssetGraphLayout>());
-
-  layoutRef.current = layout;
-  viewportRefRef.current = viewportRef;
 
   const anchorRefForGroup = React.useCallback((groupId: string) => {
     const existing = anchorCallbacksRef.current.get(groupId);
@@ -55,23 +50,25 @@ export const useAssetGroupViewportAnchor = ({
     return callback;
   }, []);
 
-  const captureBeforeToggle = React.useCallback((groupId: string, expectedExpanded: boolean) => {
-    const sourceLayout = layoutRef.current;
-    if (!sourceLayout) {
-      return;
-    }
+  const captureBeforeToggle = React.useCallback(
+    (groupId: string, expectedExpanded: boolean) => {
+      if (!layout) {
+        return;
+      }
 
-    const element = anchorElementsRef.current.get(groupId);
-    const rect = element?.getBoundingClientRect();
-    const viewport = viewportRefRef.current.current;
-    pendingRef.current = {
-      sourceLayout,
-      groupId,
-      expectedExpanded,
-      point: rect ? {left: rect.left, top: rect.top} : undefined,
-      scale: viewport?.getScale(),
-    };
-  }, []);
+      const element = anchorElementsRef.current.get(groupId);
+      const rect = element?.getBoundingClientRect();
+      const viewport = viewportRef.current;
+      pendingRef.current = {
+        sourceLayout: layout,
+        groupId,
+        expectedExpanded,
+        point: rect ? {left: rect.left, top: rect.top} : undefined,
+        scale: viewport?.getScale(),
+      };
+    },
+    [layout, viewportRef],
+  );
 
   const consumeHandledLayout = React.useCallback((handledLayout: AssetGraphLayout | null) => {
     if (!handledLayout || !handledLayoutsRef.current.has(handledLayout)) {
@@ -110,7 +107,7 @@ export const useAssetGroupViewportAnchor = ({
       return;
     }
 
-    const viewport = viewportRefRef.current.current;
+    const viewport = viewportRef.current;
     const element = anchorElementsRef.current.get(pending.groupId);
     const after = element?.getBoundingClientRect();
     if (!viewport || !pending.point || pending.scale === undefined || !after) {
@@ -125,7 +122,7 @@ export const useAssetGroupViewportAnchor = ({
 
     finish();
     viewport.shiftXY(pending.point.left - after.left, pending.point.top - after.top);
-  }, [expandedGroups, layout]);
+  }, [expandedGroups, layout, viewportRef]);
 
   return {
     anchorRefForGroup,

--- a/js_modules/ui-core/src/asset-graph/useAssetGroupViewportAnchor.ts
+++ b/js_modules/ui-core/src/asset-graph/useAssetGroupViewportAnchor.ts
@@ -1,0 +1,130 @@
+import * as React from 'react';
+
+import {AssetGraphLayout} from './layout';
+import {SVGViewportRef} from '../graph/SVGViewport';
+
+type ViewportRef = Readonly<{
+  current: Pick<SVGViewportRef, 'getScale' | 'shiftXY'> | undefined;
+}>;
+
+type PendingAnchor = {
+  sourceLayout: AssetGraphLayout;
+  groupId: string;
+  expectedExpanded: boolean;
+  point: {left: number; top: number} | undefined;
+  scale: number | undefined;
+};
+
+export const useAssetGroupViewportAnchor = (
+  layout: AssetGraphLayout | null,
+  expandedGroups: string[],
+  viewportRef: ViewportRef,
+) => {
+  const layoutRef = React.useRef(layout);
+  const viewportRefRef = React.useRef(viewportRef);
+  const anchorElementsRef = React.useRef(new Map<string, SVGForeignObjectElement>());
+  const anchorCallbacksRef = React.useRef(
+    new Map<string, React.RefCallback<SVGForeignObjectElement>>(),
+  );
+  const pendingRef = React.useRef<PendingAnchor | undefined>();
+  const handledLayoutsRef = React.useRef(new WeakSet<AssetGraphLayout>());
+
+  layoutRef.current = layout;
+  viewportRefRef.current = viewportRef;
+
+  const anchorRefForGroup = React.useCallback((groupId: string) => {
+    const existing = anchorCallbacksRef.current.get(groupId);
+    if (existing) {
+      return existing;
+    }
+
+    const callback: React.RefCallback<SVGForeignObjectElement> = (element) => {
+      if (element) {
+        anchorElementsRef.current.set(groupId, element);
+      } else {
+        anchorElementsRef.current.delete(groupId);
+      }
+    };
+    anchorCallbacksRef.current.set(groupId, callback);
+    return callback;
+  }, []);
+
+  const captureBeforeToggle = React.useCallback((groupId: string, expectedExpanded: boolean) => {
+    const sourceLayout = layoutRef.current;
+    if (!sourceLayout) {
+      return;
+    }
+
+    const element = anchorElementsRef.current.get(groupId);
+    const rect = element?.getBoundingClientRect();
+    const viewport = viewportRefRef.current.current;
+    pendingRef.current = {
+      sourceLayout,
+      groupId,
+      expectedExpanded,
+      point: rect ? {left: rect.left, top: rect.top} : undefined,
+      scale: viewport?.getScale(),
+    };
+  }, []);
+
+  const consumeHandledLayout = React.useCallback((handledLayout: AssetGraphLayout | null) => {
+    if (!handledLayout || !handledLayoutsRef.current.has(handledLayout)) {
+      return false;
+    }
+    handledLayoutsRef.current.delete(handledLayout);
+    return true;
+  }, []);
+
+  const isPendingGroup = React.useCallback((groupId: string) => {
+    return pendingRef.current?.groupId === groupId;
+  }, []);
+
+  React.useLayoutEffect(() => {
+    const pending = pendingRef.current;
+    if (!pending || !layout || layout === pending.sourceLayout) {
+      return;
+    }
+
+    const finish = () => {
+      handledLayoutsRef.current.add(layout);
+      pendingRef.current = undefined;
+    };
+
+    if (expandedGroups.includes(pending.groupId) !== pending.expectedExpanded) {
+      finish();
+      return;
+    }
+
+    const targetGroup = layout.groups[pending.groupId];
+    if (!targetGroup) {
+      finish();
+      return;
+    }
+    if (targetGroup.expanded !== pending.expectedExpanded) {
+      return;
+    }
+
+    const viewport = viewportRefRef.current.current;
+    const element = anchorElementsRef.current.get(pending.groupId);
+    const after = element?.getBoundingClientRect();
+    if (!viewport || !pending.point || pending.scale === undefined || !after) {
+      finish();
+      return;
+    }
+
+    if (viewport.getScale() !== pending.scale) {
+      finish();
+      return;
+    }
+
+    finish();
+    viewport.shiftXY(pending.point.left - after.left, pending.point.top - after.top);
+  }, [expandedGroups, layout]);
+
+  return {
+    anchorRefForGroup,
+    captureBeforeToggle,
+    consumeHandledLayout,
+    isPendingGroup,
+  };
+};

--- a/js_modules/ui-core/src/asset-graph/useAssetGroupViewportAnchor.ts
+++ b/js_modules/ui-core/src/asset-graph/useAssetGroupViewportAnchor.ts
@@ -7,6 +7,12 @@ type ViewportRef = Readonly<{
   current: Pick<SVGViewportRef, 'getScale' | 'shiftXY'> | undefined;
 }>;
 
+type UseAssetGroupViewportAnchorOptions = {
+  layout: AssetGraphLayout | null;
+  expandedGroups: string[];
+  viewportRef: ViewportRef;
+};
+
 type PendingAnchor = {
   sourceLayout: AssetGraphLayout;
   groupId: string;
@@ -15,11 +21,11 @@ type PendingAnchor = {
   scale: number | undefined;
 };
 
-export const useAssetGroupViewportAnchor = (
-  layout: AssetGraphLayout | null,
-  expandedGroups: string[],
-  viewportRef: ViewportRef,
-) => {
+export const useAssetGroupViewportAnchor = ({
+  layout,
+  expandedGroups,
+  viewportRef,
+}: UseAssetGroupViewportAnchorOptions) => {
   const layoutRef = React.useRef(layout);
   const viewportRefRef = React.useRef(viewportRef);
   const anchorElementsRef = React.useRef(new Map<string, SVGForeignObjectElement>());

--- a/js_modules/ui-core/src/graph/__tests__/SVGViewport.test.tsx
+++ b/js_modules/ui-core/src/graph/__tests__/SVGViewport.test.tsx
@@ -141,9 +141,18 @@ describe('SVGViewport', () => {
   it('shifts position with shiftXY()', () => {
     const ref = createRef<SVGViewportRef>();
     render(<SVGViewport {...DEFAULT_PROPS} ref={ref} />);
-    const initialX = ref.current?.getViewport().left;
-    ref.current?.shiftXY(100, 50);
-    expect(ref.current?.getViewport().left).toBeLessThan(initialX as number);
+    const initialViewport = ref.current?.getViewport();
+    const initialScale = ref.current?.getScale();
+    act(() => {
+      ref.current?.shiftXY(100, 50);
+    });
+    expect(ref.current?.getViewport().left).toBeCloseTo(
+      (initialViewport?.left as number) - 100 / (initialScale as number),
+    );
+    expect(ref.current?.getViewport().top).toBeCloseTo(
+      (initialViewport?.top as number) - 50 / (initialScale as number),
+    );
+    expect(ref.current?.getScale()).toEqual(initialScale);
   });
 
   it('updates scale with adjustZoomRelativeToScreenPoint()', async () => {


### PR DESCRIPTION
## Summary & Motivation

Expanding or collapsing an asset group in the asset graph re-runs Dagre layout,
which shifts every node's coordinates. The group the user just clicked jumps to a
new position on screen, so the viewport appears to lurch and the user loses their
place — especially painful in large graphs.

This change adds a `useAssetGroupViewportAnchor` hook that keeps the toggled
group visually anchored across the re-layout:

- **Capture before toggle** — just before an expand/collapse, it records the
  clicked group's on-screen bounding rect and the current viewport scale
  (`captureBeforeToggle`).
- **Restore after re-layout** — in a `useLayoutEffect` that fires once the *new*
  layout has produced the group in its expected expanded/collapsed state, it
  measures the group's new on-screen position and calls `viewport.shiftXY(...)`
  to translate the viewport by exactly the delta, so the anchored group stays put.
- **Lifecycle hardening** — the pending anchor is keyed to the source layout and
  only consumed when the resulting layout matches the expected state and the
  scale is unchanged; it bails out cleanly (no shift) on any mismatch, missing
  element, or zoom change, and tracks handled layouts via a `WeakSet` so a given
  layout is anchored at most once. Anchor DOM refs are managed through stable
  per-group ref callbacks.
- **Lineage-toggle preservation** — the anchor survives the lineage on/off
  toggle path so switching lineage no longer discards the in-flight anchor.

This PR is independent of the separate
`feature/asset-group-lineage-edge-routing` branch (#34025): the two branch from
the same point on `master` and modify disjoint files, so they can merge in any
order without conflict.

## Test Plan

Local verification on this branch (all green):

- `tsgo -p .` (ui-core TypeScript) — passes.
- `eslint src/asset-graph src/graph` — passes, no warnings.
- `jest src/asset-graph` — **75 tests across 6 suites pass** (includes the new
  `useAssetGroupViewportAnchor.test.tsx`).
- `jest src/graph/__tests__/SVGViewport` — passes.

New coverage added:

- `useAssetGroupViewportAnchor.test.tsx` (new, 448 lines) — capture/restore
  anchoring, expected-state gating, scale-change abort, missing-element fallback,
  layout-source guarding, and single-consumption via the handled-layout set.
- `SVGViewport.test.tsx` (`src/graph`) — added cases for the `shiftXY` viewport
  translation the anchor calls.

Manual verification (headless Chrome, hooli asset-groups view): starting from all
groups collapsed and expanding `ANALYTICS`, the group's header stays fixed on
screen (measured on-screen shift ≈ **0 px**). On a build without this change the
same action shifts the header by roughly **500 px**.

## Changelog

[dagster-ui] Expanding or collapsing an asset group now keeps that group anchored
in place instead of causing the viewport to jump.

### Before / After

In both rows the **yellow dot is the mouse cursor, pinned to the same screen
position** — use it as a fixed reference and watch where the `ANALYTICS` group
lands relative to it after the click.

**Before — without the anchor**

Clicking to expand `ANALYTICS` re-runs Dagre layout, and with nothing anchoring
the view the whole graph shifts: the group slides ~500 px out from under the
cursor, so the node you just clicked is no longer where you clicked.

*Before the click — cursor resting on the collapsed `ANALYTICS` group:*

<img width="1565" height="327" alt="Screenshot 2026-07-23 132736" src="https://github.com/user-attachments/assets/d0cde5a6-e9c6-49f6-ab87-a3655c749cac" />

*After the click — `ANALYTICS` expanded but jumped away; the cursor (same spot)
now floats in empty canvas, and you have to hunt for the group you just clicked:*

<img width="1565" height="646" alt="Screenshot 2026-07-23 132824" src="https://github.com/user-attachments/assets/4cac6901-29d8-446f-81d0-0826cce48614" />

**After — with the anchor**

`useAssetGroupViewportAnchor` records the group's on-screen position before the
toggle and shifts the viewport by the exact layout delta afterward, so the group
expands in place.

*Before the click — same starting point: cursor on the collapsed `ANALYTICS`
group:*

<img width="1029" height="186" alt="Screenshot 2026-07-23 152933" src="https://github.com/user-attachments/assets/459ed2f5-cbe2-41f6-9a14-86bc1ad67f3f" />

*After the click — `ANALYTICS` expands in place and stays pinned under the cursor
(~0 px shift); neighboring groups keep their relative positions:*

<img width="1586" height="574" alt="Screenshot 2026-07-23 153016" src="https://github.com/user-attachments/assets/10c0561d-1783-41ea-94cd-17f0497f6583" />

