### PR TITLE
Fix docstring Args entries that name a parameter the function does not take

### DIFF
--- a/python_modules/dagster-test/dagster_test/dg_utils/utils.py
+++ b/python_modules/dagster-test/dagster_test/dg_utils/utils.py
@@ -658,7 +658,7 @@ def dg_exits(*matches: str) -> Iterator[None]:
     message.
 
     Args:
-        match: The string to match against the warning message.
+        matches: The strings to match against the output.
     """
     with redirect_dg_output() as out:
         with pytest.raises(SystemExit):
@@ -678,7 +678,7 @@ def dg_does_not_exit(*matches: str) -> Iterator[None]:
     """Context manager that checks that dg does not emit the given output or throw an exception.
 
     Args:
-        match: The string to match against the warning message.
+        matches: The strings to match against the output.
     """
     with redirect_dg_output() as out:
         yield
@@ -698,7 +698,7 @@ def dg_warns(*matches: str) -> Iterator[None]:
     since dg warnings don't emit actual python warnings.
 
     Args:
-        match: The string to match against the warning message.
+        matches: The strings to match against the warning message.
     """
     with redirect_dg_output() as out:
         yield

--- a/python_modules/dagster/dagster/_cli/utils.py
+++ b/python_modules/dagster/dagster/_cli/utils.py
@@ -121,7 +121,6 @@ def get_instance_for_cli(
     the instance from. Requires DAGSTER_HOME to be set or instance_ref to be passed in.
 
     Parameters:
-    cli_command: The name of the command - optional, used for logging messages.
     instance_ref: For commands that delegate to other commands, they can pass in
         a serialized instance_ref object rather than loading it from a dagster.yaml file.
     logger: Customize any log messages emitted while creating the instance.

--- a/python_modules/dagster/dagster/_config/config_type.py
+++ b/python_modules/dagster/dagster/_config/config_type.py
@@ -404,7 +404,7 @@ class ScalarUnion(ConfigType):
         non_scalar_schema (ConfigSchema):
             The schema of a non-scalar Dagster configuration type. For example, :py:class:`List`,
             :py:class:`Dict`, or :py:class:`~dagster.Selector`.
-        key (Optional[str]):
+        _key (Optional[str]):
             The configuation type's unique key. If not set, then the key will be set to
             ``ScalarUnion.{scalar_type}-{non_scalar_schema}``.
 

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -902,7 +902,7 @@ def do_composition(
         config_mapping (Any): Config mapping provided to decorator by user. In
             job/graph case, this would have been constructed from a user-provided
             config_schema and config_fn.
-        ignore_output_from_composite_fn(Bool): Because of backwards compatibility
+        ignore_output_from_composition_fn(bool): Because of backwards compatibility
             issues, jobs ignore the return value out of the mapping if
             the user has not explicitly provided the output definitions.
             This should be removed in 0.11.0.

--- a/python_modules/dagster/dagster/_core/definitions/executor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/executor_definition.py
@@ -79,8 +79,6 @@ class ExecutorDefinition(NamedConfigurableDefinition):
             be met in order for the executor to be usable for a particular job execution.
         executor_creation_fn(Optional[Callable]): Should accept an :py:class:`InitExecutorContext`
             and return an instance of :py:class:`Executor`
-        required_resource_keys (Optional[Set[str]]): Keys for the resources required by the
-            executor.
         description (Optional[str]): A description of the executor.
     """
 

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -1113,7 +1113,7 @@ class MultiAssetSensorDefinition(SensorDefinition, IHasInternalInit):
 
     Args:
         name (str): The name of the sensor to create.
-        asset_keys (Sequence[AssetKey]): The asset_keys this sensor monitors.
+        monitored_assets (Union[Sequence[AssetKey], AssetSelection]): The assets this sensor monitors.
         asset_materialization_fn (Callable[[MultiAssetSensorEvaluationContext], Union[Iterator[Union[RunRequest, SkipReason]], RunRequest, SkipReason]]): The core
             evaluation function for the sensor, which is run at an interval to determine whether a
             run should be launched or not. Takes a :py:class:`~dagster.MultiAssetSensorEvaluationContext`.

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -71,7 +71,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     Args:
         name (str): Name of the op. Must be unique within any :py:class:`GraphDefinition` or
             :py:class:`JobDefinition` that contains the op.
-        input_defs (List[InputDefinition]): Inputs of the op.
+        ins (Optional[Mapping[str, In]]): Inputs of the op.
         compute_fn (Callable): The core of the op, the function that performs the actual
             computation. The signature of this function is determined by ``input_defs``, and
             optionally, an injected first argument, ``context``, a collection of information
@@ -81,7 +81,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             one :py:class:`Output` for each of the op's ``output_defs``, and additionally may
             yield other types of Dagster events, including :py:class:`AssetMaterialization` and
             :py:class:`ExpectationResult`.
-        output_defs (List[OutputDefinition]): Outputs of the op.
+        outs (Optional[Mapping[str, Out]]): Outputs of the op.
         config_schema (Optional[ConfigSchema): The schema for the config. If set, Dagster will check
             that the config provided for the op matches this schema and will fail if it does not. If
             not set, Dagster will accept any config provided for the op.

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -187,7 +187,7 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
         auto_observe_interval_minutes (Optional[float]): While the asset daemon is turned on, a run
             of the observation function for this asset will be launched at this interval. `observe_fn`
             must be provided.
-        freshness_policy (FreshnessPolicy): A constraint telling Dagster how often this asset is intended to be updated
+        legacy_freshness_policy (Optional[LegacyFreshnessPolicy]): A constraint telling Dagster how often this asset is intended to be updated
             with respect to its root data.
         tags (Optional[Mapping[str, str]]): Tags for filtering and organizing. These tags are not
             attached to runs of the asset.

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -233,7 +233,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """Check to see if storage contains a pipeline snapshot.
 
         Args:
-            pipeline_snapshot_id (str): The id of the run.
+            job_snapshot_id (str): The id of the run.
 
         Returns:
             bool

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -171,7 +171,7 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         """Get the policy evaluations for a given asset.
 
         Args:
-            asset_key (AssetKey): The asset key to query
+            key (EntityKey): The entity key to query
             limit (Optional[int]): The maximum number of evaluations to return
             cursor (Optional[int]): The cursor to paginate from
         """

--- a/python_modules/dagster/dagster/_core/types/decorator.py
+++ b/python_modules/dagster/dagster/_core/types/decorator.py
@@ -37,7 +37,6 @@ def usable_as_dagster_type(
     make them dagster types whose typecheck is an isinstance check against that python class.
 
     Args:
-        python_type (cls): The python type to make usable as python type.
         name (Optional[str]): Name of the new Dagster type. If ``None``, the name (``__name__``) of
             the ``python_type`` will be used.
         description (Optional[str]): A user-readable description of the type.

--- a/python_modules/libraries/dagster-airlift/dagster_airlift/mwaa/auth.py
+++ b/python_modules/libraries/dagster-airlift/dagster_airlift/mwaa/auth.py
@@ -38,7 +38,7 @@ class MwaaSessionAuthBackend(AirflowAuthBackend):
     uses the token to authenticate to the MWAA web server.
 
     Args:
-        mwaa_session (boto3.Session): The boto3 MWAA session
+        mwaa_client (Any): The boto3 MWAA client
         env_name (str): The name of the MWAA environment
 
     Examples:

--- a/python_modules/libraries/dagster-azure/dagster_azure/pipes/context_injectors.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/pipes/context_injectors.py
@@ -19,8 +19,6 @@ class PipesAzureBlobStorageContextInjector(PipesContextInjector):
     Args:
         container (str): The AzureBlobStorage container to write to.
         client (azure.storage.blob.BlobServiceClient): An Azure Blob Storage client.
-        key_prefix (Optional[str]): An optional prefix to use for the Azure Blob Storage key. Defaults to a random
-            string.
 
     """
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -532,8 +532,6 @@ class PipesDbfsMessageReader(PipesBlobStoreMessageReader):
     Args:
         interval (float): interval in seconds between attempts to download a chunk
         client (WorkspaceClient): A databricks `WorkspaceClient` object.
-        cluster_log_root (Optional[str]): The root path on DBFS where the cluster logs are written.
-            If set, this will be used to read stderr/stdout logs.
         include_stdio_in_messages (bool): Whether to send stdout/stderr to Dagster via Pipes messages. Defaults to False.
         log_readers (Optional[Sequence[PipesLogReader]]): A set of log readers for logs on DBFS.
     """

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -64,7 +64,7 @@ class PipesDockerClient(PipesClient, TreatAsResourceParam):
     Args:
         env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the
             container.
-        register (Optional[Mapping[str, str]]): An optional dict of registry credentials to login to
+        registry (Optional[Mapping[str, str]]): An optional dict of registry credentials to login to
             the docker client.
         context_injector (Optional[PipesContextInjector]): A context injector to use to inject
             context into the docker container process. Defaults to :py:class:`PipesEnvContextInjector`.

--- a/python_modules/libraries/dagster-github/dagster_github/resources.py
+++ b/python_modules/libraries/dagster-github/dagster_github/resources.py
@@ -121,8 +121,6 @@ class GithubClient:
         app_private_rsa_key (str): The private RSA key for the GitHub App.
         default_installation_id (Optional[int]): The default installation ID for the GitHub App.
         hostname (Optional[str]): The GitHub hostname, defaults to None.
-        installation_tokens (Dict[Any, Any]): A dictionary to store installation tokens.
-        app_token (Dict[str, Any]): A dictionary to store the app token.
     """
 
     def __init__(

--- a/python_modules/libraries/dagster-pandas/dagster_pandas/constraints.py
+++ b/python_modules/libraries/dagster-pandas/dagster_pandas/constraints.py
@@ -574,8 +574,6 @@ class MultiAggregateConstraintWithMetadata(MultiColumnConstraintWithMetadata):
         resulting_exception (type): the response to generate if validation fails. Subclass of
                                     ConstraintWithMetadataException
         raise_or_typecheck (Optional[bool]):  whether to raise an exception (true) or a failed typecheck (false)
-        type_for_internal (Optional[type]): what type to use for internal validators.  Subclass of
-                                            ConstraintWithMetadata
         name (Optional[str]): what to call the constraint, defaults to the class name.
     """
 


### PR DESCRIPTION
## Summary & Motivation

Twenty-one `Args:` entries name a parameter the function does not take. Docstrings only — no signature, no behaviour, no test touched.

Thirteen are renames where the docstring kept the old name. Several are user-facing, since these classes are in the API reference and the documented keyword would raise `TypeError` if anyone passed it:

| Where | Documented | Actual |
|---|---|---|
| `OpDefinition` | `input_defs`, `output_defs` | `ins`, `outs` |
| `MultiAssetSensorDefinition` | `asset_keys` | `monitored_assets` |
| `SourceAsset` | `freshness_policy` | `legacy_freshness_policy` |
| `ScalarUnion` | `key` | `_key` |
| `ExecutorDefinition` | `required_resource_keys` | (gone) |
| `PipesDockerClient` | `register` | `registry` |
| `MwaaSessionAuthBackend` | `mwaa_session` | `mwaa_client` |
| `RunStorage.has_job_snapshot` | `pipeline_snapshot_id` | `job_snapshot_id` |
| `get_auto_materialize_asset_evaluations` | `asset_key` | `key` |
| `do_composition` | `ignore_output_from_composite_fn` | `ignore_output_from_composition_fn` |
| `dg_exits`, `dg_does_not_exit`, `dg_warns` | `match` | `matches` |

Where the type in parentheses no longer matched either, I updated it too — leaving `ins (List[InputDefinition])` would have swapped one wrong statement for another.

The remaining eight document something that is not an argument at all: `cli_command` in `get_instance_for_cli`, `python_type` in `usable_as_dagster_type` (that is the decorated class), `key_prefix` in `PipesAzureBlobStorageContextInjector` (generated inside `inject_context`), `cluster_log_root` in `PipesDbfsMessageReader`, `installation_tokens` and `app_token` in `GithubClient` (both initialised to `{}` in the body), and `type_for_internal` in `MultiAggregateConstraintWithMetadata` (hard-coded in its `super().__init__` call).

Two things I deliberately left alone:

- `DbtCloudOutput` documents `job_id`, `job_name`, `run_id` and `docs_url` under `Args:`, but they are properties, not constructor arguments. Moving them to an `Attributes:` block is the right fix and a different kind of change — only seven files in the repo use that section, so I would rather you decide.
- `OpDefinition`'s prose still refers to `input_defs` and `output_defs` when describing `compute_fn`.

Every entry was opened and read against its signature.

## Test Plan

No behaviour change, so the existing suite covers it. `ruff check` and `ruff format --check` pass on all seventeen files with the pinned `ruff==0.15.15`.

## Changelog

Corrected `Args:` entries in the API reference that named parameters the functions do not accept.
