### PR TITLE
Remove GitPython from dagster-dbt and shallow-clone with git

### DIFF
--- a/docs/docs/deployment/troubleshooting/git-executable-error-branch-deployment-code-locations.md
+++ b/docs/docs/deployment/troubleshooting/git-executable-error-branch-deployment-code-locations.md
@@ -1,12 +1,12 @@
 ---
 title: Deployment fails with bad git executable error in branch deployment code locations
 sidebar_position: 1100
-description: Resolve "Bad git executable" DagsterImportError that affects dagster-dbt in branch deployment code locations.
+description: Resolve "Bad git executable" DagsterImportError that affects older dagster-dbt versions in branch deployment code locations.
 ---
 
 ## Problem description
 
-Users experience deployment failures with the `dagster-dbt` integration when deploying branch-deployment code locations due to a missing or improperly configured git executable.
+Users on older `dagster-dbt` versions experience deployment failures when deploying branch-deployment code locations due to a missing or improperly configured git executable.
 
 ## Symptoms
 
@@ -17,26 +17,19 @@ Users experience deployment failures with the `dagster-dbt` integration when dep
 
 ## Root cause
 
-This is a known issue in Dagster where the git executable is not properly available in the deployment environment. The `dagster-dbt` integration requires git to be accessible, but the deployment environment may not have git installed or properly configured in the `PATH`.
+Older `dagster-dbt` versions imported GitPython at module load time. GitPython probes for a git executable during import and raises if git is missing or not on `PATH`.
+
+Current `dagster-dbt` no longer depends on GitPython. It invokes the git CLI only when cloning a remote dbt project (for example, a `DbtProjectComponent` configured with `repo_url`). Importing `dagster-dbt` no longer requires git.
 
 ## Solution
 
-Pin your Dagster version to avoid the problematic version until the fix is released.
+Upgrade `dagster-dbt` to a version that no longer depends on GitPython. Importing the library will no longer fail when git is absent.
 
-### Step-by-step resolution
+If you load a remote dbt project from git, the git CLI must still be installed and on `PATH` in that environment. The clone is given 30 minutes by default; set `DAGSTER_DBT_GIT_CLONE_TIMEOUT_SECONDS` if a large repository or a slow link needs longer.
 
-1. Identify your current Dagster version and pin to a stable version in your `requirements.txt` or `pyproject.toml`:
+### Workaround for older versions
 
