### PR TITLE
Fix overlapping timeline labels at narrow widths

### DIFF
--- a/js_modules/ui-core/src/instance/backfill/ExecutionTimeline.tsx
+++ b/js_modules/ui-core/src/instance/backfill/ExecutionTimeline.tsx
@@ -67,6 +67,7 @@ export const ExecutionTimeline = (props: Props) => {
           rangeMs={rangeMs}
           annotations={annotations}
           height={runs.length > 0 ? height : 0}
+          width={Math.max(0, width - LEFT_SIDE_SPACE_ALLOTTED)}
         />
       </div>
       {runs.length ? (

--- a/js_modules/ui-core/src/runs/RunTimeline.tsx
+++ b/js_modules/ui-core/src/runs/RunTimeline.tsx
@@ -27,6 +27,7 @@ import {RowObjectType, TimelineRow, TimelineRun} from './RunTimelineTypes';
 import {TimeElapsed} from './TimeElapsed';
 import {RunBatch, batchRunsForTimeline} from './batchRunsForTimeline';
 import styles from './css/RunTimeline.module.css';
+import {getTimeLabelStride} from './getTimeLabelStride';
 import {mergeStatusToBackground} from './mergeStatusToBackground';
 import {COMMON_COLLATOR} from '../app/Util';
 import {HiddenAssetGroupJobTooltipIcon} from '../asset-graph/HiddenAssetGroupJobTooltip';
@@ -184,7 +185,12 @@ export const RunTimeline = (props: Props) => {
         Runs
       </Box>
       <div style={{position: 'relative'}}>
-        <TimeDividers interval={ONE_HOUR_MSEC} rangeMs={rangeMs} height={anyObjects ? height : 0} />
+        <TimeDividers
+          interval={ONE_HOUR_MSEC}
+          rangeMs={rangeMs}
+          height={anyObjects ? height : 0}
+          width={Math.max(0, width - LEFT_SIDE_SPACE_ALLOTTED)}
+        />
       </div>
       {repoOrder.length ? (
         <div style={{overflow: 'hidden', position: 'relative'}}>
@@ -343,12 +349,14 @@ type TimeMarker = {
   key: string;
   label: React.ReactNode;
   left: number;
+  showLabel: boolean;
 };
 
 interface TimeDividersProps {
   height: number;
   interval: number;
   rangeMs: [number, number];
+  width: number;
   annotations?: {label: string; ms: number}[];
   now?: number;
 }
@@ -376,9 +384,10 @@ const timeOnlyOptions: Intl.DateTimeFormatOptions = {
 };
 
 export const TimeDividers = (props: TimeDividersProps) => {
-  const {interval, rangeMs, annotations, height, now: _now} = props;
+  const {interval, rangeMs, width, annotations, height, now: _now} = props;
   const [start, end] = rangeMs;
   const formatDateTime = useFormatDateTime();
+  const timeLabelStride = getTimeLabelStride({interval, rangeMs, width});
 
   // Create a cursor date at midnight in the user's timezone, to be used when
   // generating date and time markers.
@@ -441,7 +450,7 @@ export const TimeDividers = (props: TimeDividersProps) => {
 
     // Create boundary markers, then slice off any markers that would be offscreen.
     return timeBoundaries
-      .map((intervalStart) => {
+      .map((intervalStart, index) => {
         const date = new Date(intervalStart);
         const startLeftMsec = intervalStart - start;
         const left = Math.max(0, (startLeftMsec / totalTime) * 100);
@@ -454,10 +463,11 @@ export const TimeDividers = (props: TimeDividersProps) => {
           label,
           key: date.toString(),
           left,
+          showLabel: index % timeLabelStride === 0,
         };
       })
       .filter((marker) => marker.left > 0);
-  }, [end, start, boundaryCursor, interval, formatDateTime]);
+  }, [end, start, boundaryCursor, interval, formatDateTime, timeLabelStride]);
 
   const now = _now || Date.now();
   const msToLeft = (ms: number) => `${(((ms - start) / (end - start)) * 100).toPrecision(3)}%`;
@@ -484,15 +494,17 @@ export const TimeDividers = (props: TimeDividersProps) => {
         ))}
       </div>
       <div className={styles.dividerLabels}>
-        {timeMarkers.map((marker) => (
-          <div
-            className={styles.timeLabel}
-            key={marker.key}
-            style={{left: `${marker.left.toPrecision(3)}%`}}
-          >
-            {marker.label}
-          </div>
-        ))}
+        {timeMarkers
+          .filter((marker) => marker.showLabel)
+          .map((marker) => (
+            <div
+              className={styles.timeLabel}
+              key={marker.key}
+              style={{left: `${marker.left.toPrecision(3)}%`}}
+            >
+              {marker.label}
+            </div>
+          ))}
       </div>
       <div className={styles.dividerLines}>
         <div

--- a/js_modules/ui-core/src/runs/RunTimeline.tsx
+++ b/js_modules/ui-core/src/runs/RunTimeline.tsx
@@ -30,6 +30,7 @@ import styles from './css/RunTimeline.module.css';
 import {getTimeLabelStride} from './getTimeLabelStride';
 import {mergeStatusToBackground} from './mergeStatusToBackground';
 import {COMMON_COLLATOR} from '../app/Util';
+import {TimeContext} from '../app/time/TimeContext';
 import {HiddenAssetGroupJobTooltipIcon} from '../asset-graph/HiddenAssetGroupJobTooltip';
 import {OVERVIEW_COLLAPSED_KEY} from '../overview/OverviewExpansionKey';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
@@ -54,6 +55,12 @@ const LABEL_WIDTH = 268;
 const MIN_DATE_WIDTH_PCT = 10;
 
 const ONE_HOUR_MSEC = 60 * 60 * 1000;
+// Includes 16px horizontal padding. With 12px Geist Mono, measured localized labels
+// reach 42.4/52px for h23 and 66.4/88px for h12; round each up to the next 8px step.
+const MIN_TIME_LABEL_SPACING = {
+  hour: {dayPeriod: 72, twentyFourHour: 48},
+  minute: {dayPeriod: 96, twentyFourHour: 56},
+};
 
 export const CONSTANTS = {
   ROW_HEIGHT,
@@ -387,7 +394,18 @@ export const TimeDividers = (props: TimeDividersProps) => {
   const {interval, rangeMs, width, annotations, height, now: _now} = props;
   const [start, end] = rangeMs;
   const formatDateTime = useFormatDateTime();
-  const timeLabelStride = getTimeLabelStride({interval, rangeMs, width});
+  const {
+    hourCycle: [storedHourCycle],
+  } = React.useContext(TimeContext);
+  const resolvedHourCycle =
+    storedHourCycle === 'Automatic'
+      ? Intl.DateTimeFormat(navigator.language, {hour: 'numeric'}).resolvedOptions().hourCycle
+      : storedHourCycle;
+  const clockFormat =
+    resolvedHourCycle === 'h23' || resolvedHourCycle === 'h24' ? 'twentyFourHour' : 'dayPeriod';
+  const labelFormat = interval < ONE_HOUR_MSEC ? 'minute' : 'hour';
+  const minLabelSpacing = MIN_TIME_LABEL_SPACING[labelFormat][clockFormat];
+  const timeLabelStride = getTimeLabelStride({interval, minLabelSpacing, rangeMs, width});
 
   // Create a cursor date at midnight in the user's timezone, to be used when
   // generating date and time markers.

--- a/js_modules/ui-core/src/runs/__stories__/RunTimeline.stories.tsx
+++ b/js_modules/ui-core/src/runs/__stories__/RunTimeline.stories.tsx
@@ -38,6 +38,17 @@ export const OneRow = () => {
   return <RunTimeline rows={rows} rangeMs={[sixHoursAgo, now]} />;
 };
 
+export const NarrowTwentyFourHourRange = () => {
+  const twentyFourHoursAgo = useMemo(() => Date.now() - 24 * 60 * 60 * 1000, []);
+  const oneHourFromNow = useMemo(() => Date.now() + 60 * 60 * 1000, []);
+
+  return (
+    <div style={{width: 700}}>
+      <RunTimeline rows={[]} rangeMs={[twentyFourHoursAgo, oneHourFromNow]} />
+    </div>
+  );
+};
+
 export const RowWithOverlappingRuns = () => {
   const sixHoursAgo = useMemo(() => Date.now() - 6 * 60 * 60 * 1000, []);
   const now = useMemo(() => Date.now(), []);

--- a/js_modules/ui-core/src/runs/__stories__/RunTimeline.stories.tsx
+++ b/js_modules/ui-core/src/runs/__stories__/RunTimeline.stories.tsx
@@ -1,7 +1,9 @@
 import faker from 'faker';
 import {useMemo} from 'react';
 
+import {TimeContext, type TimeContextValue} from '../../app/time/TimeContext';
 import {RunStatus} from '../../graphql/types';
+import {ExecutionTimeline} from '../../instance/backfill/ExecutionTimeline';
 import {RunTimeline} from '../../runs/RunTimeline';
 import {generateRunMocks} from '../../testing/generateRunMocks';
 import {buildRepoAddress} from '../../workspace/buildRepoAddress';
@@ -43,11 +45,45 @@ export const NarrowTwentyFourHourRange = () => {
   const oneHourFromNow = useMemo(() => Date.now() + 60 * 60 * 1000, []);
 
   return (
-    <div style={{width: 700}}>
+    <div style={{width: '100%', maxWidth: 700}}>
       <RunTimeline rows={[]} rangeMs={[twentyFourHoursAgo, oneHourFromNow]} />
     </div>
   );
 };
+
+const SUB_HOUR_RANGE_START = Date.UTC(2026, 7, 22, 8);
+const SUB_HOUR_RANGE_END = SUB_HOUR_RANGE_START + 4 * 60 * 60 * 1000;
+
+const timeContextValue = (hourCycle: 'h12' | 'h23') =>
+  ({
+    timezone: ['UTC', () => 'UTC', () => {}],
+    resolvedTimezone: 'UTC',
+    hourCycle: [hourCycle, () => hourCycle, () => {}],
+  }) as TimeContextValue;
+
+const NarrowSubHourExecutionTimeline = ({hourCycle}: {hourCycle: 'h12' | 'h23'}) => (
+  <TimeContext.Provider value={timeContextValue(hourCycle)}>
+    <div style={{width: '100%', maxWidth: 700}}>
+      <ExecutionTimeline
+        runs={[]}
+        rangeMs={[SUB_HOUR_RANGE_START, SUB_HOUR_RANGE_END]}
+        annotations={[
+          {label: 'Start', ms: SUB_HOUR_RANGE_START + 20 * 60 * 1000},
+          {label: 'End', ms: SUB_HOUR_RANGE_END - 20 * 60 * 1000},
+        ]}
+        now={SUB_HOUR_RANGE_START + 2.5 * 60 * 60 * 1000}
+      />
+    </div>
+  </TimeContext.Provider>
+);
+
+export const NarrowSubHourTwelveHourClock = () => (
+  <NarrowSubHourExecutionTimeline hourCycle="h12" />
+);
+
+export const NarrowSubHourTwentyFourHourClock = () => (
+  <NarrowSubHourExecutionTimeline hourCycle="h23" />
+);
 
 export const RowWithOverlappingRuns = () => {
   const sixHoursAgo = useMemo(() => Date.now() - 6 * 60 * 60 * 1000, []);

--- a/js_modules/ui-core/src/runs/__tests__/TimeDividers.test.tsx
+++ b/js_modules/ui-core/src/runs/__tests__/TimeDividers.test.tsx
@@ -1,0 +1,73 @@
+import {render, screen} from '@testing-library/react';
+
+import {TimeContext, type TimeContextValue} from '../../app/time/TimeContext';
+import {TimeDividers} from '../RunTimeline';
+import styles from '../css/RunTimeline.module.css';
+
+const ONE_MINUTE = 60 * 1000;
+const RANGE_START = Date.UTC(2026, 7, 22, 8);
+const RANGE_END = RANGE_START + 4 * 60 * ONE_MINUTE;
+const TEN_MINUTES = 10 * ONE_MINUTE;
+
+const timeContextValue = (hourCycle: 'h12' | 'h23') =>
+  ({
+    timezone: ['UTC', () => 'UTC', () => {}],
+    resolvedTimezone: 'UTC',
+    hourCycle: [hourCycle, () => hourCycle, () => {}],
+  }) as TimeContextValue;
+
+const elementsForClass = (container: HTMLElement, className: string | undefined) => {
+  if (!className) {
+    throw new Error('Expected CSS module class name');
+  }
+  return container.getElementsByClassName(className);
+};
+
+const TestTimeline = ({hourCycle = 'h12', width}: {hourCycle?: 'h12' | 'h23'; width: number}) => (
+  <TimeContext.Provider value={timeContextValue(hourCycle)}>
+    <TimeDividers
+      annotations={[
+        {label: 'Start', ms: RANGE_START + 20 * ONE_MINUTE},
+        {label: 'End', ms: RANGE_END - 20 * ONE_MINUTE},
+      ]}
+      height={160}
+      interval={TEN_MINUTES}
+      now={RANGE_START + 150 * ONE_MINUTE}
+      rangeMs={[RANGE_START, RANGE_END]}
+      width={width}
+    />
+  </TimeContext.Provider>
+);
+
+describe('TimeDividers', () => {
+  it('changes label density without removing dividers or independent markers', () => {
+    const {container, rerender} = render(<TestTimeline width={240} />);
+
+    const narrowLabelCount = elementsForClass(container, styles.timeLabel).length;
+    const narrowDividerCount = elementsForClass(container, styles.dividerLine).length;
+
+    expect(narrowLabelCount).toBe(1);
+    expect(screen.getByText('Now')).toBeVisible();
+    expect(screen.getByText('Start')).toBeVisible();
+    expect(screen.getByText('End')).toBeVisible();
+
+    rerender(<TestTimeline width={720} />);
+
+    expect(elementsForClass(container, styles.timeLabel)).toHaveLength(5);
+    expect(elementsForClass(container, styles.dividerLine)).toHaveLength(narrowDividerCount);
+    expect(elementsForClass(container, styles.timeLabel).length).toBeGreaterThan(narrowLabelCount);
+    expect(screen.getByText('Now')).toBeVisible();
+    expect(screen.getByText('Start')).toBeVisible();
+    expect(screen.getByText('End')).toBeVisible();
+  });
+
+  it('uses denser spacing for shorter 24-hour labels', () => {
+    const {container, rerender} = render(<TestTimeline hourCycle="h12" width={240} />);
+
+    expect(elementsForClass(container, styles.timeLabel)).toHaveLength(1);
+
+    rerender(<TestTimeline hourCycle="h23" width={240} />);
+
+    expect(elementsForClass(container, styles.timeLabel)).toHaveLength(3);
+  });
+});

--- a/js_modules/ui-core/src/runs/__tests__/getTimeLabelStride.test.ts
+++ b/js_modules/ui-core/src/runs/__tests__/getTimeLabelStride.test.ts
@@ -1,0 +1,50 @@
+import {getTimeLabelStride} from '../getTimeLabelStride';
+
+const ONE_HOUR = 60 * 60 * 1000;
+
+const strideForTimeline = ({selectedHours, width}: {selectedHours: number; width: number}) =>
+  getTimeLabelStride({
+    interval: ONE_HOUR,
+    rangeMs: [0, (selectedHours + 1) * ONE_HOUR],
+    width,
+  });
+
+describe('getTimeLabelStride', () => {
+  it.each([
+    {selectedHours: 1, expectedStride: 1},
+    {selectedHours: 6, expectedStride: 1},
+    {selectedHours: 12, expectedStride: 2},
+    {selectedHours: 24, expectedStride: 4},
+  ])(
+    'uses a stride of $expectedStride for a narrow $selectedHours hour timeline',
+    ({selectedHours, expectedStride}) => {
+      expect(strideForTimeline({selectedHours, width: 380})).toBe(expectedStride);
+    },
+  );
+
+  it.each([1, 6, 12, 24])('keeps hourly labels for a wide %s hour timeline', (selectedHours) => {
+    expect(strideForTimeline({selectedHours, width: 1280})).toBe(1);
+  });
+
+  it('rounds up to a readable interval', () => {
+    expect(strideForTimeline({selectedHours: 24, width: 240})).toBe(6);
+  });
+
+  it('supports sub-hour intervals used by the execution timeline', () => {
+    expect(
+      getTimeLabelStride({
+        interval: ONE_HOUR / 6,
+        rangeMs: [0, 4 * ONE_HOUR],
+        width: 240,
+      }),
+    ).toBe(6);
+  });
+
+  it.each([
+    {interval: 0, rangeMs: [0, ONE_HOUR] as [number, number], width: 500},
+    {interval: ONE_HOUR, rangeMs: [ONE_HOUR, 0] as [number, number], width: 500},
+    {interval: ONE_HOUR, rangeMs: [0, ONE_HOUR] as [number, number], width: 0},
+  ])('falls back to one for invalid dimensions', (args) => {
+    expect(getTimeLabelStride(args)).toBe(1);
+  });
+});

--- a/js_modules/ui-core/src/runs/__tests__/getTimeLabelStride.test.ts
+++ b/js_modules/ui-core/src/runs/__tests__/getTimeLabelStride.test.ts
@@ -1,10 +1,13 @@
 import {getTimeLabelStride} from '../getTimeLabelStride';
 
 const ONE_HOUR = 60 * 60 * 1000;
+const HOURLY_LABEL_SPACING = 48;
+const DAY_PERIOD_MINUTE_LABEL_SPACING = 96;
 
 const strideForTimeline = ({selectedHours, width}: {selectedHours: number; width: number}) =>
   getTimeLabelStride({
     interval: ONE_HOUR,
+    minLabelSpacing: HOURLY_LABEL_SPACING,
     rangeMs: [0, (selectedHours + 1) * ONE_HOUR],
     width,
   });
@@ -34,16 +37,82 @@ describe('getTimeLabelStride', () => {
     expect(
       getTimeLabelStride({
         interval: ONE_HOUR / 6,
+        minLabelSpacing: DAY_PERIOD_MINUTE_LABEL_SPACING,
         rangeMs: [0, 4 * ONE_HOUR],
         width: 240,
       }),
-    ).toBe(6);
+    ).toBe(12);
+  });
+
+  it('shows more sub-hour labels when enough width is available', () => {
+    expect(
+      getTimeLabelStride({
+        interval: ONE_HOUR / 6,
+        minLabelSpacing: DAY_PERIOD_MINUTE_LABEL_SPACING,
+        rangeMs: [0, 4 * ONE_HOUR],
+        width: 720,
+      }),
+    ).toBe(4);
+  });
+
+  it('keeps every label at the exact spacing boundary', () => {
+    expect(
+      getTimeLabelStride({
+        interval: ONE_HOUR / 6,
+        minLabelSpacing: DAY_PERIOD_MINUTE_LABEL_SPACING,
+        rangeMs: [0, 4 * ONE_HOUR],
+        width: 24 * DAY_PERIOD_MINUTE_LABEL_SPACING,
+      }),
+    ).toBe(1);
+  });
+
+  it('increases the stride one pixel below the spacing boundary', () => {
+    expect(
+      getTimeLabelStride({
+        interval: ONE_HOUR / 6,
+        minLabelSpacing: DAY_PERIOD_MINUTE_LABEL_SPACING,
+        rangeMs: [0, 4 * ONE_HOUR],
+        width: 24 * DAY_PERIOD_MINUTE_LABEL_SPACING - 1,
+      }),
+    ).toBe(2);
+  });
+
+  it('returns the required stride when it exceeds the predefined nice values', () => {
+    expect(
+      getTimeLabelStride({
+        interval: ONE_HOUR,
+        minLabelSpacing: HOURLY_LABEL_SPACING,
+        rangeMs: [0, 24 * ONE_HOUR],
+        width: 24,
+      }),
+    ).toBe(48);
   });
 
   it.each([
-    {interval: 0, rangeMs: [0, ONE_HOUR] as [number, number], width: 500},
-    {interval: ONE_HOUR, rangeMs: [ONE_HOUR, 0] as [number, number], width: 500},
-    {interval: ONE_HOUR, rangeMs: [0, ONE_HOUR] as [number, number], width: 0},
+    {
+      interval: 0,
+      minLabelSpacing: HOURLY_LABEL_SPACING,
+      rangeMs: [0, ONE_HOUR] as [number, number],
+      width: 500,
+    },
+    {
+      interval: ONE_HOUR,
+      minLabelSpacing: HOURLY_LABEL_SPACING,
+      rangeMs: [ONE_HOUR, 0] as [number, number],
+      width: 500,
+    },
+    {
+      interval: ONE_HOUR,
+      minLabelSpacing: HOURLY_LABEL_SPACING,
+      rangeMs: [0, ONE_HOUR] as [number, number],
+      width: 0,
+    },
+    {
+      interval: ONE_HOUR,
+      minLabelSpacing: 0,
+      rangeMs: [0, ONE_HOUR] as [number, number],
+      width: 500,
+    },
   ])('falls back to one for invalid dimensions', (args) => {
     expect(getTimeLabelStride(args)).toBe(1);
   });

--- a/js_modules/ui-core/src/runs/getTimeLabelStride.ts
+++ b/js_modules/ui-core/src/runs/getTimeLabelStride.ts
@@ -1,24 +1,24 @@
-// Time labels have 8px horizontal padding and can be four mono-spaced characters wide.
-const MIN_TIME_LABEL_SPACING = 48;
 const NICE_TIME_LABEL_STRIDES = [1, 2, 3, 4, 6, 12, 24];
 
 export const getTimeLabelStride = ({
   interval,
+  minLabelSpacing,
   rangeMs,
   width,
 }: {
   interval: number;
+  minLabelSpacing: number;
   rangeMs: [number, number];
   width: number;
 }) => {
   const duration = rangeMs[1] - rangeMs[0];
 
-  if (duration <= 0 || interval <= 0 || width <= 0) {
+  if (duration <= 0 || interval <= 0 || minLabelSpacing <= 0 || width <= 0) {
     return 1;
   }
 
   const pixelsPerInterval = (width * interval) / duration;
-  const minimumStride = Math.max(1, Math.ceil(MIN_TIME_LABEL_SPACING / pixelsPerInterval));
+  const minimumStride = Math.max(1, Math.ceil(minLabelSpacing / pixelsPerInterval));
 
   return NICE_TIME_LABEL_STRIDES.find((stride) => stride >= minimumStride) ?? minimumStride;
 };

--- a/js_modules/ui-core/src/runs/getTimeLabelStride.ts
+++ b/js_modules/ui-core/src/runs/getTimeLabelStride.ts
@@ -1,0 +1,24 @@
+// Time labels have 8px horizontal padding and can be four mono-spaced characters wide.
+const MIN_TIME_LABEL_SPACING = 48;
+const NICE_TIME_LABEL_STRIDES = [1, 2, 3, 4, 6, 12, 24];
+
+export const getTimeLabelStride = ({
+  interval,
+  rangeMs,
+  width,
+}: {
+  interval: number;
+  rangeMs: [number, number];
+  width: number;
+}) => {
+  const duration = rangeMs[1] - rangeMs[0];
+
+  if (duration <= 0 || interval <= 0 || width <= 0) {
+    return 1;
+  }
+
+  const pixelsPerInterval = (width * interval) / duration;
+  const minimumStride = Math.max(1, Math.ceil(MIN_TIME_LABEL_SPACING / pixelsPerInterval));
+
+  return NICE_TIME_LABEL_STRIDES.find((stride) => stride >= minimumStride) ?? minimumStride;
+};


### PR DESCRIPTION
## Summary

- adapt timeline label density to the available plotting width
- use format-aware spacing for hour-only and minute-bearing labels in 12-hour and 24-hour modes
- preserve every divider line, the current-time marker, and annotation markers while reducing label density
- add responsive Overview and focused sub-hour ExecutionTimeline Storybook coverage
- add numeric boundary tests and a rendered `TimeDividers` regression test

## Root cause

The original fix assumed every time label fit in 48px. That is valid only for compact hour labels. `ExecutionTimeline` uses ten-minute dividers for ranges of four hours or less, and those dividers render longer hour-and-minute labels. At a 240px plotting width, the old stride placed `10:00AM` and `11:00AM` 60px apart even though each long label rendered at 66.4px, producing 6.4px of overlap.

The footprint also depends on clock format and locale, so a single replacement constant would remain fragile.

## Measurement and spacing policy

Measurements used the actual 12px Geist Mono timeline styles, including 16px total horizontal padding.

| Format | Largest measured footprint | Minimum spacing |
| --- | ---: | ---: |
| 24-hour, hour only | 42.4px | 48px |
| 24-hour, hour + minute | 52.0px | 56px |
| 12-hour/day period, hour only | 66.4px | 72px |
| 12-hour/day period, hour + minute | 88.0px | 96px |

The localized measurement sample covered English, Spanish, Dutch, Turkish, Arabic, Persian, Japanese, Korean, and Chinese output. Values are rounded up to the next 8px layout step. The caller selects the policy from the active/resolved hour cycle and passes the numeric minimum to `getTimeLabelStride`, so the helper remains formatting-agnostic.

## Validation

- `corepack yarn jest src/runs/__tests__/getTimeLabelStride.test.ts src/runs/__tests__/TimeDividers.test.tsx src/runs/__tests__/batchRunsForTimeline.test.tsx src/runs/__tests__/useRunsForTimeline.test.tsx --runInBand --no-cache --silent` — 4 suites, 38 tests passed
- `corepack yarn tsgo -p .` — passed
- targeted ESLint for every changed TypeScript/Storybook file — passed
- `git diff --check upstream/master...HEAD` — passed

The earlier full Jest baseline remains documented separately: 152 suites passed and 13 unrelated suites failed, primarily from five-second timeouts under heavy parallel load on Windows plus an existing date-sensitive partition mock mismatch. This correction did not change those areas. Top-level auto-fixing lint remains blocked by the unrelated `Route.tsx` import rewrite on the branch base; every file in this PR passes ESLint directly. Internal `app-cloud` typechecking is unavailable because the internal repository is not present in this environment.

## Manual verification

- [x] Tested 1440px, 1024px, 768px, and 600px viewports
- [x] Verified Overview 1h, 6h, 12h, and 24h ranges
- [x] Verified ExecutionTimeline <=4h ten-minute dividers and >4h hourly dividers
- [x] Verified 12-hour and 24-hour modes
- [x] Confirmed labels do not overlap or create horizontal overflow
- [x] Confirmed every divider line remains visible
- [x] Confirmed `Now` and annotation markers remain visible
- [x] Slow-resized from 600px to 800px in 10px increments with no invalid intermediate layout
- [x] Confirmed no console errors, ResizeObserver warnings, or resize flicker

## Before

<img width="768" height="320" alt="Dagster timeline labels overlapping at a narrow viewport" src="https://github.com/user-attachments/assets/91609894-044a-4b27-8161-827ef95bd4c8" />

## After

<img width="768" height="320" alt="Responsive Dagster timeline labels without overlap" src="https://github.com/user-attachments/assets/49844541-1307-456a-91db-d5add232c54b" />

Corrective commit: `e3e060b00f`.
