### PR TITLE
fix(dagster-aws): catch UnrecognizedClientException in the Cloudwatch logger

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/cloudwatch/loggers.py
@@ -172,7 +172,7 @@ class CloudwatchLogsHandler(logging.Handler):
                 self.retry(record)
             else:
                 logging.error(f"Cloudwatch logger: Service unavailable: {res}")
-        except self.client.exceptions.ServiceUnavailableException:
+        except self.client.exceptions.UnrecognizedClientException:
             if not retry:
                 self.retry(record)
             else:


### PR DESCRIPTION
### Problem

`CloudwatchLogsHandler._emit` in `dagster_aws/cloudwatch/loggers.py` ends with two handlers for the *same* exception:

```python
except self.client.exceptions.ServiceUnavailableException:
    if not retry:
        self.retry(record)
    else:
        logging.error(f"Cloudwatch logger: Service unavailable: {res}")
except self.client.exceptions.ServiceUnavailableException:   # <- never reached
    if not retry:
        self.retry(record)
    else:
        logging.error(
            "Cloudwatch logger: Unrecognized client. Check your AWS access key id and "
            f"secret key: {res}"
        )
```

The second `except` is unreachable — the first one already catches that class.

### Which exception it was meant to be

Its body talks about an unrecognized client and about checking the AWS access key, which is `UnrecognizedClientException`. The handler chain is otherwise a 1:1 enumeration of the errors botocore models for `logs:PutLogEvents`:

| `PutLogEvents` modeled error | handled in `_emit`? |
|---|---|
| `InvalidSequenceTokenException` | ✅ |
| `DataAlreadyAcceptedException` | ✅ |
| `InvalidParameterException` | ✅ |
| `ResourceNotFoundException` | ✅ |
| `ServiceUnavailableException` | ✅ |
| `UnrecognizedClientException` | ❌ (this is the duplicated one) |

So the chain was written to cover all six and the last one lost its class in an edit.

### Impact

`emit()` calls `_emit()` with no `try`/`except` of its own, so with invalid or expired AWS credentials `UnrecognizedClientException` propagates out of the handler and out of the originating log call — instead of producing the message the code already has ready for exactly that case.

### Fix

```python
except self.client.exceptions.UnrecognizedClientException:
```

### Verification

I extracted the real `_emit` / `retry` / `log_error` with `ast.get_source_segment` (before = `git show HEAD:…`, after = working copy — neither side hand-transcribed), bound them to a stub client whose `.exceptions` namespace carries the six modeled `PutLogEvents` error classes, and had `put_log_events` raise each in turn:

```
PutLogEvents error                before patch                        after patch
InvalidParameterException         handled                             handled
InvalidSequenceTokenException     handled                             handled
DataAlreadyAcceptedException      handled                             handled
ResourceNotFoundException         handled                             handled
ServiceUnavailableException       handled                             handled
UnrecognizedClientException       ESCAPED:UnrecognizedClientException  handled   <== CHANGED

changed rows: 1 / 6
```

`ServiceUnavailableException` is still handled (by the first handler, which is untouched), and only the previously-escaping error changes behaviour.

`ruff check` and `ruff format --check` pass on the file with the pinned `0.16.2` and the repo's own `config/ruff.toml`.

### Note

I kept the retry-once-then-log shape the unreachable branch already had, so this change is limited to the exception class. If you would rather not retry on a credentials error, that is a one-line follow-up and I am happy to fold it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
