### PR TITLE
Feature: Weighted concurrency pool slots

### DIFF
--- a/docs/docs/guides/operate/managing-concurrency/concurrency-pools.md
+++ b/docs/docs/guides/operate/managing-concurrency/concurrency-pools.md
@@ -41,6 +41,28 @@ To specify a limit for the pool "database" using the `dagster` CLI, use:
 dagster instance concurrency set database 1
 ```
 
+## Weight assets or ops within a pool with `pool_slots`
+
+By default, every asset or op in a pool occupies exactly one slot while it executes. If the steps in a pool have very different resource footprints — for example, a memory-intensive export sharing a pool with lightweight database writes — a pool limit sized for the heaviest step leaves the pool underutilized whenever lighter steps run.
+
+You can use the `pool_slots` keyword argument to specify how many of the pool's slots an asset or op occupies while it executes, similar to `pool_slots` in Airflow. For example, with a `database` pool limit of 4, a `pool_slots=3` asset executes alongside at most one default-weight asset, but three default-weight assets can execute together when it is not running:
+
+<CodeExample
+  path="docs_snippets/docs_snippets/guides/operate/managing_concurrency/pool_slots_concurrency.py"
+  title="src/<project_name>/defs/assets.py"
+  language="python"
+/>
+
+`pool_slots` defaults to `1`, must be a positive integer, and must not exceed the pool's limit — a step requesting more slots than the pool's limit will fail with an error rather than wait forever.
+
+Steps waiting on a pool are granted slots in priority order, and a heavier step at the head of the queue is not overtaken by lighter steps queued behind it, even if they would fit in the currently available slots. This prevents a steady trickle of lightweight steps from starving a heavier step, at the cost of leaving some slots idle while the heavier step waits for its full slot count. Steps with a higher [priority](/deployment/execution/customizing-run-queue-priority) (set with the `dagster/priority` tag) are still granted slots first, regardless of weight.
+
+:::note
+
+`pool_slots` only applies to the default `op` pool granularity; with the pool granularity set to `run`, all runs are weighted equally.
+
+:::
+
 ## Limit the number of runs that can be in progress for a set of ops
 
 You can also use concurrency pools to limit the number of in progress runs containing those assets or ops. You can follow the steps in the [Limit the number of assets or ops actively in execution across all runs](#limit-the-number-of-assets-or-ops-actively-executing-across-all-runs) section to assign your assets and ops to pools and to configure the desired limit.

--- a/examples/docs_snippets/docs_snippets/guides/operate/managing_concurrency/pool_slots_concurrency.py
+++ b/examples/docs_snippets/docs_snippets/guides/operate/managing_concurrency/pool_slots_concurrency.py
@@ -1,0 +1,26 @@
+import time
+
+import dagster as dg
+
+
+@dg.asset(pool="database", pool_slots=3)
+def build_reporting_table(context: dg.AssetExecutionContext):
+    """Heavy asset that occupies 3 slots of the 'database' pool while executing."""
+    context.log.info("Running expensive aggregation query...")
+    time.sleep(10)  # Simulate a heavy database workload
+    return {"rows": 10_000_000}
+
+
+@dg.asset(pool="database")
+def query_customers(context: dg.AssetExecutionContext):
+    """Light asset that occupies 1 slot (the default) of the 'database' pool."""
+    context.log.info("Querying customers table...")
+    time.sleep(5)  # Simulate database query
+    return {"count": 1000}
+
+
+@dg.op(pool="database", pool_slots=2)
+def sync_warehouse(context: dg.OpExecutionContext):
+    """Op that occupies 2 slots of the 'database' pool while executing."""
+    context.log.info("Syncing warehouse tables...")
+    time.sleep(5)  # Simulate a moderately heavy database workload

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -100,6 +100,7 @@ def asset(
     owners: Sequence[str] | None = ...,
     kinds: AbstractSet[str] | None = ...,
     pool: str | None = ...,
+    pool_slots: int | None = ...,
     **kwargs: Any,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]: ...
 
@@ -189,6 +190,7 @@ def asset(
     owners: Sequence[str] | None = None,
     kinds: AbstractSet[str] | None = None,
     pool: str | None = None,
+    pool_slots: int | None = None,
     is_virtual: bool = False,
     **kwargs: Any,
 ) -> AssetsDefinition | Callable[[Callable[..., Any]], AssetsDefinition]:
@@ -272,6 +274,8 @@ def asset(
         kinds (Optional[Set[str]]): A list of strings representing the kinds of the asset. These
             will be made visible in the Dagster UI.
         pool (Optional[str]): A string that identifies the concurrency pool that governs this asset's execution.
+        pool_slots (Optional[int]): The number of slots this asset occupies in its concurrency
+            pool while executing. Must be a positive integer. Defaults to 1.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead.
             Set of asset keys that are upstream dependencies, but do not pass an input to the asset.
             Hidden parameter not exposed in the decorator signature, but passed in kwargs.
@@ -356,6 +360,7 @@ def asset(
         key=key,
         owners=owners,
         pool=pool,
+        pool_slots=pool_slots,
         is_virtual=is_virtual,
     )
 
@@ -432,6 +437,7 @@ class AssetDecoratorArgs(NamedTuple):
     check_specs: Sequence[AssetCheckSpec] | None
     owners: Sequence[str] | None
     pool: str | None
+    pool_slots: int | None
     is_virtual: bool
 
 
@@ -560,6 +566,7 @@ def create_assets_def_from_fn_and_decorator_args(
             decorator_name="@asset",
             execution_type=AssetExecutionType.MATERIALIZATION,
             pool=args.pool,
+            pool_slots=args.pool_slots,
             hooks=args.hooks,
         )
 
@@ -616,6 +623,7 @@ def multi_asset(
     specs: Sequence[AssetSpec] | None = None,
     check_specs: Sequence[AssetCheckSpec] | None = None,
     pool: str | None = None,
+    pool_slots: int | None = None,
     **kwargs: Any,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a combined definition of multiple assets that are computed using the same op and same
@@ -674,6 +682,8 @@ def multi_asset(
             execute in the decorated function after materializing the assets.
         pool (Optional[str]): A string that identifies the concurrency pool that governs this
             multi-asset's execution.
+        pool_slots (Optional[int]): The number of slots this multi-asset occupies in its
+            concurrency pool while executing. Must be a positive integer. Defaults to 1.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead.
             Set of asset keys that are upstream dependencies, but do not pass an input to the
             multi_asset.
@@ -750,6 +760,7 @@ def multi_asset(
         decorator_name="@multi_asset",
         execution_type=AssetExecutionType.MATERIALIZATION,
         pool=pool,
+        pool_slots=pool_slots,
         allow_arbitrary_check_specs=kwargs.get("allow_arbitrary_check_specs", False),
         hooks=check.opt_set_param(hooks, "hooks", of_type=HookDefinition),
     )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -251,6 +251,7 @@ class DecoratorAssetsDefinitionBuilderArgs(NamedTuple):
     execution_type: AssetExecutionType | None
     pool: str | None
     allow_arbitrary_check_specs: bool = False
+    pool_slots: int | None = None
 
     @property
     def check_specs(self) -> Sequence[AssetCheckSpec]:
@@ -574,6 +575,7 @@ class DecoratorAssetsDefinitionBuilder:
             retry_policy=self.args.retry_policy,
             code_version=self.args.code_version,
             pool=self.args.pool,
+            pool_slots=self.args.pool_slots,
         )(self.fn)
 
     def create_assets_definition(self) -> AssetsDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -50,6 +50,7 @@ class _Op:
         ins: Mapping[str, In] | None = None,
         out: Out | Mapping[str, Out] | None = None,
         pool: str | None = None,
+        pool_slots: int | None = None,
     ):
         self.name = check.opt_str_param(name, "name")
         self.decorator_takes_context = check.bool_param(
@@ -64,6 +65,7 @@ class _Op:
         self.code_version = code_version
         self.retry_policy = retry_policy
         self.pool = pool
+        self.pool_slots = pool_slots
 
         # config will be checked within OpDefinition
         self.config_schema = config_schema
@@ -132,6 +134,7 @@ class _Op:
             retry_policy=self.retry_policy,
             version=None,  # code_version has replaced version
             pool=self.pool,
+            pool_slots=self.pool_slots,
         )
         update_wrapper(op_def, compute_fn.decorated_fn)
         return op_def
@@ -155,6 +158,7 @@ def op(
     retry_policy: RetryPolicy | None = ...,
     code_version: str | None = ...,
     pool: str | None = None,
+    pool_slots: int | None = None,
 ) -> _Op: ...
 
 
@@ -176,6 +180,7 @@ def op(
     retry_policy: RetryPolicy | None = None,
     code_version: str | None = None,
     pool: str | None = None,
+    pool_slots: int | None = None,
 ) -> Union["OpDefinition", _Op]:
     """Create an op with the specified parameters from the decorated function.
 
@@ -218,6 +223,10 @@ def op(
         code_version (Optional[str]): Version of the logic encapsulated by the op. If set,
             this is used as a default version for all outputs.
         retry_policy (Optional[RetryPolicy]): The retry policy for this op.
+        pool (Optional[str]): A string that identifies the concurrency pool that governs this
+            op's execution.
+        pool_slots (Optional[int]): The number of slots this op occupies in its concurrency
+            pool while executing. Must be a positive integer. Defaults to 1.
 
     Examples:
         .. code-block:: python
@@ -270,6 +279,7 @@ def op(
         ins=ins,
         out=out,
         pool=pool,
+        pool_slots=pool_slots,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -95,6 +95,8 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             this is used as a default code version for all outputs.
         retry_policy (Optional[RetryPolicy]): The retry policy for this op.
         pool (Optional[str]): A string that identifies the pool that governs this op's execution.
+        pool_slots (Optional[int]): The number of slots this op occupies in its pool while
+            executing. Must be a positive integer. Defaults to 1.
 
 
     Examples:
@@ -117,6 +119,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     _version: str | None
     _retry_policy: RetryPolicy | None
     _pool: str | None
+    _pool_slots: int | None
 
     def __init__(
         self,
@@ -132,6 +135,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         retry_policy: RetryPolicy | None = None,
         code_version: str | None = None,
         pool: str | None = None,
+        pool_slots: int | None = None,
     ):
         from dagster._core.definitions.decorators.op_decorator import (
             DecoratedOpFunction,
@@ -179,6 +183,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         self._retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
         self._pool = pool
         pool = _validate_pool(pool, tags)
+        self._pool_slots = _validate_pool_slots(pool_slots)
 
         positional_inputs = (
             self._compute_fn.positional_inputs()
@@ -209,6 +214,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         retry_policy: RetryPolicy | None,
         code_version: str | None,
         pool: str | None,
+        pool_slots: int | None = None,
     ) -> "OpDefinition":
         return OpDefinition(
             compute_fn=compute_fn,
@@ -223,6 +229,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             retry_policy=retry_policy,
             code_version=code_version,
             pool=pool,
+            pool_slots=pool_slots,
         )
 
     @property
@@ -312,6 +319,11 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     def pool(self) -> str | None:
         """Optional[str]: The concurrency pool for this op."""
         return self._pool
+
+    @property
+    def pool_slots(self) -> int | None:
+        """Optional[int]: The number of slots this op occupies in its concurrency pool."""
+        return self._pool_slots
 
     @property
     def pools(self) -> Set[str]:
@@ -405,6 +417,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             retry_policy=self.retry_policy,
             version=None,  # code_version replaces version
             pool=self.pool,
+            pool_slots=self.pool_slots,
         )
 
     def copy_for_configured(
@@ -615,6 +628,15 @@ def _is_result_object_type(ttype):
 
 VALID_POOL_NAME_REGEX_STR = r"^\S+$"  # any non-whitespace characters
 VALID_POOL_NAME_REGEX = re.compile(VALID_POOL_NAME_REGEX_STR)
+
+
+def _validate_pool_slots(pool_slots):
+    check.opt_int_param(pool_slots, "pool_slots")
+    if pool_slots is not None and pool_slots < 1:
+        raise DagsterInvalidDefinitionError(
+            f"pool_slots must be a positive integer, got {pool_slots}."
+        )
+    return pool_slots
 
 
 def _validate_pool(pool, tags):

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -183,7 +183,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
         self._retry_policy = check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy)
         self._pool = pool
         pool = _validate_pool(pool, tags)
-        self._pool_slots = _validate_pool_slots(pool_slots)
+        self._pool_slots = _validate_pool_slots(pool_slots, pool, tags)
 
         positional_inputs = (
             self._compute_fn.positional_inputs()
@@ -630,12 +630,23 @@ VALID_POOL_NAME_REGEX_STR = r"^\S+$"  # any non-whitespace characters
 VALID_POOL_NAME_REGEX = re.compile(VALID_POOL_NAME_REGEX_STR)
 
 
-def _validate_pool_slots(pool_slots):
+def _validate_pool_slots(pool_slots, pool, tags):
     check.opt_int_param(pool_slots, "pool_slots")
-    if pool_slots is not None and pool_slots < 1:
+    if pool_slots is None:
+        return None
+
+    if pool_slots < 1:
         raise DagsterInvalidDefinitionError(
             f"pool_slots must be a positive integer, got {pool_slots}."
         )
+
+    tags = check.opt_mapping_param(tags, "tags")
+    if not pool and not tags.get(GLOBAL_CONCURRENCY_TAG):
+        raise DagsterInvalidDefinitionError(
+            f"pool_slots={pool_slots} was set without a pool, so it would have no effect. Set "
+            "the `pool` argument to specify which concurrency pool the slots apply to."
+        )
+
     return pool_slots
 
 

--- a/python_modules/dagster/dagster/_core/execution/plan/active.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/active.py
@@ -438,7 +438,7 @@ class ActiveExecution:
                     step_priority = 0
 
                 if not self._instance_concurrency_context.claim(
-                    concurrency_key, step.key, step_priority
+                    concurrency_key, step.key, step_priority, step.pool_slots or 1
                 ):
                     continue
 

--- a/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
@@ -146,8 +146,11 @@ class InstanceConcurrencyContext:
                 "lower the step's pool_slots or raise the pool's limit."
             )
 
+        # only pass slots for weighted claims, so that external EventLogStorage implementations
+        # that predate the slots parameter keep working for default-weight steps
+        slots_kwargs = {"slots": pool_slots} if pool_slots > 1 else {}
         claim_status = self._instance.event_log_storage.claim_concurrency_slot(
-            concurrency_key, self._run_id, step_key, priority, pool_slots
+            concurrency_key, self._run_id, step_key, priority, **slots_kwargs
         )
 
         if not claim_status.is_claimed:

--- a/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional
 
 from typing_extensions import Self
 
+from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.config import PoolGranularity
 from dagster._core.storage.dagster_run import DagsterRun
@@ -92,6 +93,7 @@ class InstanceConcurrencyContext:
         concurrency_key: str,
         step_key: str,
         step_priority: int = 0,
+        pool_slots: int = 1,
     ) -> bool:
         if not self._instance.event_log_storage.supports_global_concurrency_limits:
             return True
@@ -136,8 +138,16 @@ class InstanceConcurrencyContext:
                 f"Tried to claim a concurrency slot with a priority {priority} that was not in the allowed range of a 32-bit signed integer."
             )
 
+        # a limit of 0 pauses the pool, blocking rather than raising
+        if pool_info.limit > 0 and pool_slots > pool_info.limit:
+            raise DagsterInvalidInvocationError(
+                f"Step '{step_key}' requires {pool_slots} slots from pool '{concurrency_key}', "
+                f"which exceeds the pool's limit of {pool_info.limit}. The step can never run - "
+                "lower the step's pool_slots or raise the pool's limit."
+            )
+
         claim_status = self._instance.event_log_storage.claim_concurrency_slot(
-            concurrency_key, self._run_id, step_key, priority
+            concurrency_key, self._run_id, step_key, priority, pool_slots
         )
 
         if not claim_status.is_claimed:

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -301,6 +301,7 @@ class _PlanBuilder:
                         step_outputs=step_outputs,
                         tags=node.tags,
                         pool=node.definition.pool,
+                        pool_slots=node.definition.pool_slots,
                     )
                 elif has_pending_input:
                     new_step = UnresolvedCollectExecutionStep(
@@ -312,6 +313,7 @@ class _PlanBuilder:
                         step_outputs=step_outputs,
                         tags=node.tags,
                         pool=node.definition.pool,
+                        pool_slots=node.definition.pool_slots,
                     )
                 else:
                     new_step = ExecutionStep(
@@ -321,6 +323,7 @@ class _PlanBuilder:
                         step_outputs=step_outputs,
                         tags=node.tags,
                         pool=node.definition.pool,
+                        pool_slots=node.definition.pool_slots,
                     )
 
                 self.add_step(new_step)
@@ -1066,6 +1069,7 @@ class ExecutionPlan(
                     step_outputs,
                     step_snap.tags,
                     step_snap.pool,
+                    pool_slots=step_snap.pool_slots,
                 )
             elif step_snap.kind == StepKind.UNRESOLVED_MAPPED:
                 step = UnresolvedMappedExecutionStep(
@@ -1078,6 +1082,7 @@ class ExecutionPlan(
                     step_outputs,
                     step_snap.tags,
                     step_snap.pool,
+                    pool_slots=step_snap.pool_slots,
                 )
             elif step_snap.kind == StepKind.UNRESOLVED_COLLECT:
                 step = UnresolvedCollectExecutionStep(
@@ -1087,6 +1092,7 @@ class ExecutionPlan(
                     step_outputs,
                     step_snap.tags,
                     step_snap.pool,
+                    pool_slots=step_snap.pool_slots,
                 )
             else:
                 raise Exception(f"Unexpected step kind {step_snap.kind}")

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -84,6 +84,11 @@ class IExecutionStep:
 
     @property
     @abstractmethod
+    def pool_slots(self) -> int | None:
+        pass
+
+    @property
+    @abstractmethod
     def step_inputs(
         self,
     ) -> Sequence[StepInput | UnresolvedCollectStepInput | UnresolvedMappedStepInput]:
@@ -127,6 +132,7 @@ class ExecutionStep(
             ("logging_tags", Mapping[str, str]),
             ("key", str),
             ("pool", str | None),
+            ("pool_slots", int | None),
         ],
     ),
     IExecutionStep,
@@ -143,6 +149,7 @@ class ExecutionStep(
         pool: str | None,
         logging_tags: Mapping[str, str] | None = None,
         key: str | None = None,
+        pool_slots: int | None = None,
     ):
         return super().__new__(
             cls,
@@ -158,6 +165,7 @@ class ExecutionStep(
             },
             tags=tags or {},
             pool=check.opt_str_param(pool, "pool"),
+            pool_slots=check.opt_int_param(pool_slots, "pool_slots"),
             logging_tags=merge_dicts(
                 {
                     "step_key": handle.to_key(),
@@ -228,6 +236,7 @@ class UnresolvedMappedExecutionStep(
             ("step_output_dict", Mapping[str, StepOutput]),
             ("tags", Mapping[str, str]),
             ("pool", str | None),
+            ("pool_slots", int | None),
         ],
     ),
     IExecutionStep,
@@ -242,6 +251,7 @@ class UnresolvedMappedExecutionStep(
         step_outputs: Sequence[StepOutput],
         tags: Mapping[str, str] | None,
         pool: str | None,
+        pool_slots: int | None = None,
     ):
         return super().__new__(
             cls,
@@ -259,6 +269,7 @@ class UnresolvedMappedExecutionStep(
             },
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
             pool=check.opt_str_param(pool, "pool"),
+            pool_slots=check.opt_int_param(pool_slots, "pool_slots"),
         )
 
     @property
@@ -364,6 +375,7 @@ class UnresolvedMappedExecutionStep(
                     step_outputs=self.step_outputs,
                     tags=self.tags,
                     pool=self.pool,
+                    pool_slots=self.pool_slots,
                 )
             )
 
@@ -390,6 +402,7 @@ class UnresolvedCollectExecutionStep(
             ("step_output_dict", Mapping[str, StepOutput]),
             ("tags", Mapping[str, str]),
             ("pool", str | None),
+            ("pool_slots", int | None),
         ],
     ),
     IExecutionStep,
@@ -404,6 +417,7 @@ class UnresolvedCollectExecutionStep(
         step_outputs: Sequence[StepOutput],
         tags: Mapping[str, str] | None,
         pool: str | None,
+        pool_slots: int | None = None,
     ):
         return super().__new__(
             cls,
@@ -421,6 +435,7 @@ class UnresolvedCollectExecutionStep(
             },
             tags=check.opt_mapping_param(tags, "tags", key_type=str),
             pool=check.opt_str_param(pool, "pool"),
+            pool_slots=check.opt_int_param(pool_slots, "pool_slots"),
         )
 
     @property
@@ -501,4 +516,5 @@ class UnresolvedCollectExecutionStep(
             step_outputs=self.step_outputs,
             tags=self.tags,
             pool=self.pool,
+            pool_slots=self.pool_slots,
         )

--- a/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
@@ -150,7 +150,8 @@ class ExecutionPlanSnapshotErrorData(
 
 
 @whitelist_for_serdes(
-    storage_field_names={"node_handle_id": "solid_handle_id"}, skip_when_none_fields={"pool"}
+    storage_field_names={"node_handle_id": "solid_handle_id"},
+    skip_when_none_fields={"pool", "pool_slots"},
 )
 class ExecutionStepSnap(
     NamedTuple(
@@ -165,6 +166,7 @@ class ExecutionStepSnap(
             ("tags", Mapping[str, str] | None),
             ("step_handle", StepHandleUnion | None),
             ("pool", str | None),
+            ("pool_slots", int | None),
         ],
     )
 ):
@@ -179,6 +181,7 @@ class ExecutionStepSnap(
         tags: Mapping[str, str] | None = None,
         step_handle: StepHandleUnion | None = None,
         pool: str | None = None,
+        pool_slots: int | None = None,
     ):
         return super().__new__(
             cls,
@@ -196,6 +199,7 @@ class ExecutionStepSnap(
             # snapshot may have been generated before concurrency_key was added as a separate
             # argument
             pool=check.opt_str_param(pool, "pool"),
+            pool_slots=check.opt_int_param(pool_slots, "pool_slots"),
         )
 
     @property
@@ -358,6 +362,7 @@ def _snapshot_from_execution_step(execution_step: IExecutionStep) -> ExecutionSt
         tags=execution_step.tags,
         step_handle=execution_step.handle,
         pool=execution_step.pool,
+        pool_slots=execution_step.pool_slots,
     )
 
 

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/049_b64501f0ceb7_add_column_pending_steps_slots.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/049_b64501f0ceb7_add_column_pending_steps_slots.py
@@ -1,0 +1,29 @@
+"""add column pending steps slots
+
+Revision ID: b64501f0ceb7
+Revises: 29b539ebc72a
+Create Date: 2026-08-10 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from dagster._core.storage.migration.utils import has_column, has_table
+
+# revision identifiers, used by Alembic.
+revision = "b64501f0ceb7"
+down_revision = "29b539ebc72a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if has_table("pending_steps"):
+        if not has_column("pending_steps", "slots"):
+            op.add_column("pending_steps", sa.Column("slots", sa.Integer(), nullable=True))
+
+
+def downgrade():
+    if has_table("pending_steps"):
+        if has_column("pending_steps", "slots"):
+            op.drop_column("pending_steps", "slots")

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -600,6 +600,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         run_id: str,
         step_key: str,
         priority: int | None = None,
+        slots: int = 1,
     ) -> ConcurrencyClaimStatus:
         """Claim concurrency slots for step."""
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -152,6 +152,8 @@ PendingStepsTable = db.Table(
     db.Column("priority", db.Integer),
     db.Column("assigned_timestamp", db.DateTime),
     db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
+    # number of slots this step occupies in the pool; NULL is read as 1
+    db.Column("slots", db.Integer, nullable=True),
 )
 
 AssetCheckExecutionsTable = db.Table(

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2245,6 +2245,19 @@ class SqlEventLogStorage(EventLogStorage):
         # we handle in the code if its been added or not.
         return self.has_table(ConcurrencyLimitsTable.name)
 
+    @cached_property
+    def has_pending_steps_slots_col(self) -> bool:
+        # This column was added later, and to avoid forcing a migration
+        # we handle in the code if its been added or not.
+        if not self.has_table(PendingStepsTable.name):
+            return False
+
+        with self.index_connection() as conn:
+            column_names = [
+                x.get("name") for x in db.inspect(conn).get_columns(PendingStepsTable.name)
+            ]
+            return PendingStepsTable.c.slots.name in column_names
+
     def _reconcile_concurrency_limits_from_slots(self) -> None:
         """Helper function that can be reconciles the concurrency limits table from the concurrency
         slots table.  This should only run when the concurrency limits table exists and is empty,
@@ -2512,31 +2525,46 @@ class SqlEventLogStorage(EventLogStorage):
             keys_to_assign.extend([concurrency_key for _ in range(existing, num)])
         return keys_to_assign
 
-    def has_unassigned_slots(self, concurrency_key: str) -> bool:
+    def has_unassigned_slots(self, concurrency_key: str, slots: int = 1) -> bool:
+        # initialize outside of connection context
+        has_slots_col = self.has_pending_steps_slots_col
         with self.index_connection() as conn:
-            pending_row = conn.execute(
-                db_select([db.func.count()])
-                .select_from(PendingStepsTable)
-                .where(
-                    db.and_(
-                        PendingStepsTable.c.concurrency_key == concurrency_key,
-                        PendingStepsTable.c.assigned_timestamp != None,  # noqa: E711
-                    )
+            pending_count = self._assigned_pending_slots_count(conn, concurrency_key, has_slots_col)
+            slots_count = self._total_slots_count(conn, concurrency_key)
+        return slots_count - pending_count >= slots
+
+    def _total_slots_count(self, conn: Connection, concurrency_key: str) -> int:
+        row = conn.execute(
+            db_select([db.func.count()])
+            .select_from(ConcurrencySlotsTable)
+            .where(
+                db.and_(
+                    ConcurrencySlotsTable.c.concurrency_key == concurrency_key,
+                    ConcurrencySlotsTable.c.deleted == False,  # noqa: E712
                 )
-            ).fetchone()
-            slots = conn.execute(
-                db_select([db.func.count()])
-                .select_from(ConcurrencySlotsTable)
-                .where(
-                    db.and_(
-                        ConcurrencySlotsTable.c.concurrency_key == concurrency_key,
-                        ConcurrencySlotsTable.c.deleted == False,  # noqa: E712
-                    )
+            )
+        ).fetchone()
+        return cast("int", row[0]) if row else 0
+
+    def _assigned_pending_slots_count(
+        self, conn: Connection, concurrency_key: str, has_slots_col: bool
+    ) -> int:
+        """The number of slots reserved by assigned pending steps (claimed or not yet claimed)."""
+        if has_slots_col:
+            count_expr = db.func.sum(db.func.coalesce(PendingStepsTable.c.slots, 1))
+        else:
+            count_expr = db.func.count()
+        row = conn.execute(
+            db_select([count_expr])
+            .select_from(PendingStepsTable)
+            .where(
+                db.and_(
+                    PendingStepsTable.c.concurrency_key == concurrency_key,
+                    PendingStepsTable.c.assigned_timestamp != None,  # noqa: E711
                 )
-            ).fetchone()
-        pending_count = cast("int", pending_row[0]) if pending_row else 0
-        slots_count = cast("int", slots[0]) if slots else 0
-        return slots_count > pending_count
+            )
+        ).fetchone()
+        return cast("int", row[0]) if row and row[0] else 0
 
     def check_concurrency_claim(
         self, concurrency_key: str, run_id: str, step_key: str
@@ -2635,23 +2663,44 @@ class SqlEventLogStorage(EventLogStorage):
         if not concurrency_keys:
             return
 
+        # initialize outside of connection context
+        has_slots_col = self.has_pending_steps_slots_col
         with self.index_connection() as conn:
-            for key in concurrency_keys:
-                row = conn.execute(
-                    db_select([PendingStepsTable.c.id])
-                    .where(
-                        db.and_(
-                            PendingStepsTable.c.concurrency_key == key,
-                            PendingStepsTable.c.assigned_timestamp == None,  # noqa: E711
+            for key in OrderedDict.fromkeys(concurrency_keys):
+                while True:
+                    free_slots = self._total_slots_count(
+                        conn, key
+                    ) - self._assigned_pending_slots_count(conn, key, has_slots_col)
+                    if free_slots <= 0:
+                        break
+
+                    head_columns = [PendingStepsTable.c.id]
+                    if has_slots_col:
+                        head_columns.append(db.func.coalesce(PendingStepsTable.c.slots, 1))
+                    row = conn.execute(
+                        db_select(head_columns)
+                        .where(
+                            db.and_(
+                                PendingStepsTable.c.concurrency_key == key,
+                                PendingStepsTable.c.assigned_timestamp == None,  # noqa: E711
+                            )
                         )
-                    )
-                    .order_by(
-                        PendingStepsTable.c.priority.desc(),
-                        PendingStepsTable.c.create_timestamp.asc(),
-                    )
-                    .limit(1)
-                ).fetchone()
-                if row:
+                        .order_by(
+                            PendingStepsTable.c.priority.desc(),
+                            PendingStepsTable.c.create_timestamp.asc(),
+                        )
+                        .limit(1)
+                    ).fetchone()
+                    if not row:
+                        break
+
+                    head_slots = cast("int", row[1]) if has_slots_col else 1
+                    if head_slots > free_slots:
+                        # head-of-line blocking: the step at the head of the queue does not fit, so
+                        # do not assign any steps behind it, even if they would fit.  This prevents
+                        # a heavily-weighted step from being starved by lighter steps.
+                        break
+
                     conn.execute(
                         PendingStepsTable.update()
                         .where(PendingStepsTable.c.id == row[0])
@@ -2665,22 +2714,20 @@ class SqlEventLogStorage(EventLogStorage):
         step_key: str,
         priority: int | None = None,
         should_assign: bool = False,
+        slots: int = 1,
     ):
+        row = dict(
+            run_id=run_id,
+            step_key=step_key,
+            concurrency_key=concurrency_key,
+            priority=priority or 0,
+            assigned_timestamp=db.func.now() if should_assign else None,
+        )
+        if self.has_pending_steps_slots_col:
+            row["slots"] = slots
         with self.index_connection() as conn:
             try:
-                conn.execute(
-                    PendingStepsTable.insert().values(
-                        [
-                            dict(
-                                run_id=run_id,
-                                step_key=step_key,
-                                concurrency_key=concurrency_key,
-                                priority=priority or 0,
-                                assigned_timestamp=db.func.now() if should_assign else None,
-                            )
-                        ]
-                    )
-                )
+                conn.execute(PendingStepsTable.insert().values([row]))
             except db_exc.IntegrityError:
                 # do nothing
                 pass
@@ -2720,7 +2767,12 @@ class SqlEventLogStorage(EventLogStorage):
         return to_assign
 
     def claim_concurrency_slot(
-        self, concurrency_key: str, run_id: str, step_key: str, priority: int | None = None
+        self,
+        concurrency_key: str,
+        run_id: str,
+        step_key: str,
+        priority: int | None = None,
+        slots: int = 1,
     ) -> ConcurrencyClaimStatus:
         """Claim concurrency slot for step.
 
@@ -2728,19 +2780,30 @@ class SqlEventLogStorage(EventLogStorage):
             concurrency_key (str): The concurrency key to claim.
             run_id (str): The run id to claim for.
             step_key (str): The step key to claim for.
+            priority (Optional[int]): The priority of the claim, relative to other pending steps.
+            slots (int): The number of slots in the pool that the step occupies.
         """
-        # first, register the step by adding to pending queue
+        check.int_param(slots, "slots")
+        check.invariant(slots >= 1, "slots must be a positive integer")
+
+        if slots > 1:
+            self._check_weighted_claim(concurrency_key, step_key, slots)
+
+        # first, register the step by adding to pending queue, then run the assignment loop so
+        # that the step is assigned immediately if it is at the head of the queue and there is
+        # capacity for it.  Enqueued steps are never assigned out of queue order, to prevent a
+        # trickle of lightly-weighted steps from starving a heavily-weighted step at the head.
         if not self.has_pending_step(
             concurrency_key=concurrency_key, run_id=run_id, step_key=step_key
         ):
-            has_unassigned_slots = self.has_unassigned_slots(concurrency_key)
             self.add_pending_step(
                 concurrency_key=concurrency_key,
                 run_id=run_id,
                 step_key=step_key,
                 priority=priority,
-                should_assign=has_unassigned_slots,
+                slots=slots,
             )
+            self.assign_pending_steps([concurrency_key])
 
         # if the step is not assigned (i.e. has not been popped from queue), block the claim
         claim_status = self.check_concurrency_claim(
@@ -2753,12 +2816,29 @@ class SqlEventLogStorage(EventLogStorage):
         # based on the number of unclaimed slots, but this should act as a safeguard, using the slot
         # rows as a semaphore
         slot_status = self._claim_concurrency_slot(
-            concurrency_key=concurrency_key, run_id=run_id, step_key=step_key
+            concurrency_key=concurrency_key, run_id=run_id, step_key=step_key, slots=slots
         )
         return claim_status.with_slot_status(slot_status)
 
+    def _check_weighted_claim(self, concurrency_key: str, step_key: str, slots: int) -> None:
+        """Validate that a multi-slot claim can ever be satisfied, raising instead of hanging."""
+        if not self.has_pending_steps_slots_col:
+            raise DagsterInvalidInvocationError(
+                f"Step '{step_key}' requested {slots} slots from pool '{concurrency_key}', but "
+                "this instance's storage has not been migrated to support weighted pool slots. "
+                "Run `dagster instance migrate` to enable them."
+            )
+        with self.index_connection() as conn:
+            limit = self._total_slots_count(conn, concurrency_key)
+        if limit and slots > limit:
+            raise DagsterInvalidInvocationError(
+                f"Step '{step_key}' requested {slots} slots from pool '{concurrency_key}', which "
+                f"exceeds the pool's limit of {limit}. The claim can never be satisfied - lower "
+                "the step's pool_slots or raise the pool's limit."
+            )
+
     def _claim_concurrency_slot(
-        self, concurrency_key: str, run_id: str, step_key: str
+        self, concurrency_key: str, run_id: str, step_key: str, slots: int = 1
     ) -> ConcurrencySlotStatus:
         """Claim a concurrency slot for the step.  Helper method that is called for steps that are
         popped off the priority queue.
@@ -2767,9 +2847,10 @@ class SqlEventLogStorage(EventLogStorage):
             concurrency_key (str): The concurrency key to claim.
             run_id (str): The run id to claim a slot for.
             step_key (str): The step key to claim a slot for.
+            slots (int): The number of slots to claim.
         """
         with self.index_connection() as conn:
-            result = conn.execute(
+            rows = conn.execute(
                 db_select([ConcurrencySlotsTable.c.id])
                 .select_from(ConcurrencySlotsTable)
                 .where(
@@ -2780,15 +2861,34 @@ class SqlEventLogStorage(EventLogStorage):
                     )
                 )
                 .with_for_update(skip_locked=True)
-                .limit(1)
-            ).fetchone()
-            if not result or not result[0]:
+                .limit(slots)
+            ).fetchall()
+            slot_ids = [row[0] for row in rows]
+            if len(slot_ids) < slots:
+                # not enough free slots for the full claim... this should not happen for steps that
+                # have been assigned, but do not partially claim slots (which could deadlock)
                 return ConcurrencySlotStatus.BLOCKED
-            if not conn.execute(
-                ConcurrencySlotsTable.update()
-                .values(run_id=run_id, step_key=step_key)
-                .where(ConcurrencySlotsTable.c.id == result[0])
-            ).rowcount:
+            if (
+                conn.execute(
+                    ConcurrencySlotsTable.update()
+                    .values(run_id=run_id, step_key=step_key)
+                    .where(ConcurrencySlotsTable.c.id.in_(slot_ids))
+                ).rowcount
+                != slots
+            ):
+                # failed to grab all of the selected slots... release any that we did grab so that
+                # we do not hold a partial claim
+                conn.execute(
+                    ConcurrencySlotsTable.update()
+                    .values(run_id=None, step_key=None)
+                    .where(
+                        db.and_(
+                            ConcurrencySlotsTable.c.id.in_(slot_ids),
+                            ConcurrencySlotsTable.c.run_id == run_id,
+                            ConcurrencySlotsTable.c.step_key == step_key,
+                        )
+                    )
+                )
                 return ConcurrencySlotStatus.BLOCKED
 
             return ConcurrencySlotStatus.CLAIMED

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2666,11 +2666,25 @@ class SqlEventLogStorage(EventLogStorage):
         # initialize outside of connection context
         has_slots_col = self.has_pending_steps_slots_col
         with self.index_connection() as conn:
-            for key in OrderedDict.fromkeys(concurrency_keys):
+            # sort keys so that concurrent assigners always lock pools in the same order
+            for key in sorted(set(concurrency_keys)):
                 while True:
-                    free_slots = self._total_slots_count(
-                        conn, key
-                    ) - self._assigned_pending_slots_count(conn, key, has_slots_col)
+                    # lock the pool's slot rows to serialize concurrent assigners for this pool,
+                    # so that the total reserved weight can never exceed the pool's capacity
+                    slot_rows = conn.execute(
+                        db_select([ConcurrencySlotsTable.c.id])
+                        .select_from(ConcurrencySlotsTable)
+                        .where(
+                            db.and_(
+                                ConcurrencySlotsTable.c.concurrency_key == key,
+                                ConcurrencySlotsTable.c.deleted == False,  # noqa: E712
+                            )
+                        )
+                        .with_for_update()
+                    ).fetchall()
+                    free_slots = len(slot_rows) - self._assigned_pending_slots_count(
+                        conn, key, has_slots_col
+                    )
                     if free_slots <= 0:
                         break
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2688,6 +2688,9 @@ class SqlEventLogStorage(EventLogStorage):
                         .order_by(
                             PendingStepsTable.c.priority.desc(),
                             PendingStepsTable.c.create_timestamp.asc(),
+                            # deterministic tiebreak so that concurrent assigners lock pending
+                            # rows in the same order, avoiding db deadlocks
+                            PendingStepsTable.c.id.asc(),
                         )
                         .limit(1)
                     ).fetchone()

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2665,7 +2665,9 @@ class SqlEventLogStorage(EventLogStorage):
 
         # initialize outside of connection context
         has_slots_col = self.has_pending_steps_slots_col
-        with self.index_connection() as conn:
+        # a real transaction (not statement-level autocommit) is required so that the slot-row
+        # locks are held until the pending-row assignments commit
+        with self.index_transaction() as conn:
             # sort keys so that concurrent assigners always lock pools in the same order
             for key in sorted(set(concurrency_keys)):
                 while True:
@@ -2866,7 +2868,9 @@ class SqlEventLogStorage(EventLogStorage):
             step_key (str): The step key to claim a slot for.
             slots (int): The number of slots to claim.
         """
-        with self.index_connection() as conn:
+        # a real transaction (not statement-level autocommit) is required so that the
+        # FOR UPDATE SKIP LOCKED row locks are held until the claiming update commits
+        with self.index_transaction() as conn:
             rows = conn.execute(
                 db_select([ConcurrencySlotsTable.c.id])
                 .select_from(ConcurrencySlotsTable)

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -727,8 +727,11 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         priority: int | None = None,
         slots: int = 1,
     ) -> ConcurrencyClaimStatus:
+        # only pass slots for weighted claims, so that external EventLogStorage implementations
+        # that predate the slots parameter keep working for default-weight steps
+        slots_kwargs = {"slots": slots} if slots > 1 else {}
         return self._storage.event_log_storage.claim_concurrency_slot(
-            concurrency_key, run_id, step_key, priority, slots
+            concurrency_key, run_id, step_key, priority, **slots_kwargs
         )
 
     def check_concurrency_claim(self, concurrency_key: str, run_id: str, step_key: str):

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -720,10 +720,15 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
         return self._storage.event_log_storage.get_concurrency_info(concurrency_key)
 
     def claim_concurrency_slot(
-        self, concurrency_key: str, run_id: str, step_key: str, priority: int | None = None
+        self,
+        concurrency_key: str,
+        run_id: str,
+        step_key: str,
+        priority: int | None = None,
+        slots: int = 1,
     ) -> ConcurrencyClaimStatus:
         return self._storage.event_log_storage.claim_concurrency_slot(
-            concurrency_key, run_id, step_key, priority
+            concurrency_key, run_id, step_key, priority, slots
         )
 
     def check_concurrency_claim(self, concurrency_key: str, run_id: str, step_key: str):

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_execution_plan.py
@@ -132,3 +132,43 @@ def test_execution_plan_snapshot_asset_check_keys():
         dg.AssetCheckKey(dg.AssetKey("my_asset"), "my_check"),
         dg.AssetCheckKey(dg.AssetKey("my_asset"), "my_other_check"),
     }
+
+
+def test_execution_plan_pool_slots_round_trip():
+    from dagster._core.execution.plan.plan import ExecutionPlan
+    from dagster._serdes import deserialize_value, serialize_value
+
+    @dg.op(pool="heavy", pool_slots=3)
+    def heavy_op():
+        pass
+
+    @dg.op(pool="light")
+    def light_op():
+        pass
+
+    @dg.job
+    def pool_job():
+        heavy_op()
+        light_op()
+
+    execution_plan = create_execution_plan(pool_job)
+    step = execution_plan.get_step_by_key("heavy_op")
+    assert step.pool == "heavy"
+    assert step.pool_slots == 3
+    assert execution_plan.get_step_by_key("light_op").pool_slots is None
+
+    plan_snapshot = snapshot_from_execution_plan(
+        execution_plan, pool_job.get_job_snapshot().snapshot_id
+    )
+
+    # the value survives serialization and plan rebuilds
+    serialized = serialize_value(plan_snapshot)
+    rebuilt_snapshot = deserialize_value(serialized, type(plan_snapshot))
+    rebuilt_plan = ExecutionPlan.rebuild_from_snapshot("pool_job", rebuilt_snapshot)
+    assert rebuilt_plan.get_step_by_key("heavy_op").pool_slots == 3
+
+    # unset pool_slots is skipped during serialization, so existing snapshots are unchanged
+    light_step_snap = next(s for s in plan_snapshot.steps if s.key == "light_op")
+    assert light_step_snap.pool_slots is None
+    assert '"pool_slots": 3' in serialized
+    assert serialized.count('"pool_slots"') == 1

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions.py
@@ -341,3 +341,24 @@ def test_pool_slots_invalid():
             @dg.op(pool="foo", pool_slots=pool_slots)
             def my_op():
                 pass
+
+
+def test_pool_slots_without_pool():
+    with pytest.raises(dg.DagsterInvalidDefinitionError, match="without a pool"):
+
+        @dg.op(pool_slots=2)
+        def my_op():
+            pass
+
+    with pytest.raises(dg.DagsterInvalidDefinitionError, match="without a pool"):
+
+        @dg.asset(pool_slots=2)
+        def my_asset():
+            pass
+
+    # the legacy concurrency key tag also identifies a pool, so pool_slots applies to it
+    @dg.op(tags={GLOBAL_CONCURRENCY_TAG: "foo"}, pool_slots=2)
+    def tag_based_op():
+        pass
+
+    assert tag_based_op.pool_slots == 2

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions.py
@@ -303,3 +303,41 @@ def test_pool_with_special_chars_valid():
             pass
 
         assert my_op.pool == pool
+
+
+def test_pool_slots():
+    @dg.op(pool="foo", pool_slots=4)
+    def my_op():
+        pass
+
+    assert my_op.pool == "foo"
+    assert my_op.pool_slots == 4
+
+    @dg.op(pool="foo")
+    def default_op():
+        pass
+
+    assert default_op.pool_slots is None
+
+    @dg.asset(pool="foo", pool_slots=2)
+    def my_asset():
+        pass
+
+    assert my_asset.op.pool_slots == 2
+
+    @dg.multi_asset(
+        specs=[dg.AssetSpec("asset1"), dg.AssetSpec("asset2")], pool="foo", pool_slots=3
+    )
+    def my_multi_asset():
+        pass
+
+    assert my_multi_asset.op.pool_slots == 3
+
+
+def test_pool_slots_invalid():
+    for pool_slots in [0, -1]:
+        with pytest.raises(dg.DagsterInvalidDefinitionError, match="positive integer"):
+
+            @dg.op(pool="foo", pool_slots=pool_slots)
+            def my_op():
+                pass

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_active.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_active.py
@@ -250,7 +250,7 @@ class MockInstanceConcurrencyContext(InstanceConcurrencyContext):
     def global_concurrency_keys(self) -> set[str]:
         return {"foo"}
 
-    def claim(self, concurrency_key: str, step_key: str, priority: int = 0):  # ty: ignore[invalid-method-override]
+    def claim(self, concurrency_key: str, step_key: str, priority: int = 0, pool_slots: int = 1):  # ty: ignore[invalid-method-override]
         self._pending_claims.add(step_key)
         return False
 

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_instance_concurrency_context.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_instance_concurrency_context.py
@@ -50,6 +50,31 @@ def test_global_concurrency(concurrency_instance_op_granularity):
     assert foo_info.pending_step_count == 0
 
 
+def test_global_concurrency_pool_slots(concurrency_instance_op_granularity):
+    instance = concurrency_instance_op_granularity
+    run = instance.create_run_for_job(define_foo_job(), run_id=make_new_run_id())
+    instance.event_log_storage.set_concurrency_slots("foo", 4)
+
+    with InstanceConcurrencyContext(instance, run) as context:
+        # a 3-slot step occupies 3 of the pool's 4 slots
+        assert context.claim("foo", "heavy", pool_slots=3)
+        foo_info = instance.event_log_storage.get_concurrency_info("foo")
+        assert foo_info.active_slot_count == 3
+
+        assert context.claim("foo", "light")
+        assert not context.claim("foo", "light_2")
+        assert context.pending_claim_steps() == ["light_2"]
+
+        # freeing the weighted step releases all of its slots
+        context.free_step("heavy")
+        foo_info = instance.event_log_storage.get_concurrency_info("foo")
+        assert foo_info.active_slot_count == 1
+
+        # a step that can never fit raises instead of hanging
+        with pytest.raises(dg.DagsterInvalidInvocationError, match="exceeds the pool's limit"):
+            context.claim("foo", "too_heavy", pool_slots=5)
+
+
 def test_limitless_context(concurrency_instance_op_granularity):
     run = concurrency_instance_op_granularity.create_run_for_job(
         define_foo_job(), run_id=make_new_run_id()

--- a/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
@@ -518,3 +518,64 @@ def test_step_worker_failure_attempts():
     assert len(run_step_stats) == 1
     step_stat = run_step_stats[0]
     assert step_stat.attempts == 1
+
+
+def test_pending_steps_slots_column_migration():
+    from dagster._core.storage.event_log.sqlite import sqlite_event_log
+    from dagster._core.storage.sql import (
+        get_alembic_config,
+        run_alembic_downgrade,
+        run_alembic_upgrade,
+    )
+
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:
+        alembic_config = get_alembic_config(sqlite_event_log.__file__)
+        run_id = make_new_run_id()
+
+        # populate the pending_steps table with weighted and unweighted claims
+        storage = ConcurrencyEnabledSqliteTestEventLogStorage(base_dir=tmpdir_path)
+        try:
+            assert storage.has_pending_steps_slots_col
+            storage.set_concurrency_slots("foo", 4)
+            assert storage.claim_concurrency_slot("foo", run_id, "heavy", slots=3).is_claimed
+            assert storage.claim_concurrency_slot("foo", run_id, "light").is_claimed
+
+            # downgrade drops the slots column but keeps the pending steps rows
+            with storage.index_connection() as conn:
+                run_alembic_downgrade(alembic_config, conn, rev="29b539ebc72a", run_id="index")
+        finally:
+            storage.dispose()
+
+        storage = ConcurrencyEnabledSqliteTestEventLogStorage(base_dir=tmpdir_path)
+        try:
+            assert not storage.has_pending_steps_slots_col
+            info = storage.get_concurrency_info("foo")
+            assert {step.step_key for step in info.pending_steps} == {"heavy", "light"}
+
+            # unweighted claims still work against the downgraded schema
+            assert not storage.claim_concurrency_slot("foo", run_id, "extra").is_claimed
+
+            # weighted claims raise, pointing at the migration
+            with pytest.raises(dg.DagsterInvalidInvocationError, match="dagster instance migrate"):
+                storage.claim_concurrency_slot("foo", run_id, "heavy_2", slots=2)
+
+            # freeing the previously-weighted step releases all of its slots
+            storage.free_concurrency_slot_for_step(run_id, "heavy")
+            assert storage.get_concurrency_info("foo").active_slot_count == 1
+            assert storage.claim_concurrency_slot("foo", run_id, "extra").is_claimed
+
+            # upgrade restores the slots column
+            with storage.index_connection() as conn:
+                run_alembic_upgrade(alembic_config, conn, run_id="index")
+        finally:
+            storage.dispose()
+
+        storage = ConcurrencyEnabledSqliteTestEventLogStorage(base_dir=tmpdir_path)
+        try:
+            assert storage.has_pending_steps_slots_col
+
+            # rows written before the upgrade have a NULL slots value, which reads as weight 1,
+            # so two of the four slots are held (light, extra) and a 2-slot claim fits
+            assert storage.claim_concurrency_slot("foo", run_id, "heavy_2", slots=2).is_claimed
+        finally:
+            storage.dispose()

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -5785,6 +5785,120 @@ class TestEventLogStorage:
         storage.delete_events(run_id=two)
         assert storage.get_concurrency_run_ids() == set()
 
+    def test_concurrency_weighted_slots(self, storage: EventLogStorage):
+        if not storage.supports_global_concurrency_limits:
+            pytest.skip("storage does not support global op concurrency")
+
+        run_id = make_new_run_id()
+
+        def claim(key, run_id, step_key, priority=0, slots=1):
+            claim_status = storage.claim_concurrency_slot(key, run_id, step_key, priority, slots)
+            return claim_status.slot_status
+
+        storage.set_concurrency_slots("foo", 4)
+
+        # a 3-slot step claims 3 of the 4 slots
+        assert claim("foo", run_id, "heavy_1", slots=3) == ConcurrencySlotStatus.CLAIMED
+        foo_info = storage.get_concurrency_info("foo")
+        assert foo_info.active_slot_count == 3
+        assert all(slot.step_key == "heavy_1" for slot in foo_info.claimed_slots)
+
+        # a 1-slot step fits in the remaining slot
+        assert claim("foo", run_id, "light_1") == ConcurrencySlotStatus.CLAIMED
+
+        # another 1-slot step is blocked
+        assert claim("foo", run_id, "light_2") == ConcurrencySlotStatus.BLOCKED
+
+        # freeing the 3-slot step releases all 3 slots
+        storage.free_concurrency_slot_for_step(run_id, "heavy_1")
+        foo_info = storage.get_concurrency_info("foo")
+        assert foo_info.active_slot_count == 1
+
+        assert claim("foo", run_id, "light_2") == ConcurrencySlotStatus.CLAIMED
+        assert claim("foo", run_id, "light_3") == ConcurrencySlotStatus.CLAIMED
+        assert claim("foo", run_id, "light_4") == ConcurrencySlotStatus.CLAIMED
+
+    def test_concurrency_weighted_head_of_line(self, storage: EventLogStorage):
+        if not storage.supports_global_concurrency_limits:
+            pytest.skip("storage does not support global op concurrency")
+
+        run_id = make_new_run_id()
+
+        def claim(key, run_id, step_key, priority=0, slots=1):
+            claim_status = storage.claim_concurrency_slot(key, run_id, step_key, priority, slots)
+            return claim_status.slot_status
+
+        storage.set_concurrency_slots("foo", 4)
+
+        # fill two slots with 1-slot steps
+        assert claim("foo", run_id, "light_1") == ConcurrencySlotStatus.CLAIMED
+        assert claim("foo", run_id, "light_2") == ConcurrencySlotStatus.CLAIMED
+
+        # a 4-slot step does not fit and queues at the head
+        assert claim("foo", run_id, "heavy_1", slots=4) == ConcurrencySlotStatus.BLOCKED
+
+        # 1-slot steps queued behind the heavy step do not overtake it, even though 2 slots are
+        # free
+        assert claim("foo", run_id, "light_3") == ConcurrencySlotStatus.BLOCKED
+        assert claim("foo", run_id, "light_4") == ConcurrencySlotStatus.BLOCKED
+
+        # freeing one slot is not enough for the heavy step, and the light steps stay blocked
+        storage.free_concurrency_slot_for_step(run_id, "light_1")
+        assert claim("foo", run_id, "light_3") == ConcurrencySlotStatus.BLOCKED
+        assert claim("foo", run_id, "heavy_1", slots=4) == ConcurrencySlotStatus.BLOCKED
+
+        # once all slots are free, the heavy step runs
+        storage.free_concurrency_slot_for_step(run_id, "light_2")
+        assert claim("foo", run_id, "heavy_1", slots=4) == ConcurrencySlotStatus.CLAIMED
+        assert claim("foo", run_id, "light_3") == ConcurrencySlotStatus.BLOCKED
+
+        # and freeing it lets the queued light steps through
+        storage.free_concurrency_slot_for_step(run_id, "heavy_1")
+        assert claim("foo", run_id, "light_3") == ConcurrencySlotStatus.CLAIMED
+        assert claim("foo", run_id, "light_4") == ConcurrencySlotStatus.CLAIMED
+
+    def test_concurrency_weighted_no_deadlock(self, storage: EventLogStorage):
+        if not storage.supports_global_concurrency_limits:
+            pytest.skip("storage does not support global op concurrency")
+
+        run_id = make_new_run_id()
+
+        def claim(key, run_id, step_key, priority=0, slots=1):
+            claim_status = storage.claim_concurrency_slot(key, run_id, step_key, priority, slots)
+            return claim_status.slot_status
+
+        storage.set_concurrency_slots("foo", 4)
+
+        # two 3-slot steps against a 4-slot pool: one claims all of its slots, the other waits
+        # (instead of each grabbing a partial claim and deadlocking)
+        assert claim("foo", run_id, "heavy_1", slots=3) == ConcurrencySlotStatus.CLAIMED
+        assert claim("foo", run_id, "heavy_2", slots=3) == ConcurrencySlotStatus.BLOCKED
+
+        foo_info = storage.get_concurrency_info("foo")
+        assert foo_info.active_slot_count == 3
+
+        # when the first completes, the second runs
+        storage.free_concurrency_slot_for_step(run_id, "heavy_1")
+        assert claim("foo", run_id, "heavy_2", slots=3) == ConcurrencySlotStatus.CLAIMED
+        foo_info = storage.get_concurrency_info("foo")
+        assert foo_info.active_slot_count == 3
+
+    def test_concurrency_weighted_exceeds_limit(self, storage: EventLogStorage):
+        if not storage.supports_global_concurrency_limits:
+            pytest.skip("storage does not support global op concurrency")
+
+        run_id = make_new_run_id()
+
+        storage.set_concurrency_slots("foo", 2)
+
+        # a step requesting more slots than the pool limit raises instead of hanging forever
+        with pytest.raises(dg.DagsterInvalidInvocationError, match="exceeds the pool's limit"):
+            storage.claim_concurrency_slot("foo", run_id, "heavy_1", slots=3)
+
+        # invalid slot counts are rejected
+        with pytest.raises(check.CheckError):
+            storage.claim_concurrency_slot("foo", run_id, "heavy_1", slots=0)
+
     @pytest.mark.flaky(reruns=2)
     def test_threaded_concurrency(self, storage: EventLogStorage):
         if not storage.supports_global_concurrency_limits:

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -5933,6 +5933,43 @@ class TestEventLogStorage:
             assert foo_info.pending_step_count == 0
             assert foo_info.assigned_step_count == 0
 
+    @pytest.mark.flaky(reruns=2)
+    def test_threaded_weighted_concurrency(self, storage: EventLogStorage):
+        if not storage.supports_global_concurrency_limits:
+            pytest.skip("storage does not support global op concurrency")
+
+        TOTAL_TIMEOUT_TIME = 90
+
+        run_id = make_new_run_id()
+
+        storage.set_concurrency_slots("foo", 5)
+
+        def _occupy_slot(step_index: int):
+            step_key = str(step_index)
+            slots = (step_index % 3) + 1  # mix of weights 1, 2, 3 against a 5-slot pool
+            start = time.time()
+            claim_status = storage.claim_concurrency_slot("foo", run_id, step_key, None, slots)
+            while time.time() < start + TOTAL_TIMEOUT_TIME:
+                if claim_status.slot_status == ConcurrencySlotStatus.CLAIMED:
+                    break
+                else:
+                    claim_status = storage.claim_concurrency_slot(
+                        "foo", run_id, step_key, None, slots
+                    )
+                    time.sleep(0.05)
+            # every step must eventually claim; a stall here indicates over-assignment of
+            # weighted steps or a deadlock in the assignment loop
+            assert claim_status.slot_status == ConcurrencySlotStatus.CLAIMED
+            storage.free_concurrency_slot_for_step(run_id, step_key)
+
+        with ThreadPoolExecutor() as executor:
+            list(executor.map(_occupy_slot, range(30), timeout=TOTAL_TIMEOUT_TIME))
+            foo_info = storage.get_concurrency_info("foo")
+            assert foo_info.slot_count == 5
+            assert foo_info.active_slot_count == 0
+            assert foo_info.pending_step_count == 0
+            assert foo_info.assigned_step_count == 0
+
     def test_zero_concurrency(self, storage: EventLogStorage):
         assert storage
         if not storage.supports_global_concurrency_limits:


### PR DESCRIPTION
## Summary & Motivation

Adds **weighted concurrency pool slots** - Airflow-style `pool_slots` - to Dagster's concurrency pools. Resolves #12299.

```py
@asset(pool="heavy", pool_slots=4)  # occupies 4 of the pool's slots while executing
def geopackage_export(): ...

