### PR TITLE
docs: add dbt example environment template

### DIFF
--- a/examples/docs_projects/project_dbt/.env.example
+++ b/examples/docs_projects/project_dbt/.env.example
@@ -1,1 +1,1 @@
-DUCKDB_DATABASE=data/project_dbt.duckdb
+DUCKDB_DATABASE=/var/tmp/duckdb.db

--- a/examples/docs_projects/project_dbt/.env.example
+++ b/examples/docs_projects/project_dbt/.env.example
@@ -1,0 +1,1 @@
+DUCKDB_DATABASE=data/project_dbt.duckdb


### PR DESCRIPTION
## Summary
- add the missing `.env.example` referenced by the dbt full-pipeline guide
- configure `DUCKDB_DATABASE` with the same `/var/tmp/duckdb.db` path documented by the guide and used as the dbt profile fallback

## Validation
- verified the dotenv entry loads to `/var/tmp/duckdb.db`
- confirmed the value matches `profiles.yml` and the dbt project guide
- ran `git diff --check`

Closes #33415