### PR TITLE
Include is_secret in config field hash so secret fields are not unmasked by a cached type

### DIFF
--- a/python_modules/dagster/dagster/_config/field_utils.py
+++ b/python_modules/dagster/dagster/_config/field_utils.py
@@ -86,6 +86,10 @@ def compute_fields_hash(fields, description, field_aliases=None):
         _add_hash(m, ":type_key: " + field.config_type.key)
         if field.description:
             _add_hash(m, ":description: " + field.description)
+        # only added to the hash when set, so that config type keys for fields that do not
+        # opt in to is_secret are unchanged
+        if field.is_secret:
+            _add_hash(m, ":is_secret: " + str(field.is_secret))
 
     field_aliases = check.opt_dict_param(
         field_aliases, "field_aliases", key_type=str, value_type=str

--- a/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_field_hash.py
+++ b/python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_field_hash.py
@@ -31,6 +31,20 @@ def test_hash_diff():
         {"same_name": dg.Field(int, description="desc")}
     )
 
+    assert _hash({"same_name": dg.Field(str)}) != _hash(
+        {"same_name": dg.Field(str, is_secret=True)}
+    )
+
+
+def test_construct_dicts_differing_only_by_is_secret():
+    plain_dict = dg.Shape(fields={"a_token": dg.Field(str)})
+    secret_dict = dg.Shape(fields={"a_token": dg.Field(str, is_secret=True)})
+
+    assert plain_dict is not secret_dict
+    assert plain_dict.key != secret_dict.key
+    assert plain_dict.fields["a_token"].is_secret is False
+    assert secret_dict.fields["a_token"].is_secret is True
+
 
 def test_construct_same_dicts():
     int_dict_1 = dg.Shape(fields={"an_int": dg.Field(int)})

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -221,6 +221,59 @@ def test_print_root_with_secret_fields(instance) -> None:
     assert "key_456" not in yaml_output
 
 
+def job_defs_with_matching_plain_and_secret_config():
+    """Two config classes that differ only by is_secret, plain one declared first."""
+
+    class PlainOpConfig(dg.Config):
+        webhook_url: str = PyField(default="https://example.test/hook", description="the hook")
+
+    class SecretOpConfig(dg.Config):
+        webhook_url: str = PyField(
+            default="https://example.test/hook",
+            description="the hook",
+            json_schema_extra={"dagster__is_secret": True},
+        )
+
+    @dg.op
+    def plain_op(config: PlainOpConfig):
+        pass
+
+    @dg.op
+    def secret_op(config: SecretOpConfig):
+        pass
+
+    @dg.job
+    def plain_job():
+        plain_op()
+
+    @dg.job
+    def secret_job():
+        secret_op()
+
+    return dg.Definitions(jobs=[plain_job, secret_job])
+
+
+def _default_values_yaml_for_job(repo: RemoteRepository, job_name: str) -> str:
+    a_job = repo.get_full_job(job_name)
+    root_config_key = a_job.root_config_key
+    assert root_config_key
+    root_type = a_job.config_schema_snapshot.get_config_snap(root_config_key)
+    return default_values_yaml_from_type_snap(a_job.config_schema_snapshot, root_type)
+
+
+def test_print_root_secret_field_matching_earlier_plain_field(instance) -> None:
+    """A secret field is still masked when an identical non-secret field was declared first."""
+    repo = _remote_repository_for_function(instance, job_defs_with_matching_plain_and_secret_config)
+
+    secret_yaml_output = _default_values_yaml_for_job(repo, "secret_job")
+    assert "webhook_url: '********'" in secret_yaml_output
+    assert "https://example.test/hook" not in secret_yaml_output
+
+    # the non-secret field keeps its value
+    plain_yaml_output = _default_values_yaml_for_job(repo, "plain_job")
+    assert "webhook_url: https://example.test/hook" in plain_yaml_output
+
+
 class AuthToken(dg.Config):
     auth_type: Literal["token"] = "token"
     token: str


### PR DESCRIPTION
## Summary & Motivation

