### PR TITLE
Relax dagster-dg-core tomlkit constraint

### DIFF
--- a/python_modules/dagster-test/dagster_test/dg_utils/utils.py
+++ b/python_modules/dagster-test/dagster_test/dg_utils/utils.py
@@ -620,7 +620,7 @@ def convert_pyproject_toml_to_dg_toml(pyproject_toml_path: Path, dg_toml_path: P
     """Convert a pyproject.toml file to a dg.toml file."""
     pyproject_toml = tomlkit.parse(pyproject_toml_path.read_text(encoding="utf-8"))
     dg_config = get_toml_node(pyproject_toml, ("tool", "dg"), tomlkit.items.Table)
-    dg_toml_path.write_text(tomlkit.dumps(dg_config), encoding="utf-8")
+    dg_toml_path.write_text(tomlkit.dumps(dg_config.unwrap()), encoding="utf-8")
     delete_toml_node(pyproject_toml, ("tool", "dg"))
 
     # Delete the pyproject.toml file if it is empty after removing the dg section

--- a/python_modules/libraries/dagster-dg-core/pyproject.toml
+++ b/python_modules/libraries/dagster-dg-core/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{name = "Dagster Labs", email = "hello@dagsterlabs.com"}]
 license = "Apache-2.0"
 dependencies = [
     "Jinja2",
-    "tomlkit<0.13.3",  # bug in this version
+    "tomlkit!=0.13.3,<0.16",  # bug in 0.13.3
     "click>=8,<9",
     "click-aliases",
     "typing_extensions>=4.4.0,<5",

--- a/python_modules/libraries/dagster-dg-core/uv.lock
+++ b/python_modules/libraries/dagster-dg-core/uv.lock
@@ -1014,7 +1014,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.1" },
     { name = "rich" },
     { name = "setuptools" },
-    { name = "tomlkit", specifier = "<0.13.3" },
+    { name = "tomlkit", specifier = "!=0.13.3,<0.16" },
     { name = "typer", specifier = ">=0.15.1,<1.0" },
     { name = "typing-extensions", specifier = ">=4.4.0,<5" },
     { name = "watchdog" },


### PR DESCRIPTION
## Summary
- relax dagster-dg-core's tomlkit dependency to allow newer 0.15.x releases while excluding the known-bad 0.13.3
- keep the dagster-dg-core lockfile diff minimal by only updating the package metadata constraint
- normalize dg test TOML conversion through plain mappings so converted dg.toml files remain root-shaped with newer tomlkit

Fixes #33943.

## Test Plan
- uv run --group test --with tomlkit==0.15.1 pytest ./dagster_dg_core_tests -x -q --ignore=./dagster_dg_core_tests/cli_tests/test_docs_commands.py --ignore=./dagster_dg_core_tests/cli_tests/plus_tests