### PR TITLE
perf: seed component decls so cold loads avoid Θ(n²) tree walks

### DIFF
--- a/python_modules/dagster/dagster/components/core/component_tree.py
+++ b/python_modules/dagster/dagster/components/core/component_tree.py
@@ -398,6 +398,9 @@ class ComponentTree(IHaveNew):
             ComponentDecl: The component declaration loaded from the given path.
         """
         resolved_path = ComponentPath.from_resolvable(self.defs_module_path, defs_path)
+        cached = self.state_tracker.get_cache_data(resolved_path).component_decl
+        if cached is not None:
+            return cached
         decl = self._component_decl_tree().get(resolved_path)
         if decl is None:
             raise Exception(f"No component decl found for path {defs_path}")
@@ -463,9 +466,40 @@ class ComponentTree(IHaveNew):
         return component
 
     def _component_decl_tree(self) -> dict[ComponentLoc, ComponentDecl]:
-        """Constructs or returns the full component declaration tree from cache."""
+        """Materialize the full loc→decl map for the current component tree.
+
+        After the walk, cacheable child decls are seeded into the state tracker
+        so subsequent loads do not re-materialize the map once per loc (which
+        would be Θ(n²) for n components).
+
+        ``ComponentRootLoc`` and the unkeyed app-managed aggregate loc are
+        intentionally not seeded — those must stay freshly constructed so
+        app-managed discovery can pick up newly added or removed components.
+        """
         root_decl = self.find_root_decl()
-        return dict(root_decl.iterate_loc_component_decl_pairs())
+        tree = dict(root_decl.iterate_loc_component_decl_pairs())
+        self._seed_cacheable_component_decls(tree)
+        return tree
+
+    def _seed_cacheable_component_decls(self, tree: dict[ComponentLoc, ComponentDecl]) -> None:
+        """Store component_decl for locs that are safe to cache across loads.
+
+        Skips the synthetic root and the unkeyed app-managed listing wrapper so
+        those continue to be rebuilt by :meth:`find_root_decl`.
+        """
+        for loc, decl in tree.items():
+            if not self._is_cacheable_component_decl_loc(loc):
+                continue
+            if self.state_tracker.get_cache_data(loc).component_decl is None:
+                self.state_tracker.set_cache_data(loc, component_decl=decl)
+
+    @staticmethod
+    def _is_cacheable_component_decl_loc(loc: ComponentLoc) -> bool:
+        if isinstance(loc, ComponentRootLoc):
+            return False
+        if isinstance(loc, AppManagedDefinitionsLoc) and loc.instance_key is None:
+            return False
+        return True
 
     def _component_and_context_at_loc(
         self, loc: ResolvableToComponentLoc

--- a/python_modules/dagster/dagster_tests/components_tests/component_tree_tests/test_component_decl_tree_caching.py
+++ b/python_modules/dagster/dagster_tests/components_tests/component_tree_tests/test_component_decl_tree_caching.py
@@ -1,0 +1,96 @@
+"""Regression tests for O(n) component-decl tree materialization on cold load.
+
+Without seeding cacheable child decls after the first tree walk, loading n
+components re-materializes the full loc→decl map once per uncached loc
+(Θ(n²) walks). These tests pin that cold multi-loc loads stay linear in the
+number of tree materializations.
+"""
+
+from unittest.mock import patch
+
+import dagster as dg
+from dagster.components.core.component_tree import ComponentTree
+from dagster.components.core.defs_module import ComponentPath
+from dagster.components.testing import create_defs_folder_sandbox
+
+
+class EmptyComponent(dg.Component):
+    def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
+        return dg.Definitions()
+
+
+def test_cold_build_defs_materializes_component_decl_tree_once() -> None:
+    """Cold load of many sibling components should not rewalk the decl tree
+    once per component (was Θ(n²) full loc→decl map materializations).
+    """
+    n_siblings = 12
+    with create_defs_folder_sandbox() as sandbox:
+        for i in range(n_siblings):
+            sandbox.scaffold_component(
+                component_cls=EmptyComponent,
+                defs_path=f"comp_{i}",
+                defs_yaml_contents={
+                    "type": (
+                        "dagster_tests.components_tests.component_tree_tests"
+                        ".test_component_decl_tree_caching.EmptyComponent"
+                    ),
+                },
+            )
+
+        with sandbox.build_component_tree() as tree:
+            original = ComponentTree._component_decl_tree  # noqa: SLF001
+            call_count = 0
+
+            def counting_component_decl_tree(self: ComponentTree):
+                nonlocal call_count
+                call_count += 1
+                return original(self)
+
+            with patch.object(
+                ComponentTree,
+                "_component_decl_tree",
+                counting_component_decl_tree,
+            ):
+                tree.build_defs()
+
+            # One materialization is enough to seed cacheable child decls for
+            # the rest of the load. A few more is fine if root / path lookup
+            # paths need a second pass; once-per-sibling is not.
+            assert call_count < n_siblings, (
+                f"_component_decl_tree was called {call_count} times for "
+                f"{n_siblings} sibling components (expected O(1) materializations, "
+                f"not once per component)"
+            )
+
+
+def test_first_tree_walk_seeds_child_component_decls() -> None:
+    """After one tree materialization, filesystem child locs should have
+    component_decl cached without needing a second full walk.
+    """
+    with create_defs_folder_sandbox() as sandbox:
+        child_path = sandbox.scaffold_component(
+            component_cls=EmptyComponent,
+            defs_path="seeded_child",
+            defs_yaml_contents={
+                "type": (
+                    "dagster_tests.components_tests.component_tree_tests"
+                    ".test_component_decl_tree_caching.EmptyComponent"
+                ),
+            },
+        )
+
+        with sandbox.build_component_tree() as tree:
+            # Materialize the tree once (does not load components).
+            tree._component_decl_tree()  # noqa: SLF001
+
+            child_loc = ComponentPath.from_path(child_path)
+            # Yaml multi-doc uses instance key 0 for a single document.
+            child_instance_loc = ComponentPath.from_path(child_path, instance_key=0)
+
+            cached_folder = tree.state_tracker.get_cache_data(child_loc).component_decl
+            cached_instance = tree.state_tracker.get_cache_data(child_instance_loc).component_decl
+
+            assert cached_folder is not None or cached_instance is not None, (
+                "Expected first _component_decl_tree() call to seed component_decl "
+                "for the child component location"
+            )

--- a/python_modules/dagster/dagster_tests/components_tests/component_tree_tests/test_component_decl_tree_caching.py
+++ b/python_modules/dagster/dagster_tests/components_tests/component_tree_tests/test_component_decl_tree_caching.py
@@ -53,13 +53,12 @@ def test_cold_build_defs_materializes_component_decl_tree_once() -> None:
             ):
                 tree.build_defs()
 
-            # One materialization is enough to seed cacheable child decls for
-            # the rest of the load. A few more is fine if root / path lookup
-            # paths need a second pass; once-per-sibling is not.
-            assert call_count < n_siblings, (
+            # One materialization seeds cacheable child decls for the rest of
+            # the load. A looser bound (e.g. call_count < n) would still pass
+            # near-quadratic cold loads and miss regressions.
+            assert call_count == 1, (
                 f"_component_decl_tree was called {call_count} times for "
-                f"{n_siblings} sibling components (expected O(1) materializations, "
-                f"not once per component)"
+                f"{n_siblings} sibling components (expected one materialization)"
             )
 
 


### PR DESCRIPTION
## Summary

Cold multi-loc component loads rematerialized the full loc→decl map once per uncached loc, so loading n components did Θ(n²) tree walks.

- After the first `_component_decl_tree()` walk, seed `component_decl` into the state tracker for cacheable locs (`ComponentPath` and keyed app-managed locs).
- Leave `ComponentRootLoc` and the unkeyed app-managed aggregate unseeded so app-managed discovery still rebuilds from a fresh listing.
- `find_decl_at_path` checks the state tracker first after a prior walk.

### Complexity

| | Before | After |
|---|---|---|
| Cold load of n sibling components | Θ(n²) loc→decl map materializations | O(1) materializations after the first walk; per-loc loads are O(1) cache hits |

**n** = number of component locations in the project (YAML folders/files, Python defs modules, keyed app-managed IDs).

**Note:** The filesystem root decl was already cached (`_get_filesystem_decl`). The cost was re-walking the in-memory decl graph and rebuilding the loc→decl dict for every uncached child load—not re-scanning the filesystem each time.

### Audit target

`python_modules/dagster/dagster/components/core`

## Test plan

- [x] New: `test_component_decl_tree_caching.py`
  - cold `build_defs` of 12 siblings must not call `_component_decl_tree` once per sibling
  - first tree walk seeds child `component_decl` entries
- [x] Existing component tree / decl / app-managed integration tests pass
- [x] `ruff check` on touched files

```bash
pytest python_modules/dagster/dagster_tests/components_tests/component_tree_tests/ -q
pytest python_modules/dagster/dagster_tests/components_tests/unit_tests/test_app_managed_components_integration.py -q
```

## Follow-ups

None. No other deferred complexity findings from this audit of `components/core`.