### PR TITLE
Fix destructive deltalake partition overwrites

### DIFF
--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
@@ -1,11 +1,12 @@
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar, cast
+from typing import Any, Generic, TypeAlias, TypeVar, cast
 
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.dataset as ds
 from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
+from dagster._core.definitions.partitions.utils import TimeWindow
 from dagster._core.storage.db_io_manager import (
     DbTypeHandler,
     TablePartitionDimension,
@@ -27,9 +28,6 @@ except ImportError:
     from pyarrow.parquet import _filters_to_expression as filters_to_expression
 
 from dagster_deltalake.io_manager import DELTA_DATE_FORMAT, DELTA_DATETIME_FORMAT, TableConnection
-
-if TYPE_CHECKING:
-    from dagster._core.definitions.partitions.utils import TimeWindow
 
 T = TypeVar("T")
 ArrowTypes: TypeAlias = pa.Table | pa.RecordBatchReader
@@ -94,7 +92,7 @@ class DeltalakeBaseArrowTypeHandler(DbTypeHandler[T], Generic[T]):
                         context.log.debug(
                             "Table exists and is partitioned, using append mode to preserve other partitions"
                         )
-            except TableNotFoundError as e:
+            except TableNotFoundError:
                 context.log.info("Table not found, keep the original mode")
                 pass
             except Exception as e:
@@ -221,6 +219,14 @@ def partition_dimensions_to_dnf(
                 )
                 parts.append(filter_)
             elif field.type.type == "string":
+                if isinstance(partition_dimension.partitions, TimeWindow):
+                    raise ValueError(
+                        f"Partition column '{partition_dimension.partition_expr}' is "
+                        f"time-partitioned ({partition_dimension.partitions!r}), but the Delta "
+                        "table column is typed 'string' rather than 'timestamp'/'date'. Check "
+                        "that the actual column type matches the asset's time-based "
+                        "partitions_def."
+                    )
                 parts.append(_value_dnf(partition_dimension, field.type.type, str_values=True))
             else:
                 raise ValueError(f"Unsupported partition type {field.type.type}")

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
@@ -98,7 +98,7 @@ class DeltalakeBaseArrowTypeHandler(DbTypeHandler[T], Generic[T]):
             except Exception as e:
                 context.log.warning("Unhandled exception in handle_output: abort")
                 context.log.exception(e)
-                raise e
+                raise
 
         context.log.debug("Writing with mode: %s", main_save_mode)
 

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
@@ -13,6 +13,7 @@ from dagster._core.storage.db_io_manager import (
     escape_sql_string_literal,
 )
 from deltalake import CommitProperties, DeltaTable, WriterProperties, write_deltalake
+from deltalake.exceptions import TableNotFoundError
 from deltalake.schema import (
     Field as DeltaField,
     PrimitiveType,
@@ -93,9 +94,13 @@ class DeltalakeBaseArrowTypeHandler(DbTypeHandler[T], Generic[T]):
                         context.log.debug(
                             "Table exists and is partitioned, using append mode to preserve other partitions"
                         )
-            except Exception:
-                # Table doesn't exist, keep the original mode
+            except TableNotFoundError as e:
+                context.log.info("Table not found, keep the original mode")
                 pass
+            except Exception as e:
+                context.log.warning("Unhandled exception in handle_output: abort")
+                context.log.exception(e)
+                raise e
 
         context.log.debug("Writing with mode: %s", main_save_mode)
 

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_io_manager.py
@@ -40,3 +40,18 @@ def test_partition_dimensions_to_dnf(test_schema) -> None:
     ]
     dnf = partition_dimensions_to_dnf(parts, test_schema, True)
     assert dnf == [("date_col", "=", "2020-01-02")]
+
+
+def test_partition_dimensions_to_dnf_time_window_against_string_column(test_schema) -> None:
+    """A time-partitioned asset whose Delta column is actually typed 'string' (rather than
+    'date'/'timestamp') should fail with a clear schema-mismatch error, not a confusing
+    'array partition values' error from `_value_dnf`.
+    """
+    parts = [
+        TablePartitionDimension(
+            partitions=TimeWindow(datetime(2020, 1, 2), datetime(2020, 2, 3)),
+            partition_expr="string_col",
+        )
+    ]
+    with pytest.raises(ValueError, match=r"time-partitioned.*typed 'string'"):
+        partition_dimensions_to_dnf(parts, test_schema, True)

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler.py
@@ -316,6 +316,29 @@ def test_static_partitioned_asset(tmp_path, io_manager):
     assert sorted(out_df["a"].to_pylist()) == ["2", "2", "2", "3", "3", "3"]
 
 
+def test_partitioned_asset_write_when_table_does_not_exist(tmp_path, io_manager):
+    """The first write to a partitioned asset hits the `_has_partitions` branch in
+    `handle_output` before the underlying Delta table has ever been created, so
+    `DeltaTable(...)` raises. That should be swallowed, keeping the default overwrite
+    mode, rather than propagating out of the run.
+    """
+    resource_defs = {"io_manager": io_manager}
+    table_path = os.path.join(tmp_path, "my_schema/static_partitioned")
+    assert not os.path.exists(table_path)
+
+    res = materialize(
+        [static_partitioned],
+        partition_key="red",
+        resources=resource_defs,
+        run_config={"ops": {"my_schema__static_partitioned": {"config": {"value": "1"}}}},
+    )
+
+    assert res.success
+    dt = DeltaTable(table_path)
+    out_df = dt.to_pyarrow_table()
+    assert out_df["a"].to_pylist() == ["1", "1", "1"]
+
+
 @asset(
     partitions_def=StaticPartitionsDefinition(["red", "yellow", "blue"]),
     key_prefix=["my_schema"],


### PR DESCRIPTION
## Summary & Motivation

[The issue goes into more detail.](https://github.com/dagster-io/dagster/issues/34064)

Claude found a nice bug while I was scratching my head looking for missing data.

When materializing a partitioned asset, it overwrites partitions one by one, while specifying a predicate matching the partition in question.

The handle_output function previously swallowed all exceptions, assuming it meant the table did not exist, and that we should continue. We now catch that error specifically, and continue the same way. No change in behavior.

However, there are other potential errors. Namely, if we are writing a time based partitioned table, but the field was a string, a ValueError was thrown when generating the predicate, but subsequently ignored, leading to the table being overwritten, with the contents of the last partition written.

The second commit of this PR detects that precise scenario, and raises a more helpful error. It was previously a generic “Arrays are not supported” type message.

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
