### PR TITLE
refactor(ui): share asset wipe permission logic

### DIFF
--- a/js_modules/ui-core/src/assets/__tests__/assetWipePermissions.test.ts
+++ b/js_modules/ui-core/src/assets/__tests__/assetWipePermissions.test.ts
@@ -1,0 +1,63 @@
+import {PermissionResult} from '../../app/Permissions';
+import {assetHasWipePermission} from '../assetWipePermissions';
+
+const wipePermissions = (enabled: boolean): {canWipeAssets: PermissionResult} => ({
+  canWipeAssets: {enabled, disabledReason: enabled ? '' : 'Not allowed'},
+});
+
+describe('assetHasWipePermission', () => {
+  it.each([
+    {
+      name: 'deployment-wide permission',
+      unscoped: true,
+      location: false,
+      definition: false,
+      expected: true,
+    },
+    {
+      name: 'code location permission',
+      unscoped: false,
+      location: true,
+      definition: false,
+      expected: true,
+    },
+    {
+      name: 'per-asset permission',
+      unscoped: false,
+      location: false,
+      definition: true,
+      expected: true,
+    },
+    {
+      name: 'no permission',
+      unscoped: false,
+      location: false,
+      definition: false,
+      expected: false,
+    },
+  ])('returns $expected with $name', ({unscoped, location, definition, expected}) => {
+    expect(
+      assetHasWipePermission(
+        {
+          definitionHasWipePermission: definition,
+          locationName: 'location-a',
+        },
+        wipePermissions(unscoped),
+        {'location-a': wipePermissions(location)},
+      ),
+    ).toBe(expected);
+  });
+
+  it('does not use permission from a different code location', () => {
+    expect(
+      assetHasWipePermission(
+        {
+          definitionHasWipePermission: false,
+          locationName: 'location-a',
+        },
+        wipePermissions(false),
+        {'location-b': wipePermissions(true)},
+      ),
+    ).toBe(false);
+  });
+});

--- a/js_modules/ui-core/src/assets/assetWipePermissions.ts
+++ b/js_modules/ui-core/src/assets/assetWipePermissions.ts
@@ -1,0 +1,20 @@
+import {PermissionsMap} from '../app/Permissions';
+
+type AssetWipePermission = {
+  definitionHasWipePermission: boolean;
+  locationName?: string | null;
+};
+
+type WipePermissions = Pick<PermissionsMap, 'canWipeAssets'>;
+
+export const assetHasWipePermission = (
+  asset: AssetWipePermission,
+  unscopedPermissions: WipePermissions,
+  locationPermissions: Record<string, WipePermissions>,
+) => {
+  return !!(
+    unscopedPermissions.canWipeAssets.enabled ||
+    (asset.locationName && locationPermissions[asset.locationName]?.canWipeAssets.enabled) ||
+    asset.definitionHasWipePermission
+  );
+};

--- a/js_modules/ui-core/src/assets/useWipeDialog.tsx
+++ b/js_modules/ui-core/src/assets/useWipeDialog.tsx
@@ -2,6 +2,7 @@ import {Colors, Icon, MenuItem} from '@dagster-io/ui-components';
 import {AssetWipeDialog} from '@shared/assets/AssetWipeDialog';
 import {useContext, useState} from 'react';
 
+import {assetHasWipePermission} from './assetWipePermissions';
 import {CloudOSSContext} from '../app/CloudOSSContext';
 import {PermissionsContext} from '../app/Permissions';
 import {AssetKeyInput} from '../graphql/types';
@@ -21,14 +22,9 @@ export const useWipeDialog = (
     featureContext: {canSeeWipeMaterializationAction},
   } = useContext(CloudOSSContext);
 
-  // Allow if any permission level grants access:
-  // 1. Deployment-wide (unscoped) permission
-  // 2. Code location permission
-  // 3. Per-asset permission from definition (owner-based)
-  const hasWipePermission =
-    unscopedPermissions.canWipeAssets?.enabled ||
-    (opts?.locationName && locationPermissions[opts.locationName]?.canWipeAssets?.enabled) ||
-    !!opts?.definitionHasWipePermission;
+  const hasWipePermission = opts
+    ? assetHasWipePermission(opts, unscopedPermissions, locationPermissions)
+    : false;
 
   return {
     element: (

--- a/js_modules/ui-core/src/assets/useWipeMaterializations.tsx
+++ b/js_modules/ui-core/src/assets/useWipeMaterializations.tsx
@@ -3,6 +3,7 @@ import {AssetWipeDialog} from '@shared/assets/AssetWipeDialog';
 import React, {useContext, useMemo, useState} from 'react';
 
 import {RefetchQueriesFunction} from '../apollo-client';
+import {assetHasWipePermission} from './assetWipePermissions';
 import {CloudOSSContext} from '../app/CloudOSSContext';
 import {PermissionsContext} from '../app/Permissions';
 
@@ -26,18 +27,9 @@ export const useWipeMaterializations = ({
     if (selected.length === 0) {
       return false;
     }
-    // Deployment-wide permission grants access to all assets
-    if (unscopedPermissions.canWipeAssets?.enabled) {
-      return true;
-    }
-    return selected.every((a) => {
-      // Location-scoped permission grants access to assets in that location
-      if (a.locationName && locationPermissions[a.locationName]?.canWipeAssets?.enabled) {
-        return true;
-      }
-      // Per-asset permission from the definition (owner-based)
-      return !!a.definitionHasWipePermission;
-    });
+    return selected.every((asset) =>
+      assetHasWipePermission(asset, unscopedPermissions, locationPermissions),
+    );
   }, [selected, unscopedPermissions, locationPermissions]);
 
   const {


### PR DESCRIPTION
## Summary

- extract the deployment, location, and per-asset wipe permission cascade into a shared predicate
- use the same predicate for single-asset and multi-asset wipe actions
- add focused coverage for every permission level and denied/mismatched-location cases

## Why

The two wipe hooks implemented the same three-level permission rule independently. Keeping the rule in one predicate prevents the single-asset and multi-asset paths from diverging when permission behavior changes.

Fixes #34001

## Validation

- `yarn workspace @dagster-io/ui-core eslint src/assets/assetWipePermissions.ts src/assets/__tests__/assetWipePermissions.test.ts src/assets/useWipeDialog.tsx src/assets/useWipeMaterializations.tsx`
- `yarn workspace @dagster-io/ui-core ts`
- `yarn workspace @dagster-io/ui-core jest src/assets/__tests__/useAssetsPermissions.test.tsx src/assets/__tests__/assetWipePermissions.test.ts --runInBand` (10 passed)
- `yarn workspace @dagster-io/ui-core jest-all-silent` (160 suites, 1,314 passed, 4 skipped)