### PR TITLE
[helm] Support podDisruptionBudget and topologySpreadConstraints for user code deployments

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -213,6 +213,9 @@ spec:
       nodeSelector: {{ $deployment.nodeSelector | toYaml | nindent 8 }}
       affinity: {{ $deployment.affinity | toYaml | nindent 8 }}
       tolerations: {{- $deployment.tolerations | toYaml | nindent 8 }}
+      {{- if $deployment.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- $deployment.topologySpreadConstraints | toYaml | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if $.Values.includeInstance }}
         - name: dagster-instance

--- a/helm/dagster/charts/dagster-user-deployments/templates/pdb-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/pdb-user.yaml
@@ -1,0 +1,37 @@
+{{ range $deployment := .Values.deployments }}
+{{- $pdb := $deployment.podDisruptionBudget | default dict }}
+{{- if $pdb.enabled }}
+{{- $hasMinAvailable := and (hasKey $pdb "minAvailable") (not (kindIs "invalid" $pdb.minAvailable)) }}
+{{- $hasMaxUnavailable := and (hasKey $pdb "maxUnavailable") (not (kindIs "invalid" $pdb.maxUnavailable)) }}
+{{- if and $hasMinAvailable $hasMaxUnavailable }}
+{{- fail (printf "deployment %q: podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable are mutually exclusive - set only one." $deployment.name) }}
+{{- end }}
+{{- if not (or $hasMinAvailable $hasMaxUnavailable) }}
+{{- fail (printf "deployment %q: podDisruptionBudget.enabled is true, but neither minAvailable nor maxUnavailable is set." $deployment.name) }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "dagster.fullname" $ -}}-{{- $deployment.name }}
+  labels:
+    {{- include "dagster.labels" $ | nindent 4 }}
+    component: user-deployments
+    deployment: {{ $deployment.name }}
+spec:
+  {{- if $hasMinAvailable }}
+  minAvailable: {{ $pdb.minAvailable }}
+  {{- end }}
+  {{- if $hasMaxUnavailable }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- end }}
+  {{- if $pdb.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ $pdb.unhealthyPodEvictionPolicy }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "dagster.selectorLabels" $ | nindent 6 }}
+      component: user-deployments
+      deployment: {{ $deployment.name }}
+---
+{{ end }}
+{{- end }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/pdb-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/pdb-user.yaml
@@ -9,7 +9,7 @@
 {{- if not (or $hasMinAvailable $hasMaxUnavailable) }}
 {{- fail (printf "deployment %q: podDisruptionBudget.enabled is true, but neither minAvailable nor maxUnavailable is set." $deployment.name) }}
 {{- end }}
-apiVersion: policy/v1
+apiVersion: {{ if or ($.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") (semverCompare ">=1.21-0" $.Capabilities.KubeVersion.Version) }}policy/v1{{ else }}policy/v1beta1{{ end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "dagster.fullname" $ -}}-{{- $deployment.name }}
@@ -24,7 +24,7 @@ spec:
   {{- if $hasMaxUnavailable }}
   maxUnavailable: {{ $pdb.maxUnavailable }}
   {{- end }}
-  {{- if $pdb.unhealthyPodEvictionPolicy }}
+  {{- if and $pdb.unhealthyPodEvictionPolicy (semverCompare ">=1.27-0" $.Capabilities.KubeVersion.Version) }}
   unhealthyPodEvictionPolicy: {{ $pdb.unhealthyPodEvictionPolicy }}
   {{- end }}
   selector:

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -306,6 +306,15 @@
             "title": "Tolerations",
             "type": "array"
         },
+        "TopologySpreadConstraints": {
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/topologySpreadConstraints",
+            "items": {
+                "additionalProperties": true,
+                "type": "object"
+            },
+            "title": "TopologySpreadConstraints",
+            "type": "array"
+        },
         "UserDeployment": {
             "properties": {
                 "name": {
@@ -466,6 +475,28 @@
                     "anyOf": [
                         {
                             "$ref": "#/$defs/Tolerations"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "topologySpreadConstraints": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TopologySpreadConstraints"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "podDisruptionBudget": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/UserDeploymentPodDisruptionBudget"
                         },
                         {
                             "type": "null"
@@ -664,6 +695,59 @@
                 "enabled"
             ],
             "title": "UserDeploymentIncludeConfigInLaunchedRuns",
+            "type": "object"
+        },
+        "UserDeploymentPodDisruptionBudget": {
+            "properties": {
+                "enabled": {
+                    "default": false,
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "minAvailable": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Minavailable"
+                },
+                "maxUnavailable": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Maxunavailable"
+                },
+                "unhealthyPodEvictionPolicy": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Unhealthypodevictionpolicy"
+                }
+            },
+            "title": "UserDeploymentPodDisruptionBudget",
             "type": "object"
         },
         "Volume": {

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -153,6 +153,19 @@ deployments:
     nodeSelector: {}
     affinity: {}
     tolerations: []
+    # Support topology spread constraints for user code pod assignment. See:
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    #
+    # Example:
+    #
+    # topologySpreadConstraints:
+    #   - maxSkew: 1
+    #     topologyKey: topology.kubernetes.io/zone
+    #     whenUnsatisfiable: ScheduleAnyway
+    #     labelSelector:
+    #       matchLabels:
+    #         deployment: k8s-example-user-code-1
+    topologySpreadConstraints: []
     podSecurityContext: {}
     securityContext: {}
     resources: {}
@@ -183,6 +196,16 @@ deployments:
     # Strategy to follow when replacing old pods with new pods. See:
     # https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
     deploymentStrategy: {}
+
+    # Creates a PodDisruptionBudget for the user code deployment, limiting how many of its
+    # pods can be down simultaneously due to voluntary disruptions (e.g. node drains). When
+    # enabled, exactly one of minAvailable or maxUnavailable must be set. See:
+    # https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+    podDisruptionBudget:
+      enabled: false
+      # minAvailable: ~
+      # maxUnavailable: 1
+      # unhealthyPodEvictionPolicy: AlwaysAllow
 
     service:
       annotations: {}

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -7,6 +7,13 @@ class UserDeploymentIncludeConfigInLaunchedRuns(BaseModel):
     enabled: bool
 
 
+class UserDeploymentPodDisruptionBudget(BaseModel):
+    enabled: bool = False
+    minAvailable: int | str | None = None
+    maxUnavailable: int | str | None = None
+    unhealthyPodEvictionPolicy: str | None = None
+
+
 ReadinessProbeWithEnabled = create_model(
     "ReadinessProbeWithEnabled", __base__=(kubernetes.ReadinessProbe), enabled=(bool, ...)
 )
@@ -28,6 +35,8 @@ class UserDeployment(BaseModel):
     nodeSelector: kubernetes.NodeSelector | None = None
     affinity: kubernetes.Affinity | None = None
     tolerations: kubernetes.Tolerations | None = None
+    topologySpreadConstraints: kubernetes.TopologySpreadConstraints | None = None
+    podDisruptionBudget: UserDeploymentPodDisruptionBudget | None = None
     podSecurityContext: kubernetes.PodSecurityContext | None = None
     securityContext: kubernetes.SecurityContext | None = None
     resources: kubernetes.Resources | None = None

--- a/helm/dagster/schema/schema/charts/utils/kubernetes.py
+++ b/helm/dagster/schema/schema/charts/utils/kubernetes.py
@@ -111,6 +111,21 @@ class Tolerations(RootModel[list[dict[str, Any]]]):
     model_config = {"json_schema_extra": _tolerations_schema_extra}
 
 
+def _topology_spread_constraints_schema_extra(
+    schema: dict[str, Any], _model: type["TopologySpreadConstraints"]
+) -> None:
+    schema.setdefault(
+        "$ref",
+        create_definition_ref("io.k8s.api.core.v1.PodSpec/properties/topologySpreadConstraints"),
+    )
+    if "items" in schema:
+        schema["items"]["additionalProperties"] = True
+
+
+class TopologySpreadConstraints(RootModel[list[dict[str, Any]]]):
+    model_config = {"json_schema_extra": _topology_spread_constraints_schema_extra}
+
+
 class PodSecurityContext(RootModel[dict[str, Any]]):
     model_config = {
         "json_schema_extra": {

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -12,6 +12,7 @@ from schema.charts.dagster_user_deployments.subschema.user_deployments import (
     ReadinessProbeWithEnabled,
     UserDeployment,
     UserDeploymentIncludeConfigInLaunchedRuns,
+    UserDeploymentPodDisruptionBudget,
     UserDeployments,
 )
 from schema.charts.dagster_user_deployments.values import DagsterUserDeploymentsHelmValues
@@ -46,6 +47,16 @@ def subchart_helm_template() -> HelmTemplate:
         subchart_paths=[],
         output="templates/deployment-user.yaml",
         model=models.V1Deployment,
+    )
+
+
+@pytest.fixture(name="pdb_template")
+def pdb_helm_template() -> HelmTemplate:
+    return HelmTemplate(
+        helm_dir_path="helm/dagster",
+        subchart_paths=["charts/dagster-user-deployments"],
+        output="charts/dagster-user-deployments/templates/pdb-user.yaml",
+        model=models.V1PodDisruptionBudget,
     )
 
 
@@ -1959,3 +1970,172 @@ def test_include_instance(subchart_template: HelmTemplate, include_instance: boo
         )
     else:
         assert "dagster-instance" not in volume_names
+
+
+def test_user_deployment_topology_spread_constraints(template: HelmTemplate):
+    deployment = create_simple_user_deployment("foo")
+    deployment.topologySpreadConstraints = kubernetes.TopologySpreadConstraints.parse_obj(
+        [
+            {
+                "maxSkew": 1,
+                "topologyKey": "topology.kubernetes.io/zone",
+                "whenUnsatisfiable": "ScheduleAnyway",
+                "labelSelector": {"matchLabels": {"deployment": "foo"}},
+            }
+        ]
+    )
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    [dagster_user_deployment] = template.render(helm_values)
+
+    constraints = dagster_user_deployment.spec.template.spec.topology_spread_constraints
+    assert len(constraints) == 1
+    assert constraints[0].max_skew == 1
+    assert constraints[0].topology_key == "topology.kubernetes.io/zone"
+    assert constraints[0].when_unsatisfiable == "ScheduleAnyway"
+    assert constraints[0].label_selector.match_labels == {"deployment": "foo"}
+
+
+def test_user_deployment_no_topology_spread_constraints(template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(
+            deployments=[create_simple_user_deployment("foo")]
+        )
+    )
+
+    [dagster_user_deployment] = template.render(helm_values)
+
+    assert dagster_user_deployment.spec.template.spec.topology_spread_constraints is None
+
+
+def _create_user_deployment_with_pdb(
+    name: str, pdb: UserDeploymentPodDisruptionBudget
+) -> UserDeployment:
+    deployment = create_simple_user_deployment(name)
+    deployment.podDisruptionBudget = pdb
+    return deployment
+
+
+def test_user_deployment_pod_disruption_budget_max_unavailable(pdb_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(
+            deployments=[
+                _create_user_deployment_with_pdb(
+                    "foo",
+                    UserDeploymentPodDisruptionBudget.construct(enabled=True, maxUnavailable=1),
+                )
+            ]
+        )
+    )
+
+    [pdb] = pdb_template.render(helm_values)
+
+    assert pdb.metadata.name == "release-name-dagster-user-deployments-foo"
+    assert pdb.spec.max_unavailable == 1
+    assert pdb.spec.min_available is None
+    assert pdb.spec.selector.match_labels == {
+        "app.kubernetes.io/name": "dagster-user-deployments",
+        "app.kubernetes.io/instance": "release-name",
+        "component": "user-deployments",
+        "deployment": "foo",
+    }
+
+
+def test_user_deployment_pod_disruption_budget_min_available(pdb_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(
+            deployments=[
+                _create_user_deployment_with_pdb(
+                    "foo",
+                    UserDeploymentPodDisruptionBudget.construct(
+                        enabled=True,
+                        minAvailable="50%",
+                        unhealthyPodEvictionPolicy="AlwaysAllow",
+                    ),
+                )
+            ]
+        )
+    )
+
+    [pdb] = pdb_template.render(helm_values)
+
+    assert pdb.spec.min_available == "50%"
+    assert pdb.spec.max_unavailable is None
+    assert pdb.spec.unhealthy_pod_eviction_policy == "AlwaysAllow"
+
+
+def test_user_deployment_pod_disruption_budget_multiple_deployments(pdb_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(
+            deployments=[
+                _create_user_deployment_with_pdb(
+                    "foo",
+                    UserDeploymentPodDisruptionBudget.construct(enabled=True, maxUnavailable=1),
+                ),
+                create_simple_user_deployment("bar"),
+                _create_user_deployment_with_pdb(
+                    "baz", UserDeploymentPodDisruptionBudget.construct(enabled=True, minAvailable=1)
+                ),
+            ]
+        )
+    )
+
+    pdbs = pdb_template.render(helm_values)
+
+    assert len(pdbs) == 2
+    assert [pdb.spec.selector.match_labels["deployment"] for pdb in pdbs] == ["foo", "baz"]
+
+
+def test_user_deployment_pod_disruption_budget_disabled(full_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(
+            deployments=[
+                _create_user_deployment_with_pdb(
+                    "foo",
+                    UserDeploymentPodDisruptionBudget.construct(enabled=False, maxUnavailable=1),
+                ),
+                create_simple_user_deployment("bar"),
+            ]
+        )
+    )
+
+    k8s_objects = full_template.render(helm_values)
+
+    assert not [obj for obj in k8s_objects if obj["kind"] == "PodDisruptionBudget"]
+
+
+def test_user_deployment_pod_disruption_budget_min_available_and_max_unavailable_fails(
+    pdb_template: HelmTemplate,
+):
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(
+            deployments=[
+                _create_user_deployment_with_pdb(
+                    "foo",
+                    UserDeploymentPodDisruptionBudget.construct(
+                        enabled=True, minAvailable=1, maxUnavailable=1
+                    ),
+                )
+            ]
+        )
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        pdb_template.render(helm_values)
+
+
+def test_user_deployment_pod_disruption_budget_no_budget_fails(pdb_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(
+            deployments=[
+                _create_user_deployment_with_pdb(
+                    "foo", UserDeploymentPodDisruptionBudget.construct(enabled=True)
+                )
+            ]
+        )
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        pdb_template.render(helm_values)

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -3099,6 +3099,15 @@
             "title": "Tolerations",
             "type": "array"
         },
+        "TopologySpreadConstraints": {
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/topologySpreadConstraints",
+            "items": {
+                "additionalProperties": true,
+                "type": "object"
+            },
+            "title": "TopologySpreadConstraints",
+            "type": "array"
+        },
         "UserDeployment": {
             "properties": {
                 "name": {
@@ -3259,6 +3268,28 @@
                     "anyOf": [
                         {
                             "$ref": "#/$defs/Tolerations"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "topologySpreadConstraints": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TopologySpreadConstraints"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "podDisruptionBudget": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/UserDeploymentPodDisruptionBudget"
                         },
                         {
                             "type": "null"
@@ -3457,6 +3488,59 @@
                 "enabled"
             ],
             "title": "UserDeploymentIncludeConfigInLaunchedRuns",
+            "type": "object"
+        },
+        "UserDeploymentPodDisruptionBudget": {
+            "properties": {
+                "enabled": {
+                    "default": false,
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "minAvailable": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Minavailable"
+                },
+                "maxUnavailable": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Maxunavailable"
+                },
+                "unhealthyPodEvictionPolicy": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Unhealthypodevictionpolicy"
+                }
+            },
+            "title": "UserDeploymentPodDisruptionBudget",
             "type": "object"
         },
         "UserDeployments": {

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -453,6 +453,19 @@ dagster-user-deployments:
       nodeSelector: {}
       affinity: {}
       tolerations: []
+      # Support topology spread constraints for user code pod assignment. See:
+      # https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+      #
+      # Example:
+      #
+      # topologySpreadConstraints:
+      #   - maxSkew: 1
+      #     topologyKey: topology.kubernetes.io/zone
+      #     whenUnsatisfiable: ScheduleAnyway
+      #     labelSelector:
+      #       matchLabels:
+      #         deployment: k8s-example-user-code-1
+      topologySpreadConstraints: []
       podSecurityContext: {}
       securityContext: {}
       resources: {}
@@ -483,6 +496,16 @@ dagster-user-deployments:
       # Strategy to follow when replacing old pods with new pods. See:
       # https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
       deploymentStrategy: {}
+
+      # Creates a PodDisruptionBudget for the user code deployment, limiting how many of its
+      # pods can be down simultaneously due to voluntary disruptions (e.g. node drains). When
+      # enabled, exactly one of minAvailable or maxUnavailable must be set. See:
+      # https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+      podDisruptionBudget:
+        enabled: false
+        # minAvailable: ~
+        # maxUnavailable: 1
+        # unhealthyPodEvictionPolicy: AlwaysAllow
 
       service:
         annotations: {}


### PR DESCRIPTION
## Summary & Motivation

User code deployments run the gRPC servers that the webserver and daemon depend on to load definitions. When a node drain it evicts all replicas of a code location at the same time, the location becomes unavailable (gRPC `UNAVAILABLE` in the UI) even when `replicaCount > 1`, because nothing prevents simultaneous voluntary disruptions and nothing spreads the replicas across nodes/zones.

This PR adds two per-deployment options to the `dagster-user-deployments` subchart:

- **`deployments[].podDisruptionBudget`** — renders a `policy/v1` PodDisruptionBudget targeting the code location's pods. `enabled`, `minAvailable`, `maxUnavailable`, and `unhealthyPodEvictionPolicy` are supported. The template fails at render time if both `minAvailable` and `maxUnavailable` are set (the Kubernetes API rejects that combination) or if neither is set, rather than letting the apply fail later.
- **`deployments[].topologySpreadConstraints`** — passed through to the user code Deployment's pod spec, alongside the existing `nodeSelector`/`affinity`/`tolerations`.

Example:

```yaml
dagster-user-deployments:
  deployments:
    - name: "my-code-location"
      replicaCount: 2
      podDisruptionBudget:
        enabled: true
        maxUnavailable: 1
      topologySpreadConstraints:
        - maxSkew: 1
          topologyKey: kubernetes.io/hostname
          whenUnsatisfiable: DoNotSchedule
          labelSelector:
            matchLabels:
              deployment: my-code-location
```

Schema models are updated accordingly and both `values.schema.json` files were regenerated with `dagster-helm schema apply`. Scope is limited to user code deployments; the same knobs could be added to the webserver/daemon deployments in a follow-up if there's interest.

## Test Plan

- 8 new tests in `schema_tests/test_user_deployments.py` covering: topology spread constraints rendered/omitted; PDB with `maxUnavailable`, with percentage `minAvailable` + `unhealthyPodEvictionPolicy`, multiple deployments (only enabled ones render a PDB), `enabled: false` renders nothing, and render failure for the two invalid configurations.
- Full `schema_tests/test_user_deployments.py` suite passes (89 tests).
- `helm lint` and manual `helm template` verification of the rendered PodDisruptionBudget and pod spec.

## Changelog

[helm] User code deployments now support `podDisruptionBudget` and `topologySpreadConstraints` per deployment.