### PR TITLE
Fix partitioned config for dg launch

### DIFF
--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -396,6 +396,8 @@ def execute_execute_command(
         if partition:
             job_def.validate_partition_key(partition, selected_asset_keys=None, context=context)
             partition_tags = job_def.get_tags_for_partition_key(partition, selected_asset_keys=None)
+            if not run_config:
+                run_config = job_def.get_run_config_for_partition_key(partition)
         elif partition_range:
             if len(partition_range.split("...")) != 2:
                 check.failed("Invalid partition range format. Expected <start>...<end>.")

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -376,6 +376,7 @@ def execute_execute_command(
     check.inst_param(instance, "instance", DagsterInstance)
 
     run_config = get_run_config_from_cli_opts(config, config_json)
+    has_explicit_run_config = bool(config) or config_json is not None
     normalized_tags = _normalize_cli_tags(tags)
     normalized_op_selection = _normalize_cli_op_selection(op_selection)
 
@@ -396,7 +397,7 @@ def execute_execute_command(
         if partition:
             job_def.validate_partition_key(partition, selected_asset_keys=None, context=context)
             partition_tags = job_def.get_tags_for_partition_key(partition, selected_asset_keys=None)
-            if not run_config:
+            if not has_explicit_run_config:
                 run_config = job_def.get_run_config_for_partition_key(partition)
         elif partition_range:
             if len(partition_range.split("...")) != 2:

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_launch_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_launch_commands.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -66,6 +67,42 @@ def _sample_job():
     @job()
     def my_configured_job():
         my_configured_op()
+
+
+def _sample_partitioned_asset_job():
+    from dagster import (
+        AssetExecutionContext,
+        Config,
+        DailyPartitionsDefinition,
+        Definitions,
+        PartitionedConfig,
+        RunConfig,
+        asset,
+        define_asset_job,
+    )
+
+    class MyAssetConfig(Config):
+        message: str = "ASSET_DEFAULT"
+
+    daily_partitions = DailyPartitionsDefinition(start_date="2024-01-01")
+
+    @asset(partitions_def=daily_partitions)
+    def my_partitioned_asset(context: AssetExecutionContext, config: MyAssetConfig):
+        context.log.info(f"CONFIG: {config.message}")
+
+    def run_config_for_partition(partition_key: str) -> RunConfig:
+        return RunConfig(ops={"my_partitioned_asset": MyAssetConfig(message="JOB_DEFAULT")})
+
+    my_partitioned_asset_job = define_asset_job(
+        "my_partitioned_asset_job",
+        selection=[my_partitioned_asset],
+        config=PartitionedConfig(
+            partitions_def=daily_partitions,
+            run_config_for_partition_key_fn=run_config_for_partition,
+        ),
+    )
+
+    defs = Definitions(assets=[my_partitioned_asset], jobs=[my_partitioned_asset_job])  # noqa: F841
 
 
 def _sample_single_job():
@@ -281,6 +318,34 @@ def test_launch_job_partitioned() -> None:
             assert "Started execution of run for" in result.stderr.decode("utf-8")
             assert "RUN_SUCCESS" in result.stderr.decode("utf-8")
             assert "PARTITION: 2024-01-01...2024-01-05" in result.stderr.decode("utf-8")
+
+
+def test_launch_partitioned_asset_job_uses_partitioned_config(tmp_path: Path) -> None:
+    definitions_path = tmp_path / "definitions.py"
+    defs_source = textwrap.dedent(
+        inspect.getsource(_sample_partitioned_asset_job).split("\n", 1)[1]
+    )
+    definitions_path.write_text(defs_source, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            str(Path(sys.executable).parent / "dg"),
+            "launch",
+            "--python-file",
+            str(definitions_path),
+            "--job",
+            "my_partitioned_asset_job",
+            "--partition",
+            "2024-01-01",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "CONFIG: JOB_DEFAULT" in result.stderr
 
 
 def test_launch_job_configured() -> None:

--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_launch_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_launch_commands.py
@@ -348,6 +348,36 @@ def test_launch_partitioned_asset_job_uses_partitioned_config(tmp_path: Path) ->
     assert "CONFIG: JOB_DEFAULT" in result.stderr
 
 
+def test_launch_partitioned_asset_job_keeps_explicit_empty_config(tmp_path: Path) -> None:
+    definitions_path = tmp_path / "definitions.py"
+    defs_source = textwrap.dedent(
+        inspect.getsource(_sample_partitioned_asset_job).split("\n", 1)[1]
+    )
+    definitions_path.write_text(defs_source, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            str(Path(sys.executable).parent / "dg"),
+            "launch",
+            "--python-file",
+            str(definitions_path),
+            "--job",
+            "my_partitioned_asset_job",
+            "--partition",
+            "2024-01-01",
+            "--config-json",
+            "{}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "CONFIG: ASSET_DEFAULT" in result.stderr
+
+
 def test_launch_job_configured() -> None:
     with (
         ProxyRunner.test() as runner,


### PR DESCRIPTION
## Summary
- apply the job's partitioned run config when `dg launch --partition` has no explicit run config
- preserve explicit CLI config precedence
- add a direct CLI regression covering a partitioned asset job

## Validation
- `make ruff`
- `pytest dagster_dg_cli_tests/cli_tests/test_launch_commands.py -k partitioned_asset_job_uses_partitioned_config -q`

Fixes #34045