### PR TITLE
Add unprefixed partition properties to OutputContext and InputContext

### DIFF
--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Mapping
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 from dagster_shared.serdes import deserialize_value, serialize_value, whitelist_for_serdes
 
@@ -40,6 +40,7 @@ class EventLogEntry(
             ("step_key", PublicAttr[str | None]),
             ("job_name", PublicAttr[str | None]),
             ("dagster_event", PublicAttr[DagsterEvent | None]),
+            ("dagster_user_metadata", PublicAttr[Mapping[str, Any] | None]),
         ],
     )
 ):
@@ -64,6 +65,8 @@ class EventLogEntry(
             generated outside of a job context.
         dagster_event (Optional[DagsterEvent]): For framework and user events, the associated
             structured event.
+        dagster_user_metadata (Optional[Dict[str, Any]]): Arbitrary user-supplied key-value pairs
+            passed via the `extra` argument to `context.log.info()` and similar methods.
     """
 
     def __new__(
@@ -76,6 +79,7 @@ class EventLogEntry(
         step_key=None,
         job_name=None,
         dagster_event=None,
+        dagster_user_metadata=None,
     ):
         return super().__new__(
             cls,
@@ -87,6 +91,7 @@ class EventLogEntry(
             check.opt_str_param(step_key, "step_key"),
             check.opt_str_param(job_name, "job_name"),
             check.opt_inst_param(dagster_event, "dagster_event", DagsterEvent),
+            check.opt_mapping_param(dagster_user_metadata, "dagster_user_metadata"),
         )
 
     @public
@@ -192,6 +197,7 @@ def construct_event_record(logger_message: StructuredLoggerMessage) -> EventLogE
         job_name=logger_message.meta.get("job_name"),
         dagster_event=logger_message.meta.get("dagster_event"),
         error_info=None,
+        dagster_user_metadata=logger_message.meta.get("dagster_user_metadata"),
     )
 
 

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
+import warnings
 
 import dagster._check as check
 from dagster._annotations import deprecated, deprecated_param, public
@@ -71,6 +72,7 @@ class InputContext:
         asset_partitions_subset: PartitionsSubset | None = None,
         asset_partitions_def: Optional["PartitionsDefinition"] = None,
         instance: DagsterInstance | None = None,
+        warn_on_step_context_use: bool = False,
         # deprecated
         metadata: ArbitraryMetadataMapping | None = None,
     ):
@@ -98,6 +100,7 @@ class InputContext:
 
         self._asset_partitions_subset = asset_partitions_subset
         self._asset_partitions_def = asset_partitions_def
+        self._warn_on_step_context_use = warn_on_step_context_use
 
         if isinstance(resources, Resources):
             self._resources_cm = None
@@ -338,6 +341,12 @@ class InputContext:
 
     @public
     @property
+    def has_partition_keys(self) -> bool:
+        """Whether the current run covers multiple partitions (i.e. has partition keys)."""
+        return self.has_asset_partitions
+
+    @public
+    @property
     def asset_partition_key(self) -> str:
         """The partition key for input asset.
 
@@ -429,6 +438,57 @@ class InputContext:
             )
 
         return time_window_for_partition_key_range(partitions_def, self.asset_partition_key_range)
+
+    @public
+    @property
+    def partition_key_range(self) -> PartitionKeyRange:
+        """The partition key range for the input asset.
+
+        Raises an error if the input asset has no partitioning.
+        """
+        if self._warn_on_step_context_use:
+            warnings.warn(
+                "You are using InputContext.upstream_output.partition_key_range. "
+                "This use on upstream_output is deprecated and will fail in the future. "
+                "Try to obtain what you need directly from InputContext. "
+                "For more details: https://github.com/dagster-io/dagster/issues/7900"
+            )
+        return self.asset_partition_key_range
+
+    @public
+    @property
+    def partition_keys(self) -> Sequence[str]:
+        """The partition keys for the input asset.
+
+        Raises an error if the input asset has no partitioning.
+        """
+        if self._warn_on_step_context_use:
+            warnings.warn(
+                "You are using InputContext.upstream_output.partition_keys. "
+                "This use on upstream_output is deprecated and will fail in the future. "
+                "Try to obtain what you need directly from InputContext. "
+                "For more details: https://github.com/dagster-io/dagster/issues/7900"
+            )
+        return self.asset_partition_keys
+
+    @public
+    @property
+    def partition_time_window(self) -> TimeWindow:
+        """The time window for the partitions of the input asset.
+
+        Raises an error if either of the following are true:
+        - The input asset has no partitioning.
+        - The input asset is not partitioned with a TimeWindowPartitionsDefinition or a
+        MultiPartitionsDefinition with one time-partitioned dimension.
+        """
+        if self._warn_on_step_context_use:
+            warnings.warn(
+                "You are using InputContext.upstream_output.partition_time_window. "
+                "This use on upstream_output is deprecated and will fail in the future. "
+                "Try to obtain what you need directly from InputContext. "
+                "For more details: https://github.com/dagster-io/dagster/issues/7900"
+            )
+        return self.asset_partitions_time_window
 
     @public
     def get_identifier(self) -> Sequence[str]:
