### PR TITLE
[dagster-ui] Abort sensor tick apply on dynamic partition permission errors

### DIFF
--- a/js_modules/ui-core/src/app/Permissions.tsx
+++ b/js_modules/ui-core/src/app/Permissions.tsx
@@ -61,6 +61,7 @@ export type PermissionsFromJSON = {
   edit_app_managed_components?: PermissionResult;
   refresh_component_state?: PermissionResult;
   edit_workspace?: PermissionResult;
+  edit_dynamic_partitions?: PermissionResult;
 };
 
 export const DEFAULT_DISABLED_REASON = 'Insufficient permissions';
@@ -115,6 +116,7 @@ export const extractPermissions = (
     canEditConcurrencyLimit: permissionOrFallback('edit_concurrency_limit'),
     canEditWorkspace: permissionOrFallback('edit_workspace'),
     canUpdateSensorCursor: permissionOrFallback('update_sensor_cursor'),
+    canEditDynamicPartitions: permissionOrFallback('edit_dynamic_partitions'),
   };
 };
 

--- a/js_modules/ui-core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/ui-core/src/ticks/SensorDryRunDialog.tsx
@@ -29,6 +29,7 @@ import {
   SensorDryRunMutationVariables,
 } from './types/SensorDryRunDialog.types';
 import {showCustomAlert} from '../app/CustomAlertProvider';
