### PR TITLE
[dagster-snowflake] Close the connection when the with body raises

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -561,9 +561,11 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext,
             )
             conn = engine.raw_connection() if raw_conn else engine.connect()
 
-            yield conn
-            conn.close()
-            engine.dispose()
+            try:
+                yield conn
+            finally:
+                conn.close()
+                engine.dispose()
         elif self.connector == "adbc":
             import adbc_driver_snowflake.dbapi
 
@@ -571,15 +573,19 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext,
                 db_kwargs=self._adbc_connection_args,  # ty: ignore[invalid-argument-type]
             )
 
-            yield conn
-            conn.close()
+            try:
+                yield conn
+            finally:
+                conn.close()
         else:
             conn = snowflake.connector.connect(**self._connection_args)
 
-            yield conn
-            if not self.autocommit:
-                conn.commit()
-            conn.close()
+            try:
+                yield conn
+                if not self.autocommit:
+                    conn.commit()
+            finally:
+                conn.close()
 
     def get_object_to_set_on_execution_context(self) -> Any:
         # Directly create a SnowflakeConnection here for backcompat since the SnowflakeConnection

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
@@ -131,6 +131,26 @@ def test_pydantic_snowflake_resource(snowflake_connect):
 
 
 @mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)
+def test_snowflake_resource_closes_connection_on_error(snowflake_connect):
+    resource = SnowflakeResource(
+        account="foo",
+        user="bar",
+        private_key=TEST_PRIVATE_KEY,
+        database="TESTDB",
+        schema="TESTSCHEMA",
+        warehouse="TINY_WAREHOUSE",
+    )
+
+    with pytest.raises(RuntimeError, match="query failed"):
+        with resource.get_connection() as _:
+            raise RuntimeError("query failed")
+
+    mock_conn = snowflake_connect.return_value
+    mock_conn.close.assert_called_once()
+    mock_conn.commit.assert_not_called()
+
+
+@mock.patch("snowflake.connector.connect", new_callable=create_mock_connector)
 def test_snowflake_resource_from_envvars(snowflake_connect):
     @op(required_resource_keys={"snowflake"})
     def snowflake_op(context):


### PR DESCRIPTION
## Summary & Motivation

`SnowflakeResource.get_connection` yields the connection and performs cleanup on the lines after the `yield`, in all three connector branches:

```python
            conn = engine.raw_connection() if raw_conn else engine.connect()

            yield conn
            conn.close()
            engine.dispose()
```

When the body of the `with` block raises, which is the ordinary failed-query path (`cursor.execute` raising `ProgrammingError` on a bad SQL statement), the generator exits through the `yield` and none of the cleanup runs. Every failed op that uses `with snowflake.get_connection() as conn:` leaks a live Snowflake session, which is billable and counts against the account's session quota, and in the sqlalchemy branch the engine pool is never disposed either. `execute_query`, `execute_queries` and the legacy `SnowflakeConnection.get_connection` all route through this function.

The class already knows the right shape: `create_snowpark_session`, a few hundred lines down in the same file, wraps its yield in `try/finally`. This PR applies that same shape to the three `get_connection` branches. One behavioral detail kept intact: in the default connector branch, `conn.commit()` stays inside the `try` after the `yield`, so a failed body still skips the commit exactly as before; only `close` moves to `finally`.

## How I Tested These Changes

Added `test_snowflake_resource_closes_connection_on_error`, following the existing mock pattern in `test_resources.py` (`create_mock_connector`): it raises inside the `with` block and asserts the connection was closed and `commit` was not called. On the previous code that test fails because `close` is never invoked, so it pins the leak rather than the happy path. The existing happy-path tests exercise the same branches unchanged.

I could not run the dagster test harness in this environment; the changed module and test file both compile, and the test is a direct sibling of `test_pydantic_snowflake_resource` above it.

## Changelog

> Fixed an issue where `SnowflakeResource.get_connection` did not close the Snowflake connection when the body of the `with` block raised an exception.