@@ -573,6 +633,7 @@ def build_input_context(
     asset_partition_key_range: PartitionKeyRange | None = None,
     asset_partitions_def: Optional["PartitionsDefinition"] = None,
     instance: DagsterInstance | None = None,
+    warn_on_step_context_use: bool = False,
     # deprecated
     metadata: ArbitraryMetadataMapping | None = None,
 ) -> "InputContext":
@@ -671,6 +732,7 @@ def build_input_context(
         asset_partitions_subset=asset_partitions_subset,
         asset_partitions_def=asset_partitions_def,
         instance=instance,
+        warn_on_step_context_use=warn_on_step_context_use,
     )
 
 

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -583,6 +583,57 @@ class OutputContext:
 
         return time_window_for_partition_key_range(partitions_def, self.asset_partition_key_range)
 
+    @public
+    @property
+    def partition_key_range(self) -> PartitionKeyRange:
+        """The partition key range for the output asset.
+
+        Raises an error if the output asset has no partitioning.
+        """
+        if self._warn_on_step_context_use:
+            warnings.warn(
+                "You are using InputContext.upstream_output.partition_key_range. "
+                "This use on upstream_output is deprecated and will fail in the future. "
+                "Try to obtain what you need directly from InputContext. "
+                "For more details: https://github.com/dagster-io/dagster/issues/7900"
+            )
+        return self.asset_partition_key_range
+
+    @public
+    @property
+    def partition_keys(self) -> Sequence[str]:
+        """The partition keys for the output asset.
+
+        Raises an error if the output asset has no partitioning.
+        """
+        if self._warn_on_step_context_use:
+            warnings.warn(
+                "You are using InputContext.upstream_output.partition_keys. "
+                "This use on upstream_output is deprecated and will fail in the future. "
+                "Try to obtain what you need directly from InputContext. "
+                "For more details: https://github.com/dagster-io/dagster/issues/7900"
+            )
+        return self.asset_partition_keys
+
+    @public
+    @property
+    def partition_time_window(self) -> TimeWindow:
+        """The time window for the partitions of the output asset.
+
+        Raises an error if either of the following are true:
+        - The output asset has no partitioning.
+        - The output asset is not partitioned with a TimeWindowPartitionsDefinition or a
+        MultiPartitionsDefinition with one time-partitioned dimension.
+        """
+        if self._warn_on_step_context_use:
+            warnings.warn(
+                "You are using InputContext.upstream_output.partition_time_window. "
+                "This use on upstream_output is deprecated and will fail in the future. "
+                "Try to obtain what you need directly from InputContext. "
+                "For more details: https://github.com/dagster-io/dagster/issues/7900"
+            )
+        return self.asset_partitions_time_window
+
     def get_run_scoped_output_identifier(self) -> Sequence[str]:
         """Utility method to get a collection of identifiers that as a whole represent a unique
         step output.

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -466,6 +466,20 @@ class OutputContext:
 
     @public
     @property
+    def has_partition_keys(self) -> bool:
+        """Whether the current run covers multiple partitions (i.e. has partition keys)."""
+        if self._warn_on_step_context_use:
+            warnings.warn(
+                "You are using InputContext.upstream_output.has_partition_keys. "
+                "This use on upstream_output is deprecated and will fail in the future. "
+                "Try to obtain what you need directly from InputContext. "
+                "For more details: https://github.com/dagster-io/dagster/issues/7900"
+            )
+
+        return self._asset_partitions_subset is not None
+
+    @public
+    @property
     def asset_partition_key(self) -> str:
         """The partition key for output asset.
 

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -640,6 +640,7 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
             asset_partitions_subset=asset_partitions_subset,
             asset_partitions_def=asset_partitions_def,
             instance=self.instance,
