### PR TITLE
Add a deployment label to the UI navigation

### DIFF
--- a/docs/docs/deployment/oss/oss-instance-configuration.md
+++ b/docs/docs/deployment/oss/oss-instance-configuration.md
@@ -67,6 +67,7 @@ To do this, provide a `$DAGSTER_HOME/dagster.yaml` file, which the webserver and
 | Schedule evaluation    | `schedules`              | Controls how schedules are evaluated.                                                                                                           |
 | Auto-materialize       | `auto_materialize`       | Controls how assets are auto-materialized.                                                                                                      |
 | Backfills              | `backfills`              | Controls how backfills are processed.                                                                                                           |
+| UI                     | `ui`                     | Names this deployment in the UI navigation, so deployments running the same code can be told apart.                                             |
 
 :::note
 
@@ -311,6 +312,26 @@ The `telemetry` key allows you to opt in or out of Dagster collecting anonymized
 />
 
 For more information, see the [Telemetry documentation](/about/telemetry).
+
+### UI
+
+The `ui` key names this deployment in the UI navigation. Deployments that run the same code, such as production and staging, otherwise look identical in the browser.
+
+`label` is the text shown under the logo. `intent` sets the color: one of `none`, `primary`, `success`, `warning`, or `danger`. An unrecognized `intent` falls back to `none`.
+
+<CodeExample
+  path="docs_snippets/docs_snippets/deployment/oss/dagster_instance/dagster.yaml"
+  startAfter="start_marker_ui"
+  endBefore="end_marker_ui"
+/>
+
+To use one `dagster.yaml` across environments, set the label from an environment variable:
+
+```yaml
+ui:
+  label:
+    env: DAGSTER_UI_LABEL
+```
 
 ### gRPC servers
 

--- a/docs/docs/deployment/oss/oss-instance-configuration.md
+++ b/docs/docs/deployment/oss/oss-instance-configuration.md
@@ -325,12 +325,14 @@ The `ui` key names this deployment in the UI navigation. Deployments that run th
   endBefore="end_marker_ui"
 />
 
-To use one `dagster.yaml` across environments, set the label from an environment variable:
+To use one `dagster.yaml` across environments, set either value from an environment variable:
 
 ```yaml
 ui:
   label:
     env: DAGSTER_UI_LABEL
+  intent:
+    env: DAGSTER_UI_INTENT
 ```
 
 ### gRPC servers

--- a/examples/docs_snippets/docs_snippets/deployment/oss/dagster_instance/dagster.yaml
+++ b/examples/docs_snippets/docs_snippets/deployment/oss/dagster_instance/dagster.yaml
@@ -371,6 +371,15 @@ telemetry:
 
 # end_marker_telemetry
 
+# start_marker_ui
+
+# Names this deployment in the UI navigation.
+ui:
+  label: Production
+  intent: danger
+
+# end_marker_ui
+
 # start_marker_code_servers
 
 # Configures how long Dagster waits for code locations

--- a/helm/dagster/schema/schema/charts/dagster/subschema/__init__.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/__init__.py
@@ -17,4 +17,5 @@ from schema.charts.dagster.subschema.run_launcher import RunLauncher as RunLaunc
 from schema.charts.dagster.subschema.scheduler import Scheduler as Scheduler
 from schema.charts.dagster.subschema.service_account import ServiceAccount as ServiceAccount
 from schema.charts.dagster.subschema.telemetry import Telemetry as Telemetry
+from schema.charts.dagster.subschema.ui import UI as UI
 from schema.charts.dagster.subschema.webserver import Webserver as Webserver

--- a/helm/dagster/schema/schema/charts/dagster/subschema/ui.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/ui.py
@@ -2,7 +2,9 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+from schema.charts.dagster.subschema.config import StringSource
+
 
 class UI(BaseModel, extra="forbid"):
-    label: str | None = None
+    label: StringSource | None = None
     intent: Literal["none", "primary", "success", "warning", "danger"] | None = None

--- a/helm/dagster/schema/schema/charts/dagster/subschema/ui.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/ui.py
@@ -1,0 +1,8 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class UI(BaseModel, extra="forbid"):
+    label: str | None = None
+    intent: Literal["none", "primary", "success", "warning", "danger"] | None = None

--- a/helm/dagster/schema/schema/charts/dagster/subschema/ui.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/ui.py
@@ -2,9 +2,11 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-from schema.charts.dagster.subschema.config import StringSource
+from schema.charts.dagster.subschema.config import Source, StringSource
 
 
 class UI(BaseModel, extra="forbid"):
     label: StringSource | None = None
-    intent: Literal["none", "primary", "success", "warning", "danger"] | None = None
+    # Literal rather than StringSource keeps the enum check for inline values; Source
+    # still allows one values file to pick the color per environment.
+    intent: Literal["none", "primary", "success", "warning", "danger"] | Source | None = None

