### PR TITLE
Make Runs table columns resizable and selectable

### DIFF
--- a/js_modules/ui-components/src/components/VirtualizedTable.tsx
+++ b/js_modules/ui-components/src/components/VirtualizedTable.tsx
@@ -9,16 +9,19 @@ export const TABLE_HEADER_HEIGHT = 32;
 export const HeaderRow = ({
   children,
   templateColumns,
+  minWidth,
   sticky = false,
 }: {
   children: React.ReactNode;
   templateColumns: string;
+  /** Set when columns have pixel widths, allowing the table to scroll horizontally. */
+  minWidth?: number;
   sticky?: boolean;
 }) => (
   <Box
     border="top-and-bottom"
     className={clsx(styles.headerRow, sticky && styles.headerRowSticky)}
-    style={{gridTemplateColumns: templateColumns}}
+    style={{gridTemplateColumns: templateColumns, minWidth}}
   >
     {children}
   </Box>
@@ -75,16 +78,18 @@ export const Container = React.forwardRef<HTMLDivElement, React.HTMLAttributes<H
 
 export type InnerProps = {
   totalHeight: number;
+  /** Set when columns have pixel widths, allowing the table to scroll horizontally. */
+  minWidth?: number;
   children?: React.ReactNode;
 };
 
 export const Inner = React.forwardRef<
   HTMLDivElement,
   InnerProps & React.HTMLAttributes<HTMLDivElement>
->(({totalHeight, children, className, ...rest}, ref) => (
+>(({totalHeight, minWidth, children, className, ...rest}, ref) => (
   <div
     className={clsx(styles.inner, className)}
-    style={{height: `${totalHeight}px`}}
+    style={{height: `${totalHeight}px`, minWidth}}
     ref={ref}
     {...rest}
   >

--- a/js_modules/ui-core/src/runs/RunTargetLink.tsx
+++ b/js_modules/ui-core/src/runs/RunTargetLink.tsx
@@ -94,6 +94,9 @@ export const RunTargetLink = ({run, repoAddress, extraTags}: Props) => {
       showIcon
       pipelineName={run.pipelineName}
       pipelineHrefContext={repoAddress || 'repo-unknown'}
+      // The Target column is resizable, so let the column width decide how much of the
+      // job name is shown instead of cutting it at a fixed character count.
+      truncationThreshold={0}
     />
   );
 };

--- a/js_modules/ui-core/src/runs/RunTargetLink.tsx
+++ b/js_modules/ui-core/src/runs/RunTargetLink.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {AssetCheckTagCollection, AssetKeyTagCollection} from './AssetTagCollections';
 import {RUN_FEED_TARGET_ASSET_SELECTION_QUERY} from './RunTargetLinkQuery';
 import {useLazyQuery} from '../apollo-client';
+import styles from './css/RunTargetLink.module.css';
 import {
   RunFeedTargetAssetSelectionQuery,
   RunFeedTargetAssetSelectionQueryVariables,
@@ -62,7 +63,7 @@ export const RunTargetLink = ({run, repoAddress, extraTags}: Props) => {
 
   if (previewAssetKeys) {
     return (
-      <Box flex={{direction: 'column', gap: 4}}>
+      <Box className={styles.target} flex={{direction: 'column', gap: 4}}>
         <AssetKeyTagCollection
           assetKeys={previewAssetKeys}
           useTags
@@ -89,14 +90,16 @@ export const RunTargetLink = ({run, repoAddress, extraTags}: Props) => {
     );
   }
   return (
-    <PipelineTag
-      isJob
-      showIcon
-      pipelineName={run.pipelineName}
-      pipelineHrefContext={repoAddress || 'repo-unknown'}
-      // The Target column is resizable, so let the column width decide how much of the
-      // job name is shown instead of cutting it at a fixed character count.
-      truncationThreshold={0}
-    />
+    <div className={styles.target}>
+      <PipelineTag
+        isJob
+        showIcon
+        pipelineName={run.pipelineName}
+        pipelineHrefContext={repoAddress || 'repo-unknown'}
+        // The Target column is resizable, so let the column width decide how much of the
+        // job name is shown instead of cutting it at a fixed character count.
+        truncationThreshold={0}
+      />
+    </div>
   );
 };

--- a/js_modules/ui-core/src/runs/RunsFeedColumns.tsx
+++ b/js_modules/ui-core/src/runs/RunsFeedColumns.tsx
@@ -1,0 +1,439 @@
+import {Button, Icon, Menu, MenuDivider, MenuItem, Popover} from '@dagster-io/ui-components';
+import clsx from 'clsx';
+import * as React from 'react';
+
+import styles from './css/RunsFeedColumns.module.css';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+
+export type RunsFeedColumnKey =
+  | 'id'
+  | 'target'
+  | 'launchedBy'
+  | 'status'
+  | 'createdAt'
+  | 'duration';
+
+export interface RunsFeedColumnConfig {
+  key: RunsFeedColumnKey;
+  label: string;
+  // The grid track used before the column has ever been resized, preserving the
+  // proportional layout the table has always shipped with.
+  defaultTrack: string;
+  // The pixel width used when the column is seeded into pixel mode while hidden,
+  // and when its width is reset.
+  defaultWidth: number;
+  minWidth: number;
+}
+
+// The checkbox and actions columns are always present and are not resizable.
+export const CHECKBOX_COLUMN_TRACK = '60px';
+export const ACTIONS_COLUMN_TRACK = '132px';
+const FIXED_COLUMNS_WIDTH = 60 + 132;
+
+const MAX_COLUMN_WIDTH = 1200;
+
+export const RUNS_FEED_COLUMNS: RunsFeedColumnConfig[] = [
+  {key: 'id', label: 'ID', defaultTrack: 'minmax(0, 1.5fr)', defaultWidth: 320, minWidth: 120},
+  {
+    key: 'target',
+    label: 'Target',
+    defaultTrack: 'minmax(0, 1.2fr)',
+    defaultWidth: 260,
+    minWidth: 120,
+  },
+  {
+    key: 'launchedBy',
+    label: 'Launched by',
+    defaultTrack: 'minmax(0, 1fr)',
+    defaultWidth: 220,
+    minWidth: 120,
+  },
+  {key: 'status', label: 'Status', defaultTrack: '140px', defaultWidth: 140, minWidth: 90},
+  {key: 'createdAt', label: 'Created at', defaultTrack: '170px', defaultWidth: 170, minWidth: 120},
+  {key: 'duration', label: 'Duration', defaultTrack: '120px', defaultWidth: 120, minWidth: 90},
+];
+
+const COLUMNS_BY_KEY: Record<RunsFeedColumnKey, RunsFeedColumnConfig> = Object.fromEntries(
+  RUNS_FEED_COLUMNS.map((column) => [column.key, column]),
+) as Record<RunsFeedColumnKey, RunsFeedColumnConfig>;
+
+export type RunsFeedColumnWidths = Partial<Record<RunsFeedColumnKey, number>>;
+
+export interface RunsFeedColumnSettings {
+  hidden: RunsFeedColumnKey[];
+  widths: RunsFeedColumnWidths;
+}
+
+export const DEFAULT_RUNS_FEED_COLUMN_SETTINGS: RunsFeedColumnSettings = {hidden: [], widths: {}};
+
+export const RUNS_FEED_COLUMNS_STORAGE_KEY = 'runs-feed-columns';
+
+const clampWidth = (column: RunsFeedColumnConfig, width: number) =>
+  Math.round(Math.min(MAX_COLUMN_WIDTH, Math.max(column.minWidth, width)));
+
+/**
+ * localStorage is user-editable and settings written by a newer version of the app may
+ * mention columns that no longer exist, so drop anything we don't recognize.
+ */
+export const validateRunsFeedColumnSettings = (json: any): RunsFeedColumnSettings => {
+  if (!json || typeof json !== 'object') {
+    return DEFAULT_RUNS_FEED_COLUMN_SETTINGS;
+  }
+
+  const hidden = Array.isArray(json.hidden)
+    ? RUNS_FEED_COLUMNS.filter((column) => json.hidden.includes(column.key)).map(
+        (column) => column.key,
+      )
+    : [];
+
+  const widths: RunsFeedColumnWidths = {};
+  if (json.widths && typeof json.widths === 'object') {
+    for (const column of RUNS_FEED_COLUMNS) {
+      const width = json.widths[column.key];
+      if (typeof width === 'number' && Number.isFinite(width)) {
+        widths[column.key] = clampWidth(column, width);
+      }
+    }
+  }
+
+  // Never allow every column to be hidden, otherwise the table has nothing to show.
+  if (hidden.length === RUNS_FEED_COLUMNS.length) {
+    return {hidden: hidden.slice(1), widths};
+  }
+
+  return {hidden, widths};
+};
+
+export const buildTemplateColumns = (
+  visibleColumns: RunsFeedColumnConfig[],
+  widths: RunsFeedColumnWidths,
+) => {
+  const tracks = visibleColumns.map((column) => {
+    const width = widths[column.key];
+    return width === undefined ? column.defaultTrack : `${width}px`;
+  });
+  return [CHECKBOX_COLUMN_TRACK, ...tracks, ACTIONS_COLUMN_TRACK].join(' ');
+};
+
+/**
+ * Once columns have pixel widths the table is allowed to be wider than its container,
+ * which is what makes a widened ID or Target column useful. Returns the width the rows
+ * and header must reserve, or undefined while the table is still proportional.
+ */
+export const buildMinWidth = (
+  visibleColumns: RunsFeedColumnConfig[],
+  widths: RunsFeedColumnWidths,
+) => {
+  if (!visibleColumns.some((column) => widths[column.key] !== undefined)) {
+    return undefined;
+  }
+  return visibleColumns.reduce(
+    (total, column) => total + (widths[column.key] ?? column.minWidth),
+    FIXED_COLUMNS_WIDTH,
+  );
+};
+
+interface RunsFeedColumnsState {
+  columns: RunsFeedColumnConfig[];
+  visibleColumns: RunsFeedColumnConfig[];
+  templateColumns: string;
+  minWidth: number | undefined;
+  widths: RunsFeedColumnWidths;
+  isVisible: (key: RunsFeedColumnKey) => boolean;
+  toggleColumn: (key: RunsFeedColumnKey) => void;
+  resetToDefaults: () => void;
+  resetColumnWidth: (key: RunsFeedColumnKey) => void;
+  /** Enter pixel mode with the widths currently rendered, so resizing doesn't jump. */
+  beginResize: (measuredWidths: RunsFeedColumnWidths) => void;
+  setColumnWidth: (key: RunsFeedColumnKey, width: number) => void;
+  endResize: () => void;
+}
+
+const defaultVisibleColumns = RUNS_FEED_COLUMNS;
+
+const DEFAULT_STATE: RunsFeedColumnsState = {
+  columns: RUNS_FEED_COLUMNS,
+  visibleColumns: defaultVisibleColumns,
+  templateColumns: buildTemplateColumns(defaultVisibleColumns, {}),
+  minWidth: undefined,
+  widths: {},
+  isVisible: () => true,
+  toggleColumn: () => {},
+  resetToDefaults: () => {},
+  resetColumnWidth: () => {},
+  beginResize: () => {},
+  setColumnWidth: () => {},
+  endResize: () => {},
+};
+
+export const RunsFeedColumnsContext = React.createContext<RunsFeedColumnsState>(DEFAULT_STATE);
+
+export const useRunsFeedColumns = () => React.useContext(RunsFeedColumnsContext);
+
+export const useRunsFeedColumnsState = (): RunsFeedColumnsState => {
+  const [settings, setSettings] = useStateWithStorage(
+    RUNS_FEED_COLUMNS_STORAGE_KEY,
+    validateRunsFeedColumnSettings,
+  );
+
+  // While dragging we keep widths in component state and only write to localStorage when
+  // the drag ends, so a resize doesn't produce a write per mouse move.
+  const [dragWidths, setDragWidths] = React.useState<RunsFeedColumnWidths | null>(null);
+  const dragWidthsRef = React.useRef<RunsFeedColumnWidths | null>(null);
+
+  const hidden = settings.hidden;
+  const widths = dragWidths ?? settings.widths;
+
+  const visibleColumns = React.useMemo(
+    () => RUNS_FEED_COLUMNS.filter((column) => !hidden.includes(column.key)),
+    [hidden],
+  );
+
+  const templateColumns = React.useMemo(
+    () => buildTemplateColumns(visibleColumns, widths),
+    [visibleColumns, widths],
+  );
+
+  const minWidth = React.useMemo(
+    () => buildMinWidth(visibleColumns, widths),
+    [visibleColumns, widths],
+  );
+
+  const isVisible = React.useCallback((key: RunsFeedColumnKey) => !hidden.includes(key), [hidden]);
+
+  const toggleColumn = React.useCallback(
+    (key: RunsFeedColumnKey) => {
+      setSettings((current) => {
+        const isHidden = current.hidden.includes(key);
+        if (!isHidden && current.hidden.length === RUNS_FEED_COLUMNS.length - 1) {
+          // Keep at least one column visible.
+          return current;
+        }
+        return {
+          ...current,
+          hidden: isHidden
+            ? current.hidden.filter((hiddenKey) => hiddenKey !== key)
+            : [...current.hidden, key],
+        };
+      });
+    },
+    [setSettings],
+  );
+
+  const resetToDefaults = React.useCallback(() => {
+    dragWidthsRef.current = null;
+    setDragWidths(null);
+    setSettings(DEFAULT_RUNS_FEED_COLUMN_SETTINGS);
+  }, [setSettings]);
+
+  const resetColumnWidth = React.useCallback(
+    (key: RunsFeedColumnKey) => {
+      setSettings((current) => {
+        const nextWidths = {...current.widths};
+        // If other columns are in pixel mode, fall back to this column's default pixel
+        // width; a lone `fr` track next to pixel tracks would collapse.
+        if (Object.keys(nextWidths).length > 1) {
+          nextWidths[key] = COLUMNS_BY_KEY[key].defaultWidth;
+        } else {
+          delete nextWidths[key];
+        }
+        return {...current, widths: nextWidths};
+      });
+      dragWidthsRef.current = null;
+      setDragWidths(null);
+    },
+    [setSettings],
+  );
+
+  const beginResize = React.useCallback((measuredWidths: RunsFeedColumnWidths) => {
+    dragWidthsRef.current = measuredWidths;
+    setDragWidths(measuredWidths);
+  }, []);
+
+  const setColumnWidth = React.useCallback((key: RunsFeedColumnKey, width: number) => {
+    const next = {
+      ...(dragWidthsRef.current ?? {}),
+      [key]: clampWidth(COLUMNS_BY_KEY[key], width),
+    };
+    dragWidthsRef.current = next;
+    setDragWidths(next);
+  }, []);
+
+  const endResize = React.useCallback(() => {
+    const finalWidths = dragWidthsRef.current;
+    dragWidthsRef.current = null;
+    setDragWidths(null);
+    if (finalWidths) {
+      setSettings((current) => ({...current, widths: finalWidths}));
+    }
+  }, [setSettings]);
+
+  return React.useMemo(
+    () => ({
+      columns: RUNS_FEED_COLUMNS,
+      visibleColumns,
+      templateColumns,
+      minWidth,
+      widths,
+      isVisible,
+      toggleColumn,
+      resetToDefaults,
+      resetColumnWidth,
+      beginResize,
+      setColumnWidth,
+      endResize,
+    }),
+    [
+      visibleColumns,
+      templateColumns,
+      minWidth,
+      widths,
+      isVisible,
+      toggleColumn,
+      resetToDefaults,
+      resetColumnWidth,
+      beginResize,
+      setColumnWidth,
+      endResize,
+    ],
+  );
+};
+
+export const RunsFeedColumnsProvider = ({
+  value,
+  children,
+}: {
+  value: RunsFeedColumnsState;
+  children: React.ReactNode;
+}) => <RunsFeedColumnsContext.Provider value={value}>{children}</RunsFeedColumnsContext.Provider>;
+
+export const RunsFeedColumnsMenu = () => {
+  const {columns, isVisible, toggleColumn, resetToDefaults, visibleColumns} = useRunsFeedColumns();
+  const isLastVisible = visibleColumns.length === 1;
+
+  return (
+    <Popover
+      placement="bottom-end"
+      content={
+        <Menu>
+          {columns.map((column) => {
+            const visible = isVisible(column.key);
+            return (
+              <MenuItem
+                key={column.key}
+                text={column.label}
+                icon={visible ? 'checkbox_checked' : 'checkbox_empty'}
+                disabled={visible && isLastVisible}
+                onClick={() => toggleColumn(column.key)}
+              />
+            );
+          })}
+          <MenuDivider />
+          <MenuItem text="Reset columns" icon="settings_backup_restore" onClick={resetToDefaults} />
+        </Menu>
+      }
+    >
+      <Button icon={<Icon name="table_columns" />} rightIcon={<Icon name="expand_more" />}>
+        Columns
+      </Button>
+    </Popover>
+  );
+};
+
+/**
+ * Drag handle rendered at the trailing edge of a resizable header cell. On drag start we
+ * measure every rendered column so the table can switch from proportional to pixel widths
+ * without the layout shifting under the cursor.
+ */
+export const ColumnResizeHandle = ({columnKey}: {columnKey: RunsFeedColumnKey}) => {
+  const {visibleColumns, widths, beginResize, setColumnWidth, endResize, resetColumnWidth} =
+    useRunsFeedColumns();
+  const [isDragging, setIsDragging] = React.useState(false);
+  const dragState = React.useRef<{startX: number; startWidth: number} | null>(null);
+  const handleRef = React.useRef<HTMLDivElement>(null);
+
+  const measureRenderedWidths = React.useCallback((): RunsFeedColumnWidths => {
+    const measured: RunsFeedColumnWidths = {};
+    const headerRow = handleRef.current?.parentElement?.parentElement;
+    // Header cells are the grid children: [checkbox, ...visibleColumns, actions].
+    const cells = headerRow ? Array.from(headerRow.children) : [];
+    visibleColumns.forEach((column, index) => {
+      const cell = cells[index + 1];
+      const rendered = cell?.getBoundingClientRect().width;
+      measured[column.key] = Math.round(
+        rendered && rendered > 0 ? rendered : (widths[column.key] ?? column.defaultWidth),
+      );
+    });
+    // Hidden columns keep a pixel width too, so unhiding one doesn't mix `fr` and `px`.
+    RUNS_FEED_COLUMNS.forEach((column) => {
+      if (measured[column.key] === undefined) {
+        measured[column.key] = widths[column.key] ?? column.defaultWidth;
+      }
+    });
+    return measured;
+  }, [visibleColumns, widths]);
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const measured = measureRenderedWidths();
+    const startWidth = measured[columnKey] ?? COLUMNS_BY_KEY[columnKey].defaultWidth;
+    dragState.current = {startX: e.clientX, startWidth};
+
+    e.currentTarget.setPointerCapture(e.pointerId);
+    beginResize(measured);
+    setIsDragging(true);
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragState.current;
+    if (!drag) {
+      return;
+    }
+    setColumnWidth(columnKey, drag.startWidth + (e.clientX - drag.startX));
+  };
+
+  const onPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragState.current) {
+      return;
+    }
+    dragState.current = null;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    setIsDragging(false);
+    endResize();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') {
+      return;
+    }
+    e.preventDefault();
+    const measured = measureRenderedWidths();
+    const current = measured[columnKey] ?? COLUMNS_BY_KEY[columnKey].defaultWidth;
+    beginResize(measured);
+    setColumnWidth(columnKey, current + (e.key === 'ArrowRight' ? 16 : -16));
+    endResize();
+  };
+
+  return (
+    <div
+      ref={handleRef}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={`Resize ${COLUMNS_BY_KEY[columnKey].label} column`}
+      tabIndex={0}
+      className={clsx(styles.resizeHandle, isDragging && styles.resizeHandleDragging)}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      onKeyDown={onKeyDown}
+      onDoubleClick={() => resetColumnWidth(columnKey)}
+    >
+      <div />
+    </div>
+  );
+};

--- a/js_modules/ui-core/src/runs/RunsFeedColumns.tsx
+++ b/js_modules/ui-core/src/runs/RunsFeedColumns.tsx
@@ -133,6 +133,23 @@ export const buildMinWidth = (
   );
 };
 
+/**
+ * Pixel widths let the table exceed its container, so something has to provide the
+ * horizontal scrollport. With `scroll` the table's own Container does. Without it (the
+ * schedule/sensor/tick tables) and in the empty state (which renders no Container at
+ * all), the wrapper must, or widened columns are clipped and unreachable.
+ */
+export const buildTableOverflowStyle = ({
+  scroll,
+  minWidth,
+}: {
+  scroll: boolean;
+  minWidth: number | undefined;
+}): React.CSSProperties =>
+  scroll
+    ? {overflow: 'hidden', display: 'flex', flexDirection: 'column'}
+    : {overflowX: minWidth === undefined ? 'hidden' : 'auto', overflowY: 'hidden'};
+
 interface RunsFeedColumnsState {
   columns: RunsFeedColumnConfig[];
   visibleColumns: RunsFeedColumnConfig[];

--- a/js_modules/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/ui-core/src/runs/RunsFeedRow.tsx
@@ -21,6 +21,7 @@ import {DagsterTag} from './RunTag';
 import {RunTags} from './RunTags';
 import {RunTargetLink} from './RunTargetLink';
 import {RunStateSummary, RunTime, titleForRun} from './RunUtils';
+import {ColumnResizeHandle, RunsFeedColumnKey, useRunsFeedColumns} from './RunsFeedColumns';
 import {RunsFeedDialogState} from './RunsFeedTable';
 import {getBackfillPath} from './RunsFeedUtils';
 import {RunFilterToken} from './RunsFilterInput';
@@ -51,6 +52,8 @@ export const RunsFeedRow = ({
   hideCreatedBy?: boolean;
   hideTags?: string[];
 }) => {
+  const {visibleColumns, templateColumns, minWidth} = useRunsFeedColumns();
+
   const onChange = (e: React.FormEvent<HTMLInputElement>) => {
     if (e.target instanceof HTMLInputElement) {
       const {checked} = e.target;
@@ -89,17 +92,8 @@ export const RunsFeedRow = ({
   const partitionTag =
     entry.__typename === 'Run' ? entry.tags.find((t) => t.key === DagsterTag.Partition) : null;
 
-  return (
-    <Box
-      className={styles.rowGrid}
-      border="bottom"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      <RowCell>
-        <Checkbox checked={!!checked} onChange={onChange} />
-      </RowCell>
-
+  const cells: Record<RunsFeedColumnKey, React.ReactNode> = {
+    id: (
       <RowCell>
         <Box flex={{direction: 'column', gap: 5}}>
           <Link
@@ -144,6 +138,8 @@ export const RunsFeedRow = ({
           </Box>
         </Box>
       </RowCell>
+    ),
+    target: (
       <RowCell style={{flexDirection: 'row', alignItems: 'flex-start'}}>
         {entry.__typename === 'Run' ? (
           <RunTargetLink
@@ -165,9 +161,13 @@ export const RunsFeedRow = ({
           />
         )}
       </RowCell>
+    ),
+    launchedBy: (
       <RowCell>
         <CreatedByTagCell tags={entry.tags || []} onAddTag={onAddTag} repoAddress={repoAddress} />
       </RowCell>
+    ),
+    status: (
       <RowCell>
         <div>
           {entry.__typename === 'PartitionBackfill' ? (
@@ -177,6 +177,8 @@ export const RunsFeedRow = ({
           )}
         </div>
       </RowCell>
+    ),
+    createdAt: (
       <RowCell style={{flexDirection: 'column', gap: 4}}>
         <RunTime run={runTime} />
         {isReexecution ? (
@@ -185,9 +187,30 @@ export const RunsFeedRow = ({
           </div>
         ) : null}
       </RowCell>
+    ),
+    duration: (
       <RowCell>
         <RunStateSummary run={runTime} />
       </RowCell>
+    ),
+  };
+
+  return (
+    <Box
+      className={styles.rowGrid}
+      style={{gridTemplateColumns: templateColumns, minWidth}}
+      border="bottom"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <RowCell>
+        <Checkbox checked={!!checked} onChange={onChange} />
+      </RowCell>
+
+      {visibleColumns.map((column) => (
+        <React.Fragment key={column.key}>{cells[column.key]}</React.Fragment>
+      ))}
+
       <RowCell>
         {entry.__typename === 'PartitionBackfill' ? (
           <BackfillActionsMenu
@@ -203,21 +226,20 @@ export const RunsFeedRow = ({
   );
 };
 
-const TEMPLATE_COLUMNS =
-  '60px minmax(0, 1.5fr) minmax(0, 1.2fr) minmax(0, 1fr) 140px 170px 120px 132px';
-
 export const RunsFeedTableHeader = ({checkbox}: {checkbox: React.ReactNode}) => {
+  const {visibleColumns, templateColumns, minWidth} = useRunsFeedColumns();
+
   return (
-    <HeaderRow templateColumns={TEMPLATE_COLUMNS} sticky>
+    <HeaderRow templateColumns={templateColumns} minWidth={minWidth} sticky>
       <HeaderCell>
         <div style={{position: 'relative', top: '-1px'}}>{checkbox}</div>
       </HeaderCell>
-      <HeaderCell>ID</HeaderCell>
-      <HeaderCell>Target</HeaderCell>
-      <HeaderCell>Launched by</HeaderCell>
-      <HeaderCell>Status</HeaderCell>
-      <HeaderCell>Created at</HeaderCell>
-      <HeaderCell>Duration</HeaderCell>
+      {visibleColumns.map((column) => (
+        <HeaderCell key={column.key} style={{position: 'relative'}}>
+          {column.label}
+          <ColumnResizeHandle columnKey={column.key} />
+        </HeaderCell>
+      ))}
       <HeaderCell></HeaderCell>
     </HeaderRow>
   );

--- a/js_modules/ui-core/src/runs/RunsFeedTable.tsx
+++ b/js_modules/ui-core/src/runs/RunsFeedTable.tsx
@@ -17,6 +17,11 @@ import {QueuedRunCriteriaDialog} from './QueuedRunCriteriaDialog';
 import {RunBulkActionsMenu} from './RunActionsMenu';
 import {RunTableEmptyState} from './RunTableEmptyState';
 import {RunsQueryRefetchContext} from './RunUtils';
+import {
+  RunsFeedColumnsMenu,
+  RunsFeedColumnsProvider,
+  useRunsFeedColumnsState,
+} from './RunsFeedColumns';
 import {RunsFeedError} from './RunsFeedError';
 import {RunsFeedRow, RunsFeedTableHeader} from './RunsFeedRow';
 import {RunFilterToken} from './RunsFilterInput';
@@ -68,6 +73,7 @@ export const RunsFeedTable = ({
   scroll = true,
 }: RunsFeedTableProps) => {
   const parentRef = useRef<HTMLDivElement | null>(null);
+  const columns = useRunsFeedColumnsState();
 
   const entryIds = useMemo(() => entries.map((e) => e.id), [entries]);
   const [{checkedIds}, {onToggleFactory, onToggleAll}] = useSelectionReducer(entryIds);
@@ -115,6 +121,7 @@ export const RunsFeedTable = ({
       >
         {actionBarComponents ?? <span />}
         <Box flex={{gap: 12, alignItems: 'center'}} style={{marginRight: 8}}>
+          <RunsFeedColumnsMenu />
           <CursorHistoryControls
             style={{marginTop: 0}}
             hasPrevCursor={paginationProps.hasPrevCursor}
@@ -215,7 +222,7 @@ export const RunsFeedTable = ({
               <SpinnerWithText label="Loading runs…" />
             </Box>
           )}
-          <Inner totalHeight={totalHeight}>
+          <Inner totalHeight={totalHeight} minWidth={columns.minWidth}>
             {items.map(({index, size, start, key}) => {
               const entry = entries[index];
               if (!entry) {
@@ -245,17 +252,19 @@ export const RunsFeedTable = ({
   }
 
   return (
-    <Box
-      flex={{direction: 'column'}}
-      padding={{vertical: 12}}
-      style={scroll ? {height: '100%', minHeight: 0} : {}}
-    >
-      <Box flex={{direction: 'column', gap: 8}} padding={{bottom: 12}}>
-        {actionBar}
+    <RunsFeedColumnsProvider value={columns}>
+      <Box
+        flex={{direction: 'column'}}
+        padding={{vertical: 12}}
+        style={scroll ? {height: '100%', minHeight: 0} : {}}
+      >
+        <Box flex={{direction: 'column', gap: 8}} padding={{bottom: 12}}>
+          {actionBar}
+        </Box>
+        <IndeterminateLoadingBar $loading={loading} />
+        {content()}
       </Box>
-      <IndeterminateLoadingBar $loading={loading} />
-      {content()}
-    </Box>
+    </RunsFeedColumnsProvider>
   );
 };
 

--- a/js_modules/ui-core/src/runs/RunsFeedTable.tsx
+++ b/js_modules/ui-core/src/runs/RunsFeedTable.tsx
@@ -20,6 +20,7 @@ import {RunsQueryRefetchContext} from './RunUtils';
 import {
   RunsFeedColumnsMenu,
   RunsFeedColumnsProvider,
+  buildTableOverflowStyle,
   useRunsFeedColumnsState,
 } from './RunsFeedColumns';
 import {RunsFeedError} from './RunsFeedError';
@@ -170,6 +171,10 @@ export const RunsFeedTable = ({
     </Box>
   );
 
+  const wrapperStyle = buildTableOverflowStyle({scroll, minWidth: columns.minWidth});
+  // The empty state renders no Container, so it always needs the wrapper's scrollport.
+  const emptyStateStyle = buildTableOverflowStyle({scroll: false, minWidth: columns.minWidth});
+
   function content() {
     const header = (
       <RunsFeedTableHeader
@@ -186,7 +191,7 @@ export const RunsFeedTable = ({
     if (entries.length === 0 && !loading) {
       const anyFilter = !!Object.keys(filter || {}).length;
       return (
-        <div style={{overflow: 'hidden'}}>
+        <div style={emptyStateStyle}>
           {header}
           {emptyState ? (
             <div style={{minHeight: 82}}>{emptyState()}</div>
@@ -198,13 +203,7 @@ export const RunsFeedTable = ({
     }
 
     return (
-      <div
-        style={
-          scroll
-            ? {overflow: 'hidden', display: 'flex', flexDirection: 'column'}
-            : {overflow: 'hidden'}
-        }
-      >
+      <div style={wrapperStyle}>
         <BackfillPartitionsRequestedDialog
           backfillId={dialog?.type === 'partitions' ? dialog.backfillId : undefined}
           onClose={() => setDialog(null)}

--- a/js_modules/ui-core/src/runs/__tests__/RunsFeedColumns.test.tsx
+++ b/js_modules/ui-core/src/runs/__tests__/RunsFeedColumns.test.tsx
@@ -8,6 +8,7 @@ import {
   RunsFeedColumnsMenu,
   RunsFeedColumnsProvider,
   buildMinWidth,
+  buildTableOverflowStyle,
   buildTemplateColumns,
   useRunsFeedColumnsState,
   validateRunsFeedColumnSettings,
@@ -53,6 +54,32 @@ describe('buildMinWidth', () => {
 
   it('ignores hidden columns', () => {
     expect(buildMinWidth(columnsFor('id'), {id: 800})).toBe(60 + 132 + 800);
+  });
+});
+
+describe('buildTableOverflowStyle', () => {
+  it('leaves the scrolling table to its own Container', () => {
+    expect(buildTableOverflowStyle({scroll: true, minWidth: 1400})).toEqual({
+      overflow: 'hidden',
+      display: 'flex',
+      flexDirection: 'column',
+    });
+  });
+
+  it('clips a non-scrolling table only while it is still proportional', () => {
+    expect(buildTableOverflowStyle({scroll: false, minWidth: undefined})).toEqual({
+      overflowX: 'hidden',
+      overflowY: 'hidden',
+    });
+  });
+
+  it('gives a non-scrolling table a horizontal scrollport once columns have pixel widths', () => {
+    // Without this, resized columns in the schedule/sensor/tick tables are clipped by the
+    // wrapper with no way to scroll to them.
+    expect(buildTableOverflowStyle({scroll: false, minWidth: 1400})).toEqual({
+      overflowX: 'auto',
+      overflowY: 'hidden',
+    });
   });
 });
 

--- a/js_modules/ui-core/src/runs/__tests__/RunsFeedColumns.test.tsx
+++ b/js_modules/ui-core/src/runs/__tests__/RunsFeedColumns.test.tsx
@@ -1,0 +1,197 @@
+import {act, render, renderHook, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  DEFAULT_RUNS_FEED_COLUMN_SETTINGS,
+  RUNS_FEED_COLUMNS,
+  RUNS_FEED_COLUMNS_STORAGE_KEY,
+  RunsFeedColumnsMenu,
+  RunsFeedColumnsProvider,
+  buildMinWidth,
+  buildTemplateColumns,
+  useRunsFeedColumnsState,
+  validateRunsFeedColumnSettings,
+} from '../RunsFeedColumns';
+
+// The proportional layout the table shipped with before columns became configurable.
+const LEGACY_TEMPLATE =
+  '60px minmax(0, 1.5fr) minmax(0, 1.2fr) minmax(0, 1fr) 140px 170px 120px 132px';
+
+const columnsFor = (...keys: string[]) =>
+  RUNS_FEED_COLUMNS.filter((column) => keys.includes(column.key));
+
+describe('buildTemplateColumns', () => {
+  it('matches the original layout when no column has been resized', () => {
+    expect(buildTemplateColumns(RUNS_FEED_COLUMNS, {})).toBe(LEGACY_TEMPLATE);
+  });
+
+  it('uses pixel tracks for resized columns', () => {
+    expect(buildTemplateColumns(RUNS_FEED_COLUMNS, {id: 500, target: 240})).toBe(
+      '60px 500px 240px minmax(0, 1fr) 140px 170px 120px 132px',
+    );
+  });
+
+  it('drops tracks for hidden columns', () => {
+    expect(buildTemplateColumns(columnsFor('id', 'status'), {})).toBe(
+      '60px minmax(0, 1.5fr) 140px 132px',
+    );
+  });
+});
+
+describe('buildMinWidth', () => {
+  it('is undefined while the table is still proportional', () => {
+    expect(buildMinWidth(RUNS_FEED_COLUMNS, {})).toBeUndefined();
+  });
+
+  it('reserves the full pixel width so the table can scroll horizontally', () => {
+    const widths = {id: 800, target: 300, launchedBy: 200, status: 140, createdAt: 170};
+    // 60 + 132 fixed columns, pixel widths, and `duration` at its minimum.
+    expect(buildMinWidth(RUNS_FEED_COLUMNS, widths)).toBe(
+      60 + 132 + 800 + 300 + 200 + 140 + 170 + 90,
+    );
+  });
+
+  it('ignores hidden columns', () => {
+    expect(buildMinWidth(columnsFor('id'), {id: 800})).toBe(60 + 132 + 800);
+  });
+});
+
+describe('validateRunsFeedColumnSettings', () => {
+  it('falls back to defaults for missing or malformed values', () => {
+    expect(validateRunsFeedColumnSettings(undefined)).toEqual(DEFAULT_RUNS_FEED_COLUMN_SETTINGS);
+    expect(validateRunsFeedColumnSettings('nope')).toEqual(DEFAULT_RUNS_FEED_COLUMN_SETTINGS);
+    expect(validateRunsFeedColumnSettings({hidden: 'id', widths: 4})).toEqual({
+      hidden: [],
+      widths: {},
+    });
+  });
+
+  it('drops unknown columns and non-numeric widths', () => {
+    expect(
+      validateRunsFeedColumnSettings({
+        hidden: ['status', 'notARealColumn'],
+        widths: {id: 400, notARealColumn: 100, target: 'wide'},
+      }),
+    ).toEqual({hidden: ['status'], widths: {id: 400}});
+  });
+
+  it('clamps widths to the column minimum and maximum', () => {
+    expect(validateRunsFeedColumnSettings({widths: {id: 10, duration: 99999}})).toEqual({
+      hidden: [],
+      widths: {id: 120, duration: 1200},
+    });
+  });
+
+  it('never hides every column', () => {
+    const settings = validateRunsFeedColumnSettings({
+      hidden: RUNS_FEED_COLUMNS.map((column) => column.key),
+    });
+    expect(settings.hidden).toHaveLength(RUNS_FEED_COLUMNS.length - 1);
+  });
+});
+
+describe('useRunsFeedColumnsState', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('persists hidden columns and widths across mounts', () => {
+    const first = renderHook(() => useRunsFeedColumnsState());
+    act(() => {
+      first.result.current.toggleColumn('launchedBy');
+    });
+    act(() => {
+      first.result.current.beginResize({id: 300});
+      first.result.current.setColumnWidth('id', 640);
+      first.result.current.endResize();
+    });
+
+    expect(first.result.current.visibleColumns.map((column) => column.key)).toEqual([
+      'id',
+      'target',
+      'status',
+      'createdAt',
+      'duration',
+    ]);
+    expect(first.result.current.templateColumns).toContain('640px');
+
+    first.unmount();
+
+    const second = renderHook(() => useRunsFeedColumnsState());
+    expect(second.result.current.widths.id).toBe(640);
+    expect(second.result.current.isVisible('launchedBy')).toBe(false);
+  });
+
+  it('does not write to storage until a resize ends', () => {
+    const {result} = renderHook(() => useRunsFeedColumnsState());
+    act(() => {
+      result.current.beginResize({id: 300});
+      result.current.setColumnWidth('id', 500);
+    });
+
+    expect(result.current.widths.id).toBe(500);
+    expect(window.localStorage.getItem(RUNS_FEED_COLUMNS_STORAGE_KEY)).toBeNull();
+
+    act(() => {
+      result.current.endResize();
+    });
+    expect(window.localStorage.getItem(RUNS_FEED_COLUMNS_STORAGE_KEY)).toContain('500');
+  });
+
+  it('clamps a resize to the column minimum', () => {
+    const {result} = renderHook(() => useRunsFeedColumnsState());
+    act(() => {
+      result.current.beginResize({status: 140});
+      result.current.setColumnWidth('status', 10);
+      result.current.endResize();
+    });
+    expect(result.current.widths.status).toBe(90);
+  });
+
+  it('resets back to the default layout', () => {
+    const {result} = renderHook(() => useRunsFeedColumnsState());
+    act(() => {
+      result.current.toggleColumn('duration');
+      result.current.beginResize({id: 300});
+      result.current.setColumnWidth('id', 700);
+      result.current.endResize();
+    });
+    act(() => {
+      result.current.resetToDefaults();
+    });
+
+    expect(result.current.templateColumns).toBe(LEGACY_TEMPLATE);
+    expect(result.current.minWidth).toBeUndefined();
+  });
+});
+
+describe('RunsFeedColumnsMenu', () => {
+  const Test = () => {
+    const columns = useRunsFeedColumnsState();
+    return (
+      <RunsFeedColumnsProvider value={columns}>
+        <RunsFeedColumnsMenu />
+        <div data-testid="visible">
+          {columns.visibleColumns.map((column) => column.key).join(',')}
+        </div>
+      </RunsFeedColumnsProvider>
+    );
+  };
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('toggles a column off and back on', async () => {
+    render(<Test />);
+    await userEvent.click(screen.getByRole('button', {name: /columns/i}));
+
+    await userEvent.click(await screen.findByText('Launched by'));
+    expect(screen.getByTestId('visible')).toHaveTextContent('id,target,status,createdAt,duration');
+
+    await userEvent.click(screen.getByText('Launched by'));
+    expect(screen.getByTestId('visible')).toHaveTextContent(
+      'id,target,launchedBy,status,createdAt,duration',
+    );
+  });
+});

--- a/js_modules/ui-core/src/runs/css/RunTargetLink.module.css
+++ b/js_modules/ui-core/src/runs/css/RunTargetLink.module.css
@@ -1,0 +1,13 @@
+/*
+ * BaseTag caps its label at 400px. The Target column is resizable, so that cap
+ * would leave dead space in a wider column while the job name stayed ellipsized;
+ * here the column width is the only limit.
+ */
+.target {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.target :global(.BaseTag) > span {
+  max-width: 100%;
+}

--- a/js_modules/ui-core/src/runs/css/RunsFeedColumns.module.css
+++ b/js_modules/ui-core/src/runs/css/RunsFeedColumns.module.css
@@ -1,0 +1,31 @@
+.resizeHandle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 9px;
+  z-index: 2;
+  cursor: col-resize;
+  user-select: none;
+  touch-action: none;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  outline: none;
+}
+
+.resizeHandle > div {
+  width: 1px;
+  background: transparent;
+}
+
+.resizeHandle:hover > div,
+.resizeHandle:focus-visible > div {
+  width: 2px;
+  background: var(--color-accent-gray);
+}
+
+.resizeHandleDragging > div {
+  width: 2px;
+  background: var(--color-accent-blue);
+}

--- a/js_modules/ui-core/src/runs/css/RunsFeedRow.module.css
+++ b/js_modules/ui-core/src/runs/css/RunsFeedRow.module.css
@@ -1,5 +1,4 @@
 .rowGrid {
   display: grid;
-  grid-template-columns: 60px minmax(0, 1.5fr) minmax(0, 1.2fr) minmax(0, 1fr) 140px 170px 120px 132px;
   height: 100%;
 }


### PR DESCRIPTION
The runs feed rendered a hardcoded grid-template-columns, so the ID and Target columns could not be widened and unwanted columns could not be dismissed. Long run targets were unreadable at common window widths.

- Add RunsFeedColumns: per-column config, localStorage-backed widths and hidden set, a drag handle for each header cell, and a Columns menu.
- Columns keep their proportional layout until first resized, then switch to pixel widths (measured from the rendered header so nothing jumps) and the table becomes horizontally scrollable.
- Let the Target column's width decide job-name truncation instead of a fixed 40-character cap.

Widths and hidden columns persist across reloads and window resizes.

## Summary & Motivation
![Uploading image.png…]()

## Test Plan

## Changelog

> The changelog is generated by an agent that examines merged PRs and
> summarizes/categorizes user-facing changes. You can optionally replace
> this text with a terse description of any user-facing changes in your PR,
> which the agent will prioritize. Otherwise, delete this section.
