### PR TITLE
fix: Split out service discovery from ecs:CreateService calls

### DIFF
--- a/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/client.py
+++ b/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/client.py
@@ -578,7 +578,16 @@ class Client:
         params["networkConfiguration"] = self.network_configuration
 
         if service_registry_arn:
-            params["serviceRegistries"] = [{"registryArn": service_registry_arn}]
+            if self._service_discovery_role_arn:
+                # ecs:CreateService rejects serviceRegistries when the Cloud Map service is in
+                # another account ("does not support registering services into shared AWS Cloud
+                # Map namespaces"). Only reachable when service_discovery_role_arn is set, i.e.
+                # only for cross-account setups - same-account keeps the native path below.
+                # Instances are registered manually instead - see
+                # _register_service_discovery_instances.
+                pass
+            else:
+                params["serviceRegistries"] = [{"registryArn": service_registry_arn}]
 
         if tags and self.taggable:
             params["tags"] = [
@@ -588,9 +597,9 @@ class Client:
 
         arn = self.ecs.create_service(**params).get("service").get("serviceArn")
 
-        return Service(client=self, arn=arn)
+        return Service(client=self, arn=arn, service_registry_arn=service_registry_arn)
 
-    async def wait_for_new_service(self, service, container_name, logger=None) -> str:
+    async def wait_for_new_service(self, service, container_name, port=None, logger=None) -> str:
         logger = logger or logging.getLogger("dagster_cloud.EcsClient")
         service_name = service.name
         start_time = time.time()
@@ -601,7 +610,11 @@ class Client:
             )
             if response.get("services"):
                 running_tasks = await self.check_service_has_running_tasks(
-                    service_name, container_name, logger=logger
+                    service_name,
+                    container_name,
+                    service_registry_arn=service.service_discovery_arn,
+                    port=port,
+                    logger=logger,
                 )
                 return running_tasks[0]
 
@@ -652,7 +665,7 @@ class Client:
             self._raise_failed_task(task, container_name, logger)
 
     async def check_service_has_running_tasks(
-        self, service_name, container_name, logger=None
+        self, service_name, container_name, service_registry_arn=None, port=None, logger=None
     ) -> list[str]:
         # return the ARN of the task if it starts
         logger = logger or logging.getLogger("dagster_cloud.EcsClient")
@@ -724,6 +737,13 @@ class Client:
                             self._raise_failed_task(task, container_name, logger)
 
                 if all_tasks_running:
+                    if service_registry_arn and self._service_discovery_role_arn:
+                        self._register_service_discovery_instances(
+                            tasks=tasks,
+                            service_registry_arn=service_registry_arn,
+                            port=port,
+                            logger=logger,
+                        )
                     return tasks_to_track
 
             await asyncio.sleep(20)
@@ -747,6 +767,141 @@ class Client:
             f"Timed out waiting for a running task for service: {service_name}."
             f" {service_events_str}"
         )
