### PR TITLE
dagster-dbt: derive FreshnessPolicy from dbt 1.9+ model build_after

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -867,22 +867,32 @@ def default_freshness_policy_from_dbt_resource_props(
     dbt_resource_props: Mapping[str, Any],
 ) -> FreshnessPolicy | None:
     """Derive a ``FreshnessPolicy`` from either explicit ``meta.dagster.freshness_policy``
-    config or dbt's native ``sources.freshness`` block.
+    config, dbt's native ``sources.freshness`` block, or dbt 1.9+ model
+    ``config.freshness.build_after``.
 
     Precedence:
 
     1. ``meta.dagster.freshness_policy`` (any resource type) — explicit user config wins.
        Two shapes supported: ``time_window`` and ``cron``. See
-       :py:func:`_freshness_policy_from_meta_dagster`. This is the escape hatch for
-       models (which have no dbt-native freshness config) and for users who want a
-       ``CronFreshnessPolicy`` instead of dbt's warn/error timedeltas.
+       :py:func:`_freshness_policy_from_meta_dagster`. This is the escape hatch for a
+       ``CronFreshnessPolicy`` or any other custom shape that dbt doesn't natively express.
     2. ``sources.freshness.{warn_after, error_after}`` (sources only) — dbt-native
        staleness config translated to a ``TimeWindowFreshnessPolicy`` where ``error_after``
        becomes ``fail_window`` and ``warn_after`` becomes ``warn_window``.
+    3. ``models[*].config.freshness.build_after`` (models only, dbt 1.9+) — dbt's per-model
+       rebuild cadence, translated to a ``TimeWindowFreshnessPolicy`` where ``build_after``
+       becomes ``fail_window``. In dbt, ``build_after`` gates whether a model runs during
+       ``dbt build`` — models still within their fresh window emit ``no-op`` and skip.
+       Attaching a Dagster ``FreshnessPolicy`` surfaces the same SLO in the UI; the model
+       stays PASS until ``build_after`` elapses, then FAIL until the next materialization.
+       Users who want Dagster to trigger the rebuild directly can attach
+       ``AutomationCondition.freshness_failed()`` (e.g. via a translator subclass); the
+       default is to let dbt's own scheduler (or a Dagster job wrapping ``dbt build``)
+       drive the trigger.
 
-    Returns None when neither applies (non-source resources without meta config, sources
-    without freshness, or sources with only ``warn_after`` set — Dagster requires a
-    ``fail_window``).
+    Returns None when none of the above apply — non-model / non-source resources without
+    meta config, sources without freshness, sources with only ``warn_after`` set (Dagster
+    requires a ``fail_window``), or models without ``build_after``.
 
     If ``warn_after`` is greater than or equal to ``error_after`` (an invalid combination
     for Dagster's ``TimeWindowFreshnessPolicy``), the warn window is dropped rather than
@@ -890,7 +900,7 @@ def default_freshness_policy_from_dbt_resource_props(
     """
     # 1. Explicit meta.dagster.freshness_policy wins, for any resource type. This is the
     #    escape hatch that lets users:
-    #    - attach freshness policies to models (which have no dbt-native freshness config)
+    #    - override the dbt-native derivation with a custom policy shape
     #    - use a CronFreshnessPolicy where dbt only supports timedelta warn/error windows
     #    - keep freshness config alongside the dbt project rather than in Dagster YAML
     meta_dagster = dbt_resource_props.get("meta", {}).get("dagster", {})