+            warn_on_step_context_use=upstream_output is not None,
         )
 
     def for_hook(self, hook_def: HookDefinition) -> "HookContext":

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -105,6 +105,7 @@ class DagsterLogRecordMetadata(TypedDict):
     orig_message: str
     log_message_id: str
     log_timestamp: str
+    dagster_user_metadata: Optional[Mapping[str, Any]]
 
 
 def construct_log_record_message(metadata: DagsterLogRecordMetadata) -> str:
@@ -154,6 +155,7 @@ def construct_log_record_metadata(
     orig_message: str,
     event: Optional["DagsterEvent"],
     event_batch_metadata: Optional["DagsterEventBatchMetadata"],
+    dagster_user_metadata: Optional[Mapping[str, Any]] = None,
 ) -> DagsterLogRecordMetadata:
     step_key = handler_metadata["step_key"] or (event.step_key if event else None)
     timestamp = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat()
@@ -170,6 +172,7 @@ def construct_log_record_metadata(
         dagster_event=event,
         dagster_event_batch_metadata=event_batch_metadata,
         step_key=step_key,
+        dagster_user_metadata=dagster_user_metadata,
     )
 
 
@@ -230,8 +233,11 @@ class DagsterLogHandler(logging.Handler):
             if has_log_record_event_batch_metadata(record)
             else None
         )
+        # Extract extra dict that was passed via context.log.info(msg, extra={...})
+        # Python's logging smashes extra keys into record.__dict__; _extract_extra reverses that
+        extra = self._extract_extra(record)
         metadata = construct_log_record_metadata(
-            self._metadata, record.getMessage(), event, event_batch_metadata
+            self._metadata, record.getMessage(), event, event_batch_metadata, extra
         )
         message = construct_log_record_message(metadata)
 

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import logging
 import threading
 from collections.abc import Mapping, Sequence
@@ -235,9 +236,30 @@ class DagsterLogHandler(logging.Handler):
         )
         # Extract extra dict that was passed via context.log.info(msg, extra={...})
         # Python's logging smashes extra keys into record.__dict__; _extract_extra reverses that
-        extra = self._extract_extra(record)
+        raw_extra = self._extract_extra(record)
+        # Exclude dagster-internal attrs (DagsterEvent objects) that are smashed into
+        # __dict__ and would cause SerializationError when stored in dagster_user_metadata.
+        dagster_internal_attrs = {
+            LOG_RECORD_EVENT_ATTR,
+            LOG_RECORD_EVENT_BATCH_METADATA_ATTR,
+            LOG_RECORD_METADATA_ATTR,
+        }
+        user_extra = {
+            k: v for k, v in raw_extra.items() if k not in dagster_internal_attrs
+        }
+        # Guard against unserializable values so a bad extra object doesn't drop the
+        # entire log message: if JSON serialization fails we silently discard the extra
+        # rather than replacing the user event with an engine error event.
+        dagster_user_metadata: Optional[Mapping[str, Any]] = None
+        if user_extra:
+            try:
+                json.dumps(user_extra)
+                dagster_user_metadata = user_extra
+            except TypeError:
+                pass
         metadata = construct_log_record_metadata(
-            self._metadata, record.getMessage(), event, event_batch_metadata, extra
+            self._metadata, record.getMessage(), event, event_batch_metadata,
+            dagster_user_metadata if dagster_user_metadata else None,
         )
         message = construct_log_record_message(metadata)
 

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import logging
 import threading
 from collections.abc import Mapping, Sequence
@@ -213,29 +214,16 @@ class DagsterLogHandler(logging.Handler):
             handlers=self._handlers,
         )
 
