### PR TITLE
[dagster-aws] Add botocore_config passthrough to S3Resource

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/components/credentials.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/components/credentials.py
@@ -65,6 +65,13 @@ class S3CredentialsComponent(Boto3CredentialsComponent):
     use_unsigned_session: bool | None = Field(
         default=None, description="Specifies whether to use an unsigned S3 session."
     )
+    botocore_config: dict = Field(
+        default_factory=dict,
+        description=(
+            "Extra keyword arguments for botocore.config.Config, e.g. connect_timeout,"
+            " read_timeout, or max_pool_connections. A 'retries' entry is merged with max_attempts."
+        ),
+    )
 
 
 @public

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/resources.py
@@ -48,6 +48,13 @@ class ResourceWithS3Configuration(ConfigurableResource):
     aws_session_token: str | None = Field(
         default=None, description="AWS session token to use when creating the boto3 session."
     )
+    botocore_config: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Extra keyword arguments for botocore.config.Config, e.g. connect_timeout,"
+            " read_timeout, or max_pool_connections. A 'retries' entry is merged with max_attempts."
+        ),
+    )
 
 
 class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext):
@@ -79,6 +86,15 @@ class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext)
                 resources={'s3': S3Resource(region_name='us-west-1')}
             )
 
+        Use ``botocore_config`` to set timeouts or other ``botocore.config.Config`` options:
+
+        .. code-block:: python
+
+            S3Resource(
+                region_name='us-west-1',
+                botocore_config={'connect_timeout': 10, 'read_timeout': 60},
+            )
+
     """
 
     @classmethod
@@ -97,6 +113,7 @@ class S3Resource(ResourceWithS3Configuration, IAttachDifferentObjectToOpContext)
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
             aws_session_token=self.aws_session_token,
+            botocore_config=self.botocore_config,
         )
 
     def get_object_to_set_on_execution_context(self) -> Any:
@@ -173,6 +190,10 @@ def s3_resource(context) -> Any:
               # Optional[str]: The secret key to use when creating the client.
               aws_session_token: None
               # Optional[str]:  The session token to use when creating the client.
+              botocore_config:
+                connect_timeout: 10
+                read_timeout: 60
+              # Optional[dict]: Extra keyword arguments for botocore.config.Config.
     """
     return S3Resource.from_resource_context(context).get_client()
 
@@ -196,6 +217,7 @@ class S3FileManagerResource(ResourceWithS3Configuration, IAttachDifferentObjectT
                 aws_access_key_id=self.aws_access_key_id,
                 aws_secret_access_key=self.aws_secret_access_key,
                 aws_session_token=self.aws_session_token,
+                botocore_config=self.botocore_config,
             ),
             s3_bucket=self.s3_bucket,
             s3_base_key=self.s3_prefix,

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/utils.py
@@ -33,8 +33,10 @@ def construct_s3_client(
     aws_access_key_id: str | None = None,
     aws_secret_access_key: str | None = None,
     aws_session_token: str | None = None,
+    botocore_config: dict | None = None,
 ):
     check.int_param(max_attempts, "max_attempts")
+    check.opt_dict_param(botocore_config, "botocore_config", key_type=str)
     check.opt_str_param(region_name, "region_name")
     check.opt_str_param(endpoint_url, "endpoint_url")
     check.bool_param(use_unsigned_session, "use_unsigned_session")
@@ -54,7 +56,7 @@ def construct_s3_client(
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         aws_session_token=aws_session_token,
-        config=construct_boto_client_retry_config(max_attempts),
+        config=construct_boto_client_retry_config(max_attempts, botocore_config),
     ).meta.client
 
     if use_unsigned_session:

--- a/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
@@ -23,7 +23,10 @@ def construct_boto_client_retry_config(max_attempts, botocore_config=None):
         retry_config["mode"] = "standard"
 
     config_kwargs = {**botocore_config}
-    config_kwargs["retries"] = {**retry_config, **config_kwargs.get("retries", {})}
+    retries_override = check.opt_dict_param(
+        config_kwargs.get("retries"), "botocore_config['retries']"
+    )
+    config_kwargs["retries"] = {**retry_config, **retries_override}
     return Config(**config_kwargs)  # ty: ignore[invalid-argument-type]
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/utils/__init__.py
@@ -12,15 +12,19 @@ from pydantic import Field
 from dagster_aws import __file__ as dagster_aws_init_py
 
 
-def construct_boto_client_retry_config(max_attempts):
+def construct_boto_client_retry_config(max_attempts, botocore_config=None):
     check.int_param(max_attempts, "max_attempts")
