### PR TITLE
fix(dbt): produce column lineage for dbt snapshots

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import InitVar, dataclass
@@ -44,6 +46,10 @@ logger = get_dagster_logger()
 # may be used to indicate an empty value in a log message
 _EMPTY_VALUES = {"", "None", None}
 
+# Compiled SQL by unique id for the most recently read invocation manifest, alongside a digest of the
+# manifest contents it was parsed from. See `_get_compiled_code_by_unique_id`.
+_compiled_code_cache: tuple[str, Mapping[str, str]] | None = None
+
 
 class EventHistoryMetadata(NamedTuple):
     columns: dict[str, dict[str, Any]]
@@ -57,6 +63,82 @@ class CheckProperties(TypedDict):
     check_name: str
     severity: AssetCheckSeverity
     metadata: Mapping[str, Any]
+
+
+def _get_compiled_code_by_unique_id(manifest_path: Path) -> Mapping[str, str]:
+    """Compiled SQL by unique id, read from a manifest that a dbt invocation wrote to disk.
+
+    The parsed mapping is cached so that the manifest is parsed once rather than once per node, keyed
+    on a digest of the manifest's contents. Content is the key rather than the file's mtime and size,
+    because those do not identify content: invocations that pin `target_path` write the same path
+    more than once, and a rewrite that keeps the file the same size is indistinguishable by `stat` on
+    a filesystem whose timestamp granularity is coarser than the gap between the two writes.
+
+    The file is read exactly once, and both the digest and the parsed mapping are derived from those
+    same bytes. Reading it twice — once to digest, once to parse — would leave a window in which a
+    rewrite could cache the new manifest's SQL under the previous manifest's digest, so any later
+    invocation whose manifest hashed to that digest would be served the wrong SQL.
+
+    Only one manifest is retained, since a given invocation reads a single one. Concurrent callers
+    may each parse before either stores its result, which is harmless: every entry is consistent with
+    its own key, and rebinding the cache is atomic.
+    """
+    global _compiled_code_cache  # noqa: PLW0603
+
+    manifest_bytes = manifest_path.read_bytes()
+    manifest_digest = hashlib.sha256(manifest_bytes).hexdigest()
+
+    cached_entry = _compiled_code_cache
+    if cached_entry and cached_entry[0] == manifest_digest:
+        return cached_entry[1]
+
+    manifest = json.loads(manifest_bytes)
+    compiled_code_by_unique_id = {
+        unique_id: dbt_resource_props["compiled_code"]
+        for unique_id, dbt_resource_props in manifest.get("nodes", {}).items()
+        if dbt_resource_props.get("compiled_code")
+    }
+    _compiled_code_cache = (manifest_digest, compiled_code_by_unique_id)
+
+    return compiled_code_by_unique_id
+
+
+def _get_compiled_sql(dbt_resource_props: Mapping[str, Any], target_path: Path) -> str | None:
+    """Resolve the compiled SQL for a dbt node, or None if it cannot be found.
+
+    dbt writes compiled SQL to `target/compiled/` for most node types, but intentionally skips
+    snapshots and seeds (see `Compiler._write_node`). For a snapshot, the compiled query is only
+    recorded as `compiled_code` in the manifest. The `target/run/` file exists, but it wraps the
+    query in materialization DDL (`create table ... as ...`, or a `merge` on subsequent runs),
+    which is not a query sqlglot can trace column lineage through.
+
+    Sources are consulted in order of how faithfully they describe the SQL that this invocation
+    actually ran. The `target/compiled/` file and the manifest under `target_path` are both written
+    by this invocation, so they reflect its project state, vars and target. The manifest that
+    Dagster is configured with is only a last resort: it is usually parse-only, since `dbt parse`
+    does not compile and leaves `compiled_code` null, and when it does carry compiled code that
+    code may predate the invocation. Note that dbt writes the invocation manifest once the
+    invocation finishes, so it is not yet available for a node whose metadata is fetched while dbt
+    is still running.
+    """
+    node_sql_path = target_path.joinpath(
+        "compiled",
+        dbt_resource_props["package_name"],
+        dbt_resource_props["original_file_path"].replace("\\", "/"),
+    )
+    if node_sql_path.exists():
+        return node_sql_path.read_text()
+
+    manifest_path = target_path.joinpath("manifest.json")
+    if manifest_path.exists():
+        compiled_code = _get_compiled_code_by_unique_id(manifest_path).get(
+            dbt_resource_props["unique_id"]
+        )
+
+        if compiled_code:
+            return compiled_code
+
+    return dbt_resource_props.get("compiled_code")
 
 
 def _build_column_lineage_metadata(
@@ -120,16 +202,20 @@ def _build_column_lineage_metadata(
             dialect=sql_dialect,
         )
 
-    package_name = dbt_resource_props["package_name"]
-    node_sql_path = target_path.joinpath(
-        "compiled",
-        package_name,
-        dbt_resource_props["original_file_path"].replace("\\", "/"),
-    )
+    node_sql = _get_compiled_sql(dbt_resource_props, target_path)
+    if not node_sql:
+        logger.warning(
+            "Compiled SQL could not be found for the dbt resource"
+            f" `{dbt_resource_props['original_file_path']}`."
+            " Column lineage metadata will not be included in the event."
+        )
+
+        return {}
+
     optimized_node_ast = cast(
         "exp.Query",
         optimize(
-            parse_one(sql=node_sql_path.read_text(), dialect=sql_dialect),
+            parse_one(sql=node_sql, dialect=sql_dialect),
             schema=sqlglot_mapping_schema,
             dialect=sql_dialect,
         ),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -17,6 +17,7 @@ from dagster_dbt_tests.dbt_projects import (
     test_dbt_model_versions_path,
     test_dbt_python_interleaving_path,
     test_dbt_semantic_models_path,
+    test_dbt_snapshot_column_lineage_path,
     test_dbt_source_freshness_path,
     test_dbt_unit_tests_path,
     test_dependencies_path,
@@ -140,6 +141,13 @@ def test_dbt_semantic_models_manifest_fixture() -> dict[str, Any]:
     return _create_dbt_invocation(test_dbt_semantic_models_path, build_project=True).get_artifact(
         "manifest.json"
     )
+
+
+@pytest.fixture(name="test_dbt_snapshot_column_lineage_manifest", scope="session")
+def test_dbt_snapshot_column_lineage_manifest_fixture() -> dict[str, Any]:
+    return _create_dbt_invocation(
+        test_dbt_snapshot_column_lineage_path, build_project=True
+    ).get_artifact("manifest.json")
 
 
 @pytest.fixture(name="test_dbt_source_freshness_manifest", scope="session")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -1,9 +1,11 @@
+import hashlib
 import json
 import os
 import shutil
 import subprocess
 from collections.abc import Mapping
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -17,11 +19,14 @@ from dagster import (
     TableColumnDep,
     TableColumnLineage,
     TableSchema,
+    _check as check,
     materialize,
 )
 from dagster._core.definitions.metadata import TableMetadataSet
 from dagster._core.definitions.metadata.table import TableColumnConstraints
 from dagster_dbt.asset_decorator import dbt_assets
+from dagster_dbt.core import dbt_cli_event
+from dagster_dbt.core.dbt_cli_event import _get_compiled_sql
 from dagster_dbt.core.resource import DbtCliResource
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 from dagster_dbt.dbt_project import DbtProject
@@ -30,6 +35,7 @@ from sqlglot import Dialect
 
 from dagster_dbt_tests.conftest import _create_dbt_invocation
 from dagster_dbt_tests.dbt_projects import (
+    test_dbt_snapshot_column_lineage_path,
     test_dependencies_path,
     test_jaffle_shop_path,
     test_metadata_path,
@@ -939,3 +945,275 @@ def test_column_lineage_dependencies(
     assert column_lineage_by_asset_key == expected_column_lineage_by_asset_key, (
         str(column_lineage_by_asset_key) + "\n\n" + str(expected_column_lineage_by_asset_key)
     )
+
+
+def test_get_compiled_sql_prefers_compiled_file(tmp_path: Path) -> None:
+    dbt_resource_props = {
+        "package_name": "my_project",
+        "original_file_path": "models/my_model.sql",
+        "compiled_code": "select 'from_manifest' as col",
+    }
+    compiled_path = tmp_path / "compiled" / "my_project" / "models"
+    compiled_path.mkdir(parents=True)
+    compiled_path.joinpath("my_model.sql").write_text("select 'from_file' as col")
+
+    assert _get_compiled_sql(dbt_resource_props, tmp_path) == "select 'from_file' as col"
+
+
+def test_get_compiled_sql_falls_back_to_invocation_manifest(tmp_path: Path) -> None:
+    """Snapshots have no file under ``target/compiled/`` because dbt does not write one, so the
+    compiled code recorded in the manifest the invocation wrote must be used instead. The manifest
+    Dagster is configured with is frequently produced by ``dbt parse``, which does not compile and
+    leaves ``compiled_code`` null. See https://github.com/dagster-io/dagster/issues/34124.
+    """
+    unique_id = "snapshot.my_project.my_snapshot"
+    dbt_resource_props = {
+        "unique_id": unique_id,
+        "package_name": "my_project",
+        "original_file_path": "snapshots/my_snapshot.sql",
+        # As left by `dbt parse`.
+        "compiled_code": None,
+    }
+    tmp_path.joinpath("manifest.json").write_text(
+        json.dumps(
+            {"nodes": {unique_id: {"compiled_code": "select 'from_invocation_manifest' as col"}}}
+        )
+    )
+
+    assert (
+        _get_compiled_sql(dbt_resource_props, tmp_path)
+        == "select 'from_invocation_manifest' as col"
+    )
+
+
+def test_get_compiled_sql_prefers_invocation_manifest_over_configured_manifest(
+    tmp_path: Path,
+) -> None:
+    """The manifest Dagster is configured with may carry compiled code that predates the invocation,
+    e.g. when the run changes the compiled SQL through project edits, vars, target or state. Lineage
+    must describe the SQL the invocation actually ran, so the invocation's own manifest wins.
+    """
+    unique_id = "snapshot.my_project.my_snapshot"
+    dbt_resource_props = {
+        "unique_id": unique_id,
+        "package_name": "my_project",
+        "original_file_path": "snapshots/my_snapshot.sql",
+        "compiled_code": "select 'stale_configured_manifest' as col",
+    }
+    tmp_path.joinpath("manifest.json").write_text(
+        json.dumps(
+            {"nodes": {unique_id: {"compiled_code": "select 'from_invocation_manifest' as col"}}}
+        )
+    )
+
+    assert (
+        _get_compiled_sql(dbt_resource_props, tmp_path)
+        == "select 'from_invocation_manifest' as col"
+    )
+
+
+def test_get_compiled_sql_rereads_rewritten_invocation_manifest(tmp_path: Path) -> None:
+    """The invocation manifest is cached so that it is parsed once rather than once per node, but
+    invocations that pin ``target_path`` write the same path more than once. A rewrite must not be
+    served from the cache, or the second run emits the first run's lineage.
+
+    The rewrite here is made deliberately indistinguishable by ``stat``: the same file size, and the
+    same mtime down to the nanosecond. That is what a same-size rewrite looks like on a filesystem
+    whose timestamp granularity is coarser than the gap between the two writes, so the cache cannot
+    treat mtime and size as an identity for the file's contents.
+    """
+    unique_id = "snapshot.my_project.my_snapshot"
+    dbt_resource_props = {
+        "unique_id": unique_id,
+        "package_name": "my_project",
+        "original_file_path": "snapshots/my_snapshot.sql",
+        "compiled_code": None,
+    }
+    manifest_path = tmp_path / "manifest.json"
+
+    def write_manifest(compiled_code: str) -> None:
+        manifest_path.write_text(
+            json.dumps({"nodes": {unique_id: {"compiled_code": compiled_code}}})
+        )
+
+    write_manifest("select 'first_invocation' as col")
+    original_stat = manifest_path.stat()
+    assert _get_compiled_sql(dbt_resource_props, tmp_path) == "select 'first_invocation' as col"
+
+    # The cached entry is keyed on a digest of the bytes it was parsed from.
+    cached_digest, _ = check.not_none(dbt_cli_event._compiled_code_cache)  # noqa: SLF001
+    assert cached_digest == hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+    # Same length as the first manifest, restored to the same mtime, so neither is distinguishable
+    # from the other by `stat`.
+    write_manifest("select 'third_invocation' as col")
+    os.utime(manifest_path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+    rewritten_stat = manifest_path.stat()
+    assert (rewritten_stat.st_size, rewritten_stat.st_mtime_ns) == (
+        original_stat.st_size,
+        original_stat.st_mtime_ns,
+    )
+
+    assert _get_compiled_sql(dbt_resource_props, tmp_path) == "select 'third_invocation' as col"
+
+
+def test_get_compiled_sql_reuses_cached_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unchanged manifest is parsed once rather than once per node. Proven by making a second
+    parse impossible: with the manifest untouched, the cached mapping must be returned without
+    ``json`` being consulted again.
+    """
+    unique_id = "snapshot.my_project.my_snapshot"
+    dbt_resource_props = {
+        "unique_id": unique_id,
+        "package_name": "my_project",
+        "original_file_path": "snapshots/my_snapshot.sql",
+        "compiled_code": None,
+    }
+    tmp_path.joinpath("manifest.json").write_text(
+        json.dumps({"nodes": {unique_id: {"compiled_code": "select 'parsed_once' as col"}}})
+    )
+
+    assert _get_compiled_sql(dbt_resource_props, tmp_path) == "select 'parsed_once' as col"
+
+    def fail_if_parsed(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("manifest was parsed again instead of being served from the cache")
+
+    # Patched on the module rather than on `json` itself, so nothing else in the process is affected.
+    monkeypatch.setattr(dbt_cli_event, "json", SimpleNamespace(loads=fail_if_parsed))
+
+    assert _get_compiled_sql(dbt_resource_props, tmp_path) == "select 'parsed_once' as col"
+
+
+def test_get_compiled_sql_parses_the_bytes_it_digested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cache key and the parsed mapping must come from a single read of the manifest.
+
+    If the digest were computed from one read and the mapping parsed from another, a rewrite landing
+    between them would cache the replacement manifest's SQL under the previous manifest's digest, and
+    any later invocation whose manifest hashed to that digest would be served the wrong SQL. Simulated
+    by rewriting the file from inside the digest call, which is the point between the two reads.
+    """
+    unique_id = "snapshot.my_project.my_snapshot"
+    dbt_resource_props = {
+        "unique_id": unique_id,
+        "package_name": "my_project",
+        "original_file_path": "snapshots/my_snapshot.sql",
+        "compiled_code": None,
+    }
+    manifest_path = tmp_path / "manifest.json"
+
+    def write_manifest(compiled_code: str) -> None:
+        manifest_path.write_text(
+            json.dumps({"nodes": {unique_id: {"compiled_code": compiled_code}}})
+        )
+
+    write_manifest("select 'digested_manifest' as col")
+    digested_bytes = manifest_path.read_bytes()
+
+    sha256 = hashlib.sha256
+
+    def rewrite_manifest_then_digest(*args: Any, **kwargs: Any) -> "hashlib._Hash":
+        write_manifest("select 'rewritten_manifest' as col")
+        return sha256(*args, **kwargs)
+
+    monkeypatch.setattr(
+        dbt_cli_event, "hashlib", SimpleNamespace(sha256=rewrite_manifest_then_digest)
+    )
+
+    # The bytes that were digested are the bytes that get parsed, even though the file on disk has
+    # since been replaced.
+    assert _get_compiled_sql(dbt_resource_props, tmp_path) == "select 'digested_manifest' as col"
+
+    # And the entry is stored under the digest of those same bytes, so it cannot be served for the
+    # manifest now on disk.
+    cached_digest, _ = check.not_none(dbt_cli_event._compiled_code_cache)  # noqa: SLF001
+    assert cached_digest == sha256(digested_bytes).hexdigest()
+
+
+def test_get_compiled_sql_falls_back_to_configured_manifest(tmp_path: Path) -> None:
+    """The invocation manifest is only written once the invocation finishes, so it may be absent
+    when a node's metadata is fetched mid-run. The configured manifest is the last resort.
+    """
+    dbt_resource_props = {
+        "unique_id": "snapshot.my_project.my_snapshot",
+        "package_name": "my_project",
+        "original_file_path": "snapshots/my_snapshot.sql",
+        "compiled_code": "select 'from_configured_manifest' as col",
+    }
+
+    assert (
+        _get_compiled_sql(dbt_resource_props, tmp_path)
+        == "select 'from_configured_manifest' as col"
+    )
+
+
+def test_get_compiled_sql_returns_none_when_unavailable(tmp_path: Path) -> None:
+    dbt_resource_props = {
+        "unique_id": "snapshot.my_project.my_snapshot",
+        "package_name": "my_project",
+        "original_file_path": "snapshots/my_snapshot.sql",
+    }
+
+    assert _get_compiled_sql(dbt_resource_props, tmp_path) is None
+
+    # A manifest that has no compiled code for the node is also handled.
+    tmp_path.joinpath("manifest.json").write_text(json.dumps({"nodes": {}}))
+
+    assert _get_compiled_sql(dbt_resource_props, tmp_path) is None
+
+
+def test_column_lineage_snapshot(
+    test_dbt_snapshot_column_lineage_manifest: dict[str, Any],
+) -> None:
+    """Column lineage must be produced for dbt snapshots.
+
+    dbt intentionally does not write compiled snapshot SQL to ``target/compiled/`` (see
+    ``Compiler._write_node``), so resolving it only from that path raised ``FileNotFoundError``,
+    which was swallowed in ``_fetch_column_metadata``, leaving snapshots with no lineage at all.
+    See https://github.com/dagster-io/dagster/issues/34124.
+
+    Only the adapter path is exercised here (``.fetch_column_metadata()``, the repro in the
+    issue); the dbt-event-history path resolves compiled SQL through the same
+    ``_build_column_lineage_metadata`` call, and ``_get_compiled_sql`` is covered directly above.
+    """
+    dbt = DbtCliResource(project_dir=os.fspath(test_dbt_snapshot_column_lineage_path))
+
+    @dbt_assets(manifest=test_dbt_snapshot_column_lineage_manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["build"], context=context).stream().fetch_column_metadata()
+
+    result = materialize([my_dbt_assets], resources={"dbt": dbt})
+    assert result.success
+
+    column_lineage_by_asset_key = {
+        event.materialization.asset_key: TableMetadataSet.extract(
+            event.materialization.metadata
+        ).column_lineage
+        for event in result.get_asset_materialization_events()
+    }
+
+    snapshot_lineage = column_lineage_by_asset_key[AssetKey(["customers_snapshot"])]
+    assert snapshot_lineage is not None, (
+        f"Expected column lineage for the snapshot, got none: {column_lineage_by_asset_key}"
+    )
+
+    # The snapshot's own columns are derived from the model it selects from.
+    for column_name in ("customer_id", "first_name", "last_name"):
+        assert snapshot_lineage.deps_by_column[column_name] == [
+            TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name=column_name)
+        ]
+
+    # dbt adds its own bookkeeping columns to the snapshot relation. They are not selected in the
+    # compiled SQL, so they have no upstream dependencies. Asserted loosely because which columns
+    # dbt adds varies across the supported dbt versions.
+    for column_name, column_deps in snapshot_lineage.deps_by_column.items():
+        if column_name in ("customer_id", "first_name", "last_name"):
+            continue
+
+        assert column_name.startswith("dbt_"), (
+            f"Unexpected column `{column_name}` in snapshot column lineage"
+        )
+        assert column_deps == []

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/__init__.py
@@ -12,6 +12,9 @@ test_dbt_functions_path = projects_path.joinpath("test_dagster_dbt_functions")
 test_dbt_model_versions_path = projects_path.joinpath("test_dagster_dbt_model_versions")
 test_dbt_python_interleaving_path = projects_path.joinpath("test_dagster_dbt_python_interleaving")
 test_dbt_semantic_models_path = projects_path.joinpath("test_dagster_dbt_semantic_models")
+test_dbt_snapshot_column_lineage_path = projects_path.joinpath(
+    "test_dagster_dbt_snapshot_column_lineage"
+)
 test_dbt_source_freshness_path = projects_path.joinpath("test_dagster_dbt_source_freshness")
 test_dbt_unit_tests_path = projects_path.joinpath("test_dagster_dbt_unit_tests")
 test_duplicate_source_asset_key_path = projects_path.joinpath(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_snapshot_column_lineage/.gitignore
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_snapshot_column_lineage/.gitignore
@@ -1,0 +1,10 @@
+target/
+dbt_packages/
+dbt_modules/
+logs/
+**/.DS_Store
+.user.yml
+venv/
+env/
+**/*.duckdb
+**/*.duckdb.wal

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_snapshot_column_lineage/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_snapshot_column_lineage/dbt_project.yml
@@ -1,0 +1,21 @@
+name: "test_dagster_dbt_snapshot_column_lineage"
+
+config-version: 2
+version: "0.1"
+
+profile: "jaffle_shop"
+
+model-paths: ["models"]
+seed-paths: ["seeds"]
+test-paths: ["tests"]
+analysis-paths: ["analysis"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"
+clean-targets:
+  - "target"
+  - "dbt_modules"
+  - "logs"
+
+require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_snapshot_column_lineage/models/stg_customers.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_snapshot_column_lineage/models/stg_customers.sql
@@ -1,0 +1,9 @@
+select
+    id as customer_id,
+    first_name,
+    last_name
+from (
+    values
+        (1, 'Michael', 'P.'),
+        (2, 'Shawn', 'M.')
+) as raw_customers (id, first_name, last_name)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_snapshot_column_lineage/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_snapshot_column_lineage/profiles.yml
@@ -1,0 +1,7 @@
+jaffle_shop:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
+      threads: 24

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_snapshot_column_lineage/snapshots/customers_snapshot.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_snapshot_column_lineage/snapshots/customers_snapshot.sql
@@ -1,0 +1,18 @@
+{% snapshot customers_snapshot %}
+
+{{
+    config(
+        target_schema="main",
+        unique_key="customer_id",
+        strategy="check",
+        check_cols=["first_name", "last_name"],
+    )
+}}
+
+select
+    customer_id,
+    first_name,
+    last_name
+from {{ ref('stg_customers') }}
+
+{% endsnapshot %}


### PR DESCRIPTION
## Summary & Motivation

Fixes #34124.

Column-level lineage was never produced for dbt **snapshots** — no `dagster/column_lineage` metadata and no CLL icon in the UI, while models in the same project got both.

`_build_column_lineage_metadata` resolved a node's compiled SQL exclusively from `target/compiled/<package>/<original_file_path>`. dbt intentionally does not write compiled SQL there for snapshots (`Compiler._write_node` returns early for snapshots and seeds), so `node_sql_path.read_text()` raised `FileNotFoundError`, which `_fetch_column_metadata` swallowed with a warning — leaving `lineage_metadata` empty. Snapshots are in `REFABLE_NODE_TYPES`, so they were never intentionally excluded: seeds are short-circuited earlier in the function, while snapshots fell through to the failing read.

Compiled SQL is now resolved through a fallback chain:

1. the `target/compiled/...` file — unchanged behavior for models,
2. `compiled_code` from the manifest Dagster is configured with,
3. `compiled_code` from the manifest that the dbt invocation wrote to its target path.

Step 3 is what makes snapshots work in practice. The manifest supplied to Dagster is frequently produced by `dbt parse` (e.g. via `dagster-dbt project prepare-and-package`), and `dbt parse` does not compile, so its `compiled_code` is null. Verified against a real build: the parse manifest has `compiled_code=None`, while the manifest written by the `dbt build` invocation has it populated. That manifest is read once behind an `lru_cache` keyed on path + mtime + size, so a rewritten manifest is never served from a stale entry.

`target/run/...` is deliberately **not** used as a fallback (the approach taken in the closed #30493). The file does exist for snapshots, but it wraps the query in materialization DDL — `create table ... as (...)` on the first run, a `merge` on subsequent runs — which is not a query sqlglot can trace column lineage through, and would yield a column set that changes between the first and subsequent runs.

**Known limitation:** dbt writes the invocation manifest when the invocation *finishes*. For adapters where column metadata is fetched concurrently with the running dbt process — i.e. anything other than DuckDB, where the event stream is exhausted first to avoid lock contention — a snapshot's metadata may be fetched before that manifest exists. Lineage is then omitted with a warning rather than raising, which is the same outcome as today and never worse. Closing that gap would mean deferring lineage computation until the invocation completes, which is a larger behavioral change left out of this PR.

## Test Plan

- Added a `test_dagster_dbt_snapshot_column_lineage` dbt project: the test suite previously had no snapshot fixture at all.
- `test_column_lineage_snapshot` asserts the snapshot's materialization carries column lineage mapping `customer_id`, `first_name`, and `last_name` to `stg_customers`, and that dbt's own bookkeeping columns have no upstream dependencies. Verified that it **fails without the fix** (`AssetKey(['customers_snapshot']): None`) and passes with it.
- Unit tests for `_get_compiled_sql` covering the full resolution order: the compiled file wins when present, the configured manifest's `compiled_code` is next, the invocation manifest on disk is the last resort, and `None` is returned when no source is available.
- `pytest -k "column_lineage and not real_warehouse and not integration"` → 8 passed, no regressions.
- `make ruff` clean on the changed files.
- Exercised locally against dbt 1.10.11. The fixture is written to hold across the `dbt17`–`dbt111` matrix: it declares no YAML tests (avoiding the `tests:` / `data_tests:` split), configures the snapshot with `target_schema` (required in dbt 1.7/1.8 and still accepted in 1.9+), and asserts dbt's bookkeeping columns loosely, since which ones dbt adds varies by version.

## Changelog

`dagster-dbt`: Column-level lineage is now produced for dbt snapshots.
