### PR TITLE
[docs] Replace stale pyright references with ty

### DIFF
--- a/docs/docs/about/contributing-docs/formatting-style.md
+++ b/docs/docs/about/contributing-docs/formatting-style.md
@@ -193,10 +193,10 @@ You can write additional tests for them in the `docs_snippets_test` folder. See 
 You can also write tests to regenerate and test CLI snippets in the `docs_snippets_test/snippet_checks` folder. See that folder for more information.
 
 To type-check the code snippets during development, run the following command from the Dagster root folder.
-This will run `pyright` on all new/changed files relative to the master branch.
+This will run `ty` on all new/changed files relative to the master branch.
 
 ```
-make quick_pyright
+make quick_ty
 ```
 
 ### Line selection

--- a/docs/docs/about/contributing-docs/formatting-style.md
+++ b/docs/docs/about/contributing-docs/formatting-style.md
@@ -192,12 +192,10 @@ You can write additional tests for them in the `docs_snippets_test` folder. See 
 
 You can also write tests to regenerate and test CLI snippets in the `docs_snippets_test/snippet_checks` folder. See that folder for more information.
 
-To type-check the code snippets during development, run the following command from the Dagster root folder.
-This will run `ty` on all new/changed files relative to the master branch.
-
-```
-make quick_ty
-```
+Note that `examples/docs_snippets` is excluded from the `ty` type-checking environment
+(see the `exclude` list in `ty/master/pyproject.toml`), so `make ty` and `make quick_ty`
+will not surface type errors in snippet code. Snippets are validated by the load tests
+described above.
 
 ### Line selection
 

--- a/docs/docs/about/contributing.md
+++ b/docs/docs/about/contributing.md
@@ -99,9 +99,10 @@ You can develop for Dagster using macOS, Linux, or Windows. If using Windows, yo
 
 Some notes on developing in Dagster:
 
-- **Ruff/Pyright**: We use [ruff](https://github.com/charliermarsh/ruff) for formatting, linting and import sorting, and [pyright](https://github.com/microsoft/pyright) for static type-checking. We test these in our CI/CD pipeline.
+- **Ruff/ty**: We use [ruff](https://github.com/charliermarsh/ruff) for formatting, linting and import sorting, and [ty](https://github.com/astral-sh/ty) for static type-checking. We test these in our CI/CD pipeline.
   - Run `make ruff` from the repo root to format, sort imports, and autofix some lint errors. It will also print out errors that need to be manually fixed.
-  - Run `make pyright` from the repo root to analyze the whole repo for type-correctness. Note that the first time you run this, it will take several minutes because a new virtualenv will be constructed.
+  - Run `make ty` from the repo root to analyze the whole repo for type-correctness. Note that the first time you run this, it will take several minutes because a new virtualenv will be constructed.
+  - Run `make quick_ty` to type-check only the files you have changed relative to `master`.
 - **Line Width**: We use a line width of 100.
 - **IDE**: We recommend setting up your IDE to format and check with ruff on save, but you can always run `make ruff` in the root Dagster directory before submitting a pull request. If you're also using VS Code, you can see what we're using for our `settings.json` [here](https://gist.github.com/natekupp/7a17a9df8d2064e5389cc84aa118a896).
 - **Docker**: Some tests require [Docker Desktop](https://www.docker.com/products/docker-desktop) to be able to run them locally.


### PR DESCRIPTION
## Summary & Motivation

I was setting up locally and `make pyright` failed. Turns out the repo moved to `ty`
a while back, but the contributing docs still tell you to run `make pyright` and
`make quick_pyright`. Neither target exists anymore.

Updated both spots to `make ty` / `make quick_ty`, and mentioned `quick_ty` in the
contributing guide since the full run takes a few minutes.

## Test Plan

- No `pyright` left anywhere under `docs/`
- `ty` and `quick_ty` targets confirmed in the `Makefile`
- `uv run scripts/check-frontmatter.py` passes

## Changelog

NOCHANGELOG