### PR TITLE
Fix transitive dependency ordering for asset graph 

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -397,6 +397,18 @@ class _PlanBuilder:
         )
 
 
+def _is_same_computation_family(current_assets_def: object, ancestor_assets_def: object) -> bool:
+    if current_assets_def is None or ancestor_assets_def is None:
+        return False
+
+    current_computation = getattr(current_assets_def, "computation", None)
+    ancestor_computation = getattr(ancestor_assets_def, "computation", None)
+    if current_computation is None or ancestor_computation is None:
+        return False
+
+    return current_computation is ancestor_computation
+
+
 def _get_ordering_step_keys_for_view(
     input_asset_key: "AssetKey | None",
     asset_layer: AssetLayer,
@@ -423,11 +435,6 @@ def _get_ordering_step_keys_for_view(
     current_assets_def = asset_layer.get_assets_def_for_node(
         NodeHandle.from_string(current_step_key)
     )
-    current_node_def_name = (
-        current_assets_def.computation.node_def.name
-        if current_assets_def and current_assets_def.computation
-        else None
-    )
 
     ancestor_keys = asset_graph.get_non_virtual_ancestor_keys(input_asset_key)
     selected_keys = asset_layer.selected_asset_keys
@@ -441,15 +448,7 @@ def _get_ordering_step_keys_for_view(
                 continue
 
             ancestor_assets_def = asset_layer.get_assets_def_for_node(node_output_handle.node_handle)
-            ancestor_node_def_name = (
-                ancestor_assets_def.computation.node_def.name
-                if ancestor_assets_def and ancestor_assets_def.computation
-                else None
-            )
-            if (
-                current_node_def_name is not None
-                and current_node_def_name == ancestor_node_def_name
-            ):
+            if _is_same_computation_family(current_assets_def, ancestor_assets_def):
                 continue
 
             # Filter out self-references to prevent deadlock. This happens when

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -419,6 +419,16 @@ def _get_ordering_step_keys_for_view(
         asset_graph = asset_graph.source_asset_graph
     if not asset_graph.has(input_asset_key) or not asset_graph.get(input_asset_key).is_virtual:
         return set()
+
+    current_assets_def = asset_layer.get_assets_def_for_node(
+        NodeHandle.from_string(current_step_key)
+    )
+    current_node_def_name = (
+        current_assets_def.computation.node_def.name
+        if current_assets_def and current_assets_def.computation
+        else None
+    )
+
     ancestor_keys = asset_graph.get_non_virtual_ancestor_keys(input_asset_key)
     selected_keys = asset_layer.selected_asset_keys
     step_keys: set[str] = set()
@@ -426,6 +436,22 @@ def _get_ordering_step_keys_for_view(
         if ancestor_key in selected_keys:
             node_output_handle = asset_layer.get_op_output_handle(ancestor_key)
             step_key = str(node_output_handle.node_handle)
+
+            if step_key == current_step_key:
+                continue
+
+            ancestor_assets_def = asset_layer.get_assets_def_for_node(node_output_handle.node_handle)
+            ancestor_node_def_name = (
+                ancestor_assets_def.computation.node_def.name
+                if ancestor_assets_def and ancestor_assets_def.computation
+                else None
+            )
+            if (
+                current_node_def_name is not None
+                and current_node_def_name == ancestor_node_def_name
+            ):
+                continue
+
             # Filter out self-references to prevent deadlock. This happens when
             # a subsettable multi-asset has virtual intermediaries between its
             # own non-virtual outputs — the ancestor resolves to the same step.

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_view_transitive_deps.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_view_transitive_deps.py
@@ -7,6 +7,7 @@ C should still wait for A via ordering dependencies on the FromLoadableAsset inp
 import dagster as dg
 from dagster._core.definitions.assets.graph.asset_graph import AssetGraph
 from dagster._core.execution.api import create_execution_plan
+from dagster._core.execution.plan.plan import _is_same_computation_family
 from dagster._core.snap.execution_plan_snapshot import snapshot_from_execution_plan
 
 
@@ -130,6 +131,57 @@ def test_multiple_non_view_ancestors():
     assert "d" in deps
     assert "a" in deps["d"]
     assert "c" in deps["d"]
+
+
+def test_view_transitive_dep_keeps_ordering_for_distinct_nodes_with_same_name():
+    """A view transitive dependency should still create ordering deps when distinct
+    selected assets share a node definition name.
+    """
+
+    @dg.asset(key="ancestor")
+    def ancestor() -> None: ...
+
+    @dg.asset(deps=["ancestor"], is_virtual=True, key="view_asset")
+    def view_asset() -> None: ...
+
+    @dg.asset(key="downstream", deps=["view_asset"])
+    def downstream() -> None: ...
+
+    job = _resolve_job(
+        [ancestor, view_asset, downstream],
+        dg.define_asset_job(
+            "test_job", selection=dg.AssetSelection.assets("ancestor", "downstream")
+        ),
+    )
+
+    plan = create_execution_plan(job)
+    deps = plan.get_executable_step_deps()
+
+    assert "ancestor" in deps["downstream"]
+
+
+def test_same_computation_family_uses_computation_identity() -> None:
+    class _DummyComputation:
+        pass
+
+    class _DummyNodeDef:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    class _DummyAssetsDef:
+        def __init__(self, computation: object, name: str) -> None:
+            self.computation = computation
+            self.node_def = _DummyNodeDef(name)
+
+    current_computation = _DummyComputation()
+    ancestor_computation = _DummyComputation()
+
+    current_assets_def = _DummyAssetsDef(current_computation, "shared_name")
+    ancestor_assets_def = _DummyAssetsDef(ancestor_computation, "shared_name")
+    same_family_assets_def = _DummyAssetsDef(current_computation, "shared_name")
+
+    assert not _is_same_computation_family(current_assets_def, ancestor_assets_def)
+    assert _is_same_computation_family(current_assets_def, same_family_assets_def)
 
 
 def test_view_selected_no_ordering_deps():

--- a/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_view_transitive_deps.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_view_transitive_deps.py
@@ -222,3 +222,41 @@ def test_subsettable_multi_asset_no_self_dependency():
         assert step_key not in deps[step_key], (
             f"Step {step_key} has a self-dependency, which would cause a deadlock"
         )
+
+
+def test_subsettable_multi_asset_sandwich_with_virtual_intermediary() -> None:
+    """A split can_subset=True multi-asset should not cycle when an external asset is interleaved.
+
+    Shape:
+        multi (early -> view_mid[virtual]) -> external -> multi (late)
+    """
+
+    @dg.multi_asset(
+        specs=[
+            dg.AssetSpec("early"),
+            dg.AssetSpec("view_mid", deps=["early"], is_virtual=True),
+            dg.AssetSpec("late", deps=["external_bridge"]),
+        ],
+        can_subset=True,
+    )
+    def my_multi_asset(context):
+        for key in context.selected_asset_keys:
+            yield dg.MaterializeResult(asset_key=key)
+
+    @dg.asset(key="external_bridge", deps=["view_mid"])
+    def external_bridge() -> None: ...
+
+    job = _resolve_job(
+        [my_multi_asset, external_bridge],
+        dg.define_asset_job("test_job", selection=dg.AssetSelection.all()),
+    )
+
+    plan = create_execution_plan(job)
+    step_keys = [step.key for step in plan.get_steps_to_execute_in_topo_order()]
+
+    # We expect two invocations of the same multi-asset op with the external
+    # step in between, and no CircularDependencyError during plan creation.
+    assert len(step_keys) == 3
+    assert step_keys[1] == "external_bridge"
+    assert step_keys[0].startswith("my_multi_asset")
+    assert step_keys[2].startswith("my_multi_asset")


### PR DESCRIPTION
closes Issue #33764

## Summary and Motivation

Makes execution planning more reliable by ensuring downstream assets wait for the right upstream work without introducing false self-dependencies or missed ordering edges.

This fixes execution-plan ordering for view-transitive dependencies in [plan.py](https://supreme-trout-q779wxv95gp9h454j.github.dev/) by preventing incorrect edge pruning and only skipping true same-computation self-ordering cases. The motivation is to avoid premature downstream execution or dependency cycles in subsettable multi-asset scenarios, with regression tests added to lock in the correct behavior in [test_view_transitive_deps.py](https://supreme-trout-q779wxv95gp9h454j.github.dev/).

## What changed
- Avoid creating ordering dependencies when the current step and ancestor step come from the same underlying computation family.
- Added a regression test covering a subsettable multi-asset with a virtual intermediary and an external bridge.

## Testing
- python -m pytest -q python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests/test_view_transitive_deps.py
- ruff check python_modules/dagster/dagster/_core/execution/plan python_modules/dagster/dagster_tests/execution_tests/execution_plan_tests