@@ -898,23 +908,33 @@ def default_freshness_policy_from_dbt_resource_props(
     if meta_policy is not None:
         return meta_policy
 
+    resource_type = dbt_resource_props.get("resource_type")
+
     # 2. dbt-native sources.freshness (source-only).
-    if dbt_resource_props.get("resource_type") != "source":
-        return None
+    if resource_type == "source":
+        freshness_config = dbt_resource_props.get("freshness")
+        if not freshness_config:
+            return None
 
-    freshness_config = dbt_resource_props.get("freshness")
-    if not freshness_config:
-        return None
+        fail_window = _dbt_freshness_spec_to_timedelta(freshness_config.get("error_after"))
+        if fail_window is None:
+            return None
 
-    fail_window = _dbt_freshness_spec_to_timedelta(freshness_config.get("error_after"))
-    if fail_window is None:
-        return None
+        warn_window = _dbt_freshness_spec_to_timedelta(freshness_config.get("warn_after"))
+        if warn_window is not None and warn_window >= fail_window:
+            warn_window = None
 
-    warn_window = _dbt_freshness_spec_to_timedelta(freshness_config.get("warn_after"))
-    if warn_window is not None and warn_window >= fail_window:
-        warn_window = None
+        return FreshnessPolicy.time_window(fail_window=fail_window, warn_window=warn_window)
 
-    return FreshnessPolicy.time_window(fail_window=fail_window, warn_window=warn_window)
+    # 3. dbt 1.9+ model config.freshness.build_after (model-only).
+    if resource_type == "model":
+        model_freshness = dbt_resource_props.get("config", {}).get("freshness") or {}
+        build_after = _dbt_freshness_spec_to_timedelta(model_freshness.get("build_after"))
+        if build_after is None:
+            return None
+        return FreshnessPolicy.time_window(fail_window=build_after)
+
+    return None
 
 
 def default_description_fn(dbt_resource_props: Mapping[str, Any], display_raw_sql: bool = True):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -748,15 +748,21 @@ class DagsterDbtTranslator:
         """A function that takes a dictionary representing properties of a dbt resource, and
         returns the Dagster :py:class:`dagster.FreshnessPolicy` for that resource.
 
-        By default, dbt sources with a ``freshness`` block in ``sources.yml`` yield a
-        :py:class:`dagster.TimeWindowFreshnessPolicy`, where ``error_after`` becomes the
-        ``fail_window`` and ``warn_after`` becomes the ``warn_window``. Non-source resources
-        and sources without a ``freshness`` block yield ``None``. This behavior is controlled
-        by the ``enable_source_freshness_policies`` setting on :py:class:`DagsterDbtTranslatorSettings`
-        and can be disabled by setting it to ``False``.
+        By default, three derivation paths are checked in order (see
+        :py:func:`dagster_dbt.asset_utils.default_freshness_policy_from_dbt_resource_props`):
+
+        1. ``meta.dagster.freshness_policy`` on any resource — explicit user override.
+        2. ``sources.freshness.{warn_after, error_after}`` on sources — dbt-native.
+        3. ``models[*].config.freshness.build_after`` on dbt 1.9+ models — dbt-native
+           rebuild-cadence gate translated to a ``TimeWindowFreshnessPolicy``.
+
+        This behavior is controlled by the ``enable_source_freshness_policies`` setting on
+        :py:class:`DagsterDbtTranslatorSettings` and can be disabled by setting it to ``False``
+        (which suppresses paths 2 and 3; the explicit ``meta.dagster.freshness_policy`` in
+        path 1 is always respected).
 
         This method can be overridden to provide a custom :py:class:`FreshnessPolicy` for a dbt
-        resource, including deriving policies from custom ``meta`` config on models.
+        resource, including composing with the dbt-derived policy via ``super()``.
 
         Note that a dbt resource is unrelated to Dagster's resource concept, and simply represents
         a model, seed, snapshot or source in a given dbt project. You can learn more about dbt

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_source_freshness_policy.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_source_freshness_policy.py
@@ -292,3 +292,108 @@ class TestMetaDagsterFreshnessPolicy:
             "meta": {"dagster": {"freshness_policy": "0 8 * * *"}},
         }
         assert default_freshness_policy_from_dbt_resource_props(props) is None
+
+
+class TestModelBuildAfterFreshnessPolicy:
+    """Tests for the dbt 1.9+ ``models[*].config.freshness.build_after`` → ``FreshnessPolicy``
+    derivation.
+
+    dbt's ``build_after`` gates whether a model runs during ``dbt build``: models still
+    within their fresh window emit ``no-op`` and skip. We translate the same SLO to a
+    ``TimeWindowFreshnessPolicy`` so it surfaces in the Dagster UI as a freshness state.
+    """
+
+    def _model(self, build_after: Any) -> dict[str, Any]:
+        return {
+            "resource_type": "model",
+            "config": {"freshness": {"build_after": build_after}},
+        }
+
+    def test_build_after_hours(self) -> None:
+        policy = default_freshness_policy_from_dbt_resource_props(
+            self._model({"count": 6, "period": "hour"})
+        )
+        assert isinstance(policy, TimeWindowFreshnessPolicy)
+        assert policy.fail_window.to_timedelta() == timedelta(hours=6)
+        assert policy.warn_window is None
+
+    def test_build_after_days(self) -> None:
+        policy = default_freshness_policy_from_dbt_resource_props(
+            self._model({"count": 1, "period": "day"})
+        )
+        assert isinstance(policy, TimeWindowFreshnessPolicy)
+        assert policy.fail_window.to_timedelta() == timedelta(days=1)
+
+    def test_build_after_minutes(self) -> None:
+        policy = default_freshness_policy_from_dbt_resource_props(
+            self._model({"count": 30, "period": "minute"})
+        )
+        assert isinstance(policy, TimeWindowFreshnessPolicy)
+        assert policy.fail_window.to_timedelta() == timedelta(minutes=30)
+
+    def test_missing_build_after_returns_none(self) -> None:
+        # dbt 1.9+ freshness block without build_after — e.g. a stub freshness declaration.
+        assert (
+            default_freshness_policy_from_dbt_resource_props(
+                {"resource_type": "model", "config": {"freshness": {}}}
+            )
+            is None
+        )
+
+    def test_no_freshness_config_returns_none(self) -> None:
+        # Pre-1.9 dbt models have no config.freshness block at all.
+        assert (
+            default_freshness_policy_from_dbt_resource_props(
+                {"resource_type": "model", "config": {}}
+            )
+            is None
+        )
+
+    def test_no_config_returns_none(self) -> None:
+        # Defensive: manifest weirdness where config is missing entirely.
+        assert default_freshness_policy_from_dbt_resource_props({"resource_type": "model"}) is None
+
+    def test_unknown_period_returns_none(self) -> None:
+        assert (
+            default_freshness_policy_from_dbt_resource_props(
+                self._model({"count": 1, "period": "week"})
+            )
+            is None
+        )
+
+    def test_meta_dagster_overrides_build_after(self) -> None:
+        # meta.dagster.freshness_policy wins over dbt-native build_after — user gets full
+        # control when they need a CronFreshnessPolicy or a different window.
+        props = {
+            "resource_type": "model",
+            "config": {"freshness": {"build_after": {"count": 6, "period": "hour"}}},
+            "meta": {
+                "dagster": {
+                    "freshness_policy": {
+                        "type": "cron",
+                        "deadline_cron": "0 8 * * *",
+                        "lower_bound_delta_seconds": 3600,
+                    }
+                }
+            },
+        }
+        policy = default_freshness_policy_from_dbt_resource_props(props)
+        assert isinstance(policy, CronFreshnessPolicy)
+        assert policy.deadline_cron == "0 8 * * *"
+
+    def test_build_after_does_not_apply_to_sources(self) -> None:
+        # Sources use the sources.freshness.warn/error_after path, not config.freshness.build_after.
+        source_props = {
+            "resource_type": "source",
+            "config": {"freshness": {"build_after": {"count": 6, "period": "hour"}}},
+        }
+        assert default_freshness_policy_from_dbt_resource_props(source_props) is None
+
+    def test_build_after_does_not_apply_to_seeds_or_snapshots(self) -> None:
+        # Seeds and snapshots are not the target of build_after in dbt 1.9+.
+        for resource_type in ("seed", "snapshot"):
+            props = {
+                "resource_type": resource_type,
+                "config": {"freshness": {"build_after": {"count": 6, "period": "hour"}}},
+            }
+            assert default_freshness_policy_from_dbt_resource_props(props) is None


### PR DESCRIPTION
## Summary & Motivation

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
