### PR TITLE
fix: drop unused dagster-k8s google auth dependency

### DIFF
--- a/python_modules/libraries/dagster-k8s/pyproject.toml
+++ b/python_modules/libraries/dagster-k8s/pyproject.toml
@@ -12,9 +12,6 @@ requires-python = ">=3.10,<3.15"
 dependencies = [
     "dagster==1!0+dev",
     "kubernetes<37",
-    # exclude a google-auth release that added an overly restrictive urllib3 pin
-    # that confuses dependency resolvers
-    "google-auth!=2.23.1",
 ]
 
 [project.urls]

--- a/python_modules/libraries/dagster-k8s/uv.lock
+++ b/python_modules/libraries/dagster-k8s/uv.lock
@@ -1211,7 +1211,6 @@ version = "1!0+dev"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },
-    { name = "google-auth" },
     { name = "kubernetes", version = "12.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-11-dagster-k8s-test-kubernetes-12' or (extra == 'group-11-dagster-k8s-test-kubernetes-35' and extra == 'group-11-dagster-k8s-test-kubernetes-36')" },
     { name = "kubernetes", version = "35.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-11-dagster-k8s-test-kubernetes-35' or (extra == 'group-11-dagster-k8s-test-kubernetes-12' and extra == 'group-11-dagster-k8s-test-kubernetes-36')" },
     { name = "kubernetes", version = "36.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-11-dagster-k8s-test-kubernetes-36' or (extra == 'group-11-dagster-k8s-test-kubernetes-12' and extra == 'group-11-dagster-k8s-test-kubernetes-35') or (extra != 'group-11-dagster-k8s-test-kubernetes-12' and extra != 'group-11-dagster-k8s-test-kubernetes-35')" },
@@ -1245,7 +1244,6 @@ test-kubernetes-36 = [
 [package.metadata]
 requires-dist = [
     { name = "dagster", editable = "../../dagster" },
-    { name = "google-auth", specifier = "!=2.23.1" },
     { name = "kubernetes", specifier = "<37" },
 ]
 


### PR DESCRIPTION
## Summary
- remove the unused direct `google-auth` dependency from `dagster-k8s`
- retain `google-auth` only where the Kubernetes client test matrix requires it

## Validation
- `make ruff`
- `uv sync --no-dev --frozen` followed by an import-spec assertion confirming the default environment does not install `google-auth`

Closes #34035