### PR TITLE
[dagster-dbt] Support dbt functions (UDFs) as assets with lineage

### DIFF
--- a/docs/docs/integrations/libraries/dbt/reference.md
+++ b/docs/docs/integrations/libraries/dbt/reference.md
@@ -477,6 +477,37 @@ Ensure that the [`default_automation_condition_sensor` is enabled](/guides/autom
 
 Note that Dagster allows the optional specification of a [`code_version`](/guides/build/assets/defining-assets#asset-code-versions) for each asset definition, which is used to track changes. The `code_version` for an asset arising from a dbt model is defined automatically as the hash of the SQL defining the DBT model. This allows the asset graph in the UI to use the "Unsynced" status to indicate which dbt models have new SQL since they were last materialized.
 
+## Loading dbt functions as assets
+
+:::note
+
+`dbt-core` 1.11 or later is required to define [dbt functions](https://docs.getdbt.com/docs/build/udfs).
+
+:::
+
+dbt functions (user-defined functions, or UDFs) are loaded as assets, in the same way that models, seeds, and snapshots are. The asset key for a dbt function is the name of the function, and materializing the asset creates the function in your warehouse.
+
+When a dbt model calls a function, that function is an upstream dependency of the model, so Dagster materializes the function before the models that use it:
+
+```sql
+select
+  customer_id,
+  {{ function('is_positive_int') }}(customer_id) as has_valid_id
+
+from {{ ref('stg_customers') }}
+```
+
+To load only the functions in your dbt project, use dbt's `resource_type` selection method:
+
+```python
+@dbt_assets(
+    manifest=Path("target", "manifest.json"),
+    select="resource_type:function",
+)
+def my_dbt_functions(context: AssetExecutionContext, dbt: DbtCliResource):
+    yield from dbt.cli(["build"], context=context).stream()
+```
+
 ## Loading dbt tests as asset checks
 
 :::note

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -40,7 +40,12 @@ from dagster_shared.record import replace
 
 from dagster_dbt.dbt_project import DbtProject
 from dagster_dbt.metadata_set import DbtMetadataSet
-from dagster_dbt.utils import ASSET_RESOURCE_TYPES, dagster_name_fn, select_unique_ids
+from dagster_dbt.utils import (
+    ASSET_RESOURCE_TYPES,
+    dagster_name_fn,
+    iter_asset_resource_props,
+    select_unique_ids,
+)
 
 if TYPE_CHECKING:
     from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DbtManifestWrapper
@@ -173,7 +178,7 @@ def get_asset_key_for_model(dbt_assets: Sequence[AssetsDefinition], model_name: 
 
     matching_model_ids = [
         unique_id
-        for unique_id, value in manifest["nodes"].items()
+        for unique_id, value in iter_asset_resource_props(manifest)
         if value["name"] == model_name and value["resource_type"] in ASSET_RESOURCE_TYPES
     ]
 
@@ -481,7 +486,7 @@ def get_asset_keys_to_resource_props(
 ) -> Mapping[AssetKey, Mapping[str, Any]]:
     return {
         translator.get_asset_key(node): node
-        for node in manifest["nodes"].values()
+        for _, node in iter_asset_resource_props(manifest)
         if node["resource_type"] in ASSET_RESOURCE_TYPES
     }
 
@@ -861,7 +866,6 @@ def is_non_asset_node(dbt_resource_props: Mapping[str, Any]):
             resource_type == "metric",
             resource_type == "semantic_model",
             resource_type == "saved_query",
-            resource_type == "function",
             resource_type == "model"
             and dbt_resource_props.get("config", {}).get("materialized") == "ephemeral",
         ]
@@ -912,7 +916,7 @@ def _build_child_map(manifest: Mapping[str, Any]) -> Mapping[str, AbstractSet[st
         return manifest["child_map"]
 
     child_map = defaultdict(set)
-    for unique_id, node in manifest["nodes"].items():
+    for unique_id, node in iter_asset_resource_props(manifest):
         for upstream_unique_id in get_upstream_unique_ids(manifest, node):
             child_map[upstream_unique_id].add(unique_id)
     return child_map
@@ -1316,30 +1320,34 @@ def get_dbt_test_names_for_check_keys(
     return [".".join(dbt_resource_props["fqn"]) for dbt_resource_props in dbt_resource_props_gen]
 
 
+# the top-level collections of a dbt manifest that contain resources keyed by unique id
+MANIFEST_RESOURCE_COLLECTIONS = (
+    "nodes",
+    "sources",
+    "exposures",
+    "metrics",
+    "semantic_models",
+    "saved_queries",
+    "unit_tests",
+    # dbt functions (UDFs) are stored in their own collection, available in dbt-core 1.11+
+    "functions",
+)
+
+
+def find_node(manifest: Mapping[str, Any], unique_id: str) -> Mapping[str, Any] | None:
+    """Find a node by unique_id in manifest_json, returning None if it does not exist."""
+    for collection in MANIFEST_RESOURCE_COLLECTIONS:
+        node = manifest.get(collection, {}).get(unique_id)
+        if node is not None:
+            return node
+
+    return None
+
+
 def get_node(manifest: Mapping[str, Any], unique_id: str) -> Mapping[str, Any]:
     """Find a node by unique_id in manifest_json."""
-    if unique_id in manifest["nodes"]:
-        return manifest["nodes"][unique_id]
+    node = find_node(manifest, unique_id)
+    if node is None:
+        check.failed(f"Could not find {unique_id} in dbt manifest")
 
-    if unique_id in manifest["sources"]:
-        return manifest["sources"][unique_id]
-
-    if unique_id in manifest["exposures"]:
-        return manifest["exposures"][unique_id]
-
-    if unique_id in manifest["metrics"]:
-        return manifest["metrics"][unique_id]
-
-    if unique_id in manifest.get("semantic_models", {}):
-        return manifest["semantic_models"][unique_id]
-
-    if unique_id in manifest.get("saved_queries", {}):
-        return manifest["saved_queries"][unique_id]
-
-    if unique_id in manifest.get("unit_tests", {}):
-        return manifest["unit_tests"][unique_id]
-
-    if unique_id in manifest.get("functions", {}):
-        return manifest["functions"][unique_id]
-
-    check.failed(f"Could not find {unique_id} in dbt manifest")
+    return node

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -17,10 +17,10 @@ from dagster._time import get_current_timestamp
 from dateutil import parser
 from requests.exceptions import RequestException
 
-from dagster_dbt.asset_utils import build_dbt_specs, get_asset_check_key_for_test
+from dagster_dbt.asset_utils import build_dbt_specs, find_node, get_asset_check_key_for_test
 from dagster_dbt.cloud_v2.client import DbtCloudWorkspaceClient
 from dagster_dbt.cloud_v2.types import DbtCloudRun
-from dagster_dbt.compat import REFABLE_NODE_TYPES, NodeStatus, NodeType, TestStatus
+from dagster_dbt.compat import MATERIALIZABLE_NODE_TYPES, NodeStatus, NodeType, TestStatus
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
 COMPLETED_AT_TIMESTAMP_METADATA_KEY = "dagster_dbt/completed_at_timestamp"
@@ -150,7 +150,8 @@ class DbtCloudJobRunResults:
         invocation_id: str = self.run_results["metadata"]["invocation_id"]
         for result in self.run_results["results"]:
             unique_id: str = result["unique_id"]
-            dbt_resource_props: Mapping[str, Any] = manifest["nodes"].get(unique_id)
+            # note that dbt functions (UDFs) are not in `manifest["nodes"]`
+            dbt_resource_props = find_node(manifest, unique_id)
             if not dbt_resource_props:
                 logger.warning(
                     f"Unique ID {unique_id} not found in manifest. "
@@ -188,7 +189,7 @@ class DbtCloudJobRunResults:
             )
 
             if (
-                resource_type in REFABLE_NODE_TYPES
+                resource_type in MATERIALIZABLE_NODE_TYPES
                 and result_status == NodeStatus.Success
                 and not is_ephemeral
             ):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/compat.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/compat.py
@@ -85,6 +85,7 @@ else:
             SemanticModel = "semantic_model"
             Unit = "unit_test"
             Fixture = "fixture"
+            Function = "function"
 
         class NodeStatus(StrEnum):
             Success = "success"
@@ -103,5 +104,13 @@ else:
             Warn = NodeStatus.Warn
             Skipped = NodeStatus.Skipped
 
+
+# dbt resource type for user-defined functions (UDFs), available in dbt-core 1.11+.
+FUNCTION_NODE_TYPE = "function"
+
+# dbt resource types that create an object in the warehouse when they are executed, and therefore
+# materialize a Dagster asset. Functions are not refable (they cannot be `ref`d, and are stored
+# outside of `manifest["nodes"]`), but `dbt build` does create them in the warehouse.
+MATERIALIZABLE_NODE_TYPES: list[str] = [*REFABLE_NODE_TYPES, FUNCTION_NODE_TYPE]
 
 logging.getLogger().handlers = existing_root_logger_handlers

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -48,7 +48,7 @@ from dagster_dbt.dbt_project_manager import (
     NoopDbtProjectManager,
     RemoteGitDbtProjectManager,
 )
-from dagster_dbt.utils import ASSET_RESOURCE_TYPES
+from dagster_dbt.utils import ASSET_RESOURCE_TYPES, iter_asset_resource_props
 
 
 @dataclass
@@ -440,7 +440,7 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
 
         matching_model_ids = [
             unique_id
-            for unique_id, value in manifest["nodes"].items()
+            for unique_id, value in iter_asset_resource_props(manifest)
             if value["name"] == model_name and value["resource_type"] in ASSET_RESOURCE_TYPES
         ]
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -32,8 +32,15 @@ from dagster_dbt.asset_utils import (
     default_metadata_from_dbt_resource_props,
     get_asset_check_key_for_test,
     get_checks_on_sources_upstream_of_selected_assets,
+    get_node,
 )
-from dagster_dbt.compat import REFABLE_NODE_TYPES, NodeStatus, NodeType, TestStatus
+from dagster_dbt.compat import (
+    MATERIALIZABLE_NODE_TYPES,
+    REFABLE_NODE_TYPES,
+    NodeStatus,
+    NodeType,
+    TestStatus,
+)
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_translator
 from dagster_dbt.dbt_manifest import DbtManifestParam, validate_manifest
 from dagster_dbt.dbt_project import DbtProject
@@ -61,7 +68,7 @@ class CheckProperties(TypedDict):
 
 def _build_column_lineage_metadata(
     event_history_metadata: EventHistoryMetadata,
-    dbt_resource_props: dict[str, Any],
+    dbt_resource_props: Mapping[str, Any],
     manifest: Mapping[str, Any],
     dagster_dbt_translator: DagsterDbtTranslator,
     target_path: Path | None,
@@ -86,11 +93,13 @@ def _build_column_lineage_metadata(
     ):
         return {}
 
-    event_node_info: dict[str, Any] = dbt_resource_props
+    event_node_info: Mapping[str, Any] = dbt_resource_props
     unique_id: str = event_node_info["unique_id"]
 
     node_resource_type: str = event_node_info["resource_type"]
 
+    # non-refable nodes, such as dbt functions (UDFs), are not relations, so they do not have
+    # column lineage of their own
     if node_resource_type not in REFABLE_NODE_TYPES:
         return {}
 
@@ -140,8 +149,14 @@ def _build_column_lineage_metadata(
     sqlglot_column_names = set(optimized_node_ast.named_selects)
 
     # 3. For each column, retrieve its dependencies on upstream columns from direct parents.
-    dbt_parent_resource_props_by_relation_name: dict[str, dict[str, Any]] = {}
+    dbt_parent_resource_props_by_relation_name: dict[str, Mapping[str, Any]] = {}
     for parent_unique_id in dbt_resource_props["depends_on"]["nodes"]:
+        # a node may depend on a dbt function (UDF). functions are not relations, so they cannot
+        # contribute columns to the node's lineage, and they are stored outside of
+        # `manifest["nodes"]`.
+        if parent_unique_id in manifest.get("functions", {}):
+            continue
+
         is_resource_type_source = parent_unique_id.startswith("source")
         parent_dbt_resource_props = (
             manifest["sources"] if is_resource_type_source else manifest["nodes"]
@@ -270,7 +285,7 @@ class DbtCliEventMessage(ABC):
             or resource_props.get("config", {}).get("materialized")
         )
         return (
-            resource_props["resource_type"] in REFABLE_NODE_TYPES
+            resource_props["resource_type"] in MATERIALIZABLE_NODE_TYPES
             and materialized_type != "ephemeral"
             and self._get_node_status() == NodeStatus.Success
         )
@@ -282,8 +297,10 @@ class DbtCliEventMessage(ABC):
             and self._get_node_status() != NodeStatus.Skipped
         )
 
-    def _get_resource_props(self, unique_id: str, manifest: Mapping[str, Any]) -> dict[str, Any]:
-        return manifest["nodes"][unique_id]
+    def _get_resource_props(self, unique_id: str, manifest: Mapping[str, Any]) -> Mapping[str, Any]:
+        # note that dbt functions (UDFs) are not in `manifest["nodes"]`, so we can't index into it
+        # directly here
+        return get_node(manifest, unique_id)
 
     def _get_execution_duration_metadata(self) -> Mapping[str, float]:
         raw_started_at = self._raw_node_info.get("node_started_at")
@@ -492,7 +509,13 @@ class DbtCliEventMessage(ABC):
             logger.warning(message)
 
         for upstream_unique_id in resource_props["depends_on"]["nodes"]:
-            upstream_resource_props: dict[str, Any] = validated_manifest["nodes"].get(
+            # a test may depend on a dbt function (UDF), which is stored outside of
+            # `manifest["nodes"]`. functions are not relations, so a test result says nothing about
+            # them.
+            if upstream_unique_id in validated_manifest.get("functions", {}):
+                continue
+
+            upstream_resource_props: Mapping[str, Any] = validated_manifest["nodes"].get(
                 upstream_unique_id
             ) or validated_manifest["sources"].get(upstream_unique_id)
             upstream_asset_key = dagster_dbt_translator.get_asset_key(upstream_resource_props)
@@ -595,7 +618,14 @@ class DbtCoreCliEventMessage(DbtCliEventMessage):
             return False
 
         return self.raw_event["info"]["name"] in set(
-            ["LogSeedResult", "LogModelResult", "LogSnapshotResult", "LogTestResult"]
+            [
+                "LogSeedResult",
+                "LogModelResult",
+                "LogSnapshotResult",
+                "LogTestResult",
+                # emitted for dbt functions (UDFs) in dbt-core 1.11+
+                "LogFunctionResult",
+            ]
         ) and not unique_id.startswith("unit_test")
 
     def _get_check_passed(self) -> bool:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
@@ -111,7 +111,7 @@ class DbtCliInvocation:
     )
 
     def _get_columns_from_dbt_resource_props(
-        self, adapter: BaseAdapter, dbt_resource_props: dict[str, Any]
+        self, adapter: BaseAdapter, dbt_resource_props: Mapping[str, Any]
     ) -> RelationData:
         """Given a dbt resource properties dictionary, fetches the resource's column metadata from
         the database, or returns the cached metadata if it has already been fetched.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
@@ -18,8 +18,8 @@ from dagster._core.utils import exhaust_iterator_and_yield_results_with_exceptio
 from dagster._utils import pushd
 from typing_extensions import TypeVar
 
-from dagster_dbt.asset_utils import default_metadata_from_dbt_resource_props
-from dagster_dbt.compat import DBT_PYTHON_VERSION
+from dagster_dbt.asset_utils import default_metadata_from_dbt_resource_props, get_node
+from dagster_dbt.compat import DBT_PYTHON_VERSION, FUNCTION_NODE_TYPE
 from dagster_dbt.core.dbt_cli_event import EventHistoryMetadata, _build_column_lineage_metadata
 
 if TYPE_CHECKING:
@@ -41,9 +41,11 @@ T = TypeVar("T", bound=DbtDagsterEventType)
 
 def _get_dbt_resource_props_from_event(
     invocation: "DbtCliInvocation", event: DbtDagsterEventType
-) -> dict[str, Any]:
+) -> Mapping[str, Any]:
     unique_id = cast("TextMetadataValue", event.metadata["unique_id"]).text
-    return check.not_none(invocation.manifest["nodes"].get(unique_id))
+    # note that dbt functions (UDFs) are not in `manifest["nodes"]`, so we can't index into it
+    # directly here
+    return get_node(invocation.manifest, check.not_none(unique_id))
 
 
 def _fetch_column_metadata(
@@ -64,6 +66,10 @@ def _fetch_column_metadata(
     adapter = check.not_none(invocation.adapter)
 
     dbt_resource_props = _get_dbt_resource_props_from_event(invocation, event)
+
+    # dbt functions (UDFs) are not relations, so they have no columns to fetch
+    if dbt_resource_props["resource_type"] == FUNCTION_NODE_TYPE:
+        return {}
 
     with (
         pushd(str(invocation.project_dir)),
@@ -109,6 +115,11 @@ def _fetch_column_metadata(
                     dbt_parent_resource_props = invocation.manifest["nodes"].get(
                         parent_unique_id
                     ) or invocation.manifest["sources"].get(parent_unique_id)
+
+                    # parents which are not relations, such as dbt functions (UDFs), have no
+                    # columns to contribute to the lineage of this node
+                    if dbt_parent_resource_props is None:
+                        continue
 
                     parent_name, parent_columns = invocation._get_columns_from_dbt_resource_props(  # noqa: SLF001
                         adapter=adapter, dbt_resource_props=dbt_parent_resource_props
@@ -158,6 +169,11 @@ def _fetch_row_count_metadata(
     adapter = check.not_none(invocation.adapter)
 
     dbt_resource_props = _get_dbt_resource_props_from_event(invocation, event)
+
+    # dbt functions (UDFs) are not relations, so there are no rows to count
+    if dbt_resource_props["resource_type"] == FUNCTION_NODE_TYPE:
+        return None
+
     is_view = dbt_resource_props["config"]["materialized"] == "view"
 
     # Avoid counting rows for views, since they may include complex SQL queries

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -14,10 +14,24 @@ from dagster_dbt.compat import DBT_PYTHON_VERSION
 if TYPE_CHECKING:
     from dagster_dbt.core.resource import DbtProject
 
-# dbt resource types that may be considered assets
-ASSET_RESOURCE_TYPES = ["model", "seed", "snapshot"]
+# dbt resource types that may be considered assets. Note that functions (dbt UDFs, available in
+# dbt-core 1.11+) are stored in the top-level `functions` collection of the manifest rather than
+# alongside models, seeds, and snapshots in `nodes`.
+ASSET_RESOURCE_TYPES = ["model", "seed", "snapshot", "function"]
 
 clean_name = clean_name_lower
+
+
+def iter_asset_resource_props(
+    manifest_json: Mapping[str, Any],
+) -> Iterator[tuple[str, Mapping[str, Any]]]:
+    """Iterate over the resources in a manifest that may be represented as Dagster assets.
+
+    dbt functions (UDFs) are stored in the top-level `functions` collection of the manifest, so
+    they must be iterated over separately from models, seeds, and snapshots.
+    """
+    yield from manifest_json["nodes"].items()
+    yield from manifest_json.get("functions", {}).items()
 
 
 def default_node_info_to_asset_key(node_info: Mapping[str, Any]) -> AssetKey:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -1186,18 +1186,14 @@ def test_dbt_with_unit_tests(test_dbt_unit_tests_manifest: dict[str, Any], selec
     DBT_PYTHON_VERSION is not None and DBT_PYTHON_VERSION < version.parse("1.11.0"),
     reason="dbt udf support is only available in `dbt-core>=1.11.0`",
 )
-@pytest.mark.parametrize("select", ["fqn:*", "tag:test"])
+@pytest.mark.parametrize("select", ["fqn:*", "tag:test", "resource_type:function"])
 def test_dbt_with_functions(test_dbt_functions_manifest: dict[str, Any], select: str) -> None:
     @dbt_assets(
         manifest=test_dbt_functions_manifest,
         select=select,
     )
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        # duckdb does not support building functions, so we exclude them here
-        # we only want to test a manifest with function nodes works
-        yield from dbt.cli(
-            ["build", "--exclude", "resource_type:function"], context=context
-        ).stream()
+        yield from dbt.cli(["build"], context=context).stream()
 
     result = materialize(
         [my_dbt_assets],

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_functions.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_functions.py
@@ -1,0 +1,236 @@
+"""Tests for dbt functions (UDFs), which are available in dbt-core 1.11+.
+
+dbt functions are stored in the top-level `functions` collection of the manifest rather than
+alongside models, seeds, and snapshots in `nodes`.
+"""
+
+import os
+from typing import Any
+
+import pytest
+from dagster import (
+    AssetExecutionContext,
+    AssetKey,
+    AssetMaterialization,
+    AssetSelection,
+    TableColumnDep,
+    materialize,
+)
+from dagster._core.definitions.metadata import TableMetadataSet, TextMetadataValue
+from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.compat import DBT_PYTHON_VERSION
+from dagster_dbt.core.dbt_cli_event import DbtCoreCliEventMessage
+from dagster_dbt.core.resource import DbtCliResource
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+from dagster_dbt.metadata_set import DbtMetadataSet
+from packaging import version
+
+from dagster_dbt_tests.dbt_projects import test_dbt_functions_path
+
+FUNCTION_UNIQUE_ID = "function.test_dagster_dbt_functions.is_positive_int"
+FUNCTION_ASSET_KEY = AssetKey(["is_positive_int"])
+# the model in the test project which calls the function
+MODEL_USING_FUNCTION_ASSET_KEY = AssetKey(["customers_with_valid_ids"])
+
+requires_dbt_functions = pytest.mark.skipif(
+    DBT_PYTHON_VERSION is not None and DBT_PYTHON_VERSION < version.parse("1.11.0"),
+    reason="dbt udf support is only available in `dbt-core>=1.11.0`",
+)
+
+
+def test_log_function_result_to_asset_materialization() -> None:
+    """`LogFunctionResult` is the event dbt emits once a function has been created in the
+    warehouse. Since function nodes are not in `manifest["nodes"]`, generating an event for one
+    used to raise a `KeyError`.
+
+    Below is an example of a `LogFunctionResult` produced by an actual dbt==1.11.12 invocation.
+    """
+    log_function_result = {
+        "data": {
+            "description": "function dev.is_positive_int",
+            "execution_time": 0.038336992,
+            "index": 1,
+            "node_info": {
+                "materialized": "function",
+                "meta": {},
+                "node_finished_at": "2026-08-06T02:27:11.441493",
+                "node_name": "is_positive_int",
+                "node_path": "is_positive_int.sql",
+                "node_relation": {
+                    "alias": "is_positive_int",
+                    "database": "local",
+                    "relation_name": "",
+                    "schema": "dev",
+                },
+                "node_started_at": "2026-08-06T02:27:11.402435",
+                "node_status": "success",
+                "resource_type": "function",
+                "unique_id": FUNCTION_UNIQUE_ID,
+            },
+            "status": "success",
+            "total": 1,
+        },
+        "info": {
+            "category": "",
+            "code": "Q047",
+            "extra": {},
+            "invocation_id": "ff829904-01c6-49ed-b235-935d45582992",
+            "level": "info",
+            "msg": "1 of 1 OK created function dev.is_positive_int  [SUCCESS in 0.04s]",
+            "name": "LogFunctionResult",
+            "pid": 98784,
+            "thread": "Thread-1 (worker)",
+            "ts": "2026-08-06T02:27:11.441699Z",
+        },
+    }
+
+    manifest = {
+        "metadata": {
+            "adapter_type": "duckdb",
+            "invocation_id": "ff829904-01c6-49ed-b235-935d45582992",
+        },
+        "nodes": {},
+        "functions": {
+            FUNCTION_UNIQUE_ID: {
+                "unique_id": FUNCTION_UNIQUE_ID,
+                "name": "is_positive_int",
+                "resource_type": "function",
+                "database": "local",
+                "schema": "dev",
+                "alias": "is_positive_int",
+                "original_file_path": "functions/is_positive_int.sql",
+                "config": {"materialized": "function"},
+                "depends_on": {"nodes": []},
+                "description": "",
+                "raw_code": "regexp_matches(a_string, '^[0-9]+$')::integer",
+            }
+        },
+    }
+
+    event_message = DbtCoreCliEventMessage(raw_event=log_function_result, event_history_metadata={})
+    assert event_message.is_result_event
+
+    [asset_event] = list(event_message.to_default_asset_events(manifest, DagsterDbtTranslator()))
+
+    assert isinstance(asset_event, AssetMaterialization)
+    assert asset_event.asset_key == FUNCTION_ASSET_KEY
+    assert asset_event.metadata["unique_id"] == TextMetadataValue(FUNCTION_UNIQUE_ID)
+
+
+@requires_dbt_functions
+def test_function_asset_specs(test_dbt_functions_manifest: dict[str, Any]) -> None:
+    @dbt_assets(manifest=test_dbt_functions_manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource): ...
+
+    # the function is an asset of its own
+    assert FUNCTION_ASSET_KEY in my_dbt_assets.keys
+
+    # and the model which calls it depends on it
+    model_spec = my_dbt_assets.get_asset_spec(MODEL_USING_FUNCTION_ASSET_KEY)
+    assert FUNCTION_ASSET_KEY in {dep.asset_key for dep in model_spec.deps}
+
+    function_spec = my_dbt_assets.get_asset_spec(FUNCTION_ASSET_KEY)
+    assert function_spec.deps == []
+    assert DbtMetadataSet.extract(function_spec.metadata).materialization_type == "function"
+
+
+@requires_dbt_functions
+def test_select_only_functions(test_dbt_functions_manifest: dict[str, Any]) -> None:
+    @dbt_assets(manifest=test_dbt_functions_manifest, select="resource_type:function")
+    def my_dbt_functions(context: AssetExecutionContext, dbt: DbtCliResource): ...
+
+    assert my_dbt_functions.keys == {FUNCTION_ASSET_KEY}
+
+
+@requires_dbt_functions
+def test_unselected_function_is_upstream_of_model(
+    test_dbt_functions_manifest: dict[str, Any],
+) -> None:
+    """A function which is not selected is still an upstream dependency of the models which use
+    it, in the same way that an unselected model is.
+    """
+
+    @dbt_assets(manifest=test_dbt_functions_manifest, select="resource_type:model")
+    def my_dbt_models(context: AssetExecutionContext, dbt: DbtCliResource): ...
+
+    assert FUNCTION_ASSET_KEY not in my_dbt_models.keys
+
+    model_spec = my_dbt_models.get_asset_spec(MODEL_USING_FUNCTION_ASSET_KEY)
+    assert FUNCTION_ASSET_KEY in {dep.asset_key for dep in model_spec.deps}
+
+
+@requires_dbt_functions
+def test_materialize_functions(test_dbt_functions_manifest: dict[str, Any]) -> None:
+    @dbt_assets(manifest=test_dbt_functions_manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["build"], context=context).stream()
+
+    resources = {"dbt": DbtCliResource(project_dir=os.fspath(test_dbt_functions_path))}
+
+    result = materialize([my_dbt_assets], resources=resources)
+    assert result.success
+    materialized_keys = {
+        event.asset_key for event in result.get_asset_materialization_events() if event.asset_key
+    }
+    assert FUNCTION_ASSET_KEY in materialized_keys
+    assert MODEL_USING_FUNCTION_ASSET_KEY in materialized_keys
+
+    # subsetted execution: the function is selected by itself
+    result = materialize(
+        [my_dbt_assets], resources=resources, selection=AssetSelection.assets(FUNCTION_ASSET_KEY)
+    )
+    assert result.success
+    assert [event.asset_key for event in result.get_asset_materialization_events()] == [
+        FUNCTION_ASSET_KEY
+    ]
+
+    # subsetted execution: only the model which depends on the function is selected
+    result = materialize(
+        [my_dbt_assets],
+        resources=resources,
+        selection=AssetSelection.assets(MODEL_USING_FUNCTION_ASSET_KEY),
+    )
+    assert result.success
+    assert [event.asset_key for event in result.get_asset_materialization_events()] == [
+        MODEL_USING_FUNCTION_ASSET_KEY
+    ]
+
+
+@requires_dbt_functions
+@pytest.mark.derived_metadata
+def test_materialize_functions_with_derived_metadata(
+    test_dbt_functions_manifest: dict[str, Any],
+) -> None:
+    @dbt_assets(manifest=test_dbt_functions_manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from (
+            dbt.cli(["build"], context=context).stream().fetch_row_counts().fetch_column_metadata()
+        )
+
+    result = materialize(
+        [my_dbt_assets],
+        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_dbt_functions_path))},
+    )
+    assert result.success
+
+    materializations_by_key = {
+        event.asset_key: event.materialization
+        for event in result.get_asset_materialization_events()
+        if event.asset_key
+    }
+
+    # a function is not a relation, so it has no rows to count and no columns to fetch
+    function_table_metadata = TableMetadataSet.extract(
+        materializations_by_key[FUNCTION_ASSET_KEY].metadata
+    )
+    assert function_table_metadata.row_count is None
+    assert function_table_metadata.column_schema is None
+
+    # a model which depends on a function still gets column lineage for its other dependencies
+    model_column_lineage = TableMetadataSet.extract(
+        materializations_by_key[MODEL_USING_FUNCTION_ASSET_KEY].metadata
+    ).column_lineage
+    assert model_column_lineage
+    assert model_column_lineage.deps_by_column["customer_id"] == [
+        TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="customer_id")
+    ]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_functions/functions/is_positive_int.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_functions/functions/is_positive_int.py
@@ -1,5 +1,0 @@
-import re
-
-
-def main(a_string):
-    return 1 if re.search(r"^[0-9]+$", a_string or "") else 0

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_functions/functions/is_positive_int.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_functions/functions/is_positive_int.sql
@@ -1,0 +1,1 @@
+regexp_matches(a_string, '^[0-9]+$')::integer

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_functions/functions/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_functions/functions/schema.yml
@@ -2,13 +2,10 @@ functions:
   - name: is_positive_int # required
     description: My UDF that returns 1 if a string represents a naked positive integer (like "10", "+8" is not allowed). # optional
     config:
-      runtime_version: "3.11"
-      entry_point: main
       volatility: deterministic
     arguments:
       - name: a_string
-        data_type: string
+        data_type: varchar
         description: The string that I want to check if it's representing a positive integer (like "10")
-        default_value: "'1'"
     returns:
       data_type: integer

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_functions/macros/duckdb_scalar_function.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_functions/macros/duckdb_scalar_function.sql
@@ -1,0 +1,22 @@
+{#-
+    dbt-duckdb does not implement the macros that dbt's `function` materialization dispatches to,
+    so building a UDF against duckdb fails out of the box. duckdb does not support
+    `CREATE FUNCTION ... RETURNS ... LANGUAGE SQL`, but `CREATE MACRO` is the equivalent, so we
+    override the dispatched macros here. This lets these tests actually materialize a dbt function,
+    which is what exercises the dbt event streaming code path for function nodes.
+-#}
+
+{% macro duckdb__scalar_function_sql(target_relation) %}
+    CREATE OR REPLACE MACRO {{ target_relation.render() }} ({{ formatted_scalar_function_args_sql() }}) AS (
+        {{ model.compiled_code }}
+    )
+{% endmacro %}
+
+{% macro duckdb__formatted_scalar_function_args_sql() %}
+    {#- duckdb macros are not typed, so the argument data types are dropped here -#}
+    {% set args = [] %}
+    {% for arg in model.arguments -%}
+        {%- do args.append(arg.name) -%}
+    {%- endfor %}
+    {{ args | join(', ') }}
+{% endmacro %}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_functions/models/customers_with_valid_ids.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_functions/models/customers_with_valid_ids.sql
@@ -1,0 +1,7 @@
+{#- a model that depends on a dbt function (UDF), which creates function -> model lineage -#}
+
+select
+    customer_id,
+    {{ function('is_positive_int') }}(cast(customer_id as varchar)) as has_valid_id
+
+from {{ ref('stg_customers') }}


### PR DESCRIPTION
## Summary & Motivation

dbt 1.11 introduced [user-defined functions](https://docs.getdbt.com/docs/build/udfs) (UDFs). #33245 stopped function nodes from raising in Dagster by treating them as non-asset nodes, which also made them invisible in the asset graph. #33570 started loading them as assets, but only at the manifest/selection level — the execution paths still assumed every node lives in `manifest["nodes"]`, and function nodes live in a separate top-level `functions` collection.

This PR loads dbt functions as assets end to end, so a function is materialized by `dbt build` like any other node and the models that call it depend on it.

- `function` is added to `ASSET_RESOURCE_TYPES` and removed from `is_non_asset_node`, which makes function nodes assets and valid upstreams of the models that call them (`{{ function('...') }}` puts the function in the model's `depends_on.nodes`).
- Resources are now resolved by unique id across every manifest collection (`find_node` / `get_node`) instead of indexing into `manifest["nodes"]`. This is what raised `KeyError` for function nodes in:
  - `DbtCliEventMessage._get_resource_props` (event streaming)
  - `_get_dbt_resource_props_from_event` (`fetch_row_counts`, `fetch_column_metadata`)
  - `get_asset_keys_to_resource_props` (freshness policies), `get_asset_key_for_model`, `_build_child_map`
- Materializations are emitted for functions: dbt's `LogFunctionResult` event is now treated as a result event, and `function` is included in a new `MATERIALIZABLE_NODE_TYPES` (functions are not "refable" in dbt's sense, but `dbt build` does create them in the warehouse).
- Paths that require a relation skip functions: row counts, column schema, and column lineage — both for the function itself and for the models and tests that depend on one. Without this, a model that calls a UDF silently lost its column lineage.
- `cloud_v2/run_handler.py` handles function results from dbt platform runs.

## Behavior change

On dbt 1.11+ projects that define UDFs:

- `select="fqn:*"` (the default) now produces additional function assets.
- Models that call a UDF gain a new upstream dependency on it. If the functions are not selected, the function shows up as an external upstream asset, the same way an unselected model does.
- A function and a model with the same name now collide in the duplicate-asset-key check, where functions were previously ignored entirely. The error message names both resources, and the key can be overridden with dbt `meta` config as usual.

## How I Tested These Changes

New `dagster_dbt_tests/core/test_functions.py` covers:

- generating an `AssetMaterialization` from a real `LogFunctionResult` event (this is the `KeyError` regression, and it runs on every dbt version)
- the function asset spec, and the function appearing as a dep of the model that calls it, whether or not the function itself is selected
- materializing the whole project (functions included), plus subsetted materialization of only the function and of only the model that calls it — subsetting builds an explicit `--select` from the node's file name or FQN, and both forms resolve function nodes
- `fetch_row_counts` / `fetch_column_metadata` skipping the function, while the model that calls it still gets column lineage for its table dependencies

The `test_dagster_dbt_functions` fixture project now defines a SQL UDF (instead of a Python one) that is called by a new `customers_with_valid_ids` model, plus a project-level `duckdb__scalar_function_sql` macro override, because dbt-duckdb does not implement the macros dbt's `function` materialization dispatches to. That override is what lets these tests actually build a function against duckdb and exercise the event streaming path — previously the test had to pass `--exclude resource_type:function`, so no function was ever materialized in CI. Nothing in `dagster-dbt` branches on the function's language, so the switch from Python to SQL is not a coverage loss.

Verified locally against `dbt-core` 1.11 (functions built and materialized) and 1.10 (function tests skipped, everything else green).

## Changelog

* dbt functions (UDFs, `dbt-core` 1.11+) are now loaded as Dagster assets, and models that call a function depend on it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NWJG7jJzsWYpmECBHoYS1
