### PR TITLE
docs: document max_runtime tag precedence over run_monitoring.max_runtime_seconds

### DIFF
--- a/docs/docs/deployment/execution/run-monitoring.md
+++ b/docs/docs/deployment/execution/run-monitoring.md
@@ -57,6 +57,37 @@ The below code example shows how to set a run timeout of 10 seconds on a per-job
   title="src/my_project/assets.py"
 />
 
+### Precedence of the tag over the deployment-wide setting
+
+When a run carries a `dagster/max_runtime` tag, that value **replaces**
+`run_monitoring.max_runtime_seconds` for that run instead of being combined with it. The two values
+are not intersected, so the tag can raise the limit as well as lower it: with
+`max_runtime_seconds: 7200` in your deployment, a run tagged
+`{"dagster/max_runtime": 14400}` is allowed to run for four hours.
+
+The resolution order for a single run is:
+
+1. The run's `dagster/max_runtime` tag, if set.
+2. Otherwise, the deployment-wide `run_monitoring.max_runtime_seconds`, if set.
+3. Otherwise, no maximum runtime is enforced.
+
+:::warning
+
+If the tag value cannot be parsed as a number, the run has **no** maximum runtime — the deployment-wide
+`run_monitoring.max_runtime_seconds` is not used as a fallback. The daemon logs a
+`Invalid max runtime value: <value>` warning and leaves the run alone, so a typo such as
+`{"dagster/max_runtime": "10m"}` silently opts a job out of run timeouts.
+
+:::
+
+:::note
+
+`dagster/max_runtime_seconds` is accepted as an alias for `dagster/max_runtime` and behaves
+identically. Prefer `dagster/max_runtime`, which is the value of the `dagster.MAX_RUNTIME_SECONDS_TAG`
+constant.
+
+:::
+
 ## Freeing concurrency slots after run completion
 
 When using [op concurrency limits](/guides/operate/managing-concurrency) with the `dagster/concurrency_key` tag, concurrency slots are claimed by steps during execution. If a run is cancelled or fails while steps hold concurrency slots, those slots can become stale and permanently block the concurrency pool. Without cleanup, this results in a deadlock where no future runs can claim slots for that concurrency key.

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py
@@ -521,6 +521,54 @@ def test_long_running_termination_failure(
         )
 
 
