### PR TITLE
[declarative-automation] Add AutomationCondition.any_deps_required_but_nonexistent()

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -34,7 +34,11 @@ from dagster._core.definitions.partitions.definition import (
     MultiPartitionsDefinition,
     TimeWindowPartitionsDefinition,
 )
-from dagster._core.definitions.partitions.mapping import UpstreamPartitionsResult
+from dagster._core.definitions.partitions.mapping import (
+    PartitionMapping,
+    TimeWindowPartitionMapping,
+    UpstreamPartitionsResult,
+)
 from dagster._core.definitions.partitions.subset import (
     AllPartitionsSubset,
     TimeWindowPartitionsSubset,
@@ -427,6 +431,117 @@ class AssetGraphView(LoadingContext):
         )
 
         return parent_subset, required_but_nonexistent_subset
+
+    @use_partition_loading_context
+    def compute_child_subset_with_required_but_nonexistent_parents(
+        self, parent_key: AssetKey, child_subset: EntitySubset[T_EntityKey]
+    ) -> EntitySubset[T_EntityKey]:
+        """Returns the subset of child_subset containing all child partitions whose mapped parent
+        partitions include at least one partition key which does not exist in parent_key's
+        PartitionsDefinition.
+        """
+        child_partitions_def = self.asset_graph.get(child_subset.key).partitions_def
+        partition_mapping = self.asset_graph.get_partition_mapping(child_subset.key, parent_key)  # ty: ignore[invalid-argument-type]
+
+        # some partition mappings (e.g. multi-partition mappings) short-circuit
+        # AllPartitionsSubset-backed subsets in a way that loses the
+        # required_but_nonexistent_subset, so evaluate against a concrete subset;
+        # TimeWindowPartitionMapping converts AllPartitionsSubset natively, so those
+        # edges skip the expensive materialization
+        if (
+            child_partitions_def is not None
+            and type(partition_mapping) is not TimeWindowPartitionMapping
+            and isinstance(child_subset.get_internal_subset_value(), AllPartitionsSubset)
+        ):
+            child_subset = self.get_subset_from_partition_keys(
+                child_subset.key,
+                child_partitions_def,
+                child_subset.expensively_compute_partition_keys(),
+            )
+
+        _, required_but_nonexistent_subset = (
+            self.compute_parent_subset_and_required_but_nonexistent_subset(parent_key, child_subset)
+        )
+        # in the common case, no required parent partitions are nonexistent, and we can return
+        # after a single mapping evaluation over the entire child subset
+        if required_but_nonexistent_subset.is_empty:
+            return self.get_empty_subset(key=child_subset.key)
+
+        if child_partitions_def is None:
+            return child_subset
+
+        # nonexistent parent partition keys cannot be mapped back down to the child keys that
+        # require them, so localize responsibility by evaluating the mapping per child key
+        def _has_nonexistent_parents(partition_key: str) -> bool:
+            return not self.compute_parent_subset_and_required_but_nonexistent_subset(
+                parent_key,
+                self.get_subset_from_partition_keys(
+                    child_subset.key, child_partitions_def, {partition_key}
+                ),
+            )[1].is_empty
+
+        responsible_keys = self._localize_required_but_nonexistent_child_keys(
+            parent_key,
+            child_subset,
+            child_partitions_def,
+            partition_mapping,
+            _has_nonexistent_parents,
+        )
+        return self.get_subset_from_partition_keys(
+            child_subset.key, child_partitions_def, responsible_keys
+        )
+
+    def _localize_required_but_nonexistent_child_keys(
+        self,
+        parent_key: AssetKey,
+        child_subset: EntitySubset[T_EntityKey],
+        child_partitions_def: "PartitionsDefinition",
+        partition_mapping: PartitionMapping,
+        has_nonexistent_parents: Callable[[str], bool],
+    ) -> AbstractSet[str]:
+        parent_partitions_def = self.asset_graph.get(parent_key).partitions_def
+
+        # for a TimeWindowPartitionMapping between time-window partitions definitions which
+        # share a cron schedule (or whose mapping carries no offsets), mapped windows are
+        # monotonic in time and the parent's existent range is contiguous, so child keys
+        # mapping past the end of the parent's existent range form a suffix of the
+        # chronologically-ordered candidate keys, which can be located with a logarithmic
+        # number of mapping evaluations. mismatched cron schedules combined with nonzero
+        # offsets can realign per-key windows to zero width, producing periodic (non-suffix)
+        # responsibility patterns which defeat the endpoint checks below, so those
+        # configurations fall through to the exhaustive scan
+        if (
+            type(partition_mapping) is TimeWindowPartitionMapping
+            and isinstance(child_partitions_def, TimeWindowPartitionsDefinition)
+            and isinstance(parent_partitions_def, TimeWindowPartitionsDefinition)
+            and (
+                child_partitions_def.cron_schedule == parent_partitions_def.cron_schedule
+                or (partition_mapping.start_offset == 0 and partition_mapping.end_offset == 0)
+            )
+        ):
+            keys = list(child_subset.get_internal_subset_value().get_partition_keys())
+            if (
+                len(keys) > 1
+                # a responsible first key would indicate nonexistence before the start of the
+                # parent's range, which breaks the suffix structure
+                and not has_nonexistent_parents(keys[0])
+                and has_nonexistent_parents(keys[-1])
+            ):
+                lo, hi = 0, len(keys) - 1
+                while hi - lo > 1:
+                    mid = (lo + hi) // 2
+                    if has_nonexistent_parents(keys[mid]):
+                        hi = mid
+                    else:
+                        lo = mid
+                return set(keys[hi:])
+
+        # fall back to an exhaustive scan, the legacy rule's exact cost profile
+        return {
+            partition_key
+            for partition_key in child_subset.expensively_compute_partition_keys()
+            if has_nonexistent_parents(partition_key)
+        }
 
     @use_partition_loading_context
     def compute_parent_subset(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
         ChecksAutomationCondition,
     )
     from dagster._core.definitions.declarative_automation.operators.dep_operators import (
+        BaseDepsAutomationCondition,
         DepsAutomationCondition,
     )
     from dagster._core.definitions.declarative_automation.operators.job_operators import (
@@ -877,6 +878,39 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
         return AutomationCondition.any_deps_match(
             AutomationCondition.missing() & ~AutomationCondition.will_be_requested()
         ).with_label("any_deps_missing")
+
+    @public
+    @staticmethod
+    def any_deps_required_but_nonexistent() -> "BaseDepsAutomationCondition[AssetOrCheckKey]":
+        """Returns an AutomationCondition that is true for any partition of the target which
+        requires at least one upstream partition key that does not exist in the upstream
+        PartitionsDefinition.
+
+        This commonly occurs when an upstream asset uses a time-based PartitionsDefinition with
+        an end_offset, meaning the latest downstream partitions map onto upstream partitions
+        which have not yet come into existence. Such partitions are invisible to conditions
+        such as `AutomationCondition.any_deps_missing()`, as they cannot be represented in a
+        subset of the upstream PartitionsDefinition.
+
+        Dependencies with a PartitionMapping that sets
+        `allow_nonexistent_upstream_partitions=True` are never considered to have required but
+        nonexistent parent partitions.
+
+        Selections passed to `.allow()` / `.ignore()` are applied to the target's direct
+        parents; virtual dependency resolution has no effect on this condition.
+
+        This condition can only detect nonexistent partitions which the dependency's
+        PartitionMapping reports. TimeWindowPartitionMappings with positive offsets currently
+        clamp future windows to the upstream's existing range before that report is computed,
+        so those dependencies are not detected (see issue #26935).
+        """
+        from dagster._core.definitions.declarative_automation.operators import (
+            AnyDepsRequiredButNonexistentCondition,
+        )
+
+        return AnyDepsRequiredButNonexistentCondition().with_label(
+            "any_deps_required_but_nonexistent"
+        )
 
     @public
     @staticmethod

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/__init__.py
@@ -14,6 +14,7 @@ from dagster._core.definitions.declarative_automation.operators.check_operators 
 from dagster._core.definitions.declarative_automation.operators.dep_operators import (
     AllDepsCondition as AllDepsCondition,
     AnyDepsCondition as AnyDepsCondition,
+    AnyDepsRequiredButNonexistentCondition as AnyDepsRequiredButNonexistentCondition,
     BaseDepsAutomationCondition as BaseDepsAutomationCondition,
     DepsAutomationCondition as DepsAutomationCondition,
     EntityMatchesCondition as EntityMatchesCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/__init__.py
@@ -14,6 +14,7 @@ from dagster._core.definitions.declarative_automation.operators.check_operators 
 from dagster._core.definitions.declarative_automation.operators.dep_operators import (
     AllDepsCondition as AllDepsCondition,
     AnyDepsCondition as AnyDepsCondition,
+    BaseDepsAutomationCondition as BaseDepsAutomationCondition,
     DepsAutomationCondition as DepsAutomationCondition,
     EntityMatchesCondition as EntityMatchesCondition,
 )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -110,8 +110,10 @@ class EntityMatchesCondition(
 
 
 @record
-class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
-    operand: AutomationCondition
+class BaseDepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
+    """Base class for conditions which are evaluated against the dependencies of a target,
+    supporting `.allow()` / `.ignore()` scoping of which dependencies are considered.
+    """
 
     # Should be AssetSelection, but this causes circular reference issues
     allow_selection: Any | None = None
@@ -139,10 +141,6 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return name
 
     @property
-    def children(self) -> Sequence[AutomationCondition]:
-        return [self.operand]
-
-    @property
     def requires_cursor(self) -> bool:
         return False
 
@@ -158,7 +156,7 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return non_secure_md5_hash_str("".join(parts).encode())
 
     @public
-    def allow(self, selection: "AssetSelection") -> "DepsAutomationCondition":
+    def allow(self, selection: "AssetSelection") -> Self:
         """Returns a copy of this condition that will only consider dependencies within the provided
         AssetSelection.
         """
@@ -171,7 +169,7 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         return copy(self, allow_selection=allow_selection)
 
     @public
-    def ignore(self, selection: "AssetSelection") -> "DepsAutomationCondition":
+    def ignore(self, selection: "AssetSelection") -> Self:
         """Returns a copy of this condition that will ignore dependencies within the provided
         AssetSelection.
         """
@@ -183,8 +181,17 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         )
         return copy(self, ignore_selection=ignore_selection)
 
-    def resolve_through_virtual(self, value: bool = True) -> "DepsAutomationCondition":
+    def resolve_through_virtual(self, value: bool = True) -> Self:
         return copy(self, resolves_virtual_deps=value)
+
+    def _apply_dep_selections(
+        self, dep_keys: AbstractSet[AssetKey], asset_graph: BaseAssetGraph[BaseAssetNode]
+    ) -> AbstractSet[AssetKey]:
+        if self.allow_selection is not None:
+            dep_keys &= self.allow_selection.resolve(asset_graph, allow_missing=True)
+        if self.ignore_selection is not None:
+            dep_keys -= self.ignore_selection.resolve(asset_graph, allow_missing=True)
+        return dep_keys
 
     def _get_dep_keys(
         self, key: T_EntityKey, asset_graph: BaseAssetGraph[BaseAssetNode]
@@ -194,11 +201,20 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
             if self.resolves_virtual_deps
             else {k for k in asset_graph.get(key).parent_entity_keys if isinstance(k, AssetKey)}
         )
-        if self.allow_selection is not None:
-            dep_keys &= self.allow_selection.resolve(asset_graph, allow_missing=True)
-        if self.ignore_selection is not None:
-            dep_keys -= self.ignore_selection.resolve(asset_graph, allow_missing=True)
-        return dep_keys
+        return self._apply_dep_selections(dep_keys, asset_graph)
+
+
+@record
+class DepsAutomationCondition(BaseDepsAutomationCondition[T_EntityKey]):
+    """Base class for dependency conditions which evaluate an inner operand condition against
+    each dependency of the target.
+    """
+
+    operand: AutomationCondition
+
+    @property
+    def children(self) -> Sequence[AutomationCondition]:
+        return [self.operand]
 
     def _merge_timing_metadata(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -316,3 +316,58 @@ class AllDepsCondition(DepsAutomationCondition[T_EntityKey]):
             true_subset = true_subset.compute_intersection(dep_result.true_subset)
 
         return AutomationResult(context, true_subset=true_subset, child_results=dep_results)  # ty: ignore[invalid-argument-type]
+
+
+@whitelist_for_serdes
+class AnyDepsRequiredButNonexistentCondition(BaseDepsAutomationCondition[T_EntityKey]):
+    """Condition which is true for any candidate partition which requires at least one parent
+    partition key which does not exist in that parent's PartitionsDefinition.
+
+    Unlike other dependency conditions, this condition has no inner operand: an inner condition
+    would need to be evaluated against parent partitions which, by definition, cannot be
+    represented in a subset of the parent's PartitionsDefinition.
+
+    Only direct parents are considered; `resolves_virtual_deps` has no effect on this condition.
+    For asset check targets, the direct parents are the checked asset and any additional deps.
+    """
+
+    @property
+    def base_name(self) -> str:
+        return "ANY_DEPS_REQUIRED_BUT_NONEXISTENT"
+
+    @property
+    def description(self) -> str:
+        return "required parent partitions do not exist"
+
+    async def evaluate(  # ty: ignore[invalid-method-override]
+        self, context: AutomationContext[T_EntityKey]
+    ) -> AutomationResult[T_EntityKey]:
+        true_subset = context.get_empty_subset()
+
+        if not context.candidate_subset.is_empty:
+            # always walk the direct parents of the target (for check keys, the checked asset
+            # and any additional deps): partition mappings are only defined along direct
+            # dependency edges, so resolves_virtual_deps is a no-op for this condition
+            dep_keys = self._apply_dep_selections(
+                {
+                    k
+                    for k in context.asset_graph.get(context.key).parent_entity_keys
+                    if isinstance(k, AssetKey)
+                },
+                context.asset_graph,
+            )
+            for dep_key in sorted(dep_keys):
+                if (
+                    not context.asset_graph.has(dep_key)
+                    or context.asset_graph.get(dep_key).partitions_def is None
+                ):
+                    continue
+                true_subset = true_subset.compute_union(
+                    context.asset_graph_view.compute_child_subset_with_required_but_nonexistent_parents(
+                        dep_key,
+                        context.candidate_subset,  # ty: ignore[invalid-argument-type]
+                    )
+                )
+            true_subset = context.candidate_subset.compute_intersection(true_subset)
+
+        return AutomationResult(context, true_subset=true_subset)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/utils.py
@@ -9,8 +9,8 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 if TYPE_CHECKING:
     from dagster._core.definitions.declarative_automation.operators import (
         AndAutomationCondition,
+        BaseDepsAutomationCondition,
         ChecksAutomationCondition,
-        DepsAutomationCondition,
         NotAutomationCondition,
         OrAutomationCondition,
         SinceCondition,
@@ -22,8 +22,8 @@ def has_allow_ignore(
 ) -> TypeIs[
     Union[
         "AndAutomationCondition",
+        "BaseDepsAutomationCondition",
         "ChecksAutomationCondition",
-        "DepsAutomationCondition",
         "NotAutomationCondition",
         "OrAutomationCondition",
         "SinceCondition",
@@ -31,8 +31,8 @@ def has_allow_ignore(
 ]:
     from dagster._core.definitions.declarative_automation.operators import (
         AndAutomationCondition,
+        BaseDepsAutomationCondition,
         ChecksAutomationCondition,
-        DepsAutomationCondition,
         NotAutomationCondition,
         OrAutomationCondition,
         SinceCondition,
@@ -42,8 +42,8 @@ def has_allow_ignore(
         condition,
         (
             AndAutomationCondition,
+            BaseDepsAutomationCondition,
             ChecksAutomationCondition,
-            DepsAutomationCondition,
             NotAutomationCondition,
             OrAutomationCondition,
             SinceCondition,
@@ -56,7 +56,7 @@ def has_resolve_through_virtual(
 ) -> TypeIs[
     Union[
         "AndAutomationCondition",
-        "DepsAutomationCondition",
+        "BaseDepsAutomationCondition",
         "NotAutomationCondition",
         "OrAutomationCondition",
         "SinceCondition",
@@ -64,7 +64,7 @@ def has_resolve_through_virtual(
 ]:
     from dagster._core.definitions.declarative_automation.operators import (
         AndAutomationCondition,
-        DepsAutomationCondition,
+        BaseDepsAutomationCondition,
         NotAutomationCondition,
         OrAutomationCondition,
         SinceCondition,
@@ -74,7 +74,7 @@ def has_resolve_through_virtual(
         condition,
         (
             AndAutomationCondition,
-            DepsAutomationCondition,
+            BaseDepsAutomationCondition,
             NotAutomationCondition,
             OrAutomationCondition,
             SinceCondition,

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_required_but_nonexistent_condition.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_required_but_nonexistent_condition.py
@@ -1,0 +1,632 @@
+import datetime
+
+import dagster as dg
+from dagster import AssetKey, AssetSelection, AutomationCondition
+from dagster_shared.serdes import deserialize_value, serialize_value
+
+# data for the latest two hours never exists yet, a common shape for e.g. warehouse
+# tables whose data lands with a delay
+hourly_offset_partitions_def = dg.HourlyPartitionsDefinition(
+    start_date="2013-01-05-00:00", end_offset=-2
+)
+hourly_partitions_def = dg.HourlyPartitionsDefinition(start_date="2013-01-05-00:00")
+daily_partitions_def = dg.DailyPartitionsDefinition(start_date="2013-01-05")
+
+
+def _at(**kwargs) -> datetime.datetime:
+    return datetime.datetime(2013, 1, 5) + datetime.timedelta(**kwargs)
+
+
+def _materialize_existing_partitions(
+    instance: dg.DagsterInstance,
+    partitions_def: dg.PartitionsDefinition,
+    asset_key: str,
+    evaluation_time: datetime.datetime,
+    already_materialized: set[str],
+) -> None:
+    """Reports a materialization for every partition which exists at the given time, so that the
+    only possible reason to consider a parent incomplete is nonexistence, never staleness.
+    """
+    existing = set(partitions_def.get_partition_keys(current_time=evaluation_time))
+    for partition_key in sorted(existing - already_materialized):
+        instance.report_runless_asset_event(
+            dg.AssetMaterialization(asset_key, partition=partition_key)
+        )
+    already_materialized |= existing
+
+
+def test_hourly_downstream_of_offset_hourly() -> None:
+    @dg.asset(partitions_def=hourly_offset_partitions_def)
+    def A() -> None: ...
+
+    @dg.asset(
+        partitions_def=hourly_partitions_def,
+        deps=[A],
+        automation_condition=AutomationCondition.any_deps_required_but_nonexistent(),
+    )
+    def B() -> None: ...
+
+    defs = dg.Definitions(assets=[A, B])
+    instance = dg.DagsterInstance.ephemeral()
+
+    # at 12:01, A's partitions exist through 09:00, while B has partitions through 11:00
+    result = dg.evaluate_automation_conditions(
+        defs=defs, instance=instance, evaluation_time=_at(days=2, hours=12, minutes=1)
+    )
+    assert result.get_requested_partitions(AssetKey("B")) == {
+        "2013-01-07-10:00",
+        "2013-01-07-11:00",
+    }
+
+    # two hours later, A's partitions through 11:00 exist, so B's 10:00 and 11:00 partitions are
+    # released without any parent event -- purely because the parent keys came into existence
+    result = dg.evaluate_automation_conditions(
+        defs=defs,
+        instance=instance,
+        cursor=result.cursor,
+        evaluation_time=_at(days=2, hours=14, minutes=1),
+    )
+    assert result.get_requested_partitions(AssetKey("B")) == {
+        "2013-01-07-12:00",
+        "2013-01-07-13:00",
+    }
+
+
+def test_unguarded_eager_requests_nonexistent_parent_partitions() -> None:
+    """Demonstrates the behavior this condition exists to guard against: eager() requests a
+    downstream partition whose mapped upstream partitions do not exist.
+    """
+
+    @dg.asset(partitions_def=hourly_offset_partitions_def)
+    def A() -> None: ...
+
+    @dg.asset(
+        partitions_def=daily_partitions_def,
+        deps=[A],
+        automation_condition=AutomationCondition.eager(),
+    )
+    def B() -> None: ...
+
+    defs = dg.Definitions(assets=[A, B])
+    instance = dg.DagsterInstance.ephemeral()
+    materialized: set[str] = set()
+
+    evaluation_time = _at(hours=23, minutes=59)
+    _materialize_existing_partitions(
+        instance, hourly_offset_partitions_def, "A", evaluation_time, materialized
+    )
+    result = dg.evaluate_automation_conditions(
+        defs=defs, instance=instance, evaluation_time=evaluation_time
+    )
+    assert result.total_requested == 0
+
+    # B's first daily partition comes into existence at midnight, and is immediately requested
+    # even though A's partitions for 22:00 and 23:00 of that day do not exist
+    evaluation_time = _at(days=1, minutes=1)
+    _materialize_existing_partitions(
+        instance, hourly_offset_partitions_def, "A", evaluation_time, materialized
+    )
+    result = dg.evaluate_automation_conditions(
+        defs=defs, instance=instance, cursor=result.cursor, evaluation_time=evaluation_time
+    )
+    assert result.get_requested_partitions(AssetKey("B")) == {"2013-01-05"}
+
+
+def test_guarded_eager_waits_for_parent_partitions_to_exist() -> None:
+    @dg.asset(partitions_def=hourly_offset_partitions_def)
+    def A() -> None: ...
+
+    @dg.asset(
+        partitions_def=daily_partitions_def,
+        deps=[A],
+        automation_condition=AutomationCondition.eager()
+        & ~AutomationCondition.any_deps_required_but_nonexistent(),
+    )
+    def B() -> None: ...
+
+    defs = dg.Definitions(assets=[A, B])
+    instance = dg.DagsterInstance.ephemeral()
+    materialized: set[str] = set()
+
+    evaluation_time = _at(hours=23, minutes=59)
+    _materialize_existing_partitions(
+        instance, hourly_offset_partitions_def, "A", evaluation_time, materialized
+    )
+    result = dg.evaluate_automation_conditions(
+        defs=defs, instance=instance, evaluation_time=evaluation_time
+    )
+    assert result.total_requested == 0
+
+    # B's first daily partition comes into existence, but A's partitions for 22:00 and 23:00
+    # of that day do not exist yet, so nothing is requested
+    evaluation_time = _at(days=1, minutes=1)
+    _materialize_existing_partitions(
+        instance, hourly_offset_partitions_def, "A", evaluation_time, materialized
+    )
+    result = dg.evaluate_automation_conditions(
+        defs=defs, instance=instance, cursor=result.cursor, evaluation_time=evaluation_time
+    )
+    assert result.total_requested == 0
+
+    # by 02:01, all of A's partitions for the day exist; once they are materialized, B's daily
+    # partition is requested exactly once
+    evaluation_time = _at(days=1, hours=2, minutes=1)
+    _materialize_existing_partitions(
+        instance, hourly_offset_partitions_def, "A", evaluation_time, materialized
+    )
+    result = dg.evaluate_automation_conditions(
+        defs=defs, instance=instance, cursor=result.cursor, evaluation_time=evaluation_time
+    )
+    assert result.get_requested_partitions(AssetKey("B")) == {"2013-01-05"}
+
+    # the request is not repeated on the next evaluation
+    result = dg.evaluate_automation_conditions(
+        defs=defs,
+        instance=instance,
+        cursor=result.cursor,
+        evaluation_time=_at(days=1, hours=2, minutes=31),
+    )
+    assert result.total_requested == 0
+
+
+def test_respects_allow_nonexistent_upstream_partitions() -> None:
+    @dg.asset(partitions_def=hourly_offset_partitions_def)
+    def A() -> None: ...
+
+    @dg.asset(
+        partitions_def=daily_partitions_def,
+        deps=[
+            dg.AssetDep(
+                "A",
+                partition_mapping=dg.TimeWindowPartitionMapping(
+                    allow_nonexistent_upstream_partitions=True
+                ),
+            )
+        ],
+        automation_condition=AutomationCondition.eager()
+        & ~AutomationCondition.any_deps_required_but_nonexistent(),
+    )
+    def B() -> None: ...
+
+    defs = dg.Definitions(assets=[A, B])
+    instance = dg.DagsterInstance.ephemeral()
+    materialized: set[str] = set()
+
+    evaluation_time = _at(hours=23, minutes=59)
+    _materialize_existing_partitions(
+        instance, hourly_offset_partitions_def, "A", evaluation_time, materialized
+    )
+    result = dg.evaluate_automation_conditions(
+        defs=defs, instance=instance, evaluation_time=evaluation_time
+    )
+    assert result.total_requested == 0
+
+    # B's daily partition maps onto A partitions which do not exist, but the mapping explicitly
+    # allows this, so the guard is a no-op and eager() fires as if unguarded
+    evaluation_time = _at(days=1, minutes=1)
+    _materialize_existing_partitions(
+        instance, hourly_offset_partitions_def, "A", evaluation_time, materialized
+    )
+    result = dg.evaluate_automation_conditions(
+        defs=defs, instance=instance, cursor=result.cursor, evaluation_time=evaluation_time
+    )
+    assert result.get_requested_partitions(AssetKey("B")) == {"2013-01-05"}
+
+
+def test_allow_ignore_scoping() -> None:
+    def build_defs(condition: AutomationCondition) -> dg.Definitions:
+        @dg.asset(partitions_def=hourly_offset_partitions_def)
+        def A() -> None: ...
+
+        @dg.asset(partitions_def=hourly_partitions_def)
+        def B() -> None: ...
+
+        @dg.asset(partitions_def=hourly_partitions_def, deps=[A, B], automation_condition=condition)
+        def C() -> None: ...
+
+        return dg.Definitions(assets=[A, B, C])
+
+    evaluation_time = _at(days=2, hours=12, minutes=1)
+
+    # C's latest partitions require nonexistent partitions of A, but B is fully existent
+    result = dg.evaluate_automation_conditions(
+        defs=build_defs(AutomationCondition.any_deps_required_but_nonexistent()),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=evaluation_time,
+    )
+    assert result.get_requested_partitions(AssetKey("C")) == {
+        "2013-01-07-10:00",
+        "2013-01-07-11:00",
+    }
+
+    result = dg.evaluate_automation_conditions(
+        defs=build_defs(
+            AutomationCondition.any_deps_required_but_nonexistent().ignore(
+                AssetSelection.assets("A")
+            )
+        ),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=evaluation_time,
+    )
+    assert result.total_requested == 0
+
+    result = dg.evaluate_automation_conditions(
+        defs=build_defs(
+            AutomationCondition.any_deps_required_but_nonexistent().allow(
+                AssetSelection.assets("B")
+            )
+        ),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=evaluation_time,
+    )
+    assert result.total_requested == 0
+
+
+def test_unpartitioned_child_of_partitioned_parent() -> None:
+    @dg.asset(partitions_def=hourly_offset_partitions_def)
+    def A() -> None: ...
+
+    @dg.asset(
+        deps=[A], automation_condition=AutomationCondition.any_deps_required_but_nonexistent()
+    )
+    def B() -> None: ...
+
+    # an unpartitioned child maps onto the existing partitions of its parent
+    result = dg.evaluate_automation_conditions(
+        defs=dg.Definitions(assets=[A, B]),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=_at(days=2, hours=12, minutes=1),
+    )
+    assert result.total_requested == 0
+
+
+def test_unpartitioned_parent_of_partitioned_child() -> None:
+    @dg.asset
+    def A() -> None: ...
+
+    @dg.asset(
+        partitions_def=hourly_partitions_def,
+        deps=[A],
+        automation_condition=AutomationCondition.any_deps_required_but_nonexistent(),
+    )
+    def B() -> None: ...
+
+    result = dg.evaluate_automation_conditions(
+        defs=dg.Definitions(assets=[A, B]),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=_at(days=2, hours=12, minutes=1),
+    )
+    assert result.total_requested == 0
+
+
+def test_no_deps() -> None:
+    @dg.asset(automation_condition=AutomationCondition.any_deps_required_but_nonexistent())
+    def A() -> None: ...
+
+    result = dg.evaluate_automation_conditions(
+        defs=dg.Definitions(assets=[A]), instance=dg.DagsterInstance.ephemeral()
+    )
+    assert result.total_requested == 0
+
+
+def test_self_dependency_at_series_start() -> None:
+    # the first partition of a self-dependent asset maps onto a window before the start of the
+    # partitions def, which the mapping clamps to an empty subset rather than treating as
+    # nonexistent
+    @dg.asset(
+        partitions_def=hourly_partitions_def,
+        deps=[
+            dg.AssetDep(
+                "A",
+                partition_mapping=dg.TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
+            )
+        ],
+        automation_condition=AutomationCondition.any_deps_required_but_nonexistent(),
+    )
+    def A() -> None: ...
+
+    result = dg.evaluate_automation_conditions(
+        defs=dg.Definitions(assets=[A]),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=_at(hours=4, minutes=1),
+    )
+    assert result.total_requested == 0
+
+
+def test_dynamic_partitions_identity_mapping() -> None:
+    @dg.asset(partitions_def=dg.DynamicPartitionsDefinition(name="dp_A"))
+    def A() -> None: ...
+
+    @dg.asset(
+        partitions_def=dg.DynamicPartitionsDefinition(name="dp_B"),
+        deps=[dg.AssetDep("A", partition_mapping=dg.IdentityPartitionMapping())],
+        automation_condition=AutomationCondition.any_deps_required_but_nonexistent(),
+    )
+    def B() -> None: ...
+
+    instance = dg.DagsterInstance.ephemeral()
+    instance.add_dynamic_partitions("dp_A", ["p1"])
+    instance.add_dynamic_partitions("dp_B", ["p1", "p2"])
+
+    result = dg.evaluate_automation_conditions(
+        defs=dg.Definitions(assets=[A, B]), instance=instance
+    )
+    # B's p2 partition has no identity-mapped counterpart in A
+    assert result.get_requested_partitions(AssetKey("B")) == {"p2"}
+
+
+def test_multi_partitioned_child_multi_to_single_dimension_mapping() -> None:
+    daily_offset = dg.DailyPartitionsDefinition(start_date="2013-01-05", end_offset=-1)
+
+    @dg.asset(partitions_def=daily_offset)
+    def A() -> None: ...
+
+    @dg.asset(
+        partitions_def=dg.MultiPartitionsDefinition(
+            {"date": daily_partitions_def, "static": dg.StaticPartitionsDefinition(["a", "b"])}
+        ),
+        deps=[
+            dg.AssetDep(
+                "A",
+                partition_mapping=dg.MultiToSingleDimensionPartitionMapping(
+                    partition_dimension_name="date"
+                ),
+            )
+        ],
+        automation_condition=AutomationCondition.any_deps_required_but_nonexistent(),
+    )
+    def B() -> None: ...
+
+    # at 01-08, B has date partitions through 01-07 while A (end_offset=-1) only exists
+    # through 01-06
+    result = dg.evaluate_automation_conditions(
+        defs=dg.Definitions(assets=[A, B]),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=_at(days=3, minutes=1),
+    )
+    assert result.get_requested_partitions(AssetKey("B")) == {
+        "2013-01-07|a",
+        "2013-01-07|b",
+    }
+
+
+def test_multi_partitioned_child_time_window_dimension_mapping() -> None:
+    static_partitions_def = dg.StaticPartitionsDefinition(["a", "b"])
+
+    @dg.asset(
+        partitions_def=dg.MultiPartitionsDefinition(
+            {"time": hourly_offset_partitions_def, "static": static_partitions_def}
+        )
+    )
+    def A() -> None: ...
+
+    @dg.asset(
+        partitions_def=dg.MultiPartitionsDefinition(
+            {"time": hourly_partitions_def, "static": static_partitions_def}
+        ),
+        deps=[
+            dg.AssetDep(
+                "A",
+                partition_mapping=dg.MultiPartitionMapping(
+                    {
+                        "time": dg.DimensionPartitionMapping(
+                            dimension_name="time",
+                            partition_mapping=dg.TimeWindowPartitionMapping(),
+                        ),
+                        "static": dg.DimensionPartitionMapping(
+                            dimension_name="static",
+                            partition_mapping=dg.IdentityPartitionMapping(),
+                        ),
+                    }
+                ),
+            )
+        ],
+        automation_condition=AutomationCondition.any_deps_required_but_nonexistent(),
+    )
+    def B() -> None: ...
+
+    # at 05:30, B has time partitions through 04:00 while A (end_offset=-2) only exists
+    # through 02:00
+    result = dg.evaluate_automation_conditions(
+        defs=dg.Definitions(assets=[A, B]),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=_at(hours=5, minutes=30),
+    )
+    assert result.get_requested_partitions(AssetKey("B")) == {
+        "a|2013-01-05-03:00",
+        "b|2013-01-05-03:00",
+        "a|2013-01-05-04:00",
+        "b|2013-01-05-04:00",
+    }
+
+
+def test_resolve_through_virtual_is_a_no_op() -> None:
+    daily_offset = dg.DailyPartitionsDefinition(start_date="2013-01-05", end_offset=-1)
+
+    @dg.asset(partitions_def=daily_offset)
+    def grandparent() -> None: ...
+
+    virtual = dg.AssetSpec("virtual", deps=["grandparent"], is_virtual=True)
+
+    @dg.asset(
+        deps=["virtual"],
+        partitions_def=daily_partitions_def,
+        automation_condition=AutomationCondition.any_deps_required_but_nonexistent().resolve_through_virtual(),
+    )
+    def child() -> None: ...
+
+    # partition mappings are only defined along direct dependency edges, so virtual resolution
+    # is a no-op for this condition rather than an error
+    result = dg.evaluate_automation_conditions(
+        defs=dg.Definitions(assets=[grandparent, virtual, child]),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=_at(days=3, minutes=1),
+    )
+    assert result.total_requested == 0
+
+
+def test_cross_cadence_offset_mapping_uses_exhaustive_scan() -> None:
+    # a daily child of a weekly parent with a nonzero mapping offset: cross-cadence
+    # realignment can collapse individual mapped windows to zero width, so the responsible
+    # child keys form a periodic pattern rather than a suffix of the chronologically-ordered
+    # candidates. the bisection fast path must not be used here (see the gate in
+    # AssetGraphView._localize_required_but_nonexistent_child_keys)
+    @dg.asset(partitions_def=dg.WeeklyPartitionsDefinition(start_date="2013-06-08", end_offset=-2))
+    def A() -> None: ...
+
+    @dg.asset(
+        partitions_def=dg.DailyPartitionsDefinition(start_date="2013-06-15"),
+        deps=[
+            dg.AssetDep(
+                "A",
+                partition_mapping=dg.TimeWindowPartitionMapping(start_offset=0, end_offset=-1),
+            )
+        ],
+        automation_condition=AutomationCondition.any_deps_required_but_nonexistent(),
+    )
+    def B() -> None: ...
+
+    result = dg.evaluate_automation_conditions(
+        defs=dg.Definitions(assets=[A, B]),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=datetime.datetime(2013, 7, 5, 23, 1),
+    )
+    # 2013-06-16, 2013-06-23, and 2013-06-30 map to zero-width (empty) parent windows,
+    # requiring nothing, and must not be flagged; 2013-06-15 maps onto the existing parent week
+    assert result.get_requested_partitions(AssetKey("B")) == {
+        "2013-06-17",
+        "2013-06-18",
+        "2013-06-19",
+        "2013-06-20",
+        "2013-06-21",
+        "2013-06-22",
+        "2013-06-24",
+        "2013-06-25",
+        "2013-06-26",
+        "2013-06-27",
+        "2013-06-28",
+        "2013-06-29",
+        "2013-07-01",
+        "2013-07-02",
+        "2013-07-03",
+        "2013-07-04",
+    }
+
+
+def test_resolve_through_virtual_with_partitioned_virtual_parent() -> None:
+    def build_defs(condition: AutomationCondition) -> dg.Definitions:
+        virtual = dg.AssetSpec(
+            "virtual", is_virtual=True, partitions_def=hourly_offset_partitions_def
+        )
+
+        @dg.asset(
+            partitions_def=hourly_partitions_def,
+            deps=["virtual"],
+            automation_condition=condition,
+        )
+        def child() -> None: ...
+
+        return dg.Definitions(assets=[virtual, child])
+
+    evaluation_time = _at(days=2, hours=12, minutes=1)
+    expected = {"2013-01-07-10:00", "2013-01-07-11:00"}
+
+    result = dg.evaluate_automation_conditions(
+        defs=build_defs(AutomationCondition.any_deps_required_but_nonexistent()),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=evaluation_time,
+    )
+    assert result.get_requested_partitions(AssetKey("child")) == expected
+
+    # a partitioned virtual parent is still a direct parent: resolving through virtual
+    # deps is a no-op for this condition and must not drop the edge
+    result = dg.evaluate_automation_conditions(
+        defs=build_defs(
+            AutomationCondition.any_deps_required_but_nonexistent().resolve_through_virtual()
+        ),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=evaluation_time,
+    )
+    assert result.get_requested_partitions(AssetKey("child")) == expected
+
+
+def test_partitioned_asset_check_with_partitioned_dep() -> None:
+    @dg.asset(partitions_def=dg.DailyPartitionsDefinition(start_date="2013-01-07"))
+    def parent() -> None: ...
+
+    @dg.asset(
+        partitions_def=daily_partitions_def,
+        check_specs=[
+            dg.AssetCheckSpec(
+                "my_check",
+                asset="child",
+                additional_deps=["parent"],
+                partitions_def=daily_partitions_def,
+                automation_condition=AutomationCondition.any_deps_required_but_nonexistent(),
+            )
+        ],
+    )
+    def child(): ...
+
+    result = dg.evaluate_automation_conditions(
+        defs=dg.Definitions(assets=[parent, child]),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=_at(days=4, minutes=1),
+    )
+    check_key = dg.AssetCheckKey(AssetKey("child"), "my_check")
+    check_result = next(r for r in result.results if r.key == check_key)
+    # the check's 01-05 and 01-06 partitions require parent partitions which do not exist
+    assert set(check_result.true_subset.expensively_compute_partition_keys()) == {
+        "2013-01-05",
+        "2013-01-06",
+    }
+
+
+def test_positive_mapping_offset_not_detected() -> None:
+    # a mapping with a positive end_offset requires future parent partitions, but
+    # TimeWindowPartitionMapping clamps those windows to the parent's existing range before
+    # the required_but_nonexistent report is computed, so no consumer of the report can see
+    # them (https://github.com/dagster-io/dagster/issues/26935). this test documents that
+    # inherited limitation
+    @dg.asset(partitions_def=hourly_partitions_def)
+    def A() -> None: ...
+
+    @dg.asset(
+        partitions_def=hourly_partitions_def,
+        deps=[
+            dg.AssetDep(
+                "A",
+                partition_mapping=dg.TimeWindowPartitionMapping(start_offset=0, end_offset=2),
+            )
+        ],
+        automation_condition=AutomationCondition.any_deps_required_but_nonexistent(),
+    )
+    def B() -> None: ...
+
+    result = dg.evaluate_automation_conditions(
+        defs=dg.Definitions(assets=[A, B]),
+        instance=dg.DagsterInstance.ephemeral(),
+        evaluation_time=_at(days=2, hours=12, minutes=1),
+    )
+    assert result.total_requested == 0
+
+
+def test_serialization() -> None:
+    condition = (
+        AutomationCondition.eager() & ~AutomationCondition.any_deps_required_but_nonexistent()
+    )
+    assert condition.is_serializable
+    assert deserialize_value(serialize_value(condition)) == condition
+
+    scoped = AutomationCondition.any_deps_required_but_nonexistent().ignore(
+        AssetSelection.assets("A")
+    )
+    assert deserialize_value(serialize_value(scoped)) == scoped
+
+
+def test_name_and_description() -> None:
+    condition = AutomationCondition.any_deps_required_but_nonexistent()
+    assert condition.get_label() == "any_deps_required_but_nonexistent"
+    assert condition.name == "ANY_DEPS_REQUIRED_BUT_NONEXISTENT"
+    # string parity with AutoMaterializeRule.skip_on_required_but_nonexistent_parents()
+    assert condition.description == "required parent partitions do not exist"


### PR DESCRIPTION

## Summary & Motivation

Addresses [#34094](https://github.com/dagster-io/dagster/issues/34094).

Declarative Automation has no equivalent of the legacy `AutoMaterializeRule.skip_on_required_but_nonexistent_parents()` rule (part of `AutoMaterializePolicy.eager()`'s default rule set), so `AutomationCondition.eager()` will request a downstream partition whose mapped upstream partitions **do not exist** in the upstream `PartitionsDefinition` — most commonly downstream of an upstream with a time-based `end_offset`. For assets that declare parents as `deps` without loading inputs (e.g. any dbt model), nothing validates partition-mapping existence at run time, so the run completes with `RUN_SUCCESS` on incomplete data. We hit this as a production incident after migrating an eager AMP per the migration guide, which never mentions the rule.

`any_deps_missing()` cannot cover this: dep conditions map the candidate subset up to each parent, and the "up" mapping keeps only the valid half of the mapping's answer — the `required_but_nonexistent_subset` that the mapping already computes (and that both backfill paths already consume and raise on) is discarded before any inner condition can see it. Since the missing keys are expressed in parent-key space and cannot appear in the parent subsets that inner conditions evaluate over, the fix is a **leaf condition with no inner operand, computed child-side per dependency edge**:

```python
condition = AutomationCondition.eager() & ~AutomationCondition.any_deps_required_but_nonexistent()
```

The implementation is in three commits, each independently reviewable:

1. **Pure refactor** — extracts `BaseDepsAutomationCondition` (the `.allow()`/`.ignore()` scoping and cursor-stable node-id machinery) from `DepsAutomationCondition`. No behavior change: serialized field sets and condition-node unique ids of all existing conditions are byte-identical before and after.
2. **Graph primitive** — `AssetGraphView.compute_child_subset_with_required_but_nonexistent_parents`, the child-side sibling of the existing `compute_parent_subset_and_required_but_nonexistent_subset`. A whole-subset mapping evaluation is the fast path for the common empty case; a logarithmic bisection localizes responsibility on `TimeWindowPartitionMapping` edges whose definitions share a cron schedule or whose mapping carries no offsets (outside that regime, cross-cadence realignment can collapse individual mapped windows to zero width, producing periodic rather than suffix responsibility patterns); an exhaustive per-key scan is the general fallback, so correctness never depends on the fast paths.
3. **The condition** — serdes-whitelisted `AnyDepsRequiredButNonexistentCondition`, exposed as `AutomationCondition.any_deps_required_but_nonexistent()`, plus tests.

Properties of the condition:

- **Additive and opt-in** — no builtin condition changes behavior. Composing the guard into `eager()`/`on_missing()` (restoring AMP parity by default) is a deliberate non-goal here: it is a behavior change deserving its own PR, and [#34099](https://github.com/dagster-io/dagster/pull/34099) explores exactly that direction — this PR provides the opt-in capability such a change could be built on.
- **Stateless, wall-clock release** — the answer is recomputed from current partition definitions each tick, so blocked partitions release the moment parent keys come into existence, with no parent event required (the legacy rule's event-driven recheck could strand children of quiet parents).
- **Honors `allow_nonexistent_upstream_partitions=True`** — such mappings report an empty nonexistent subset, so those edges contribute nothing.
- **Supports `.allow()`/`.ignore()`** dependency scoping; walks the direct parents of its target; asset check targets are supported (checked asset + additional deps); virtual dependency resolution is a documented no-op.
- **Renders as a normal labeled node** in the evaluation UI; description matches the legacy rule ("required parent partitions do not exist").

Known limitation, documented in the docstring: the condition can only detect nonexistent partitions that the dependency's `PartitionMapping` reports. `TimeWindowPartitionMapping` with **positive offsets** currently clamps future windows to the upstream's existing range *before* the nonexistent report is computed, so those remain undetected until [#26935](https://github.com/dagster-io/dagster/issues/26935) is fixed at the mapping layer — at which point this condition picks them up automatically. Also worth noting for adopters: a same-cadence downstream of an `end_offset` upstream under a guarded plain `eager()` will never fire (the newest partition's parents perpetually don't exist yet); remedies are a matching downstream `end_offset`, `in_latest_time_window(lookback_delta=...)`, or the per-mapping opt-out.

## Test Plan

- **19 new unit tests** (`test_required_but_nonexistent_condition.py`) covering: the unguarded-eager bug demonstration; guarded-eager block-then-release (requested exactly once, released purely by wall clock); `allow_nonexistent_upstream_partitions=True`; `.allow()`/`.ignore()` scoping; unpartitioned parent/child combinations; self-dependency at series start; dynamic-partitions identity mapping; multi-partitioned children (single- and multi-dimension mappings, exercising the `AllPartitionsSubset` materialization path); partitioned virtual parents under `resolve_through_virtual()` (no-op in both directions); partitioned asset checks with additional deps; a cross-cadence + offset regression pinning the exhaustive-scan fallback against a periodic (non-suffix) responsibility pattern; the documented [#26935](https://github.com/dagster-io/dagster/issues/26935) positive-offset pass-through; serdes round-trips including scoped conditions; name/label/description parity with the legacy rule.
- **Full suites green**: 501 passed across `declarative_automation_tests` (builtins + legacy), `general_tests/test_serdes.py`, and both `asset_graph_view_tests` suites; `ruff` and `ty` clean.
- **Serde/cursor compatibility**: serialized forms and node-unique-id trees of existing builtin conditions (eager, on_cron, on_missing, any/all_deps variants, scoped and unscoped) verified byte-identical before/after the base-class extraction.
- **Differential validation**: the bisection fast path was verified against per-key exhaustive ground truth across randomized configurations (mixed cadences, mapping/def offsets, DST transitions, exclusion crons, end-bounded and late-starting definitions), with instrumentation confirming the fast path was actually exercised; configurations outside the gated regime fall back to the scan and were verified correct there.
- Each commit was tested standalone (the history bisects cleanly).

## Changelog

Added `AutomationCondition.any_deps_required_but_nonexistent()`, which is true for partitions of the target that require upstream partition keys that do not exist in the upstream `PartitionsDefinition` (e.g. downstream of a time-partitioned asset with an `end_offset`). This provides a Declarative Automation replacement for the legacy `AutoMaterializeRule.skip_on_required_but_nonexistent_parents()`; compose it as `AutomationCondition.eager() & ~AutomationCondition.any_deps_required_but_nonexistent()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