-    # Attributes that dagster's logging machinery injects into LogRecord.__dict__ via
-    # set_log_record_metadata / set_log_record_event / set_log_record_event_batch_metadata.
-    # These are internal and must not be confused with user-supplied extra dict entries.
-    _DAGSTER_INTERNAL_ATTRS = frozenset([
-        "dagster_event",
-        "dagster_event_batch_metadata",
-        "dagster_meta",
-        "dagster_log_message_id",
-        "dagster_log_step_key",
-        "dagster_user_metadata",
-    ])
-
     def _extract_extra(self, record: logging.LogRecord) -> Mapping[str, Any]:
         """In the logging.Logger log() implementation, the elements of the `extra` dictionary
         argument are smashed into the __dict__ of the underlying logging.LogRecord.
         This function figures out what the original `extra` values of the log call were by
-        comparing the set of attributes in the received record to those of a default record,
-        while also excluding dagster's own internal attributes.
+        comparing the set of attributes in the received record to those of a default record.
         """
-        ref_attrs = set(logging.makeLogRecord({}).__dict__.keys()) | {
+        ref_attrs = list(logging.makeLogRecord({}).__dict__.keys()) + [
             "message",
             "asctime",
-        } | self._DAGSTER_INTERNAL_ATTRS
+        ]
         return {k: v for k, v in record.__dict__.items() if k not in ref_attrs}
 
     def _convert_record(self, record: logging.LogRecord) -> logging.LogRecord:
@@ -248,20 +236,30 @@ class DagsterLogHandler(logging.Handler):
         )
         # Extract extra dict that was passed via context.log.info(msg, extra={...})
         # Python's logging smashes extra keys into record.__dict__; _extract_extra reverses that
-        extra = self._extract_extra(record)
-        # Attempt to capture user-supplied extra dict for dagster_user_metadata.
+        raw_extra = self._extract_extra(record)
+        # Exclude dagster-internal attrs (DagsterEvent objects) that are smashed into
+        # __dict__ and would cause SerializationError when stored in dagster_user_metadata.
+        dagster_internal_attrs = {
+            LOG_RECORD_EVENT_ATTR,
+            LOG_RECORD_EVENT_BATCH_METADATA_ATTR,
+            LOG_RECORD_METADATA_ATTR,
+        }
+        user_extra = {
+            k: v for k, v in raw_extra.items() if k not in dagster_internal_attrs
+        }
         # Guard against unserializable values so a bad extra object doesn't drop the
         # entire log message: if JSON serialization fails we silently discard the extra
         # rather than replacing the user event with an engine error event.
         dagster_user_metadata: Optional[Mapping[str, Any]] = None
-        if extra:
+        if user_extra:
             try:
-                json.dumps(extra)
-                dagster_user_metadata = extra
+                json.dumps(user_extra)
+                dagster_user_metadata = user_extra
             except TypeError:
                 pass
         metadata = construct_log_record_metadata(
-            self._metadata, record.getMessage(), event, event_batch_metadata, dagster_user_metadata
+            self._metadata, record.getMessage(), event, event_batch_metadata,
+            dagster_user_metadata if dagster_user_metadata else None,
         )
         message = construct_log_record_message(metadata)
 

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -105,6 +105,7 @@ class DagsterLogRecordMetadata(TypedDict):
     orig_message: str
     log_message_id: str
     log_timestamp: str
+    dagster_user_metadata: Optional[Mapping[str, Any]]
 
 
 def construct_log_record_message(metadata: DagsterLogRecordMetadata) -> str:
@@ -154,6 +155,7 @@ def construct_log_record_metadata(
     orig_message: str,
     event: Optional["DagsterEvent"],
     event_batch_metadata: Optional["DagsterEventBatchMetadata"],
+    dagster_user_metadata: Optional[Mapping[str, Any]] = None,
 ) -> DagsterLogRecordMetadata:
     step_key = handler_metadata["step_key"] or (event.step_key if event else None)
     timestamp = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat()
@@ -170,6 +172,7 @@ def construct_log_record_metadata(
         dagster_event=event,
         dagster_event_batch_metadata=event_batch_metadata,
         step_key=step_key,
+        dagster_user_metadata=dagster_user_metadata,
     )
 
 
@@ -210,16 +213,29 @@ class DagsterLogHandler(logging.Handler):
             handlers=self._handlers,
         )
 
