### PR TITLE
[graphql] Reject cancel/resume on backfills in a terminal state

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -325,6 +325,17 @@ def cancel_partition_backfill(
 
     assert_permission_for_backfill(graphene_info, Permissions.CANCEL_PARTITION_BACKFILL, backfill)
 
+    # A terminal backfill is no longer polled by the daemon, so moving it to CANCELING both
+    # re-enqueues finished work and destroys the record of how it originally ended: the daemon's
+    # next iteration overwrites backfill_end_timestamp on its way to CANCELED, and only the latest
+    # status is stored, so the original outcome cannot be recovered.
+    if backfill.status in BULK_ACTION_TERMINAL_STATUSES:
+        raise DagsterInvariantViolationError(
+            f"Cannot cancel backfill {backfill_id} because it is already in a terminal state "
+            f"({backfill.status.value}). Any runs of this backfill that are still in flight can "
+            f"be stopped individually with terminateRuns."
+        )
+
     graphene_info.context.instance.update_backfill(backfill.with_status(BulkActionStatus.CANCELING))
 
     return GrapheneCancelBackfillSuccess(backfill_id=backfill_id)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -341,6 +341,20 @@ def resume_partition_backfill(
 
     assert_permission_for_backfill(graphene_info, Permissions.LAUNCH_PARTITION_BACKFILL, backfill)
 
+    # FAILED is the only state a backfill can be resumed from. It is the one terminal state whose
+    # closure is involuntary -- the daemon hit an error, so partitions may remain unlaunched -- which
+    # makes it the only state where returning to REQUESTED is meaningful. Every other terminal state
+    # either finished its work (COMPLETED*) or was stopped on purpose (CANCELED), and resuming those
+    # launches runs the operator never asked for. Forking a finished backfill into a new one is what
+    # retry_partition_backfill is for.
+    if backfill.status != BulkActionStatus.FAILED:
+        raise DagsterInvariantViolationError(
+            f"Cannot resume backfill {backfill_id} because it is not in a failed state "
+            f"(current status: {backfill.status.value}). To re-run a backfill that has already "
+            f"finished, re-execute it instead, which allocates a new backfill and leaves this "
+            f"one's record intact."
+        )
+
     graphene_info.context.instance.update_backfill(backfill.with_status(BulkActionStatus.REQUESTED))
     return GrapheneResumeBackfillSuccess(backfill_id=backfill_id)
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -336,6 +336,17 @@ def cancel_partition_backfill(
             f"be stopped individually with terminateRuns."
         )
 
+    # FAILING is already a teardown. execute_job_backfill_iteration handles FAILING and CANCELING
+    # through the same path, cancelling the in-flight runs either way and differing only in the
+    # status it settles on. Cancelling a FAILING backfill therefore changes nothing the daemon
+    # does; it only relabels the outcome as an operator cancellation while the daemon's error
+    # object and failure count stay attached to the record.
+    if backfill.status == BulkActionStatus.FAILING:
+        raise DagsterInvariantViolationError(
+            f"Cannot cancel backfill {backfill_id} because it is already being torn down after a "
+            f"failure and will move to {BulkActionStatus.FAILED.value}."
+        )
+
     graphene_info.context.instance.update_backfill(backfill.with_status(BulkActionStatus.CANCELING))
 
     return GrapheneCancelBackfillSuccess(backfill_id=backfill_id)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -2549,3 +2549,81 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
 
         assert retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == backfill_id
         assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
+
+
+class TestBackfillTerminalStateGuards(ExecutingGraphQLContextTestMatrix):
+    """cancel and resume must reject a backfill whose current status makes the transition invalid.
+
+    Both mutations used to transition unconditionally, so any of the eight statuses was accepted by
+    either one -- including driving a finished backfill back into an active state, which loses the
+    record of how it originally ended and lets the daemon launch partitions the operator had
+    cancelled.
+    """
+
+    def _launch_backfill(self, graphql_context):
+        result = execute_dagster_graphql(
+            graphql_context,
+            LAUNCH_PARTITION_BACKFILL_MUTATION,
+            variables={
+                "backfillParams": {
+                    "selector": {
+                        "repositorySelector": infer_repository_selector(graphql_context),
+                        "partitionSetName": "integers_partition_set",
+                    },
+                    "partitionNames": ["2", "3"],
+                }
+            },
+        )
+        assert not result.errors
+        assert result.data
+        assert result.data["launchPartitionBackfill"]["__typename"] == "LaunchBackfillSuccess"
+        return result.data["launchPartitionBackfill"]["backfillId"]
+
+    def _backfill_in_status(self, graphql_context, status):
+        backfill_id = self._launch_backfill(graphql_context)
+        backfill = graphql_context.instance.get_backfill(backfill_id)
+        graphql_context.instance.update_backfill(backfill.with_status(status))
+        return backfill_id
+
+    def test_resume_rejects_backfill_that_is_not_failed(self, graphql_context):
+        for status in (
+            BulkActionStatus.REQUESTED,
+            BulkActionStatus.CANCELING,
+            BulkActionStatus.FAILING,
+            BulkActionStatus.CANCELED,
+            BulkActionStatus.COMPLETED_SUCCESS,
+            BulkActionStatus.COMPLETED_FAILED,
+            BulkActionStatus.COMPLETED,
+        ):
+            backfill_id = self._backfill_in_status(graphql_context, status)
+
+            result = execute_dagster_graphql(
+                graphql_context,
+                RESUME_BACKFILL_MUTATION,
+                variables={"backfillId": backfill_id},
+            )
+
+            assert not result.errors
+            assert result.data
+            assert result.data["resumePartitionBackfill"]["__typename"] == "PythonError"
+            assert "not in a failed state" in result.data["resumePartitionBackfill"]["message"]
+            assert status.value in result.data["resumePartitionBackfill"]["message"]
+
+            # a rejected mutation must not have written anything
+            assert graphql_context.instance.get_backfill(backfill_id).status == status
+
+    def test_resume_still_accepts_failed_backfill(self, graphql_context):
+        backfill_id = self._backfill_in_status(graphql_context, BulkActionStatus.FAILED)
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            RESUME_BACKFILL_MUTATION,
+            variables={"backfillId": backfill_id},
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["resumePartitionBackfill"]["__typename"] == "ResumeBackfillSuccess"
+        assert (
+            graphql_context.instance.get_backfill(backfill_id).status == BulkActionStatus.REQUESTED
+        )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -2551,6 +2551,21 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
 
+# The states each mutation accepts, spelled out rather than derived from the implementation so the
+# table is an independent statement of intent. Keep in sync with cancel_partition_backfill and
+# resume_partition_backfill in dagster_graphql/implementation/execution/backfill.py.
+BACKFILL_GUARD_MATRIX = {
+    BulkActionStatus.REQUESTED: {"cancel": True, "resume": False},
+    BulkActionStatus.CANCELING: {"cancel": True, "resume": False},
+    BulkActionStatus.FAILING: {"cancel": True, "resume": False},
+    BulkActionStatus.FAILED: {"cancel": False, "resume": True},
+    BulkActionStatus.CANCELED: {"cancel": False, "resume": False},
+    BulkActionStatus.COMPLETED_SUCCESS: {"cancel": False, "resume": False},
+    BulkActionStatus.COMPLETED_FAILED: {"cancel": False, "resume": False},
+    BulkActionStatus.COMPLETED: {"cancel": False, "resume": False},
+}
+
+
 class TestBackfillTerminalStateGuards(ExecutingGraphQLContextTestMatrix):
     """cancel and resume must reject a backfill whose current status makes the transition invalid.
 
@@ -2627,3 +2642,85 @@ class TestBackfillTerminalStateGuards(ExecutingGraphQLContextTestMatrix):
         assert (
             graphql_context.instance.get_backfill(backfill_id).status == BulkActionStatus.REQUESTED
         )
+
+    def test_cancel_rejects_terminal_backfill(self, graphql_context):
+        for status in (
+            BulkActionStatus.COMPLETED_SUCCESS,
+            BulkActionStatus.COMPLETED_FAILED,
+            BulkActionStatus.COMPLETED,
+            BulkActionStatus.CANCELED,
+            BulkActionStatus.FAILED,
+        ):
+            backfill_id = self._backfill_in_status(graphql_context, status)
+
+            result = execute_dagster_graphql(
+                graphql_context,
+                CANCEL_BACKFILL_MUTATION,
+                variables={"backfillId": backfill_id},
+            )
+
+            assert not result.errors
+            assert result.data
+            assert result.data["cancelPartitionBackfill"]["__typename"] == "PythonError"
+            assert (
+                "already in a terminal state" in result.data["cancelPartitionBackfill"]["message"]
+            )
+            assert status.value in result.data["cancelPartitionBackfill"]["message"]
+
+            assert graphql_context.instance.get_backfill(backfill_id).status == status
+
+    def test_cancel_still_accepts_active_backfill(self, graphql_context):
+        for status in (
+            BulkActionStatus.REQUESTED,
+            BulkActionStatus.CANCELING,
+            BulkActionStatus.FAILING,
+        ):
+            backfill_id = self._backfill_in_status(graphql_context, status)
+
+            result = execute_dagster_graphql(
+                graphql_context,
+                CANCEL_BACKFILL_MUTATION,
+                variables={"backfillId": backfill_id},
+            )
+
+            assert not result.errors
+            assert result.data
+            assert result.data["cancelPartitionBackfill"]["__typename"] == "CancelBackfillSuccess"
+            assert (
+                graphql_context.instance.get_backfill(backfill_id).status
+                == BulkActionStatus.CANCELING
+            )
+
+    def test_guard_matrix(self, graphql_context):
+        """Every status x {cancel, resume} cell, so a change to either guard shows up as a diff
+        against the table rather than as a missing test. Collects all mismatches before failing.
+        """
+        mutations = {
+            "cancel": (CANCEL_BACKFILL_MUTATION, "cancelPartitionBackfill"),
+            "resume": (RESUME_BACKFILL_MUTATION, "resumePartitionBackfill"),
+        }
+
+        mismatches = []
+        for status, expected in BACKFILL_GUARD_MATRIX.items():
+            for name, (mutation, field) in mutations.items():
+                backfill_id = self._backfill_in_status(graphql_context, status)
+
+                result = execute_dagster_graphql(
+                    graphql_context, mutation, variables={"backfillId": backfill_id}
+                )
+                assert not result.errors
+                assert result.data
+
+                typename = result.data[field]["__typename"]
+                accepted = typename != "PythonError"
+                if accepted != expected[name]:
+                    mismatches.append(
+                        f"{status.value}/{name}: expected "
+                        f"{'accept' if expected[name] else 'reject'}, got {typename}"
+                    )
+
+        assert not mismatches, "guard matrix mismatches:\n" + "\n".join(mismatches)
+
+    def test_guard_matrix_covers_every_status(self):
+        """The matrix is only exhaustive if it lists every enum member."""
+        assert set(BACKFILL_GUARD_MATRIX) == set(BulkActionStatus)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -2557,7 +2557,7 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
 BACKFILL_GUARD_MATRIX = {
     BulkActionStatus.REQUESTED: {"cancel": True, "resume": False},
     BulkActionStatus.CANCELING: {"cancel": True, "resume": False},
-    BulkActionStatus.FAILING: {"cancel": True, "resume": False},
+    BulkActionStatus.FAILING: {"cancel": False, "resume": False},
     BulkActionStatus.FAILED: {"cancel": False, "resume": True},
     BulkActionStatus.CANCELED: {"cancel": False, "resume": False},
     BulkActionStatus.COMPLETED_SUCCESS: {"cancel": False, "resume": False},
@@ -2670,11 +2670,7 @@ class TestBackfillTerminalStateGuards(ExecutingGraphQLContextTestMatrix):
             assert graphql_context.instance.get_backfill(backfill_id).status == status
 
     def test_cancel_still_accepts_active_backfill(self, graphql_context):
-        for status in (
-            BulkActionStatus.REQUESTED,
-            BulkActionStatus.CANCELING,
-            BulkActionStatus.FAILING,
-        ):
+        for status in (BulkActionStatus.REQUESTED, BulkActionStatus.CANCELING):
             backfill_id = self._backfill_in_status(graphql_context, status)
 
             result = execute_dagster_graphql(
@@ -2690,6 +2686,21 @@ class TestBackfillTerminalStateGuards(ExecutingGraphQLContextTestMatrix):
                 graphql_context.instance.get_backfill(backfill_id).status
                 == BulkActionStatus.CANCELING
             )
+
+    def test_cancel_rejects_failing_backfill(self, graphql_context):
+        backfill_id = self._backfill_in_status(graphql_context, BulkActionStatus.FAILING)
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            CANCEL_BACKFILL_MUTATION,
+            variables={"backfillId": backfill_id},
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["cancelPartitionBackfill"]["__typename"] == "PythonError"
+        assert "already being torn down" in result.data["cancelPartitionBackfill"]["message"]
+        assert graphql_context.instance.get_backfill(backfill_id).status == BulkActionStatus.FAILING
 
     def test_guard_matrix(self, graphql_context):
         """Every status x {cancel, resume} cell, so a change to either guard shows up as a diff


### PR DESCRIPTION
## Summary & Motivation

Written with AI assistance (Claude); the commits carry `Co-Authored-By` trailers. Every line reference and measurement below was re-verified against the source at `8e7f0b7425` before opening.

Addresses #33798.

`cancelPartitionBackfill` and `resumePartitionBackfill` write a new status with `with_status(...)` without checking the current one, so either can pull a backfill out of a terminal state; `retry_partition_backfill` already has the corresponding check. The issue has the full diagnosis and a reproducer. This adds the two missing guards.

**`resume` — `FAILED` only.** This is the one place the PR deliberately differs from the diff in the issue, which proposed `status != FAILING`. `FAILING` is an *active* state: the daemon polls `{REQUESTED, CANCELING, FAILING}` (`_daemon/backfill.py:127,130,133`) and is mid-teardown when it sees one — the enum comment says "launched runs will be canceled and then the backfill marked FAILED" (`_core/execution/backfill.py:53`). The only state a resume is meaningful from is `FAILED`. The commit that introduced the mutation says so ("This will mark a failed job as requested", `2b45dca4ff`), `BackfillActionsMenu.tsx:70` has enforced it client-side all along, and `test_resume_backfill` exercises it today. One consequence worth naming: resume's entire valid domain is a single *terminal* state, so the issue's fallback position — "at minimum, terminal states should not be allowed" — can't be applied to resume.

**`cancel` — reject terminal.** Exactly the guard proposed in the issue. I dropped the accompanying `CANCELING` early-return: reject-terminal already admits `CANCELING`, and `update_backfill` writes only `status` and `body` (`sql_run_storage.py:1113-1120`), so re-writing `CANCELING → CANCELING` is a no-op.

**The third commit is optional.** `FAILING` isn't terminal, so reject-terminal leaves it cancellable — and cancelling it relabels a daemon failure as an operator cancellation while the daemon's `error` object stays attached to the record. Same integrity problem, so the last commit rejects that too. It goes beyond what the issue asked: drop that one commit and the behavior is exactly what was proposed.

**One cost worth knowing before merge.** `dagster job backfill` submits its runs asynchronously and then writes `COMPLETED` with no check for unfinished ones (`_cli/job.py:927-931`), so a CLI-created backfill can be terminal while its runs are still `QUEUED`. Cancelling that record does real work today — measured over a 3-partition job: two daemon iterations, 3/3 runs canceled. With this guard it raises instead. I don't think that should widen the guard: the daemon's own completion path checks for unfinished runs first (`job_backfill.py:141-155`), so the unconditional CLI write looks like a separate defect of the same class, and `terminateRuns` still stops those runs by id. Happy to file it separately.

**Known limitation: the guard is read-check-write.** If a daemon iteration completes a `REQUESTED` backfill between this mutation's read and its write, the guard validates a stale status and the write still lands, overwriting the terminal outcome. Greptile flagged this below; the thread has the detail. Two things bound it: it applies to `cancel` only — `resume` admits only `FAILED`, which the daemon never polls (`_daemon/backfill.py:127,130,133`), so it has no concurrent writer — and this PR does not widen it, because master writes `CANCELING` over any status with no check at all, so that interleaving already produces the same record today. What this PR removes is every *non*-racing path to it.

Closing the race means a conditional write at the storage layer — `UPDATE bulk_actions SET ... WHERE key = ? AND status = ?`, which the schema already supports (`storage/runs/schema.py:119`) — and that changes the `RunStorage.update_backfill` contract (`storage/runs/base.py:399`) across every implementation, including `dagster_cloud/storage/runs/storage.py:571`, whose `updateBackfill` mutation accepts only the serialized record. I'd rather not fold that into a PR that currently touches one function and its tests; happy to open it as a follow-up. The race is already known in-tree — `job_backfill.py:78,126,134` and `asset_backfill.py:1199,1216` all refetch mid-iteration, two of them under the comment "Refetch, in case the backfill was forcibly marked as canceled/failed in the meantime."

Line references are against `8e7f0b7425`.

## Test Plan

New `TestBackfillTerminalStateGuards` in `test_partition_backfill.py`: every `BulkActionStatus` × {cancel, resume}, with the expected accept/reject table written out rather than derived from the implementation, plus a test that fails if a new enum member is added without a row.

Run locally against `8e7f0b7425`:

- guard tests — 18 passed `-m sqlite_instance`, 12 passed `-m postgres_instance`
- `test_partition_backfill.py -m sqlite_instance` — 104 passed on base, 122 on this branch (the +18)
- the issue's four reproducers, verbatim — 4 pass on base, 3 fail here. The fourth, `test_resume_failed_corrupts_state`, asserts `FAILED → REQUESTED` succeeds, which this PR keeps legal, so it passes on both
- full `dagster_graphql_tests/graphql/` — 1131 passed `-m sqlite_instance`, 727 `-m postgres_instance`, each with the same 3 pre-existing failures in the `non_launchable_*_lazy_repository` variant that fail identically on base. Measured on the pre-rebase tip, whose diff is byte-identical to this one
- `ruff format --diff` and `ruff check` clean

## Changelog

Cancelling or resuming a backfill that has already reached a terminal state now raises instead of silently overwriting its final status.

