### PR TITLE
Fix EnvFileLoader joining ".env" onto base_dir twice

### DIFF
--- a/python_modules/dagster/dagster/_core/secrets/env_file.py
+++ b/python_modules/dagster/dagster/_core/secrets/env_file.py
@@ -83,9 +83,9 @@ class EnvFileLoader(SecretsLoader, ConfigurableClass):
         self._base_dir = base_dir or os.getcwd()
 
     def get_secrets_for_environment(self, location_name: str | None) -> dict[str, str]:
-        env_file_path = os.path.join(self._base_dir, ".env")
-
-        env_var_dict = get_env_var_dict(env_file_path)
+        # get_env_var_dict takes the directory containing the .env file and joins
+        # ".env" onto it itself - joining it here too would look for <base_dir>/.env/.env
+        env_var_dict = get_env_var_dict(self._base_dir)
 
         if len(env_var_dict):
             logging.getLogger("dagster").info(

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -23,7 +23,7 @@ from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.instance.config import DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
 from dagster._core.launcher import LaunchRunContext, RunLauncher
 from dagster._core.remote_representation.external_data import PartitionsSnap
-from dagster._core.secrets.env_file import PerProjectEnvFileLoader
+from dagster._core.secrets.env_file import EnvFileLoader, PerProjectEnvFileLoader
 from dagster._core.snap import create_execution_plan_snapshot_id, snapshot_from_execution_plan
 from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecordStatus
 from dagster._core.storage.partition_status_cache import AssetPartitionStatus, AssetStatusCacheValue
@@ -170,6 +170,48 @@ def test_custom_per_project_secrets_manager():
             "FOO": "BAR"
         }
         assert instance._secrets_loader.get_secrets_for_environment("other_location") == {}  # noqa: SLF001
+
+
+def test_env_file_secrets_manager():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        (Path(temp_dir) / ".env").write_text("FOO=BAR")
+
+        assert EnvFileLoader(base_dir=temp_dir).get_secrets_for_environment(None) == {"FOO": "BAR"}
+
+
+def test_env_file_secrets_manager_defaults_to_cwd():
+    with tempfile.TemporaryDirectory() as temp_dir, new_cwd(temp_dir):
+        (Path(temp_dir) / ".env").write_text("FOO=BAR")
+
+        assert EnvFileLoader().get_secrets_for_environment(None) == {"FOO": "BAR"}
+
+
+def test_env_file_secrets_manager_no_env_file():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        assert EnvFileLoader(base_dir=temp_dir).get_secrets_for_environment(None) == {}
+
+
+def test_custom_env_file_secrets_manager():
+    with (
+        tempfile.TemporaryDirectory() as temp_dir,
+        dg.instance_for_test(
+            overrides={
+                "secrets": {
+                    "custom": {
+                        "module": "dagster._core.secrets.env_file",
+                        "class": "EnvFileLoader",
+                        "config": {"base_dir": str(temp_dir)},
+                    }
+                }
+            }
+        ) as instance,
+    ):
+        assert isinstance(instance._secrets_loader, EnvFileLoader)  # noqa: SLF001
+        (Path(temp_dir) / ".env").write_text("FOO=BAR")
+
+        with environ({"FOO": None}):
+            instance.inject_env_vars(None)
+            assert os.environ["FOO"] == "BAR"
 
 
 def test_custom_secrets_manager():


### PR DESCRIPTION
## Summary & Motivation

Fixes #34056.

`get_env_var_dict()` takes the **directory** containing the `.env` file and joins `".env"` onto it itself:

```python
def get_env_var_dict(base_dir: str) -> dict[str, str]:
    env_file_path = os.path.join(base_dir, ".env")
    ...
```

`EnvFileLoader.get_secrets_for_environment()` joined `".env"` on *before* calling it, then passed the resulting **file** path in as if it were a directory — so it stat'd `<base_dir>/.env/.env`, a path that can never exist, and silently returned `{}`.

The failure is silent, which is what makes it costly. Configuring:

```yaml
secrets:
  module: dagster._core.secrets.env_file
  class: EnvFileLoader
  config:
    base_dir: /path/to/dir   # directory containing .env
```

in `dagster.yaml` looks like it works, but `DagsterInstance.inject_env_vars()` never injects anything, so `EnvVar` resolution quietly falls through to whatever the ambient environment holds (or fails at run launch). The default no-`base_dir` path (`base_dir or os.getcwd()`) was broken the same way — `dagster dev`'s cwd-based `.env` loading only works because it goes through `_inject_local_env_file`, which calls `get_env_var_dict(os.getcwd())` correctly and never touches this loader.

`PerProjectEnvFileLoader`, in the same module, already gets this right: it passes a directory and lets `get_env_var_dict` do the single join. This change makes `EnvFileLoader` match.

The removed `env_file_path` local had no other use, so the fix is a one-liner. I left a comment at the call site since the double-join is easy to reintroduce.

## Test Plan

`EnvFileLoader` had no test coverage, so this adds four tests in `dagster_tests/core_tests/instance_tests/test_instance.py`, next to the existing `PerProjectEnvFileLoader` ones:

- `test_env_file_secrets_manager` — explicit `base_dir` loads the `.env`
- `test_env_file_secrets_manager_defaults_to_cwd` — the default `base_dir or os.getcwd()` path
- `test_env_file_secrets_manager_no_env_file` — a directory with no `.env` still returns `{}`
- `test_custom_env_file_secrets_manager` — the reported path end to end: configured via `dagster.yaml`-style `secrets:` overrides, asserting `instance.inject_env_vars()` actually sets the variable in `os.environ`

All four were confirmed to fail against `master` before the fix (the three that assert loaded values; the empty-directory one is a regression guard) and pass after. Full file: 42 passed.

## Changelog

Fixed a bug where `EnvFileLoader` configured under `secrets:` in `dagster.yaml` never loaded any environment variables, because `.env` was appended to the configured `base_dir` twice.

---

Thanks to @winklemad for independently reproducing this on `master` and confirming it also fails through the configured `dagster.yaml` path, not just the constructor.
