### PR TITLE
[helm] Add --timeout-keep-alive to dagster-webserver and expose it in the chart

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -42,6 +42,7 @@ class Webserver(BaseModel, extra="forbid"):
     dbStatementTimeout: int | None = None
     dbPoolRecycle: int | None = None
     dbPoolMaxOverflow: int | None = None
+    timeoutKeepAlive: int | None = None
     logLevel: str | None = None
     logFormat: str | None = None
     schedulerName: str | None = None

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -312,6 +312,18 @@ def test_webserver_db_pool_max_overflow(deployment_template: HelmTemplate):
     assert f"--db-pool-max-overflow {pool_max_overflow_s}" in command
 
 
+def test_webserver_timeout_keep_alive(deployment_template: HelmTemplate):
+    timeout_keep_alive_s = 65
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct(timeoutKeepAlive=timeout_keep_alive_s)
+    )
+
+    webserver_deployments = deployment_template.render(helm_values)
+    command = " ".join(webserver_deployments[0].spec.template.spec.containers[0].command)
+
+    assert f"--timeout-keep-alive {timeout_keep_alive_s}" in command
+
+
 def test_webserver_log_level(deployment_template: HelmTemplate):
     log_level = "trace"
     helm_values = DagsterHelmValues.construct(

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -324,6 +324,26 @@ def test_webserver_timeout_keep_alive(deployment_template: HelmTemplate):
     assert f"--timeout-keep-alive {timeout_keep_alive_s}" in command
 
 
+def test_webserver_timeout_keep_alive_zero(deployment_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        dagsterWebserver=Webserver.construct(timeoutKeepAlive=0)
+    )
+
+    webserver_deployments = deployment_template.render(helm_values)
+    command = " ".join(webserver_deployments[0].spec.template.spec.containers[0].command)
+
+    assert "--timeout-keep-alive 0" in command
+
+
+def test_webserver_timeout_keep_alive_unset(deployment_template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(dagsterWebserver=Webserver.construct())
+
+    webserver_deployments = deployment_template.render(helm_values)
+    command = " ".join(webserver_deployments[0].spec.template.spec.containers[0].command)
+
+    assert "--timeout-keep-alive" not in command
+
+
 def test_webserver_log_level(deployment_template: HelmTemplate):
     log_level = "trace"
     helm_values = DagsterHelmValues.construct(

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -57,6 +57,7 @@ If release name contains chart name it will be used as a full name.
 {{- with $_.Values.dagsterWebserver.dbStatementTimeout }} --db-statement-timeout {{ . }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbPoolRecycle }} --db-pool-recycle {{ . }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbPoolMaxOverflow }} --db-pool-max-overflow {{ . }} {{- end -}}
+{{- with $_.Values.dagsterWebserver.timeoutKeepAlive }} --timeout-keep-alive {{ . }} {{- end -}}
 {{- if $_.Values.dagsterWebserver.pathPrefix }} --path-prefix {{ $_.Values.dagsterWebserver.pathPrefix }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.logLevel }} --log-level {{ . }} {{- end -}}
 {{- if .webserverReadOnly }} --read-only {{- end -}}

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -57,7 +57,7 @@ If release name contains chart name it will be used as a full name.
 {{- with $_.Values.dagsterWebserver.dbStatementTimeout }} --db-statement-timeout {{ . }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbPoolRecycle }} --db-pool-recycle {{ . }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.dbPoolMaxOverflow }} --db-pool-max-overflow {{ . }} {{- end -}}
-{{- with $_.Values.dagsterWebserver.timeoutKeepAlive }} --timeout-keep-alive {{ . }} {{- end -}}
+{{- if not (kindIs "invalid" $_.Values.dagsterWebserver.timeoutKeepAlive) }} --timeout-keep-alive {{ $_.Values.dagsterWebserver.timeoutKeepAlive }} {{- end -}}
 {{- if $_.Values.dagsterWebserver.pathPrefix }} --path-prefix {{ $_.Values.dagsterWebserver.pathPrefix }} {{- end -}}
 {{- with $_.Values.dagsterWebserver.logLevel }} --log-level {{ . }} {{- end -}}
 {{- if .webserverReadOnly }} --read-only {{- end -}}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -3684,6 +3684,18 @@
                     "default": null,
                     "title": "Dbpoolmaxoverflow"
                 },