--- a/helm/dagster/schema/schema/charts/dagster/values.py
+++ b/helm/dagster/schema/schema/charts/dagster/values.py
@@ -33,6 +33,7 @@ class DagsterHelmValues(BaseModel, extra="allow"):
     busybox: subschema.Busybox
     migrate: subschema.Migrate
     telemetry: subschema.Telemetry
+    ui: subschema.UI
     serviceAccount: subschema.ServiceAccount
     global_: subschema.Global = Field(..., alias="global")
     retention: subschema.Retention

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -23,6 +23,7 @@ from schema.charts.dagster.subschema.compute_log_manager import (
     LocalComputeLogManager as LocalComputeLogManagerModel,
     S3ComputeLogManager as S3ComputeLogManagerModel,
 )
+from schema.charts.dagster.subschema.config import Source
 from schema.charts.dagster.subschema.daemon import (
     BlockOpConcurrencyLimitedRuns,
     ConfigurableClass,
@@ -1009,6 +1010,15 @@ def test_ui_label(template: HelmTemplate):
     instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
 
     assert instance["ui"] == {"label": "Staging", "intent": "warning"}
+
+
+def test_ui_label_from_env(template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(ui=UI.construct(label=Source(env="DAGSTER_UI_LABEL")))
+
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert instance["ui"]["label"] == {"env": "DAGSTER_UI_LABEL"}
 
 
 def test_ui_label_omitted_by_default(template: HelmTemplate):

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -45,6 +45,7 @@ from schema.charts.dagster.subschema.run_launcher import (
     RunLauncherType,
 )
 from schema.charts.dagster.subschema.telemetry import Telemetry
+from schema.charts.dagster.subschema.ui import UI
 from schema.charts.dagster.values import DagsterHelmValues
 from schema.charts.utils import kubernetes
 from schema.utils.helm_template import HelmTemplate
@@ -999,6 +1000,24 @@ def test_telemetry(template: HelmTemplate, enabled: bool):
     telemetry_config = instance.get("telemetry")
 
     assert telemetry_config["enabled"] == enabled
+
+
+def test_ui_label(template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(ui=UI.construct(label="Staging", intent="warning"))
+
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert instance["ui"] == {"label": "Staging", "intent": "warning"}
+
+
+def test_ui_label_omitted_by_default(template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(ui=UI.construct())
+
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert "ui" not in instance
 
 
 @pytest.mark.parametrize(

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -1021,6 +1021,17 @@ def test_ui_label_from_env(template: HelmTemplate):
     assert instance["ui"]["label"] == {"env": "DAGSTER_UI_LABEL"}
 
 
+def test_ui_intent_from_env(template: HelmTemplate):
+    helm_values = DagsterHelmValues.construct(
+        ui=UI.construct(label="Staging", intent=Source(env="DAGSTER_UI_INTENT"))
+    )
+
+    configmaps = template.render(helm_values)
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert instance["ui"]["intent"] == {"env": "DAGSTER_UI_INTENT"}
+
+
 def test_ui_label_omitted_by_default(template: HelmTemplate):
     helm_values = DagsterHelmValues.construct(ui=UI.construct())
 

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -160,6 +160,16 @@ data:
     telemetry:
       enabled: {{ .Values.telemetry.enabled }}
 
+    {{- if or .Values.ui.label .Values.ui.intent }}
+    ui:
+      {{- if .Values.ui.label }}
+      label: {{ .Values.ui.label | quote }}
+      {{- end }}
+      {{- if .Values.ui.intent }}
+      intent: {{ .Values.ui.intent | quote }}
+      {{- end }}
+    {{- end }}
+
     {{- if .Values.retention.enabled }}
     retention:
       {{- if .Values.retention.sensor }}

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -163,7 +163,11 @@ data:
     {{- if or .Values.ui.label .Values.ui.intent }}
     ui:
       {{- if .Values.ui.label }}
+      {{- if kindIs "string" .Values.ui.label }}
       label: {{ .Values.ui.label | quote }}
+      {{- else }}
+      label: {{- .Values.ui.label | toYaml | nindent 8 }}
+      {{- end }}
       {{- end }}
       {{- if .Values.ui.intent }}
       intent: {{ .Values.ui.intent | quote }}

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -170,7 +170,11 @@ data:
       {{- end }}
       {{- end }}
       {{- if .Values.ui.intent }}
+      {{- if kindIs "string" .Values.ui.intent }}
       intent: {{ .Values.ui.intent | quote }}
+      {{- else }}
+      intent: {{- .Values.ui.intent | toYaml | nindent 8 }}
+      {{- end }}
       {{- end }}
     {{- end }}
 

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -3108,6 +3108,9 @@
                             "type": "string"
                         },
                         {
+                            "$ref": "#/$defs/Source"
+                        },
+                        {
                             "type": "null"
                         }
                     ],

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -3099,6 +3099,44 @@
             "title": "Tolerations",
             "type": "array"
         },
+        "UI": {
+            "additionalProperties": false,
+            "properties": {
+                "label": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Label"
+                },
+                "intent": {
+                    "anyOf": [
+                        {
+                            "enum": [
+                                "none",
+                                "primary",
+                                "success",
+                                "warning",
+                                "danger"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Intent"
+                }
+            },
+            "title": "UI",
+            "type": "object"
+        },
         "UserDeployment": {
             "properties": {
                 "name": {
@@ -4082,6 +4120,9 @@
         "telemetry": {
             "$ref": "#/$defs/Telemetry"
         },
+        "ui": {
+            "$ref": "#/$defs/UI"
+        },
         "serviceAccount": {
             "$ref": "#/$defs/ServiceAccount"
         },
@@ -4139,6 +4180,7 @@
         "busybox",
         "migrate",
         "telemetry",
+        "ui",
         "serviceAccount",
         "global",
         "retention"

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -3130,6 +3130,9 @@
                             "type": "string"
                         },
                         {
+                            "$ref": "#/$defs/Source"
+                        },
+                        {
                             "type": "null"
                         }
                     ],

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1432,6 +1432,13 @@ migrate:
 telemetry:
   enabled: true
 
+# Name this deployment in the UI navigation, so that deployments running the same
+# code can be told apart. Leave label empty to show nothing.
+ui:
+  label: ~
+  # One of: none, primary, success, warning, danger.
+  intent: ~
+
 serviceAccount:
   create: true
 

--- a/js_modules/app-oss/src/App.tsx
+++ b/js_modules/app-oss/src/App.tsx
@@ -13,7 +13,8 @@ import {CommunityNux} from './NUX/CommunityNux';
 import {extractInitializationData} from './extractInitializationData';
 import {telemetryLink} from './telemetryLink';
 
-const {pathPrefix, telemetryEnabled, liveDataPollRate, instanceId} = extractInitializationData();
+const {pathPrefix, telemetryEnabled, liveDataPollRate, instanceId, uiLabel, uiIntent} =
+  extractInitializationData();
 
 const apolloLinks = [logLink, createErrorLink(true), timeStartLink];
 
@@ -31,6 +32,8 @@ const config = {
   telemetryEnabled,
   statusPolling: new Set<DeploymentStatusType>(['code-locations', 'daemons']),
   idempotentMutations: false,
+  uiLabel,
+  uiIntent,
 };
 
 const appCache = createAppCache();

--- a/js_modules/app-oss/src/extractInitializationData.ts
+++ b/js_modules/app-oss/src/extractInitializationData.ts
@@ -3,20 +3,24 @@ export const PREFIX_PLACEHOLDER = '__PATH_PREFIX__';
 export const TELEMETRY_PLACEHOLDER = '__TELEMETRY_ENABLED__';
 export const LIVE_DATA_POLL_RATE_PLACEHOLDER = '__LIVE_DATA_POLL_RATE__';
 export const INSTANCE_ID_PLACEHOLDER = '__INSTANCE_ID__';
+export const UI_LABEL_PLACEHOLDER = '__UI_LABEL__';
+export const UI_INTENT_PLACEHOLDER = '__UI_INTENT__';
 
-let value:
-  | {pathPrefix: string; telemetryEnabled: boolean; liveDataPollRate?: number; instanceId: string}
-  | undefined = undefined;
-
-// Determine the path prefix value, which is set server-side.
-// This value will be used for prefixing paths for the GraphQL
-// endpoint and dynamically loaded bundles.
-export const extractInitializationData = (): {
+export interface InitializationData {
   pathPrefix: string;
   telemetryEnabled: boolean;
   liveDataPollRate?: number;
   instanceId: string;
-} => {
+  uiLabel?: string;
+  uiIntent?: string;
+}
+
+let value: InitializationData | undefined = undefined;
+
+// Determine the path prefix value, which is set server-side.
+// This value will be used for prefixing paths for the GraphQL
+// endpoint and dynamically loaded bundles.
+export const extractInitializationData = (): InitializationData => {
   if (!value) {
     value = {pathPrefix: '', telemetryEnabled: false, instanceId: ''};
     const element = document.getElementById(ELEMENT_ID);
@@ -33,6 +37,12 @@ export const extractInitializationData = (): {
       }
       if (parsed.instanceId !== INSTANCE_ID_PLACEHOLDER) {
         value.instanceId = parsed.instanceId;
+      }
+      if (parsed.uiLabel && parsed.uiLabel !== UI_LABEL_PLACEHOLDER) {
+        value.uiLabel = parsed.uiLabel;
+      }
+      if (parsed.uiIntent && parsed.uiIntent !== UI_INTENT_PLACEHOLDER) {
+        value.uiIntent = parsed.uiIntent;
       }
     }
   }

--- a/js_modules/app-oss/src/pages/_document.tsx
+++ b/js_modules/app-oss/src/pages/_document.tsx
@@ -9,6 +9,8 @@ import {
   LIVE_DATA_POLL_RATE_PLACEHOLDER,
   PREFIX_PLACEHOLDER,
   TELEMETRY_PLACEHOLDER,
+  UI_INTENT_PLACEHOLDER,
+  UI_LABEL_PLACEHOLDER,
 } from '../extractInitializationData';
 
 function getSecurityPolicy() {
@@ -34,6 +36,8 @@ export default function Document() {
     telemetryEnabled: TELEMETRY_PLACEHOLDER,
     liveDataPollRate: LIVE_DATA_POLL_RATE_PLACEHOLDER,
     instanceId: isDev ? 'dev' : INSTANCE_ID_PLACEHOLDER,
+    uiLabel: UI_LABEL_PLACEHOLDER,
+    uiIntent: UI_INTENT_PLACEHOLDER,
   };
   const prefix = getPrefix();
   return (

--- a/js_modules/ui-core/src/app/AppContext.tsx
+++ b/js_modules/ui-core/src/app/AppContext.tsx
@@ -10,6 +10,9 @@ export type AppContextValue = {
   statusPolling?: Set<DeploymentStatusType>;
   localCacheIdPrefix?: string;
   shouldUseAssetManifestForWorkspace?: boolean;
+  // Deployment name and tag color from dagster.yaml, shown in the navigation.
+  uiLabel?: string;
+  uiIntent?: string;
 };
 
 export const AppContext = createContext<AppContextValue>({

--- a/js_modules/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/ui-core/src/app/AppProvider.tsx
@@ -65,6 +65,8 @@ export interface AppProviderProps {
     telemetryEnabled?: boolean;
     statusPolling: Set<DeploymentStatusType>;
     idempotentMutations?: boolean;
+    uiLabel?: string;
+    uiIntent?: string;
   };
 
   // Used for localStorage/IndexedDB caching to be isolated between instances/deployments
@@ -86,6 +88,8 @@ export const AppProvider = (props: AppProviderProps) => {
     telemetryEnabled = false,
     statusPolling,
     idempotentMutations = true,
+    uiLabel,
+    uiIntent,
   } = config;
 
   // todo dish: Change `deleteExisting` to true soon. (Current: 1.4.5)
@@ -170,6 +174,8 @@ export const AppProvider = (props: AppProviderProps) => {
       telemetryEnabled,
       localCacheIdPrefix,
       shouldUseAssetManifestForWorkspace,
+      uiLabel,
+      uiIntent,
     }),
     [
       basePath,
@@ -177,6 +183,8 @@ export const AppProvider = (props: AppProviderProps) => {
       telemetryEnabled,
       localCacheIdPrefix,
       shouldUseAssetManifestForWorkspace,
+      uiLabel,
+      uiIntent,
     ],
   );
 

--- a/js_modules/ui-core/src/app/navigation/DeploymentLabelTag.tsx
+++ b/js_modules/ui-core/src/app/navigation/DeploymentLabelTag.tsx
@@ -1,0 +1,44 @@
+import {Box, Intent, Tag, Tooltip} from '@dagster-io/ui-components';
+import {useContext} from 'react';
+
+import {AppContext} from '../AppContext';
+import styles from './css/DeploymentLabelTag.module.css';
+
+const INTENTS: Intent[] = ['none', 'primary', 'success', 'warning', 'danger'];
+
+const toIntent = (value: string | undefined): Intent =>
+  INTENTS.includes(value as Intent) ? (value as Intent) : 'none';
+
+interface Props {
+  collapsed: boolean;
+}
+
+// Set via the `ui` block in dagster.yaml, so that deployments running the same
+// code (production, staging) are distinguishable at a glance.
+export const DeploymentLabelTag = ({collapsed}: Props) => {
+  const {uiLabel, uiIntent} = useContext(AppContext);
+
+  if (!uiLabel) {
+    return null;
+  }
+
+  const intent = toIntent(uiIntent);
+
+  // The collapsed rail is too narrow for the label, but that is exactly when the
+  // deployment cue is easiest to lose, so keep a dot carrying the same color.
+  if (collapsed) {
+    return (
+      <Box padding={{left: 8, bottom: 8}}>
+        <Tooltip content={uiLabel} placement="right">
+          <div className={styles.dot} data-intent={intent} />
+        </Tooltip>
+      </Box>
+    );
+  }
+
+  return (
+    <Box padding={{horizontal: 8, bottom: 8}}>
+      <Tag intent={intent}>{uiLabel}</Tag>
+    </Box>
+  );
+};

--- a/js_modules/ui-core/src/app/navigation/__stories__/DeploymentLabelTag.stories.tsx
+++ b/js_modules/ui-core/src/app/navigation/__stories__/DeploymentLabelTag.stories.tsx
@@ -1,0 +1,59 @@
+import {Box, Intent} from '@dagster-io/ui-components';
+
+import {AppContext, AppContextValue} from '../../AppContext';
+import {DeploymentLabelTag} from '../DeploymentLabelTag';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'DeploymentLabelTag',
+  component: DeploymentLabelTag,
+};
+
+const WithContext = ({
+  uiLabel,
+  uiIntent,
+  collapsed = false,
+}: {
+  uiLabel?: string;
+  uiIntent?: string;
+  collapsed?: boolean;
+}) => {
+  const value: AppContextValue = {
+    basePath: '',
+    rootServerURI: '',
+    telemetryEnabled: false,
+    uiLabel,
+    uiIntent,
+  };
+  return (
+    <AppContext.Provider value={value}>
+      <DeploymentLabelTag collapsed={collapsed} />
+    </AppContext.Provider>
+  );
+};
+
+const INTENTS: Intent[] = ['none', 'primary', 'success', 'warning', 'danger'];
+
+export const AllIntents = () => (
+  <Box flex={{direction: 'column', gap: 8}} style={{width: 240}}>
+    {INTENTS.map((intent) => (
+      <WithContext key={intent} uiLabel={`Deployment (${intent})`} uiIntent={intent} />
+    ))}
+  </Box>
+);
+
+export const DefaultIntent = () => <WithContext uiLabel="Production" />;
+
+// An intent the server did not recognize is dropped before it reaches the client,
+// so the tag falls back to the default color rather than rendering unstyled.
+export const UnknownIntent = () => <WithContext uiLabel="Production" uiIntent="chartreuse" />;
+
+export const NoLabel = () => <WithContext />;
+
+export const Collapsed = () => (
+  <Box flex={{direction: 'column', gap: 8}} style={{width: 68}}>
+    {INTENTS.map((intent) => (
+      <WithContext key={intent} uiLabel={`Deployment (${intent})`} uiIntent={intent} collapsed />
+    ))}
+  </Box>
+);

--- a/js_modules/ui-core/src/app/navigation/__stories__/MainNavigation.stories.tsx
+++ b/js_modules/ui-core/src/app/navigation/__stories__/MainNavigation.stories.tsx
@@ -3,6 +3,7 @@ import {FeatureFlag} from '@shared/FeatureFlags';
 import {MainNavigation} from '@shared/app/navigation/MainNavigation';
 import {useContext} from 'react';
 
+import {AppContext, AppContextValue} from '../../AppContext';
 import {NavCollapseContext, NavCollapseProvider} from '../NavCollapseProvider';
 import {getBottomGroups, getTopGroups} from '../mainNavigationItems';
 
@@ -37,5 +38,25 @@ export const Default = () => {
         <Nav />
       </NavCollapseProvider>
     </MockedProvider>
+  );
+};
+
+const labelled: AppContextValue = {
+  basePath: '',
+  rootServerURI: '',
+  telemetryEnabled: false,
+  uiLabel: 'Production',
+  uiIntent: 'danger',
+};
+
+export const WithDeploymentLabel = () => {
+  return (
+    <AppContext.Provider value={labelled}>
+      <MockedProvider mocks={[]}>
+        <NavCollapseProvider>
+          <Nav />
+        </NavCollapseProvider>
+      </MockedProvider>
+    </AppContext.Provider>
   );
 };

--- a/js_modules/ui-core/src/app/navigation/__tests__/DeploymentLabelTag.test.tsx
+++ b/js_modules/ui-core/src/app/navigation/__tests__/DeploymentLabelTag.test.tsx
@@ -1,0 +1,35 @@
+import {render, screen} from '@testing-library/react';
+
+import {AppContext, AppContextValue} from '../../AppContext';
+import {DeploymentLabelTag} from '../DeploymentLabelTag';
+
+const renderTag = (context: Partial<AppContextValue>, collapsed = false) =>
+  render(
+    <AppContext.Provider
+      value={{basePath: '', rootServerURI: '', telemetryEnabled: false, ...context}}
+    >
+      <DeploymentLabelTag collapsed={collapsed} />
+    </AppContext.Provider>,
+  );
+
+describe('DeploymentLabelTag', () => {
+  it('renders nothing without a label', () => {
+    const {container} = renderTag({uiIntent: 'danger'});
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the label', () => {
+    renderTag({uiLabel: 'Production', uiIntent: 'danger'});
+    expect(screen.getByText('Production')).toBeVisible();
+  });
+
+  it('falls back to the none intent for an unrecognized value', () => {
+    const {container} = renderTag({uiLabel: 'Production', uiIntent: 'chartreuse'}, true);
+    expect(container.querySelector('[data-intent]')).toHaveAttribute('data-intent', 'none');
+  });
+
+  it('keeps a recognized intent', () => {
+    const {container} = renderTag({uiLabel: 'Production', uiIntent: 'warning'}, true);
+    expect(container.querySelector('[data-intent]')).toHaveAttribute('data-intent', 'warning');
+  });
+});

--- a/js_modules/ui-core/src/app/navigation/css/DeploymentLabelTag.module.css
+++ b/js_modules/ui-core/src/app/navigation/css/DeploymentLabelTag.module.css
@@ -1,0 +1,25 @@
+/* The collapsed rail has no room for the label, so carry the intent color alone.
+   Accent rather than background tokens: the tag fills are translucent, which a
+   10px dot cannot carry. The tooltip supplies the text. */
+.dot {
+  border-radius: 50%;
+  height: 10px;
+  width: 10px;
+  background-color: var(--color-accent-gray);
+}
+
+.dot[data-intent='primary'] {
+  background-color: var(--color-accent-blue);
+}
+
+.dot[data-intent='success'] {
+  background-color: var(--color-accent-green);
+}
+
+.dot[data-intent='warning'] {
+  background-color: var(--color-accent-yellow);
+}
+
+.dot[data-intent='danger'] {
+  background-color: var(--color-accent-red);
+}

--- a/js_modules/ui-core/src/shared/app/navigation/MainNavigation.tsx
+++ b/js_modules/ui-core/src/shared/app/navigation/MainNavigation.tsx
@@ -2,6 +2,7 @@ import {Box, DagsterIcon, DagsterLogo} from '@dagster-io/ui-components';
 import clsx from 'clsx';
 import {Link} from 'react-router-dom';
 
+import {DeploymentLabelTag} from '../../../app/navigation/DeploymentLabelTag';
 import {NavigationGroupDisplay} from '../../../app/navigation/NavigationGroupDisplay';
 import styles from '../../../app/navigation/css/MainNavigation.module.css';
 import {NavigationGroup} from '../../../app/navigation/types';
@@ -25,6 +26,7 @@ export const MainNavigation = ({collapsed, topGroups, bottomGroups}: Props) => {
           </Box>
         </Link>
       </div>
+      <DeploymentLabelTag collapsed={collapsed} />
       <NavigationGroupDisplay list={topGroups} className={styles.topGroups} collapsed={collapsed} />
       <NavigationGroupDisplay
         list={bottomGroups}

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -49,6 +49,15 @@ TRequestContext = TypeVar("TRequestContext", bound=BaseWorkspaceRequestContext)
 TProcessContext = TypeVar("TProcessContext", bound=IWorkspaceProcessContext)
 
 
+def _json_for_script_tag(value: object) -> str:
+    """Serialize an operator-supplied value for embedding in a JSON <script> body.
+
+    json.dumps does not escape "<", so a value containing "</script>" would otherwise close
+    the tag early.
+    """
+    return json.dumps(value).replace("<", "\\u003c")
+
+
 class DagsterWebserver(
     GraphQLServer[TRequestContext],
     Generic[TProcessContext, TRequestContext],
@@ -237,6 +246,10 @@ class DagsterWebserver(
                         content = content.replace(
                             "__LIVE_DATA_POLL_RATE__", str(self._live_data_poll_rate)
                         )
+
+                    content = content.replace(
+                        '"__UI_LABEL__"', _json_for_script_tag(context.instance.ui_label)
+                    ).replace('"__UI_INTENT__"', _json_for_script_tag(context.instance.ui_intent))
                     return HTMLResponse(content, headers=headers)
             except FileNotFoundError:
                 raise Exception(

--- a/python_modules/dagster-webserver/dagster_webserver_tests/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/test_app.py
@@ -123,6 +123,67 @@ def test_index_view_at_path_prefix(instance):
         assert b'"pathPrefix": "/dagster-path",' in res.content
 
 
+def test_index_view_ui_label():
+    with instance_for_test(
+        overrides={"ui": {"label": "Staging", "intent": "warning"}}
+    ) as configured:
+        with load_workspace_process_context_from_yaml_paths(
+            configured, [file_relative_path(__file__, "./workspace.yaml")]
+        ) as workspace_process_context:
+            client = TestClient(
+                create_app_from_workspace_process_context(workspace_process_context)
+            )
+            res = client.get("/")
+
+            assert res.status_code == 200, res.content
+            assert b'"uiLabel": "Staging"' in res.content
+            assert b'"uiIntent": "warning"' in res.content
+
+
+def test_index_view_ui_label_unset(instance):
+    with load_workspace_process_context_from_yaml_paths(
+        instance, [file_relative_path(__file__, "./workspace.yaml")]
+    ) as workspace_process_context:
+        client = TestClient(create_app_from_workspace_process_context(workspace_process_context))
+        res = client.get("/")
+
+        assert res.status_code == 200, res.content
+        assert b'"uiLabel": null' in res.content
+        assert b"__UI_LABEL__" not in res.content
+
+
+def test_index_view_ui_label_rejects_unknown_intent():
+    with instance_for_test(overrides={"ui": {"label": "Staging", "intent": "chartreuse"}}) as bad:
+        with load_workspace_process_context_from_yaml_paths(
+            bad, [file_relative_path(__file__, "./workspace.yaml")]
+        ) as workspace_process_context:
+            client = TestClient(
+                create_app_from_workspace_process_context(workspace_process_context)
+            )
+            res = client.get("/")
+
+            assert res.status_code == 200, res.content
+            assert b'"uiIntent": null' in res.content
+
+
+def test_index_view_ui_label_escapes_script_tag():
+    with instance_for_test(
+        overrides={"ui": {"label": "</script><script>alert(1)</script>"}}
+    ) as configured:
+        with load_workspace_process_context_from_yaml_paths(
+            configured, [file_relative_path(__file__, "./workspace.yaml")]
+        ) as workspace_process_context:
+            client = TestClient(
+                create_app_from_workspace_process_context(workspace_process_context)
+            )
+            res = client.get("/")
+
+            assert res.status_code == 200, res.content
+            # The "<" of the injected markup is escaped, so it cannot close the JSON script tag.
+            assert b"<script>alert(1)" not in res.content
+            assert rb"\u003c/script>\u003cscript>alert(1)" in res.content
+
+
 def test_graphql_view(instance):
     with load_workspace_process_context_from_yaml_paths(
         instance, [file_relative_path(__file__, "./workspace.yaml")]

--- a/python_modules/dagster-webserver/dagster_webserver_tests/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/test_app.py
@@ -152,6 +152,27 @@ def test_index_view_ui_label_unset(instance):
         assert b"__UI_LABEL__" not in res.content
 
 
+def test_index_view_ui_label_from_env(monkeypatch):
+    monkeypatch.setenv("DAGSTER_UI_LABEL", "Production")
+    monkeypatch.setenv("DAGSTER_UI_INTENT", "danger")
+    with instance_for_test(
+        overrides={
+            "ui": {"label": {"env": "DAGSTER_UI_LABEL"}, "intent": {"env": "DAGSTER_UI_INTENT"}}
+        }
+    ) as configured:
+        with load_workspace_process_context_from_yaml_paths(
+            configured, [file_relative_path(__file__, "./workspace.yaml")]
+        ) as workspace_process_context:
+            client = TestClient(
+                create_app_from_workspace_process_context(workspace_process_context)
+            )
+            res = client.get("/")
+
+            assert res.status_code == 200, res.content
+            assert b'"uiLabel": "Production"' in res.content
+            assert b'"uiIntent": "danger"' in res.content
+
+
 def test_index_view_ui_label_rejects_unknown_intent():
     with instance_for_test(overrides={"ui": {"label": "Staging", "intent": "chartreuse"}}) as bad:
         with load_workspace_process_context_from_yaml_paths(

--- a/python_modules/dagster/dagster/_core/instance/config.py
+++ b/python_modules/dagster/dagster/_core/instance/config.py
@@ -538,6 +538,23 @@ def dagster_instance_config_schema() -> Mapping[str, Field]:
         "nux": Field(
             {"enabled": Field(Bool, is_required=False)},
         ),
+        "ui": Field(
+            {
+                "label": Field(
+                    StringSource,
+                    is_required=False,
+                    description="Name for this deployment, shown in the UI navigation. Use it to "
+                    "tell deployments apart, e.g. 'Production' or 'Staging'.",
+                ),
+                "intent": Field(
+                    StringSource,
+                    is_required=False,
+                    description="Color scheme for the deployment label: one of none, primary, "
+                    "success, warning, danger.",
+                ),
+            },
+            is_required=False,
+        ),
         "instance_class": config_field_for_configurable_class(),
         "python_logs": python_logs_config_schema(),
         "run_monitoring": Field(

--- a/python_modules/dagster/dagster/_core/instance/methods/settings_methods.py
+++ b/python_modules/dagster/dagster/_core/instance/methods/settings_methods.py
@@ -74,6 +74,19 @@ class SettingsMethods:
             return dagster_telemetry_enabled_default
 
     @property
+    def ui_label(self) -> str | None:
+        label = (self.get_settings("ui") or {}).get("label") or ""
+        return label.strip() or None
+
+    @property
+    def ui_intent(self) -> str | None:
+        """Color scheme for the UI label. Unrecognized values fall back to the default tag color."""
+        # Mirrors the Intent type in js_modules/ui-components/src/components/Intent.tsx.
+        valid = {"none", "primary", "success", "warning", "danger"}
+        intent = (self.get_settings("ui") or {}).get("intent")
+        return intent if intent in valid else None
+
+    @property
     def nux_enabled(self) -> bool:
         if self.is_ephemeral:
             return False

--- a/python_modules/dagster/dagster/_core/instance/methods/settings_methods.py
+++ b/python_modules/dagster/dagster/_core/instance/methods/settings_methods.py
@@ -1,5 +1,6 @@
 """Settings methods for DagsterInstance."""
 
+import os
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -73,17 +74,26 @@ class SettingsMethods:
         else:
             return dagster_telemetry_enabled_default
 
+    def _ui_setting(self, key: str) -> str | None:
+        # The instance schema types these as StringSource, but instance config is only
+        # validated, never processed, so an `{env: VAR}` source arrives unresolved.
+        value = (self.get_settings("ui") or {}).get(key)
+        if isinstance(value, Mapping):
+            value = os.getenv(check.str_elem(value, "env"))
+        if not isinstance(value, str):
+            return None
+        return value.strip() or None
+
     @property
     def ui_label(self) -> str | None:
-        label = (self.get_settings("ui") or {}).get("label") or ""
-        return label.strip() or None
+        return self._ui_setting("label")
 
     @property
     def ui_intent(self) -> str | None:
         """Color scheme for the UI label. Unrecognized values fall back to the default tag color."""
         # Mirrors the Intent type in js_modules/ui-components/src/components/Intent.tsx.
         valid = {"none", "primary", "success", "warning", "danger"}
-        intent = (self.get_settings("ui") or {}).get("intent")
+        intent = self._ui_setting("intent")
         return intent if intent in valid else None
 
     @property

--- a/python_modules/dagster/dagster/_core/instance/ref.py
+++ b/python_modules/dagster/dagster/_core/instance/ref.py
@@ -478,6 +478,7 @@ class InstanceRef(
             "sensors",
             "schedules",
             "nux",
+            "ui",
             "auto_materialize",
             "concurrency",
             "freshness",


### PR DESCRIPTION
## Summary & Motivation

Related: #24989 (partly addresses; no logo replacement)

Run more than one Dagster deployment and they look identical in the browser, so it's easy to fire off a run against prod when you meant staging.

This adds a `ui` block to `dagster.yaml`:

```yaml
ui:
  label: Production
  intent: danger  # none | primary | success | warning | danger
```

The label shows as a tag in the nav under the logo. Collapse the nav and it becomes a dot in the same colour with the label in a tooltip, since that's when the cue is easiest to lose. With no label set, nothing renders.

`intent` rather than a free CSS colour because `Tag` picks matching fill and text per intent, so contrast survives both themes. An unrecognised intent gets dropped server-side and falls back to `none`.

I put it in instance config rather than a webserver CLI flag because the label describes the deployment, not one replica. Several webserver replicas would each need the arg, and this way `dagster dev` picks it up too. Both fields are `StringSource`, so one `dagster.yaml` covers several environments:

```yaml
ui:
  label:
    env: DAGSTER_UI_LABEL
```

Helm gets typed `ui.label` / `ui.intent` values templated into the instance ConfigMap.

The other half of #24989 is logo replacement, which I've left alone. It needs a static asset route, CSP changes and volume mounts, and I didn't want to guess at the design from outside. The label covers the prod-vs-staging problem people described in the thread.

The label and intent are operator-supplied and land in the `<script type="application/json">` block. `json.dumps` doesn't escape `<`, so a label containing `</script>` would close the tag early. Escaped, with a test.

I saw DES-173 linked on the issue. If this cuts across something you've already planned, or `ui` is the wrong home for it, say so and I'll rework or drop it.

## Test Plan

Four webserver tests: values present, unset (`null`, no placeholder left in the page), unrecognised intent, and the `</script>` escaping. Two Helm tests for the rendered ConfigMap with and without the block.

Storybook stories for the tag and for the nav with a label set. Checking the dot in both themes turned up a bug worth mentioning: the tag fill tokens are translucent, which is invisible at 10px, so the dot uses the solid accent tokens instead.

`ruff`, `yarn tsgo`, `yarn lint`, `yarn jest` and `helm template` are clean. The Helm tests need dagster-aws/azure/gcp, which I don't have installed, so CI runs those first.

## Changelog

`dagster.yaml` accepts a `ui` block with `label` and `intent` to name a deployment in the UI navigation.
