### PR TITLE
fix(dagster-dbt): error on colliding dbt test names at definition time

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -136,11 +136,12 @@ DUPLICATE_ASSET_KEY_ERROR_MESSAGE = (
     " https://docs.dagster.io/integrations/libraries/dbt/reference#customizing-asset-keys."
 )
 
-DUPLICATE_ASSET_CHECK_KEY_ERROR_MESSAGE = (
-    "The following dbt tests generate identical Dagster asset check keys."
-    " This typically happens when two tests on the same model share the same synthesized name"
-    " (e.g., tests that differ only in config options like `where`)."
-    " To fix this, add a unique `name` to each test in your dbt schema YAML."
+DUPLICATE_ASSET_CHECK_IDENTIFIER_ERROR_MESSAGE = (
+    "The following dbt tests generate conflicting Dagster asset check identifiers."
+    " This typically happens when two tests generate the same asset check key, or when distinct"
+    " asset check keys normalize to the same Python identifier."
+    " To fix this, add a unique `name` to each test in your dbt schema YAML, or customize the"
+    " asset keys so that their Python identifiers are unique."
 )
 
 logger = get_dagster_logger()
@@ -942,7 +943,7 @@ def build_dbt_specs(
     specs: list[AssetSpec] = []
     check_specs: dict[str, AssetCheckSpec] = {}
     key_by_unique_id: dict[str, AssetKey] = {}
-    test_unique_ids_by_check_key: dict[AssetCheckKey, set[str]] = defaultdict(set)
+    test_check_keys_by_identifier: dict[str, dict[str, AssetCheckKey]] = defaultdict(dict)
 
     child_map = _build_child_map(manifest)
     for unique_id in selected_unique_ids:
@@ -980,8 +981,9 @@ def build_dbt_specs(
             )
 
             if check_spec:
-                check_specs[check_spec.get_python_identifier()] = check_spec
-                test_unique_ids_by_check_key[check_spec.key].add(child_unique_id)
+                check_identifier = check_spec.get_python_identifier()
+                check_specs[check_identifier] = check_spec
+                test_check_keys_by_identifier[check_identifier][child_unique_id] = check_spec.key
 
         # update the keys_by_unqiue_id dictionary to include keys created for upstream
         # assets. note that this step may need to change once the translator is updated
@@ -1003,11 +1005,14 @@ def build_dbt_specs(
                         project=project,
                     )
                     if check_spec:
-                        check_specs[check_spec.get_python_identifier()] = check_spec
-                        test_unique_ids_by_check_key[check_spec.key].add(child_unique_id)
+                        check_identifier = check_spec.get_python_identifier()
+                        check_specs[check_identifier] = check_spec
+                        test_check_keys_by_identifier[check_identifier][child_unique_id] = (
+                            check_spec.key
+                        )
 
     _validate_asset_keys(translator, manifest, key_by_unique_id)
-    _validate_check_keys(manifest, test_unique_ids_by_check_key)
+    _validate_check_identifiers(manifest, test_check_keys_by_identifier)
     return specs, list(check_specs.values())
 
 
@@ -1049,22 +1054,23 @@ def _validate_asset_keys(
         )
 
 
-def _validate_check_keys(
+def _validate_check_identifiers(
     manifest: Mapping[str, Any],
-    test_unique_ids_by_check_key: Mapping[AssetCheckKey, AbstractSet[str]],
+    test_check_keys_by_identifier: Mapping[str, Mapping[str, AssetCheckKey]],
 ) -> None:
     error_messages = []
-    for check_key, unique_ids in test_unique_ids_by_check_key.items():
-        if len(unique_ids) <= 1:
+    for check_identifier, check_keys_by_unique_id in test_check_keys_by_identifier.items():
+        if len(check_keys_by_unique_id) <= 1:
             continue
         formatted_ids = [
-            f"  - `{id}` ({get_node(manifest, id)['original_file_path']})"
-            for id in sorted(unique_ids)
+            f"  - `{unique_id}` ({get_node(manifest, unique_id)['original_file_path']}; "
+            f"asset check key `{check_key.to_user_string()}`)"
+            for unique_id, check_key in sorted(check_keys_by_unique_id.items())
         ]
         error_messages.append(
             "\n".join(
                 [
-                    f"The following dbt tests have the asset check key `{check_key.to_user_string()}`:",
+                    f"The following dbt tests have the Python identifier `{check_identifier}`:",
                     *formatted_ids,
                 ]
             )
@@ -1072,7 +1078,7 @@ def _validate_check_keys(
 
     if error_messages:
         raise DagsterInvalidDefinitionError(
-            "\n\n".join([DUPLICATE_ASSET_CHECK_KEY_ERROR_MESSAGE, *error_messages])
+            "\n\n".join([DUPLICATE_ASSET_CHECK_IDENTIFIER_ERROR_MESSAGE, *error_messages])
         )
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -136,6 +136,13 @@ DUPLICATE_ASSET_KEY_ERROR_MESSAGE = (
     " https://docs.dagster.io/integrations/libraries/dbt/reference#customizing-asset-keys."
 )
 
+DUPLICATE_ASSET_CHECK_KEY_ERROR_MESSAGE = (
+    "The following dbt tests generate identical Dagster asset check keys."
+    " This typically happens when two tests on the same model share the same synthesized name"
+    " (e.g., tests that differ only in config options like `where`)."
+    " To fix this, add a unique `name` to each test in your dbt schema YAML."
+)
+
 logger = get_dagster_logger()
 
 
@@ -935,6 +942,7 @@ def build_dbt_specs(
     specs: list[AssetSpec] = []
     check_specs: dict[str, AssetCheckSpec] = {}
     key_by_unique_id: dict[str, AssetKey] = {}
+    test_unique_ids_by_check_key: dict[AssetCheckKey, set[str]] = defaultdict(set)
 
     child_map = _build_child_map(manifest)
     for unique_id in selected_unique_ids:
@@ -973,6 +981,7 @@ def build_dbt_specs(
 
             if check_spec:
                 check_specs[check_spec.get_python_identifier()] = check_spec
+                test_unique_ids_by_check_key[check_spec.key].add(child_unique_id)
 
         # update the keys_by_unqiue_id dictionary to include keys created for upstream
         # assets. note that this step may need to change once the translator is updated
@@ -995,8 +1004,10 @@ def build_dbt_specs(
                     )
                     if check_spec:
                         check_specs[check_spec.get_python_identifier()] = check_spec
+                        test_unique_ids_by_check_key[check_spec.key].add(child_unique_id)
 
     _validate_asset_keys(translator, manifest, key_by_unique_id)
+    _validate_check_keys(manifest, test_unique_ids_by_check_key)
     return specs, list(check_specs.values())
 
 
@@ -1035,6 +1046,33 @@ def _validate_asset_keys(
     if error_messages:
         raise DagsterInvalidDefinitionError(
             "\n\n".join([DUPLICATE_ASSET_KEY_ERROR_MESSAGE, *error_messages])
+        )
+
+
+def _validate_check_keys(
+    manifest: Mapping[str, Any],
+    test_unique_ids_by_check_key: Mapping[AssetCheckKey, AbstractSet[str]],
+) -> None:
+    error_messages = []
+    for check_key, unique_ids in test_unique_ids_by_check_key.items():
+        if len(unique_ids) <= 1:
+            continue
+        formatted_ids = [
+            f"  - `{id}` ({get_node(manifest, id)['original_file_path']})"
+            for id in sorted(unique_ids)
+        ]
+        error_messages.append(
+            "\n".join(
+                [
+                    f"The following dbt tests have the asset check key `{check_key.to_user_string()}`:",
+                    *formatted_ids,
+                ]
+            )
+        )
+
+    if error_messages:
+        raise DagsterInvalidDefinitionError(
+            "\n\n".join([DUPLICATE_ASSET_CHECK_KEY_ERROR_MESSAGE, *error_messages])
         )
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -12,6 +12,7 @@ from dagster import (
     AssetKey,
     AssetsDefinition,
     AssetSelection,
+    DagsterInvalidDefinitionError,
     ExecuteInProcessResult,
     OpExecutionContext,
     Output,
@@ -950,8 +951,7 @@ def test_dbt_source_tests_checks_enabled(
 
 def test_duplicate_asset_check_keys_are_rejected() -> None:
     """Distinct dbt tests that generate the same AssetCheckKey must raise at definition time."""
-    from dagster import DagsterInvalidDefinitionError
-    from dagster_dbt.asset_utils import _validate_check_keys
+    from dagster_dbt.asset_utils import _validate_check_identifiers
 
     manifest = {
         "nodes": {
@@ -972,22 +972,68 @@ def test_duplicate_asset_check_keys_are_rejected() -> None:
     }
 
     check_key = AssetCheckKey(asset_key=AssetKey(["my_model"]), name="test_name")
-    test_unique_ids_by_check_key = {
-        check_key: {
-            "test.test_project.test_name.abc123",
-            "test.test_project.test_name.def456",
+    check_identifier = AssetCheckSpec(
+        asset=check_key.asset_key, name=check_key.name
+    ).get_python_identifier()
+    test_check_keys_by_identifier = {
+        check_identifier: {
+            "test.test_project.test_name.abc123": check_key,
+            "test.test_project.test_name.def456": check_key,
         }
     }
 
     with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
-        _validate_check_keys(manifest, test_unique_ids_by_check_key)
+        _validate_check_identifiers(manifest, test_check_keys_by_identifier)
 
     error_message = str(exc_info.value)
-    assert "identical Dagster asset check keys" in error_message
+    assert "conflicting Dagster asset check identifiers" in error_message
+    assert check_identifier in error_message
     assert "test.test_project.test_name.abc123" in error_message
     assert "test.test_project.test_name.def456" in error_message
     assert "models/_models.yml" in error_message
     assert "models/_other.yml" in error_message
+
+
+def test_distinct_asset_check_keys_with_same_python_identifier_are_rejected() -> None:
+    from dagster_dbt.asset_utils import _validate_check_identifiers
+
+    manifest = {
+        "nodes": {
+            "test.test_project.test_name.abc123": {
+                "original_file_path": "models/_models.yml",
+            },
+            "test.test_project.test_name.def456": {
+                "original_file_path": "models/_other.yml",
+            },
+        },
+        "sources": {},
+    }
+    first_key = AssetCheckKey(asset_key=AssetKey(["foo-bar"]), name="test_name")
+    second_key = AssetCheckKey(asset_key=AssetKey(["foo.bar"]), name="test_name")
+    check_identifier = AssetCheckSpec(
+        asset=first_key.asset_key, name=first_key.name
+    ).get_python_identifier()
+
+    assert first_key != second_key
+    assert (
+        check_identifier
+        == AssetCheckSpec(asset=second_key.asset_key, name=second_key.name).get_python_identifier()
+    )
+
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+        _validate_check_identifiers(
+            manifest,
+            {
+                check_identifier: {
+                    "test.test_project.test_name.abc123": first_key,
+                    "test.test_project.test_name.def456": second_key,
+                }
+            },
+        )
+
+    error_message = str(exc_info.value)
+    assert first_key.to_user_string() in error_message
+    assert second_key.to_user_string() in error_message
 
 
 def test_same_test_via_multiple_parents_is_valid(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -946,3 +946,65 @@ def test_dbt_source_tests_checks_enabled(
         if eval_result.asset_key == AssetKey(["jaffle_shop", "raw_customers"])
     ]
     assert len(asset_check_results) == expected_num_source_test_execs
+
+
+def test_duplicate_asset_check_keys_are_rejected() -> None:
+    """Distinct dbt tests that generate the same AssetCheckKey must raise at definition time."""
+    from dagster import DagsterInvalidDefinitionError
+    from dagster_dbt.asset_utils import _validate_check_keys
+
+    manifest = {
+        "nodes": {
+            "test.test_project.test_name.abc123": {
+                "unique_id": "test.test_project.test_name.abc123",
+                "resource_type": "test",
+                "name": "test_name",
+                "original_file_path": "models/_models.yml",
+            },
+            "test.test_project.test_name.def456": {
+                "unique_id": "test.test_project.test_name.def456",
+                "resource_type": "test",
+                "name": "test_name",
+                "original_file_path": "models/_other.yml",
+            },
+        },
+        "sources": {},
+    }
+
+    check_key = AssetCheckKey(asset_key=AssetKey(["my_model"]), name="test_name")
+    test_unique_ids_by_check_key = {
+        check_key: {
+            "test.test_project.test_name.abc123",
+            "test.test_project.test_name.def456",
+        }
+    }
+
+    with pytest.raises(DagsterInvalidDefinitionError) as exc_info:
+        _validate_check_keys(manifest, test_unique_ids_by_check_key)
+
+    error_message = str(exc_info.value)
+    assert "identical Dagster asset check keys" in error_message
+    assert "test.test_project.test_name.abc123" in error_message
+    assert "test.test_project.test_name.def456" in error_message
+    assert "models/_models.yml" in error_message
+    assert "models/_other.yml" in error_message
+
+
+def test_same_test_via_multiple_parents_is_valid(
+    test_asset_checks_manifest: dict[str, Any],
+) -> None:
+    """A test reachable from multiple parents (e.g., relationships test) should remain valid."""
+
+    @dbt_assets(
+        manifest=test_asset_checks_manifest,
+        dagster_dbt_translator=dagster_dbt_translator_with_checks,
+    )
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        yield from dbt.cli(["build"], context=context).stream()
+
+    relationship_checks = [
+        spec
+        for spec in my_dbt_assets.check_specs_by_output_name.values()
+        if "relationships" in spec.name
+    ]
+    assert len(relationship_checks) > 0


### PR DESCRIPTION
## Summary

Distinct dbt tests that collapse to one Dagster `AssetCheckKey` were silently overwritten in `build_dbt_specs` (`check_specs[check_spec.get_python_identifier()] = check_spec`). Asset keys already validate uniqueness; checks did not. The failure showed up at runtime.

## Fix

Track dbt `unique_id`s per `AssetCheckKey`. Raise `DagsterInvalidDefinitionError` only when **distinct** unique_ids share a key (include file paths). The same unique_id via two parents (relationships tests) stays valid.

## Tests

- Collision of two unique_ids on one check key raises with both ids and paths
- Multi-parent / relationships checks still load

Fixes #34155

Note: #34160 addressed this and was closed unmerged.