+    # Attributes that dagster's logging machinery injects into LogRecord.__dict__ via
+    # set_log_record_metadata / set_log_record_event / set_log_record_event_batch_metadata.
+    # These are internal and must not be confused with user-supplied extra dict entries.
+    _DAGSTER_INTERNAL_ATTRS = frozenset([
+        "dagster_event",
+        "dagster_event_batch_metadata",
+        "dagster_meta",
+        "dagster_log_message_id",
+        "dagster_log_step_key",
+        "dagster_user_metadata",
+    ])
+
     def _extract_extra(self, record: logging.LogRecord) -> Mapping[str, Any]:
         """In the logging.Logger log() implementation, the elements of the `extra` dictionary
         argument are smashed into the __dict__ of the underlying logging.LogRecord.
         This function figures out what the original `extra` values of the log call were by
-        comparing the set of attributes in the received record to those of a default record.
+        comparing the set of attributes in the received record to those of a default record,
+        while also excluding dagster's own internal attributes.
         """
-        ref_attrs = list(logging.makeLogRecord({}).__dict__.keys()) + [
+        ref_attrs = set(logging.makeLogRecord({}).__dict__.keys()) | {
             "message",
             "asctime",
-        ]
+        } | self._DAGSTER_INTERNAL_ATTRS
         return {k: v for k, v in record.__dict__.items() if k not in ref_attrs}
 
     def _convert_record(self, record: logging.LogRecord) -> logging.LogRecord:
@@ -230,8 +246,22 @@ class DagsterLogHandler(logging.Handler):
             if has_log_record_event_batch_metadata(record)
             else None
         )
+        # Extract extra dict that was passed via context.log.info(msg, extra={...})
+        # Python's logging smashes extra keys into record.__dict__; _extract_extra reverses that
+        extra = self._extract_extra(record)
+        # Attempt to capture user-supplied extra dict for dagster_user_metadata.
+        # Guard against unserializable values so a bad extra object doesn't drop the
+        # entire log message: if JSON serialization fails we silently discard the extra
+        # rather than replacing the user event with an engine error event.
+        dagster_user_metadata: Optional[Mapping[str, Any]] = None
+        if extra:
+            try:
+                json.dumps(extra)
+                dagster_user_metadata = extra
+            except TypeError:
+                pass
         metadata = construct_log_record_metadata(
-            self._metadata, record.getMessage(), event, event_batch_metadata
+            self._metadata, record.getMessage(), event, event_batch_metadata, dagster_user_metadata
         )
         message = construct_log_record_message(metadata)
 

--- a/python_modules/dagster/dagster_tests/logging_tests/test_log_manager.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_log_manager.py
@@ -346,3 +346,70 @@ def test_log_handler_extra_context_captured_in_metadata():
 
     # The extra context should be present in the EventLogEntry
     assert event_record.dagster_user_metadata == test_extra
+
+
+def test_log_handler_excludes_internal_attrs_from_user_metadata():
+    """When logging a DagsterEvent (which injects dagster_event and dagster_event_batch_metadata
+    into the LogRecord via extra), those internal attrs must NOT leak into
+    dagster_user_metadata, or serialization of EventLogEntry will fail with a
+    SerializationError because DagsterEvent objects are not JSON-serializable.
+    """
+
+    class MockCaptureHandler(logging.Handler):
+        def __init__(self):
+            self.captured = []
+            super().__init__()
+
+        def emit(self, record):
+            self.captured.append(record)
+
+    capture_handler = MockCaptureHandler()
+
+    step_output_event = dg.DagsterEvent(
+        event_type_value="STEP_OUTPUT",
+        job_name="my_job",
+        step_key="op2",
+        node_handle=NodeHandle("op2", None),
+        step_kind_value="COMPUTE",
+        logging_tags={},
+        event_specific_data=StepOutputData(step_output_handle=StepOutputHandle("op2", "result")),
+        message='Yielded output "result"',
+        pid=54348,
+    )
+
+    log_manager = dg.DagsterLogManager(
+        dagster_handler=DagsterLogHandler(
+            metadata=_construct_log_handler_metadata(
+                run_id="123456", job_name="job", step_key="some_step"
+            ),
+            loggers=[],
+            handlers=[capture_handler],
+        ),
+        managed_loggers=[],
+    )
+    log_manager.log_dagster_event(
+        level="info", msg="test event message", dagster_event=step_output_event
+    )
+
+    assert len(capture_handler.captured) >= 1
+    captured_record = capture_handler.captured[0]
+
+    # dagster_user_metadata should not contain internal dagster attrs
+    user_meta = captured_record.dagster_meta.get("dagster_user_metadata")
+    assert user_meta is None or "dagster_event" not in user_meta
+    assert user_meta is None or "dagster_event_batch_metadata" not in user_meta
+
+    # EventLogEntry should be serializable without error
+    from dagster._core.events.log import construct_event_record
+    from dagster._utils.log import StructuredLoggerMessage
+
+    logger_message = StructuredLoggerMessage(
+        name=captured_record.name,
+        message=captured_record.msg,
+        level=captured_record.levelno,
+        meta=captured_record.dagster_meta,
+        record=captured_record,
+    )
+    event_record = construct_event_record(logger_message)
+    # Should not raise SerializationError
+    event_record.to_json()

