### PR TITLE
Resolve parameterized generic annotations to an unchecked DagsterType

### DIFF
--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -879,6 +879,75 @@ class TypeHintInferredDagsterType(DagsterType):
         return self.python_type.__name__
 
 
+_GENERIC_FALLBACK_CACHE: t.Dict[object, DagsterType] = {}
+"""Memoizes the DagsterType for a parameterized generic annotation, keyed by the annotation."""
+
+
+def _short_type_name(annotation_arg: object) -> str:
+    return getattr(annotation_arg, "__name__", None) or str(annotation_arg)
+
+
+class UncheckedGenericDagsterType(DagsterType):
+    """Created from a parameterized generic annotation whose type parameters Dagster cannot check,
+    e.g. `pandera.typing.polars.DataFrame[MySchema]`. Checking a type parameter requires logic
+    specific to the library that defined it, so values are not validated against the parameters.
+    """
+
+    def __init__(self, annotation: t.Any, origin: type):
+        rendered = str(annotation)
+        note = "Type parameters not validated."
+
+        def _type_check(_context, _value) -> TypeCheck:
+            return TypeCheck(success=True, description=note)
+
+        self.origin = origin
+        # DagsterType.__init__ reads display_name, so this has to be set beforehand.
+        args = ", ".join(_short_type_name(arg) for arg in get_args(annotation))
+        self._display_name = f"{origin.__name__}[{args}]"
+
+        super(UncheckedGenericDagsterType, self).__init__(
+            key=f"_UncheckedGeneric[{rendered}]",
+            description=(
+                f"{note} To validate values of `{rendered}`, set `dagster_type` explicitly, or map"
+                f" the unparameterized `{origin.__name__}` to a DagsterType with"
+                " `make_python_type_usable_as_dagster_type`."
+            ),
+            metadata={"unchecked_type_parameters": MetadataValue.text(rendered)},
+            type_check_fn=_type_check,
+            # Preserved so that IO managers can still dispatch on the unparameterized type.
+            typing_type=origin,
+        )
+
+    @property
+    def display_name(self) -> str:
+        return self._display_name
+
+
+def _is_unchecked_generic_origin(origin: object) -> bool:
+    # Limited to classes defined outside the stdlib typing machinery, so that annotations Dagster
+    # deliberately does not accept -- `Callable[..., X]`, `type[X]` -- keep raising.
+    return isinstance(origin, type) and origin.__module__ not in (
+        "builtins",
+        "typing",
+        "collections.abc",
+    )
+
+
+def _resolve_unchecked_generic(annotation: object, origin: type) -> DagsterType:
+    # A DagsterType mapped to the origin wins, so that
+    # `make_python_type_usable_as_dagster_type(Foo, my_type)` also covers `Foo[Bar]`. Read only:
+    # resolving an annotation must not claim the origin's registry slot.
+    registered = _PYTHON_TYPE_TO_DAGSTER_TYPE_MAPPING_REGISTRY.get(origin)
+    if registered is not None:
+        return registered
+
+    if annotation not in _GENERIC_FALLBACK_CACHE:
+        _GENERIC_FALLBACK_CACHE[annotation] = UncheckedGenericDagsterType(
+            annotation, origin
+        )
+    return _GENERIC_FALLBACK_CACHE[annotation]
+
+
 def resolve_dagster_type(dagster_type: object) -> DagsterType:
     # circular dep
     from dagster._core.definitions.result import MaterializeResult, ObserveResult
@@ -966,11 +1035,10 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
     if isinstance(dagster_type, type):
         return resolve_python_type_to_dagster_type(dagster_type)
 
-    # Fall back to origin for generic type hints and
-    # resolves it, reading as unparameterized type instead.
+    # A parameterized generic, e.g. `Foo[Bar]`: resolve it with its parameters left unchecked.
     origin = get_origin(dagster_type)
