### PR TITLE
fix(dagster-snowflake): execute_queries discards results when use_pandas_result=True

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -1014,7 +1014,7 @@ class SnowflakeConnection:
                     parameters = dict(parameters) if isinstance(parameters, Mapping) else parameters
                     cursor.execute(sql, parameters)
                     if use_pandas_result:
-                        results = results.append(cursor.fetch_pandas_all())  # type: ignore
+                        results.append(cursor.fetch_pandas_all())
                     elif fetch_results:
                         results.append(cursor.fetchall())
 


### PR DESCRIPTION
## Summary

`SnowflakeConnection.execute_queries` (dagster-snowflake) initializes
`results: list[Any] = []` and, in the `fetch_results` branch, correctly does:

```python
results.append(cursor.fetchall())
```

But the `use_pandas_result` branch a few lines above writes:

```python
results = results.append(cursor.fetch_pandas_all())  # type: ignore
```

`list.append()` returns `None`, so `results` is rebound to `None`:

- With **multiple** queries, the second iteration raises
  `AttributeError: 'NoneType' object has no attribute 'append'`.
- With a **single** query, the final `return results if len(results) > 0 else None`
  raises `TypeError: object of type 'NoneType' has no len()`.

So `execute_queries(..., use_pandas_result=True)` currently fails for every
call. The `# type: ignore` comment was suppressing exactly this type mismatch.

## Fix

Append in place, matching the sibling `fetch_results` branch, so the collected
DataFrames are actually accumulated and returned. +1/−1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
