### PR TITLE
[docs] Add project_dbt environment example

### DIFF
--- a/examples/docs_projects/project_dbt/.env.example
+++ b/examples/docs_projects/project_dbt/.env.example
@@ -1,0 +1,1 @@
+DUCKDB_DATABASE=data/project_dbt.duckdb


### PR DESCRIPTION
## Summary & Motivation

The dbt full-pipeline guide tells users to copy `.env.example`, but that file is missing from `examples/docs_projects/project_dbt`. Add the template with the `DUCKDB_DATABASE` variable consumed by the example.

Fixes #33415.

## Test Plan

- verified `DUCKDB_DATABASE` is consumed by `src/project_dbt/defs/resources.py`
- verified the configured `data` directory exists in the example project
- verified the new file contains the expected environment key

## Changelog

Add the missing environment template used by the dbt example setup instructions.

## AI assistance

Codex (GPT-5) assisted with investigating the example and drafting this change. I manually reviewed the final diff and validated the environment variable against its consumer.