-   ```text
-   dagster==1.8.x  # Replace x with the last working version
-   ```
-
-2. Redeploy your code location with the pinned version.
-3. Verify the deployment completes successfully without git executable errors.
-
-### Alternative solutions
-
-If pinning the version doesn't work, you can try setting the `GIT_PYTHON_REFRESH` environment variable to suppress the error:
+If you cannot upgrade yet, set the `GIT_PYTHON_REFRESH` environment variable to suppress GitPython's import-time check:
 
 ```bash
 export GIT_PYTHON_REFRESH=quiet
@@ -44,8 +37,8 @@ export GIT_PYTHON_REFRESH=quiet
 
 ## Prevention
 
-Monitor Dagster release notes for updates on this issue and upgrade to newer versions once the fix is available. Consider testing deployments in a staging environment before promoting to production.
+Keep `dagster-dbt` current. When using a remote git dbt project, install git in the deployment image and confirm it is on `PATH`.
 
 ## Related documentation
 
-- [GitHub PR with fix](https://github.com/dagster-io/dagster/pull/32756)
+- [GitHub PR that deferred the GitPython import](https://github.com/dagster-io/dagster/pull/32756)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project_manager.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project_manager.py
@@ -1,11 +1,14 @@
 import os
+import re
 import shutil
+import subprocess
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 from urllib.parse import quote, urlparse, urlunparse
 
+import dagster._check as check
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster.components.resolved.base import Resolvable
 from dagster.components.resolved.model import Resolver
@@ -14,6 +17,50 @@ from dagster_dbt.dbt_project import DbtProject
 
 if TYPE_CHECKING:
     from dagster_dbt.components.dbt_project.component import DbtProjectArgs
+
+# GitPython imposed no clone timeout, so the default here has to be generous enough that a large
+# shallow clone on a slow link does not start failing on upgrade. Overridable for the rest.
+_GIT_CLONE_TIMEOUT_SECONDS = int(os.getenv("DAGSTER_DBT_GIT_CLONE_TIMEOUT_SECONDS", "1800"))
+_URL_USERINFO = re.compile(r"(https?://)[^/\s'\"@]+@")
+
+
+def _redact_userinfo(text: str) -> str:
+    """Strip URL userinfo so clone tokens are not interpolated into errors."""
+    return _URL_USERINFO.sub(r"\1", text)
+
+
+def _shallow_clone(repo_url: str, dest: Path, *, display_url: str | None = None) -> None:
+    """Shallow-clone ``repo_url`` into ``dest`` using the git CLI."""
+    repo_url = check.str_param(repo_url, "repo_url")
+    dest = check.inst_param(dest, "dest", Path)
+    label = _redact_userinfo(display_url if display_url is not None else repo_url)
+    env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
+    try:
+        completed = subprocess.run(
+            ["git", "clone", "--depth", "1", "--", repo_url, str(dest)],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stdin=subprocess.DEVNULL,
+            timeout=_GIT_CLONE_TIMEOUT_SECONDS,
+            env=env,
+        )
+    except FileNotFoundError as err:
+        raise DagsterInvalidDefinitionError(
+            "git executable not found on PATH. Install git to clone remote dbt projects."
+        ) from err
+    except subprocess.TimeoutExpired:
+        # Do not chain TimeoutExpired: its argv includes the clone URL with credentials.
+        raise DagsterInvalidDefinitionError(
+            f"Timed out cloning git repository {label} into {dest}."
+        ) from None
+    if completed.returncode != 0:
+        raise DagsterInvalidDefinitionError(
+            f"Failed to clone git repository {label} into {dest}. "
+            f"git exited with code {completed.returncode}: {_redact_userinfo(completed.stderr)}"
+        )
 
 
 def _ignore_nested_dest(dest: Path):
@@ -170,10 +217,11 @@ class RemoteGitDbtProjectManager(DbtProjectManager, Resolvable):
             return urlunparse(parts._replace(netloc=f"{token}@{parts.netloc}"))
 
     def sync(self, state_path: Path) -> None:
-        # defer git import to avoid side-effects on import
-        from git import Repo
-
-        Repo.clone_from(self._get_clone_url(), self._local_project_dir(state_path), depth=1)
+        _shallow_clone(
+            self._get_clone_url(),
+            self._local_project_dir(state_path),
+            display_url=self.repo_url,
+        )
         project = self.get_project(state_path)
         project.preparer.prepare(project)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component_remote.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component_remote.py
@@ -1,19 +1,28 @@
 import shutil
+import subprocess
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import ANY, patch
 
 import dagster as dg
 import pytest
 from dagster._core.definitions.definitions_load_context import DefinitionsLoadType
 from dagster._core.definitions.repository_definition.repository_definition import RepositoryLoadData
+from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.instance_for_test import instance_for_test
 from dagster._utils.env import environ
 from dagster._utils.test.definitions import scoped_definitions_load_context
 from dagster.components.testing import create_defs_folder_sandbox
 from dagster_dbt import DbtProjectComponent
-from dagster_dbt.dbt_project_manager import RemoteGitDbtProjectManager
+from dagster_dbt.dbt_project_manager import (
+    _GIT_CLONE_TIMEOUT_SECONDS,
+    RemoteGitDbtProjectManager,
+    _shallow_clone,
+)
+
+_SHALLOW_CLONE = "dagster_dbt.dbt_project_manager._shallow_clone"
+_SUBPROCESS_RUN = "dagster_dbt.dbt_project_manager.subprocess.run"
 
 # Path to the jaffle shop test project
 STUB_LOCATION_PATH = Path(__file__).parent / "code_locations" / "dbt_project_location"
@@ -32,16 +41,15 @@ def dbt_project_dir() -> Iterator[Path]:
 def mock_git_clone(dbt_project_dir: Path):
     """Create a mock function that simulates git clone by copying the prepared project."""
 
-    def _clone_from(repo_url: str, to_path: Path, depth: int = 1):
-        # we expect to_path to be an empty directory
-        assert to_path.exists()
-        assert to_path.is_dir()
-        assert not any(to_path.iterdir())
+    def _clone(repo_url: str, dest: Path, **_kwargs):
+        # we expect dest to be an empty directory
+        assert dest.exists()
+        assert dest.is_dir()
+        assert not any(dest.iterdir())
         # Instead of actually cloning, copy our prepared test project
-        shutil.copytree(dbt_project_dir, to_path, dirs_exist_ok=True)
-        return MagicMock()
+        shutil.copytree(dbt_project_dir, dest, dirs_exist_ok=True)
 
-    return _clone_from
+    return _clone
 
 
 def test_remote_dbt_project_dev_mode_calls_fetch(dbt_project_dir: Path) -> None:
@@ -51,7 +59,7 @@ def test_remote_dbt_project_dev_mode_calls_fetch(dbt_project_dir: Path) -> None:
     with (
         instance_for_test(),
         create_defs_folder_sandbox() as sandbox,
-        patch("git.Repo.clone_from") as mock_clone,
+        patch(_SHALLOW_CLONE) as mock_clone,
         environ({"DAGSTER_IS_DEV_CLI": "1"}),
     ):
         mock_clone.side_effect = mock_git_clone(dbt_project_dir)
@@ -101,7 +109,7 @@ def test_remote_dbt_project_reconstruction_mode_no_fetch(dbt_project_dir: Path) 
     with (
         instance_for_test(),
         create_defs_folder_sandbox() as sandbox,
-        patch("git.Repo.clone_from") as mock_clone,
+        patch(_SHALLOW_CLONE) as mock_clone,
     ):
         mock_clone.side_effect = mock_git_clone(dbt_project_dir)
 
@@ -178,7 +186,7 @@ def test_remote_dbt_project_with_profile_and_repo_relative_path(
     with (
         instance_for_test(),
         create_defs_folder_sandbox() as sandbox,
-        patch("git.Repo.clone_from") as mock_clone,
+        patch(_SHALLOW_CLONE) as mock_clone,
         environ({"DAGSTER_IS_DEV_CLI": "1"}),
     ):
         mock_clone.side_effect = mock_git_clone(dbt_project_dir)
@@ -221,7 +229,7 @@ def test_remote_dbt_project_with_token(dbt_project_dir: Path) -> None:
     with (
         instance_for_test(),
         create_defs_folder_sandbox() as sandbox,
-        patch("git.Repo.clone_from") as mock_clone,
+        patch(_SHALLOW_CLONE) as mock_clone,
         environ({"DAGSTER_IS_DEV_CLI": "1"}),
     ):
         mock_clone.side_effect = mock_git_clone(dbt_project_dir)
@@ -254,7 +262,7 @@ def test_remote_dbt_project_with_token(dbt_project_dir: Path) -> None:
             assert len(specs) > 0
 
             # fetch should have been called
-            mock_clone.assert_called_once_with(repo_url_with_token, ANY, depth=1)
+            mock_clone.assert_called_once_with(repo_url_with_token, ANY, display_url=repo_url)
 
 
 @pytest.mark.parametrize("project_path", [None, "."])
@@ -267,7 +275,7 @@ def test_scaffold_component_with_git_url_params(
     with (
         instance_for_test(),
         create_defs_folder_sandbox() as sandbox,
-        patch("git.Repo.clone_from") as mock_clone,
+        patch(_SHALLOW_CLONE) as mock_clone,
         environ({"DAGSTER_IS_DEV_CLI": "1"}),
     ):
         mock_clone.side_effect = mock_git_clone(dbt_project_dir)
@@ -288,3 +296,71 @@ def test_scaffold_component_with_git_url_params(
             assert isinstance(component.project, RemoteGitDbtProjectManager)
             assert component.project.repo_url == repo_url
             # Component instantiated successfully - no error means the scaffolder created valid YAML
+
+
+def _assert_shallow_clone_argv(mock_run, repo_url: str, dest: Path) -> None:
+    assert mock_run.call_args.args[0] == [
+        "git",
+        "clone",
+        "--depth",
+        "1",
+        "--",
+        repo_url,
+        str(dest),
+    ]
+
+
+def test_shallow_clone_invokes_git_cli(tmp_path: Path) -> None:
+    dest = tmp_path / "project"
+    dest.mkdir()
+    repo_url = "https://github.com/fake/repo.git"
+    completed = subprocess.CompletedProcess(
+        args=["git", "clone", "--depth", "1", "--", repo_url, str(dest)],
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
+
+    with patch(_SUBPROCESS_RUN, return_value=completed) as mock_run:
+        _shallow_clone(repo_url, dest)
+
+    _assert_shallow_clone_argv(mock_run, repo_url, dest)
+    assert mock_run.call_args.kwargs["stdin"] is subprocess.DEVNULL
+    assert mock_run.call_args.kwargs["timeout"] == _GIT_CLONE_TIMEOUT_SECONDS
+    assert mock_run.call_args.kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+
+
+def test_shallow_clone_missing_executable(tmp_path: Path) -> None:
+    dest = tmp_path / "project"
+    dest.mkdir()
+    repo_url = "https://github.com/fake/repo.git"
+
+    with patch(
+        _SUBPROCESS_RUN, side_effect=FileNotFoundError(2, "No such file or directory", "git")
+    ) as mock_run:
+        with pytest.raises(DagsterInvalidDefinitionError, match="git executable not found"):
+            _shallow_clone(repo_url, dest)
+
+    _assert_shallow_clone_argv(mock_run, repo_url, dest)
+
+
+def test_shallow_clone_nonzero_exit(tmp_path: Path) -> None:
+    dest = tmp_path / "project"
+    dest.mkdir()
+    repo_url = "https://secret_token@github.com/fake/repo.git"
+    display_url = "https://github.com/fake/repo.git"
+    failed = subprocess.CompletedProcess(
+        args=["git", "clone", "--depth", "1", "--", repo_url, str(dest)],
+        returncode=128,
+        stdout="",
+        stderr=f"fatal: repository '{repo_url}/' not found",
+    )
+
+    with patch(_SUBPROCESS_RUN, return_value=failed) as mock_run:
+        with pytest.raises(DagsterInvalidDefinitionError, match="Failed to clone") as exc_info:
+            _shallow_clone(repo_url, dest, display_url=display_url)
+
+    _assert_shallow_clone_argv(mock_run, repo_url, dest)
+    message = str(exc_info.value)
+    assert "secret_token" not in message
+    assert display_url in message

--- a/python_modules/libraries/dagster-dbt/kitchen-sink/uv.lock
+++ b/python_modules/libraries/dagster-dbt/kitchen-sink/uv.lock
@@ -573,7 +573,6 @@ source = { editable = "../" }
 dependencies = [
     { name = "dagster" },
     { name = "dbt-core" },
-    { name = "gitpython" },
     { name = "jinja2" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -589,7 +588,6 @@ dependencies = [
 requires-dist = [
     { name = "dagster", editable = "../../../dagster" },
     { name = "dbt-core", specifier = ">=1.7,<1.12" },
-    { name = "gitpython" },
     { name = "jinja2" },
     { name = "networkx" },
     { name = "orjson" },
@@ -1071,30 +1069,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/57/ecad709ff03e636c90b93067d54a289da49cac97258b626929933e792fb1/fsspec-2024.3.0.tar.gz", hash = "sha256:f13a130c0ed07e15c4e1aeb0472a823e9c426b0b5792a1f40d902b0a71972d43", size = 170720, upload-time = "2024-03-15T20:17:28.991Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/be/ba7cf9660a7f566fe6b63eab725e962d23ffc340324ba1eb837833e4b90a/fsspec-2024.3.0-py3-none-any.whl", hash = "sha256:779001bd0122c9c4975cf03827d5e86c3afb914a3ae27040f15d341ab506a693", size = 171917, upload-time = "2024-03-15T20:17:27.272Z" },
-]
-
-[[package]]
-name = "gitdb"
-version = "4.0.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "smmap" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
-]
-
-[[package]]
-name = "gitpython"
-version = "3.1.50"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "gitdb" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -2851,15 +2825,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "smmap"
-version = "5.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
 ]
 
 [[package]]

--- a/python_modules/libraries/dagster-dbt/pyproject.toml
+++ b/python_modules/libraries/dagster-dbt/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     # Follow the version support constraints for dbt Core:
     # https://docs.getdbt.com/docs/dbt-versions/core
     "dbt-core>=1.7,<1.12",
-    "gitpython",
     "Jinja2",
     "networkx",
     "orjson",

--- a/python_modules/libraries/dagster-dbt/uv.lock
+++ b/python_modules/libraries/dagster-dbt/uv.lock
@@ -834,7 +834,6 @@ dependencies = [
     { name = "dbt-core", version = "1.9.10", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt111') or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt17') or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra == 'group-11-dagster-dbt-test-dbt111' and extra == 'group-11-dagster-dbt-test-dbt17') or (extra == 'group-11-dagster-dbt-test-dbt111' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra == 'group-11-dagster-dbt-test-dbt17' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra != 'group-11-dagster-dbt-test-dbt18' and extra == 'group-11-dagster-dbt-test-dbt19') or (extra != 'group-11-dagster-dbt-test-dbt110' and extra != 'group-11-dagster-dbt-test-dbt111' and extra != 'group-11-dagster-dbt-test-dbt17' and extra == 'group-11-dagster-dbt-test-dbt19')" },
     { name = "dbt-core", version = "1.10.20", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-11-dagster-dbt-test-dbt110' or (extra == 'group-11-dagster-dbt-test-dbt111' and extra == 'group-11-dagster-dbt-test-dbt17') or (extra == 'group-11-dagster-dbt-test-dbt111' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra == 'group-11-dagster-dbt-test-dbt111' and extra == 'group-11-dagster-dbt-test-dbt19') or (extra == 'group-11-dagster-dbt-test-dbt17' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra == 'group-11-dagster-dbt-test-dbt17' and extra == 'group-11-dagster-dbt-test-dbt19') or (extra == 'group-11-dagster-dbt-test-dbt18' and extra == 'group-11-dagster-dbt-test-dbt19')" },
     { name = "dbt-core", version = "1.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and extra == 'group-11-dagster-dbt-test-dbt17') or (python_full_version >= '3.13' and extra == 'group-11-dagster-dbt-test-dbt18') or extra == 'group-11-dagster-dbt-test-dbt111' or (extra == 'group-11-dagster-dbt-test-dbt17' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra == 'group-11-dagster-dbt-test-dbt17' and extra == 'group-11-dagster-dbt-test-dbt19') or (extra == 'group-11-dagster-dbt-test-dbt18' and extra == 'group-11-dagster-dbt-test-dbt19') or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt17') or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt19') or (extra != 'group-11-dagster-dbt-test-dbt110' and extra != 'group-11-dagster-dbt-test-dbt17' and extra != 'group-11-dagster-dbt-test-dbt18' and extra != 'group-11-dagster-dbt-test-dbt19')" },
-    { name = "gitpython" },
     { name = "jinja2" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt111') or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt17') or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt19') or (extra == 'group-11-dagster-dbt-test-dbt111' and extra == 'group-11-dagster-dbt-test-dbt17') or (extra == 'group-11-dagster-dbt-test-dbt111' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra == 'group-11-dagster-dbt-test-dbt111' and extra == 'group-11-dagster-dbt-test-dbt19') or (extra == 'group-11-dagster-dbt-test-dbt17' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra == 'group-11-dagster-dbt-test-dbt17' and extra == 'group-11-dagster-dbt-test-dbt19') or (extra == 'group-11-dagster-dbt-test-dbt18' and extra == 'group-11-dagster-dbt-test-dbt19')" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt111') or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt17') or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra == 'group-11-dagster-dbt-test-dbt110' and extra == 'group-11-dagster-dbt-test-dbt19') or (extra == 'group-11-dagster-dbt-test-dbt111' and extra == 'group-11-dagster-dbt-test-dbt17') or (extra == 'group-11-dagster-dbt-test-dbt111' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra == 'group-11-dagster-dbt-test-dbt111' and extra == 'group-11-dagster-dbt-test-dbt19') or (extra == 'group-11-dagster-dbt-test-dbt17' and extra == 'group-11-dagster-dbt-test-dbt18') or (extra == 'group-11-dagster-dbt-test-dbt17' and extra == 'group-11-dagster-dbt-test-dbt19') or (extra == 'group-11-dagster-dbt-test-dbt18' and extra == 'group-11-dagster-dbt-test-dbt19')" },
@@ -899,7 +898,6 @@ test-dbt19 = [
 requires-dist = [
     { name = "dagster", editable = "../../dagster" },
     { name = "dbt-core", specifier = ">=1.7,<1.12" },
-    { name = "gitpython" },
     { name = "jinja2" },
     { name = "networkx" },
     { name = "orjson" },
@@ -2040,18 +2038,6 @@ wheels = [
 ]
 
 [[package]]
-name = "gitdb"
-version = "4.0.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "smmap" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
-]
-
-[[package]]
 name = "github3-py"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2064,18 +2050,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/91/603bcaf8cd1b3927de64bf56c3a8915f6653ea7281919140c5bcff2bfe7b/github3.py-4.0.1.tar.gz", hash = "sha256:30d571076753efc389edc7f9aaef338a4fcb24b54d8968d5f39b1342f45ddd36", size = 36214038, upload-time = "2023-04-26T17:56:37.677Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/2394d4fb542574678b0ba342daf734d4d811768da3c2ee0c84d509dcb26c/github3.py-4.0.1-py3-none-any.whl", hash = "sha256:a89af7de25650612d1da2f0609622bcdeb07ee8a45a1c06b2d16a05e4234e753", size = 151800, upload-time = "2023-04-26T17:56:25.015Z" },
-]
-
-[[package]]
-name = "gitpython"
-version = "3.1.50"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "gitdb" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -4745,15 +4719,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "smmap"
-version = "5.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary & Motivation

`dagster-dbt` imported GitPython at module load. Environments without a `git` executable then failed on import, including code locations that never clone a remote dbt project. #32756 deferred the import; the remaining fix is to drop the dependency.

joshuataylor's 2026-08-15 decision on #34091 still stands: use `git clone --depth 1`, do not add a `[git]` extra.

I removed `gitpython` from `dagster-dbt` runtime deps and replaced `git.Repo.clone_from` with a `_shallow_clone` helper that shells out to the git CLI. I updated the troubleshooting doc so the prescribed fix is "upgrade `dagster-dbt`" rather than pin an old version.

One helper in `dbt_project_manager.py`:

- `git clone --depth 1 -- <url> <dest>`
- `GIT_TERMINAL_PROMPT=0`, stdin closed, 30-minute timeout (`DAGSTER_DBT_GIT_CLONE_TIMEOUT_SECONDS`)
- `FileNotFoundError` → "install git"
- nonzero exit / timeout → `DagsterInvalidDefinitionError` with the URL redacted so a token in the clone URL does not land in the error

I did not add a `[git]` extra. Tests no longer need GitPython; they patch `_shallow_clone` / `subprocess.run` instead.

Importing `dagster-dbt` no longer requires GitPython or a `git` binary. Remote dbt projects still need `git` on `PATH` in that environment. Clone URLs with embedded tokens are not interpolated into errors.

## Test Plan

Retargeted the five `git.Repo.clone_from` patches to `_shallow_clone`. Added:

- `test_shallow_clone_invokes_git_cli` — argv, timeout, `GIT_TERMINAL_PROMPT=0`
- `test_shallow_clone_missing_executable`
- `test_shallow_clone_nonzero_exit` — token redacted from the exception

```
make ruff
pytest python_modules/libraries/dagster-dbt/dagster_dbt_tests/components/test_dbt_project_component_remote.py
```

## Changelog

dagster-dbt no longer depends on GitPython. Remote dbt projects are shallow-cloned with the git CLI (`git clone --depth 1`). Importing the library no longer fails when git is absent.

Fixes https://github.com/dagster-io/dagster/issues/34091

Made with [Cursor](https://cursor.com)