### PR TITLE
[dagster-dbt] Avoid pointless manifest walk when building selections with default asset selectors

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -369,9 +369,9 @@ def build_dbt_asset_selection(
         project=dbt_project,
     )
 
-    # If the assets definition has no selection of its own, it spans the whole manifest,
-    # so intersecting with it cannot narrow the requested selection — but it does cost
-    # an extra dbt selector walk over the manifest every time the selection is resolved.
+    # If the assets definition itself has a selection, we need to AND it with the requested
+    # selection. If it doesn't, save a pointless selector walk over the manifest and just
+    # return the requested selection directly.
     if (
         dbt_assets_select == DBT_DEFAULT_SELECT
         and dbt_assets_exclude == DBT_DEFAULT_EXCLUDE

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -360,20 +360,35 @@ def build_dbt_asset_selection(
 
     from dagster_dbt.dbt_manifest_asset_selection import DbtManifestAssetSelection
 
-    return DbtManifestAssetSelection.build(
-        manifest=manifest,
-        dagster_dbt_translator=dagster_dbt_translator,
-        select=dbt_assets_select,
-        exclude=dbt_assets_exclude,
-        selector=dbt_assets_selector,
-        project=dbt_project,
-    ) & DbtManifestAssetSelection.build(
+    requested_selection = DbtManifestAssetSelection.build(
         manifest=manifest,
         dagster_dbt_translator=dagster_dbt_translator,
         select=dbt_select,
         exclude=dbt_exclude or DBT_DEFAULT_EXCLUDE,
         selector=dbt_selector or DBT_DEFAULT_SELECTOR,
         project=dbt_project,
+    )
+
+    # If the assets definition has no selection of its own, it spans the whole manifest,
+    # so intersecting with it cannot narrow the requested selection — but it does cost
+    # an extra dbt selector walk over the manifest every time the selection is resolved.
+    if (
+        dbt_assets_select == DBT_DEFAULT_SELECT
+        and dbt_assets_exclude == DBT_DEFAULT_EXCLUDE
+        and dbt_assets_selector == DBT_DEFAULT_SELECTOR
+    ):
+        return requested_selection
+
+    return (
+        DbtManifestAssetSelection.build(
+            manifest=manifest,
+            dagster_dbt_translator=dagster_dbt_translator,
+            select=dbt_assets_select,
+            exclude=dbt_assets_exclude,
+            selector=dbt_assets_selector,
+            project=dbt_project,
+        )
+        & requested_selection
     )
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest import mock
 
 import pytest
+from dagster._core.definitions.asset_selection import AndAssetSelection
 from dagster._core.definitions.assets.graph.asset_graph import AssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster._record import replace
@@ -13,7 +14,6 @@ from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.asset_utils import DBT_DEFAULT_EXCLUDE, DBT_DEFAULT_SELECT
 from dagster_dbt.compat import DBT_PYTHON_VERSION
 from dagster_dbt.dbt_manifest_asset_selection import DbtManifestAssetSelection
-from dagster_dbt.utils import select_unique_ids
 from dagster_shared.check.functions import ParameterCheckError
 
 from dagster_dbt_tests.dbt_projects import test_jaffle_shop_path
@@ -224,28 +224,19 @@ def test_dbt_asset_selection_default_assets_def_skips_intersection(
 ) -> None:
     # An assets definition without its own select/exclude/selector spans the whole
     # manifest, so the requested selection is returned directly instead of being
-    # intersected with a catch-all selection that cannot narrow it. Resolving the
-    # selection then walks the manifest with the dbt selector once, not twice.
+    # intersected with a catch-all selection that cannot narrow it (but would walk
+    # the manifest with the dbt selector a second time on every resolution).
     @dbt_assets(manifest=test_jaffle_shop_manifest)
     def my_dbt_assets(): ...
 
     asset_selection = build_dbt_asset_selection([my_dbt_assets], dbt_select="raw_customers+")
+
     assert isinstance(asset_selection, DbtManifestAssetSelection)
-
-    with mock.patch(
-        "dagster_dbt.dbt_manifest_asset_selection.select_unique_ids",
-        wraps=select_unique_ids,
-    ) as tracked_select_unique_ids:
-        selected_asset_keys = asset_selection.resolve(
-            all_assets=AssetGraph.from_assets([my_dbt_assets])
-        )
-
-    assert selected_asset_keys == {
+    assert asset_selection.resolve(all_assets=AssetGraph.from_assets([my_dbt_assets])) == {
         AssetKey("raw_customers"),
         AssetKey("stg_customers"),
         AssetKey("customers"),
     }
-    assert tracked_select_unique_ids.call_count == 1
 
     # An assets definition with its own selection is still intersected with the
     # requested selection.
@@ -253,12 +244,12 @@ def test_dbt_asset_selection_default_assets_def_skips_intersection(
     def selected_dbt_assets(): ...
 
     asset_selection = build_dbt_asset_selection([selected_dbt_assets], dbt_select="raw_customers+")
-    assert not isinstance(asset_selection, DbtManifestAssetSelection)
 
-    selected_asset_keys = asset_selection.resolve(
-        all_assets=AssetGraph.from_assets([selected_dbt_assets])
-    )
-    assert selected_asset_keys == {AssetKey("raw_customers"), AssetKey("stg_customers")}
+    assert isinstance(asset_selection, AndAssetSelection)
+    assert asset_selection.resolve(all_assets=AssetGraph.from_assets([selected_dbt_assets])) == {
+        AssetKey("raw_customers"),
+        AssetKey("stg_customers"),
+    }
 
 
 def test_dbt_asset_selection_manifest_argument(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -1,7 +1,7 @@
 import copy
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -13,12 +13,10 @@ from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.asset_utils import DBT_DEFAULT_EXCLUDE, DBT_DEFAULT_SELECT
 from dagster_dbt.compat import DBT_PYTHON_VERSION
 from dagster_dbt.dbt_manifest_asset_selection import DbtManifestAssetSelection
+from dagster_dbt.utils import select_unique_ids
 from dagster_shared.check.functions import ParameterCheckError
 
 from dagster_dbt_tests.dbt_projects import test_jaffle_shop_path
-
-if TYPE_CHECKING:
-    from dagster._core.definitions.asset_selection import AndAssetSelection
 
 
 @pytest.mark.parametrize(
@@ -221,6 +219,48 @@ def test_dbt_asset_selection_on_asset_definition_with_existing_selection(
     assert selected_asset_keys == expected_asset_keys
 
 
+def test_dbt_asset_selection_default_assets_def_skips_intersection(
+    test_jaffle_shop_manifest: dict[str, Any],
+) -> None:
+    # An assets definition without its own select/exclude/selector spans the whole
+    # manifest, so the requested selection is returned directly instead of being
+    # intersected with a catch-all selection that cannot narrow it. Resolving the
+    # selection then walks the manifest with the dbt selector once, not twice.
+    @dbt_assets(manifest=test_jaffle_shop_manifest)
+    def my_dbt_assets(): ...
+
+    asset_selection = build_dbt_asset_selection([my_dbt_assets], dbt_select="raw_customers+")
+    assert isinstance(asset_selection, DbtManifestAssetSelection)
+
+    with mock.patch(
+        "dagster_dbt.dbt_manifest_asset_selection.select_unique_ids",
+        wraps=select_unique_ids,
+    ) as tracked_select_unique_ids:
+        selected_asset_keys = asset_selection.resolve(
+            all_assets=AssetGraph.from_assets([my_dbt_assets])
+        )
+
+    assert selected_asset_keys == {
+        AssetKey("raw_customers"),
+        AssetKey("stg_customers"),
+        AssetKey("customers"),
+    }
+    assert tracked_select_unique_ids.call_count == 1
+
+    # An assets definition with its own selection is still intersected with the
+    # requested selection.
+    @dbt_assets(manifest=test_jaffle_shop_manifest, select="+stg_customers")
+    def selected_dbt_assets(): ...
+
+    asset_selection = build_dbt_asset_selection([selected_dbt_assets], dbt_select="raw_customers+")
+    assert not isinstance(asset_selection, DbtManifestAssetSelection)
+
+    selected_asset_keys = asset_selection.resolve(
+        all_assets=AssetGraph.from_assets([selected_dbt_assets])
+    )
+    assert selected_asset_keys == {AssetKey("raw_customers"), AssetKey("stg_customers")}
+
+
 def test_dbt_asset_selection_manifest_argument(
     test_jaffle_shop_manifest_path: Path, test_jaffle_shop_manifest: dict[str, Any]
 ) -> None:
@@ -274,7 +314,8 @@ def test_dbt_asset_selection_equality(
             [my_dbt_assets], dbt_select="new_select"
         )
 
-        dbt_manifest_asset_selection = cast("AndAssetSelection", asset_selection).operands[0]
+        # the assets definition has no selection of its own, so no intersection is built
+        dbt_manifest_asset_selection = asset_selection
 
         assert isinstance(dbt_manifest_asset_selection, DbtManifestAssetSelection)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -222,10 +222,8 @@ def test_dbt_asset_selection_on_asset_definition_with_existing_selection(
 def test_dbt_asset_selection_default_assets_def_skips_intersection(
     test_jaffle_shop_manifest: dict[str, Any],
 ) -> None:
-    # An assets definition without its own select/exclude/selector spans the whole
-    # manifest, so the requested selection is returned directly instead of being
-    # intersected with a catch-all selection that cannot narrow it (but would walk
-    # the manifest with the dbt selector a second time on every resolution).
+    # An assets definition with no selection of its own resolves the requested
+    # selection directly, with no intersection wrapped around it.
     @dbt_assets(manifest=test_jaffle_shop_manifest)
     def my_dbt_assets(): ...
 
@@ -238,7 +236,7 @@ def test_dbt_asset_selection_default_assets_def_skips_intersection(
         AssetKey("customers"),
     }
 
-    # An assets definition with its own selection is still intersected with the
+    # An assets definition with its own selection is intersected with the
     # requested selection.
     @dbt_assets(manifest=test_jaffle_shop_manifest, select="+stg_customers")
     def selected_dbt_assets(): ...

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_schedules.py
@@ -1,9 +1,8 @@
-from collections.abc import Mapping, Sequence
-from typing import Any, cast
+from collections.abc import Mapping
+from typing import Any
 
 import pytest
 from dagster import DefaultScheduleStatus, RunConfig
-from dagster._core.definitions.asset_selection import AndAssetSelection
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from dagster_dbt import DbtManifestAssetSelection, build_schedule_from_dbt_selection, dbt_assets
 
@@ -101,15 +100,9 @@ def test_dbt_build_schedule(
     assert job.tags == (tags or {})
     assert job.config == (config.to_config_dict() if config else None)
 
-    assert isinstance(job.selection, AndAssetSelection)
-    assert len(job.selection.operands) == 2
-
-    [dbt_assets_selection, job_selection] = cast(
-        "Sequence[DbtManifestAssetSelection]", job.selection.operands
-    )
-    assert dbt_assets_selection.select == "fqn:*"
-    assert dbt_assets_selection.exclude == ""
-    assert dbt_assets_selection.selector == ""
-    assert job_selection.select == (dbt_select or "fqn:*")
-    assert job_selection.exclude == (dbt_exclude or "")
-    assert job_selection.selector == (dbt_selector or "")
+    # the assets definition has no selection of its own, so the job's selection is
+    # the requested selection directly, with no intersection built around it
+    assert isinstance(job.selection, DbtManifestAssetSelection)
+    assert job.selection.select == (dbt_select or "fqn:*")
+    assert job.selection.exclude == (dbt_exclude or "")
+    assert job.selection.selector == (dbt_selector or "")


### PR DESCRIPTION
## Summary & Motivation
This PR is meant to partially alleviate issue #22523.

In `build_dbt_asset_selection` (dagster_dbt/asset_utils.py) we take the requested selection of the job and we AND it with the asset definition select/exclude. You have to walk the manifest twice each time you resolve this selection. This really adds up when the manifest has thousands of nodes to consider. 

But in many cases, you're not doing any asset subsetting and you just have the dbt defaults. With the defaults set, this second walk of the manifest returns everything, which means the AND with the requested selection will just equal the requested selection. So if all three of dbt_assets_select/ dbt_assets_exclude/ dbt_assets_selector are the default values, we should skip this walk of the manifest entirely, doubling the speed of this step.

On our project (~7500 nodes, ~50 jobs), this change cut definition load time from 90s to 64s (-29%).

## Test Plan
New test `test_dbt_asset_selection_default_assets_def_skips_intersection`. If you have no select on the asset, it should get the selection directly; if the assets definition has its own select, the intersection should continue to be resolved properly.

test_dbt_asset_selection_equality and test_dbt_build_schedule are updated to match; they no longer need to unwrap the AND structure to reach the inner selection. The assertions on select/exclude/selector are unchanged.

Existing parametrized selections all pass unchanged.

Did some other local tests to verify the old and new resolutions are identical for both asset keys and check keys across all selection methods:  `fqn:`, graph operators, `resource_type:`, `test_type:`, `source:`, `path:`.

## Changelog

- [dagster-dbt] Improved definition-resolution performance for dbt asset selections built from @dbt_assets definitions with no select/exclude/selector; they now resolve with half as many dbt selector walks over the manifest.