### PR TITLE
doc: Update api docs for Definitions

### DIFF
--- a/docs/sphinx/sections/api/dagster/definitions.rst
+++ b/docs/sphinx/sections/api/dagster/definitions.rst
@@ -5,7 +5,7 @@ Definitions
 ###########
 
 .. autoclass:: Definitions
-    :members: get_job_def, get_sensor_def, get_schedule_def, load_asset_value, get_asset_value_loader
+    :members: resolve_job_def, get_job_def, get_sensor_def, get_schedule_def, load_asset_value, get_asset_value_loader
 
 .. autodecorator:: definitions
 

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -464,7 +464,8 @@ class Definitions(IHaveNew):
         If that is not found, the Definitions object is resolved (transforming UnresolvedAssetJobDefinitions to JobDefinitions and an example). It
         also finds jobs passed to sensors and schedules and retrieves them from the repository.
 
-        After dagster 1.11, this resolution step will not happen, and will throw an error if the job is not found.
+        After dagster 1.11, this resolution step will not happen, and will throw an error if the job is not found. You must use :py:func:`resolve_job_def`
+        to resolve to JobDefinitions.
         """
         found_direct = False
         for job in self.jobs or []:
@@ -486,6 +487,7 @@ class Definitions(IHaveNew):
 
         return self.resolve_job_def(name)
 
+    @public
     def resolve_job_def(self, name: str) -> JobDefinition:
         """Resolve a job definition by name. If you passed in an :py:class:`UnresolvedAssetJobDefinition`
         (return value of :py:func:`define_asset_job`) it will be resolved to a :py:class:`JobDefinition` when returned


### PR DESCRIPTION
- Expose docstring for resolve_job_def to public
- Update get_job_def to reference resolve_job_def

## Summary & Motivation
The documentation on Definitions API page is outdated, needs to expose the `resolve_job_def` as a public docstring

Related to #34078

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
