### PR TITLE
fix(dlt): do not mutate live schema when extracting table metadata

### DIFF
--- a/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt/resource.py
@@ -80,7 +80,11 @@ class DagsterDltResource(ConfigurableResource):
                             other=[*column.keys()],  # e.g. "primary_key" or "foreign_key"
                         ),
                     )
-                    for column in schema.get_table_columns(table_name).values()
+                    for column in (
+                        # copy so the pop() calls below do not mutate the live dlt schema
+                        dict(c)
+                        for c in schema.get_table_columns(table_name).values()
+                    )
                 ]
             )
         except KeyError:

--- a/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_fetch_metadata.py
+++ b/python_modules/libraries/dagster-dlt/dagster_dlt_tests/test_fetch_metadata.py
@@ -127,3 +127,26 @@ def test_fetch_row_count_failure(dlt_pipeline: Pipeline):
             for asset_materialization in asset_materializations
         ]
         assert not any(["dagster/row_count" in metadata for metadata in metadatas]), str(metadatas)
+
+
+def test_extract_resource_metadata_does_not_mutate_dlt_schema(dlt_pipeline: Pipeline) -> None:
+    """Regression test for #34052: extracting table schema metadata must not pop keys
+    off the live dlt schema, or downstream runs re-derive columns from data and
+    `dataset()` sees them as incomplete.
+    """
+    @dlt_assets(dlt_source=pipeline(), dlt_pipeline=dlt_pipeline)
+    def example_pipeline_assets(
+        context: AssetExecutionContext, dlt_pipeline_resource: DagsterDltResource
+    ):
+        yield from dlt_pipeline_resource.run(context=context)
+
+    res = materialize(
+        [example_pipeline_assets],
+        resources={"dlt_pipeline_resource": DagsterDltResource()},
+    )
+    assert res.success
+
+    repos = dlt_pipeline.default_schema.get_table("repos")
+    for col_name, column in repos["columns"].items():
+        assert column.get("name") == col_name, f"column {col_name} lost its inner name"
+        assert "data_type" in column, f"column {col_name} lost its data_type"


### PR DESCRIPTION
## Summary

`DagsterDltResource._extract_table_schema_metadata` popped keys (`name`, `data_type`, `nullable`, `unique`) off the **live** dlt column dicts returned by `schema.get_table_columns(...)`, mutating the pipeline's schema in place.

Fixes #34052.

## Impact

After `extract_resource_metadata` ran, the live schema's columns had lost `name`, `data_type`, `nullable`, and `unique`. Downstream this caused:

- dlt re-deriving those columns from data on every subsequent run (the popped hints were gone);
- `dlt.dataset(...)` seeing the affected columns as incomplete / invisible (no `data_type`);
- any naming normalization on the mutated schema raising `KeyError: 'name'` (reported upstream as dlt-hub/dlt#4253).

## Fix

Iterate over shallow copies of the column dicts so the `pop()` calls cannot reach the live schema:

```python
for column in (
    dict(c)
    for c in schema.get_table_columns(table_name).values()
)
```

## Test

`test_extract_resource_metadata_does_not_mutate_dlt_schema` materializes a dagster-dlt asset backed by a duckdb pipeline, then asserts the live schema's columns still carry `name` and `data_type`. Fails on the previous code (columns stripped), passes with the fix.
