### PR TITLE
dagster-dbt: mid-run per-model monitoring for dbt Cloud (monitor_runs)

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/cli_invocation.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/cli_invocation.py
@@ -52,8 +52,42 @@ class DbtCloudCliInvocation:
         )
 
     def wait(
-        self, timeout: float | None = None
+        self,
+        timeout: float | None = None,
+        *,
+        monitor_runs: bool = False,
+        fail_fast: bool = False,
+        poll_interval: int = 5,
     ) -> Iterator[AssetCheckEvaluation | AssetCheckResult | AssetMaterialization | Output]:
+        """Wait for a dbt Cloud run to finish, yielding Dagster events.
+
+        Default behavior (``monitor_runs=False``): block until the run is done, then
+        emit events from ``run_results.json``. Preserves existing semantics — no
+        change for callers that don't opt into monitoring.
+
+        When ``monitor_runs=True``: poll the run's step debug logs and emit
+        materializations/asset-check-results as models complete mid-run. Downstream
+        automation reacts in seconds instead of waiting for the whole Cloud run.
+
+        - ``fail_fast=True``: cancel the Cloud run on first failure, raise ``Failure``.
+        - ``fail_fast=False``: log failures, keep yielding partials, raise ``Failure``
+          only after the run itself terminates.
+        - ``poll_interval``: seconds between debug-log polls (default 5).
+        """
+        if monitor_runs:
+            from dagster_dbt.cloud_v2.run_monitor import monitor_run_iter
+
+            yield from monitor_run_iter(
+                run_id=self.run_handler.run_id,
+                client=self.client,
+                manifest=self.manifest,
+                translator=self.dagster_dbt_translator,
+                context=self.context,
+                fail_fast=fail_fast,
+                poll_interval=poll_interval,
+            )
+            return
+
         run = self.run_handler.wait(timeout=timeout)
 
         # Write dbt Cloud run logs to stdout

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/component/dbt_cloud_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/component/dbt_cloud_component.py
@@ -544,6 +544,44 @@ class DbtCloudComponent(StateBackedComponent, dg.Resolvable, dg.Model):
         ),
     ] = None
 
+    monitor_runs: Annotated[
+        bool,
+        Resolver.default(
+            description=(
+                "When True, emit AssetMaterializations / AssetCheckResults for each dbt "
+                "model / test as it completes mid-run — instead of waiting for the whole "
+                "Cloud run to finish. The component polls step debug logs "
+                "(`GET /steps/{id}/?include_related=debug_logs`) every `poll_interval` "
+                "seconds and parses per-model OK/ERROR status. Downstream `AutomationCondition` "
+                "subscriptions can react in seconds instead of minutes. Default `False` "
+                "preserves the OOTB wait-for-completion behavior for existing users."
+            ),
+        ),
+    ] = False
+
+    fail_fast: Annotated[
+        bool,
+        Resolver.default(
+            description=(
+                "When `monitor_runs=True`: on the first model/test failure, cancel the "
+                "Cloud run via `POST /runs/{id}/cancel/` and raise `Failure` after "
+                "yielding any partials. Default `False` keeps the run going so all "
+                "failures are captured (matches dbt's own `--fail-fast` off default)."
+            ),
+        ),
+    ] = False
+
+    poll_interval: Annotated[
+        int,
+        Resolver.default(
+            description=(
+                "Seconds between debug-log polls when `monitor_runs=True`. Default 5. "
+                "Lower = faster reaction to model completions but more API calls. dbt "
+                "Cloud rate-limits debug-log requests, so don't drop below 2."
+            ),
+        ),
+    ] = 5
+
     @property
     def defs_state_config(self) -> DefsStateConfig:
         key = f"DbtCloudComponent[{self.workspace.unique_id}]"
@@ -786,7 +824,11 @@ class DbtCloudComponent(StateBackedComponent, dg.Resolvable, dg.Model):
             dagster_dbt_translator=self.translator,
             context=context,
         )
