### PR TITLE
fix(docs): avoid duplicate op names in project_mini example

### DIFF
--- a/examples/docs_projects/project_mini/src/project_mini/defs/dynamic_vs_parallel/dynamic_outputs.py
+++ b/examples/docs_projects/project_mini/src/project_mini/defs/dynamic_vs_parallel/dynamic_outputs.py
@@ -20,7 +20,7 @@ def compute_piece(piece_to_compute: str):
 
 
 @dg.op
-def merge_and_analyze(context: dg.OpExecutionContext, computed_pieces: list[str]):
+def merge_dynamic_results(context: dg.OpExecutionContext, computed_pieces: list[str]):
     context.log.info(f"Finished processing, result is ... {computed_pieces}")
     return
 
@@ -29,7 +29,7 @@ def merge_and_analyze(context: dg.OpExecutionContext, computed_pieces: list[str]
 def dynamic_graph():
     pieces = load_pieces()
     results = pieces.map(compute_piece)
-    merge_and_analyze(results.collect())
+    merge_dynamic_results(results.collect())
 
 
 defs = dg.Definitions(jobs=[dynamic_graph])

--- a/examples/docs_projects/project_mini/src/project_mini/defs/dynamic_vs_parallel/python_parallelism.py
+++ b/examples/docs_projects/project_mini/src/project_mini/defs/dynamic_vs_parallel/python_parallelism.py
@@ -25,14 +25,14 @@ def compute_piece(piece_to_compute: str):
 
 
 @dg.op
-def merge_and_analyze(context: dg.OpExecutionContext, computed_pieces: list[str]):
+def merge_parallel_results(context: dg.OpExecutionContext, computed_pieces: list[str]):
     context.log.info(f"Finished processing, result is ... {computed_pieces}")
     return
 
 
 @dg.job
 def python_parallelism():
-    merge_and_analyze(load_and_process_pieces())
+    merge_parallel_results(load_and_process_pieces())
 
 
 defs = dg.Definitions(jobs=[python_parallelism])

--- a/examples/docs_projects/project_mini/tests/test_defs.py
+++ b/examples/docs_projects/project_mini/tests/test_defs.py
@@ -4,11 +4,18 @@ Full defs loading is skipped because project_mini uses dagster internal APIs
 not yet released on PyPI. Pure-function coverage is in test_pii.py and test_assets.py.
 """
 
+from dagster import Definitions
 from project_mini.defs.dynamic_fanout.dynamic_fanout import (  # ty: ignore[unresolved-import]
     aggregate_unit_results,
     extract_processing_units,
     final_report,
     process_single_unit,
+)
+from project_mini.defs.dynamic_vs_parallel.dynamic_outputs import (  # ty: ignore[unresolved-import]
+    defs as dynamic_outputs_defs,
+)
+from project_mini.defs.dynamic_vs_parallel.python_parallelism import (  # ty: ignore[unresolved-import]
+    defs as python_parallelism_defs,
 )
 from project_mini.defs.partitions_vs_config.with_config import (  # ty: ignore[unresolved-import]
     CustomerConfig,
@@ -28,6 +35,10 @@ def test_dynamic_fanout_importable():
     assert callable(process_single_unit)
     assert callable(aggregate_unit_results)
     assert callable(final_report)
+
+
+def test_dynamic_vs_parallel_defs_load_together():
+    Definitions.validate_loadable(Definitions.merge(dynamic_outputs_defs, python_parallelism_defs))
 
 
 def test_customer_orders_importable():


### PR DESCRIPTION
## Summary & Motivation

Fixes #32576.

The `project_mini` docs project currently defines two ops named `merge_and_analyze` in the `dynamic_vs_parallel` examples. When Dagster loads the project definitions together, those duplicate op names cause a `DagsterInvalidDefinitionError` before the project can run.

This renames the merge op in each example to a name specific to that example while preserving the behavior shown in the docs.

## Test Plan

- `python -m pytest examples/docs_projects/project_mini/tests -q`
- `ruff format --check examples/docs_projects/project_mini/src/project_mini/defs/dynamic_vs_parallel/dynamic_outputs.py examples/docs_projects/project_mini/src/project_mini/defs/dynamic_vs_parallel/python_parallelism.py examples/docs_projects/project_mini/tests/test_defs.py`
- `ruff check examples/docs_projects/project_mini/src/project_mini/defs/dynamic_vs_parallel/dynamic_outputs.py examples/docs_projects/project_mini/src/project_mini/defs/dynamic_vs_parallel/python_parallelism.py examples/docs_projects/project_mini/tests/test_defs.py`

## Changelog

Fixed a docs example project loading error caused by duplicate op names in the dynamic outputs vs Python parallelism examples.