### PR TITLE
[dagster-k8s] Include all container logs in pod failure diagnostics

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -776,16 +776,11 @@ class DagsterKubernetesClient:
             elif state.terminated is not None:
                 container_name = container_status.name
                 if state.terminated.exit_code != 0:
-                    tail_lines = int(
-                        os.getenv("DAGSTER_K8S_WAIT_FOR_POD_FAILURE_LOG_LINE_COUNT", "100")
-                    )
-                    raw_logs = self.retrieve_pod_logs(
-                        pod_name, namespace, container_name=container_name, tail_lines=tail_lines
-                    )
-                    message = state.terminated.message
                     msg = (
-                        f'Container "{container_name}" failed with message: "{message}". '
-                        f'Last {tail_lines} log lines: "{raw_logs}"'
+                        f'Container "{container_name}" failed with '
+                        f'message: "{state.terminated.message}". '
+                        f'exit_code={state.terminated.exit_code}, '
+                        f'reason="{state.terminated.reason}".'
                     )
 
                     self.logger(msg)
@@ -802,9 +797,19 @@ class DagsterKubernetesClient:
                     continue
 
                 if error_logs:
+                    tail_lines = int(
+                        os.getenv("DAGSTER_K8S_WAIT_FOR_POD_FAILURE_LOG_LINE_COUNT", "100")
+                    )
+                    debug_info = self.get_pod_debug_info(
+                        pod_name,
+                        namespace,
+                        pod=pod,
+                        log_tail_lines=tail_lines,
+                    )
                     logs = "\n\n".join(error_logs)
                     raise DagsterK8sError(
                         f"Pod {pod_name} terminated but some containers exited with errors:\n{logs}"
+                        f"{debug_info}"
                     )
                 else:
                     self.logger(f"Pod {pod_name} exited successfully")
@@ -951,6 +956,7 @@ class DagsterKubernetesClient:
         namespace,
         pod: Optional[kubernetes.client.V1Pod] = None,  # the already fetched pod  # noqa: UP045
         include_container_logs: bool | None = True,
+        log_tail_lines: int = 25,
     ) -> str:
         if pod is None:
             pods = self.core_api.list_namespaced_pod(
@@ -987,7 +993,7 @@ class DagsterKubernetesClient:
                             pod_name,
                             namespace,
                             container_name,
-                            tail_lines=25,
+                            tail_lines=log_tail_lines,
                             timestamps=True,
                         )
                         # Remove trailing newline if present
@@ -1000,13 +1006,18 @@ class DagsterKubernetesClient:
                                 " docker image with the `--platform linux/amd64` flag set."
                             )
                         log_str = (
-                            f"Last 25 log lines for container '{container_name}':\n{pod_logs}"
+                            f"Last {log_tail_lines} log lines for container '{container_name}':\n{pod_logs}"
                             if pod_logs
                             else f"No logs for container '{container_name}'."
                         )
 
                     except kubernetes.client.rest.ApiException as e:
-                        log_str = f"Failure fetching pod logs for container '{container_name}': {e}"
+                        if e.status == 400:
+                            log_str = f"No logs available for container '{container_name}'."
+                        else:
+                            log_str = (
+                                f"Failure fetching pod logs for container '{container_name}': {e}"
+                            )
 
                 log_strs.append(log_str)
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -800,7 +800,6 @@ class DagsterKubernetesClient:
                     tail_lines = int(
                         os.getenv("DAGSTER_K8S_WAIT_FOR_POD_FAILURE_LOG_LINE_COUNT", "100")
                     )
-                    logs = "\n\n".join(error_logs)
                     try:
                         debug_info = self.get_pod_debug_info(
                             pod_name,
@@ -810,12 +809,14 @@ class DagsterKubernetesClient:
                         )
                     except Exception as e:
                         debug_info = (
-                            f"Debug information for pod {pod_name} could not be collected: "
-                            f"{e.__class__.__name__}: {e}"
+                            f"Failed to collect debug information for pod {pod_name}: "
+                            f"{type(e).__name__}: {e}"
                         )
+
+                    logs = "\n\n".join(error_logs)
                     raise DagsterK8sError(
-                        f"Pod {pod_name} terminated but some containers exited with errors:\n{logs}"
-                        f"\n\n{debug_info}"
+                        f"Pod {pod_name} terminated but some containers exited with errors:\n"
+                        f"{logs}\n\n{debug_info}"
                     )
                 else:
                     self.logger(f"Pod {pod_name} exited successfully")
