### PR TITLE
[core] Fix UPathIOManager async partition loading

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/upath_io_manager.py
@@ -377,6 +377,48 @@ class UPathIOManager(IOManager):
             else:
                 raise e
 
+    async def _load_partition_from_path_async(
+        self,
+        context: InputContext,
+        partition_key: str,
+        path: "UPath",
+        backcompat_path: Optional["UPath"] = None,
+    ) -> Any:
+        """Same as `_load_partition_from_path`, but for async `load_from_path`.
+
+        An async `load_from_path` only raises once it's awaited, so the awaits have to happen
+        inside the try blocks for the backcompat and missing partition handling to run at all.
+        """
+        allow_missing_partitions = (
+            context.definition_metadata.get("allow_missing_partitions", False)
+            if context.definition_metadata is not None
+            else False
+        )
+
+        try:
+            context.log.debug(self.get_loading_input_partition_log_message(path, partition_key))
+            return await self.load_from_path(context=context, path=path)
+        except FileNotFoundError as e:
+            if backcompat_path is not None:
+                try:
+                    obj = await self.load_from_path(context=context, path=backcompat_path)
+                    context.log.debug(
+                        f"File not found at {path}. Loaded instead from backcompat path:"
+                        f" {backcompat_path}"
+                    )
+                    return obj
+                except FileNotFoundError:
+                    if allow_missing_partitions:
+                        context.log.warning(self.get_missing_partition_log_message(partition_key))
+                        return None
+                    else:
+                        raise e
+            if allow_missing_partitions:
+                context.log.warning(self.get_missing_partition_log_message(partition_key))
+                return None
+            else:
+                raise e
+
     def load_partitions_async(self, context: InputContext):
         """Same as `load_partitions`, but for async."""
         paths = self._get_paths_for_partitions(context)  # paths for normal partitions
