### PR TITLE
dagster-dbt: emit dbt semantic layer (semantic_models + metrics) as AssetSpecs (opt-in)

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_specs.py
@@ -23,6 +23,12 @@ DAGSTER_DBT_EXPOSURE_TYPE_METADATA_KEY = "dagster_dbt/exposure_type"
 DAGSTER_DBT_EXPOSURE_URL_METADATA_KEY = "dagster_dbt/exposure_url"
 DAGSTER_DBT_EXPOSURE_MATURITY_METADATA_KEY = "dagster_dbt/exposure_maturity"
 
+DAGSTER_DBT_SEMANTIC_MODEL_MEASURES_METADATA_KEY = "dagster_dbt/measures"
+DAGSTER_DBT_SEMANTIC_MODEL_DIMENSIONS_METADATA_KEY = "dagster_dbt/dimensions"
+DAGSTER_DBT_SEMANTIC_MODEL_ENTITIES_METADATA_KEY = "dagster_dbt/entities"
+DAGSTER_DBT_METRIC_TYPE_METADATA_KEY = "dagster_dbt/metric_type"
+DAGSTER_DBT_METRIC_LABEL_METADATA_KEY = "dagster_dbt/metric_label"
+
 
 # dbt exposure types (https://docs.getdbt.com/reference/exposure-properties#type):
 # dashboard, notebook, analysis, ml, application. We map each to a kind that