+                "timeoutKeepAlive": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Timeoutkeepalive"
+                },
                 "logLevel": {
                     "anyOf": [
                         {

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -95,6 +95,11 @@ dagsterWebserver:
   # The maximum overflow size of the sqlalchemy pool. Set to -1 to disable.
   dbPoolMaxOverflow: ~
 
+  # The number of seconds an idle keep-alive connection is held open, defaults to 5 if not
+  # set. Raise this above the idle timeout of any reverse proxy in front of the webserver,
+  # so that the proxy closes idle connections first.
+  timeoutKeepAlive: ~
+
   # The log level of the uvicorn web server, defaults to warning if not set
   logLevel: ~
 

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -97,7 +97,8 @@ dagsterWebserver:
 
   # The number of seconds an idle keep-alive connection is held open, defaults to 5 if not
   # set. Raise this above the idle timeout of any reverse proxy in front of the webserver,
-  # so that the proxy closes idle connections first.
+  # so that the proxy closes idle connections first. Set to 0 to close idle connections
+  # immediately.
   timeoutKeepAlive: ~
 
   # The log level of the uvicorn web server, defaults to warning if not set

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -44,6 +44,7 @@ DEFAULT_WEBSERVER_PORT = 3000
 DEFAULT_DB_STATEMENT_TIMEOUT = 15000  # 15 sec
 DEFAULT_POOL_RECYCLE = 3600  # 1 hr
 DEFAULT_POOL_MAX_OVERFLOW = 20
+DEFAULT_TIMEOUT_KEEP_ALIVE = 5  # 5 sec, uvicorn's own default
 
 
 @click.command(
@@ -133,6 +134,17 @@ DEFAULT_POOL_MAX_OVERFLOW = 20
     show_default=True,
 )
 @click.option(
+    "--timeout-keep-alive",
+    help=(
+        "The number of seconds to hold an idle keep-alive connection open before closing it."
+        " Raise this above the idle timeout of any reverse proxy sitting in front of the"
+        " webserver, so that the proxy closes idle connections first."
+    ),
+    default=DEFAULT_TIMEOUT_KEEP_ALIVE,
+    type=click.INT,
+    show_default=True,
+)
+@click.option(
     "--read-only",
     help=(
         "Start server in read-only mode, where all mutations such as launching runs and "
@@ -208,6 +220,7 @@ def dagster_webserver(
     db_statement_timeout: int,
     db_pool_recycle: int,
     db_pool_max_overflow: int,
+    timeout_keep_alive: int,
     read_only: bool,
     suppress_warnings: bool,
     uvicorn_log_level: str,
@@ -265,6 +278,7 @@ def dagster_webserver(
                 path_prefix,
                 uvicorn_log_level,
                 live_data_poll_rate,
+                timeout_keep_alive,
             )
 
 
@@ -288,6 +302,7 @@ def host_dagster_ui_with_workspace_process_context(
     path_prefix: str,
     log_level: str,
     live_data_poll_rate: int | None = None,
+    timeout_keep_alive: int = DEFAULT_TIMEOUT_KEEP_ALIVE,
 ):
     check.inst_param(
         workspace_process_context, "workspace_process_context", IWorkspaceProcessContext
@@ -296,6 +311,7 @@ def host_dagster_ui_with_workspace_process_context(
     check.opt_int_param(port, "port")
     check.str_param(path_prefix, "path_prefix")
     check.opt_int_param(live_data_poll_rate, "live_data_poll_rate")
+    check.int_param(timeout_keep_alive, "timeout_keep_alive")
 
     logger = logging.getLogger(WEBSERVER_LOGGER_NAME)
 
@@ -320,6 +336,7 @@ def host_dagster_ui_with_workspace_process_context(
             host=host,
             port=port,
             log_level=log_level,
+            timeout_keep_alive=timeout_keep_alive,
         )
 
 

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -138,7 +138,8 @@ DEFAULT_TIMEOUT_KEEP_ALIVE = 5  # 5 sec, uvicorn's own default
     help=(
         "The number of seconds to hold an idle keep-alive connection open before closing it."
         " Raise this above the idle timeout of any reverse proxy sitting in front of the"
-        " webserver, so that the proxy closes idle connections first."
+        " webserver, so that the proxy closes idle connections first. Set to 0 to close idle"
+        " connections immediately."
     ),
     default=DEFAULT_TIMEOUT_KEEP_ALIVE,
     type=click.INT,

--- a/python_modules/dagster-webserver/dagster_webserver_tests/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/test_app.py
@@ -14,6 +14,7 @@ from dagster_shared import seven
 from dagster_shared.telemetry import cleanup_telemetry_logger, get_telemetry_logger
 from dagster_webserver.app import create_app_from_workspace_process_context
 from dagster_webserver.cli import (
+    DEFAULT_TIMEOUT_KEEP_ALIVE,
     DEFAULT_WEBSERVER_PORT,
     dagster_webserver,
     host_dagster_ui_with_workspace_process_context,
@@ -163,7 +164,13 @@ def test_successful_host_dagster_ui_from_workspace():
                 log_level="warning",
             )
 
-        server_call.assert_called_with(mock.ANY, host="127.0.0.1", port=2343, log_level="warning")
+        server_call.assert_called_with(
+            mock.ANY,
+            host="127.0.0.1",
+            port=2343,
+            log_level="warning",
+            timeout_keep_alive=DEFAULT_TIMEOUT_KEEP_ALIVE,
+        )
 
 
 @pytest.fixture
@@ -197,7 +204,11 @@ def test_host_dagster_webserver_choose_port(mock_is_port_in_use, mock_find_free_
             )
 
         server_call.assert_called_with(
-            mock.ANY, host="127.0.0.1", port=DEFAULT_WEBSERVER_PORT, log_level="warning"
+            mock.ANY,
+            host="127.0.0.1",
+            port=DEFAULT_WEBSERVER_PORT,
+            log_level="warning",
+            timeout_keep_alive=DEFAULT_TIMEOUT_KEEP_ALIVE,
         )
 
         mock_is_port_in_use.return_value = True
@@ -212,7 +223,13 @@ def test_host_dagster_webserver_choose_port(mock_is_port_in_use, mock_find_free_
                 log_level="warning",
             )
 
-        server_call.assert_called_with(mock.ANY, host="127.0.0.1", port=1234, log_level="warning")
+        server_call.assert_called_with(
+            mock.ANY,
+            host="127.0.0.1",
+            port=1234,
+            log_level="warning",
+            timeout_keep_alive=DEFAULT_TIMEOUT_KEEP_ALIVE,
+        )
 
 
 def test_successful_host_dagster_ui_from_multiple_workspace_files():


### PR DESCRIPTION
## Summary & Motivation

`dagster-webserver` runs uvicorn with only `host`, `port` and `log_level`, so its keep-alive timeout is always uvicorn's default of 5 seconds and cannot be configured:

```python
uvicorn.run(
    app,
    host=host,
    port=port,
    log_level=log_level,
)
```

That is a problem behind a reverse proxy. A proxy that holds idle upstream connections *longer* than the backend will eventually reuse a socket the backend has just closed, and the request fails. With ingress-nginx the default `upstream-keepalive-timeout` is **60s** against uvicorn's **5s**, which produces a steady trickle of:

```
upstream prematurely closed connection while reading response header from upstream
recv() failed (104: Connection reset by peer) while reading response header from upstream
```

nginx transparently retries idempotent requests, so the visible symptom is a 502 on POST — for the webserver that means the UI's own `POST /graphql` polling.

On our production deployment this is currently **44 of the 63 ingress 502s over a 15-day window**, spread across 8 separate days rather than clustered in an incident. Upstream response times on those requests run from 0.000s to 0.012s, i.e. a socket that was already dead when it was reused, not a timeout. 42 of the 44 are `CodeLocationStatusQuery`, the remainder `SingleJobQuery` and `SensorAssetSelectionQuery` — all of them ordinary UI traffic.

The usual fix is to raise the backend keep-alive above the proxy's. `dagster-webserver` offers no way to do that: there is no CLI flag, and the Helm chart builds the container command itself, so there is no `command`/`args`/`extraArgs` escape hatch either.

This adds `--timeout-keep-alive` to the CLI and `dagsterWebserver.timeoutKeepAlive` to the chart, following the existing `--db-pool-recycle` / `dbPoolRecycle` pattern exactly. The default is 5, uvicorn's own, so behaviour is unchanged unless the value is set.

`host_dagster_ui_with_workspace_process_context` takes the new argument last and with a default, and `debug.py` calls it by keyword, so the other call sites are unaffected.

Deliberately out of scope: `dagster dev` and `dg dev` forward only a subset of webserver flags to the subprocess (`--path-prefix`, `--read-only` and `--uvicorn-log-level` are already not forwarded), and a keep-alive timeout only matters behind a reverse proxy, which is not a local-dev topology. Happy to plumb it through both if you would rather have it there too.

## Test Plan

Chart rendering is covered by three tests in `helm/dagster/schema/schema_tests/test_dagit.py`, mirroring `test_webserver_db_pool_recycle`: a positive value, `0`, and unset.

The three `assert_called_with` checks in `test_app.py` match the `uvicorn.run` call exactly, so they now assert the forwarded default as well. The expected value is imported from the CLI module rather than hardcoded, so it tracks the default if it ever changes.

Verified locally with `helm template`, for all three cases:

```
# --set dagsterWebserver.timeoutKeepAlive=65
"dagster-webserver -h 0.0.0.0 -p 80 -w /dagster-workspace/workspace.yaml --timeout-keep-alive 65"

# --set dagsterWebserver.timeoutKeepAlive=0
"dagster-webserver -h 0.0.0.0 -p 80 -w /dagster-workspace/workspace.yaml --timeout-keep-alive 0"

# no value set
"dagster-webserver -h 0.0.0.0 -p 80 -w /dagster-workspace/workspace.yaml"
```

`0` is a meaningful uvicorn setting — close idle connections immediately — so the template uses a nil check rather than `{{- with }}`, whose truthiness guard would drop it.

- `ruff format --check` and `ruff check` at the 0.16.2 required by `config/ruff.toml`, on the three changed Python files — clean.
- `ruff check --select F821,F811,F841` on the same files — clean, confirming the new parameter is in scope at every call site.
- `values.schema.json` regenerated with `dagster-helm schema apply` rather than hand-edited; the diff is 12 added lines with no unrelated churn.

Not run locally, left to CI:

- the Helm schema test suite, which needs the full `dagster[test]` environment;
- `make quick_ty`, which drives `scripts/run-ty.py` and needs the full dev environment.

## Changelog

`dagster-webserver` now accepts `--timeout-keep-alive` (Helm: `dagsterWebserver.timeoutKeepAlive`) to set how long idle keep-alive connections are held open. Raise it above the idle timeout of any reverse proxy in front of the webserver to avoid 502s caused by the proxy reusing a connection the webserver has already closed.
