### PR TITLE
Match defs.yaml in generated VS Code schema extension

### DIFF
--- a/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_configure_editor_commands.py
+++ b/python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/test_configure_editor_commands.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import mock
@@ -40,6 +41,32 @@ def test_utils_configure_editor(editor: str) -> None:
             expected_vscode_plugin_folder_filepath / "dagster-components-schema.vsix"
         )
         assert expected_compiled_plugin_filepath.exists()
+
+        package_json = json.loads(
+            (expected_vscode_plugin_folder_filepath / "package.json").read_text()
+        )
+        file_matches = {
+            entry["fileMatch"] for entry in package_json["contributes"]["yamlValidation"]
+        }
+        assert f"{Path.cwd()}/**/defs.y*ml" in file_matches
+        assert f"{Path.cwd()}/**/component.y*ml" in file_matches
+
+        # Running configure-editor again for a different project must keep the first
+        # project's entries alongside the new ones, not overwrite them.
+        with isolated_example_project_foo_bar(
+            runner, in_workspace=False, project_name="other-project"
+        ):
+            out = runner.invoke("utils", "configure-editor", editor)
+            assert out.exit_code == 0
+
+            package_json = json.loads(
+                (expected_vscode_plugin_folder_filepath / "package.json").read_text()
+            )
+            file_matches = {
+                entry["fileMatch"] for entry in package_json["contributes"]["yamlValidation"]
+            }
+            assert f"{Path.cwd()}/**/defs.y*ml" in file_matches
+            assert f"{Path.cwd()}/**/component.y*ml" in file_matches
 
 
 @pytest.mark.parametrize("output_path", [None, "schema.json"])

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/editor/__init__.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/utils/editor/__init__.py
@@ -59,7 +59,9 @@ def install_or_update_yaml_schema_extension(
     template_package_json_path = Path(__file__).parent / "vscode_extension_package.json"
     template_package_json = json.loads(template_package_json_path.read_text())
     template_package_json["contributes"]["yamlValidation"] = [
-        {"fileMatch": f"{yaml_dir}/**/component.y*ml", "url": f"{schema_path}"}
+        {"fileMatch": f"{yaml_dir}/**/defs.y*ml", "url": f"{schema_path}"},
+        # component.yaml is deprecated in favor of defs.yaml, but is still supported as a backcompat alias.
+        {"fileMatch": f"{yaml_dir}/**/component.y*ml", "url": f"{schema_path}"},
     ]
 
     extension_working_dir.mkdir(parents=True, exist_ok=True)
@@ -73,7 +75,8 @@ def install_or_update_yaml_schema_extension(
             template_package_json["contributes"]["yamlValidation"].extend(
                 entry
                 for entry in existing_yaml_validation
-                if entry["fileMatch"] != f"{yaml_dir}/**/component.y*ml"
+                if entry["fileMatch"]
+                not in (f"{yaml_dir}/**/defs.y*ml", f"{yaml_dir}/**/component.y*ml")
             )
 
     extension_package_json_path.write_text(json.dumps(template_package_json, indent=2))


### PR DESCRIPTION
## Summary

The `dg` VS Code extension for Components YAML schema validation matches file names by glob. The glob matches only `component.yaml`. It does not match `defs.yaml`. Dagster 1.10.18 renamed `component.yaml` to `defs.yaml`. `component.yaml` remains valid as a deprecated backcompat alias.

Result before this change: `defs.yaml` files get no schema validation or completions in the generated extension.

This change adds a second `fileMatch` entry for `defs.yaml`, alongside the existing `component.yaml` entry.

## Test plan

- [x] `ruff check` and `ruff format --check` pass on the changed file