`compute_fields_hash` in `python_modules/dagster/dagster/_config/field_utils.py` builds the key
that `Shape`, `Permissive` and `Selector` are memoized under. It hashes the field name, the
default value, `is_required`, the type key and the description. It does not hash `is_secret`.

So two config types whose fields are identical apart from `is_secret` produce the same key.
`_memoize_inst_in_field_cache` hands back the instance that was built first, and `__init__`
returns early on `if self._initialized`, which throws away the second type's fields. Whichever
config type is constructed first in the process decides whether the field is treated as secret,
for both of them.

`is_secret` is read in three places:

- `_core/snap/snap_to_yaml.py` masks secret defaults in the launchpad YAML.
- `GrapheneConfigTypeField.resolve_default_value_as_json` masks the default in GraphQL.
- `GrapheneConfiguredValue` marks a resource value as `SECRET` on the resources page.

The collision can therefore show a plaintext default where the author asked for masking, and
it can show asterisks where they did not.

Here are two config classes that differ only by the flag:

    class PlainOpConfig(dg.Config):
        webhook_url: str = PyField(default="https://example.test/hook", description="the hook")

    class SecretOpConfig(dg.Config):
        webhook_url: str = PyField(
            default="https://example.test/hook",
            description="the hook",
            json_schema_extra={"dagster__is_secret": True},
        )

Launchpad default YAML for the op that uses `SecretOpConfig`, with `SecretOpConfig` declared
first:

    ops:
      secret_op:
        config:
          webhook_url: '********'

The same op, with `PlainOpConfig` declared first:

    ops:
      secret_op:
        config:
          webhook_url: https://example.test/hook

Nothing about the secret class changed. Only the declaration order elsewhere in the process did.

I add `is_secret` to the hash, but only when it is set. That keeps config type keys unchanged
for every field that does not use the flag, so stored job snapshots and config schema snapshots
do not churn on upgrade. It follows the pattern already used for `description` and
`default_provided` in the same loop.

## Test Plan

Two regression tests, both of which fail without the change to `field_utils.py`.

`test_field_hash.py` covers the hash itself: one new assertion in `test_hash_diff`, and
`test_construct_dicts_differing_only_by_is_secret`, which checks that the two shapes are
separate objects and that each keeps its own flag.

`test_snap_to_yaml.py` covers what a user sees:
`test_print_root_secret_field_matching_earlier_plain_field` declares the non-secret config class
first, then asserts the secret default is still masked and that the non-secret one still shows
its value.

Run locally on macOS with Python 3.12:

    pytest python_modules/dagster/dagster_tests/core_tests/config_types_tests/test_field_hash.py \
           python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
    24 passed

With only the `field_utils.py` change reverted, the same command gives 3 failed, 21 passed:
`test_hash_diff`, `test_construct_dicts_differing_only_by_is_secret` and
`test_print_root_secret_field_matching_earlier_plain_field`.

Wider suites, to check nothing that depends on config type keys moved:

    pytest python_modules/dagster/dagster_tests/core_tests/config_types_tests/ \
           python_modules/dagster/dagster_tests/core_tests/snap_tests/ \
           python_modules/dagster/dagster_tests/general_tests/test_serdes.py
    418 passed (30 snapshots passed)

    pytest python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/ \
           python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/ \
           --ignore=python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_type_signatures.py
    265 passed, 1 skipped

    pytest python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_config_secret_fields.py
    1 passed

    ruff 0.16.2 check     # clean on the three changed files
    ruff 0.16.2 format --check   # clean on the three changed files
    ty 0.0.69 check python_modules/dagster/dagster/_config/field_utils.py   # clean

I did not run the full test suite locally. `test_type_signatures.py` is excluded above because
it needs a `typesignature` marker that my local install does not register, which is unrelated to
this change.

## Changelog

Fixed a bug where a config field marked with `is_secret` could show its default value unmasked
in the launchpad and on the resources page, if a config type with the same fields but without
the flag was built first in the same process.