@@ -887,7 +888,8 @@ class DagsterKubernetesClient:
         if pod.status.init_container_statuses:
             pod_status.extend(
                 [
-                    f"Init container '{status.name}' status: {self._get_container_status_str(status)}"
+                    f"Init container '{status.name}' status: "
+                    f"{self._get_container_status_str(status)}"
                     for status in pod.status.init_container_statuses
                 ]
             )
@@ -986,12 +988,13 @@ class DagsterKubernetesClient:
 
         container_statuses = []
         containers = []
-        if pod and pod.status:
-            container_statuses.extend(pod.status.init_container_statuses or [])
-            container_statuses.extend(pod.status.container_statuses or [])
-        if pod and pod.spec:
-            containers.extend(pod.spec.init_containers or [])
-            containers.extend(pod.spec.containers or [])
+        if pod:
+            if pod.status:
+                container_statuses.extend(pod.status.init_container_statuses or [])
+                container_statuses.extend(pod.status.container_statuses or [])
+            if pod.spec:
+                containers.extend(pod.spec.init_containers or [])
+                containers.extend(pod.spec.containers or [])
 
         container_statuses_by_name = {status.name: status for status in container_statuses}
 
@@ -1035,6 +1038,10 @@ class DagsterKubernetesClient:
                             log_str = (
                                 f"Failure fetching pod logs for container '{container_name}': {e}"
                             )
+                    except urllib3.exceptions.HTTPError as e:
+                        log_str = (
+                            f"Failure fetching pod logs for container '{container_name}': {e}"
+                        )
 
                 log_strs.append(log_str)
 
@@ -1059,7 +1066,7 @@ class DagsterKubernetesClient:
                         event_strs.append(f"{event.reason}: {event.message}{count_str}")
                     warning_str = "Warning events for pod:\n" + "\n".join(event_strs)
 
-            except kubernetes.client.rest.ApiException as e:
+            except (kubernetes.client.rest.ApiException, urllib3.exceptions.HTTPError) as e:
                 warning_str = f"Failure fetching pod events: {e}"
 
         return (

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -764,7 +764,9 @@ class DagsterKubernetesClient:
                     KubernetesWaitingReasons.CrashLoopBackOff,
                     KubernetesWaitingReasons.RunContainerError,
                 ]:
