### PR TITLE
[ui] Fix TableMetadataEntry story fixture to use JSON records

### DIFF
--- a/js_modules/ui-core/src/metadata/__stories__/MetadataEntry.stories.tsx
+++ b/js_modules/ui-core/src/metadata/__stories__/MetadataEntry.stories.tsx
@@ -250,7 +250,11 @@ function buildMockMetadataEntry(type: MetadataEntryFragment['__typename']): Meta
         table: {
           __typename: 'Table',
           schema: MetadataTableSchema,
-          records: ['1\tBen\tGotow', '2\tOther\tUser', '3\tFirst\tLast'],
+          records: [
+            JSON.stringify({id: 1, first_name: 'Ben', last_name: 'Gotow'}),
+            JSON.stringify({id: 2, first_name: 'Other', last_name: 'User'}),
+            JSON.stringify({id: 3, first_name: 'First', last_name: 'Last'}),
+          ],
         },
       };
     case 'TableSchemaMetadataEntry':


### PR DESCRIPTION
## Summary & Motivation

Noticed while fixing #34088.

The `TableMetadataEntry` fixture in `MetadataEntry.stories.tsx` supplies tab-separated records:

```ts
records: ['1\tBen\tGotow', '2\tOther\tUser', '3\tFirst\tLast'],
```

`TableMetadataEntryComponent` parses each record with `JSON.parse` and routes failures into `invalidRecords`. All three of these throw, so the story renders three "Could not parse record" warnings instead of a table, and never exercises the table rendering path it exists to demonstrate.

`TableMetadataEntryComponent.test.tsx` uses the correct format (`'{"foo": 1, "bar": 2}'`) and reserves invalid JSON for its explicit unparseable-row case, so JSON is the intended contract here.

This converts the fixture to JSON, preserving the same three rows and the existing `id` / `first_name` / `last_name` schema.

## Test Plan

`yarn workspace @dagster-io/ui-core storybook`, open the MetadataEntries story, and confirm the `my_table` entry renders a three-row table rather than three parse warnings.

Before: three "Could not parse record" rows.
After: `id | first_name | last_name` with rows `1 Ben Gotow`, `2 Other User`, `3 First Last`.
