### PR TITLE
Fix provenance for observed partitioned source assets

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/data_version_cache.py
+++ b/python_modules/dagster/dagster/_core/execution/context/data_version_cache.py
@@ -125,7 +125,11 @@ class DataVersionCache:
                     # constraint should be removed when we have thoroughly examined the performance of
                     # the data version retrieval query and can guarantee decent performance.
                     if len(input_keys) < SKIP_PARTITION_DATA_VERSION_DEPENDENCY_THRESHOLD:
-                        data_version = self._get_partitions_data_version_from_keys(key, input_keys)
+                        data_version = self._get_partitions_data_version_from_keys(
+                            key,
+                            input_keys,
+                            check.not_none(event.event_log_entry.dagster_event).event_type,
+                        )
                     else:
                         data_version = extract_data_version_from_entry(event.event_log_entry)
                 else:
@@ -185,13 +189,10 @@ class DataVersionCache:
             )
 
     def _get_partitions_data_version_from_keys(
-        self, key: AssetKey, partition_keys: Sequence[str]
+        self, key: AssetKey, partition_keys: Sequence[str], event_type: "DagsterEventType"
     ) -> "DataVersion":
         from dagster._core.definitions.data_version import DataVersion
-        from dagster._core.events import DagsterEventType
 
-        # TODO: this needs to account for observations also
-        event_type = DagsterEventType.ASSET_MATERIALIZATION
         tags_by_partition = self._context.instance._event_storage.get_latest_tags_by_partition(  # noqa: SLF001
             key, event_type, [DATA_VERSION_TAG], asset_partitions=list(partition_keys)
         )

--- a/python_modules/dagster/dagster_tests/execution_tests/versioning_tests/test_data_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/versioning_tests/test_data_versions.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime, timedelta
+from hashlib import sha256
 from random import randint
 from unittest import mock
 
@@ -87,6 +88,43 @@ def test_source_asset_versioned_asset():
 
     mat1, mat2 = materialize_twice([source1, asset1], asset1, instance)
     assert_same_versions(mat1, mat2, "abc")
+
+
+def test_partitioned_observable_source_data_versions_are_used_for_input_provenance():
+    datasets = dg.StaticPartitionsDefinition(["a", "b"])
+    codes = dg.StaticPartitionsDefinition(["c", "d"])
+    downstream_partitions = dg.MultiPartitionsDefinition({"datasets": datasets, "codes": codes})
+
+    @dg.observable_source_asset(partitions_def=datasets)
+    def dataset_source():
+        return dg.DataVersionsByPartition({"a": "1", "b": "2"})
+
+    @dg.observable_source_asset(partitions_def=codes)
+    def code_source():
+        return dg.DataVersionsByPartition({"c": "3", "d": "4"})
+
+    @dg.asset(partitions_def=downstream_partitions, deps=[dataset_source, code_source])
+    def downstream(): ...
+
+    with dg.instance_for_test() as instance:
+        observe([dataset_source], instance=instance)
+        observe([code_source], instance=instance)
+        result = dg.materialize(
+            [dataset_source, code_source, downstream],
+            selection=[downstream],
+            partition_key=dg.MultiPartitionKey({"datasets": "a", "codes": "c"}),
+            instance=instance,
+        )
+
+    materialization = result.asset_materializations_for_node("downstream")[0]
+    assert (
+        get_upstream_version_from_mat_provenance(materialization, dataset_source.key)
+        == sha256(b"1").hexdigest()
+    )
+    assert (
+        get_upstream_version_from_mat_provenance(materialization, code_source.key)
+        == sha256(b"3").hexdigest()
+    )
 
 
 def test_source_asset_non_versioned_asset_deps():


### PR DESCRIPTION
## Summary
- query partition data-version tags using the event type that supplied the selected upstream record
- preserve the existing materialization behavior while supporting `ASSET_OBSERVATION` records from partitioned observable source assets
- add a regression covering two differently partitioned observable sources feeding a multipartitioned downstream asset

## Validation
- `uv run --frozen --project python_modules/dagster --extra test pytest python_modules/dagster/dagster_tests/execution_tests/versioning_tests/test_data_versions.py -k partitioned_observable_source_data_versions_are_used_for_input_provenance -q`
- `uv run --frozen --project python_modules/dagster --extra test ruff check --fix .`
- `uv run --frozen --project python_modules/dagster --extra test ruff format .`
- `git diff --check`

Closes #33988.