### PR TITLE
docs: fix broken links in .vscode/README.md

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -4,7 +4,7 @@ If you use VS Code, we recommend the following configuration:
 
 ## Step 1: Install the recommended extensions
 
-The [recommended extensions](.vscode/extensions.json) will automatically show up when browsing
+The [recommended extensions](extensions.json) will automatically show up when browsing
 extensions for your editor. Install them.
 
 See [VS Code's documentation on recommended extensions](https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions)
@@ -12,7 +12,7 @@ to add new extensions to the recommended list.
 
 ## Step 2: Enable the default editor settings
 
-The recommended editor settings, [`settings.json.default`](.vscode/settings.json.default), are not enabled by default. To
+The recommended editor settings, [`settings.json.default`](settings.json.default), are not enabled by default. To
 enable the default settings, copy the file to `.vscode/settings.json` to enable them for this
 repository. These settings will override any existing user or workspace settings you have already
 configured.
@@ -22,6 +22,6 @@ recommended editor settings to your user or workspace settings.
 
 See the [settings precedence](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence) for more details.
 
-Likewise, the recommended debugger entrypoints, [`launch.json.default`](.vscode/launch.json.default)
-and [`tasks.json.default`](.vscode/tasks.json.default), are not enabled by default. To enable the
+Likewise, the recommended debugger entrypoints, [`launch.json.default`](launch.json.default)
+and [`tasks.json.default`](tasks.json.default), are not enabled by default. To enable the
 default, copy these files to `.vscode/launch.json` and `.vscode/tasks.json`.


### PR DESCRIPTION
`.vscode/README.md` links four files with a `.vscode/` prefix:

- `[recommended extensions](.vscode/extensions.json)`
- `[settings.json.default](.vscode/settings.json.default)`
- `[launch.json.default](.vscode/launch.json.default)`
- `[tasks.json.default](.vscode/tasks.json.default)`

Since the README itself is inside `.vscode/`, those resolve to `.vscode/.vscode/extensions.json` etc. and 404 on GitHub. The four files are siblings of the README, so this drops the `.vscode/` prefix.