@@ -389,7 +431,7 @@ class UPathIOManager(IOManager):
 
             tasks = [
                 loop.create_task(
-                    self._load_partition_from_path(
+                    self._load_partition_from_path_async(
                         context,
                         partition_key,
                         paths[partition_key],
@@ -401,42 +443,22 @@ class UPathIOManager(IOManager):
 
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
-            # need to handle missing partitions here because exceptions don't get propagated from async calls
-            allow_missing_partitions = (
-                context.definition_metadata.get("allow_missing_partitions", False)
-                if context.definition_metadata is not None
-                else False
-            )
-
-            results_without_errors = []
-            found_errors = False
+            # exceptions don't get propagated from async calls, so they are handled here
+            objs = {}
+            failed_partitions = 0
             for partition_key, result in zip(context.asset_partition_keys, results):
-                if isinstance(result, FileNotFoundError):
-                    if allow_missing_partitions:
-                        context.log.warning(self.get_missing_partition_log_message(partition_key))
-                    else:
-                        context.log.error(str(result))
-                        found_errors = True
-                elif isinstance(result, Exception):
+                if isinstance(result, Exception):
                     context.log.error(str(result))
-                    found_errors = True
-                else:
-                    results_without_errors.append(result)
+                    failed_partitions += 1
+                elif result is not None:  # in case some partitions were skipped
+                    objs[partition_key] = result
 
-                if found_errors:
-                    raise RuntimeError(
-                        f"{len(paths) - len(results_without_errors)} partitions could not be loaded"
-                    )
+            if failed_partitions:
+                raise RuntimeError(f"{failed_partitions} partitions could not be loaded")
 
-            return results_without_errors
+            return objs
 
-        awaited_objects = asyncio.run(collect())
-
-        return {
-            partition_key: awaited_object
-            for partition_key, awaited_object in zip(context.asset_partition_keys, awaited_objects)
-            if awaited_object is not None
-        }
+        return asyncio.run(collect())
 
     def _load_partitions(self, context: InputContext) -> dict[str, Any]:
         # load multiple partitions

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -739,6 +739,160 @@ def test_upath_io_manager_async_allow_missing_partitions(
     assert len(downstream_asset_data) == 1, "1 partition should be missing"
 
 
+@pytest.mark.parametrize("materialized_days", [(1, 2, 3, 4), (1, 3)])
+def test_upath_io_manager_async_allow_missing_partitions_keeps_keys_aligned(
+    tmp_path: Path,
+    daily: DailyPartitionsDefinition,
+    start: datetime,
+    materialized_days: tuple[int, ...],
+):
+    manager = AsyncJSONIOManager(base_dir=str(tmp_path))
+
+    @dg.asset(partitions_def=daily, io_manager_def=manager)
+    def upstream_asset(context: AssetExecutionContext) -> str:
+        return context.partition_key
+
+    @dg.asset(
+        partitions_def=daily,
+        io_manager_def=manager,
+        ins={
+            "upstream_asset": dg.AssetIn(
+                partition_mapping=dg.TimeWindowPartitionMapping(start_offset=-4),
+                metadata={"allow_missing_partitions": True},
+            )
+        },
+    )
+    def downstream_asset(upstream_asset: dict[str, str]):
+        return upstream_asset
+
+    materialized_keys = [
+        (start + timedelta(days=days)).strftime(daily.fmt) for days in materialized_days
+    ]
+    for partition_key in materialized_keys:
+        dg.materialize([upstream_asset], partition_key=partition_key)
+
+    result = dg.materialize(
+        [upstream_asset.to_source_asset(), downstream_asset],
+        partition_key=(start + timedelta(days=4)).strftime(daily.fmt),
+    )
+    downstream_asset_data = result.output_for_node("downstream_asset", "result")
+    # every upstream partition returns its own partition key, so a key mapped to
+    # anything but itself means the results were shifted onto the wrong keys
+    assert downstream_asset_data == {key: key for key in materialized_keys}
+
+
+def test_upath_io_manager_async_fail_on_missing_partitions_error_message(
+    tmp_path: Path,
+    daily: DailyPartitionsDefinition,
+    start: datetime,
+):
+    manager = AsyncJSONIOManager(base_dir=str(tmp_path))
+
+    @dg.asset(partitions_def=daily, io_manager_def=manager)
+    def upstream_asset(context: AssetExecutionContext) -> str:
+        return context.partition_key
+
+    @dg.asset(
+        partitions_def=daily,
+        io_manager_def=manager,
+        ins={
+            "upstream_asset": dg.AssetIn(
+                partition_mapping=dg.TimeWindowPartitionMapping(start_offset=-2)
+            )
+        },
+    )
+    def downstream_asset(upstream_asset: dict[str, str]):
+        return upstream_asset
+
+    for days in (1, 2):
+        dg.materialize(
+            [upstream_asset],
+            partition_key=(start + timedelta(days=days)).strftime(daily.fmt),
+        )
+
+    # only the first of the 3 mapped partitions is missing
+    with pytest.raises(RuntimeError, match="1 partitions could not be loaded"):
+        dg.materialize(
+            [upstream_asset.to_source_asset(), downstream_asset],
+            partition_key=(start + timedelta(days=2)).strftime(daily.fmt),
+        )
+
+
+def test_upath_io_manager_async_multipartitions_backcompat_path(tmp_path: Path):
+    manager = AsyncJSONIOManager(base_dir=str(tmp_path))
+    partitions_def = dg.MultiPartitionsDefinition(
+        {
+            "abc": dg.StaticPartitionsDefinition(["a", "b"]),
+            "n": dg.StaticPartitionsDefinition(["1"]),
+        }
+    )
+
+    @dg.asset(partitions_def=partitions_def, io_manager_def=manager)
+    def upstream_asset(context: AssetExecutionContext) -> str:
+        return context.partition_key
+
+    @dg.asset(io_manager_def=manager)
+    def downstream_asset(upstream_asset: dict[str, str]):
+        return upstream_asset
+
+    dg.materialize([upstream_asset], partition_key=dg.MultiPartitionKey({"abc": "a", "n": "1"}))
+
+    # very old Dagster versions stored multipartitions in a flat "b|1" file instead of "b/1"
+    backcompat_path = UPath(tmp_path) / "upstream_asset" / "b|1"
+    backcompat_path.parent.mkdir(parents=True, exist_ok=True)
+    with backcompat_path.open("w") as file:
+        json.dump("b|1", file)
+
+    result = dg.materialize([upstream_asset.to_source_asset(), downstream_asset])
+    assert result.output_for_node("downstream_asset", "result") == {"a|1": "a|1", "b|1": "b|1"}
+
+
+def test_upath_io_manager_async_multipartitions_allow_missing_partitions(tmp_path: Path):
+    manager = AsyncJSONIOManager(base_dir=str(tmp_path))
+    partitions_def = dg.MultiPartitionsDefinition(
+        {
+            "abc": dg.StaticPartitionsDefinition(["a", "b"]),
+            "n": dg.StaticPartitionsDefinition(["1"]),
+        }
+    )
+
+    @dg.asset(partitions_def=partitions_def, io_manager_def=manager)
+    def upstream_asset(context: AssetExecutionContext) -> str:
+        return context.partition_key
+
+    @dg.asset(
+        io_manager_def=manager,
+        ins={"upstream_asset": dg.AssetIn(metadata={"allow_missing_partitions": True})},
+    )
+    def downstream_asset(upstream_asset: dict[str, str]):
+        return upstream_asset
+
+    # "b|1" is missing from both the normal and the backcompat location
+    dg.materialize([upstream_asset], partition_key=dg.MultiPartitionKey({"abc": "a", "n": "1"}))
+
+    result = dg.materialize([upstream_asset.to_source_asset(), downstream_asset])
+    assert result.output_for_node("downstream_asset", "result") == {"a|1": "a|1"}
+
+
+def test_upath_io_manager_async_keeps_falsy_partition_values(tmp_path: Path):
+    manager = AsyncJSONIOManager(base_dir=str(tmp_path))
+    values: dict[str, Any] = {"a": 0, "b": "", "c": [], "d": False}
+
+    @dg.asset(partitions_def=dg.StaticPartitionsDefinition(list(values)), io_manager_def=manager)
+    def upstream_asset(context: AssetExecutionContext):
+        return values[context.partition_key]
+
+    @dg.asset(io_manager_def=manager)
+    def downstream_asset(upstream_asset: dict[str, Any]):
+        return upstream_asset
+
+    for partition_key in values:
+        dg.materialize([upstream_asset], partition_key=partition_key)
+
+    result = dg.materialize([upstream_asset.to_source_asset(), downstream_asset])
+    assert result.output_for_node("downstream_asset", "result") == values
+
+
 def test_upath_can_transition_from_non_partitioned_to_partitioned(
     tmp_path: Path, daily: DailyPartitionsDefinition, start: datetime
 ):


### PR DESCRIPTION
## Summary & Motivation

`UPathIOManager.load_partitions_async` (used whenever a subclass defines `async def load_from_path`) diverges from its sync twin `load_partitions` in three ways, all in the same partition-load path. Its docstring says "Same as `load_partitions`, but for async", so the divergence looks unintended.

**1. Results are re-keyed positionally, so partitions get another partition's data (silent, no error).**
Successful loads were appended to a list and then zipped back against `context.asset_partition_keys`. Any partition skipped under `allow_missing_partitions=True` shifts every later result one slot left and drops the trailing one. With a daily-partitioned upstream, a downstream `AssetIn(partition_mapping=TimeWindowPartitionMapping(start_offset=-2), metadata={"allow_missing_partitions": True})`, and only `2022-01-02`/`2022-01-03` materialized:

```
got:      {"2022-01-01": "2022-01-02", "2022-01-02": "2022-01-03"}
expected: {"2022-01-02": "2022-01-02", "2022-01-03": "2022-01-03"}
```

The same asset with a sync `load_from_path` returns the expected dict. Only the case where the *last* mapped partition is the missing one happened to line up, which is what the existing test covers. The fix is to key the results dict by `partition_key` as `load_partitions` already does.

**2. The multipartition backcompat fallback never ran in async mode.**
`_load_partition_from_path` is a plain `def` whose `try/except FileNotFoundError` wraps `self.load_from_path(...)`. When `load_from_path` is a coroutine function the call returns a coroutine and raises nothing, so the `except` body — the legacy `"a|1"`-layout fallback and the per-partition skip — was unreachable; the error only surfaces later out of `asyncio.gather`. Assets written by very old Dagster versions therefore failed to load in async mode while the sync path falls back transparently (`_load_single_input` already awaits the coroutine correctly). Added `_load_partition_from_path_async`, an async twin that awaits inside the same `try`, which also makes it the single place handling `allow_missing_partitions`.

**3. The failure count in the error message was wrong.**
The `if found_errors: raise RuntimeError(...)` guard was indented inside the per-partition loop, so it fired on the first failing partition and reported `total - successes_so_far`. Three mapped partitions with only the first missing produced `RuntimeError: 3 partitions could not be loaded`. Dedenting it after the loop leaves *whether* the error is raised unchanged and only fixes when and with what count.

No public API change; `load_partitions_async` returns the same shape as before.

## Test Plan

`python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py`, using the existing `AsyncJSONIOManager`:

- `test_upath_io_manager_async_allow_missing_partitions_keeps_keys_aligned` (parametrized): a missing partition that is not the last key, and multiple non-contiguous missing partitions — every returned key maps to its own data. Fails on master with keys shifted onto the wrong partitions.
- `test_upath_io_manager_async_fail_on_missing_partitions_error_message`: 1 of 3 mapped partitions missing reports `1 partitions could not be loaded`. Fails on master with `3`.
- `test_upath_io_manager_async_multipartitions_backcompat_path`: a multipartition stored in the legacy flat `"b|1"` layout resolves through the backcompat path, mirroring `test_fs_io_manager.py::test_backcompat_multipartitions_fs_io_manager`. Fails on master with `RuntimeError: 1 partitions could not be loaded`.
- `test_upath_io_manager_async_multipartitions_allow_missing_partitions`: async multipartition missing from both the normal and backcompat location is skipped with a warning rather than raised.
- `test_upath_io_manager_async_keeps_falsy_partition_values`: `0`, `""`, `[]`, `False` partition values survive the `is not None` filtering.
- The existing async tests (`..._async_allow_missing_partitions`, `..._async_fail_on_missing_partitions`, `..._async_multiple_time_partitions`) are unchanged and still pass.

```
pytest dagster_tests/storage_tests/test_upath_io_manager.py -q          -> 39 passed
pytest dagster_tests/storage_tests/test_fs_io_manager.py -q -k backcompat -> 1 passed
pytest dagster_tests/storage_tests/ -q                                   -> 1042 passed, 102 skipped
ruff check / ruff format --check                                         -> clean
```

## Changelog

Fixed a bug where `UPathIOManager` subclasses with an async `load_from_path` returned partition data under the wrong partition keys when an upstream partition was missing and `allow_missing_partitions` was set, never fell back to the legacy multipartition storage layout, and reported the wrong partition count when a partition failed to load.