### PR TITLE
Fix mutation of parent_entity_keys in DepConditionWrapperCondition (#33720)

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -194,6 +194,8 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
             if self.resolves_virtual_deps
             else {k for k in asset_graph.get(key).parent_entity_keys if isinstance(k, AssetKey)}
         )
+        # Create a copy to avoid mutating the original set when applying &= / -=
+        dep_keys = set(dep_keys)
         if self.allow_selection is not None:
             dep_keys &= self.allow_selection.resolve(asset_graph, allow_missing=True)
         if self.ignore_selection is not None:

--- a/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_dep_operators_mutation_bug_33720.py
+++ b/python_modules/dagster/dagster_tests/declarative_automation_tests/automation_condition_tests/builtins/test_dep_operators_mutation_bug_33720.py
@@ -1,0 +1,56 @@
+"""
+Regression test for issue #33720: any_deps_match().allow() permanently corrupts AssetNode.parent_keys
+
+This test verifies that the fix for the mutation bug in _get_dep_keys works correctly.
+The bug was that dep_keys was a reference to the live parent_entity_keys set, so &= and -=
+operations mutated the original set instead of a copy.
+"""
+
+import dagster as dg
+
+
+def test_any_deps_match_allow_does_not_corrupt_parent_keys():
+    """Test that .allow() and .ignore() don't permanently corrupt parent_entity_keys across ticks."""
+    @dg.asset(
+        automation_condition=dg.AutomationCondition.any_deps_match(
+            dg.AutomationCondition.newly_updated()
+        ).allow(dg.AssetSelection.keys("A"))
+    )
+    def downstream(A, B):
+        pass
+
+    @dg.asset
+    def A():
+        pass
+
+    @dg.asset
+    def B():
+        pass
+
+    instance = dg.DagsterInstance.ephemeral()
+    defs = dg.Definitions(assets=[A, B, downstream])
+
+    # First evaluation - no updates yet
+    result = dg.evaluate_automation_conditions(defs=defs, instance=instance)
+    assert result.total_requested == 0
+
+    # Materialize A - should fire because A is in the allow list
+    instance.report_runless_asset_event(dg.AssetMaterialization("A"))
+    result = dg.evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1
+
+    # Materialize A again - should still fire (bug fix verification)
+    # Before the fix, parent_keys would be corrupted after the first evaluation
+    instance.report_runless_asset_event(dg.AssetMaterialization("A"))
+    result = dg.evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1
+
+    # Materialize B - should NOT fire because B is not in the allow list
+    instance.report_runless_asset_event(dg.AssetMaterialization("B"))
+    result = dg.evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 0
+
+    # Materialize A again - should fire again (verify parent_keys still intact)
+    instance.report_runless_asset_event(dg.AssetMaterialization("A"))
+    result = dg.evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1


### PR DESCRIPTION
## Summary

Fixes a bug where parent_entity_keys could be unintentionally mutated in
DepConditionWrapperCondition._get_dep_keys().

The issue occurred because set operations (&= / -=) modified the original
set returned from parent_entity_keys, causing incorrect automation condition
evaluation across subsequent ticks.

## Changes

- Create a defensive copy of dep_keys before applying mutations.
- Add a regression test covering the multi-tick evaluation scenario.

## Testing

Added:
- 	est_dep_operators_mutation_bug_33720.py`n
The test verifies that automation conditions continue to evaluate correctly
across multiple ticks and that the underlying set is not mutated.

Fixes #33720