### PR TITLE
docs: use context.multi_partition_key in the two-dimensional partitions snippet

### DIFF
--- a/docs/docs/guides/build/partitions-and-backfills/partitioning-assets.md
+++ b/docs/docs/guides/build/partitions-and-backfills/partitioning-assets.md
@@ -47,6 +47,7 @@ In this example:
 
 - Using `MultiPartitionsDefinition`, the `two_dimensional_partitions` is defined with two dimensions: `date` and `region`
 - The partition key would be: `2024-08-01|us`
+- Inside the asset, `context.multi_partition_key` returns that key as a `MultiPartitionKey`, and its `keys_by_dimension` property maps each dimension name to its value, for example `{"date": "2024-08-01", "region": "us"}`. Use it instead of `context.partition_key`, which is typed as a plain `str`
 - The `daily_regional_sales_data` and `daily_regional_sales_summary` assets are defined with the same two-dimensional partitioning scheme
 - The `daily_regional_sales_schedule` runs daily at 1:00 AM, processing the previous day's data for all regions. It uses `MultiPartitionKey` to specify partition keys for both date and region dimensions, resulting in three runs per day, one for each region.
 

--- a/examples/docs_snippets/docs_snippets/guides/build/partitions_backfills/partitioning/two_dimensional_partitioning.py
+++ b/examples/docs_snippets/docs_snippets/guides/build/partitions_backfills/partitioning/two_dimensional_partitioning.py
@@ -16,11 +16,12 @@ two_dimensional_partitions = dg.MultiPartitionsDefinition(
 # Define the partitioned asset
 @dg.asset(partitions_def=two_dimensional_partitions)
 def daily_regional_sales_data(context: dg.AssetExecutionContext) -> None:
-    # partition_key looks like "2024-01-01|us"
-    keys_by_dimension: dg.MultiPartitionKey = context.partition_key.keys_by_dimension
+    # context.partition_key looks like "2024-01-01|us"; multi_partition_key is the
+    # same key typed as a MultiPartitionKey, which exposes each dimension by name
+    keys_by_dimension = context.multi_partition_key.keys_by_dimension
 
-    date = keys_by_dimension["date"]  # ty: ignore[invalid-argument-type]
-    region = keys_by_dimension["region"]  # ty: ignore[invalid-argument-type]
+    date = keys_by_dimension["date"]
+    region = keys_by_dimension["region"]
 
     # Simulate fetching daily sales data
     df = pd.DataFrame(
@@ -43,11 +44,12 @@ def daily_regional_sales_data(context: dg.AssetExecutionContext) -> None:
     deps=[daily_regional_sales_data],
 )
 def daily_regional_sales_summary(context):
-    # partition_key looks like "2024-01-01|us"
-    keys_by_dimension: dg.MultiPartitionKey = context.partition_key.keys_by_dimension
+    # context.partition_key looks like "2024-01-01|us"; multi_partition_key is the
+    # same key typed as a MultiPartitionKey, which exposes each dimension by name
+    keys_by_dimension = context.multi_partition_key.keys_by_dimension
 
-    date = keys_by_dimension["date"]  # ty: ignore[invalid-argument-type]
-    region = keys_by_dimension["region"]  # ty: ignore[invalid-argument-type]
+    date = keys_by_dimension["date"]
+    region = keys_by_dimension["region"]
 
     filename = f"data/daily_regional_sales/sales_{context.partition_key}.csv"
     df = pd.read_csv(filename)

--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/build_tests/partitions_backfills_tests/test_two_dimensional_partitioning.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/build_tests/partitions_backfills_tests/test_two_dimensional_partitioning.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from dagster import MultiPartitionKey, materialize
+from docs_snippets.guides.build.partitions_backfills.partitioning.two_dimensional_partitioning import (
+    daily_regional_sales_data,
+    daily_regional_sales_summary,
+)
+
+
+def test_two_dimensional_partitioning(tmp_path, monkeypatch):
+    # the snippet writes its CSV relative to the working directory
+    monkeypatch.chdir(tmp_path)
+
+    partition_key = MultiPartitionKey({"date": "2024-01-01", "region": "us"})
+    result = materialize(
+        [daily_regional_sales_data, daily_regional_sales_summary],
+        partition_key=partition_key,
+    )
+    assert result.success
+
+    # each dimension of the partition key must reach the asset body
+    df = pd.read_csv(
+        tmp_path / "data" / "daily_regional_sales" / "sales_2024-01-01|us.csv"
+    )
+    assert set(df["date"]) == {"2024-01-01"}
+    assert set(df["region"]) == {"us"}


### PR DESCRIPTION
## Summary

`docs/guides/build/partitions-and-backfills/partitioning-assets.md` (section *Two-dimensional partitions*) teaches this pattern:

```python
keys_by_dimension: dg.MultiPartitionKey = context.partition_key.keys_by_dimension

date = keys_by_dimension["date"]  # ty: ignore[invalid-argument-type]
region = keys_by_dimension["region"]  # ty: ignore[invalid-argument-type]
```

Two things are wrong with it, and #32762 reports the consequence ("the `context.partition_key` is str, and str has not `.keys_by_dimension` attribute"):

* `AssetExecutionContext.partition_key` is declared `-> str` (`asset_execution_context.py:382`), so `.keys_by_dimension` is not part of its published type. Dagster already has a property for exactly this: `context.multi_partition_key`, declared `-> MultiPartitionKey`, whose docstring points at `keys_by_dimension`.
* `MultiPartitionKey.keys_by_dimension` returns `Mapping[str, str]` (`partitions/utils/multi.py:173`), **not** a `MultiPartitionKey`. Measured on `upstream/master`:

```
AssetExecutionContext.partition_key -> <class 'str'>
AssetExecutionContext.multi_partition_key -> MultiPartitionKey
MultiPartitionKey.keys_by_dimension -> collections.abc.Mapping[str, str]
type(keys_by_dimension) = dict   value = {'date': '2024-01-01', 'region': 'us'}
isinstance(keys_by_dimension, dg.MultiPartitionKey) = False
```

That incorrect annotation is what made the two `# ty: ignore[invalid-argument-type]` suppressions necessary: annotated as a `MultiPartitionKey` (a `str` subclass), `keys_by_dimension["date"]` is string indexing, not a mapping lookup.

## Approach

Use the public, correctly typed property and let `keys_by_dimension` keep its inferred `Mapping[str, str]` type:

```python
keys_by_dimension = context.multi_partition_key.keys_by_dimension

date = keys_by_dimension["date"]
region = keys_by_dimension["region"]
```

Both `# ty: ignore` suppressions are dropped because the diagnostic they hid is gone. One bullet is added to the guide so readers know which property to use and why.

## Testing

**Static check (`ty` 0.0.78, run against the repo venv).** The current snippet with the suppression comments stripped, i.e. what the docs actually teach:

```
$ uvx ty check --python ../../.venv _before_32762.py
error[invalid-argument-type]: Method `__getitem__` ... cannot be called with key of type `Literal["date"]` on object of type `MultiPartitionKey`
  --> _before_32762.py:22:12
... (4 diagnostics: lines 22, 23, 49, 50)
Found 4 diagnostics
```

Same command on the file in this PR:

```
$ uvx ty check --python ../../.venv docs_snippets/guides/build/partitions_backfills/partitioning/two_dimensional_partitioning.py
All checks passed!
```

**Runtime.** The snippet had no test; this PR adds `test_two_dimensional_partitioning.py`, which materializes both assets with `MultiPartitionKey({"date": "2024-01-01", "region": "us"})` and asserts each dimension reaches the asset body through the written CSV.

```
$ pytest docs_snippets_tests/guides_tests/build_tests/partitions_backfills_tests/ -q
13 passed, 2 warnings in 1.93s
```

**Docs gates.** `prettier@3.3.3 --check` on the changed page: *All matched files use Prettier code style!* `uv run scripts/check-frontmatter.py` (from `docs/`): exit 0.

## Deliberately left out

* **No behaviour change.** I verified the two spellings are runtime-equivalent, so this is a typing/documentation fix only: with a `MultiPartitionKey` both forms log `{'date': '2024-01-01', 'region': 'us'}`, and with a plain string key both fail identically upstream of the asset body (`DagsterUnknownPartitionError`). The new test therefore guards the snippet against bitrot; it is not a regression test for a runtime bug (the regression evidence is the `ty` output above).
* **Sibling snippets not touched:** `integrations/{snowflake,bigquery,deltalake,duckdb,iceberg}` multi-partition snippets and `guides/build/partitions_backfills/multipartitions_asset.py` also read `context.partition_key.keys_by_dimension`. They contain no incorrect annotation and need no suppressions, and they belong to other pages, so I kept them out of this diff. Happy to follow up with them in a separate PR if you want the pattern unified.

Fixes #32762

---

AI tooling was used for the analysis and the measurements above; every command was executed locally and the output is verbatim.
