### PR TITLE
fix(dagster-cloud/ecs): _run_task raises TypeError instead of returning the task logs

### DIFF
--- a/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/client.py
+++ b/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/client.py
@@ -531,7 +531,7 @@ class Client:
         )
 
         if exit_code:
-            raise Exception(self.get_task_logs(task_arn))  # ty: ignore[missing-argument]
+            raise Exception(self.get_task_logs(task_arn, container_name=name))
 
         return True
 


### PR DESCRIPTION
## Problem

`Client.get_task_logs` is declared

```python
def get_task_logs(self, task_arn, container_name, limit=10):
```

but the failure path of `Client._run_task`
([`client.py:534`](https://github.com/dagster-io/dagster/blob/master/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/client.py#L534))
calls it with only the ARN:

```python
if exit_code:
    raise Exception(self.get_task_logs(task_arn))  # ty: ignore[missing-argument]
```

So when the task actually exits non-zero, the caller gets

```
TypeError: Client.get_task_logs() missing 1 required positional argument: 'container_name'
```

instead of the ECS logs — i.e. the branch that exists specifically to explain *why* the
task failed replaces that explanation with an unrelated `TypeError`. The
`# ty: ignore[missing-argument]` on the line is the type checker having already caught
this; the suppression silences the diagnostic without fixing the call.

`_run_task` is documented as an integration-test utility for network configurations, so
this is precisely the path a developer hits when a test task fails and they need the logs.

## Which container name

`_run_task` registers its task definition as

```python
task_definition_arn = self.register_task_definition(
    family=name, image=image, command=command, execution_role_arn=execution_role_arn,
)
```

with no explicit `container_name`, and `register_task_definition` does
`container_name = container_name or family` ([`client.py:235`](https://github.com/dagster-io/dagster/blob/master/python_modules/dagster-cloud/dagster_cloud/workspace/ecs/client.py#L235)).
The container is therefore named `name`, so `container_name=name` is the value
`get_task_logs` needs to find the matching container definition and log stream.

The other two call sites already pass it: `_raise_failed_task` (`client.py:635`) and
`launcher.py:594` (`container_name=CONTAINER_NAME, limit=25`).

## Verification

`get_task_logs`'s signature was rebuilt from the source with `ast` and every call site
replayed through `inspect.Signature.bind`, with the two working call sites as a control
group:

```
Client.get_task_logs (self, task_arn, container_name, limit='10')

[PASS] client.py:534 _run_task (BUG, silenced by `# ty: ignore[missing-argument]`)  self.get_task_logs(task_arn)
         bind -> TypeError: missing a required argument: 'container_name'
[PASS] client.py:635 _raise_failed_task (control)  self.get_task_logs(task_arn, container_name=container_name)
         bind -> OK
[PASS] launcher.py:594 (control)                   self.client.get_task_logs(task_arn, container_name=CONTAINER_NAME, limit=25)
         bind -> OK
[PASS] AFTER PATCH                                 self.get_task_logs(task_arn, container_name=name)
         bind -> OK
```

## Scope

One line, plus removing the `# ty: ignore[missing-argument]` it no longer needs
(78 chars, well inside the line-length limit). No signature or behaviour change on any
path that works today.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
