### PR TITLE
fix(dagster-cloud): bound BigQuery Insights cost query by invocation time

### DIFF
--- a/.empty-commit
+++ b/.empty-commit
@@ -1,1 +1,0 @@
-chore: empty commit to retrigger CI

--- a/.empty-commit
+++ b/.empty-commit
@@ -1,0 +1,1 @@
+chore: empty commit to retrigger CI

--- a/python_modules/dagster-cloud/dagster_cloud/dagster_insights/bigquery/bigquery_utils.py
+++ b/python_modules/dagster-cloud/dagster_cloud/dagster_insights/bigquery/bigquery_utils.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from dagster import AssetKey, JobDefinition
@@ -7,6 +8,7 @@ OUTPUT_NON_ASSET_SIGIL = "__bigquery_query_metadata_"
 BIGQUERY_METADATA_BYTES_BILLED = "__bigquery_bytes_billed"
 BIGQUERY_METADATA_SLOTS_MS = "__bigquery_slots_ms"
 BIGQUERY_METADATA_JOB_IDS = "__bigquery_job_ids"
+INVOCATION_TIME_BUFFER = timedelta(hours=1)
 
 
 def marker_asset_key_for_job(
@@ -25,3 +27,56 @@ def build_bigquery_cost_metadata(
     if job_ids:
         metadata[BIGQUERY_METADATA_JOB_IDS] = job_ids  # ty: ignore[invalid-assignment]
     return metadata
+
+
+def _parse_run_results_timestamp(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def derive_invocation_time_bounds(run_results_json: Mapping[str, Any]) -> tuple[datetime, datetime]:
+    """Return UTC bounds for filtering INFORMATION_SCHEMA.JOBS on creation_time."""
+    metadata = run_results_json.get("metadata", {})
+    results = run_results_json.get("results", [])
+
+    if metadata.get("invocation_started_at"):
+        start = _parse_run_results_timestamp(metadata["invocation_started_at"])
+    elif metadata.get("generated_at") and run_results_json.get("elapsed_time") is not None:
+        generated_at = _parse_run_results_timestamp(metadata["generated_at"])
+        start = generated_at - timedelta(seconds=float(run_results_json["elapsed_time"]))
+    else:
+        started_at_values = [
+            timing["started_at"]
+            for result in results
+            for timing in result.get("timing", [])
+            if timing.get("started_at")
+        ]
+        if started_at_values:
+            start = _parse_run_results_timestamp(min(started_at_values))
+        else:
+            start = datetime.now(timezone.utc) - timedelta(days=2)
+
+    if metadata.get("generated_at"):
+        end = _parse_run_results_timestamp(metadata["generated_at"])
+    else:
+        completed_at_values = [
+            timing["completed_at"]
+            for result in results
+            for timing in result.get("timing", [])
+            if timing.get("completed_at")
+        ]
+        if completed_at_values:
+            end = _parse_run_results_timestamp(max(completed_at_values))
+        else:
+            end = datetime.now(timezone.utc)
+
+    return start - INVOCATION_TIME_BUFFER, end + INVOCATION_TIME_BUFFER
+
+
+def format_bigquery_timestamp(value: datetime) -> str:
+    utc = value.astimezone(timezone.utc)
+    return utc.strftime("%Y-%m-%d %H:%M:%S") + f".{utc.microsecond:06d} UTC"

--- a/python_modules/dagster-cloud/dagster_cloud/dagster_insights/bigquery/dbt_wrapper.py
+++ b/python_modules/dagster-cloud/dagster_cloud/dagster_insights/bigquery/dbt_wrapper.py
@@ -20,6 +20,8 @@ from packaging import version
 
 from dagster_cloud.dagster_insights.bigquery.bigquery_utils import (
     build_bigquery_cost_metadata,
+    derive_invocation_time_bounds,
+    format_bigquery_timestamp,
     marker_asset_key_for_job,
 )
 from dagster_cloud.dagster_insights.insights_utils import (
@@ -77,7 +79,7 @@ def dbt_with_bigquery_insights(
 
     Args:
         context (AssetExecutionContext): The context of the asset that is being materialized.
-        dbt_cli_invocation (DbtCliInvocation): The invocation of the dbt CLI to wrap.
+        dbt_cli_invocation (DbtCliInvocation): The invocation of the dbt CLI invocation to wrap.
         dagster_events (Optional[Iterable[Union[Output, AssetObservation, AssetCheckResult, AssetCheckEvaluation]]]):
             The events that were produced by the dbt CLI invocation. If not provided, it is assumed
             that the dbt CLI invocation has not yet been run, and it will be run and the events
@@ -106,7 +108,6 @@ def dbt_with_bigquery_insights(
         dbt_project_config = safe_load_yaml(
             (dbt_cli_invocation.project_dir / "dbt_project.yml").open("r")
         )
-        # sanity check that the sigil is present somewhere in the query comment
         query_comment = dbt_project_config.get("query-comment")
         if query_comment is None:
             raise RuntimeError("query-comment is required in dbt_project.yml but it was missing")
@@ -149,8 +150,10 @@ def dbt_with_bigquery_insights(
     marker_asset_key = marker_asset_key_for_job(context.job_def)
     run_results_json = dbt_cli_invocation.get_artifact("run_results.json")
     invocation_id = run_results_json["metadata"]["invocation_id"]
+    creation_time_lower_bound, creation_time_upper_bound = derive_invocation_time_bounds(
+        run_results_json
+    )
 
-    # backcompat-proof in case the invocation does not have an instantiated adapter on it
     adapter: BaseAdapter | None = getattr(dbt_cli_invocation, "adapter", None)
     if not adapter:
         if version.parse(dagster_dbt_version) < version.parse(MIN_DAGSTER_DBT_VERSION):
@@ -170,10 +173,6 @@ def dbt_with_bigquery_insights(
             client: bigquery.Client = adapter.connections.get_thread_connection().handle
 
             if (client.location or adapter.config.credentials.location) and client.project:
-                # we should populate the location/project from the client, and use that to determine
-                # the correct INFORMATION_SCHEMA.JOBS table to query for cost information
-                # If the client doesn't have a location, fall back to the location provided
-                # in the dbt profile config
                 location = client.location or adapter.config.credentials.location
                 project = client.project
             else:
@@ -197,6 +196,8 @@ def dbt_with_bigquery_insights(
                     total_slot_ms AS slots_ms
                     FROM `{project}`.`region-{location.lower()}`.INFORMATION_SCHEMA.JOBS
                     WHERE query like '%{invocation_id}%'
+                    AND creation_time >= TIMESTAMP('{format_bigquery_timestamp(creation_time_lower_bound)}')
+                    AND creation_time <= TIMESTAMP('{format_bigquery_timestamp(creation_time_upper_bound)}')
                 """
             )
             for row in query_result:

--- a/python_modules/dagster-cloud/dagster_cloud/dagster_insights/bigquery/dbt_wrapper.py
+++ b/python_modules/dagster-cloud/dagster_cloud/dagster_insights/bigquery/dbt_wrapper.py
@@ -79,7 +79,7 @@ def dbt_with_bigquery_insights(
 
     Args:
         context (AssetExecutionContext): The context of the asset that is being materialized.
-        dbt_cli_invocation (DbtCliInvocation): The invocation of the dbt CLI invocation to wrap.
+        dbt_cli_invocation (DbtCliInvocation): The invocation of the dbt CLI to wrap.
         dagster_events (Optional[Iterable[Union[Output, AssetObservation, AssetCheckResult, AssetCheckEvaluation]]]):
             The events that were produced by the dbt CLI invocation. If not provided, it is assumed
             that the dbt CLI invocation has not yet been run, and it will be run and the events
@@ -108,6 +108,7 @@ def dbt_with_bigquery_insights(
         dbt_project_config = safe_load_yaml(
             (dbt_cli_invocation.project_dir / "dbt_project.yml").open("r")
         )
+        # sanity check that the sigil is present somewhere in the query comment
         query_comment = dbt_project_config.get("query-comment")
         if query_comment is None:
             raise RuntimeError("query-comment is required in dbt_project.yml but it was missing")
@@ -154,6 +155,7 @@ def dbt_with_bigquery_insights(
         run_results_json
     )
 
+    # backcompat-proof in case the invocation does not have an instantiated adapter on it
     adapter: BaseAdapter | None = getattr(dbt_cli_invocation, "adapter", None)
     if not adapter:
         if version.parse(dagster_dbt_version) < version.parse(MIN_DAGSTER_DBT_VERSION):
@@ -173,6 +175,10 @@ def dbt_with_bigquery_insights(
             client: bigquery.Client = adapter.connections.get_thread_connection().handle
 
             if (client.location or adapter.config.credentials.location) and client.project:
+                # we should populate the location/project from the client, and use that to determine
+                # the correct INFORMATION_SCHEMA.JOBS table to query for cost information
+                # If the client doesn't have a location, fall back to the location provided
+                # in the dbt profile config
                 location = client.location or adapter.config.credentials.location
                 project = client.project
             else:

--- a/python_modules/dagster-cloud/dagster_cloud_tests/dagster_insights_tests/test_dagster_insights.py
+++ b/python_modules/dagster-cloud/dagster_cloud_tests/dagster_insights_tests/test_dagster_insights.py
@@ -1,6 +1,6 @@
 import os
 from contextlib import nullcontext
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from dagster import AssetExecutionContext, materialize
@@ -8,6 +8,8 @@ from dagster_cloud.dagster_insights import dbt_with_bigquery_insights, dbt_with_
 from dagster_cloud.dagster_insights.bigquery.bigquery_utils import (
     BIGQUERY_METADATA_BYTES_BILLED,
     BIGQUERY_METADATA_SLOTS_MS,
+    derive_invocation_time_bounds,
+    format_bigquery_timestamp,
 )
 from dagster_cloud.dagster_insights.snowflake.dagster_snowflake_insights import (
     get_cost_data_for_hour,
@@ -164,6 +166,71 @@ def test_bigquery_asset_metadata_added(
     assert asset_keys_with_metadata == JAFFLE_SHOP_ASSET_KEYS
 
 
+def test_derive_invocation_time_bounds_prefers_invocation_started_at():
+    run_results = {
+        "metadata": {
+            "invocation_started_at": "2026-09-06T06:45:17.109273Z",
+            "generated_at": "2026-09-06T06:45:20.715770Z",
+        },
+        "results": [],
+        "elapsed_time": 3.0,
+    }
+
+    lower_bound, upper_bound = derive_invocation_time_bounds(run_results)
+
+    assert lower_bound.isoformat() == "2026-09-06T05:45:17.109273+00:00"
+    assert upper_bound.isoformat() == "2026-09-06T07:45:20.715770+00:00"
+
+
+def test_derive_invocation_time_bounds_falls_back_to_node_timing():
+    run_results = {
+        "metadata": {
+            "generated_at": "2026-09-06T06:45:20.715770Z",
+        },
+        "results": [
+            {
+                "timing": [
+                    {
+                        "started_at": "2026-09-06T06:45:18.271103Z",
+                        "completed_at": "2026-09-06T06:45:18.354161Z",
+                    },
+                    {
+                        "started_at": "2026-09-06T06:45:18.356879Z",
+                        "completed_at": "2026-09-06T06:45:18.644936Z",
+                    },
+                ]
+            }
+        ],
+    }
+
+    lower_bound, upper_bound = derive_invocation_time_bounds(run_results)
+
+    assert lower_bound.isoformat() == "2026-09-06T05:45:18.271103+00:00"
+    assert upper_bound.isoformat() == "2026-09-06T07:45:20.715770+00:00"
+
+
+def test_derive_invocation_time_bounds_falls_back_to_elapsed_time():
+    run_results = {
+        "metadata": {
+            "generated_at": "2026-09-06T06:45:20.715770Z",
+        },
+        "results": [],
+        "elapsed_time": 10.0,
+    }
+
+    lower_bound, upper_bound = derive_invocation_time_bounds(run_results)
+
+    assert lower_bound.isoformat() == "2026-09-06T05:45:10.715770+00:00"
+    assert upper_bound.isoformat() == "2026-09-06T07:45:20.715770+00:00"
+
+
+def test_format_bigquery_timestamp_uses_utc():
+    assert (
+        format_bigquery_timestamp(datetime(2026, 9, 6, 6, 45, 17, 109273, tzinfo=timezone.utc))
+        == "2026-09-06 06:45:17.109273 UTC"
+    )
+
+
 @pytest.mark.parametrize(
     "bq_client_args",
     [
@@ -206,6 +273,8 @@ def test_bigquery_client(bigquery_manifest_path, bigquery_jaffle_dir, bq_client_
         assert client.query.call_count == 1
         query_arg = client.query.call_args[0][0]
         assert f"FROM {expected_cost_table}" in query_arg
+        assert "creation_time >=" in query_arg
+        assert "creation_time <=" in query_arg
 
 
 def test_bigquery_with_check_failures_cost_metadata_added(
@@ -275,7 +344,6 @@ def test_bigquery_with_execution_project(
     assert asset_keys_with_metadata == JAFFLE_SHOP_ASSET_KEYS
     assert not result.success
 
-    # Assert that the query was executed in the execution project, not the default project
     assert (
         "`fake_exec_project`.`region-us`.INFORMATION_SCHEMA.JOBS"
         in bigquery_client_with_execution_project.query.call_args[0][0]

--- a/python_modules/dagster-cloud/dagster_cloud_tests/dagster_insights_tests/test_dagster_insights.py
+++ b/python_modules/dagster-cloud/dagster_cloud_tests/dagster_insights_tests/test_dagster_insights.py
@@ -344,6 +344,7 @@ def test_bigquery_with_execution_project(
     assert asset_keys_with_metadata == JAFFLE_SHOP_ASSET_KEYS
     assert not result.success
 
+    # Assert that the query was executed in the execution project, not the default project
     assert (
         "`fake_exec_project`.`region-us`.INFORMATION_SCHEMA.JOBS"
         in bigquery_client_with_execution_project.query.call_args[0][0]


### PR DESCRIPTION
Closes #34137

## Summary & Motivation

`dbt_with_bigquery_insights` queries BigQuery `INFORMATION_SCHEMA.JOBS` using only `WHERE query LIKE '%{invocation_id}%'`, which can scan up to 180 days of job history. This PR derives `creation_time` bounds from `run_results.json` timing metadata and adds them to the cost query, reducing scan cost.

Bounds use a 1-hour buffer and fall back in order: `invocation_started_at`, `generated_at - elapsed_time`, min node `started_at`, then `now() - 2 days`.

## Test Plan

- `pytest python_modules/dagster-cloud/dagster_cloud_tests/dagster_insights_tests/test_dagster_insights.py -k "derive_invocation_time_bounds or format_bigquery_timestamp" -q`
- `pytest python_modules/dagster-cloud/dagster_cloud_tests/dagster_insights_tests/test_dagster_insights.py -k "not snowflake" -q`

## Changelog

BigQuery Insights cost queries now filter `INFORMATION_SCHEMA.JOBS` by invocation `creation_time` bounds derived from dbt `run_results.json`.