-    if isinstance(origin, type):
-        return resolve_dagster_type(origin)
+    if _is_unchecked_generic_origin(origin):
+        return _resolve_unchecked_generic(dagster_type, t.cast(type, origin))
 
     raise DagsterInvalidDefinitionError(
         DAGSTER_INVALID_TYPE_ERROR_MESSAGE.format(

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -966,6 +966,12 @@ def resolve_dagster_type(dagster_type: object) -> DagsterType:
     if isinstance(dagster_type, type):
         return resolve_python_type_to_dagster_type(dagster_type)
 
+    # Fall back to origin for generic type hints and
+    # resolves it, reading as unparameterized type instead.
+    origin = get_origin(dagster_type)
+    if isinstance(origin, type):
+        return resolve_dagster_type(origin)
+
     raise DagsterInvalidDefinitionError(
         DAGSTER_INVALID_TYPE_ERROR_MESSAGE.format(
             dagster_type=str(dagster_type), additional_msg="."

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -9,7 +9,6 @@ from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.types.dagster_type import ListType, resolve_dagster_type
 
 
-
 class BarObj:
     pass
 

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -1,12 +1,13 @@
 import re
 import typing
+from typing import Generic, TypeVar
 
 import dagster as dg
 import pytest
 from dagster import DagsterEventType
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.types.dagster_type import ListType, resolve_dagster_type
-from typing import Generic, TypeVar
+
 
 
 class BarObj:
@@ -658,7 +659,6 @@ def test_tuple_inner_types_not_mutable():
     assert isinstance(inner_types[0], ListType)
     assert inner_types[0].inner_type == inner_types[1]
     assert len(inner_types) == 2
-
 
 
 def test_generic_annotation_resolves_to_origin():

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -660,7 +660,74 @@ def test_tuple_inner_types_not_mutable():
     assert len(inner_types) == 2
 
 
-def test_generic_annotation_resolves_to_origin():
-    T = TypeVar("T")
-    class Foo(Generic[T]): ...
-    assert resolve_dagster_type(Foo[int]) == resolve_dagster_type(Foo) # expect matching class, disregarding arguments
+T = TypeVar("T")
+
+
+class GenericContainer(Generic[T]):
+    """Stands in for library generics such as `pandera.typing.polars.DataFrame`, whose values are
+    instances of an unparameterized base class rather than of the annotation itself.
+    """
+
+
+class Schema:
+    pass
+
+
+def test_generic_annotation_resolves_to_unchecked_type():
+    dagster_type = resolve_dagster_type(GenericContainer[Schema])
+
+    # The origin is preserved so that IO managers can still dispatch on it, but the type parameter
+    # is not checked -- Dagster has no way to derive a runtime check from it.
+    assert dagster_type.typing_type is GenericContainer
+    assert dagster_type.display_name == "GenericContainer[Schema]"
+    assert dagster_type.description and "not validated" in dagster_type.description
+
+    # The check passes for any value, including one that is not an instance of the origin, and
+    # records that the parameters went unchecked on the input/output event.
+    type_check = dagster_type.type_check(None, "not a GenericContainer")  # pyright: ignore[reportArgumentType]
+    assert type_check.success
+    assert type_check.description and "not validated" in type_check.description
+
+
+def test_generic_annotation_cached_per_parameterization():
+    assert resolve_dagster_type(GenericContainer[Schema]) is resolve_dagster_type(
+        GenericContainer[Schema]
+    )
+    assert (
+        resolve_dagster_type(GenericContainer[Schema]).key
+        != resolve_dagster_type(GenericContainer[int]).key
+    )
+
+
+def test_generic_annotation_resolves_when_nested():
+    assert (
+        resolve_dagster_type(GenericContainer[Schema] | None).display_name
+        == "GenericContainer[Schema]?"
+    )
+    assert (
+        resolve_dagster_type(list[GenericContainer[Schema]]).display_name
+        == "[GenericContainer[Schema]]"
+    )
+
+
+def test_unsupported_typing_constructs_still_raise():
+    for annotation in (typing.Callable[[int], str], type[GenericContainer]):
+        with pytest.raises(dg.DagsterInvalidDefinitionError, match="Invalid type"):
+            resolve_dagster_type(annotation)
+
+
+def test_generic_annotation_does_not_claim_origin_in_registry():
+    U = TypeVar("U")
+
+    class OtherContainer(Generic[U]):
+        pass
+
+    resolve_dagster_type(OtherContainer[Schema])
+
+    # Resolving the parameterized annotation must not auto-register the origin, or it would lock
+    # users out of the mapping they are pointed at to get real validation.
+    mapped = dg.DagsterType(type_check_fn=lambda _, value: value == "ok", name="Mapped")
+    dg.make_python_type_usable_as_dagster_type(OtherContainer, mapped)
+
+    # And once mapped, the mapping wins over the unchecked fallback.
+    assert resolve_dagster_type(OtherContainer[Schema]) is mapped

--- a/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/runtime_types_tests/test_types.py
@@ -6,6 +6,7 @@ import pytest
 from dagster import DagsterEventType
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.types.dagster_type import ListType, resolve_dagster_type
+from typing import Generic, TypeVar
 
 
 class BarObj:
@@ -657,3 +658,10 @@ def test_tuple_inner_types_not_mutable():
     assert isinstance(inner_types[0], ListType)
     assert inner_types[0].inner_type == inner_types[1]
     assert len(inner_types) == 2
+
+
+
+def test_generic_annotation_resolves_to_origin():
+    T = TypeVar("T")
+    class Foo(Generic[T]): ...
+    assert resolve_dagster_type(Foo[int]) == resolve_dagster_type(Foo) # expect matching class, disregarding arguments


### PR DESCRIPTION
## Summary & Motivation

Today this raises `DagsterInvalidDefinitionError`:

```python
@dg.asset
def upstream() -> pandera.typing.polars.DataFrame[MySchema]: ...
```

Dagster can't turn `MySchema` into a runtime check -- doing that requires pandera-specific logic -- so the annotation is rejected outright. The workaround is to drop the generic from the signature and hand Dagster a type instead:

```python
@dg.asset(dagster_type=pandera_schema_to_dagster_type(MySchema))
def upstream():
    return pl.DataFrame(...)
```

That works, but it means giving up the annotation that made the code readable in the first place, on every asset.

This PR makes the first form load. The parameters still aren't validated -- Dagster still can't read them -- but you keep the annotation, the type displays as `DataFrame[MySchema]`, and the step input/output event records that the parameters went unchecked. Nothing is emitted at definition time and no new events are created.

Validation stays available and is now less repetitive: a DagsterType mapped to the origin takes precedence, so a single `make_python_type_usable_as_dagster_type(DataFrame, my_type)` covers every `DataFrame[...]` annotation instead of one `dagster_type=` per asset.

`Callable[..., X]`, `type[X]` and other annotations Dagster deliberately rejects keep raising.

### Why not resolve through the origin

An earlier revision resolved `Foo[Bar]` by calling `resolve_dagster_type(origin)`. That produces an `isinstance(value, origin)` check, which annotation-only generics never satisfy -- `pandera.typing.polars.DataFrame` subclasses `pl.DataFrame` and is never instantiated -- so the asset above failed at runtime with `DagsterTypeCheckDidNotPass` instead of at import. It also wrote the origin into `_PYTHON_TYPE_TO_DAGSTER_TYPE_MAPPING_REGISTRY`, which then blocked `make_python_type_usable_as_dagster_type` for that class depending on import order.

## How I Tested These Changes

- Ran the #22694 example end to end; it materializes, with the note on the step output and input events.
- New unit tests: the unchecked type and its check, caching per parameterization, nesting in `Optional`/`list`, unsupported constructs still raising, and that resolution doesn't claim the origin's registry entry.
- `dagster_tests/core_tests` passes.