+    botocore_config = check.opt_dict_param(botocore_config, "botocore_config", key_type=str)
 
     # retry mode option was introduced in botocore 1.15.0
     # https://botocore.amazonaws.com/v1/documentation/api/1.15.0/reference/config.html
     retry_config = {"max_attempts": max_attempts}
     if version.parse(botocore_version) >= version.parse("1.15.0"):
         retry_config["mode"] = "standard"
-    return Config(retries=retry_config)  # ty: ignore[invalid-argument-type]
+
+    config_kwargs = {**botocore_config}
+    config_kwargs["retries"] = {**retry_config, **config_kwargs.get("retries", {})}
+    return Config(**config_kwargs)  # ty: ignore[invalid-argument-type]
 
 
 T = TypeVar("T")

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_manager.py
@@ -216,6 +216,16 @@ def test_construct_boto_client_retry_config_retries_override():
     assert config.retries["mode"] == "adaptive"
 
 
+def test_construct_boto_client_retry_config_invalid_retries():
+    from dagster._check import CheckError
+
+    from dagster_aws.utils import construct_boto_client_retry_config
+
+    # A non-dict "retries" value should raise a clear param error, not an opaque TypeError.
+    with pytest.raises(CheckError):
+        construct_boto_client_retry_config(5, botocore_config={"retries": 5})
+
+
 @mock.patch("boto3.session.Session.resource")
 def test_s3_resource_botocore_config_passthrough(mock_boto3_resource):
     from dagster_aws.s3 import S3Resource

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_file_manager.py
@@ -188,6 +188,63 @@ def test_s3_file_manager_resource(MockS3FileManager, mock_boto3_resource):
     assert did_it_run["it_ran"]
 
 
+def test_construct_boto_client_retry_config_botocore_config_passthrough():
+    from dagster_aws.utils import construct_boto_client_retry_config
+
+    config = construct_boto_client_retry_config(
+        5,
+        botocore_config={
+            "connect_timeout": 10,
+            "read_timeout": 60,
+            "max_pool_connections": 20,
+        },
+    )
+    assert config.retries["max_attempts"] == 5
+    assert config.connect_timeout == 10
+    assert config.read_timeout == 60
+    assert config.max_pool_connections == 20
+
+
+def test_construct_boto_client_retry_config_retries_override():
+    from dagster_aws.utils import construct_boto_client_retry_config
+
+    # A user-supplied "retries" dict merges on top of the max_attempts defaults.
+    config = construct_boto_client_retry_config(
+        5, botocore_config={"retries": {"mode": "adaptive"}}
+    )
+    assert config.retries["max_attempts"] == 5
+    assert config.retries["mode"] == "adaptive"
+
+
+@mock.patch("boto3.session.Session.resource")
+def test_s3_resource_botocore_config_passthrough(mock_boto3_resource):
+    from dagster_aws.s3 import S3Resource
+
+    S3Resource(
+        botocore_config={"connect_timeout": 10, "read_timeout": 60, "max_pool_connections": 20}
+    ).get_client()
+
+    _, call_kwargs = mock_boto3_resource.call_args
+
+    mock_boto3_resource.assert_called_once_with(
+        "s3",
+        region_name=None,
+        endpoint_url=None,
+        use_ssl=True,
+        config=call_kwargs["config"],
+        aws_access_key_id=None,
+        aws_secret_access_key=None,
+        aws_session_token=None,
+        verify=None,
+    )
+
+    config = call_kwargs["config"]
+    assert config.connect_timeout == 10
+    assert config.read_timeout == 60
+    assert config.max_pool_connections == 20
+    assert config.retries["max_attempts"] == 5
+
+
 def test_s3_file_manager_resource_with_profile():
     resource_config = {
         "use_unsigned_session": True,


### PR DESCRIPTION
## Summary & Motivation

When using an S3Resource, I was looking at add in additional botocore configurations for timeouts and I noticed that it only passes retries into the Config option.

This PR adds an optional botocore_config dictionary that allows additional kwargs to be passed through to the config.  IE 

```
S3Resource(                                                                                                                                     
    region_name = "my-region",          
    botocore_config={"connect_timeout": 10, "read_timeout": 60, "max_pool_connections": 20},                                                                
      )
```

In order to not block backward compatibility, the param is optional.  To avoid breaking when aws changes things, I have made it an arbitrary dict. A retries entry, if given,  is merged on top of the max_attempts setting. This also applies to S3FileManagerResource and the S3 components, and flows through to  S3PickleIOManager.  

## Test Plan

New unit tests added to show params correctly passed through.  Existing unit tests pass in dagster-aws.


## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
