### PR TITLE
dagster-dbt: emit dbt exposures as downstream observable AssetSpecs (opt-in)

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_specs.py
@@ -1,19 +1,39 @@
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
-from dagster import AssetKey, AssetSpec
+from dagster import AssetDep, AssetKey, AssetSpec
 from dagster._core.definitions.assets.definition.asset_spec import (
     SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET,
 )
+from dagster._utils.tags import is_valid_tag_key
 
 from dagster_dbt.asset_utils import (
+    DAGSTER_DBT_UNIQUE_ID_METADATA_KEY,
     DBT_DEFAULT_EXCLUDE,
     DBT_DEFAULT_SELECT,
     DBT_DEFAULT_SELECTOR,
     build_dbt_specs,
+    get_node,
 )
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_translator
 from dagster_dbt.dbt_manifest import DbtManifestParam, validate_manifest
 from dagster_dbt.dbt_project import DbtProject
+
+DAGSTER_DBT_EXPOSURE_TYPE_METADATA_KEY = "dagster_dbt/exposure_type"
+DAGSTER_DBT_EXPOSURE_URL_METADATA_KEY = "dagster_dbt/exposure_url"
+DAGSTER_DBT_EXPOSURE_MATURITY_METADATA_KEY = "dagster_dbt/exposure_maturity"
+
+
+# dbt exposure types (https://docs.getdbt.com/reference/exposure-properties#type):
+# dashboard, notebook, analysis, ml, application. We map each to a kind that
+# Dagster's UI can render with a distinct icon.
+_DBT_EXPOSURE_TYPE_TO_KIND: Mapping[str, str] = {
+    "dashboard": "dashboard",
+    "notebook": "notebook",
+    "analysis": "analysis",
+    "ml": "ml",
+    "application": "application",
+}
 
 
 def build_dbt_asset_specs(
@@ -111,6 +131,124 @@ def build_dbt_source_asset_specs(
         # spec and merges into the winning declaration.
         specs.append(
             spec.merge_attributes(metadata={SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET: True})
+        )
+
+    return specs
+
+
+def _dep_asset_key_for_exposure_upstream(
+    manifest: Mapping[str, Any],
+    translator: DagsterDbtTranslator,
+    upstream_unique_id: str,
+) -> AssetKey | None:
+    """Resolve the Dagster ``AssetKey`` for one entry in an exposure's ``depends_on.nodes``.
+
+    Exposures depend on models, sources, seeds, snapshots, and (rarely) metrics. Anything
+    the ``get_node`` lookup can find + that the translator produces a key for becomes a
+    dep. Missing / non-existent references are silently skipped rather than raising, since
+    dbt manifests occasionally carry stale references.
+    """
+    try:
+        upstream_props = get_node(manifest, upstream_unique_id)
+    except Exception:
+        return None
+    return translator.get_asset_key(upstream_props)
+
+
+def build_dbt_exposure_asset_specs(
+    *,
+    manifest: DbtManifestParam,
+    dagster_dbt_translator: DagsterDbtTranslator | None = None,
+    project: DbtProject | None = None,
+) -> Sequence[AssetSpec]:
+    """Build observable external ``AssetSpec`` objects for every dbt exposure declared in
+    ``exposures.yml``.
+
+    Each exposure becomes a downstream node in the Dagster graph, with deps on the
+    referenced upstream models (from ``depends_on.nodes``). Exposures are NOT materialized
+    by Dagster — they are external artifacts (BI dashboards, notebooks, ML models,
+    applications) declared in dbt so users can trace "if this model breaks, which
+    dashboards are affected?" in the graph.
+
+    Kind is derived from ``exposure.type`` (dashboard / notebook / analysis / application
+    / ml) so the Dagster UI renders a distinct icon per exposure type.
+
+    Metadata surfaced (under the ``dagster_dbt/`` namespace):
+
+    - ``exposure_type`` (str): the raw ``exposure.type`` value from dbt.
+    - ``exposure_url`` (str): the ``exposure.url`` — link to the actual dashboard /
+      notebook so users can navigate from Dagster.
+    - ``exposure_maturity`` (str): ``low`` / ``medium`` / ``high`` per dbt's exposure
+      maturity taxonomy.
+    - ``unique_id`` (str): the dbt ``unique_id`` (e.g. ``exposure.my_project.dash``).
+
+    Owners are pulled from ``exposure.owner.email`` when present. Tags are copied from
+    ``exposure.tags``.
+
+    The ``AssetKey`` is derived via ``translator.get_asset_key`` (which honors
+    ``meta.dagster.asset_key`` on the exposure); by default this collapses to the raw
+    exposure name.
+
+    Args:
+        manifest: The contents of a ``manifest.json`` file or the path to one.
+        dagster_dbt_translator: Optional translator; defaults to :py:class:`DagsterDbtTranslator`.
+        project: Reserved for future use (code references); currently unused.
+
+    Returns:
+        Sequence[AssetSpec]: One ``AssetSpec`` per exposure in the manifest.
+    """
+    del project  # currently unused; kept in signature to match the source-spec helper
+    manifest = validate_manifest(manifest)
+    translator = validate_translator(dagster_dbt_translator or DagsterDbtTranslator())
+
+    specs: list[AssetSpec] = []
+    for exposure_unique_id, exposure_props in manifest.get("exposures", {}).items():
+        exposure_type = str(exposure_props.get("type") or "").lower()
+        kind = _DBT_EXPOSURE_TYPE_TO_KIND.get(exposure_type)
+        kinds = {kind} if kind else None
+
+        deps: list[AssetDep] = []
+        seen_dep_keys: set[AssetKey] = set()
+        for upstream_unique_id in exposure_props.get("depends_on", {}).get("nodes", []) or []:
+            upstream_key = _dep_asset_key_for_exposure_upstream(
+                manifest, translator, upstream_unique_id
+            )
+            if upstream_key is None or upstream_key in seen_dep_keys:
+                continue
+            seen_dep_keys.add(upstream_key)
+            deps.append(AssetDep(asset=upstream_key))
+
+        owner_config = exposure_props.get("owner") or {}
+        owner_email = owner_config.get("email")
+        owners = [owner_email] if isinstance(owner_email, str) and owner_email else None
+
+        tags = {
+            tag: ""
+            for tag in exposure_props.get("tags") or []
+            if isinstance(tag, str) and is_valid_tag_key(tag)
+        }
+
+        metadata: dict[str, Any] = {
+            DAGSTER_DBT_UNIQUE_ID_METADATA_KEY: exposure_unique_id,
+            DAGSTER_DBT_EXPOSURE_TYPE_METADATA_KEY: exposure_type or "",
+        }
+        url = exposure_props.get("url")
+        if isinstance(url, str) and url:
+            metadata[DAGSTER_DBT_EXPOSURE_URL_METADATA_KEY] = url
+        maturity = exposure_props.get("maturity")
+        if isinstance(maturity, str) and maturity:
+            metadata[DAGSTER_DBT_EXPOSURE_MATURITY_METADATA_KEY] = maturity
+
+        specs.append(
+            AssetSpec(
+                key=translator.get_asset_key(exposure_props),
+                deps=deps,
+                description=exposure_props.get("description"),
+                metadata=metadata,
+                owners=owners,
+                tags=tags,
+                kinds=kinds,
+            )
         )
 
     return specs

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/component/dbt_cloud_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/component/dbt_cloud_component.py
@@ -22,7 +22,7 @@ from dagster.components.utils.translation import (
 from dagster_shared.serdes import deserialize_value, serialize_value
 from pydantic import Field
 
-from dagster_dbt.asset_specs import build_dbt_source_asset_specs
+from dagster_dbt.asset_specs import build_dbt_exposure_asset_specs, build_dbt_source_asset_specs
 from dagster_dbt.asset_utils import (
     DBT_DEFAULT_EXCLUDE,
     DBT_DEFAULT_SELECT,
@@ -364,17 +364,32 @@ class DbtCloudComponent(StateBackedComponent, dg.Resolvable, dg.Model):
         # so freshness policies, table metadata, kinds, etc. flow into the graph. dbt Cloud
         # has no local DbtProject object, so pass project=None (code references derived
         # from local file paths aren't meaningful for Cloud-loaded manifests anyway).
+        validated_manifest = validate_manifest(manifest)
         source_specs = (
             build_dbt_source_asset_specs(
-                manifest=validate_manifest(manifest),
+                manifest=validated_manifest,
                 dagster_dbt_translator=self.translator,
                 project=None,
             )
             if self.translator.settings.enable_source_assets
             else []
         )
+        # Emit dbt exposures (dashboards, notebooks, etc.) as downstream observable specs
+        # so users can trace materialization -> consumption chains through the graph.
+        exposure_specs = (
+            build_dbt_exposure_asset_specs(
+                manifest=validated_manifest,
+                dagster_dbt_translator=self.translator,
+                project=None,
+            )
+            if self.translator.settings.enable_exposure_assets
+            else []
+        )
 
-        return Definitions(assets=[_dbt_cloud_assets, *source_specs], sensors=sensors)
+        return Definitions(
+            assets=[_dbt_cloud_assets, *source_specs, *exposure_specs],
+            sensors=sensors,
+        )
 
     def execute(self, context: AssetExecutionContext) -> Iterator:
         invocation = self.workspace.cli(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -21,7 +21,7 @@ from dagster.components.utils.translation import (
 )
 from dagster_shared.serdes.objects.models.defs_state_info import DefsStateManagementType
 
-from dagster_dbt.asset_specs import build_dbt_source_asset_specs
+from dagster_dbt.asset_specs import build_dbt_exposure_asset_specs, build_dbt_source_asset_specs
 from dagster_dbt.asset_utils import (
     DAGSTER_DBT_TRANSLATOR_METADATA_KEY,
     DBT_DEFAULT_EXCLUDE,
@@ -383,17 +383,31 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
         # external observable assets (no op, no io_manager). When another integration
         # declares the same AssetKey (Fivetran, Sling, a manual observable_source_asset),
         # Dagster merges the two — dbt contributes freshness policy, table schema, kinds.
+        validated_manifest = validate_manifest(project.manifest_path)
+        validated_translator = validate_translator(self.translator)
         source_specs = (
             build_dbt_source_asset_specs(
-                manifest=validate_manifest(project.manifest_path),
-                dagster_dbt_translator=validate_translator(self.translator),
+                manifest=validated_manifest,
+                dagster_dbt_translator=validated_translator,
                 project=project,
             )
             if self.translator.settings.enable_source_assets
             else []
         )
+        # dbt exposures (dashboards, notebooks, ML models, applications, analyses) are
+        # emitted as observable external AssetSpecs with deps on the referenced upstream
+        # models, giving users a downstream relationship in the graph.
+        exposure_specs = (
+            build_dbt_exposure_asset_specs(
+                manifest=validated_manifest,
+                dagster_dbt_translator=validated_translator,
+                project=project,
+            )
+            if self.translator.settings.enable_exposure_assets
+            else []
+        )
 
-        return dg.Definitions(assets=[_fn, *source_specs])
+        return dg.Definitions(assets=[_fn, *source_specs, *exposure_specs])
 
     def get_cli_args(self, context: dg.AssetExecutionContext) -> list[str]:
         return resolve_cli_args(self.cli_args, context)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -100,6 +100,14 @@ class DagsterDbtTranslatorSettings(Resolvable):
             different failure mode from asset checks. Users who want per-column
             verification should keep using explicit dbt tests, which ``dagster-dbt`` lifts
             into per-column asset checks separately.
+        enable_exposure_assets (bool): Whether to emit dbt exposures (dashboards, notebooks,
+            ML models, applications, analyses declared in ``exposures.yml``) as observable
+            external :py:class:`dagster.AssetSpec` objects, with deps on the upstream models
+            they reference. Defaults to False (opt-in). This gives users a downstream
+            relationship in the graph — "if this model breaks, which dashboards are
+            affected?" — without materializing anything. Exposure kind is derived from
+            ``exposure.type`` (``dashboard`` / ``notebook`` / ``analysis`` / ``application``
+            / ``ml``) so the UI can render a distinct icon.
     """
 
     enable_asset_checks: bool = True
@@ -112,6 +120,7 @@ class DagsterDbtTranslatorSettings(Resolvable):
     enable_source_assets: bool = False
     enable_source_freshness_policies: bool = False
     enable_contract_metadata: bool = False
+    enable_exposure_assets: bool = False
 
 
 class DagsterDbtTranslator:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_component.py
@@ -105,6 +105,61 @@ def test_dbt_cloud_component_state_cycle(tmp_path, mock_workspace, mock_workspac
     assert asset_def.node_def.name == "dbt_cloud_assets"
 
 
+def test_dbt_cloud_component_emits_exposure_assets(tmp_path, mock_workspace_data):
+    """Dbt Cloud manifests that declare exposures should get corresponding observable
+    external `AssetSpec` objects when `enable_exposure_assets=True`. Deps on referenced
+    models flow through so the graph shows a materialization -> consumption chain.
+    """
+    mock_workspace_data.manifest["exposures"] = {
+        "exposure.my_project.my_dash": {
+            "resource_type": "exposure",
+            "unique_id": "exposure.my_project.my_dash",
+            "name": "my_dash",
+            "package_name": "my_project",
+            "fqn": ["my_project", "my_dash"],
+            "type": "dashboard",
+            "description": "a critical dashboard",
+            "url": "https://tableau.example.com/my_dash",
+            "maturity": "high",
+            "owner": {"email": "team@example.com"},
+            "tags": ["priority"],
+            "meta": {},
+            "config": {},
+            "depends_on": {"nodes": ["model.my_project.my_model"]},
+        }
+    }
+    mock_workspace_data.manifest["child_map"]["exposure.my_project.my_dash"] = []
+    mock_workspace_data.manifest["parent_map"]["exposure.my_project.my_dash"] = [
+        "model.my_project.my_model"
+    ]
+
+    workspace = MagicMock(spec=DbtCloudWorkspace)
+    workspace.unique_id = "123-456"
+    workspace.project_id = 123
+    workspace.environment_id = 456
+    workspace.credentials = MagicMock(account_id=999)
+    workspace.fetch_workspace_data.return_value = mock_workspace_data
+    workspace.get_or_fetch_workspace_data.return_value = mock_workspace_data
+
+    component = DbtCloudComponent(
+        workspace=workspace,
+        defs_state=DefsStateConfigArgs.local_filesystem(),
+        translation_settings={"enable_exposure_assets": True},  # type: ignore
+    )
+    state_path = tmp_path / "dbt_cloud_state.json"
+    component.write_state_to_path(state_path)
+
+    defs = component.build_defs_from_state(MagicMock(), state_path)
+    all_specs = list(defs.resolve_all_asset_specs())
+    specs_by_str = {spec.key.to_user_string(): spec for spec in all_specs}
+
+    assert "my_dash" in specs_by_str, list(specs_by_str)
+    exposure_spec = specs_by_str["my_dash"]
+    assert exposure_spec.kinds == {"dashboard"}
+    dep_keys = {dep.asset_key for dep in exposure_spec.deps}
+    assert dg.AssetKey("my_model") in dep_keys
+
+
 def test_dbt_cloud_component_emits_source_assets(tmp_path, mock_workspace_data):
     """Dbt Cloud manifests that declare sources should get corresponding observable
     external `AssetSpec` objects emitted alongside the model AssetsDefinition, so

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_exposures.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_exposures.py
@@ -1,0 +1,225 @@
+"""Tests for surfacing dbt exposures as observable external Dagster ``AssetSpec`` objects.
+
+Exposures are declared in dbt ``exposures.yml`` and represent downstream consumers of dbt
+models (BI dashboards, notebooks, ML models, applications, analyses). Emitting them as
+downstream ``AssetSpec`` objects gives users a downstream relationship in the Dagster
+graph — "if this model breaks, which dashboards are affected?" — without materializing
+anything. Opt-in via ``translation_settings.enable_exposure_assets``.
+"""
+
+from typing import Any
+
+from dagster import AssetKey
+from dagster_dbt.asset_specs import (
+    DAGSTER_DBT_EXPOSURE_MATURITY_METADATA_KEY,
+    DAGSTER_DBT_EXPOSURE_TYPE_METADATA_KEY,
+    DAGSTER_DBT_EXPOSURE_URL_METADATA_KEY,
+    build_dbt_exposure_asset_specs,
+)
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+
+
+def _model_props(name: str) -> dict[str, Any]:
+    return {
+        "resource_type": "model",
+        "name": name,
+        "unique_id": f"model.my_project.{name}",
+        "config": {"materialized": "table"},
+        "depends_on": {"nodes": []},
+    }
+
+
+def _exposure_props(
+    name: str,
+    exposure_type: str = "dashboard",
+    *,
+    upstream_models: list[str] | None = None,
+    url: str | None = "https://dashboards.example.com/x",
+    maturity: str | None = "high",
+    description: str = "an important dashboard",
+    tags: list[str] | None = None,
+    owner_email: str | None = "team@example.com",
+) -> dict[str, Any]:
+    return {
+        "resource_type": "exposure",
+        "unique_id": f"exposure.my_project.{name}",
+        "name": name,
+        "type": exposure_type,
+        "description": description,
+        "url": url,
+        "maturity": maturity,
+        "owner": ({"email": owner_email} if owner_email else {}),
+        "tags": tags or [],
+        "meta": {},
+        # Exposures always carry a `config` field in the manifest; include it here
+        # so the shared `default_asset_key_fn` doesn't KeyError on synthetic fixtures.
+        "config": {},
+        "depends_on": {"nodes": [f"model.my_project.{model}" for model in (upstream_models or [])]},
+    }
+
+
+def _synthetic_manifest(
+    exposures: dict[str, dict[str, Any]] | None = None,
+    nodes: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "metadata": {"adapter_type": "duckdb"},
+        "nodes": nodes or {},
+        "sources": {},
+        "exposures": exposures or {},
+        "metrics": {},
+        "semantic_models": {},
+        "saved_queries": {},
+        "groups": {},
+        "child_map": {},
+        "parent_map": {},
+    }
+
+
+def test_no_exposures_returns_empty() -> None:
+    specs = build_dbt_exposure_asset_specs(manifest=_synthetic_manifest())
+    assert specs == []
+
+
+def test_exposure_emitted_with_kind_from_type() -> None:
+    manifest = _synthetic_manifest(
+        exposures={"exposure.my_project.dash": _exposure_props("dash", "dashboard")}
+    )
+    specs = build_dbt_exposure_asset_specs(manifest=manifest)
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec.key == AssetKey("dash")
+    assert spec.kinds == {"dashboard"}
+
+
+def test_exposure_types_map_to_distinct_kinds() -> None:
+    manifest = _synthetic_manifest(
+        exposures={
+            f"exposure.my_project.{name}": _exposure_props(name, kind)
+            for name, kind in [
+                ("d", "dashboard"),
+                ("n", "notebook"),
+                ("a", "analysis"),
+                ("m", "ml"),
+                ("app", "application"),
+            ]
+        }
+    )
+    specs = build_dbt_exposure_asset_specs(manifest=manifest)
+    kinds_by_name = {str(spec.key.to_user_string()): spec.kinds for spec in specs}
+    assert kinds_by_name["d"] == {"dashboard"}
+    assert kinds_by_name["n"] == {"notebook"}
+    assert kinds_by_name["a"] == {"analysis"}
+    assert kinds_by_name["m"] == {"ml"}
+    assert kinds_by_name["app"] == {"application"}
+
+
+def test_unknown_exposure_type_yields_no_kind() -> None:
+    manifest = _synthetic_manifest(
+        exposures={"exposure.my_project.weird": _exposure_props("weird", "made_up_type")}
+    )
+    specs = build_dbt_exposure_asset_specs(manifest=manifest)
+    assert specs[0].kinds is None or specs[0].kinds == set()
+
+
+def test_exposure_has_deps_on_referenced_models() -> None:
+    manifest = _synthetic_manifest(
+        nodes={
+            "model.my_project.customers": _model_props("customers"),
+            "model.my_project.orders": _model_props("orders"),
+        },
+        exposures={
+            "exposure.my_project.dash": _exposure_props(
+                "dash", upstream_models=["customers", "orders"]
+            )
+        },
+    )
+    specs = build_dbt_exposure_asset_specs(manifest=manifest)
+    dep_keys = {dep.asset_key for dep in specs[0].deps}
+    assert dep_keys == {AssetKey("customers"), AssetKey("orders")}
+
+
+def test_exposure_metadata_includes_url_type_and_maturity() -> None:
+    manifest = _synthetic_manifest(
+        exposures={
+            "exposure.my_project.dash": _exposure_props(
+                "dash",
+                exposure_type="dashboard",
+                url="https://tableau.example.com/dash",
+                maturity="high",
+            )
+        }
+    )
+    spec = build_dbt_exposure_asset_specs(manifest=manifest)[0]
+    assert spec.metadata[DAGSTER_DBT_EXPOSURE_TYPE_METADATA_KEY] == "dashboard"
+    assert (
+        spec.metadata[DAGSTER_DBT_EXPOSURE_URL_METADATA_KEY] == "https://tableau.example.com/dash"
+    )
+    assert spec.metadata[DAGSTER_DBT_EXPOSURE_MATURITY_METADATA_KEY] == "high"
+
+
+def test_exposure_url_and_maturity_omitted_when_missing() -> None:
+    manifest = _synthetic_manifest(
+        exposures={"exposure.my_project.dash": _exposure_props("dash", url=None, maturity=None)}
+    )
+    metadata = build_dbt_exposure_asset_specs(manifest=manifest)[0].metadata
+    assert DAGSTER_DBT_EXPOSURE_URL_METADATA_KEY not in metadata
+    assert DAGSTER_DBT_EXPOSURE_MATURITY_METADATA_KEY not in metadata
+
+
+def test_exposure_description_owner_tags() -> None:
+    manifest = _synthetic_manifest(
+        exposures={
+            "exposure.my_project.dash": _exposure_props(
+                "dash",
+                description="team dashboard",
+                owner_email="team@example.com",
+                tags=["priority", "audited"],
+            )
+        }
+    )
+    spec = build_dbt_exposure_asset_specs(manifest=manifest)[0]
+    assert spec.description == "team dashboard"
+    assert spec.owners == ["team@example.com"]
+    assert "priority" in spec.tags
+    assert "audited" in spec.tags
+
+
+def test_exposure_with_missing_upstream_skips_that_dep() -> None:
+    # Dep on a model that doesn't exist in the manifest should be silently skipped, not raise.
+    manifest = _synthetic_manifest(
+        nodes={"model.my_project.customers": _model_props("customers")},
+        exposures={
+            "exposure.my_project.dash": _exposure_props(
+                "dash", upstream_models=["customers", "does_not_exist"]
+            )
+        },
+    )
+    spec = build_dbt_exposure_asset_specs(manifest=manifest)[0]
+    dep_keys = {dep.asset_key for dep in spec.deps}
+    assert dep_keys == {AssetKey("customers")}
+
+
+def test_exposure_asset_key_respects_meta_dagster_override() -> None:
+    exposure = _exposure_props("dash")
+    exposure["meta"] = {"dagster": {"asset_key": ["custom", "path"]}}
+    manifest = _synthetic_manifest(exposures={"exposure.my_project.dash": exposure})
+    spec = build_dbt_exposure_asset_specs(manifest=manifest)[0]
+    assert spec.key == AssetKey(["custom", "path"])
+
+
+def test_custom_translator_applies() -> None:
+    # A translator subclass overriding get_asset_key should be respected by
+    # build_dbt_exposure_asset_specs.
+    class PrefixTranslator(DagsterDbtTranslator):
+        def get_asset_key(self, dbt_resource_props):
+            base = super().get_asset_key(dbt_resource_props)
+            if dbt_resource_props.get("resource_type") == "exposure":
+                return AssetKey(["exposures", *base.path])
+            return base
+
+    manifest = _synthetic_manifest(exposures={"exposure.my_project.dash": _exposure_props("dash")})
+    spec = build_dbt_exposure_asset_specs(
+        manifest=manifest, dagster_dbt_translator=PrefixTranslator()
+    )[0]
+    assert spec.key == AssetKey(["exposures", "dash"])


### PR DESCRIPTION
## Summary & Motivation

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