+def test_max_runtime_tag_overrides_global_setting(
+    instance: DagsterInstance,
+    workspace_context: WorkspaceProcessContext,
+    logger: Logger,
+) -> None:
+    """A dagster/max_runtime tag replaces run_monitoring.max_runtime_seconds for that run.
+
+    The `instance` fixture sets max_runtime_seconds=750. A run tagged with a *larger* value must be
+    allowed to keep running past 750 seconds, proving the two limits are not intersected. See the
+    "Precedence of the tag over the deployment-wide setting" section of
+    docs/docs/deployment/execution/run-monitoring.md.
+    """
+    with environ({"DAGSTER_TEST_RUN_HEALTH_CHECK_RESULT": "healthy"}):
+        initial = create_datetime(2021, 1, 1)
+        with freeze_time(initial):
+            longer_than_global_run = create_run_for_test(
+                instance,
+                job_name="foo",
+                status=DagsterRunStatus.STARTING,
+                tags={dg.MAX_RUNTIME_SECONDS_TAG: "2000"},
+            )
+        started_time = initial + datetime.timedelta(seconds=1)
+        with freeze_time(started_time):
+            report_started_event(instance, longer_than_global_run, started_time.timestamp())
+
+        record = instance.get_run_record_by_id(longer_than_global_run.run_id)
+        assert record is not None
+
+        workspace = workspace_context.create_request_context()
+        run_launcher = cast("MockRunLauncher", instance.run_launcher)
+
+        # Past the deployment-wide 750s limit but still within the tag's 2000s limit.
+        with freeze_time(started_time + datetime.timedelta(seconds=1000)):
+            monitor_started_run(instance, workspace, record, logger)
+            run = instance.get_run_by_id(longer_than_global_run.run_id)
+            assert run
+            assert run.status == DagsterRunStatus.STARTED
+            assert not run_launcher.termination_calls
+
+        # Past the tag's limit: now it is terminated.
+        with freeze_time(started_time + datetime.timedelta(seconds=2001)):
+            monitor_started_run(instance, workspace, record, logger)
+            assert len(run_launcher.termination_calls) == 1
+            run = instance.get_run_by_id(longer_than_global_run.run_id)
+            assert run
+            assert run.status == DagsterRunStatus.FAILURE
+
+
 def test_invalid_max_runtime_tag_value(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,


### PR DESCRIPTION
## Summary & Motivation

Fixes #31904.

The [run monitoring docs](https://docs.dagster.io/deployment/execution/run-monitoring#general-run-timeouts) mention both the deployment-wide `run_monitoring.max_runtime_seconds` setting and the per-run `dagster/max_runtime` tag, but never say how the two interact. The issue reporter assumed "job tags would override the global setting" — that is correct, but the docs did not say so, and the actual behaviour has two non-obvious consequences.

Verified in `check_run_timeout` (`python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py`):

```python
max_time_str = run_record.dagster_run.tags.get(
    MAX_RUNTIME_SECONDS_TAG, run_record.dagster_run.tags.get("dagster/max_runtime_seconds")
)
if max_time_str:
    try:
        max_time = float(max_time_str)
    except ValueError:
        logger.warning(f"Invalid max runtime value: {max_time_str}")
        max_time = None
else:
    max_time = default_timeout_seconds
```

1. The tag **replaces** the deployment-wide default; the values are not intersected, so the tag can *raise* a run's limit above the global setting, not only lower it.
2. If the tag value cannot be parsed as a float, `max_time` becomes `None` and the run gets **no** timeout at all — it does not fall back to `max_runtime_seconds`. A typo like `{"dagster/max_runtime": "10m"}` silently opts a job out of run timeouts.
3. `dagster/max_runtime_seconds` is accepted as an undocumented alias for `dagster/max_runtime`.

## Approach

- `docs/docs/deployment/execution/run-monitoring.md`: adds a "Precedence of the tag over the deployment-wide setting" subsection under "General run timeouts" with the resolution order, the replace-not-narrow semantics, a warning about unparseable tag values, and a note on the alias. Docs only — no behaviour change.
- Adds `test_max_runtime_tag_overrides_global_setting` to `test_monitoring_daemon.py`. The existing tests did not cover the "tag larger than the global setting" case: `test_long_running_termination` only evaluates at t+501s, below the fixture's global 750s, so nothing there would notice if the tag were intersected with the global limit. The new test tags a run with 2000s against the fixture's `max_runtime_seconds: 750`, asserts the run is still `STARTED` at t+1000s, and asserts it is terminated and `FAILURE` at t+2001s.

## Test Plan

Ran with a local editable install of `dagster` at `560289892c` (branch is based on that upstream `master` tip):

```
$ .venv/bin/python -m pytest python_modules/dagster/dagster_tests/daemon_tests/test_monitoring_daemon.py -q
9 passed in 16.67s
```

Sabotage run proving the new test bites — temporarily intersecting the tag with the global setting inside `check_run_timeout`:

```python
max_time = float(max_time_str)
if default_timeout_seconds:
    max_time = min(max_time, default_timeout_seconds)   # SABOTAGE
```

```
$ .venv/bin/python -m pytest ... -k "max_runtime_tag_overrides" -q
FAILED test_monitoring_daemon.py::test_max_runtime_tag_overrides_global_setting
E   AssertionError: assert <DagsterRunStatus.FAILURE> == <DagsterRunStatus.STARTED>
    dagster.daemon.MonitoringDaemon - INFO - Run ... has exceeded maximum runtime of 750.0 seconds
1 failed, 8 deselected
```

The sabotage was reverted before committing (`git diff --stat` is the two files below only).

Gates:

- `ruff check` / `ruff format --check` on the changed test file: clean.
- `prettier@3.3.3 --check docs/deployment/execution/run-monitoring.md` (from `docs/`, using the repo's `.prettierrc.js`): "All matched files use Prettier code style!".
- `uv run scripts/check-frontmatter.py` from `docs/`: no errors.

```
 docs/docs/deployment/execution/run-monitoring.md   | 31 ++++++++++++++
 .../daemon_tests/test_monitoring_daemon.py         | 48 ++++++++++++++++++++++
 2 files changed, 79 insertions(+)
```

## Deliberately left out

- No behaviour change. In particular the "invalid tag value means no timeout at all" pitfall is documented as-is rather than changed to fall back to the global setting — that would be a behaviour decision for maintainers, and the existing `test_invalid_max_runtime_tag_value` pins today's behaviour on purpose.
- Did not touch the Dagster+ [full deployment settings reference](https://docs.dagster.io/deployment/dagster-plus/deploying-code/full-deployments/full-deployment-settings-reference), which documents `max_runtime_seconds` separately; happy to mirror the precedence note there if you'd like.
- No docs site build (`yarn build`) — it needs `yarn build-api-docs` and a full `make dev_install`; the change adds no new `PyObject` or cross-page links, only relative anchors that already exist on the page.

## Changelog

Documented how the `dagster/max_runtime` run tag interacts with the deployment-wide `run_monitoring.max_runtime_seconds` setting.
