### PR TITLE
Reduce partition status query overhead

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitions/definition/time_window.py
@@ -1195,6 +1195,34 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
 
     def has_partition_key(self, partition_key: str) -> bool:
         """Returns a boolean representing if the given partition key is valid."""
+        return self._has_partition_key(
+            partition_key,
+            self.get_first_partition_window(),
+            self.get_last_partition_window(),
+        )
+
+    def filter_valid_partition_keys(self, partition_keys: Iterable[str]) -> set[str]:
+        first_partition_window = self.get_first_partition_window()
+        last_partition_window = self.get_last_partition_window()
+        if first_partition_window is None or last_partition_window is None:
+            return set()
+
+        return {
+            partition_key
+            for partition_key in partition_keys
+            if self._has_partition_key(
+                partition_key,
+                first_partition_window,
+                last_partition_window,
+            )
+        }
+
+    def _has_partition_key(
+        self,
+        partition_key: str,
+        first_partition_window: TimeWindow | None,
+        last_partition_window: TimeWindow | None,
+    ) -> bool:
         try:
             partition_start_time = self.start_time_for_partition_key(partition_key)
             partition_start_timestamp = partition_start_time.timestamp()
@@ -1205,8 +1233,6 @@ class TimeWindowPartitionsDefinition(PartitionsDefinition, IHaveNew):
         if self.is_window_start_excluded(partition_start_time):
             return False
 
-        first_partition_window = self.get_first_partition_window()
-        last_partition_window = self.get_last_partition_window()
         return not (
             # no partitions at all
             first_partition_window is None

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2036,55 +2036,31 @@ class SqlEventLogStorage(EventLogStorage):
             after_cursor=after_storage_id,
         )
 
-        latest_events_subquery = db_subquery(
-            db_select(
-                [
-                    SqlEventLogStorageTable.c.dagster_event_type,
-                    SqlEventLogStorageTable.c.partition,
-                    SqlEventLogStorageTable.c.run_id,
-                    SqlEventLogStorageTable.c.id,
-                ]
-            ).select_from(
-                latest_event_ids_subquery.join(
-                    SqlEventLogStorageTable,
-                    SqlEventLogStorageTable.c.id == latest_event_ids_subquery.c.id,
-                ),
-            ),
-            "latest_events_subquery",
-        )
-
-        materialization_planned_events = db_select(
+        latest_events = db_select(
             [
-                latest_events_subquery.c.dagster_event_type,
-                latest_events_subquery.c.partition,
-                latest_events_subquery.c.run_id,
-                latest_events_subquery.c.id,
+                SqlEventLogStorageTable.c.dagster_event_type,
+                SqlEventLogStorageTable.c.partition,
+                SqlEventLogStorageTable.c.run_id,
+                SqlEventLogStorageTable.c.id,
             ]
-        ).where(
-            latest_events_subquery.c.dagster_event_type
-            == DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value
-        )
-
-        materialization_events = db_select(
-            [
-                latest_events_subquery.c.dagster_event_type,
-                latest_events_subquery.c.partition,
-                latest_events_subquery.c.run_id,
-                latest_events_subquery.c.id,
-            ]
-        ).where(
-            latest_events_subquery.c.dagster_event_type
-            == DagsterEventType.ASSET_MATERIALIZATION.value
+        ).select_from(
+            latest_event_ids_subquery.join(
+                SqlEventLogStorageTable,
+                SqlEventLogStorageTable.c.id == latest_event_ids_subquery.c.id,
+            )
         )
 
         with self.index_connection() as conn:
-            materialization_planned_rows = db_fetch_mappings(conn, materialization_planned_events)
-            materialization_rows = db_fetch_mappings(conn, materialization_events)
+            latest_event_rows = db_fetch_mappings(conn, latest_events)
 
         materialization_planned_rows_by_partition = {
-            row["partition"]: (row["run_id"], row["id"]) for row in materialization_planned_rows
+            row["partition"]: (row["run_id"], row["id"])
+            for row in latest_event_rows
+            if row["dagster_event_type"] == DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value
         }
-        for mat_row in materialization_rows:
+        for mat_row in latest_event_rows:
+            if mat_row["dagster_event_type"] != DagsterEventType.ASSET_MATERIALIZATION.value:
+                continue
             mat_partition = mat_row["partition"]
             mat_event_id = mat_row["id"]
             if mat_partition not in materialization_planned_rows_by_partition:

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -248,7 +248,7 @@ def get_validated_partition_keys(
     else:
         if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
             check.failed("Unexpected partitions definition type {partitions_def}")
-        validated_partitions = {pk for pk in partition_keys if partitions_def.has_partition_key(pk)}
+        validated_partitions = partitions_def.filter_valid_partition_keys(partition_keys)
     return validated_partitions
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1802,6 +1802,47 @@ def test_has_partition_key():
     assert partitions_def.has_partition_key("2020-03-15")
 
 
+def test_filter_valid_partition_keys():
+    partition_defs_and_keys = [
+        (
+            dg.DailyPartitionsDefinition(
+                start_date="2020-01-01",
+                end_date="2020-01-06",
+                exclusions=[datetime(2020, 1, 3)],
+            ),
+            {
+                "fdsjkl",
+                "2019-12-31",
+                "2020-01-01",
+                "2020-01-03",
+                "2020-01-05",
+                "2020-01-06",
+            },
+        ),
+        (
+            dg.HourlyPartitionsDefinition(
+                start_date="2020-11-01-00:00",
+                end_date="2020-11-01-04:00",
+                timezone="US/Pacific",
+            ),
+            {
+                "2020-11-01-00:00",
+                "2020-11-01-01:00",
+                "2020-11-01-01:00-0800",
+                "2020-11-01-01:00-0700",
+                "2020-11-01-04:00",
+            },
+        ),
+    ]
+
+    for partitions_def, partition_keys in partition_defs_and_keys:
+        assert partitions_def.filter_valid_partition_keys(partition_keys) == {
+            partition_key
+            for partition_key in partition_keys
+            if partitions_def.has_partition_key(partition_key)
+        }
+
+
 @pytest.mark.parametrize(
     "partitions_def,first_partition_window,last_partition_window,number_of_partitions,fmt",
     [


### PR DESCRIPTION
Codex:

> ## Summary & Motivation
>
> Computing partition status for a large time-window asset currently repeats two avoidable costs. For every candidate key, `has_partition_key` recomputes the definition’s first and last partition windows; for planned-versus-materialized status, SQL event-log storage executes two queries over the same latest-events subquery. An asset with tens of thousands of active planned partitions amplifies both costs.
>
> Add a bulk time-window validation path that computes the boundary windows once, and fetch both latest event types in a single query before separating them in memory. The existing single-key validation behavior and planned/materialized precedence are preserved.
>
> On a local production-shaped dataset with 74,388 planned partitions, the exact status-computation prototype improved from 1.605 s to 1.071 s (about 33%).
>
> ## Test Plan
>
> - `test_filter_valid_partition_keys` covers boundaries, exclusions, invalid keys, and DST ambiguity
> - Existing SQLite planned/materialized behavior and event-ID tests (3 targeted tests passed total)
> - Ruff format and lint checks on all changed files
> - `ty check` on the changed implementation files (only the existing `datetime.utcfromtimestamp` deprecation diagnostic)
>
> ## Changelog
>
> Improved asset partition-status responsiveness for assets with large time-window backlogs.