### PR TITLE
Retry ECS tasks when container agents disconnect

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/utils.py
@@ -61,7 +61,9 @@ def run_ecs_task(ecs, run_task_kwargs) -> Mapping[str, Any]:
 
         failure_message = "\n".join(failure_messages) if failure_messages else "Task failed."
 
-        if "Capacity is unavailable at this time" in failure_message:
+        if any(failure.get("reason") == "AGENT" for failure in failures) or (
+            "Capacity is unavailable at this time" in failure_message
+        ):
             raise RetryableEcsException(failure_message)
 
         raise Exception(failure_message)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_failures.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_failures.py
@@ -71,6 +71,34 @@ def test_run_task_retryrable_failure(ecs, instance, workspace, run, other_run, m
     assert ex.match("Capacity is unavailable")
 
 
+def test_run_task_agent_failure_is_retryable(ecs, instance, workspace, run):
+    original = ecs.run_task
+
+    retryable_failures = iter(
+        [
+            {
+                "tasks": [],
+                "failures": [
+                    {
+                        "arn": "disconnected-container-instance",
+                        "reason": "AGENT",
+                    }
+                ],
+            }
+        ]
+    )
+
+    def run_task(*args, **kwargs):
+        try:
+            return next(retryable_failures)
+        except StopIteration:
+            return original(*args, **kwargs)
+
+    instance.run_launcher.ecs.run_task = run_task
+
+    instance.launch_run(run.run_id, workspace)
+
+
 def test_run_task_throttle_failure(ecs, instance, workspace, run, other_run, monkeypatch):
     original = ecs.run_task
 


### PR DESCRIPTION
## Summary & Motivation

When ECS `RunTask` returns an `AGENT` failure, Dagster currently raises a generic exception. This bypasses the ECS launcher's existing retry and backoff handling, even though the failure can be transient while an ECS container agent reconnects.

Classify the structured `AGENT` failure reason as a `RetryableEcsException` so run and step launches use the existing retry behavior.

## Test Plan

- Added a regression test that failed before the change with `Failure reason: AGENT`.
- Verified the regression test passes after the change.
- Ran the complete ECS launcher test suite: 63 passed, 1 pre-existing skip.
- Ran repository-wide Ruff checks.
- Ran diff-scoped `ty`: 0 errors and 0 warnings.
- Completed the development installation and OSS UI production build.

## Changelog

`dagster-aws`: ECS task launches now retry when ECS reports an `AGENT` failure.
