### PR TITLE
Fix KeyError when a dbt Fusion seed omits config.materialized

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -172,7 +172,12 @@ class DbtCloudJobRunResults:
 
             resource_type: str = dbt_resource_props["resource_type"]
             result_status: str = result["status"]
-            materialization: str = dbt_resource_props["config"]["materialized"]
+            # Fusion leaves "materialized" out of a seed's config entirely (it only
+            # writes the key for models and tests), while Core always sets it to the
+            # resource type for a seed. Falling back to resource_type here matches
+            # what Core would have written, and a seed can never end up read as
+            # "ephemeral" this way since seeds don't support that materialization.
+            materialization: str = dbt_resource_props["config"].get("materialized", resource_type)
 
             is_ephemeral = materialization == "ephemeral"
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
@@ -7,6 +7,8 @@ from dagster_dbt.cloud_v2.run_handler import DbtCloudJobRunResults
 
 from dagster_dbt_tests.cloud_v2.conftest import TEST_RUN_URL, get_sample_run_results_json
 
+SEED_UNIQUE_ID = "seed.jaffle_shop.raw_customers"
+
 
 def test_default_asset_events_from_run_results(
     workspace: DbtCloudWorkspace, fetch_workspace_data_api_mocks: responses.RequestsMock
@@ -67,3 +69,32 @@ def test_default_asset_events_from_run_results_missing_failures_key(
     # Without a `failures` count, we should not attach failed row count metadata.
     for check_eval in asset_check_evaluations:
         assert "dagster_dbt/failed_row_count" not in check_eval.metadata
+
+
+def test_default_asset_events_from_run_results_seed_missing_materialized_config(
+    workspace: DbtCloudWorkspace, fetch_workspace_data_api_mocks: responses.RequestsMock
+):
+    """Fusion doesn't write `config.materialized` for seeds at all (it only
+    sets that key for models and tests), unlike dbt Core, which always writes
+    it as the resource type. A manifest built by Fusion should translate the
+    same way a Core one does instead of raising.
+    """
+    run_results = DbtCloudJobRunResults.from_run_results_json(
+        run_results_json=get_sample_run_results_json()
+    )
+
+    manifest = copy.deepcopy(dict(workspace.get_or_fetch_workspace_data().manifest))
+    del manifest["nodes"][SEED_UNIQUE_ID]["config"]["materialized"]
+
+    events = list(
+        run_results.to_default_asset_events(client=workspace.get_client(), manifest=manifest)
+    )
+
+    asset_materializations = [event for event in events if isinstance(event, AssetMaterialization)]
+    asset_check_evaluations = [event for event in events if isinstance(event, AssetCheckEvaluation)]
+
+    # Same counts as the normal run: the seed still materializes, it just no
+    # longer needs its config to say so explicitly.
+    assert len(asset_materializations) == 8
+    assert len(asset_check_evaluations) == 20
+    assert any(mat.asset_key.path == ["raw_customers"] for mat in asset_materializations)


### PR DESCRIPTION
## Summary & Motivation

Fixes #34148.

`DbtCloudJobRunResults.to_default_asset_events` reads `dbt_resource_props["config"]["materialized"]` directly to decide whether a node is ephemeral. dbt Core always writes that key, using the resource type as the value for a seed, but dbt Fusion only writes it for models and tests and leaves it out of a seed's config entirely. When a run result includes a seed built by Fusion, that lookup raises a `KeyError` and the whole run's asset event generation aborts, which is worse than just mishandling that one node since it takes down materializations and check results for everything else in the run too.

The fix falls back to the resource type when `materialized` is missing, which reproduces what Core would have written for a seed. That fallback can't accidentally read a seed as `ephemeral`, since seeds don't support that materialization, so the existing skip-ephemeral-models behavior is untouched.

## Test Plan

Added `test_default_asset_events_from_run_results_seed_missing_materialized_config` in `dagster_dbt_tests/cloud_v2/test_run_events.py`, which deletes `config.materialized` from a seed node in the sample manifest fixture and asserts the seed still produces an `AssetMaterialization` event instead of raising.

Confirmed the new test fails with the original `KeyError: 'materialized'` when the fix is reverted, and passes with it in place. Ran the full `dagster_dbt_tests/cloud_v2/` suite locally; the only failures/errors present are pre-existing ones unrelated to this change (a `responses` mock leaking across a couple of `test_resources.py` tests when the directory runs as a whole), which reproduce identically on `master` without this change.

## Changelog

`dagster-dbt`: Fixed a `KeyError` in `DbtCloudJobRunResults.to_default_asset_events` when processing a dbt Cloud run built with dbt Fusion that includes a seed, since Fusion omits `config.materialized` for seed nodes.