### PR TITLE
fix(dbt): handle missing materialized config for Fusion seeds

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -172,7 +172,9 @@ class DbtCloudJobRunResults:
 
             resource_type: str = dbt_resource_props["resource_type"]
             result_status: str = result["status"]
-            materialization: str = dbt_resource_props["config"]["materialized"]
+            materialization: str = dbt_resource_props.get("config", {}).get(
+                "materialized", resource_type
+            )
 
             is_ephemeral = materialization == "ephemeral"
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
@@ -67,3 +67,29 @@ def test_default_asset_events_from_run_results_missing_failures_key(
     # Without a `failures` count, we should not attach failed row count metadata.
     for check_eval in asset_check_evaluations:
         assert "dagster_dbt/failed_row_count" not in check_eval.metadata
+
+
+def test_default_asset_events_from_run_results_missing_materialized_key(
+    workspace: DbtCloudWorkspace, fetch_workspace_data_api_mocks: responses.RequestsMock
+):
+    manifest = copy.deepcopy(dict(workspace.get_or_fetch_workspace_data().manifest))
+    for node in manifest["nodes"].values():
+        if node["resource_type"] == "seed":
+            node["config"].pop("materialized")
+
+    run_results = DbtCloudJobRunResults.from_run_results_json(
+        run_results_json=get_sample_run_results_json()
+    )
+
+    events = list(
+        run_results.to_default_asset_events(
+            client=workspace.get_client(),
+            manifest=manifest,
+        )
+    )
+
+    asset_materializations = [event for event in events if isinstance(event, AssetMaterialization)]
+    asset_check_evaluations = [event for event in events if isinstance(event, AssetCheckEvaluation)]
+
+    assert len(asset_materializations) == 8
+    assert len(asset_check_evaluations) == 20


### PR DESCRIPTION
## Summary & Motivation

Fixes #34148. dbt Fusion can omit `config.materialized` for seed nodes, which caused event conversion to raise `KeyError` and abort the run. Fall back to the node resource type so seeds remain non-ephemeral and other events continue to be emitted.

## Test Plan

- Added a regression test covering seed nodes without `config.materialized`
- `test_run_events.py`: 3 passed
- Ruff check and format validation passed
- `git diff --check` passed

## Changelog

Fixed dbt Cloud event conversion for Fusion manifests whose seed nodes omit `config.materialized`.