### PR TITLE
Add Redis resource settings to Helm schema

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/redis.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/redis.py
@@ -1,5 +1,11 @@
 from pydantic import BaseModel
 
+from schema.charts.utils import kubernetes
+
+
+class RedisNode(BaseModel, extra="allow"):
+    resources: kubernetes.Resources | None = None
+
 
 class Redis(BaseModel, extra="allow"):
     enabled: bool
@@ -12,3 +18,5 @@ class Redis(BaseModel, extra="allow"):
     backendDbNumber: int
     brokerUrl: str
     backendUrl: str
+    master: RedisNode | None = None
+    slave: RedisNode | None = None

--- a/helm/dagster/schema/schema_tests/test_redis.py
+++ b/helm/dagster/schema/schema_tests/test_redis.py
@@ -18,6 +18,26 @@ def helm_template() -> HelmTemplate:
     )
 
 
+@pytest.fixture(name="redis_master_template")
+def redis_master_template() -> HelmTemplate:
+    return HelmTemplate(
+        helm_dir_path="helm/dagster",
+        subchart_paths=["charts/dagster-user-deployments"],
+        output="charts/redis/templates/redis-master-statefulset.yaml",
+        model=models.V1StatefulSet,
+    )
+
+
+@pytest.fixture(name="redis_slave_template")
+def redis_slave_template() -> HelmTemplate:
+    return HelmTemplate(
+        helm_dir_path="helm/dagster",
+        subchart_paths=["charts/dagster-user-deployments"],
+        output="charts/redis/templates/redis-slave-statefulset.yaml",
+        model=models.V1StatefulSet,
+    )
+
+
 def test_default_redis_config(template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(
         generateCeleryConfigSecret=True,
@@ -174,3 +194,51 @@ def test_celery_backend_override_only_one(template: HelmTemplate):
     assert secret.data["DAGSTER_CELERY_BACKEND_URL"] == base64.b64encode(
         bytes(custom_url, encoding="utf-8")
     ).decode("utf-8")
+
+
+def test_internal_redis_master_resources(redis_master_template: HelmTemplate):
+    resources = {
+        "limits": {"cpu": "200m", "memory": "256Mi"},
+        "requests": {"cpu": "100m", "memory": "128Mi"},
+    }
+
+    [stateful_set] = redis_master_template.render(
+        values_dict={
+            "redis": {
+                "enabled": True,
+                "internal": True,
+                "master": {"resources": resources},
+            }
+        }
+    )
+
+    assert (
+        redis_master_template.api_client.sanitize_for_serialization(
+            stateful_set.spec.template.spec.containers[0].resources
+        )
+        == resources
+    )
+
+
+def test_internal_redis_slave_resources(redis_slave_template: HelmTemplate):
+    resources = {
+        "limits": {"cpu": "200m", "memory": "256Mi"},
+        "requests": {"cpu": "100m", "memory": "128Mi"},
+    }
+
+    [stateful_set] = redis_slave_template.render(
+        values_dict={
+            "redis": {
+                "enabled": True,
+                "internal": True,
+                "slave": {"resources": resources},
+            }
+        }
+    )
+
+    assert (
+        redis_slave_template.api_client.sanitize_for_serialization(
+            stateful_set.spec.template.spec.containers[0].resources
+        )
+        == resources
+    )

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -2197,6 +2197,28 @@
                 "backendUrl": {
                     "title": "Backendurl",
                     "type": "string"
+                },
+                "master": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/RedisNode"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "slave": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/RedisNode"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
                 }
             },
             "required": [
@@ -2212,6 +2234,24 @@
                 "backendUrl"
             ],
             "title": "Redis",
+            "type": "object"
+        },
+        "RedisNode": {
+            "additionalProperties": true,
+            "properties": {
+                "resources": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Resources"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                }
+            },
+            "title": "RedisNode",
             "type": "object"
         },
         "ResourceRequirements": {

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -929,6 +929,14 @@ redis:
   brokerUrl: ""
   backendUrl: ""
 
+  # Set resources for the internal Redis master pod.
+  master:
+    resources: {}
+
+  # Set resources for the internal Redis slave pods.
+  slave:
+    resources: {}
+
 ####################################################################################################
 # Flower: (Optional) The flower web interface for diagnostics and debugging Celery queues & workers
 ####################################################################################################


### PR DESCRIPTION
Closes  #33953 & #29403 

## Summary & Motivation
Make it easier to configure CPU and memory resources for Dagster’s internal Redis.

The bundled Bitnami Redis chart already supports resource settings through `redis.master.resources` and `redis.slave.resources`, but these options were not shown in Dagster’s default values or schema.

This change adds those options to `values.yaml`, updates the generated schema, and adds tests to confirm the resource settings are applied to both Redis master and slave pods.

## Test Plan
**Manual Testing:** 
Deployed the Helm chart to a local Docker Desktop Kubernetes cluster with internal Redis enabled.
First, deployed without Redis resource settings and confirmed that the Redis master and slave pods had no CPU or memory requests or limits.

<img width="3462" height="543" alt="Image" src="https://github.com/user-attachments/assets/da4dee70-e0fe-4bd5-8779-557cb181d9d9" />

<img width="3710" height="813" alt="Image" src="https://github.com/user-attachments/assets/250569c3-fec1-423e-84d7-235d497948a7" /> 

Then, added `redis.master.resources` and `redis.slave.resources`, redeployed the chart, and verified with `kubectl` that both Redis pod specs contained the expected requests and limits.

<img width="1619" height="916" alt="Image" src="https://github.com/user-attachments/assets/0f706fde-f74b-458c-bc1b-4f74eddafec1" />

**Automated Testing:**
```bash
cd helm/dagster/schema
uv run --group test pytest schema_tests/test_redis.py -q
uv run --group test pytest schema_tests -q
```
## Changelog
Added Helm chart values for configuring CPU and memory resources for internal Redis master and slave pods.