--- a/python_modules/dagster/dagster_tests/logging_tests/test_log_manager.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_log_manager.py
@@ -284,3 +284,65 @@ def test_log_handler_emit_by_handlers_level():
 
     for k, v in test_extra.items():
         assert getattr(captured_record, k) == v
+
+
+def test_log_handler_extra_context_captured_in_metadata():
+    """Regression test for https://github.com/dagster-io/dagster/issues/29443.
+
+    When using context.log.info(msg, extra={...}), the extra dict was silently dropped.
+    It should be captured in dagster_meta['dagster_user_metadata'] and included in EventLogEntry.
+    """
+
+    class MockCaptureHandler(logging.Handler):
+        def __init__(self):
+            self.captured = []
+            super().__init__()
+
+        def emit(self, record):
+            self.captured.append(record)
+
+    capture_handler = MockCaptureHandler()
+
+    test_extra = {"foo": 1, "bar": "baz"}
+
+    with user_code_error_boundary(
+        dg.DagsterUserCodeExecutionError,
+        lambda: "Some Error Message",
+        log_manager=dg.DagsterLogManager(
+            dagster_handler=DagsterLogHandler(
+                metadata=_construct_log_handler_metadata(
+                    run_id="123456", job_name="job", step_key="some_step"
+                ),
+                loggers=[],
+                handlers=[capture_handler],
+            ),
+            managed_loggers=[logging.getLogger("python_log")],
+        ),
+    ):
+        python_log = logging.getLogger("python_log")
+        python_log.setLevel(logging.INFO)
+        python_log.info("test message", extra=test_extra)
+
+    assert len(capture_handler.captured) == 1
+    captured_record = capture_handler.captured[0]
+
+    # The extra dict should appear in dagster_meta as dagster_user_metadata
+    assert captured_record.dagster_meta.get("dagster_user_metadata") == test_extra
+
+    # Also verify it round-trips through construct_event_record
+    from dagster._core.events.log import construct_event_record
+    from dagster._utils.log import StructuredLoggerMessage
+
+    # Simulate what StructuredLoggerHandler does: creates a StructuredLoggerMessage
+    # from the captured record
+    logger_message = StructuredLoggerMessage(
+        name=captured_record.name,
+        message=captured_record.msg,
+        level=captured_record.levelno,
+        meta=captured_record.dagster_meta,
+        record=captured_record,
+    )
+    event_record = construct_event_record(logger_message)
+
+    # The extra context should be present in the EventLogEntry
+    assert event_record.dagster_user_metadata == test_extra


### PR DESCRIPTION
## Summary

Addresses #18330 by adding new unprefixed partition properties to OutputContext and InputContext to match the naming convention used in the op/asset execution context, and deprecating the old asset_-prefixed versions.

## Changes

### New properties added (no prefix)
- `has_partition_keys` — whether the run covers multiple partitions
- `partition_keys` — list of partition keys
- `partition_key_range` — the partition key range
- `partition_time_window` — the time window (for time-partitioned assets)

### Deprecated (breaking in 2.0)
- `asset_partition_key_range` → use `partition_key_range`
- `asset_partition_keys` → use `partition_keys`
- `asset_partitions_time_window` → use `partition_time_window`

The old properties now delegate to the new ones and emit deprecation warnings.

## Motivation

The asset_-prefixed names on OutputContext/InputContext are inconsistent with the op/asset context which uses unprefixed names like `partition_keys`, `partition_key_range`, `partition_time_window`. This makes the APIs confusing and harder to use. See #18330 for full context.