@asset(pool="heavy")                # unchanged: occupies 1 slot
def small_postgres_write(): ...
```

Also available on `@multi_asset` and `@op`. Default is 1 everywhere, so existing behaviour is unchanged unless a step opts in.

**Why:** a pool limit today counts _steps_, not _cost_. When one pool governs steps with very different resource footprints - say a 24 GB in-memory export and a 500 MB write both under `pool="heavy"` - the limit has to be sized for the worst case, leaving the pool under-utilised whenever lighter steps run. The workarounds are poor: tiered pools (`heavy` / `very_heavy`) statically partition capacity instead of sharing it, and per-step limits multiply the number of pools to manage. Airflow has solved this with [`pool_slots`](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/pools.html) since 1.10.4, and for my org it's our biggest pain point in using Dagster - this brings the pool model to parity, with the same semantics.

### Design: weight the assignment, not the claim

Making the claim stage grab N rows independently would deadlock (two 3-slot steps against a 4-slot pool each grab 2 and neither proceeds). Instead the weighting lives in `assign_pending_steps`, which is already the priority-ordered serialisation point:

> If the head of the queue fits in the pool's free capacity, assign it and continue; if it doesn't fit, **stop** - do not skip ahead to smaller steps behind it.

This one rule gives:

* **No deadlock** - a step is only assigned once its full slot count is available, so the (all-or-nothing, `FOR UPDATE SKIP LOCKED`) claim never partially succeeds.
* **No starvation** - a heavy step at the head cannot be indefinitely overtaken by a trickle of light steps. Priority ordering is preserved: higher-priority steps still sort ahead of the head, so `dagster/priority` keeps its meaning unchanged.
* **Head-of-line blocking** as the explicit trade-off, matching Airflow's semantics.

One behavioural refinement this required: `claim_concurrency_slot` previously self-assigned new arrivals whenever free capacity existed, which would let late-arriving 1-slot steps starve a queued heavy step. Enqueue now always routes through the single priority-ordered assignment path. For weight-1 workloads this is equivalent capacity-wise, and strictly fairer - a freed slot now always goes to the highest-priority waiter rather than whichever step happened to poll first.

### Backwards compatibility

* New nullable `slots` column on `pending_steps` (`NULL` reads as 1) - no backfill, no table rewrite. Migration follows the `048_add_column_concurrency_default_limit` pattern; applied via `dagster instance migrate`.
* Un-migrated instances keep working unchanged at weight 1 via a `has_pending_steps_slots_col` guard (same pattern as `has_default_pool_limit_col`); a weighted claim against un-migrated storage raises with a message pointing at the migration.
* `claim_concurrency_slot` gains `slots` as keyword-with-default on the `EventLogStorage` ABC, and callers only pass it for weighted claims - external storage implementations with the pre-`slots` signature keep working for all default-weight steps.
* `pool_slots` rides the execution-plan snapshot with `skip_when_none`: serialization is byte-identical when unset, and old snapshots deserialize cleanly.
* `pool_granularity: run` is unaffected; a pool limit of 0 still pauses (blocks) rather than raises.

`pool_slots < 1` is rejected at definition time; `pool_slots` greater than the pool's limit raises a clear error at claim time (naming step, pool, requested slots, and limit) instead of hanging forever.

Out of scope, per the issue discussion: UI display of slot weights, weighted run-granularity pools, and `pool_slots` on `@asset_check` / library decorators (`@dbt_assets` etc.) - all straightforward follow-ups.

## Test Plan

* New cases in the shared `TestEventLogStorage` suite (runs against sqlite, Postgres and MySQL in CI): a 3-slot step waits for and then holds 3 slots; freeing releases all of them; head-of-line blocking (a 4-slot head is not overtaken by queued 1-slot steps); no deadlock for two 3-slot steps against a 4-slot pool; `slots > limit` raises.
* Migration up/down against a populated `pending_steps` table, including weight-1 operation and the weighted-claim error on the downgraded schema, and `NULL`-slots rows reading as weight 1 after re-upgrade.
* Definition-time validation, execution-plan snapshot round-trip (including the byte-identical-when-unset assertion), and an `InstanceConcurrencyContext`-level test of the full claim path.
* Existing concurrency suite passes unchanged (weight-1 regression guard); full `storage_tests/test_event_log.py` + `definitions_tests` run: 544 passed. `ruff` and type checks clean.
* Verified end-to-end via `dg.materialize` on a concurrency-enabled instance, and verified a storage subclass with the pre-`slots` claim signature still executes pooled weight-1 runs.

## Changelog

Added `pool_slots` to `@asset`, `@multi_asset`, and `@op`, allowing a step to occupy multiple slots of its concurrency pool (matching Airflow's `pool_slots`). Requires `dagster instance migrate` to use weights greater than 1; defaults to 1 with no behaviour change otherwise.