### PR TITLE
Add explicit "From cancellation" re-execution behaviors

### DIFF
--- a/js_modules/ui-core/src/runs/RunActionButtons.tsx
+++ b/js_modules/ui-core/src/runs/RunActionButtons.tsx
@@ -1,22 +1,22 @@
-import { Box, Button, Icon, Tooltip, showToast } from '@dagster-io/ui-components';
-import { useCallback, useState } from 'react';
+import {Box, Button, Icon, Tooltip, showToast} from '@dagster-io/ui-components';
+import {useCallback, useState} from 'react';
 
-import { IRunMetadataDict, IStepState } from './RunMetadataProvider';
-import { doneStatuses, failedStatuses } from './RunStatuses';
-import { DagsterTag } from './RunTag';
-import { getReexecutionParamsForSelection } from './RunUtils';
-import { StepSelection } from './StepSelection';
-import { TerminationDialog, TerminationDialogResult } from './TerminationDialog';
-import { RunFragment, RunPageFragment } from './types/RunFragments.types';
-import { useJobAvailabilityErrorForRun } from './useJobAvailabilityErrorForRun';
-import { useJobReexecution } from './useJobReExecution';
-import { GraphQueryItem, filterByQuery } from '../app/GraphQueryImpl';
-import { DEFAULT_DISABLED_REASON } from '../app/Permissions';
-import { ReexecutionStrategy, RunStatus } from '../graphql/types';
-import { isNewTabClick } from '../hooks/useOpenInNewTab';
-import { LaunchButtonConfiguration, LaunchButtonDropdown } from '../launchpad/LaunchButton';
-import { filterRunSelectionByQuery } from '../run-selection/AntlrRunSelection';
-import { useRepositoryForRunWithParentSnapshot } from '../workspace/useRepositoryForRun';
+import {IRunMetadataDict, IStepState} from './RunMetadataProvider';
+import {doneStatuses, failedStatuses} from './RunStatuses';
+import {DagsterTag} from './RunTag';
+import {getReexecutionParamsForSelection} from './RunUtils';
+import {StepSelection } from './StepSelection';
+import {TerminationDialog, TerminationDialogResult } from './TerminationDialog';
+import {RunFragment, RunPageFragment} from './types/RunFragments.types';
+import {useJobAvailabilityErrorForRun} from './useJobAvailabilityErrorForRun';
+import {useJobReexecution} from './useJobReExecution';
+import {GraphQueryItem, filterByQuery} from '../app/GraphQueryImpl';
+import {DEFAULT_DISABLED_REASON} from '../app/Permissions';
+import {ReexecutionStrategy, RunStatus} from '../graphql/types';
+import {isNewTabClick} from '../hooks/useOpenInNewTab';
+import {LaunchButtonConfiguration, LaunchButtonDropdown } from '../launchpad/LaunchButton';
+import {filterRunSelectionByQuery} from '../run-selection/AntlrRunSelection';
+import {useRepositoryForRunWithParentSnapshot} from '../workspace/useRepositoryForRun';
 
 interface RunActionButtonsProps {
   run: RunPageFragment;
@@ -25,14 +25,14 @@ interface RunActionButtonsProps {
   metadata: IRunMetadataDict;
 }
 
-export const CancelRunButton = ({ run }: { run: RunFragment }) => {
-  const { id: runId, canTerminate, hasTerminatePermission } = run;
+export const CancelRunButton = ({run}: {run: RunFragment}) => {
+  const {id: runId, canTerminate, hasTerminatePermission} = run;
   const [showDialog, setShowDialog] = useState<boolean>(false);
   const closeDialog = useCallback(() => setShowDialog(false), []);
 
   const onComplete = useCallback(
     async (result: TerminationDialogResult) => {
-      const { errors } = result;
+      const {errors} = result;
       const error = runId && errors[runId];
       if (error && 'message' in error) {
         showToast({
@@ -67,7 +67,7 @@ export const CancelRunButton = ({ run }: { run: RunFragment }) => {
         isOpen={showDialog}
         onClose={closeDialog}
         onComplete={onComplete}
-        selectedRuns={{ [runId]: canTerminate }}
+        selectedRuns={{[runId]: canTerminate}}
       />
     </>
   ) : (
@@ -100,7 +100,7 @@ function stepSelectionFromRunTags(
     return null;
   }
   return stepSelectionWithState(
-    { keys: filterByQuery(graph, tag.value).all.map((k) => k.name), query: tag.value },
+    {keys: filterByQuery(graph, tag.value).all.map((k) => k.name), query: tag.value},
     metadata,
   );
 }
@@ -110,7 +110,7 @@ export const canRunFromFailure = (run: Pick<RunFragment, 'status' | 'executionPl
   run.executionPlan && failedStatuses.has(run.status);
 
 export const RunActionButtons = (props: RunActionButtonsProps) => {
-  const { metadata, graph, run } = props;
+  const {metadata, graph, run} = props;
 
   const repoMatch = useRepositoryForRunWithParentSnapshot(run);
   const jobError = useJobAvailabilityErrorForRun(run);
@@ -304,8 +304,8 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
   );
 };
 
-const StepSelectionDescription = ({ selection }: { selection: StepSelection | null }) => (
-  <div style={{ paddingLeft: '10px' }}>
+const StepSelectionDescription = ({selection}: {selection: StepSelection | null }) => (
+  <div style={{paddingLeft: '10px'}}>
     {(selection?.keys || []).map((step) => (
       <span key={step} style={{ display: 'block' }}>{`* ${step}`}</span>
     ))}

--- a/js_modules/ui-core/src/runs/RunActionButtons.tsx
+++ b/js_modules/ui-core/src/runs/RunActionButtons.tsx
@@ -1,22 +1,22 @@
-import {Box, Button, Icon, Tooltip, showToast} from '@dagster-io/ui-components';
-import {useCallback, useState} from 'react';
+import { Box, Button, Icon, Tooltip, showToast } from '@dagster-io/ui-components';
+import { useCallback, useState } from 'react';
 
-import {IRunMetadataDict, IStepState} from './RunMetadataProvider';
-import {doneStatuses, failedStatuses} from './RunStatuses';
-import {DagsterTag} from './RunTag';
-import {getReexecutionParamsForSelection} from './RunUtils';
-import {StepSelection} from './StepSelection';
-import {TerminationDialog, TerminationDialogResult} from './TerminationDialog';
-import {RunFragment, RunPageFragment} from './types/RunFragments.types';
-import {useJobAvailabilityErrorForRun} from './useJobAvailabilityErrorForRun';
-import {useJobReexecution} from './useJobReExecution';
-import {GraphQueryItem, filterByQuery} from '../app/GraphQueryImpl';
-import {DEFAULT_DISABLED_REASON} from '../app/Permissions';
-import {ReexecutionStrategy} from '../graphql/types';
-import {isNewTabClick} from '../hooks/useOpenInNewTab';
-import {LaunchButtonConfiguration, LaunchButtonDropdown} from '../launchpad/LaunchButton';
-import {filterRunSelectionByQuery} from '../run-selection/AntlrRunSelection';
-import {useRepositoryForRunWithParentSnapshot} from '../workspace/useRepositoryForRun';
+import { IRunMetadataDict, IStepState } from './RunMetadataProvider';
+import { doneStatuses, failedStatuses } from './RunStatuses';
+import { DagsterTag } from './RunTag';
+import { getReexecutionParamsForSelection } from './RunUtils';
+import { StepSelection } from './StepSelection';
+import { TerminationDialog, TerminationDialogResult } from './TerminationDialog';
+import { RunFragment, RunPageFragment } from './types/RunFragments.types';
+import { useJobAvailabilityErrorForRun } from './useJobAvailabilityErrorForRun';
+import { useJobReexecution } from './useJobReExecution';
+import { GraphQueryItem, filterByQuery } from '../app/GraphQueryImpl';
+import { DEFAULT_DISABLED_REASON } from '../app/Permissions';
+import { ReexecutionStrategy, RunStatus } from '../graphql/types';
+import { isNewTabClick } from '../hooks/useOpenInNewTab';
+import { LaunchButtonConfiguration, LaunchButtonDropdown } from '../launchpad/LaunchButton';
+import { filterRunSelectionByQuery } from '../run-selection/AntlrRunSelection';
+import { useRepositoryForRunWithParentSnapshot } from '../workspace/useRepositoryForRun';
 
 interface RunActionButtonsProps {
   run: RunPageFragment;
@@ -25,14 +25,14 @@ interface RunActionButtonsProps {
   metadata: IRunMetadataDict;
 }
 
-export const CancelRunButton = ({run}: {run: RunFragment}) => {
-  const {id: runId, canTerminate, hasTerminatePermission} = run;
+export const CancelRunButton = ({ run }: { run: RunFragment }) => {
+  const { id: runId, canTerminate, hasTerminatePermission } = run;
   const [showDialog, setShowDialog] = useState<boolean>(false);
   const closeDialog = useCallback(() => setShowDialog(false), []);
 
   const onComplete = useCallback(
     async (result: TerminationDialogResult) => {
-      const {errors} = result;
+      const { errors } = result;
       const error = runId && errors[runId];
       if (error && 'message' in error) {
         showToast({
@@ -67,7 +67,7 @@ export const CancelRunButton = ({run}: {run: RunFragment}) => {
         isOpen={showDialog}
         onClose={closeDialog}
         onComplete={onComplete}
-        selectedRuns={{[runId]: canTerminate}}
+        selectedRuns={{ [runId]: canTerminate }}
       />
     </>
   ) : (
@@ -100,7 +100,7 @@ function stepSelectionFromRunTags(
     return null;
   }
   return stepSelectionWithState(
-    {keys: filterByQuery(graph, tag.value).all.map((k) => k.name), query: tag.value},
+    { keys: filterByQuery(graph, tag.value).all.map((k) => k.name), query: tag.value },
     metadata,
   );
 }
@@ -110,7 +110,7 @@ export const canRunFromFailure = (run: Pick<RunFragment, 'status' | 'executionPl
   run.executionPlan && failedStatuses.has(run.status);
 
 export const RunActionButtons = (props: RunActionButtonsProps) => {
-  const {metadata, graph, run} = props;
+  const { metadata, graph, run } = props;
 
   const repoMatch = useRepositoryForRunWithParentSnapshot(run);
   const jobError = useJobAvailabilityErrorForRun(run);
@@ -145,7 +145,7 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
     disabled: !canRunAllSteps(run),
     onClick: (e) => {
       const openInNewTab = isNewTabClick(e);
-      return reexecute.onClick(run, ReexecutionStrategy.ALL_STEPS, e.shiftKey, {openInNewTab});
+      return reexecute.onClick(run, ReexecutionStrategy.ALL_STEPS, e.shiftKey, { openInNewTab });
     },
   };
 
@@ -212,26 +212,31 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
   };
 
   const fromFailureEnabled = canRunFromFailure(run);
+  const isCanceled = run.status === RunStatus.CANCELED;
 
   const fromFailure: LaunchButtonConfiguration = {
     icon: 'arrow_forward',
-    title: 'From failure',
+    title: isCanceled ? 'From cancellation' : 'From failure',
     disabled: !fromFailureEnabled,
     tooltip: !fromFailureEnabled
-      ? 'Retry is only enabled when the pipeline has failed.'
-      : 'Retry the pipeline run, skipping steps that completed successfully. Shift-click to adjust tags.',
+      ? isCanceled
+        ? 'Retry is only enabled when the pipeline has been canceled.'
+        : 'Retry is only enabled when the pipeline has failed.'
+      : 'Retry the pipeline run, skipping steps that completed successfully.',
     onClick: (e) => {
       const openInNewTab = isNewTabClick(e);
-      return reexecute.onClick(run, ReexecutionStrategy.FROM_FAILURE, e.shiftKey, {openInNewTab});
+      return reexecute.onClick(run, ReexecutionStrategy.FROM_FAILURE, e.shiftKey, { openInNewTab });
     },
   };
 
   const fromAssetFailure: LaunchButtonConfiguration = {
     icon: 'arrow_forward',
-    title: 'From asset failure',
+    title: isCanceled ? 'From asset cancellation' : 'From asset failure',
     disabled: !fromFailureEnabled,
     tooltip: !fromFailureEnabled
-      ? 'Retry is only enabled when the pipeline has failed.'
+      ? isCanceled
+        ? 'Retry is only enabled when the pipeline has been canceled.'
+        : 'Retry is only enabled when the pipeline has failed.'
       : 'Retry the pipeline run, selecting only assets that did not complete successfully. Shift-click to adjust tags.',
     onClick: (e) => {
       const openInNewTab = isNewTabClick(e);
@@ -255,11 +260,11 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
     selected,
     fromSelected,
     fromFailure,
-    run.executionPlan?.assetKeys.length ? fromAssetFailure : null,
+    run.executionPlan?.assetKeys?.length ? fromAssetFailure : null,
   ].filter(Boolean) as LaunchButtonConfiguration[];
   const preferredRerun = selection.present
     ? selected
-    : fromFailureEnabled && currentRunIsFromFailure
+    : fromFailureEnabled
       ? fromFailure
       : currentRunSelection?.present
         ? same
@@ -275,8 +280,8 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
   };
 
   return (
-    <Box flex={{direction: 'row', gap: 8}}>
-      <Box flex={{direction: 'row'}}>
+    <Box flex={{ direction: 'row', gap: 8 }}>
+      <Box flex={{ direction: 'row' }}>
         <LaunchButtonDropdown
           runCount={1}
           primary={primary}
@@ -299,10 +304,10 @@ export const RunActionButtons = (props: RunActionButtonsProps) => {
   );
 };
 
-const StepSelectionDescription = ({selection}: {selection: StepSelection | null}) => (
-  <div style={{paddingLeft: '10px'}}>
+const StepSelectionDescription = ({ selection }: { selection: StepSelection | null }) => (
+  <div style={{ paddingLeft: '10px' }}>
     {(selection?.keys || []).map((step) => (
-      <span key={step} style={{display: 'block'}}>{`* ${step}`}</span>
+      <span key={step} style={{ display: 'block' }}>{`* ${step}`}</span>
     ))}
   </div>
 );

--- a/js_modules/ui-core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/ui-core/src/runs/RunActionsMenu.tsx
@@ -40,7 +40,7 @@ import {DagsterTag} from './RunTag';
 import {AppContext} from '../app/AppContext';
 import {DEFAULT_DISABLED_REASON} from '../app/Permissions';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
-import {ReexecutionStrategy} from '../graphql/types';
+import {ReexecutionStrategy, RunStatus} from '../graphql/types';
 import {getPipelineSnapshotLink} from '../pipelines/PipelinePathUtils';
 import {AnchorButton} from '../ui/AnchorButton';
 import {CopyButton} from '../ui/CopyButton';
@@ -320,7 +320,12 @@ export const RunBulkActionsMenu = React.memo((props: RunBulkActionsMenuProps) =>
   const {refetch} = React.useContext(RunsQueryRefetchContext);
 
   const [visibleDialog, setVisibleDialog] = React.useState<
-    'none' | 'terminate' | 'delete' | 'reexecute-from-failure' | 'reexecute'
+    | 'none'
+    | 'terminate'
+    | 'delete'
+    | 'reexecute-from-failure'
+    | 'reexecute-from-cancellation'
+    | 'reexecute'
   >('none');
 
   const canTerminateAny = React.useMemo(() => {
@@ -347,10 +352,17 @@ export const RunBulkActionsMenu = React.memo((props: RunBulkActionsMenuProps) =>
   const deletionMap = Object.fromEntries(selected.map((r) => [r.id, r.canTerminate]));
 
   const reexecuteFromFailureRuns = selected.filter(
-    (r) => failedStatuses.has(r.status) && r.hasReExecutePermission,
+    (r) => r.status === RunStatus.FAILURE && r.hasReExecutePermission,
   );
   const reexecuteFromFailureMap = Object.fromEntries(
     reexecuteFromFailureRuns.map((r) => [r.id, r.id]),
+  );
+
+  const reexecuteFromCancellationRuns = selected.filter(
+    (r) => r.status === RunStatus.CANCELED && r.hasReExecutePermission,
+  );
+  const reexecuteFromCancellationMap = Object.fromEntries(
+    reexecuteFromCancellationRuns.map((r) => [r.id, r.id]),
   );
   const selectedRunBackfillIds = uniq(
     selected
@@ -426,6 +438,16 @@ export const RunBulkActionsMenu = React.memo((props: RunBulkActionsMenuProps) =>
                     setVisibleDialog('reexecute-from-failure');
                   }}
                 />
+                <MenuItem
+                  icon="refresh"
+                  text={`Re-execute ${reexecuteFromCancellationRuns.length} ${
+                    reexecuteFromCancellationRuns.length === 1 ? 'run' : 'runs'
+                  } from cancellation`}
+                  disabled={reexecuteFromCancellationRuns.length === 0}
+                  onClick={() => {
+                    setVisibleDialog('reexecute-from-cancellation');
+                  }}
+                />
               </>
             ) : null}
           </Menu>
@@ -458,6 +480,14 @@ export const RunBulkActionsMenu = React.memo((props: RunBulkActionsMenuProps) =>
         onClose={closeDialogs}
         onComplete={onComplete}
         selectedRuns={reexecuteFromFailureMap}
+        selectedRunBackfillIds={selectedRunBackfillIds}
+        reexecutionStrategy={ReexecutionStrategy.FROM_FAILURE}
+      />
+      <ReexecutionDialog
+        isOpen={visibleDialog === 'reexecute-from-cancellation'}
+        onClose={closeDialogs}
+        onComplete={onComplete}
+        selectedRuns={reexecuteFromCancellationMap}
         selectedRunBackfillIds={selectedRunBackfillIds}
         reexecutionStrategy={ReexecutionStrategy.FROM_FAILURE}
       />


### PR DESCRIPTION
## Summary & Motivation

Currently in the Dagster UI, when a pipeline run is canceled, the "Re-execute" dropdown options still display "From failure", which is unintuitive since the run didn't technically fail. 

This PR improves the UX around run cancellations by treating them explicitly:
* **Dynamic Button Labels:** The "Re-execute" dropdown now dynamically reads "From cancellation" if the run was explicitly canceled, or reading "From failure" if the run actually failed.
* **Bulk Actions:** Added a new bulk action to the Runs page allowing users to "Re-execute from cancellation" for multiple canceled runs.
* **Smarter Defaults:** Updated the re-execute action logic. If a run has failed or been canceled, the default primary button now automatically displays the "From failure" or "From cancellation" action without requiring the user to open the dropdown menu.

## Test Plan

- **Manual Testing:** Spun up a local `dagster-webserver` and UI via `make dev_webapp`. Launched an asset materialization run and canceled it mid-execution. Verified that the primary UI button dynamically updated to "From cancellation". Repeated the same for a forced code failure to verify it still read "From failure".
- **Automated Tests:** Ran the full `@dagster-io/ui-core` Jest test suite locally. Verified all 1,309 tests passed successfully.

## Changelog

The "Re-execute" dropdown options now dynamically display "From cancellation" or "From failure" for unsuccessful runs, and will automatically set themselves as the default primary action for any runs that did not complete successfully. Closes #17754