### PR TITLE
Fix SQLite event log reentrant logging deadlock

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -108,8 +108,10 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         # ensuring that the database will be created if it doesn't exist
         self._initialized_dbs = set()
 
-        # Ensure that multiple threads (like the event log watcher) interact safely with each other
-        self._db_lock = threading.Lock()
+        # Ensure that multiple threads (like the event log watcher) interact safely with each other.
+        # This must be re-entrant because managed Python logging can synchronously store an event
+        # while SQLite initialization is opening a connection on the same thread.
+        self._db_lock = threading.RLock()
 
         if not os.path.exists(self.path_for_shard(INDEX_SHARD_NAME)):
             conn_string = self.conn_string_for_shard(INDEX_SHARD_NAME)

--- a/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
@@ -97,6 +97,17 @@ class TestSqliteEventLogStorage(TestEventLogStorage):
     def can_wipe_asset_partitions(self) -> bool:
         return False
 
+    def test_filesystem_event_log_storage_lock_is_reentrant(self, storage):
+        # SQLite initialization can emit a managed Python log that synchronously stores an event,
+        # re-entering event-log storage on the same thread.
+        lock = storage._db_lock  # noqa: SLF001
+        assert lock.acquire(blocking=False)
+        try:
+            assert lock.acquire(blocking=False)
+            lock.release()
+        finally:
+            lock.release()
+
     def test_filesystem_event_log_storage_run_corrupted(self, storage):
         # URL begins sqlite:///
 


### PR DESCRIPTION
**AI-assisted analysis; submitted under human responsibility.**

## Summary & Motivation

Fixes #32217.

`SqliteEventLogStorage._connect()` serializes SQLite access with a non-reentrant
`threading.Lock`. During first-use database initialization, Alembic can emit a Python log.
When the root logger is configured in `managed_python_loggers`, Dagster synchronously stores
that log as an event on the same thread, which re-enters `_connect()` and blocks forever on
the lock it already owns.

Dagster's `DagsterLogHandler` already disables nested log capture while a managed log record
is being emitted, so allowing same-thread lock re-entry does not create recursive event
logging. `threading.RLock` preserves the existing mutual exclusion between different threads
while allowing that synchronous storage callback to complete.

This changes the SQLite event-log serialization lock from `Lock` to `RLock` and adds a
regression test pinning the required same-thread re-entrancy invariant.

## How I Tested These Changes

- `make ruff`
- targeted regression:
  `python -m pytest -q python_modules/dagster/dagster_tests/storage_tests/test_event_log.py::TestSqliteEventLogStorage::test_filesystem_event_log_storage_lock_is_reentrant`
- full SQLite event-log storage class:
  `python -m pytest -q python_modules/dagster/dagster_tests/storage_tests/test_event_log.py::TestSqliteEventLogStorage`
  - 138 passed, 12 skipped
- repository changed-file typecheck: `make quick_ty`
- `git diff --check`

## Changelog

- Fixed a SQLite event-log deadlock that could occur when dynamic-partition access triggered
  first-use database initialization while the root Python logger was managed by Dagster.
