### PR TITLE
Cache event log schema capability checks

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/instance.py
+++ b/python_modules/dagster/dagster/_core/instance/instance.py
@@ -867,6 +867,7 @@ class DagsterInstance(
             if print_fn:
                 print_fn("Updating event storage...")
             self._event_storage.upgrade()
+            self._event_storage.clear_cached_schema_capabilities()
             self._event_storage.reindex_assets(print_fn=print_fn)
 
             if print_fn:

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -334,6 +334,9 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     ) -> None:
         """Allows for optimizing database connection / use in the context of a long lived webserver process."""
 
+    def clear_cached_schema_capabilities(self) -> None:
+        """Clear storage capability values that may change after a schema migration."""
+
     @abstractmethod
     def get_event_records(
         self,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -228,8 +228,19 @@ class SqlEventLogStorage(EventLogStorage):
         }
 
     def has_asset_key_col(self, column_name: str) -> bool:
-        with self.index_connection() as conn:
-            return self._has_asset_key_col_on_connection(conn, column_name)
+        # SQLAlchemy schema introspection opens a database connection. These capabilities are
+        # stable between migrations, so avoid repeating that round trip for every asset resolver.
+        cache = getattr(self, "_asset_key_column_cache", None)
+        if cache is None:
+            cache = self._asset_key_column_cache = {}
+        if column_name not in cache:
+            with self.index_connection() as conn:
+                cache[column_name] = self._has_asset_key_col_on_connection(conn, column_name)
+        return cache[column_name]
+
+    def clear_cached_schema_capabilities(self) -> None:
+        self._asset_key_column_cache: dict[str, bool] = {}
+        self._supports_asset_checks_cache: bool | None = None
 
     def _has_asset_key_col_on_connection(self, conn: Connection, column_name: str) -> bool:
         column_names = [x.get("name") for x in db.inspect(conn).get_columns(AssetKeyTable.name)]
@@ -3425,7 +3436,12 @@ class SqlEventLogStorage(EventLogStorage):
 
     @property
     def supports_asset_checks(self):
-        return self.has_table(AssetCheckExecutionsTable.name)
+        cached_value = getattr(self, "_supports_asset_checks_cache", None)
+        if cached_value is None:
+            cached_value = self._supports_asset_checks_cache = self.has_table(
+                AssetCheckExecutionsTable.name
+            )
+        return cached_value
 
     def get_latest_planned_materialization_info(
         self,

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -455,6 +455,35 @@ class TestEventLogStorage:
         else:
             assert storage.is_persistent
 
+    def test_schema_capabilities_are_cached(self, storage):
+        if not isinstance(storage, SqlEventLogStorage):
+            pytest.skip("schema capability caching is only available for SQL storage")
+
+        can_read = storage.can_read_asset_status_cache()
+        storage.clear_cached_schema_capabilities()
+        with mock.patch.object(
+            storage,
+            "_has_asset_key_col_on_connection",
+            return_value=can_read,
+        ) as column_probe:
+            assert storage.can_read_asset_status_cache() is can_read
+            assert storage.can_write_asset_status_cache() is can_read
+            assert column_probe.call_count == 1
+
+            storage.clear_cached_schema_capabilities()
+            assert storage.can_read_asset_status_cache() is can_read
+            assert column_probe.call_count == 2
+
+        storage.clear_cached_schema_capabilities()
+        with mock.patch.object(storage, "has_table", wraps=storage.has_table) as table_probe:
+            supports_asset_checks = storage.supports_asset_checks
+            assert storage.supports_asset_checks is supports_asset_checks
+            assert table_probe.call_count == 1
+
+            storage.clear_cached_schema_capabilities()
+            assert storage.supports_asset_checks is supports_asset_checks
+            assert table_probe.call_count == 2
+
     def test_log_storage_run_not_found(self, storage):
         assert storage.get_logs_for_run(make_new_run_id()) == []
 


### PR DESCRIPTION
Codex:

> ## Summary & Motivation
>
> Asset catalog requests repeatedly ask event-log storage whether asset-status and asset-check schema features are available. SQL storage currently answers those calls through SQLAlchemy schema introspection, opening database connections and repeating stable catalog queries for every resolver. With a high-latency production database, these probes become a material fixed cost on every asset-catalog request.
>
> Cache asset-key column and asset-check table capabilities for the lifetime of the storage object. Explicitly clear the cache after event-storage migrations, before asset reindexing, so an in-process upgrade observes the new schema. Non-SQL storage keeps a no-op invalidation method.
>
> ## Test Plan
>
> - `pytest ...::TestSqliteEventLogStorage::test_schema_capabilities_are_cached ...::TestConsolidatedSqliteEventLogStorage::test_schema_capabilities_are_cached` (2 passed)
> - Ruff format and lint checks on all changed files
> - `ty check` on the changed implementation files (only the existing `datetime.utcfromtimestamp` deprecation diagnostic)
>
> ## Changelog
>
> Improved asset-catalog responsiveness by avoiding repeated event-log schema introspection.