### PR TITLE
[dagster-postgres] Close the connection checked out by event log has_table

### DIFF
--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -360,7 +360,8 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                     yield conn
 
     def has_table(self, table_name: str) -> bool:
-        return bool(self._engine.dialect.has_table(self._engine.connect(), table_name))
+        with self._connect() as conn:
+            return bool(self._engine.dialect.has_table(conn, table_name))
 
     def has_secondary_index(self, name: str) -> bool:
         if name not in self._secondary_index_cache:


### PR DESCRIPTION
## Summary & Motivation

Fixes #34153.

`PostgresEventLogStorage.has_table` checks a connection out of the SQLAlchemy pool via `self._engine.connect()` and never closes it, so it is returned only when the garbage collector finalizes it.

The webserver hits this method through the uncached `supports_asset_checks` property once per asset node when resolving `assetChecksOrError` (e.g. `LaunchAssetLoaderJobQuery`). Opening the launchpad on a large asset job (~800 nodes) floods the event log engine's pool (`pool_size=1 + max_overflow=20` under `optimize_for_webserver`) and every other query — including run launches — times out with `QueuePool limit of size 1 overflow 20 reached`, with the database near-idle. Same failure signature as #33461.

This change uses the same context-managed pattern as the rest of the module and as `MySQLEventLogStorage.has_table`.

Caching `supports_asset_checks` (the compounding hot path, see #34153) is left as a separate decision for maintainers since it touches core storage.

## How I Tested These Changes

- Existing dagster-postgres storage test suite covers `has_table` via `wipe`/instance bootstrap paths; no behaviour change, only connection lifetime. Relying on CI to run it.
- The bug itself was observed in a Helm-deployed webserver (Postgres-backed, ~780-asset dbt job): opening the launchpad produced repeated `QueuePool limit of size 1 overflow 20 reached` for ~14 minutes with the database near-idle. I have not run a patched webserver against that environment; the change is a mechanical switch to the context-managed pattern already used by every other call site in this module and by `MySQLEventLogStorage.has_table`.

## Changelog

> Fixed a connection leak in `dagster-postgres` where `PostgresEventLogStorage.has_table` did not return its connection to the pool, which could exhaust the webserver's connection pool on instances with many asset nodes.
