### PR TITLE
Skip the concurrency limits insert when there are no active slots

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -2272,6 +2272,12 @@ class SqlEventLogStorage(EventLogStorage):
                     ConcurrencySlotsTable.c.concurrency_key,
                 )
             ).fetchall()
+            if not rows:
+                # All slots are soft-deleted, so there is nothing to reconcile. Passing an empty
+                # list to insert().values() emits `INSERT INTO concurrency_limits () VALUES ()`,
+                # which inserts a row with a NULL concurrency_key and violates the NOT NULL
+                # constraint. See https://github.com/sqlalchemy/sqlalchemy/issues/9645.
+                return
             conn.execute(
                 ConcurrencyLimitsTable.insert().values(
                     [


### PR DESCRIPTION
## Summary & Motivation
Fixes #34073.

_reconcile_concurrency_limits_from_slots guards on `self._has_rows(ConcurrencySlotsTable)`, but _has_rows is generic and does not filter soft-deleted rows, while the reconciliation query does filter them with `WHERE deleted = false`. When every slot is soft-deleted the guard passes and the query returns no rows.

`insert().values([])` then emits `INSERT INTO concurrency_limits () VALUES ()`, which inserts a row with a NULL concurrency_key and raises NotNullViolation. The practical symptom is that the Deployment > Concurrency page 500s.

Returning early is also correct on its own terms: per the docstring this function reconciles limits from slots, so with no active slots there is nothing to reconcile.

Not changing _has_rows to filter on `deleted`, since it is a shared helper used for tables that have no such column.

## Test Plan
Reproduced on 1.13.16 with Postgres storage: configure a concurrency pool, run jobs to  populate `concurrency_slots`, remove the pool config, let runs finish so the slots become  soft-deleted, ensure `concurrency_limits` is empty, then open Deployment > Concurrency.  Fails before this change, loads after.

`ruff format` and `ruff check` pass with the repo-pinned 0.15.15.

## Changelog
Fixed a bug where the Concurrency page could fail to load with a `NotNullViolation` when all  concurrency slots had been soft-deleted.