@@ -248,6 +254,119 @@ def build_dbt_exposure_asset_specs(
                 owners=owners,
                 tags=tags,
                 kinds=kinds,
+            )
+        )
+
+    return specs
+
+
+def _semantic_layer_deps(
+    manifest: Mapping[str, Any],
+    translator: DagsterDbtTranslator,
+    props: Mapping[str, Any],
+) -> list[AssetDep]:
+    """Build AssetDep list from a semantic_model or metric's ``depends_on.nodes``."""
+    deps: list[AssetDep] = []
+    seen: set[AssetKey] = set()
+    for upstream_id in props.get("depends_on", {}).get("nodes", []) or []:
+        try:
+            upstream_props = get_node(manifest, upstream_id)
+        except Exception:
+            continue
+        upstream_key = translator.get_asset_key(upstream_props)
+        if upstream_key in seen:
+            continue
+        seen.add(upstream_key)
+        deps.append(AssetDep(asset=upstream_key))
+    return deps
+
+
+def build_dbt_semantic_layer_asset_specs(
+    *,
+    manifest: DbtManifestParam,
+    dagster_dbt_translator: DagsterDbtTranslator | None = None,
+    project: DbtProject | None = None,
+) -> Sequence[AssetSpec]:
+    """Build observable external ``AssetSpec`` objects for every dbt ``semantic_model`` and
+    ``metric`` declared in the manifest.
+
+    dbt's semantic layer represents entities, dimensions, measures, and metrics that sit
+    on top of models. Surfacing them as Dagster ``AssetSpec`` objects lets users:
+
+    - See semantic_models and metrics in the graph with their upstream lineage back to
+      the models they're built from.
+    - Query on them via ``kind:semantic_model`` / ``kind:metric`` asset selections.
+    - Layer freshness / owners / tags on top via ``post_processing:``.
+
+    Emitted specs are NOT materialized by Dagster — the semantic layer is queried
+    (typically via dbt Cloud's semantic layer API) rather than materialized. ``AssetSpec``
+    without an ``op`` behaves as an observable external asset.
+
+    Semantic models are keyed via ``translator.get_asset_key`` (which honors
+    ``meta.dagster.asset_key`` overrides). Metrics likewise.
+
+    Metadata surfaced (under the ``dagster_dbt/`` namespace):
+
+    - semantic_model specs: ``measures`` (list of measure names), ``dimensions`` (list of
+      dimension names), ``entities`` (list of entity names).
+    - metric specs: ``metric_type`` (``simple`` / ``ratio`` / ``cumulative`` / ``derived``),
+      ``metric_label`` (human-readable label from dbt).
+
+    Args:
+        manifest: The contents of a ``manifest.json`` file or the path to one.
+        dagster_dbt_translator: Optional translator; defaults to :py:class:`DagsterDbtTranslator`.
+        project: Reserved for future use; currently unused.
+
+    Returns:
+        Sequence[AssetSpec]: One ``AssetSpec`` per semantic_model and metric.
+    """
+    del project  # currently unused; kept in signature for parity with source/exposure helpers
+    manifest = validate_manifest(manifest)
+    translator = validate_translator(dagster_dbt_translator or DagsterDbtTranslator())
+
+    specs: list[AssetSpec] = []
+
+    for semantic_model_unique_id, props in (manifest.get("semantic_models") or {}).items():
+        deps = _semantic_layer_deps(manifest, translator, props)
+        measures = [m.get("name") for m in (props.get("measures") or []) if m.get("name")]
+        dimensions = [d.get("name") for d in (props.get("dimensions") or []) if d.get("name")]
+        entities = [e.get("name") for e in (props.get("entities") or []) if e.get("name")]
+
+        metadata: dict[str, Any] = {
+            DAGSTER_DBT_UNIQUE_ID_METADATA_KEY: semantic_model_unique_id,
+            DAGSTER_DBT_SEMANTIC_MODEL_MEASURES_METADATA_KEY: measures,
+            DAGSTER_DBT_SEMANTIC_MODEL_DIMENSIONS_METADATA_KEY: dimensions,
+            DAGSTER_DBT_SEMANTIC_MODEL_ENTITIES_METADATA_KEY: entities,
+        }
+
+        specs.append(
+            AssetSpec(
+                key=translator.get_asset_key(props),
+                deps=deps,
+                description=props.get("description"),
+                metadata=metadata,
+                kinds={"semantic_model"},
+            )
+        )
+
+    for metric_unique_id, props in (manifest.get("metrics") or {}).items():
+        deps = _semantic_layer_deps(manifest, translator, props)
+        metric_type = str(props.get("type") or "").lower()
+        metadata = {
+            DAGSTER_DBT_UNIQUE_ID_METADATA_KEY: metric_unique_id,
+            DAGSTER_DBT_METRIC_TYPE_METADATA_KEY: metric_type,
+        }
+        label = props.get("label")
+        if isinstance(label, str) and label:
+            metadata[DAGSTER_DBT_METRIC_LABEL_METADATA_KEY] = label
+
+        specs.append(
+            AssetSpec(
+                key=translator.get_asset_key(props),
+                deps=deps,
+                description=props.get("description"),
+                metadata=metadata,
+                kinds={"metric"},
             )
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/component/dbt_cloud_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/component/dbt_cloud_component.py
@@ -22,7 +22,11 @@ from dagster.components.utils.translation import (
 from dagster_shared.serdes import deserialize_value, serialize_value
 from pydantic import Field
 
-from dagster_dbt.asset_specs import build_dbt_exposure_asset_specs, build_dbt_source_asset_specs
+from dagster_dbt.asset_specs import (
+    build_dbt_exposure_asset_specs,
+    build_dbt_semantic_layer_asset_specs,
+    build_dbt_source_asset_specs,
+)
 from dagster_dbt.asset_utils import (
     DBT_DEFAULT_EXCLUDE,
     DBT_DEFAULT_SELECT,
@@ -410,9 +414,23 @@ class DbtCloudComponent(StateBackedComponent, dg.Resolvable, dg.Model):
             if self.translator.settings.enable_exposure_assets
             else []
         )
+        semantic_layer_specs = (
+            build_dbt_semantic_layer_asset_specs(
+                manifest=validated_manifest,
+                dagster_dbt_translator=self.translator,
+                project=None,
+            )
+            if self.translator.settings.enable_semantic_layer_assets
+            else []
+        )
 
         return Definitions(
-            assets=[_dbt_cloud_assets, *source_specs, *exposure_specs],
+            assets=[
+                _dbt_cloud_assets,
+                *source_specs,
+                *exposure_specs,
+                *semantic_layer_specs,
+            ],
             sensors=sensors,
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/components/dbt_project/component.py
@@ -21,7 +21,11 @@ from dagster.components.utils.translation import (
 )
 from dagster_shared.serdes.objects.models.defs_state_info import DefsStateManagementType
 
-from dagster_dbt.asset_specs import build_dbt_exposure_asset_specs, build_dbt_source_asset_specs
+from dagster_dbt.asset_specs import (
+    build_dbt_exposure_asset_specs,
+    build_dbt_semantic_layer_asset_specs,
+    build_dbt_source_asset_specs,
+)
 from dagster_dbt.asset_utils import (
     DAGSTER_DBT_STATE_TAG_KEY,
     DAGSTER_DBT_TRANSLATOR_METADATA_KEY,
@@ -475,8 +479,19 @@ class DbtProjectComponent(StateBackedComponent, dg.Resolvable):
             if self.translator.settings.enable_exposure_assets
             else []
         )
+        # dbt semantic_models and metrics — observable external specs so users can trace
+        # semantic layer lineage back to the underlying models in the graph.
+        semantic_layer_specs = (
+            build_dbt_semantic_layer_asset_specs(
+                manifest=validated_manifest,
+                dagster_dbt_translator=validated_translator,
+                project=project,
+            )
+            if self.translator.settings.enable_semantic_layer_assets
+            else []
+        )
 
-        return dg.Definitions(assets=[_fn, *source_specs, *exposure_specs])
+        return dg.Definitions(assets=[_fn, *source_specs, *exposure_specs, *semantic_layer_specs])
 
     def get_cli_args(self, context: dg.AssetExecutionContext) -> list[str]:
         return resolve_cli_args(self.cli_args, context)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -108,6 +108,12 @@ class DagsterDbtTranslatorSettings(Resolvable):
             affected?" — without materializing anything. Exposure kind is derived from
             ``exposure.type`` (``dashboard`` / ``notebook`` / ``analysis`` / ``application``
             / ``ml``) so the UI can render a distinct icon.
+        enable_semantic_layer_assets (bool): Whether to emit dbt semantic layer resources
+            (``semantic_models`` and ``metrics``) as observable external
+            :py:class:`dagster.AssetSpec` objects. Defaults to False (opt-in). Semantic
+            models depend on the model they're built from; metrics depend on the semantic
+            models they aggregate. Kinds are set to ``semantic_model`` and ``metric``
+            respectively so the UI renders distinct icons.
     """
 
     enable_asset_checks: bool = True
@@ -121,6 +127,7 @@ class DagsterDbtTranslatorSettings(Resolvable):
     enable_source_freshness_policies: bool = False
     enable_contract_metadata: bool = False
     enable_exposure_assets: bool = False
+    enable_semantic_layer_assets: bool = False
 
 
 class DagsterDbtTranslator:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_semantic_layer.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_semantic_layer.py
@@ -1,0 +1,240 @@
+"""Tests for surfacing dbt semantic_models and metrics as observable external Dagster
+``AssetSpec`` objects.
+
+Emitted specs give users a downstream lineage view of dbt's semantic layer: semantic_models
+depend on the model they're built from; metrics depend on the semantic_models they
+aggregate. Opt-in via ``translation_settings.enable_semantic_layer_assets``.
+"""
+
+from typing import Any
+
+from dagster import AssetKey
+from dagster_dbt.asset_specs import (
+    DAGSTER_DBT_METRIC_LABEL_METADATA_KEY,
+    DAGSTER_DBT_METRIC_TYPE_METADATA_KEY,
+    DAGSTER_DBT_SEMANTIC_MODEL_DIMENSIONS_METADATA_KEY,
+    DAGSTER_DBT_SEMANTIC_MODEL_ENTITIES_METADATA_KEY,
+    DAGSTER_DBT_SEMANTIC_MODEL_MEASURES_METADATA_KEY,
+    build_dbt_semantic_layer_asset_specs,
+)
+
+
+def _model_node(name: str) -> dict[str, Any]:
+    return {
+        "resource_type": "model",
+        "name": name,
+        "unique_id": f"model.my_project.{name}",
+        "config": {"materialized": "table"},
+        "depends_on": {"nodes": []},
+    }
+
+
+def _semantic_model(
+    name: str,
+    *,
+    upstream_model: str,
+    measures: list[str] | None = None,
+    dimensions: list[str] | None = None,
+    entities: list[str] | None = None,
+    description: str = "",
+) -> dict[str, Any]:
+    return {
+        "resource_type": "semantic_model",
+        "unique_id": f"semantic_model.my_project.{name}",
+        "name": name,
+        "config": {},
+        "description": description,
+        "depends_on": {"nodes": [f"model.my_project.{upstream_model}"]},
+        "meta": {},
+        "measures": [{"name": m} for m in (measures or [])],
+        "dimensions": [{"name": d} for d in (dimensions or [])],
+        "entities": [{"name": e} for e in (entities or [])],
+    }
+
+
+def _metric(
+    name: str,
+    metric_type: str = "simple",
+    *,
+    upstream_semantic_models: list[str] | None = None,
+    label: str | None = None,
+    description: str = "",
+) -> dict[str, Any]:
+    return {
+        "resource_type": "metric",
+        "unique_id": f"metric.my_project.{name}",
+        "name": name,
+        "type": metric_type,
+        "label": label,
+        "description": description,
+        "config": {},
+        "meta": {},
+        "depends_on": {
+            "nodes": [f"semantic_model.my_project.{sm}" for sm in (upstream_semantic_models or [])]
+        },
+    }
+
+
+def _synthetic_manifest(
+    nodes: dict[str, dict[str, Any]] | None = None,
+    semantic_models: dict[str, dict[str, Any]] | None = None,
+    metrics: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "metadata": {"adapter_type": "duckdb"},
+        "nodes": nodes or {},
+        "sources": {},
+        "exposures": {},
+        "metrics": metrics or {},
+        "semantic_models": semantic_models or {},
+        "saved_queries": {},
+        "groups": {},
+        "child_map": {},
+        "parent_map": {},
+    }
+
+
+def test_empty_manifest_returns_empty() -> None:
+    specs = build_dbt_semantic_layer_asset_specs(manifest=_synthetic_manifest())
+    assert specs == []
+
+
+def test_semantic_model_emitted_with_upstream_model_dep() -> None:
+    manifest = _synthetic_manifest(
+        nodes={"model.my_project.orders": _model_node("orders")},
+        semantic_models={
+            "semantic_model.my_project.orders_sm": _semantic_model(
+                "orders_sm",
+                upstream_model="orders",
+                measures=["revenue", "order_count"],
+                dimensions=["order_date"],
+                entities=["customer"],
+            )
+        },
+    )
+    specs = build_dbt_semantic_layer_asset_specs(manifest=manifest)
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec.key == AssetKey("orders_sm")
+    assert spec.kinds == {"semantic_model"}
+    dep_keys = {dep.asset_key for dep in spec.deps}
+    assert dep_keys == {AssetKey("orders")}
+    assert spec.metadata[DAGSTER_DBT_SEMANTIC_MODEL_MEASURES_METADATA_KEY] == [
+        "revenue",
+        "order_count",
+    ]
+    assert spec.metadata[DAGSTER_DBT_SEMANTIC_MODEL_DIMENSIONS_METADATA_KEY] == ["order_date"]
+    assert spec.metadata[DAGSTER_DBT_SEMANTIC_MODEL_ENTITIES_METADATA_KEY] == ["customer"]
+
+
+def test_metric_emitted_with_semantic_model_dep() -> None:
+    manifest = _synthetic_manifest(
+        nodes={"model.my_project.orders": _model_node("orders")},
+        semantic_models={
+            "semantic_model.my_project.orders_sm": _semantic_model(
+                "orders_sm", upstream_model="orders"
+            )
+        },
+        metrics={
+            "metric.my_project.total_revenue": _metric(
+                "total_revenue",
+                metric_type="simple",
+                upstream_semantic_models=["orders_sm"],
+                label="Total Revenue",
+            )
+        },
+    )
+    specs = build_dbt_semantic_layer_asset_specs(manifest=manifest)
+    metric_spec = next(spec for spec in specs if spec.key == AssetKey("total_revenue"))
+    assert metric_spec.kinds == {"metric"}
+    dep_keys = {dep.asset_key for dep in metric_spec.deps}
+    assert dep_keys == {AssetKey("orders_sm")}
+    assert metric_spec.metadata[DAGSTER_DBT_METRIC_TYPE_METADATA_KEY] == "simple"
+    assert metric_spec.metadata[DAGSTER_DBT_METRIC_LABEL_METADATA_KEY] == "Total Revenue"
+
+
+def test_metric_label_omitted_when_missing() -> None:
+    manifest = _synthetic_manifest(
+        metrics={
+            "metric.my_project.total_revenue": _metric(
+                "total_revenue", label=None, upstream_semantic_models=[]
+            )
+        }
+    )
+    spec = build_dbt_semantic_layer_asset_specs(manifest=manifest)[0]
+    assert DAGSTER_DBT_METRIC_LABEL_METADATA_KEY not in spec.metadata
+
+
+def test_metric_types_normalized_to_lowercase() -> None:
+    manifest = _synthetic_manifest(
+        metrics={
+            f"metric.my_project.{metric_type}_metric": _metric(
+                f"{metric_type}_metric", metric_type=metric_type
+            )
+            for metric_type in ("Simple", "RATIO", "cumulative", "Derived")
+        }
+    )
+    specs = build_dbt_semantic_layer_asset_specs(manifest=manifest)
+    types = {
+        spec.key.to_user_string(): spec.metadata[DAGSTER_DBT_METRIC_TYPE_METADATA_KEY]
+        for spec in specs
+    }
+    assert types["Simple_metric"] == "simple"
+    assert types["RATIO_metric"] == "ratio"
+    assert types["cumulative_metric"] == "cumulative"
+    assert types["Derived_metric"] == "derived"
+
+
+def test_multiple_semantic_models_and_metrics() -> None:
+    manifest = _synthetic_manifest(
+        nodes={
+            "model.my_project.orders": _model_node("orders"),
+            "model.my_project.customers": _model_node("customers"),
+        },
+        semantic_models={
+            "semantic_model.my_project.orders_sm": _semantic_model(
+                "orders_sm", upstream_model="orders"
+            ),
+            "semantic_model.my_project.customers_sm": _semantic_model(
+                "customers_sm", upstream_model="customers"
+            ),
+        },
+        metrics={
+            "metric.my_project.m1": _metric("m1", upstream_semantic_models=["orders_sm"]),
+            "metric.my_project.m2": _metric(
+                "m2", upstream_semantic_models=["orders_sm", "customers_sm"]
+            ),
+        },
+    )
+    specs = build_dbt_semantic_layer_asset_specs(manifest=manifest)
+    assert len(specs) == 4
+    kinds_by_key = {spec.key: spec.kinds for spec in specs}
+    assert kinds_by_key[AssetKey("orders_sm")] == {"semantic_model"}
+    assert kinds_by_key[AssetKey("customers_sm")] == {"semantic_model"}
+    assert kinds_by_key[AssetKey("m1")] == {"metric"}
+    assert kinds_by_key[AssetKey("m2")] == {"metric"}
+
+
+def test_missing_upstream_skips_that_dep_silently() -> None:
+    # Dep on a semantic_model that isn't in the manifest should be silently skipped,
+    # matching the exposure spec behavior (stale references shouldn't fail load).
+    manifest = _synthetic_manifest(
+        nodes={"model.my_project.orders": _model_node("orders")},
+        semantic_models={
+            "semantic_model.my_project.orders_sm": _semantic_model(
+                "orders_sm", upstream_model="orders"
+            ),
+        },
+        metrics={
+            "metric.my_project.m1": _metric(
+                "m1", upstream_semantic_models=["orders_sm", "does_not_exist"]
+            )
+        },
+    )
+    metric_spec = next(
+        spec
+        for spec in build_dbt_semantic_layer_asset_specs(manifest=manifest)
+        if spec.key == AssetKey("m1")
+    )
+    dep_keys = {dep.asset_key for dep in metric_spec.deps}
+    assert dep_keys == {AssetKey("orders_sm")}


### PR DESCRIPTION
## Summary & Motivation

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
