### PR TITLE
[dagster-dbt] Fix "Conflicting metadata found on AssetDeps" for sources shared across multiple DbtProjectComponent instances of the same project #34140

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -209,10 +209,21 @@ class DagsterDbtTranslator:
                 # code location fail to load. Only the value-stable dagster table metadata (table
                 # name, column schema, storage kind) is kept, so identical sources produce identical
                 # dep metadata.
+                #
+                # Code references are dropped for the same reason. State-backed components (e.g.
+                # several DbtProjectComponent instances scoped over one physical dbt project via
+                # `select`) each prepare their own local copy of the project, so an identical
+                # source's code reference resolves to a different absolute path per component even
+                # though the underlying declaration is unchanged. That path isn't a property of the
+                # data either, so it shouldn't be part of the identity check.
+                excluded_keys = {
+                    CodeReferencesMetadataSet._namespaced_key("code_references")
+                }
                 dep_metadata = {
                     key: value
                     for key, value in spec.metadata.items()
                     if not key.startswith(DAGSTER_DBT_METADATA_NAMESPACE)
+                    and key not in excluded_keys
                 }
 
             deps.append(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -1,10 +1,12 @@
 import inspect
 import os
+import shutil
 from pathlib import Path
 from typing import Any
 
 import dagster as dg
 import pytest
+from dagster import AssetKey
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.metadata.source_code import (
     AnchorBasedFilePathMapping,
@@ -19,7 +21,7 @@ from dagster_dbt import DbtCliResource, DbtProject
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
 
-from dagster_dbt_tests.dbt_projects import test_jaffle_shop_path
+from dagster_dbt_tests.dbt_projects import test_asset_checks_path, test_jaffle_shop_path
 
 JAFFLE_SHOP_ROOT_PATH = os.path.normpath(test_jaffle_shop_path)
 
@@ -139,3 +141,63 @@ def test_link_to_git_wrapper(test_jaffle_shop_manifest: dict[str, Any]) -> None:
         assert isinstance(source_reference, UrlCodeReference)
         line_no = inspect.getsourcelines(my_dbt_assets.op.compute_fn.decorated_fn)[1]  # ty: ignore[unresolved-attribute]
         assert source_reference.url.endswith(f"test_code_references.py#L{line_no}")
+
+
+def test_code_references_do_not_conflict_across_distinct_project_copies(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """State-backed components (e.g. several DbtProjectComponent instances scoped over one
+    physical dbt project) each prepare their own local copy of the project. A source shared by
+    two such components resolves to a different absolute `dagster/code_references` path per
+    component even though the underlying declaration is unchanged, since the path is derived
+    from each component's own project_dir. That shouldn't be treated as a real metadata conflict.
+    """
+    # `dbt parse` doesn't need real data, just a value for the profile's env_var() call.
+    monkeypatch.setenv("DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH", "unused.duckdb")
+    manifest = (
+        DbtCliResource(project_dir=os.fspath(test_asset_checks_path))
+        .cli(["parse"])
+        .wait()
+        .get_artifact("manifest.json")
+    )
+
+    other_project_dir = tmp_path / "other_project_copy"
+    shutil.copytree(test_asset_checks_path, other_project_dir)
+
+    settings = DagsterDbtTranslatorSettings(enable_source_metadata=True, enable_code_references=True)
+
+    @dbt_assets(
+        manifest=manifest,
+        select="stg_customers",
+        dagster_dbt_translator=DagsterDbtTranslator(settings=settings),
+        project=DbtProject(project_dir=os.fspath(test_asset_checks_path)),
+    )
+    def project_a_assets(): ...
+
+    @dbt_assets(
+        manifest=manifest,
+        select="stg_customers_again",
+        dagster_dbt_translator=DagsterDbtTranslator(settings=settings),
+        project=DbtProject(project_dir=os.fspath(other_project_dir)),
+    )
+    def project_b_assets(): ...
+
+    # Resolves without raising "Conflicting metadata found on AssetDeps", even though the two
+    # components' code references point at different absolute paths for the same source.
+    Definitions(assets=[project_a_assets, project_b_assets]).resolve_asset_graph()
+
+    raw_customers_key = AssetKey(["jaffle_shop", "raw_customers"])
+    checked_at_least_one_dep = False
+    for assets_def in (project_a_assets, project_b_assets):
+        for spec in assets_def.specs:
+            for dep in spec.deps:
+                if dep.asset_key == raw_customers_key:
+                    checked_at_least_one_dep = True
+                    # Value-stable metadata survives...
+                    assert "dagster/table_name" in dep.metadata
+                    assert "dagster/storage_kind" in dep.metadata
+                    # ...but code references, which vary per project copy, are dropped from the
+                    # dep rather than causing a conflict.
+                    assert "dagster/code_references" not in dep.metadata
+    assert checked_at_least_one_dep


### PR DESCRIPTION
## Summary & Motivation

Fixes [#34140](https://github.com/dagster-io/dagster/issues/34140)
Fixes a regression from `enable_source_metadata` defaulting to `True` in Dagster 1.13.1.

When a single dbt project is split across multiple `DbtProjectComponent` instances (state-backed components, each scoped over the project via `select`), `dg check defs` fails with `DagsterInvalidDefinitionError: Conflicting metadata found on AssetDeps ...`, even though the shared source is declared exactly once.

This happens because each state-backed component prepares its own local copy of the project (under its own `defs_state_config` key), so `dagster/code_references` — a `LocalFileCodeReference` built from each component's own `project_dir` — resolves to a different absolute path per component for the same source, even though the underlying declaration is unchanged. `get_asset_spec` already strips `dagster_dbt/`-namespaced bookkeeping metadata for exactly this reason ("the same source can be referenced by multiple dbt projects... only the value-stable dagster table metadata... is kept"), but `dagster/code_references` isn't `dagster_dbt/`-namespaced, so it survived the filter and tripped the identity check.

This PR excludes `dagster/code_references` from that same filter, alongside the existing `dagster_dbt/`-namespaced exclusion.

## Impact

- Fixes spurious code-location load failures for any project using multiple `DbtProjectComponent`/state-backed components scoped over one physical dbt project with shared sources.
- `dagster/table_name` and `dagster/storage_kind` (the actual value-stable identity signals) are unaffected and still required to match.
- No effect on setups with a single component, or with `enable_code_references`/`enable_source_metadata` disabled.

## How I Tested These Changes

- Added `test_code_references_do_not_conflict_across_distinct_project_copies` in `test_code_references.py`: two `@dbt_assets` defs, each backed by its own copy of the same dbt project directory (mirroring the `.local_defs_state` per-component copy behavior), both depending on the same source, with `enable_source_metadata=True` and `enable_code_references=True`.
- Verified the shared dep's metadata keeps `dagster/table_name` and `dagster/storage_kind` while dropping `dagster/code_references`.
- Verified the test **fails** with `DagsterInvalidDefinitionError` against the pre-fix code, and **passes** with the fix — confirming it exercises the regression rather than passing vacuously.
- Ran the full existing `test_code_references.py` suite (4 pre-existing tests) — all pass, no regressions.