-                    debug_info = self.get_pod_debug_info(pod_name, namespace, pod=pod)
+                    debug_info = self._get_pod_debug_info_for_failure(
+                        pod_name, namespace, pod=pod
+                    )
                     raise DagsterK8sError(
                         f'Failed: Reason="{state.waiting.reason}"'
                         f' Message="{state.waiting.message}"\n{debug_info}'
@@ -800,18 +802,12 @@ class DagsterKubernetesClient:
                     tail_lines = int(
                         os.getenv("DAGSTER_K8S_WAIT_FOR_POD_FAILURE_LOG_LINE_COUNT", "100")
                     )
-                    try:
-                        debug_info = self.get_pod_debug_info(
-                            pod_name,
-                            namespace,
-                            pod=pod,
-                            log_tail_lines=tail_lines,
-                        )
-                    except Exception as e:
-                        debug_info = (
-                            f"Failed to collect debug information for pod {pod_name}: "
-                            f"{type(e).__name__}: {e}"
-                        )
+                    debug_info = self._get_pod_debug_info_for_failure(
+                        pod_name,
+                        namespace,
+                        pod=pod,
+                        log_tail_lines=tail_lines,
+                    )
 
                     logs = "\n\n".join(error_logs)
                     raise DagsterK8sError(
@@ -966,6 +962,28 @@ class DagsterKubernetesClient:
             + "".join(["\n\n" + event_str for event_str in event_strs])
         )
 
+    def _get_pod_debug_info_for_failure(
+        self,
+        pod_name: str,
+        namespace: str,
+        pod: Optional[kubernetes.client.V1Pod] = None,
+        log_tail_lines: int | None = None,
+    ) -> str:
+        try:
+            if log_tail_lines is None:
+                return self.get_pod_debug_info(pod_name, namespace, pod=pod)
+            return self.get_pod_debug_info(
+                pod_name,
+                namespace,
+                pod=pod,
+                log_tail_lines=log_tail_lines,
+            )
+        except Exception as e:
+            return (
+                f"Failed to collect debug information for pod {pod_name}: "
+                f"{type(e).__name__}: {e}"
+            )
+
     def get_pod_debug_info(
         self,
         pod_name,
@@ -1038,9 +1056,10 @@ class DagsterKubernetesClient:
                             log_str = (
                                 f"Failure fetching pod logs for container '{container_name}': {e}"
                             )
-                    except urllib3.exceptions.HTTPError as e:
+                    except Exception as e:
                         log_str = (
-                            f"Failure fetching pod logs for container '{container_name}': {e}"
+                            f"Failure fetching pod logs for container '{container_name}': "
+                            f"{type(e).__name__}: {e}"
                         )
 
                 log_strs.append(log_str)
@@ -1066,8 +1085,8 @@ class DagsterKubernetesClient:
                         event_strs.append(f"{event.reason}: {event.message}{count_str}")
                     warning_str = "Warning events for pod:\n" + "\n".join(event_strs)
 
-            except (kubernetes.client.rest.ApiException, urllib3.exceptions.HTTPError) as e:
-                warning_str = f"Failure fetching pod events: {e}"
+            except Exception as e:
+                warning_str = f"Failure fetching pod events: {type(e).__name__}: {e}"
 
         return (
             f"Debug information for pod {pod_name}:"

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -800,16 +800,22 @@ class DagsterKubernetesClient:
                     tail_lines = int(
                         os.getenv("DAGSTER_K8S_WAIT_FOR_POD_FAILURE_LOG_LINE_COUNT", "100")
                     )
-                    debug_info = self.get_pod_debug_info(
-                        pod_name,
-                        namespace,
-                        pod=pod,
-                        log_tail_lines=tail_lines,
-                    )
                     logs = "\n\n".join(error_logs)
+                    try:
+                        debug_info = self.get_pod_debug_info(
+                            pod_name,
+                            namespace,
+                            pod=pod,
+                            log_tail_lines=tail_lines,
+                        )
+                    except Exception as e:
+                        debug_info = (
+                            f"Debug information for pod {pod_name} could not be collected: "
+                            f"{e.__class__.__name__}: {e}"
+                        )
                     raise DagsterK8sError(
                         f"Pod {pod_name} terminated but some containers exited with errors:\n{logs}"
-                        f"{debug_info}"
+                        f"\n\n{debug_info}"
                     )
                 else:
                     self.logger(f"Pod {pod_name} exited successfully")
@@ -877,6 +883,14 @@ class DagsterKubernetesClient:
             f"Pod status: {pod.status.phase}"
             + (f": {pod.status.message}" if pod.status.message else "")
         ]
+
+        if pod.status.init_container_statuses:
+            pod_status.extend(
+                [
+                    f"Init container '{status.name}' status: {self._get_container_status_str(status)}"
+                    for status in pod.status.init_container_statuses
+                ]
+            )
 
         if pod.status.container_statuses:
             pod_status.extend(
@@ -970,16 +984,19 @@ class DagsterKubernetesClient:
 
         specific_warnings = []
 
-        container_statuses_by_name = (
-            {status.name: status for status in pod.status.container_statuses}
-            if pod and pod.status and pod.status.container_statuses
-            else {}
-        )
+        container_statuses = []
+        containers = []
+        if pod and pod.status:
+            container_statuses.extend(pod.status.init_container_statuses or [])
+            container_statuses.extend(pod.status.container_statuses or [])
+        if pod and pod.spec:
+            containers.extend(pod.spec.init_containers or [])
+            containers.extend(pod.spec.containers or [])
+
+        container_statuses_by_name = {status.name: status for status in container_statuses}
 
         if include_container_logs:
-            for container in (
-                pod.spec.containers if (pod and pod.spec and pod.spec.containers) else []
-            ):
+            for container in containers:
                 container_name = container.name
                 log_str = ""
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -658,31 +658,139 @@ def test_wait_for_ready_but_terminated_unsuccessfully():
     single_pod_terminated_unsuccessful = _pod_list_for_container_status(
         _create_status(
             state=V1ContainerState(
-                terminated=V1ContainerStateTerminated(exit_code=1, message="error_message")
+                terminated=V1ContainerStateTerminated(
+                    exit_code=1,
+                    reason="Error",
+                    message="error_message",
+                )
             ),
             ready=False,
         )
     )
+    failed_pod = single_pod_terminated_unsuccessful.items[0]
 
     mock_client.core_api.list_namespaced_pod.side_effect = [
         single_not_ready_running_pod,
         single_pod_terminated_unsuccessful,
     ]
 
-    retrieve_pod_logs_mock = mock.MagicMock()
-    retrieve_pod_logs_mock.side_effect = ["raw_logs_ret_val"]
-    mock_client.retrieve_pod_logs = retrieve_pod_logs_mock
+    mock_client.get_pod_debug_info = mock.MagicMock(return_value="pod debug info")
 
     pod_name = "a_pod"
     container_name = "a_name"
 
-    with pytest.raises(DagsterK8sError) as exc_info:
-        mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace")
+    with (
+        mock.patch.dict(
+            os.environ,
+            {"DAGSTER_K8S_WAIT_FOR_POD_FAILURE_LOG_LINE_COUNT": "42"},
+        ),
+        pytest.raises(DagsterK8sError) as exc_info,
+    ):
+        mock_client.wait_for_pod(
+            pod_name=pod_name,
+            namespace="namespace",
+        )
 
     assert (
         str(exc_info.value)
-        == f'Pod {pod_name} terminated but some containers exited with errors:\nContainer "{container_name}" failed with message: "error_message".'
-        ' Last 100 log lines: "raw_logs_ret_val"'
+        == (
+            f'Pod {pod_name} terminated but some containers exited with errors:\n'
+            f'Container "{container_name}" failed with message: "error_message". '
+            'exit_code=1, reason="Error".'
+            'pod debug info'
+        )
+    )
+
+    mock_client.get_pod_debug_info.assert_called_once_with(
+        pod_name,
+        "namespace",
+        pod=failed_pod,
+        log_tail_lines=42,
+    )
+
+    # failed-container logs should not be fetched before collecting logs for the entire pod
+    mock_client.core_api.read_namespaced_pod_log.assert_not_called()
+
+def test_get_pod_debug_info_preserves_containers_logs():
+    mock_client = create_mocked_client()
+
+    healthy_status = _create_status(
+        state=V1ContainerState(
+            terminated=V1ContainerStateTerminated(
+                exit_code=0,
+                reason="Completed",
+            )
+        ),
+        ready=False,
+        name="healthy",
+    )
+    broken_status = _create_status(
+        state=V1ContainerState(
+            terminated=V1ContainerStateTerminated(
+                exit_code=1,
+                reason="DeadlineExceeded",
+                message="The container could not be located when the pod was terminated",
+            )
+        ),
+        ready=False,
+        name="broken-config",
+    )
+
+    pod = V1Pod(
+        spec=kubernetes.client.V1PodSpec(
+            containers=[
+                kubernetes.client.V1Container(name="healthy"),
+                kubernetes.client.V1Container(name="broken-config"),
+            ]
+        ),
+        status=V1PodStatus(
+            phase="Failed",
+            container_statuses=[healthy_status, broken_status],
+        ),
+    )
+
+    mock_client.retrieve_pod_logs = mock.MagicMock(
+        side_effect=[
+            "message from a healthy container",
+            kubernetes.client.rest.ApiException(
+                status=400,
+                reason="Bad Request",
+            ),
+        ]
+    )
+    mock_client.retrieve_pod_events = mock.MagicMock(return_value=[])
+
+    debug_info = mock_client.get_pod_debug_info(
+        pod_name="a_pod",
+        namespace="namespace",
+        pod=pod,
+        log_tail_lines=25,
+    )
+
+    assert "Last 25 log lines for container 'healthy':" in debug_info
+    assert "message from a healthy container" in debug_info
+    assert "No logs available for container 'broken-config'." in debug_info
+
+    # hide generic k8s API failure as the primary diagnostic
+    assert "Bad Request" not in debug_info
+
+    mock_client.retrieve_pod_logs.assert_has_calls(
+        [
+            mock.call(
+                "a_pod",
+                "namespace",
+                "healthy",
+                tail_lines=25,
+                timestamps=True,
+            ),
+            mock.call(
+                "a_pod",
+                "namespace",
+                "broken-config",
+                tail_lines=25,
+                timestamps=True,
+            ),
+        ]
     )
 
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -697,6 +697,7 @@ def test_wait_for_ready_but_terminated_unsuccessfully():
             f'Pod {pod_name} terminated but some containers exited with errors:\n'
             f'Container "{container_name}" failed with message: "error_message". '
             'exit_code=1, reason="Error".'
+            '\n\n'
             'pod debug info'
         )
     )


### PR DESCRIPTION
## Summary & Motivation

When a multi-container Kubernetes pod terminates with an error, `wait_for_pod` currently retrieves logs only for the failed container. Example of the script to reproduce the error is attached.

This is problematic when the failed container never started. For example, because of a `CreateContainerConfigError`. Kubernetes returns HTTP 400 when logs are requested for that container, and the resulting generic API error prevents Dagster from forwarding logs from other containers in the same pod.

This change uses the existing pod debug information path when reporting unsuccessful pod termination. The resulting `DagsterK8sError` now includes:

* The termination details for the failed container.
* Status information for all containers.
* Available logs from every container in the pod.
* Kubernetes warning events.
* "No logs available" message when Kubernetes returns HTTP 400 for a container that never started.

## Changes Tested

Added unit tests:
* Unsuccessful pod termination calls `get_pod_debug_info` with the configured log tail length.
* Logs from a healthy container remain present when another container log request returns HTTP 400.
* HTTP 400 from the Kubernetes log API is reported as unavailable logs.
* Non-400 Kubernetes log API errors remain visible.

## Changelog

dagster-k8s FIXED - Pod failure diagnostics now include available logs from all containers. Containers that never started and return HTTP 400 from the Kubernetes log API are reported as having no available logs instead of masking logs from other containers.

## Breaking Changes

None.

## Related Issue

No linked issue.

## Test Script
```python
# One pod, two containers: 
# - One logs HEALTHY PINGs
# - Another one fails to start (CreateContainerConfigError)
# 
# Expected: Last N logs from healthy pods are retrieved, fail reason is stated.
# Actual: HTTP 400 is logged.
#
# Execute: `dagster job execute -f ./script.py -j repro_job`

import os

from dagster import Definitions, OpExecutionContext, job, op
from dagster_k8s import PipesK8sClient


NAMESPACE = "default"
IMAGE = "busybox:1.38"
ACTIVE_DEADLINE_SECONDS = "12"
POD_WAIT_TIMEOUT_SECONDS = "25"

FAKE_CONFIG_MAP = "this-one-is-fake"


@op
def reproduce_config_error(
    context: OpExecutionContext,
    k8s: PipesK8sClient,
) -> None:
    healthy_container_run = r"""
set -eu
i=0
while true; do
    echo "HEALTHY PING $i"
    i=$((i + 1))
    sleep 1
done
""".strip()

    context.log.info(
        "Launching pod: namespace=%s activeDeadlineSeconds=%s "
        "pod_wait_timeout=%s missing_config_map=%s",
        NAMESPACE,
        ACTIVE_DEADLINE_SECONDS,
        POD_WAIT_TIMEOUT_SECONDS,
        FAKE_CONFIG_MAP,
    )

    k8s.run(
        context=context,
        namespace=NAMESPACE,
        enable_multi_container_logs=True,
        pod_wait_timeout=POD_WAIT_TIMEOUT_SECONDS,
        delete_pod_on_completion=False,
        base_pod_meta={
            "labels": {
                "app": "dagster-pipes-config-error-repro",
            },
        },
        base_pod_spec={
            "restartPolicy": "Never",
            "activeDeadlineSeconds": ACTIVE_DEADLINE_SECONDS,
            "terminationGracePeriodSeconds": 5,
            "containers": [
                {
                    "name": "healthy",
                    "image": IMAGE,
                    "imagePullPolicy": "IfNotPresent",
                    "command": ["/bin/sh", "-c"],
                    "args": [healthy_container_run],
                },
                {
                    "name": "broken-config",
                    "image": IMAGE,
                    "imagePullPolicy": "IfNotPresent",
                    "command": ["/bin/sh", "-c"],
                    "args": ["echo THIS_LINE_MUST_NEVER_RUN"],
                    "env": [
                        {
                            "name": "FAKE",
                            "valueFrom": {
                                "configMapKeyRef": {
                                    "name": FAKE_CONFIG_MAP,
                                    "key": "value",
                                    "optional": False,
                                }
                            },
                        }
                    ],
                },
            ],
        },
    )


@job
def repro_job():
    reproduce_config_error()


defs = Definitions(
    jobs=[repro_job],
    resources={
        "k8s": PipesK8sClient(
            kube_context=None,
            poll_interval=0.5,
        )
    },
)

```