+import {usePermissionsForLocation} from '../app/Permissions';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {assertUnreachable} from '../app/Util';
@@ -89,6 +90,11 @@ export const SensorDryRunDialog = (props: Props) => {
 
 const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Props) => {
   const trackEvent = useTrackEvent();
+
+  const {
+    permissions: {canEditDynamicPartitions},
+    disabledReasons: {canEditDynamicPartitions: canEditDynamicPartitionsDisabledReason},
+  } = usePermissionsForLocation(repoAddress.location);
 
   const [sensorDryRun] = useMutation<SensorDryRunMutation, SensorDryRunMutationVariables>(
     EVALUATE_SENSOR_MUTATION,
@@ -223,6 +229,21 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
       return;
     }
 
+    // Preflight: partition mutations fire in parallel, so a mid-flight failure
+    // would leave successful siblings committed. For the common Launcher-role
+    // case (missing EDIT_DYNAMIC_PARTITIONS applies uniformly to all requests
+    // for this location), bail before any mutation dispatches to keep the
+    // apply atomic — no partitions created or deleted, no runs launched.
+    if (dynamicPartitionRequests?.length && !canEditDynamicPartitions) {
+      showCustomAlert({
+        title: 'Insufficient permissions',
+        body:
+          canEditDynamicPartitionsDisabledReason ||
+          'You do not have permission to create or delete dynamic partitions for this code location.',
+      });
+      return;
+    }
+
     trackEvent('launch-all-sensor');
     setLaunching(true);
 
@@ -323,6 +344,8 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
     onClose();
   }, [
     canApply,
+    canEditDynamicPartitions,
+    canEditDynamicPartitionsDisabledReason,
     createPartition,
     deletePartition,
     dynamicPartitionRequests,

--- a/js_modules/ui-core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/ui-core/src/ticks/SensorDryRunDialog.tsx
@@ -92,9 +92,16 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
   const trackEvent = useTrackEvent();
 
   const {
-    permissions: {canEditDynamicPartitions},
-    disabledReasons: {canEditDynamicPartitions: canEditDynamicPartitionsDisabledReason},
+    permissions: {canEditDynamicPartitions: _canEditDynamicPartitions},
+    disabledReasons: {canEditDynamicPartitions: _canEditDynamicPartitionsDisabledReason},
   } = usePermissionsForLocation(repoAddress.location);
+  // TEMP: manual repro for ASSIST-163. OSS webserver grants all perms, so the
+  // preflight is inert without this. Revert this commit before merging.
+  const canEditDynamicPartitions = false;
+  const canEditDynamicPartitionsDisabledReason =
+    'TEMP: simulated Launcher role (missing EDIT_DYNAMIC_PARTITIONS)';
+  void _canEditDynamicPartitions;
+  void _canEditDynamicPartitionsDisabledReason;
 
   const [sensorDryRun] = useMutation<SensorDryRunMutation, SensorDryRunMutationVariables>(
     EVALUATE_SENSOR_MUTATION,

--- a/js_modules/ui-core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/ui-core/src/ticks/SensorDryRunDialog.tsx
@@ -92,16 +92,9 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
   const trackEvent = useTrackEvent();
 
   const {
-    permissions: {canEditDynamicPartitions: _canEditDynamicPartitions},
-    disabledReasons: {canEditDynamicPartitions: _canEditDynamicPartitionsDisabledReason},
+    permissions: {canEditDynamicPartitions},
+    disabledReasons: {canEditDynamicPartitions: canEditDynamicPartitionsDisabledReason},
   } = usePermissionsForLocation(repoAddress.location);
-  // TEMP: manual repro for ASSIST-163. OSS webserver grants all perms, so the
-  // preflight is inert without this. Revert this commit before merging.
-  const canEditDynamicPartitions = false;
-  const canEditDynamicPartitionsDisabledReason =
-    'TEMP: simulated Launcher role (missing EDIT_DYNAMIC_PARTITIONS)';
-  void _canEditDynamicPartitions;
-  void _canEditDynamicPartitionsDisabledReason;
 
   const [sensorDryRun] = useMutation<SensorDryRunMutation, SensorDryRunMutationVariables>(
     EVALUATE_SENSOR_MUTATION,

--- a/js_modules/ui-core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/ui-core/src/ticks/SensorDryRunDialog.tsx
@@ -16,7 +16,7 @@ import {
   Tooltip,
   showToast,
 } from '@dagster-io/ui-components';
-import {useCallback, useMemo, useState} from 'react';
+import {ReactNode, useCallback, useMemo, useState} from 'react';
 import {Link} from 'react-router-dom';
 
 import {DynamicPartitionRequests} from './DynamicPartitionRequests';
@@ -228,12 +228,14 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
 
     try {
       if (dynamicPartitionRequests?.length) {
+        const partitionErrors: Array<{title: string; body: ReactNode}> = [];
+
         await Promise.all(
           dynamicPartitionRequests.map(async (request) => {
             if (request.type === DynamicPartitionsRequestType.ADD_PARTITIONS) {
               await Promise.all(
                 (request.partitionKeys || []).map(async (partitionKey) => {
-                  await createPartition({
+                  const result = await createPartition({
                     variables: {
                       repositorySelector: {
                         repositoryName: repoAddress.name,
@@ -243,10 +245,32 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
                       partitionKey,
                     },
                   });
+                  const data = result.data?.addDynamicPartition;
+                  switch (data?.__typename) {
+                    case 'AddDynamicPartitionSuccess':
+                    // Daemon silently skips partitions that already exist; do the same
+                    // in the UI so re-applying the same tick is not treated as a failure.
+                    case 'DuplicateDynamicPartitionError':
+                      return;
+                    case 'UnauthorizedError':
+                      partitionErrors.push({
+                        title: 'Insufficient permissions',
+                        body:
+                          data.message ??
+                          'You do not have permission to create dynamic partitions.',
+                      });
+                      return;
+                    case 'PythonError':
+                      partitionErrors.push({
+                        title: 'Could not add partition',
+                        body: <PythonErrorInfo error={data} />,
+                      });
+                      return;
+                  }
                 }),
               );
             } else if (request.partitionKeys && request.partitionKeys.length) {
-              await deletePartition({
+              const result = await deletePartition({
                 variables: {
                   repositorySelector: {
                     repositoryName: repoAddress.name,
@@ -256,9 +280,36 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
                   partitionKeys: request.partitionKeys,
                 },
               });
+              const data = result.data?.deleteDynamicPartitions;
+              switch (data?.__typename) {
+                case 'DeleteDynamicPartitionsSuccess':
+                  return;
+                case 'UnauthorizedError':
+                  partitionErrors.push({
+                    title: 'Insufficient permissions',
+                    body:
+                      data.message ?? 'You do not have permission to delete dynamic partitions.',
+                  });
+                  return;
+                case 'PythonError':
+                  partitionErrors.push({
+                    title: 'Could not delete partitions',
+                    body: <PythonErrorInfo error={data} />,
+                  });
+                  return;
+              }
             }
           }),
         );
+
+        const firstPartitionError = partitionErrors[0];
+        if (firstPartitionError) {
+          // A dynamic partition request failed — do not launch runs against
+          // partitions that don't exist, and do not commit the tick.
+          showCustomAlert({title: firstPartitionError.title, body: firstPartitionError.body});
+          setLaunching(false);
+          return;
+        }
       }
       if (executionParamsList) {
         await launchMultipleRunsWithTelemetry({executionParamsList}, 'toast');

--- a/js_modules/ui-core/src/ticks/__fixtures__/SensorDryRunDialog.fixtures.tsx
+++ b/js_modules/ui-core/src/ticks/__fixtures__/SensorDryRunDialog.fixtures.tsx
@@ -15,9 +15,11 @@ import {
   buildSensor,
   buildSensorData,
   buildTickEvaluation,
+  buildUnauthorizedError,
 } from '../../graphql/builders';
 import {DynamicPartitionsRequestType, InstigationStatus, RunStatus} from '../../graphql/types';
 import {UI_EXECUTION_TAGS} from '../../launchpad/uiExecutionTags';
+import {buildCreatePartitionMutation} from '../../partitions/__fixtures__/CreatePartitionDialog.fixture';
 import {LAUNCH_MULTIPLE_RUNS_MUTATION} from '../../runs/RunUtils';
 import {LaunchMultipleRunsMutation} from '../../runs/types/RunUtils.types';
 import {SET_CURSOR_MUTATION} from '../../sensors/EditCursorDialog';
@@ -378,6 +380,54 @@ export const SensorLaunchAllMutation: MockedResponse<LaunchMultipleRunsMutation>
     },
   },
 };
+
+export const SensorDryRunMutationWithDynamicPartitionRequest: MockedResponse<SensorDryRunMutation> =
+  {
+    request: {
+      query: EVALUATE_SENSOR_MUTATION,
+      variables: {
+        selectorData: {
+          sensorName: 'test',
+          repositoryLocationName: 'testLocation',
+          repositoryName: 'testName',
+        },
+        cursor: 'testCursortesting123',
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        sensorDryRun: buildDryRunInstigationTick({
+          evaluationResult: buildTickEvaluation({
+            cursor: 'a new cursor',
+            runRequests,
+            error: null,
+            dynamicPartitionsRequests: [
+              buildDynamicPartitionRequest({
+                partitionKeys: ['unauthorized_key'],
+                partitionsDefName: 'colors',
+                type: DynamicPartitionsRequestType.ADD_PARTITIONS,
+              }),
+            ],
+          }),
+        }),
+      },
+    },
+  };
+
+export const AddDynamicPartitionUnauthorizedMock = buildCreatePartitionMutation({
+  variables: {
+    partitionsDefName: 'colors',
+    partitionKey: 'unauthorized_key',
+    repositorySelector: {
+      repositoryLocationName: 'testLocation',
+      repositoryName: 'testName',
+    },
+  },
+  data: buildUnauthorizedError({
+    message: 'You do not have permission to create dynamic partitions.',
+  }),
+});
 
 export const SensorDryRunMutationDynamicPartitionsOnly: MockedResponse<SensorDryRunMutation> = {
   request: {

--- a/js_modules/ui-core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
+++ b/js_modules/ui-core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import {MemoryRouter, useHistory} from 'react-router-dom';
 
 import {Resolvers} from '../../apollo-client';
+import * as CustomAlertProvider from '../../app/CustomAlertProvider';
 import {useTrackEvent} from '../../app/analytics';
 import {SensorDryRunDialog} from '../SensorDryRunDialog';
 import * as Mocks from '../__fixtures__/SensorDryRunDialog.fixtures';
@@ -24,6 +25,11 @@ jest.mock('react-router-dom', () => ({
 // Mocking useTrackEvent
 jest.mock('../../app/analytics', () => ({
   useTrackEvent: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../../app/CustomAlertProvider', () => ({
+  CustomAlertProvider: jest.fn(({children}) => children),
+  showCustomAlert: jest.fn(),
 }));
 
 const onCloseMock = jest.fn();
@@ -157,6 +163,51 @@ describe('SensorDryRunTest', () => {
     // Should show "Apply requests & commit tick result", not just "Commit tick result"
     expect(await screen.findByTestId('launch-all')).toBeVisible();
     expect(screen.queryByTestId('commit-tick-result')).toBe(null);
+  });
+
+  it('does not launch runs when a dynamic partition request fails with UnauthorizedError', async () => {
+    // Regression test: a Launcher-role user (lacks EDIT_DYNAMIC_PARTITIONS) previously
+    // saw the partition mutation silently fail while the runs launched anyway,
+    // producing a DagsterInvalidInvocationError against a nonexistent partition.
+    const showCustomAlertSpy = jest.spyOn(CustomAlertProvider, 'showCustomAlert');
+    showCustomAlertSpy.mockClear();
+    onCloseMock.mockClear();
+
+    (useHistory as jest.Mock).mockReturnValue({push: jest.fn(), createHref: jest.fn()});
+    (useTrackEvent as jest.Mock).mockReturnValue(jest.fn());
+
+    const user = userEvent.setup();
+    render(
+      <Test
+        mocks={[
+          Mocks.SensorDryRunMutationWithDynamicPartitionRequest,
+          Mocks.AddDynamicPartitionUnauthorizedMock,
+          // Intentionally no SensorLaunchAllMutation mock — if the fix is wrong
+          // the test will fail loudly on the unmatched launch mutation.
+        ]}
+      />,
+    );
+
+    const cursorInput = await screen.findByTestId('cursor-input');
+    await user.type(cursorInput, 'testing123');
+    await user.click(screen.getByTestId('continue'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('launch-all')).not.toBeDisabled();
+    });
+
+    await user.click(screen.getByTestId('launch-all'));
+
+    await waitFor(() => {
+      expect(showCustomAlertSpy).toHaveBeenCalledWith({
+        title: 'Insufficient permissions',
+        body: 'You do not have permission to create dynamic partitions.',
+      });
+    });
+
+    // The dialog must remain open so the user can see the failure — Apply is
+    // effectively a no-op when partition creation is unauthorized.
+    expect(onCloseMock).not.toHaveBeenCalled();
   });
 
   it('launches all runs for 1 runrequest with undefined job name in the runrequest', async () => {

--- a/js_modules/ui-core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
+++ b/js_modules/ui-core/src/ticks/__tests__/SensorDryRunDialog.test.tsx
@@ -6,6 +6,7 @@ import {MemoryRouter, useHistory} from 'react-router-dom';
 import {Resolvers} from '../../apollo-client';
 import * as CustomAlertProvider from '../../app/CustomAlertProvider';
 import {useTrackEvent} from '../../app/analytics';
+import {TestPermissionsProvider} from '../../testing/TestPermissions';
 import {SensorDryRunDialog} from '../SensorDryRunDialog';
 import * as Mocks from '../__fixtures__/SensorDryRunDialog.fixtures';
 
@@ -34,21 +35,42 @@ jest.mock('../../app/CustomAlertProvider', () => ({
 
 const onCloseMock = jest.fn();
 
-function Test({mocks, resolvers}: {mocks?: MockedResponse[]; resolvers?: Resolvers}) {
+function Test({
+  mocks,
+  resolvers,
+  canEditDynamicPartitions = true,
+}: {
+  mocks?: MockedResponse[];
+  resolvers?: Resolvers;
+  canEditDynamicPartitions?: boolean;
+}) {
   return (
     <MemoryRouter>
       <MockedProvider mocks={mocks} resolvers={resolvers}>
-        <SensorDryRunDialog
-          name="test"
-          onClose={onCloseMock}
-          isOpen={true}
-          repoAddress={{
-            name: 'testName',
-            location: 'testLocation',
+        <TestPermissionsProvider
+          locationOverrides={{
+            testLocation: {
+              canEditDynamicPartitions: {
+                enabled: canEditDynamicPartitions,
+                disabledReason: canEditDynamicPartitions
+                  ? ''
+                  : 'You do not have permission to create dynamic partitions.',
+              },
+            },
           }}
-          jobName="testJobName"
-          currentCursor="testCursor"
-        />
+        >
+          <SensorDryRunDialog
+            name="test"
+            onClose={onCloseMock}
+            isOpen={true}
+            repoAddress={{
+              name: 'testName',
+              location: 'testLocation',
+            }}
+            jobName="testJobName"
+            currentCursor="testCursor"
+          />
+        </TestPermissionsProvider>
       </MockedProvider>
     </MemoryRouter>
   );
@@ -165,10 +187,11 @@ describe('SensorDryRunTest', () => {
     expect(screen.queryByTestId('commit-tick-result')).toBe(null);
   });
 
-  it('does not launch runs when a dynamic partition request fails with UnauthorizedError', async () => {
-    // Regression test: a Launcher-role user (lacks EDIT_DYNAMIC_PARTITIONS) previously
-    // saw the partition mutation silently fail while the runs launched anyway,
-    // producing a DagsterInvalidInvocationError against a nonexistent partition.
+  it('preflights EDIT_DYNAMIC_PARTITIONS and fires no mutations when the user lacks it', async () => {
+    // Regression test for Pylon 21598: a Launcher-role user previously saw the
+    // partition mutation silently fail while the runs launched anyway, producing
+    // a DagsterInvalidInvocationError against a nonexistent partition. The
+    // preflight makes the apply atomic — no partition ops fire and no runs launch.
     const showCustomAlertSpy = jest.spyOn(CustomAlertProvider, 'showCustomAlert');
     showCustomAlertSpy.mockClear();
     onCloseMock.mockClear();
@@ -179,11 +202,12 @@ describe('SensorDryRunTest', () => {
     const user = userEvent.setup();
     render(
       <Test
+        canEditDynamicPartitions={false}
         mocks={[
           Mocks.SensorDryRunMutationWithDynamicPartitionRequest,
-          Mocks.AddDynamicPartitionUnauthorizedMock,
-          // Intentionally no SensorLaunchAllMutation mock — if the fix is wrong
-          // the test will fail loudly on the unmatched launch mutation.
+          // No createPartition or launchMultipleRuns mock — if either fires,
+          // MockedProvider will fail the test on the unmatched request. This is
+          // the whole point of the preflight: no side effects at all.
         ]}
       />,
     );
@@ -205,8 +229,49 @@ describe('SensorDryRunTest', () => {
       });
     });
 
-    // The dialog must remain open so the user can see the failure — Apply is
-    // effectively a no-op when partition creation is unauthorized.
+    expect(onCloseMock).not.toHaveBeenCalled();
+  });
+
+  it('does not launch runs when a mid-flight partition mutation returns UnauthorizedError', async () => {
+    // Defense-in-depth: even if the preflight passes (permission racy or
+    // stale), the backend's UnauthorizedError return still aborts the flow
+    // before launchMultipleRuns fires and before the tick is committed.
+    const showCustomAlertSpy = jest.spyOn(CustomAlertProvider, 'showCustomAlert');
+    showCustomAlertSpy.mockClear();
+    onCloseMock.mockClear();
+
+    (useHistory as jest.Mock).mockReturnValue({push: jest.fn(), createHref: jest.fn()});
+    (useTrackEvent as jest.Mock).mockReturnValue(jest.fn());
+
+    const user = userEvent.setup();
+    render(
+      <Test
+        canEditDynamicPartitions={true}
+        mocks={[
+          Mocks.SensorDryRunMutationWithDynamicPartitionRequest,
+          Mocks.AddDynamicPartitionUnauthorizedMock,
+          // No SensorLaunchAllMutation mock — an unmatched request fails the test.
+        ]}
+      />,
+    );
+
+    const cursorInput = await screen.findByTestId('cursor-input');
+    await user.type(cursorInput, 'testing123');
+    await user.click(screen.getByTestId('continue'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('launch-all')).not.toBeDisabled();
+    });
+
+    await user.click(screen.getByTestId('launch-all'));
+
+    await waitFor(() => {
+      expect(showCustomAlertSpy).toHaveBeenCalledWith({
+        title: 'Insufficient permissions',
+        body: 'You do not have permission to create dynamic partitions.',
+      });
+    });
+
     expect(onCloseMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Bugfix to Pylon 21598 / ASSIST-163.
The correct fix here would be an atomic mutation but that's out of scope.

### Before
Can click this and queue up a
<img width="935" height="459" alt="Screenshot 2026-07-28 at 11 18 36 AM" src="https://github.com/user-attachments/assets/c0200cb2-ea7a-4937-a299-41a459295aed" />
 run

<img width="1285" height="1247" alt="Screenshot 2026-07-28 at 11 18 13 AM" src="https://github.com/user-attachments/assets/f1b7ae4c-e83c-4dab-9d0f-1da79bf978be" />

### After
<img width="1215" height="821" alt="Screenshot 2026-07-28 at 11 15 17 AM" src="https://github.com/user-attachments/assets/51236ef0-39e5-43d6-b20f-419fad3bb7d2" />


`SensorDryRunDialog`'s "Apply requests & commit tick result" flow launched runs even when `createPartition` / `deletePartition` failed. The backend returns `UnauthorizedError` / `PythonError` as members of the `AddDynamicPartitionResult` / `DeleteDynamicPartitionsResult` union — Apollo resolves the mutation "successfully" — and the frontend never checked `__typename`. For a user without `EDIT_DYNAMIC_PARTITIONS` (e.g. a Launcher-role user in Dagster+), the partition was silently not created and the run then failed at execution time with `DagsterInvalidInvocationError: Nonexistent partition keys`.

`onApply` now discriminates each mutation result:
- `AddDynamicPartitionSuccess` / `DeleteDynamicPartitionsSuccess` → continue
- `DuplicateDynamicPartitionError` → continue (matches the daemon's silent-skip-existing behavior in `_daemon/sensor.py`)
- `UnauthorizedError` / `PythonError` → `showCustomAlert`, abort before `launchMultipleRunsWithTelemetry`, do not commit the tick
  
## Test Plan

New regression test `does not launch runs when a dynamic partition request fails with UnauthorizedError` in `SensorDryRunDialog.test.tsx`:
- Dry-run returns both `runRequests` and `dynamicPartitionsRequests`.
- `createPartition` returns `UnauthorizedError`.
- Deliberately provides **no** `launchMultipleRuns` mock — if the regression returns, MockedProvider will fail the test on an unmatched mutation.
- Asserts `showCustomAlert` is called with "Insufficient permissions" and that the dialog stays open (`onClose` not called).

Local verification:
- `yarn tsgo` clean
- `yarn lint` clean
- All 8 `SensorDryRunDialog` tests pass

## Changelog

[dagster-ui] Fixed a bug where "Apply requests & commit tick result" on a sensor tick preview would launch runs even when the accompanying dynamic partition creation was unauthorized, producing runs that failed against nonexistent partitions. The Apply flow now surfaces the permission error and stops before launching runs or committing the tick.