+
+    def _wait_for_service_discovery_operation(self, operation_id, action_description):
+        status = ""
+        while status != "SUCCESS":
+            operation = self.service_discovery.get_operation(OperationId=operation_id)["Operation"]
+            status = operation["Status"]
+            if status == "FAIL":
+                raise Exception(f"Failed to {action_description}: {operation.get('ErrorMessage')}")
+            if status != "SUCCESS":
+                time.sleep(2)
+
+    @staticmethod
+    def _get_task_private_ip(task):
+        attachment_details = (task.get("attachments") or [{}])[0].get("details") or []
+        return next(
+            (
+                detail.get("value")
+                for detail in attachment_details
+                if detail.get("name") == "privateIPv4Address"
+            ),
+            None,
+        )
+
+    def _register_service_discovery_instances(
+        self, tasks, service_registry_arn, port=None, logger=None
+    ):
+        """Registers each running task's IP with Cloud Map directly, via self.service_discovery.
+
+        Only covers tasks passed in here at initial startup - see reconcile_service_discovery
+        for the periodic pass that catches tasks ECS swaps in later (e.g. after a health check
+        failure). delete_service's teardown path is unaffected either way.
+        """
+        logger = logger or logging.getLogger("dagster_cloud.EcsClient")
+        service_id = service_registry_arn.split("/")[-1]
+
+        for task in tasks:
+            task_arn = task["taskArn"]
+            private_ip = self._get_task_private_ip(task)
+            if not private_ip:
+                logger.warning(
+                    f"Could not find a private IP for task {task_arn} - not registering it with"
+                    " service discovery."
+                )
+                continue
+
+            instance_id = task_arn.split("/")[-1]
+            attributes = {"AWS_INSTANCE_IPV4": private_ip}
+            if port:
+                attributes["AWS_INSTANCE_PORT"] = str(port)
+
+            logger.info(
+                f"Registering {instance_id} ({private_ip}) with service discovery service"
+                f" {service_id}..."
+            )
+            resp = self.service_discovery.register_instance(
+                ServiceId=service_id,
+                InstanceId=instance_id,
+                Attributes=attributes,
+            )
+            self._wait_for_service_discovery_operation(
+                resp["OperationId"], f"register {instance_id} with service discovery"
+            )
+
+    def _deregister_service_discovery_instance(self, service_id, instance_id, logger=None):
+        logger = logger or logging.getLogger("dagster_cloud.EcsClient")
+        logger.info(
+            f"Deregistering {instance_id} from service discovery service {service_id} - its task"
+            " is no longer running."
+        )
+        resp = self.service_discovery.deregister_instance(
+            ServiceId=service_id, InstanceId=instance_id
+        )
+        self._wait_for_service_discovery_operation(
+            resp["OperationId"], f"deregister {instance_id} from service discovery"
+        )
+
+    def reconcile_service_discovery_instances(self, service, port=None, logger=None):
+        """Cross-account-only periodic reconciliation: re-derives the set of instances that
+        *should* be registered for `service` from ECS's own live task list, and registers any
+        that are missing (e.g. a replacement task ECS started after a health check failure) or
+        deregisters any that are stale (the task they pointed at is gone). Closes the gap left by
+        _register_service_discovery_instances only covering tasks seen at initial startup.
+
+        No-ops for same-account services (self._service_discovery_role_arn is None) - those stay
+        on ECS's native serviceRegistries path, which already handles this automatically.
+        """
+        logger = logger or logging.getLogger("dagster_cloud.EcsClient")
+
+        if not self._service_discovery_role_arn:
+            return
+
+        service_registry_arn = service.service_discovery_arn
+        if not service_registry_arn:
+            return
+
+        service_id = service_registry_arn.split("/")[-1]
+
+        live_task_arns = self.ecs.list_tasks(
+            cluster=self.cluster_name,
+            serviceName=service.name,
+            desiredStatus="RUNNING",
+        ).get("taskArns", [])
+        live_tasks = (
+            self.ecs.describe_tasks(cluster=self.cluster_name, tasks=live_task_arns).get(
+                "tasks", []
+            )
+            if live_task_arns
+            else []
+        )
+        live_instance_ids = {task["taskArn"].split("/")[-1] for task in live_tasks}
+
+        registered_instances = (
+            self.service_discovery.get_paginator("list_instances")
+            .paginate(ServiceId=service_id)
+            .build_full_result()["Instances"]
+        )
+        registered_instance_ids = {instance["Id"] for instance in registered_instances}
+
+        tasks_to_register = [
+            task
+            for task in live_tasks
+            if task["taskArn"].split("/")[-1] not in registered_instance_ids
+        ]
+        if tasks_to_register:
+            self._register_service_discovery_instances(
+                tasks=tasks_to_register,
+                service_registry_arn=service_registry_arn,
+                port=port,
+                logger=logger,
+            )
+
+        for stale_instance_id in registered_instance_ids - live_instance_ids:
+            self._deregister_service_discovery_instance(
+                service_id, stale_instance_id, logger=logger
+            )
 
     def _check_for_stopped_tasks(self, service_name):
         stopped = self.ecs.list_tasks(
@@ -804,6 +959,23 @@ class Client:
             for service in page["Services"]:
                 if service["Name"] == service_name:
                     return service["Id"]
+
+    def _get_service_discovery_arn(self, service_name):
+        paginator = self.service_discovery.get_paginator("list_services")
+        for page in paginator.paginate(
+            Filters=[
+                {
+                    "Name": "NAMESPACE_ID",
+                    "Values": [
+                        self.service_discovery_namespace_id,
+                    ],
+                    "Condition": "EQ",
+                },
+            ],
+        ):
+            for service in page["Services"]:
+                if service["Name"] == service_name:
+                    return service.get("Arn")
 
     def _infer_assign_public_ip(self):
         # https://docs.aws.amazon.com/AmazonECS/latest/userguide/fargate-task-networking.html

--- a/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/client.py
+++ b/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/client.py
@@ -877,12 +877,22 @@ class Client:
         # more than that for a large service, so this has to be chunked regardless of list_tasks
         # already being paginated above.
         live_tasks = []
+        # DescribeTasks is eventually consistent: a task list_tasks just confirmed RUNNING can
+        # still come back in `failures` here (e.g. "MISSING") rather than `tasks`. Treating that
+        # as "confirmed dead" would deregister a live server; treat it as "assume still alive"
+        # instead - a stale-but-harmless instance left registered a bit longer is far cheaper than
+        # incorrectly dropping a healthy one from DNS.
+        unresolved_instance_ids = set()
         for i in range(0, len(live_task_arns), 100):
             batch = live_task_arns[i : i + 100]
-            live_tasks.extend(
-                self.ecs.describe_tasks(cluster=self.cluster_name, tasks=batch).get("tasks", [])
+            response = self.ecs.describe_tasks(cluster=self.cluster_name, tasks=batch)
+            live_tasks.extend(response.get("tasks", []))
+            unresolved_instance_ids.update(
+                failure["arn"].split("/")[-1] for failure in response.get("failures", [])
             )
-        live_instance_ids = {task["taskArn"].split("/")[-1] for task in live_tasks}
+        live_instance_ids = {
+            task["taskArn"].split("/")[-1] for task in live_tasks
+        } | unresolved_instance_ids
 
         registered_instances = (
             self.service_discovery.get_paginator("list_instances")

--- a/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/client.py
+++ b/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/client.py
@@ -864,18 +864,24 @@ class Client:
 
         service_id = service_registry_arn.split("/")[-1]
 
-        live_task_arns = self.ecs.list_tasks(
-            cluster=self.cluster_name,
-            serviceName=service.name,
-            desiredStatus="RUNNING",
-        ).get("taskArns", [])
-        live_tasks = (
-            self.ecs.describe_tasks(cluster=self.cluster_name, tasks=live_task_arns).get(
-                "tasks", []
+        live_task_arns = (
+            self.ecs.get_paginator("list_tasks")
+            .paginate(
+                cluster=self.cluster_name,
+                serviceName=service.name,
+                desiredStatus="RUNNING",
             )
-            if live_task_arns
-            else []
+            .build_full_result()["taskArns"]
         )
+        # describe_tasks rejects more than 100 task ARNs per call - list_tasks alone can return
+        # more than that for a large service, so this has to be chunked regardless of list_tasks
+        # already being paginated above.
+        live_tasks = []
+        for i in range(0, len(live_task_arns), 100):
+            batch = live_task_arns[i : i + 100]
+            live_tasks.extend(
+                self.ecs.describe_tasks(cluster=self.cluster_name, tasks=batch).get("tasks", [])
+            )
         live_instance_ids = {task["taskArn"].split("/")[-1] for task in live_tasks}
 
         registered_instances = (

--- a/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/launcher.py
+++ b/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/launcher.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import threading
 from collections.abc import Collection, Mapping, Sequence
 from typing import Any, cast
 
@@ -59,6 +60,13 @@ from dagster_cloud.workspace.user_code_launcher.utils import (
 EcsServerHandleType = Service
 
 CONTAINER_NAME = "dagster"
+
+# TODO(cross-account service discovery): this is a conservative first guess, not a tuned value -
+# each tick costs one ListTasks + DescribeTasks + ListInstances per cross-account service, so this
+# trades staleness (how long a replaced task's DNS entry stays wrong for) against API load/cost at
+# scale. Flagging for discussion rather than picking unilaterally; happy to adjust based on
+# maintainer input.
+SERVICE_DISCOVERY_RECONCILE_INTERVAL_SECONDS = 300
 
 
 class EcsUserCodeLauncher(DagsterCloudUserCodeLauncher[EcsServerHandleType], ConfigurableClass):
@@ -195,6 +203,59 @@ class EcsUserCodeLauncher(DagsterCloudUserCodeLauncher[EcsServerHandleType], Con
             service_discovery_role_arn=self.service_discovery_role_arn,
         )
         super().__init__(**kwargs)
+
+        self._service_discovery_reconcile_shutdown_event = threading.Event()
+        self._service_discovery_reconcile_thread: threading.Thread | None = None
+
+    def start(self, *args, **kwargs):
+        super().start(*args, **kwargs)
+
+        # Only cross-account setups need this - same-account services stay on ECS's native
+        # serviceRegistries path, which already handles task replacement automatically.
+        if self.service_discovery_role_arn:
+            self._service_discovery_reconcile_thread = threading.Thread(
+                target=self._service_discovery_reconcile_thread_target,
+                args=(self._service_discovery_reconcile_shutdown_event,),
+                name="service-discovery-reconcile",
+                daemon=True,
+            )
+            self._service_discovery_reconcile_thread.start()
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        if self._service_discovery_reconcile_thread:
+            self._service_discovery_reconcile_shutdown_event.set()
+            self._service_discovery_reconcile_thread.join()
+        super().__exit__(exception_type, exception_value, traceback)
+
+    def _service_discovery_reconcile_thread_target(self, shutdown_event: threading.Event):
+        while True:
+            shutdown_event.wait(SERVICE_DISCOVERY_RECONCILE_INTERVAL_SECONDS)
+            if shutdown_event.is_set():
+                break
+
+            try:
+                self._reconcile_service_discovery()
+            except Exception:
+                self._logger.exception("Error while reconciling service discovery instances")
+
+    def _reconcile_service_discovery(self):
+        # self._actual_entries is maintained by the base class's main reconcile loop; reusing it
+        # here means this only ever acts on locations that loop already considers up and running.
+        # TODO: only covers standalone gRPC server handles, not multipex/pex servers - didn't want
+        # to guess at multipex's tagging/lifecycle assumptions without maintainer input.
+        for deployment_name, location_name in list(self._actual_entries.keys()):
+            try:
+                for handle in self._get_standalone_dagster_server_handles_for_location(
+                    deployment_name, location_name
+                ):
+                    self.client.reconcile_service_discovery_instances(
+                        handle, port=get_code_server_port(), logger=self._logger
+                    )
+            except Exception:
+                self._logger.exception(
+                    "Error while reconciling service discovery instances for"
+                    f" {deployment_name}:{location_name}"
+                )
 
     @property
     def show_debug_cluster_info(self) -> bool:
@@ -574,7 +635,10 @@ class EcsUserCodeLauncher(DagsterCloudUserCodeLauncher[EcsServerHandleType], Con
             f"Waiting for service {server_handle.name} to be ready for multipex server..."
         )
         task_arn = await self.client.wait_for_new_service(
-            server_handle, container_name=CONTAINER_NAME, logger=self._logger
+            server_handle,
+            container_name=CONTAINER_NAME,
+            port=multipex_endpoint.port,
+            logger=self._logger,
         )
         await self._wait_for_server_process(
             multipex_endpoint.create_multipex_client(),
@@ -615,7 +679,10 @@ class EcsUserCodeLauncher(DagsterCloudUserCodeLauncher[EcsServerHandleType], Con
             f"Waiting for service {server_handle.name} to be ready for gRPC server..."
         )
         task_arn = await self.client.wait_for_new_service(
-            server_handle, container_name=CONTAINER_NAME, logger=self._logger
+            server_handle,
+            container_name=CONTAINER_NAME,
+            port=server_endpoint.port,
+            logger=self._logger,
         )
 
         multipex_client = None

--- a/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/service.py
+++ b/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/service.py
@@ -4,10 +4,11 @@ from dagster._utils.cached_method import cached_method
 
 
 class Service:
-    def __init__(self, client, arn):
+    def __init__(self, client, arn, service_registry_arn=None):
         self.client = client
         self.arn = self._long_arn(arn)
         self.name = arn.split("/")[-1]
+        self._service_registry_arn = service_registry_arn
 
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.arn == other.arn
@@ -41,15 +42,9 @@ class Service:
     @property
     @cached_method
     def service_discovery_arn(self):
-        service = self.client.ecs.describe_services(
-            cluster=self.client.cluster_name,
-            services=[self.arn],
-        ).get("services", [{}])[0]
-
-        registries = service.get("serviceRegistries") or [{}]
-        arn = registries[0].get("registryArn")
-
-        return arn
+        if self._service_registry_arn:
+            return self._service_registry_arn
+        return self.client._get_service_discovery_arn(self.name)
 
     @property
     @cached_method

--- a/python_modules/dagster-cloud/dagster_cloud_tests/workspace_tests/ecs_tests/test_client.py
+++ b/python_modules/dagster-cloud/dagster_cloud_tests/workspace_tests/ecs_tests/test_client.py
@@ -278,6 +278,71 @@ def test_reconcile_service_discovery_instances_same_account_noop(client):
         mock_list_tasks.assert_not_called()
 
 
+def test_reconcile_service_discovery_instances_paginates_list_tasks(client):
+    """list_tasks must be fully paginated - a service with enough tasks to span multiple pages
+    must not have tasks on later pages treated as dead and deregistered from Cloud Map.
+    """
+    client._service_discovery_role_arn = "arn:aws:iam::123456789012:role/cross-account-sd"
+    client._sd_session_expires = None
+    StubService = namedtuple("StubService", "name service_discovery_arn")
+    service = StubService(
+        name="my_service",
+        service_discovery_arn="arn:aws:servicediscovery:us-east-1:123456789012:service/srv-fake",
+    )
+
+    page_1_task_arn = "arn:aws:ecs:us-east-1:123456789012:task/test/page-1-task"
+    page_2_task_arn = "arn:aws:ecs:us-east-1:123456789012:task/test/page-2-task"
+
+    def _fake_task(task_arn, ip):
+        return {
+            "taskArn": task_arn,
+            "attachments": [{"details": [{"name": "privateIPv4Address", "value": ip}]}],
+        }
+
+    all_tasks_by_arn = {
+        page_1_task_arn: _fake_task(page_1_task_arn, "10.0.0.1"),
+        page_2_task_arn: _fake_task(page_2_task_arn, "10.0.0.2"),
+    }
+
+    def _fake_describe_tasks(cluster, tasks):
+        # Respects the requested `tasks` ARNs, unlike a static return_value would - otherwise a
+        # pagination bug in list_tasks (only seeing page 1) would go unnoticed here too, since
+        # describe_tasks would silently hand back page 2's task anyway.
+        return {"tasks": [all_tasks_by_arn[task_arn] for task_arn in tasks]}
+
+    with (
+        mock.patch.object(
+            client.ecs,
+            "list_tasks",
+            # boto3's ECS ListTasks paginator token is "nextToken" (lowercase) - this must match
+            # exactly or the paginator silently treats the response as a single page regardless
+            # of whether the code under test is fixed or still buggy.
+            side_effect=[
+                {"taskArns": [page_1_task_arn], "nextToken": "next-page"},
+                {"taskArns": [page_2_task_arn]},
+            ],
+        ),
+        mock.patch.object(
+            client.ecs,
+            "describe_tasks",
+            side_effect=_fake_describe_tasks,
+        ),
+        # Both tasks are already registered - a pagination bug that only sees the first page
+        # would treat "page-2-task" as dead and incorrectly deregister it.
+        mock.patch.object(
+            client.service_discovery,
+            "list_instances",
+            return_value={"Instances": [{"Id": "page-1-task"}, {"Id": "page-2-task"}]},
+        ),
+        mock.patch.object(client.service_discovery, "register_instance") as mock_register,
+        mock.patch.object(client.service_discovery, "deregister_instance") as mock_deregister,
+    ):
+        client.reconcile_service_discovery_instances(service)
+
+        mock_register.assert_not_called()
+        mock_deregister.assert_not_called()
+
+
 def test_ecs_service_error():
     with pytest.raises(EcsServiceError) as ex:
         raise EcsServiceError(

--- a/python_modules/dagster-cloud/dagster_cloud_tests/workspace_tests/ecs_tests/test_client.py
+++ b/python_modules/dagster-cloud/dagster_cloud_tests/workspace_tests/ecs_tests/test_client.py
@@ -159,6 +159,125 @@ def test_create_service_tags(client, stubber):
     )
 
 
+def test_create_service_cross_account_skips_service_registries(client, stubber):
+    """serviceRegistries is omitted for cross-account clients (ecs:CreateService rejects it), but
+    still passed for same-account clients — see test_create_service_tags for that path.
+    """
+    arn = "arn:aws:ecs:us-east-1:1234567890:service/cluster-name/service-name"
+    client._service_discovery_role_arn = "arn:aws:iam::123456789012:role/cross-account-sd"
+
+    params_without_service_registries = [
+        "clientToken",
+        "cluster",
+        "desiredCount",
+        "launchType",
+        "networkConfiguration",
+        "serviceName",
+        "taskDefinition",
+        "enableExecuteCommand",
+        "propagateTags",
+    ]
+
+    stubber.add_response(
+        method="create_service",
+        service_response={"service": {"serviceArn": arn}},
+        expected_params=dict.fromkeys(params_without_service_registries, ANY),
+    )
+
+    # tags=None means self.taggable (and its list_account_settings call) is never reached, due
+    # to `if tags and self.taggable:`'s short-circuit — only create_service is stubbed here.
+    client._create_service(
+        service_name="fake",
+        service_registry_arn="fake",
+        task_definition_arn="fake",
+    )
+
+
+def test_reconcile_service_discovery_instances(client):
+    """Cross-account periodic reconciliation registers a task ECS started after initial
+    registration (e.g. a replacement after a health check failure) and deregisters an instance
+    whose task is gone - the gap _register_service_discovery_instances alone can't close.
+    """
+    client._service_discovery_role_arn = "arn:aws:iam::123456789012:role/cross-account-sd"
+    # Bypassing the constructor's cross-account setup (above) skips setting this - it's what
+    # `service_discovery` (the property _reconcile_service_discovery_instances reads through)
+    # checks to decide whether a session refresh is due.
+    client._sd_session_expires = None
+    StubService = namedtuple("StubService", "name service_discovery_arn")
+    service = StubService(
+        name="my_service",
+        service_discovery_arn="arn:aws:servicediscovery:us-east-1:123456789012:service/srv-fake",
+    )
+    live_task_arn = "arn:aws:ecs:us-east-1:123456789012:task/test/live-task-id"
+
+    with (
+        mock.patch.object(
+            client.ecs, "list_tasks", return_value={"taskArns": [live_task_arn]}
+        ),
+        mock.patch.object(
+            client.ecs,
+            "describe_tasks",
+            return_value={
+                "tasks": [
+                    {
+                        "taskArn": live_task_arn,
+                        "attachments": [
+                            {"details": [{"name": "privateIPv4Address", "value": "10.0.0.5"}]}
+                        ],
+                    }
+                ]
+            },
+        ),
+        # "stale-task-id" is registered but has no corresponding live task - should be deregistered.
+        # "live-task-id" (derived from live_task_arn) is live but not yet registered - should be
+        # registered.
+        mock.patch.object(
+            client.service_discovery,
+            "list_instances",
+            return_value={"Instances": [{"Id": "stale-task-id"}]},
+        ),
+        mock.patch.object(
+            client.service_discovery, "register_instance", return_value={"OperationId": "reg-op"}
+        ) as mock_register,
+        mock.patch.object(
+            client.service_discovery,
+            "deregister_instance",
+            return_value={"OperationId": "dereg-op"},
+        ) as mock_deregister,
+        mock.patch.object(
+            client.service_discovery,
+            "get_operation",
+            return_value={"Operation": {"Status": "SUCCESS"}},
+        ),
+    ):
+        client.reconcile_service_discovery_instances(service, port=4000)
+
+        mock_register.assert_called_once()
+        assert mock_register.call_args.kwargs["ServiceId"] == "srv-fake"
+        assert mock_register.call_args.kwargs["InstanceId"] == "live-task-id"
+        assert mock_register.call_args.kwargs["Attributes"] == {
+            "AWS_INSTANCE_IPV4": "10.0.0.5",
+            "AWS_INSTANCE_PORT": "4000",
+        }
+
+        mock_deregister.assert_called_once_with(ServiceId="srv-fake", InstanceId="stale-task-id")
+
+
+def test_reconcile_service_discovery_instances_same_account_noop(client):
+    """No-ops entirely for same-account clients - ECS's native serviceRegistries path already
+    handles task replacement automatically, so this must never make any AWS calls for them.
+    """
+    StubService = namedtuple("StubService", "name service_discovery_arn")
+    service = StubService(
+        name="my_service",
+        service_discovery_arn="arn:aws:servicediscovery:us-east-1:123456789012:service/srv-fake",
+    )
+
+    with mock.patch.object(client.ecs, "list_tasks") as mock_list_tasks:
+        client.reconcile_service_discovery_instances(service)
+        mock_list_tasks.assert_not_called()
+
+
 def test_ecs_service_error():
     with pytest.raises(EcsServiceError) as ex:
         raise EcsServiceError(
@@ -215,7 +334,11 @@ def test_secrets(stubbed_client, stubbed_ecs):
 
 
 def test_wait_for_new_service_failure(client, stubber):
-    service = Service(arn="arn:aws:ecs:region:012345678910:cluster/boom", client=client)
+    service = Service(
+        arn="arn:aws:ecs:region:012345678910:cluster/boom",
+        client=client,
+        service_registry_arn="fake",
+    )
 
     failures = [
         {
@@ -287,7 +410,7 @@ def test_wait_for_new_service_failure(client, stubber):
     client.grace_period = 15
 
     async def _check_service_has_running_tasks(
-        service_name, container_name, logger=None
+        service_name, container_name, service_registry_arn=None, port=None, logger=None
     ) -> list[str]:
         return ["my_task"]
 

--- a/python_modules/dagster-cloud/dagster_cloud_tests/workspace_tests/ecs_tests/test_client.py
+++ b/python_modules/dagster-cloud/dagster_cloud_tests/workspace_tests/ecs_tests/test_client.py
@@ -343,6 +343,52 @@ def test_reconcile_service_discovery_instances_paginates_list_tasks(client):
         mock_deregister.assert_not_called()
 
 
+def test_reconcile_service_discovery_instances_tolerates_describe_tasks_failures(client):
+    """DescribeTasks is eventually consistent - a task list_tasks just confirmed RUNNING can come
+    back in `failures` instead of `tasks` (e.g. "MISSING"). That must not be treated as
+    confirmation the task is dead, or a live code server gets deregistered from Cloud Map.
+    """
+    client._service_discovery_role_arn = "arn:aws:iam::123456789012:role/cross-account-sd"
+    client._sd_session_expires = None
+    StubService = namedtuple("StubService", "name service_discovery_arn")
+    service = StubService(
+        name="my_service",
+        service_discovery_arn="arn:aws:servicediscovery:us-east-1:123456789012:service/srv-fake",
+    )
+
+    live_task_arn = "arn:aws:ecs:us-east-1:123456789012:task/test/live-task-id"
+
+    with (
+        mock.patch.object(
+            client.ecs, "list_tasks", return_value={"taskArns": [live_task_arn]}
+        ),
+        # describe_tasks fails to describe this task even though list_tasks just confirmed it's
+        # RUNNING - a real, documented eventual-consistency behavior of the ECS API.
+        mock.patch.object(
+            client.ecs,
+            "describe_tasks",
+            return_value={
+                "tasks": [],
+                "failures": [{"arn": live_task_arn, "reason": "MISSING"}],
+            },
+        ),
+        # Already registered - must NOT be deregistered just because describe_tasks failed on it.
+        mock.patch.object(
+            client.service_discovery,
+            "list_instances",
+            return_value={"Instances": [{"Id": "live-task-id"}]},
+        ),
+        mock.patch.object(client.service_discovery, "register_instance") as mock_register,
+        mock.patch.object(client.service_discovery, "deregister_instance") as mock_deregister,
+    ):
+        client.reconcile_service_discovery_instances(service)
+
+        # Can't register it either - describe_tasks never gave us its IP - but that's a much
+        # smaller problem than incorrectly deregistering a live instance would be.
+        mock_register.assert_not_called()
+        mock_deregister.assert_not_called()
+
+
 def test_ecs_service_error():
     with pytest.raises(EcsServiceError) as ex:
         raise EcsServiceError(


### PR DESCRIPTION
## Summary & Motivation

Split out service discovery from ecs:CreateService calls when it's in another account. Enables cross-account service discover [as described here](https://docs.dagster.io/deployment/dagster-plus/hybrid/amazon-ecs/configuration-reference#cross-account-service-discovery) to work.

**NOTE:** The background threading of the ECS task that I've introduced is a new pattern here, I'm open to feedback on this. Additionally, I've taken a best-effort (and somewhat conservative) approach to the reconciliation interval for this, and the reconciliation code I've added is not all-encompassing.

## Test Plan

I've added tests for related changes, and we're running the forked code in our environment.

