### PR TITLE
fix(dbt): reject duplicate asset check keys

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -934,6 +934,7 @@ def build_dbt_specs(
 
     specs: list[AssetSpec] = []
     check_specs: dict[str, AssetCheckSpec] = {}
+    test_ids_by_check_key: defaultdict[AssetCheckKey, set[str]] = defaultdict(set)
     key_by_unique_id: dict[str, AssetKey] = {}
 
     child_map = _build_child_map(manifest)
@@ -973,6 +974,7 @@ def build_dbt_specs(
 
             if check_spec:
                 check_specs[check_spec.get_python_identifier()] = check_spec
+                test_ids_by_check_key[check_spec.key].add(child_unique_id)
 
         # update the keys_by_unqiue_id dictionary to include keys created for upstream
         # assets. note that this step may need to change once the translator is updated
@@ -995,8 +997,10 @@ def build_dbt_specs(
                     )
                     if check_spec:
                         check_specs[check_spec.get_python_identifier()] = check_spec
+                        test_ids_by_check_key[check_spec.key].add(child_unique_id)
 
     _validate_asset_keys(translator, manifest, key_by_unique_id)
+    _validate_check_keys(manifest, test_ids_by_check_key)
     return specs, list(check_specs.values())
 
 
@@ -1036,6 +1040,44 @@ def _validate_asset_keys(
         raise DagsterInvalidDefinitionError(
             "\n\n".join([DUPLICATE_ASSET_KEY_ERROR_MESSAGE, *error_messages])
         )
+
+
+def _validate_check_keys(
+    manifest: Mapping[str, Any],
+    test_ids_by_check_key: Mapping[AssetCheckKey, AbstractSet[str]],
+) -> None:
+    collisions = {
+        key: unique_ids for key, unique_ids in test_ids_by_check_key.items() if len(unique_ids) > 1
+    }
+    if not collisions:
+        return
+
+    error_messages = []
+    for key, unique_ids in collisions.items():
+        formatted_ids = [
+            f"  - `{unique_id}` ({get_node(manifest, unique_id)['original_file_path']})"
+            for unique_id in sorted(unique_ids)
+        ]
+        error_messages.append(
+            "\n".join(
+                [
+                    f"The following dbt tests generate the same asset check key `{key}`:",
+                    *formatted_ids,
+                ]
+            )
+        )
+
+    raise DagsterInvalidDefinitionError(
+        "\n\n".join(
+            [
+                (
+                    "The following dbt tests generate identical Dagster asset check keys."
+                    " Please ensure that each dbt test has a unique name."
+                ),
+                *error_messages,
+            ]
+        )
+    )
 
 
 def has_self_dependency(dbt_resource_props: Mapping[str, Any]) -> bool:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -23,7 +23,7 @@ from dagster import (
     op,
 )
 from dagster_dbt.asset_decorator import dbt_assets
-from dagster_dbt.asset_utils import DAGSTER_DBT_UNIQUE_ID_METADATA_KEY, _validate_check_keys
+from dagster_dbt.asset_utils import DAGSTER_DBT_UNIQUE_ID_METADATA_KEY
 from dagster_dbt.core.resource import DbtCliResource
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
 from dagster_shared.record import replace
@@ -54,26 +54,71 @@ def _get_select_args(dbt_cli_invocation) -> set[str]:
     return set(dbt_select_args.split())
 
 
-def test_duplicate_asset_check_keys_are_rejected() -> None:
-    check_key = AssetCheckKey(asset_key=AssetKey("orders"), name="validates_amount")
+def test_duplicate_asset_check_keys_are_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    model_ids = {"model.project.first", "model.project.second"}
+    test_ids = {"test.project.first", "test.project.second"}
+    duplicate_test_ids = sorted(test_ids)
     manifest = {
+        "metadata": {"dbt_version": "1.9.0", "project_name": "project"},
         "nodes": {
-            "test.project.first": {"original_file_path": "tests/first.yml"},
-            "test.project.second": {"original_file_path": "tests/second.yml"},
-        }
+            **{
+                model_id: {
+                    "resource_type": "model",
+                    "name": model_id.rsplit(".", 1)[-1],
+                    "unique_id": model_id,
+                    "config": {},
+                    "original_file_path": f"models/{model_id.rsplit('.', 1)[-1]}.sql",
+                }
+                for model_id in model_ids
+            },
+            **{
+                test_id: {
+                    "resource_type": "test",
+                    "name": test_id.rsplit(".", 1)[-1],
+                    "unique_id": test_id,
+                    "attached_node": f"model.project.{test_id.rsplit('.', 1)[-1]}",
+                    "depends_on": {"nodes": [f"model.project.{test_id.rsplit('.', 1)[-1]}"]},
+                    "original_file_path": f"tests/{test_id.rsplit('.', 1)[-1]}.yml",
+                }
+                for test_id in test_ids
+            },
+        },
+        "child_map": {
+            "model.project.first": ["test.project.first"],
+            "model.project.second": ["test.project.second"],
+        },
+        "parent_map": {
+            "test.project.first": ["model.project.first"],
+            "test.project.second": ["model.project.second"],
+        },
     }
+    monkeypatch.setattr(
+        "dagster_dbt.asset_utils.select_unique_ids",
+        lambda **_: model_ids | test_ids,
+    )
+    class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+        def get_asset_check_spec(self, asset_spec, manifest, unique_id, project):
+            check_spec = super().get_asset_check_spec(asset_spec, manifest, unique_id, project)
+            if check_spec and unique_id in duplicate_test_ids:
+                return check_spec._replace(
+                    asset_key=AssetKey("duplicate"),
+                    name="duplicate_check",
+                )
+            return check_spec
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match="identical Dagster asset check keys",
     ) as exc_info:
-        _validate_check_keys(
-            manifest,
-            {check_key: {"test.project.first", "test.project.second"}},
+        @dbt_assets(
+            manifest=manifest,
+            dagster_dbt_translator=CustomDagsterDbtTranslator(),
         )
+        def my_dbt_assets(): ...
 
-    assert "test.project.first" in str(exc_info.value)
-    assert "test.project.second" in str(exc_info.value)
+    for unique_id in duplicate_test_ids:
+        assert unique_id in str(exc_info.value)
+        assert manifest["nodes"][unique_id]["original_file_path"] in str(exc_info.value)
 
 
 def test_without_asset_checks(test_asset_checks_manifest: dict[str, Any]) -> None:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -12,6 +12,7 @@ from dagster import (
     AssetKey,
     AssetsDefinition,
     AssetSelection,
+    DagsterInvalidDefinitionError,
     ExecuteInProcessResult,
     OpExecutionContext,
     Output,
@@ -22,7 +23,7 @@ from dagster import (
     op,
 )
 from dagster_dbt.asset_decorator import dbt_assets
-from dagster_dbt.asset_utils import DAGSTER_DBT_UNIQUE_ID_METADATA_KEY
+from dagster_dbt.asset_utils import DAGSTER_DBT_UNIQUE_ID_METADATA_KEY, _validate_check_keys
 from dagster_dbt.core.resource import DbtCliResource
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
 from dagster_shared.record import replace
@@ -51,6 +52,28 @@ def _get_select_args(dbt_cli_invocation) -> set[str]:
     *_, dbt_select_flag, dbt_select_args = list(dbt_cli_invocation.process.args)
     assert dbt_select_flag == "--select"
     return set(dbt_select_args.split())
+
+
+def test_duplicate_asset_check_keys_are_rejected() -> None:
+    check_key = AssetCheckKey(asset_key=AssetKey("orders"), name="validates_amount")
+    manifest = {
+        "nodes": {
+            "test.project.first": {"original_file_path": "tests/first.yml"},
+            "test.project.second": {"original_file_path": "tests/second.yml"},
+        }
+    }
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="identical Dagster asset check keys",
+    ) as exc_info:
+        _validate_check_keys(
+            manifest,
+            {check_key: {"test.project.first", "test.project.second"}},
+        )
+
+    assert "test.project.first" in str(exc_info.value)
+    assert "test.project.second" in str(exc_info.value)
 
 
 def test_without_asset_checks(test_asset_checks_manifest: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

Fixes #34155.

`build_dbt_specs` previously keyed generated asset checks by their Python identifier. When two distinct dbt tests produced the same `AssetCheckKey`, the later test silently replaced the earlier one. This patch records the contributing dbt test unique IDs and raises a definition error only when distinct tests collide; repeated discovery of the same test through multiple parents remains valid.

## Changes

- Track test unique IDs for each generated `AssetCheckKey` in both regular and source-test paths.
- Reject collisions between distinct dbt tests with an error listing each test and its original file path.
- Add a focused regression test for the collision diagnostic.

## Compatibility

Projects with distinct tests that generate the same asset check key now fail during definition loading with an actionable error instead of silently losing a check and failing later at runtime. The same test discovered through multiple parents is not treated as a collision.

## Validation

Passed:

- `python -m compileall -q python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py`
- `uvx ruff check --isolated --select ISC004 ...` on the changed files
- `python -m pytest python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py -k duplicate_asset_check_keys_are_rejected -vv -o 'markers=core:core tests'` (1 passed)
- `git diff --check`

Not run:

- The full `test_asset_checks.py` suite was not run because the sparse checkout does not contain the complete Dagster monorepo test environment. The new regression uses a minimal in-memory manifest while still exercising the production `dbt_assets`/`build_dbt_specs` path.
- Full repository checks were not run for the same environment limitation.

## AI assistance

This contribution was prepared with AI assistance. The implementation was reviewed against both check-spec collection paths and the existing duplicate-source-asset-key validation behavior.
