### PR TITLE
Treat nonexistent dependency partitions as missing in automation

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -806,13 +806,22 @@ class AssetGraphView(LoadingContext):
             return from_subset.compute_difference(materialized_subset)
         else:
             # more expensive call
+            queryable_asset_partitions = from_subset.expensively_compute_asset_partitions()
+            queryable_subset = self.get_asset_subset_from_asset_partitions(
+                key=key, asset_partitions=queryable_asset_partitions
+            )
             missing_asset_partitions = {
                 ap
-                for ap in from_subset.expensively_compute_asset_partitions()
+                for ap in queryable_asset_partitions
                 if not self._queryer.asset_partition_has_materialization_or_observation(ap)
             }
-            return self.get_asset_subset_from_asset_partitions(
+            missing_queryable_subset = self.get_asset_subset_from_asset_partitions(
                 key=key, asset_partitions=missing_asset_partitions
+            )
+            # Some subset representations cannot enumerate keys outside the partition definition's
+            # bounds. Those keys cannot have a materialization or observation, so they are missing.
+            return missing_queryable_subset.compute_union(
+                from_subset.compute_difference(queryable_subset)
             )
 
     @cached_method

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -56,9 +56,24 @@ class EntityMatchesCondition(
         else:
             to_direction, from_direction = "up", "down"
 
-        to_candidate_subset = context.candidate_subset.compute_mapped_subset(
-            self.key, direction=to_direction
-        )
+        if (
+            to_direction == "up"
+            and self.key in context.asset_graph.get(context.key).parent_entity_keys  # ty: ignore[no-matching-overload]
+        ):
+            (
+                to_candidate_subset,
+                required_but_nonexistent_subset,
+            ) = context.asset_graph_view.compute_parent_subset_and_required_but_nonexistent_subset(
+                self.key, context.candidate_subset
+            )
+            # Dependency conditions evaluate every required partition, including keys that fall
+            # outside the dependency's partition definition. This lets missing() classify those
+            # keys while other operands filter them according to their own semantics.
+            to_candidate_subset = to_candidate_subset.compute_union(required_but_nonexistent_subset)
+        else:
+            to_candidate_subset = context.candidate_subset.compute_mapped_subset(
+                self.key, direction=to_direction
+            )
         to_context = context.for_child_condition(
             child_condition=self.operand,
             child_indices=[0],

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_dep_condition.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from datetime import datetime, timezone
 
 import dagster as dg
 import pytest
@@ -124,6 +125,54 @@ async def test_dep_missing_partitioned(is_any: bool) -> None:
     else:
         # now partition 2 has all parents true
         assert result.true_subset.size == 2
+
+
+@pytest.mark.parametrize(
+    ("allow_nonexistent_upstream_partitions", "expected_requested_partitions"),
+    [
+        (False, {"2024-01-01", "2024-01-02"}),
+        (True, {"2023-12-31", "2024-01-01", "2024-01-02"}),
+    ],
+)
+def test_any_deps_missing_with_required_but_nonexistent_partition(
+    allow_nonexistent_upstream_partitions: bool,
+    expected_requested_partitions: set[str],
+) -> None:
+    parent_partitions_def = dg.DailyPartitionsDefinition(start_date="2024-01-01")
+    child_partitions_def = dg.DailyPartitionsDefinition(start_date="2023-12-31")
+
+    @dg.asset(partitions_def=parent_partitions_def)
+    def parent() -> None: ...
+
+    @dg.asset(
+        deps=[
+            dg.AssetDep(
+                parent,
+                partition_mapping=dg.TimeWindowPartitionMapping(
+                    allow_nonexistent_upstream_partitions=allow_nonexistent_upstream_partitions
+                ),
+            )
+        ],
+        partitions_def=child_partitions_def,
+        automation_condition=(
+            dg.AutomationCondition.missing() & ~dg.AutomationCondition.any_deps_missing()
+        ),
+    )
+    def child() -> None: ...
+
+    instance = dg.DagsterInstance.ephemeral()
+    for partition_key in ["2024-01-01", "2024-01-02"]:
+        instance.report_runless_asset_event(
+            dg.AssetMaterialization(parent.key, partition=partition_key)
+        )
+
+    result = dg.evaluate_automation_conditions(
+        defs=[parent, child],
+        instance=instance,
+        evaluation_time=datetime(2024, 1, 3, tzinfo=timezone.utc),
+    )
+
+    assert result.get_requested_partitions(child.key) == expected_requested_partitions
 
 
 @pytest.mark.asyncio

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_dep_condition.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from datetime import datetime, timezone
+from typing import Literal
 
 import dagster as dg
 import pytest
@@ -134,9 +135,11 @@ async def test_dep_missing_partitioned(is_any: bool) -> None:
         (True, {"2023-12-31", "2024-01-01", "2024-01-02"}),
     ],
 )
+@pytest.mark.parametrize("parent_kind", ["materializable", "source", "observable_source"])
 def test_any_deps_missing_with_required_but_nonexistent_partition(
     allow_nonexistent_upstream_partitions: bool,
     expected_requested_partitions: set[str],
+    parent_kind: Literal["materializable", "source", "observable_source"],
 ) -> None:
     parent_partitions_def = dg.DailyPartitionsDefinition(start_date="2024-01-01")
     child_partitions_def = dg.DailyPartitionsDefinition(start_date="2023-12-31")
@@ -160,14 +163,26 @@ def test_any_deps_missing_with_required_but_nonexistent_partition(
     )
     def child() -> None: ...
 
+    if parent_kind == "materializable":
+        parent_def = parent
+        event_type = dg.AssetMaterialization
+    elif parent_kind == "source":
+        parent_def = parent.to_source_asset()
+        event_type = dg.AssetMaterialization
+    else:
+        parent_def = dg.SourceAsset(
+            key=parent.key,
+            partitions_def=parent_partitions_def,
+            observe_fn=lambda _: dg.DataVersionsByPartition({}),
+        )
+        event_type = dg.AssetObservation
+
     instance = dg.DagsterInstance.ephemeral()
     for partition_key in ["2024-01-01", "2024-01-02"]:
-        instance.report_runless_asset_event(
-            dg.AssetMaterialization(parent.key, partition=partition_key)
-        )
+        instance.report_runless_asset_event(event_type(parent.key, partition=partition_key))
 
     result = dg.evaluate_automation_conditions(
-        defs=[parent, child],
+        defs=dg.Definitions(assets=[parent_def, child]),
         instance=instance,
         evaluation_time=datetime(2024, 1, 3, tzinfo=timezone.utc),
     )


### PR DESCRIPTION
Codex:

> `any_deps_missing()` can allow an asset partition to be requested even when its partition mapping requires a dependency key that does not exist. For example, if a daily child starts one day before its daily dependency, `missing() & ~any_deps_missing()` requests that first child partition, but the asset backfill planner rejects it because the required dependency partition is outside the dependency definition.
>
> Dependency conditions currently evaluate only the valid subset returned by the partition mapping and discard `required_but_nonexistent_subset`. This change includes both subsets when evaluating direct dependencies, so `missing()` treats required nonexistent keys as missing and the automation result agrees with the backfill planner.
>
> Source and observable dependencies need an additional safeguard because their missing-state path enumerates partitions to query materializations and observations, and out-of-range time keys cannot be enumerated. The non-queryable remainder is now retained as missing. Mappings configured with `allow_nonexistent_upstream_partitions=True` remain permissive.
>
> Verification:
>
> - Added strict and permissive regression cases for materializable, source, and observable-source dependencies with mismatched daily partition ranges.
> - Ran all declarative automation built-in condition tests: 207 passed.
> - Ran the asset graph view tests: 68 passed.
> - Ran the changed-file ty check and Ruff check/format check.
> - Manually verified that strict source automation requests only the valid January 1–2 children and that the backfill planner produces exactly those two runs.