### PR TITLE
fix: capture extra context from context.log.info() in EventLogEntry

### DIFF
--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Mapping
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 from dagster_shared.serdes import deserialize_value, serialize_value, whitelist_for_serdes
 
@@ -40,6 +40,7 @@ class EventLogEntry(
             ("step_key", PublicAttr[str | None]),
             ("job_name", PublicAttr[str | None]),
             ("dagster_event", PublicAttr[DagsterEvent | None]),
+            ("dagster_user_metadata", PublicAttr[Mapping[str, Any] | None]),
         ],
     )
 ):
@@ -64,6 +65,8 @@ class EventLogEntry(
             generated outside of a job context.
         dagster_event (Optional[DagsterEvent]): For framework and user events, the associated
             structured event.
+        dagster_user_metadata (Optional[Dict[str, Any]]): Arbitrary user-supplied key-value pairs
+            passed via the `extra` argument to `context.log.info()` and similar methods.
     """
 
     def __new__(
@@ -76,6 +79,7 @@ class EventLogEntry(
         step_key=None,
         job_name=None,
         dagster_event=None,
+        dagster_user_metadata=None,
     ):
         return super().__new__(
             cls,
@@ -87,6 +91,7 @@ class EventLogEntry(
             check.opt_str_param(step_key, "step_key"),
             check.opt_str_param(job_name, "job_name"),
             check.opt_inst_param(dagster_event, "dagster_event", DagsterEvent),
+            check.opt_mapping_param(dagster_user_metadata, "dagster_user_metadata"),
         )
 
     @public
@@ -192,6 +197,7 @@ def construct_event_record(logger_message: StructuredLoggerMessage) -> EventLogE
         job_name=logger_message.meta.get("job_name"),
         dagster_event=logger_message.meta.get("dagster_event"),
         error_info=None,
+        dagster_user_metadata=logger_message.meta.get("dagster_user_metadata"),
     )
 
 

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -105,6 +105,7 @@ class DagsterLogRecordMetadata(TypedDict):
     orig_message: str
     log_message_id: str
     log_timestamp: str
+    dagster_user_metadata: Optional[Mapping[str, Any]]
 
 
 def construct_log_record_message(metadata: DagsterLogRecordMetadata) -> str:
@@ -154,6 +155,7 @@ def construct_log_record_metadata(
     orig_message: str,
     event: Optional["DagsterEvent"],
     event_batch_metadata: Optional["DagsterEventBatchMetadata"],
+    dagster_user_metadata: Optional[Mapping[str, Any]] = None,
 ) -> DagsterLogRecordMetadata:
     step_key = handler_metadata["step_key"] or (event.step_key if event else None)
     timestamp = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat()
@@ -170,6 +172,7 @@ def construct_log_record_metadata(
         dagster_event=event,
         dagster_event_batch_metadata=event_batch_metadata,
         step_key=step_key,
+        dagster_user_metadata=dagster_user_metadata,
     )
 
 
@@ -230,8 +233,24 @@ class DagsterLogHandler(logging.Handler):
             if has_log_record_event_batch_metadata(record)
             else None
         )
+        # Extract extra dict that was passed via context.log.info(msg, extra={...})
+        # Python's logging smashes extra keys into record.__dict__; _extract_extra reverses that.
+        # Exclude dagster-internal attrs that were also smashed into __dict__ to avoid
+        # leaking DagsterEvent objects (not JSON-serializable) into dagster_user_metadata.
+        _INTERNAL_LOG_ATTRS = frozenset([
+            LOG_RECORD_EVENT_ATTR,
+            LOG_RECORD_EVENT_BATCH_METADATA_ATTR,
+            LOG_RECORD_METADATA_ATTR,
+        ])
+        raw_extra = self._extract_extra(record)
+        dagster_user_metadata = {
+            k: v for k, v in raw_extra.items()
+            if k not in _INTERNAL_LOG_ATTRS
+            and isinstance(v, (str, int, float, bool, type(None), list, dict))
+        }
         metadata = construct_log_record_metadata(
-            self._metadata, record.getMessage(), event, event_batch_metadata
+            self._metadata, record.getMessage(), event, event_batch_metadata,
+            dagster_user_metadata or None
         )
         message = construct_log_record_message(metadata)
 

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -105,7 +105,7 @@ class DagsterLogRecordMetadata(TypedDict):
     orig_message: str
     log_message_id: str
     log_timestamp: str
-    dagster_user_metadata: Optional[Mapping[str, Any]]
+    dagster_user_metadata: Mapping[str, Any] | None
 
 
 def construct_log_record_message(metadata: DagsterLogRecordMetadata) -> str:
@@ -155,7 +155,7 @@ def construct_log_record_metadata(
     orig_message: str,
     event: Optional["DagsterEvent"],
     event_batch_metadata: Optional["DagsterEventBatchMetadata"],
-    dagster_user_metadata: Optional[Mapping[str, Any]] = None,
+    dagster_user_metadata: Mapping[str, Any] | None = None,
 ) -> DagsterLogRecordMetadata:
     step_key = handler_metadata["step_key"] or (event.step_key if event else None)
     timestamp = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat()
@@ -237,20 +237,26 @@ class DagsterLogHandler(logging.Handler):
         # Python's logging smashes extra keys into record.__dict__; _extract_extra reverses that.
         # Exclude dagster-internal attrs that were also smashed into __dict__ to avoid
         # leaking DagsterEvent objects (not JSON-serializable) into dagster_user_metadata.
-        _INTERNAL_LOG_ATTRS = frozenset([
-            LOG_RECORD_EVENT_ATTR,
-            LOG_RECORD_EVENT_BATCH_METADATA_ATTR,
-            LOG_RECORD_METADATA_ATTR,
-        ])
+        _INTERNAL_LOG_ATTRS = frozenset(
+            [
+                LOG_RECORD_EVENT_ATTR,
+                LOG_RECORD_EVENT_BATCH_METADATA_ATTR,
+                LOG_RECORD_METADATA_ATTR,
+            ]
+        )
         raw_extra = self._extract_extra(record)
         dagster_user_metadata = {
-            k: v for k, v in raw_extra.items()
+            k: v
+            for k, v in raw_extra.items()
             if k not in _INTERNAL_LOG_ATTRS
             and isinstance(v, (str, int, float, bool, type(None), list, dict))
         }
         metadata = construct_log_record_metadata(
-            self._metadata, record.getMessage(), event, event_batch_metadata,
-            dagster_user_metadata or None
+            self._metadata,
+            record.getMessage(),
+            event,
+            event_batch_metadata,
+            dagster_user_metadata or None,
         )
         message = construct_log_record_message(metadata)
 

--- a/python_modules/dagster/dagster_tests/logging_tests/test_log_manager.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_log_manager.py
@@ -367,7 +367,7 @@ def test_log_handler_extra_drops_non_serializable_and_internal_attrs():
     non_serializable_value = object()
     test_extra = {
         "valid_key": "valid_value",
-        "internal_dagster_attr": "should_be_dropped",
+        "non_serializable": non_serializable_value,
     }
 
     with user_code_error_boundary(
@@ -393,5 +393,5 @@ def test_log_handler_extra_drops_non_serializable_and_internal_attrs():
 
     dagster_user_metadata = captured_record.dagster_meta.get("dagster_user_metadata") or {}
     assert dagster_user_metadata.get("valid_key") == "valid_value"
-    assert "internal_dagster_attr" not in dagster_user_metadata
+    assert "non_serializable" not in dagster_user_metadata
     assert non_serializable_value not in dagster_user_metadata.values()

--- a/python_modules/dagster/dagster_tests/logging_tests/test_log_manager.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_log_manager.py
@@ -284,3 +284,114 @@ def test_log_handler_emit_by_handlers_level():
 
     for k, v in test_extra.items():
         assert getattr(captured_record, k) == v
+
+
+def test_log_handler_extra_context_captured_in_metadata():
+    """Regression test for https://github.com/dagster-io/dagster/issues/29443.
+
+    When using context.log.info(msg, extra={...}), the extra dict was silently dropped.
+    It should be captured in dagster_meta['dagster_user_metadata'] and included in EventLogEntry.
+    """
+
+    class MockCaptureHandler(logging.Handler):
+        def __init__(self):
+            self.captured = []
+            super().__init__()
+
+        def emit(self, record):
+            self.captured.append(record)
+
+    capture_handler = MockCaptureHandler()
+
+    test_extra = {"foo": 1, "bar": "baz"}
+
+    with user_code_error_boundary(
+        dg.DagsterUserCodeExecutionError,
+        lambda: "Some Error Message",
+        log_manager=dg.DagsterLogManager(
+            dagster_handler=DagsterLogHandler(
+                metadata=_construct_log_handler_metadata(
+                    run_id="123456", job_name="job", step_key="some_step"
+                ),
+                loggers=[],
+                handlers=[capture_handler],
+            ),
+            managed_loggers=[logging.getLogger("python_log")],
+        ),
+    ):
+        python_log = logging.getLogger("python_log")
+        python_log.setLevel(logging.INFO)
+        python_log.info("test message", extra=test_extra)
+
+    assert len(capture_handler.captured) == 1
+    captured_record = capture_handler.captured[0]
+
+    # The extra dict should appear in dagster_meta as dagster_user_metadata
+    assert captured_record.dagster_meta.get("dagster_user_metadata") == test_extra
+
+    # Also verify it round-trips through construct_event_record
+    from dagster._core.events.log import construct_event_record
+    from dagster._utils.log import StructuredLoggerMessage
+
+    # Simulate what StructuredLoggerHandler does: creates a StructuredLoggerMessage
+    # from the captured record
+    logger_message = StructuredLoggerMessage(
+        name=captured_record.name,
+        message=captured_record.msg,
+        level=captured_record.levelno,
+        meta=captured_record.dagster_meta,
+        record=captured_record,
+    )
+    event_record = construct_event_record(logger_message)
+
+    # The extra context should be present in the EventLogEntry
+    assert event_record.dagster_user_metadata == test_extra
+
+
+def test_log_handler_extra_drops_non_serializable_and_internal_attrs():
+    """Extra values that are not JSON-serializable or are dagster-internal attrs
+    must be silently dropped — they must not appear in dagster_user_metadata,
+    otherwise EventLogEntry serialization crashes.
+    """
+
+    class MockCaptureHandler(logging.Handler):
+        def __init__(self):
+            self.captured = []
+            super().__init__()
+
+        def emit(self, record):
+            self.captured.append(record)
+
+    capture_handler = MockCaptureHandler()
+
+    non_serializable_value = object()
+    test_extra = {
+        "valid_key": "valid_value",
+        "internal_dagster_attr": "should_be_dropped",
+    }
+
+    with user_code_error_boundary(
+        dg.DagsterUserCodeExecutionError,
+        lambda: "Some Error Message",
+        log_manager=dg.DagsterLogManager(
+            dagster_handler=DagsterLogHandler(
+                metadata=_construct_log_handler_metadata(
+                    run_id="123456", job_name="job", step_key="some_step"
+                ),
+                loggers=[],
+                handlers=[capture_handler],
+            ),
+            managed_loggers=[logging.getLogger("python_log")],
+        ),
+    ):
+        python_log = logging.getLogger("python_log")
+        python_log.setLevel(logging.INFO)
+        python_log.info("test message", extra=test_extra)
+
+    assert len(capture_handler.captured) == 1
+    captured_record = capture_handler.captured[0]
+
+    dagster_user_metadata = captured_record.dagster_meta.get("dagster_user_metadata") or {}
+    assert dagster_user_metadata.get("valid_key") == "valid_value"
+    assert "internal_dagster_attr" not in dagster_user_metadata
+    assert non_serializable_value not in dagster_user_metadata.values()


### PR DESCRIPTION
## Summary

Fixes [#29443](https://github.com/dagster-io/dagster/issues/29443) — `context.log.info()` ignores `extra` dict argument.

### Root cause

When calling `context.log.info(msg, extra={"key": "value"})`, the `extra` dict was silently dropped:

1. Python's logging smashes `extra` keys into `LogRecord.__dict__`
2. `DagsterLogHandler._convert_record` never extracted or preserved them
3. `DagsterLogRecordMetadata` never included them
4. `EventLogEntry` had no field to store them

### Changes

**`dagster/_core/log_manager.py`:**
- `DagsterLogRecordMetadata`: added `dagster_user_metadata: Optional[Mapping[str, Any]]` field
- `DagsterLogHandler._convert_record`: extract `extra` via existing `_extract_extra()` and pass to `construct_log_record_metadata`
- `construct_log_record_metadata`: accept and propagate `dagster_user_metadata`

**`dagster/_core/events/log.py`:**
- `EventLogEntry`: added `dagster_user_metadata` field (backward-compatible via `whitelist_for_serdes`; old records deserialize with `None`)
- `construct_event_record`: propagate `dagster_user_metadata` to `EventLogEntry`

**`dagster_tests/logging_tests/test_log_manager.py`:**
- Added `test_log_handler_extra_context_captured_in_metadata` regression test

### Backward compatibility

`EventLogEntry` is decorated with `@whitelist_for_serdes`. The new `dagster_user_metadata` field is added as a new field (not removed), so old serialized records deserialize with `None` for this field — no migration needed.