-        yield from invocation.wait()
+        yield from invocation.wait(
+            monitor_runs=self.monitor_runs,
+            fail_fast=self.fail_fast,
+            poll_interval=self.poll_interval,
+        )
 
 
 class DbtCloudComponentTranslator(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_monitor.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_monitor.py
@@ -1,0 +1,417 @@
+"""Debug-log parsing for dbt Cloud mid-run per-model monitoring.
+
+dbt Cloud writes per-model progress lines to a step's ``debug_logs`` field as the
+run streams — e.g. ``2 of 4 OK created sql table model dev.stg_customers ...``.
+By polling ``debug_logs`` mid-run we can emit ``AssetMaterialization`` /
+``AssetCheckResult`` / ``Output`` events for each model as it completes, rather
+than waiting for the whole Cloud run to finish. Downstream ``AutomationCondition``
+subscriptions react in seconds instead of minutes.
+
+We prefer log parsing over ``run_results.json`` for this because ``run_results.json``
+is only available after the whole run finishes — too late for mid-run reaction.
+
+The regex intentionally accepts a wide set of dbt's progress verbiage (``created``,
+``creating``, ``updated``, ``refreshing``, etc.) because dbt's exact wording depends
+on adapter + materialization + version. We match the ``N of M STATUS ... name ..``
+skeleton, which has been stable across recent dbt releases.
+"""
+
+import re
+import time
+from collections.abc import Iterator, Mapping
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from dagster import (
+    AssetCheckEvaluation,
+    AssetCheckResult,
+    AssetCheckSeverity,
+    AssetExecutionContext,
+    AssetMaterialization,
+    Failure,
+    MetadataValue,
+    Output,
+    get_dagster_logger,
+)
+from dagster._record import record
+
+if TYPE_CHECKING:
+    from dagster_dbt.cloud_v2.client import DbtCloudWorkspaceClient
+    from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+
+# Strip ANSI color codes (e.g. ``\x1b[32m``) — dbt Cloud debug logs come colorized.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+# Model progress line. Example (Snowflake adapter):
+#   1 of 4 OK created sql table model DEV.STG_CUSTOMERS .......... [SUCCESS 1 in 0.10s]
+#   2 of 4 ERROR creating sql view model dev.stg_orders ........... [ERROR in 0.11s]
+#   3 of 4 SKIP relation dev.stg_products ......................... [SKIP]
+#
+# We capture the terminal status word (OK / ERROR / SKIP) and the last dotted segment
+# of the identifier (``STG_CUSTOMERS``, i.e. the model name). The prefix
+# (``created`` / ``creating`` / etc.) is permissive on purpose.
+_MODEL_LINE_RE = re.compile(
+    r"\b(?P<current>\d+)\s+of\s+(?P<total>\d+)\s+"
+    r"(?P<status>OK|ERROR|SKIP)\b"
+    r".*?"
+    r"(?:^|[\s.])(?P<qualified>[A-Za-z0-9_.]+?)"
+    r"\s+\.{3,}",
+    re.IGNORECASE,
+)
+
+# Test progress line. Example:
+#   1 of 4 PASS not_null_customers_id ............................ [PASS in 0.10s]
+#   2 of 4 FAIL not_null_orders_id ................................ [FAIL 1 in 0.11s]
+#   3 of 4 WARN unique_customers_email ............................ [WARN 1 in 0.10s]
+_TEST_LINE_RE = re.compile(
+    r"\b(?P<current>\d+)\s+of\s+(?P<total>\d+)\s+"
+    r"(?P<status>PASS|FAIL|WARN|ERROR)\s+"
+    r"(?P<name>\S+)\s+\.{3,}",
+    re.IGNORECASE,
+)
+
+
+class ParsedLogKind(str, Enum):
+    """Kind of terminal event parsed out of a dbt Cloud step's debug log."""
+
+    MODEL_OK = "MODEL_OK"
+    MODEL_ERROR = "MODEL_ERROR"
+    MODEL_SKIP = "MODEL_SKIP"
+    TEST_PASS = "TEST_PASS"
+    TEST_FAIL = "TEST_FAIL"
+    TEST_WARN = "TEST_WARN"
+
+    @property
+    def is_failure(self) -> bool:
+        """Failures include model errors and test failures (WARN is NOT a failure —
+        matches dbt's own semantics where WARN is a soft signal, not a hard failure).
+        """
+        return self in (ParsedLogKind.MODEL_ERROR, ParsedLogKind.TEST_FAIL)
+
+
+@record
+class ParsedLogResult:
+    """One terminal event parsed out of dbt Cloud debug logs.
+
+    ``name`` is the model/test's short name (last dotted segment). Callers resolve
+    it to a manifest ``unique_id`` via the current run's manifest — necessary
+    because dbt logs schema-qualified names but Dagster keys off the unique_id.
+    """
+
+    kind: ParsedLogKind
+    name: str
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI color codes so regex parsing doesn't fight terminal formatting."""
+    return _ANSI_RE.sub("", text)
+
+
+def _short_name(qualified: str) -> str:
+    """Return the last dotted segment of a schema-qualified identifier.
+
+    ``DEV.STG_CUSTOMERS`` -> ``STG_CUSTOMERS``; ``STG_ORDERS`` -> ``STG_ORDERS``.
+    Case is preserved — dbt keys models by the source-file name which is
+    case-sensitive on some adapters.
+    """
+    return qualified.rsplit(".", 1)[-1]
+
+
+def parse_debug_logs(text: str) -> Iterator[ParsedLogResult]:
+    """Yield one ``ParsedLogResult`` per matched progress line in ``text``.
+
+    Order matches log order. Callers should dedupe by ``(kind_category, name)`` if
+    they poll incrementally-growing logs (the same lines will appear on every poll).
+    Deduping lives in the caller because a caller may hold cross-poll state that the
+    parser shouldn't know about.
+    """
+    stripped = strip_ansi(text)
+    for line in stripped.splitlines():
+        model_match = _MODEL_LINE_RE.search(line)
+        if model_match:
+            status = model_match.group("status").upper()
+            qualified = model_match.group("qualified")
+            name = _short_name(qualified)
+            if status == "OK":
+                yield ParsedLogResult(kind=ParsedLogKind.MODEL_OK, name=name)
+            elif status == "ERROR":
+                yield ParsedLogResult(kind=ParsedLogKind.MODEL_ERROR, name=name)
+            elif status == "SKIP":
+                yield ParsedLogResult(kind=ParsedLogKind.MODEL_SKIP, name=name)
+            continue
+
+        test_match = _TEST_LINE_RE.search(line)
+        if test_match:
+            status = test_match.group("status").upper()
+            name = test_match.group("name")
+            if status == "PASS":
+                yield ParsedLogResult(kind=ParsedLogKind.TEST_PASS, name=name)
+            elif status in ("FAIL", "ERROR"):
+                yield ParsedLogResult(kind=ParsedLogKind.TEST_FAIL, name=name)
+            elif status == "WARN":
+                yield ParsedLogResult(kind=ParsedLogKind.TEST_WARN, name=name)
+
+
+def collect_step_debug_logs(run_details: dict) -> str:
+    """Extract the concatenated ``debug_logs`` from every ``run_step`` in a run.
+
+    dbt Cloud returns ``run_steps`` as a list on the run detail response when
+    ``include_related=["run_steps", "debug_logs"]`` is passed. Each step has its
+    own ``debug_logs`` field that grows as the step runs. We concatenate across
+    steps so a single ``parse_debug_logs`` call sees the whole run's progress.
+    """
+    parts: list[str] = []
+    for step in run_details.get("run_steps") or []:
+        step_logs = step.get("debug_logs")
+        if step_logs:
+            parts.append(step_logs)
+    return "\n".join(parts)
+
+
+logger = get_dagster_logger()
+
+
+def find_model_unique_id_by_name(manifest: Mapping[str, Any], name: str) -> str | None:
+    """Case-insensitive lookup: given a model's short name (as it appears in dbt logs),
+    return the manifest ``unique_id`` (e.g. ``model.jaffle_shop.stg_customers``) or
+    ``None`` if not found. Case-insensitive because Snowflake logs uppercase names
+    but manifests store the source-file case.
+    """
+    target = name.lower()
+    nodes = manifest.get("nodes") or {}
+    for uid, node in nodes.items():
+        if uid.startswith("model.") and (node.get("name") or "").lower() == target:
+            return uid
+    return None
+
+
+def find_test_unique_id_by_name(manifest: Mapping[str, Any], name: str) -> str | None:
+    """Case-insensitive lookup: given a test's short name (as in dbt logs),
+    return the manifest ``unique_id`` (e.g. ``test.jaffle_shop.not_null_customers_id``).
+    """
+    target = name.lower()
+    nodes = manifest.get("nodes") or {}
+    for uid, node in nodes.items():
+        if uid.startswith("test.") and (node.get("name") or "").lower() == target:
+            return uid
+    return None
+
+
+def _events_for_parsed(
+    parsed: ParsedLogResult,
+    manifest: Mapping[str, Any],
+    translator: "DagsterDbtTranslator",
+    context: AssetExecutionContext | None,
+    partition_key: str | None,
+    run_url: str | None,
+) -> Iterator:
+    """Convert one parsed log result into Dagster events (Output/AssetMaterialization
+    for model completions, AssetCheckResult/AssetCheckEvaluation for tests).
+
+    Silently skips events we can't map to the manifest (e.g. model_error where no
+    materialization event fits, or unknown model names — rare, but possible when
+    the manifest is stale relative to the run).
+    """
+    from dagster_dbt.asset_utils import build_dbt_specs, get_asset_check_key_for_test
+
+    has_asset_def: bool = bool(context and context.has_assets_def)
+
+    def _base_metadata(unique_id: str) -> dict:
+        m: dict = {
+            "unique_id": unique_id,
+            "dagster_dbt/monitored": MetadataValue.bool(True),
+        }
+        if run_url:
+            m["run_url"] = MetadataValue.url(run_url)
+        return m
+
+    if parsed.kind == ParsedLogKind.MODEL_OK:
+        unique_id = find_model_unique_id_by_name(manifest, parsed.name)
+        if unique_id is None:
+            logger.warning(f"monitor_runs: no manifest match for model {parsed.name!r}; skipping.")
+            return
+        select = ".".join(manifest["nodes"][unique_id]["fqn"])
+        asset_specs, _ = build_dbt_specs(
+            manifest=manifest,
+            translator=translator,
+            select=select,
+            exclude="",
+            selector="",
+            io_manager_key=None,
+            project=None,
+        )
+        if not asset_specs:
+            return
+        spec = asset_specs[0]
+        metadata = _base_metadata(unique_id)
+        if context and has_asset_def:
+            yield Output(
+                value=None,
+                output_name=spec.key.to_python_identifier(),
+                metadata=metadata,
+            )
+        else:
+            yield AssetMaterialization(
+                asset_key=spec.key,
+                metadata=metadata,
+                partition=partition_key,
+            )
+        return
+
+    if parsed.kind in (ParsedLogKind.MODEL_ERROR, ParsedLogKind.MODEL_SKIP):
+        # No materialization for errored / skipped models — they didn't produce data.
+        # The failure itself is surfaced via `Failure` raised at the end of the loop.
+        return
+
+    # Test events -> AssetCheck events.
+    if parsed.kind in (ParsedLogKind.TEST_PASS, ParsedLogKind.TEST_FAIL, ParsedLogKind.TEST_WARN):
+        unique_id = find_test_unique_id_by_name(manifest, parsed.name)
+        if unique_id is None:
+            logger.warning(f"monitor_runs: no manifest match for test {parsed.name!r}; skipping.")
+            return
+        asset_check_key = get_asset_check_key_for_test(
+            manifest=manifest,
+            dagster_dbt_translator=translator,
+            test_unique_id=unique_id,
+            project=None,
+        )
+        if asset_check_key is None:
+            return
+        passed = parsed.kind == ParsedLogKind.TEST_PASS
+        severity = (
+            AssetCheckSeverity.WARN
+            if parsed.kind == ParsedLogKind.TEST_WARN
+            else AssetCheckSeverity.ERROR
+        )
+        metadata = _base_metadata(unique_id)
+        if context and has_asset_def and asset_check_key in context.selected_asset_check_keys:
+            yield AssetCheckResult(
+                passed=passed,
+                asset_key=asset_check_key.asset_key,
+                check_name=asset_check_key.name,
+                metadata=metadata,
+                severity=severity,
+            )
+        elif not has_asset_def:
+            yield AssetCheckEvaluation(
+                passed=passed,
+                asset_key=asset_check_key.asset_key,
+                check_name=asset_check_key.name,
+                metadata=metadata,
+                severity=severity,
+            )
+
+
+def _dedup_key(parsed: ParsedLogResult) -> tuple[str, str]:
+    """Key used to dedupe repeated parsings of the same log line across polls.
+
+    Group MODEL_* under ``"model"`` and TEST_* under ``"test"`` so a MODEL_ERROR and
+    a hypothetical MODEL_OK for the same name (which would indicate a dbt log bug)
+    aren't both emitted — first-seen wins.
+    """
+    prefix = "model" if parsed.kind.name.startswith("MODEL") else "test"
+    return (prefix, parsed.name.lower())
+
+
+def monitor_run_iter(
+    run_id: int,
+    client: "DbtCloudWorkspaceClient",
+    manifest: Mapping[str, Any],
+    translator: "DagsterDbtTranslator",
+    context: AssetExecutionContext | None,
+    fail_fast: bool,
+    poll_interval: int,
+    run_url: str | None = None,
+) -> Iterator:
+    """Poll a dbt Cloud run's step debug logs and yield Dagster events as models
+    complete — before the whole Cloud run finishes.
+
+    Contract:
+
+    - Polls at ``poll_interval`` seconds.
+    - Deduplicates against a per-invocation seen set, so repeated log lines across
+      polls don't emit duplicate materializations.
+    - On ``fail_fast=True``: on first model_error or test_fail, cancel the Cloud run
+      via the API and raise ``Failure`` after yielding partials.
+    - On ``fail_fast=False``: log the failure, keep going, yield partials as they
+      arrive, then raise ``Failure`` after the run's own terminal status.
+    - Successful models are always materialized — even when the run ultimately
+      fails — matching OOTB partial-result behavior.
+    """
+    from dagster_dbt.cloud_v2.types import DbtCloudJobRunStatusType, DbtCloudRun
+
+    seen: set[tuple[str, str]] = set()
+    saw_failure = False
+    terminal = {
+        DbtCloudJobRunStatusType.SUCCESS,
+        DbtCloudJobRunStatusType.ERROR,
+        DbtCloudJobRunStatusType.CANCELLED,
+    }
+    partition_key: str | None = (
+        context.partition_key if context and context.has_partition_key else None
+    )
+
+    while True:
+        run_details = client.get_run_details(
+            run_id=run_id,
+            include_related=["run_steps", "debug_logs"],
+        )
+        run = DbtCloudRun.from_run_details(run_details=run_details)
+        debug_logs = collect_step_debug_logs(run_details)
+
+        for parsed in parse_debug_logs(debug_logs):
+            key = _dedup_key(parsed)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            yield from _events_for_parsed(
+                parsed=parsed,
+                manifest=manifest,
+                translator=translator,
+                context=context,
+                partition_key=partition_key,
+                run_url=run.url,
+            )
+
+            if parsed.kind.is_failure:
+                saw_failure = True
+                if fail_fast:
+                    logger.warning(
+                        f"monitor_runs (fail_fast=True): cancelling run {run_id} "
+                        f"due to failure in {parsed.name!r}"
+                    )
+                    try:
+                        client.cancel_run(run_id)
+                    except Exception as e:
+                        logger.warning(f"cancel_run failed for {run_id}: {e}")
+                    raise Failure(
+                        description=(
+                            f"dbt Cloud run {run_id} cancelled by monitor_runs "
+                            f"after {parsed.name!r} {parsed.kind.name}."
+                        ),
+                        metadata={
+                            "dbt_cloud_run_id": MetadataValue.int(run_id),
+                            "failed_name": MetadataValue.text(parsed.name),
+                            "failure_kind": MetadataValue.text(parsed.kind.name),
+                        },
+                    )
+
+        if run.status in terminal:
+            break
+        time.sleep(poll_interval)
+
+    if run.status != DbtCloudJobRunStatusType.SUCCESS or saw_failure:
+        raise Failure(
+            description=(
+                f"dbt Cloud run {run_id} finished with status "
+                f"{run.status.name if run.status else 'UNKNOWN'}."
+            ),
+            metadata={
+                "dbt_cloud_run_id": MetadataValue.int(run_id),
+                "dbt_cloud_status": MetadataValue.text(
+                    run.status.name if run.status else "UNKNOWN"
+                ),
+                **({"run_url": MetadataValue.url(run.url)} if run.url else {}),
+            },
+        )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_component.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_component.py
@@ -1139,6 +1139,71 @@ def test_dbt_cloud_component_sensor_included_by_default(
     assert isinstance(sensors[0], SensorDefinition)
 
 
+def test_dbt_cloud_component_monitor_runs_defaults_off(mock_workspace):
+    """`monitor_runs` defaults to `False`, and `fail_fast` / `poll_interval` carry
+    sensible defaults. Backward compat: existing users get the same wait-for-completion
+    behavior as before Feature 6.5.
+    """
+    component = DbtCloudComponent(workspace=mock_workspace)
+    assert component.monitor_runs is False
+    assert component.fail_fast is False
+    assert component.poll_interval == 5
+
+
+def test_dbt_cloud_component_monitor_runs_from_yaml():
+    """`monitor_runs`, `fail_fast`, `poll_interval` are settable via YAML —
+    the primary UX for opting into mid-run monitoring.
+    """
+    body = {
+        **BASIC_DBT_CLOUD_COMPONENT_BODY,
+        "attributes": {
+            **BASIC_DBT_CLOUD_COMPONENT_BODY["attributes"],
+            "monitor_runs": True,
+            "fail_fast": True,
+            "poll_interval": 3,
+        },
+    }
+    with create_defs_folder_sandbox() as sandbox:
+        defs_path = sandbox.scaffold_component(
+            component_cls=DbtCloudComponent,
+            defs_yaml_contents=body,
+        )
+        with (
+            scoped_definitions_load_context(),
+            sandbox.load_component_and_build_defs(defs_path=defs_path) as (component, _defs),
+        ):
+            assert isinstance(component, DbtCloudComponent)
+            assert component.monitor_runs is True
+            assert component.fail_fast is True
+            assert component.poll_interval == 3
+
+
+def test_dbt_cloud_component_execute_forwards_monitor_flags(mock_workspace):
+    """`execute()` must forward `monitor_runs`/`fail_fast`/`poll_interval` to
+    `invocation.wait()` — otherwise the fields are declarative decor with no
+    runtime effect. Verified by capturing the call args on the mocked invocation.
+    """
+    component = DbtCloudComponent(
+        workspace=mock_workspace,
+        cli_args=["build"],
+        monitor_runs=True,
+        fail_fast=True,
+        poll_interval=2,
+    )
+    context = MagicMock()
+    context.has_partition_key = False
+    context.has_partition_key_range = False
+
+    dummy_resolution_context = ResolutionContext.default()
+    with _set_resolution_context(dummy_resolution_context):
+        list(component.execute(context))
+
+    wait_kwargs = mock_workspace.cli.return_value.wait.call_args.kwargs
+    assert wait_kwargs["monitor_runs"] is True
+    assert wait_kwargs["fail_fast"] is True
+    assert wait_kwargs["poll_interval"] == 2
+
+
 def test_dbt_cloud_component_from_yaml_with_sensor(mock_workspace_data):
     """Test that create_sensor can be set via YAML configuration."""
     body = {

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_monitor.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_monitor.py
@@ -1,0 +1,456 @@
+"""Tests for the mid-run debug-log parser used by monitor_runs.
+
+The parser turns dbt Cloud's stringly-typed progress logs into typed events.
+These tests pin the regex to real-looking dbt output so schema changes on the
+dbt or adapter side surface as regressions here (rather than silently producing
+zero events at runtime).
+"""
+
+from dagster_dbt.cloud_v2.run_monitor import (
+    ParsedLogKind,
+    _short_name,
+    collect_step_debug_logs,
+    parse_debug_logs,
+    strip_ansi,
+)
+
+
+def test_strip_ansi_removes_color_codes():
+    """Dbt Cloud debug logs come colorized; the parser needs to see clean text
+    or regex anchors don't fire.
+    """
+    text = "\x1b[32m1 of 4 OK created sql table model dev.stg_customers\x1b[0m .........."
+    assert "\x1b" not in strip_ansi(text)
+    assert "1 of 4 OK" in strip_ansi(text)
+
+
+def test_short_name_pulls_last_dotted_segment():
+    """Dbt logs schema-qualified names (``DEV.STG_CUSTOMERS``) but Dagster keys off
+    the model name only. Extract the last segment so downstream unique_id lookup
+    works.
+    """
+    assert _short_name("DEV.STG_CUSTOMERS") == "STG_CUSTOMERS"
+    assert _short_name("analytics.dev.stg_orders") == "stg_orders"
+    assert _short_name("bare_name") == "bare_name"
+
+
+def test_parse_debug_logs_model_ok():
+    """A successful model line produces one MODEL_OK event with the short name."""
+    log = "1 of 4 OK created sql table model DEV.STG_CUSTOMERS .......... [SUCCESS 1 in 0.10s]"
+    results = list(parse_debug_logs(log))
+    assert len(results) == 1
+    assert results[0].kind == ParsedLogKind.MODEL_OK
+    assert results[0].name == "STG_CUSTOMERS"
+
+
+def test_parse_debug_logs_model_error():
+    """A failed model line produces a MODEL_ERROR event. This is what drives
+    `fail_fast` cancellation and downstream alerts.
+    """
+    log = "2 of 4 ERROR creating sql view model dev.stg_orders ........... [ERROR in 0.11s]"
+    results = list(parse_debug_logs(log))
+    assert len(results) == 1
+    assert results[0].kind == ParsedLogKind.MODEL_ERROR
+    assert results[0].name == "stg_orders"
+    assert results[0].kind.is_failure
+
+
+def test_parse_debug_logs_model_skip():
+    """Skipped models (upstream failed) produce a MODEL_SKIP event — not a failure,
+    but also not a materialization. We surface it so users can see what didn't run.
+    """
+    log = "3 of 4 SKIP relation dev.stg_products ......................... [SKIP]"
+    results = list(parse_debug_logs(log))
+    assert len(results) == 1
+    assert results[0].kind == ParsedLogKind.MODEL_SKIP
+    assert not results[0].kind.is_failure
+
+
+def test_parse_debug_logs_test_pass_and_fail():
+    """Tests emit PASS/FAIL/WARN events; asset checks are keyed off these."""
+    log = (
+        "1 of 4 PASS not_null_customers_id ............................ [PASS in 0.10s]\n"
+        "2 of 4 FAIL not_null_orders_id ................................ [FAIL 1 in 0.11s]\n"
+        "3 of 4 WARN unique_customers_email ............................ [WARN 1 in 0.10s]\n"
+    )
+    results = list(parse_debug_logs(log))
+    kinds = [r.kind for r in results]
+    assert kinds == [ParsedLogKind.TEST_PASS, ParsedLogKind.TEST_FAIL, ParsedLogKind.TEST_WARN]
+    assert results[1].kind.is_failure
+    assert not results[2].kind.is_failure  # WARN is not a hard failure — matches dbt
+
+
+def test_parse_debug_logs_ignores_non_terminal_lines():
+    """START lines and pre-status output are informational, not terminal. Parsing
+    them would produce duplicate materializations, so we skip everything except
+    the terminal status words.
+    """
+    log = (
+        "1 of 4 START sql view model dev.stg_customers ... [RUN]\n"
+        "Concurrency: 4 threads (target='dev')\n"
+        "Finished running 4 view models\n"
+    )
+    assert list(parse_debug_logs(log)) == []
+
+
+def test_parse_debug_logs_ansi_colored_input():
+    """Full end-to-end: ANSI-colored input still parses correctly. dbt Cloud
+    debug logs always come colorized so this is the common case.
+    """
+    log = (
+        "\x1b[32m1 of 2 OK created sql table model dev.customers\x1b[0m .......... "
+        "[SUCCESS 1 in 0.10s]\n"
+        "\x1b[31m2 of 2 ERROR creating sql view model dev.orders\x1b[0m ........... "
+        "[ERROR in 0.11s]"
+    )
+    results = list(parse_debug_logs(log))
+    assert [r.kind for r in results] == [ParsedLogKind.MODEL_OK, ParsedLogKind.MODEL_ERROR]
+    assert [r.name for r in results] == ["customers", "orders"]
+
+
+def test_parse_debug_logs_multiple_lines_all_matched():
+    """When logs contain multiple terminal events, all are emitted in order."""
+    log = (
+        "1 of 3 OK created sql table model dev.a .......... [SUCCESS 1 in 0.10s]\n"
+        "2 of 3 OK created sql table model dev.b .......... [SUCCESS 1 in 0.10s]\n"
+        "3 of 3 OK created sql table model dev.c .......... [SUCCESS 1 in 0.10s]"
+    )
+    results = list(parse_debug_logs(log))
+    assert [r.name for r in results] == ["a", "b", "c"]
+
+
+def test_parse_debug_logs_deduplication_is_callers_responsibility():
+    """The parser does NOT dedupe — it emits every match in order. Callers polling
+    an incrementally-growing log MUST dedupe by ``(kind_category, name)`` themselves,
+    because a single parser call has no state across polls.
+    """
+    log = (
+        "1 of 2 OK created sql table model dev.a .......... [SUCCESS 1 in 0.10s]\n"
+        "1 of 2 OK created sql table model dev.a .......... [SUCCESS 1 in 0.10s]"  # dup
+    )
+    results = list(parse_debug_logs(log))
+    assert len(results) == 2  # both are emitted; caller must dedupe
+
+
+def test_collect_step_debug_logs_concatenates_across_steps():
+    """A dbt Cloud run has multiple `run_steps` (one per CLI invocation, e.g. `dbt run`
+    then `dbt test`). The monitor loop needs the concatenation so a single parse pass
+    sees the whole run's progress.
+    """
+    run_details = {
+        "run_steps": [
+            {"id": 1, "debug_logs": "step1-line1\nstep1-line2"},
+            {"id": 2, "debug_logs": "step2-line1"},
+            {"id": 3, "debug_logs": None},  # step not yet started
+        ],
+    }
+    result = collect_step_debug_logs(run_details)
+    assert "step1-line1" in result
+    assert "step1-line2" in result
+    assert "step2-line1" in result
+
+
+def test_collect_step_debug_logs_empty_run_steps():
+    """A run with no steps yet (still queued) returns empty string — safe to pass
+    to the parser (which yields no results).
+    """
+    assert collect_step_debug_logs({}) == ""
+    assert collect_step_debug_logs({"run_steps": []}) == ""
+    assert collect_step_debug_logs({"run_steps": None}) == ""
+
+
+# ============================================================================
+# monitor_run_iter integration tests (poll -> parse -> emit)
+# ============================================================================
+
+from unittest.mock import MagicMock
+
+import dagster as dg
+import pytest
+from dagster_dbt.cloud_v2.run_monitor import (
+    find_model_unique_id_by_name,
+    find_test_unique_id_by_name,
+    monitor_run_iter,
+)
+from dagster_dbt.cloud_v2.types import DbtCloudJobRunStatusType
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+
+
+def _manifest_with_models(model_names: list[str], test_names: list[str] | None = None) -> dict:
+    """Build a minimal dbt manifest with the given model + test unique_ids."""
+    nodes = {}
+    for name in model_names:
+        uid = f"model.pkg.{name}"
+        nodes[uid] = {
+            "resource_type": "model",
+            "package_name": "pkg",
+            "path": f"{name}.sql",
+            "original_file_path": f"models/{name}.sql",
+            "unique_id": uid,
+            "fqn": ["pkg", name],
+            "name": name,
+            "config": {"enabled": True, "materialized": "table"},
+            "tags": [],
+            "depends_on": {"nodes": []},
+            "description": "",
+        }
+    for name in test_names or []:
+        uid = f"test.pkg.{name}"
+        nodes[uid] = {
+            "resource_type": "test",
+            "package_name": "pkg",
+            "path": f"tests/{name}.sql",
+            "original_file_path": f"tests/{name}.sql",
+            "unique_id": uid,
+            "fqn": ["pkg", name],
+            "name": name,
+            "config": {"enabled": True, "materialized": "test"},
+            "tags": [],
+            "depends_on": {"nodes": [f"model.pkg.{model_names[0]}"]}
+            if model_names
+            else {"nodes": []},
+            "description": "",
+            "attached_node": f"model.pkg.{model_names[0]}" if model_names else None,
+        }
+    return {
+        "metadata": {"dbt_schema_version": "1.0.0", "adapter_type": "postgres"},
+        "nodes": nodes,
+        "sources": {},
+        "metrics": {},
+        "semantic_models": {},
+        "exposures": {},
+        "child_map": {uid: [] for uid in nodes},
+        "parent_map": {uid: [] for uid in nodes},
+        "selectors": {},
+    }
+
+
+def test_find_model_unique_id_by_name_case_insensitive():
+    """Snowflake logs uppercase names; manifests store the source-file case. The
+    lookup must not care about case, otherwise Snowflake users get zero matches.
+    """
+    manifest = _manifest_with_models(["stg_customers", "stg_orders"])
+    assert find_model_unique_id_by_name(manifest, "STG_CUSTOMERS") == "model.pkg.stg_customers"
+    assert find_model_unique_id_by_name(manifest, "stg_orders") == "model.pkg.stg_orders"
+    assert find_model_unique_id_by_name(manifest, "not_a_model") is None
+
+
+def test_find_test_unique_id_by_name_case_insensitive():
+    """Same case-insensitivity for tests."""
+    manifest = _manifest_with_models(["customers"], test_names=["not_null_customers_id"])
+    assert (
+        find_test_unique_id_by_name(manifest, "NOT_NULL_CUSTOMERS_ID")
+        == "test.pkg.not_null_customers_id"
+    )
+
+
+def _mock_client_with_run(final_status: int, logs_stream: list[str]):
+    """Build a mock dbt Cloud client that returns pre-canned run details across
+    successive `get_run_details` calls. Each call returns the next log snapshot
+    from `logs_stream`; the last snapshot is paired with `final_status`.
+    """
+    client = MagicMock()
+    responses = []
+    for i, snapshot in enumerate(logs_stream):
+        is_last = i == len(logs_stream) - 1
+        status = final_status if is_last else DbtCloudJobRunStatusType.RUNNING.value
+        responses.append(
+            {
+                "id": 1,
+                "status": status,
+                "href": f"https://cloud.getdbt.com/runs/1?snapshot={i}",
+                "run_steps": [{"id": 100 + i, "debug_logs": snapshot}],
+            }
+        )
+    client.get_run_details.side_effect = responses
+    client.cancel_run.return_value = {}
+    return client
+
+
+def test_monitor_run_iter_emits_materialization_per_model_ok():
+    """A run with one MODEL_OK per poll yields one AssetMaterialization per model.
+    Dedup ensures repeated log lines across polls don't emit duplicates.
+    """
+    logs = [
+        "1 of 2 OK created sql table model dev.stg_customers .......... [SUCCESS 1 in 0.10s]",
+        (
+            "1 of 2 OK created sql table model dev.stg_customers .......... [SUCCESS 1 in 0.10s]\n"
+            "2 of 2 OK created sql table model dev.stg_orders .......... [SUCCESS 1 in 0.10s]"
+        ),
+    ]
+    manifest = _manifest_with_models(["stg_customers", "stg_orders"])
+    client = _mock_client_with_run(
+        final_status=DbtCloudJobRunStatusType.SUCCESS.value, logs_stream=logs
+    )
+
+    events = list(
+        monitor_run_iter(
+            run_id=1,
+            client=client,
+            manifest=manifest,
+            translator=DagsterDbtTranslator(),
+            context=None,
+            fail_fast=False,
+            poll_interval=0,  # no sleep in tests
+        )
+    )
+    mats = [e for e in events if isinstance(e, dg.AssetMaterialization)]
+    assert len(mats) == 2  # deduplication: each model materialized once
+    names = {mat.asset_key.to_user_string() for mat in mats}
+    assert names == {"stg_customers", "stg_orders"}
+
+
+def test_monitor_run_iter_raises_failure_on_terminal_error():
+    """When the Cloud run ends with ERROR status, the iterator yields partial
+    materializations then raises `Failure` — matches OOTB semantics.
+    """
+    logs = [
+        (
+            "1 of 2 OK created sql table model dev.stg_customers .......... [SUCCESS 1 in 0.10s]\n"
+            "2 of 2 ERROR creating sql view model dev.stg_orders ........... [ERROR in 0.11s]"
+        ),
+    ]
+    manifest = _manifest_with_models(["stg_customers", "stg_orders"])
+    client = _mock_client_with_run(
+        final_status=DbtCloudJobRunStatusType.ERROR.value, logs_stream=logs
+    )
+
+    events = []
+    with pytest.raises(dg.Failure) as excinfo:
+        for e in monitor_run_iter(
+            run_id=1,
+            client=client,
+            manifest=manifest,
+            translator=DagsterDbtTranslator(),
+            context=None,
+            fail_fast=False,
+            poll_interval=0,
+        ):
+            events.append(e)
+    # Partial: the OK model was materialized before the raise.
+    mats = [e for e in events if isinstance(e, dg.AssetMaterialization)]
+    assert [mat.asset_key.to_user_string() for mat in mats] == ["stg_customers"]
+    assert "ERROR" in str(excinfo.value) or "error" in str(excinfo.value).lower()
+
+
+def test_monitor_run_iter_fail_fast_cancels_on_first_error():
+    """`fail_fast=True`: on the first MODEL_ERROR seen mid-run, cancel the Cloud
+    run and raise immediately — even though the run itself may still be RUNNING.
+    """
+    logs = [
+        (
+            "1 of 2 OK created sql table model dev.stg_customers .......... [SUCCESS 1 in 0.10s]\n"
+            "2 of 2 ERROR creating sql view model dev.stg_orders ........... [ERROR in 0.11s]"
+        ),
+        # This second snapshot never gets consumed because we cancel first.
+        "should not be reached",
+    ]
+    manifest = _manifest_with_models(["stg_customers", "stg_orders"])
+    client = _mock_client_with_run(
+        # Even though we set SUCCESS as terminal, fail_fast should cancel BEFORE reaching it.
+        final_status=DbtCloudJobRunStatusType.SUCCESS.value,
+        logs_stream=logs,
+    )
+
+    events = []
+    with pytest.raises(dg.Failure):
+        for e in monitor_run_iter(
+            run_id=1,
+            client=client,
+            manifest=manifest,
+            translator=DagsterDbtTranslator(),
+            context=None,
+            fail_fast=True,
+            poll_interval=0,
+        ):
+            events.append(e)
+    # First model was materialized, then cancel was triggered.
+    mats = [e for e in events if isinstance(e, dg.AssetMaterialization)]
+    assert [mat.asset_key.to_user_string() for mat in mats] == ["stg_customers"]
+    client.cancel_run.assert_called_once_with(1)
+
+
+def test_monitor_run_iter_skips_unknown_model_names():
+    """A dbt log line naming a model NOT in the manifest is skipped silently (with
+    a warning). Otherwise a stale-manifest run would crash the whole invocation.
+    """
+    logs = [
+        (
+            "1 of 2 OK created sql table model dev.stg_customers .......... [SUCCESS 1 in 0.10s]\n"
+            "2 of 2 OK created sql table model dev.completely_unknown .......... [SUCCESS 1 in 0.10s]"
+        ),
+    ]
+    manifest = _manifest_with_models(["stg_customers"])  # unknown model is NOT here
+    client = _mock_client_with_run(
+        final_status=DbtCloudJobRunStatusType.SUCCESS.value, logs_stream=logs
+    )
+    events = list(
+        monitor_run_iter(
+            run_id=1,
+            client=client,
+            manifest=manifest,
+            translator=DagsterDbtTranslator(),
+            context=None,
+            fail_fast=False,
+            poll_interval=0,
+        )
+    )
+    mats = [e for e in events if isinstance(e, dg.AssetMaterialization)]
+    assert [mat.asset_key.to_user_string() for mat in mats] == ["stg_customers"]
+
+
+def test_monitor_run_iter_polls_until_terminal_status():
+    """The iterator keeps polling until the run reaches SUCCESS/ERROR/CANCELLED —
+    it doesn't stop just because the log stopped growing.
+    """
+    logs = [
+        "",  # first poll: no logs yet (run STARTING)
+        "1 of 1 OK created sql table model dev.stg_customers .......... [SUCCESS 1 in 0.10s]",
+    ]
+    manifest = _manifest_with_models(["stg_customers"])
+    client = _mock_client_with_run(
+        final_status=DbtCloudJobRunStatusType.SUCCESS.value, logs_stream=logs
+    )
+    events = list(
+        monitor_run_iter(
+            run_id=1,
+            client=client,
+            manifest=manifest,
+            translator=DagsterDbtTranslator(),
+            context=None,
+            fail_fast=False,
+            poll_interval=0,
+        )
+    )
+    # Two get_run_details calls (empty snapshot + final), one materialization.
+    assert client.get_run_details.call_count == 2
+    mats = [e for e in events if isinstance(e, dg.AssetMaterialization)]
+    assert len(mats) == 1
+
+
+def test_monitor_run_iter_emits_asset_check_evaluation_for_tests():
+    """Test PASS lines emit AssetCheckEvaluation when there's no asset def in the
+    context (ad hoc usage) — same shape as OOTB run-results-based emission.
+    """
+    logs = [
+        "1 of 1 PASS not_null_customers_id ............................ [PASS in 0.10s]",
+    ]
+    manifest = _manifest_with_models(["customers"], test_names=["not_null_customers_id"])
+    client = _mock_client_with_run(
+        final_status=DbtCloudJobRunStatusType.SUCCESS.value, logs_stream=logs
+    )
+    events = list(
+        monitor_run_iter(
+            run_id=1,
+            client=client,
+            manifest=manifest,
+            translator=DagsterDbtTranslator(),
+            context=None,
+            fail_fast=False,
+            poll_interval=0,
+        )
+    )
+    checks = [e for e in events if isinstance(e, dg.AssetCheckEvaluation)]
+    assert len(checks) == 1
+    assert checks[0].passed
+    assert checks[0].check_name == "not_null_customers_id"


### PR DESCRIPTION
## Summary & Motivation

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
