### PR TITLE
[ui] Fix ui-core Storybook failing to start on Windows

### DIFF
--- a/js_modules/ui-core/.storybook/main.mjs
+++ b/js_modules/ui-core/.storybook/main.mjs
@@ -1,4 +1,4 @@
-import path, {dirname, join} from 'path';
+import path, {dirname} from 'path';
 import {fileURLToPath} from 'url';
 import graphql from '@rollup/plugin-graphql';
 
@@ -7,7 +7,7 @@ import graphql from '@rollup/plugin-graphql';
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.
  */
 function getAbsolutePath(value) {
-  return dirname(fileURLToPath(import.meta.resolve(join(value, 'package.json'))));
+  return dirname(fileURLToPath(import.meta.resolve(`${value}/package.json`)));
 }
 
 const config = {


### PR DESCRIPTION
## Summary & Motivation

`.storybook/main.mjs` resolves addon paths through `getAbsolutePath`, which builds the module specifier with `path.join`:

```js
return dirname(fileURLToPath(import.meta.resolve(join(value, 'package.json'))));
```

On Windows `path.join` emits backslashes, producing `@storybook\addon-themes\package.json`. `import.meta.resolve()` requires a POSIX-style specifier and rejects that, so Storybook fails while evaluating its config, before any story is loaded:

```
SB_CORE-SERVER_0007 (MainFileEvaluationError): Storybook couldn't evaluate your .storybook\main.mjs file.
TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module "@storybook\addon-themes\package.json" is not a valid package name
```

The result is that `yarn storybook` cannot run at all on Windows.

Using a template literal keeps the specifier POSIX-style on every platform. On macOS and Linux `path.join` already produced forward slashes, so the resolved value is unchanged there and this is a no-op.

`join` has no remaining uses and is dropped from the import. `path` and `dirname` are still used.

## Test Plan

- Windows 11, Node 20.19.0: `yarn workspace @dagster-io/ui-core storybook` fails on master with the error above, and starts successfully with this change. Stories render normally once it is up.
- No change expected on macOS or Linux, where `path.join` already yields forward slashes and the resolved specifier is identical.
