### PR TITLE
[core] Raise a clear error for partition context methods on stub assets

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -1087,7 +1087,22 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
         upstream_asset_key = asset_layer.get_asset_key_for_node_input(self.node_handle, input_name)
 
         if upstream_asset_key is not None:
-            upstream_asset_partitions_def = asset_layer.get(upstream_asset_key).partitions_def
+            upstream_asset_node = asset_layer.get(upstream_asset_key)
+            upstream_asset_partitions_def = upstream_asset_node.partitions_def
+
+            upstream_is_auto_created_stub = upstream_asset_node.assets_def.is_auto_created_stub
+            if upstream_asset_partitions_def is None and upstream_is_auto_created_stub:
+                raise DagsterInvariantViolationError(
+                    f"Cannot access partition information for input '{input_name}' of step"
+                    f" '{self.step.key}': upstream asset '{upstream_asset_key.to_string()}' has no"
+                    " partitions_def because it was auto-created as a stub asset. This happens"
+                    " when an asset dependency references a key with no corresponding definition"
+                    " in this Definitions object (for example, an asset that is defined in a"
+                    " different code location). To use partition-based context methods such as"
+                    " `asset_partition_key_for_input` for this input, the upstream asset's"
+                    " definition (including its partitions_def) must be included in this"
+                    " Definitions object."
+                )
 
             if upstream_asset_partitions_def is not None:
                 partitions_def = self.entity_partitions_def if assets_def else None

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -758,6 +758,26 @@ def test_partition_mapping_with_asset_deps():
     assert multi_asset_2.get_partition_mapping(dg.AssetKey("asset_2")) == asset_2_partition_mapping
 
 
+def test_asset_partition_key_for_input_against_auto_created_stub_asset():
+    """A dep on an asset key with no corresponding definition in the Definitions object (e.g. an
+    asset that actually lives in another code location) gets resolved to an auto-created stub
+    asset with no partitions_def. Calling a partition-based context method for that input should
+    raise a clear, actionable error rather than an opaque internal CheckError.
+    """
+    partitions_def = dg.StaticPartitionsDefinition(["a", "b"])
+
+    @dg.asset(
+        partitions_def=partitions_def,
+        deps=[dg.AssetDep("upstream", partition_mapping=dg.IdentityPartitionMapping())],
+    )
+    def downstream(context: AssetExecutionContext):
+        context.asset_partition_key_for_input("upstream")
+
+    # Note: `upstream` is intentionally not included here, so it resolves to a stub asset.
+    with pytest.raises(dg.DagsterInvariantViolationError, match="auto-created as a stub asset"):
+        dg.materialize([downstream], partition_key="a")
+
+
 def test_conflicting_mappings_with_asset_deps():
     partitions_def = dg.DailyPartitionsDefinition(start_date="2023-08-15")
 


### PR DESCRIPTION
## Summary & Motivation

Fixes #33822.

`context.asset_partition_key_for_input` (and the other partition-based context input methods) fails with an opaque `CheckError: Failure condition: The input has no asset partitions` when the upstream asset key resolves to an auto-created stub `AssetsDefinition` instead of a real one.

This happens whenever an asset dependency (`AssetDep` / `deps=[...]`) references a key that has no corresponding definition in the local `Definitions` object — most commonly because the upstream asset lives in a different code location. `resolve_stub_assets_defs` fabricates a minimal stub for that key with no `partitions_def`, since `AssetDep` only carries an `asset_key`, `partition_mapping`, and `metadata` — it discards richer information (like `partitions_def`) even when constructed from a real `AssetsDefinition` object.

Rather than changing `AssetDep`'s public API to smuggle partition info through (a larger, riskier change), this PR keeps the existing stub-asset behavior and raises a clear, actionable `DagsterInvariantViolationError` at the point of failure, explaining that the upstream asset's definition needs to be included in the local `Definitions` object for partition-aware context methods to work on that input.

## Test Plan

Added `test_asset_partition_key_for_input_against_auto_created_stub_asset` to `test_asset_partition_mappings.py`, which reproduces the stub-asset scenario (an `AssetDep` referencing a key not included in the materialized `Definitions`) without requiring a real multi-code-location setup.

- `python -m pytest python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py -v` — all 24 tests pass
- Verified the new test fails with the original opaque error when the `system.py` fix is reverted, confirming it's a real regression test
- `ruff format --check` / `ruff check` on both changed files — clean

## Changelog

Improved the error message when a partition-based context method (e.g. `asset_partition_key_for_input`) is called for an input whose upstream asset is an auto-created stub with no partition information, such as when the upstream asset is defined in a different code location.